### PR TITLE
Add exception handling logic at NotionPageReader

### DIFF
--- a/llama_index/readers/notion.py
+++ b/llama_index/readers/notion.py
@@ -56,6 +56,8 @@ class NotionPageReader(BaseReader):
                 "GET", block_url, headers=self.headers, json=query_dict
             )
             data = res.json()
+            if data["status"] != 200:
+                raise Exception(f'HTTP error {res.status_code}: {data.get("message")}')
 
             for result in data["results"]:
                 result_type = result["type"]

--- a/llama_index/readers/notion.py
+++ b/llama_index/readers/notion.py
@@ -56,7 +56,7 @@ class NotionPageReader(BaseReader):
                 "GET", block_url, headers=self.headers, json=query_dict
             )
             data = res.json()
-            if data["status"] != 200:
+            if res.status_code != 200:
                 raise Exception(f'HTTP error {res.status_code}: {data.get("message")}')
 
             for result in data["results"]:


### PR DESCRIPTION
# Description

**Add exception handling logic at NotionPageReader.** 

**When we use `load_data` method of NotionPageReader, it requests with HTTP inside of `readers.notion` module**
```python
page_ids = ["6a6e34ef-f855-4b4b-81ed-bea310778be0"]
documents = NotionPageReader(integration_token=integration_token).load_data(page_ids=page_ids)
```


**But when request is fail, We can't get exact info from error like this. It's not that useful error message for user.**
<img width="667" alt="image" src="https://github.com/jerryjliu/llama_index/assets/29794325/e43fe052-5aa1-46f1-afa4-1ba12e5af6d8">


**So, I added exception handling logic after request code. So, we can get more useful error from notion API server.**
<img width="660" alt="image" src="https://github.com/jerryjliu/llama_index/assets/29794325/c2a21c0f-a152-455f-ae14-33df10cb43db">


Fixes # (issue)
- related issue https://github.com/jerryjliu/llama_index/issues/3777

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
