### PR TITLE
Include context_str in string returned by _get_table_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added support for knowledge graph querying w/ cypyer+nebula (#6642)
 - Added `Document.example()` to create documents for fast prototyping (#6739)
 
+### Bug Fixes / Nits
+- Fixed support for using SQLTableSchema context_str attribute (#6891)
+
 ## [v0.7.6] - 2023-07-12
 
 ### New Features

--- a/docs/end_to_end_tutorials/structured_data/sql_guide.md
+++ b/docs/end_to_end_tutorials/structured_data/sql_guide.md
@@ -70,6 +70,7 @@ construct natural language queries that are synthesized into SQL queries.
 Note that we need to specify the tables we want to use with this query engine.
 If we don't the query engine will pull all the schema context, which could
 overflow the context window of the LLM.
+
 ```python
 query_engine = NLSQLTableQueryEngine(
     sql_database=sql_database,
@@ -80,6 +81,7 @@ query_str = (
 )
 response = query_engine.query(query_str)
 ```
+
 This query engine should used in any case where you can specify the tables you want
 to query over beforehand, or the total size of all the table schema plus the rest of
 the prompt fits your context window.
@@ -103,13 +105,15 @@ obj_index = ObjectIndex.from_objects(
     VectorStoreIndex,
 )
 ```
+
 Here you can see we define our table_node_mapping, and a single SQLTableSchema with the
 "city_stats" table name. We pass these into the ObjectIndex constructor, along with the
 VectorStoreIndex class definition we want to use. This will give us a VectorStoreIndex where
 each Node contains table schema and other context information. You can also add any additional
 context information you'd like.
+
 ```python
-# manually set context text
+# manually set extra context text
 city_stats_text = (
     "This table gives information regarding the population and country of a given city.\n"
     "The user will query with codewords, where 'foo' corresponds to population and 'bar'"

--- a/llama_index/indices/struct_store/sql_query.py
+++ b/llama_index/indices/struct_store/sql_query.py
@@ -352,6 +352,12 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
                 else:
                     raise ValueError(f"Unknown table type: {table}")
                 table_info = self._sql_database.get_single_table_info(table_str)
+
+                if self._context_query_kwargs.get(table_str, None) is not None:
+                    table_opt_context = " The table description is: "
+                    table_opt_context += self._context_query_kwargs[table_str]
+                    table_info += table_opt_context
+
                 context_strs.append(table_info)
 
         else:
@@ -359,6 +365,12 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
             table_names = self._sql_database.get_usable_table_names()
             for table_name in table_names:
                 table_info = self._sql_database.get_single_table_info(table_name)
+
+                if self._context_query_kwargs.get(table_name, None) is not None:
+                    table_opt_context = " The table description is: "
+                    table_opt_context += self._context_query_kwargs[table_name]
+                    table_info += table_opt_context
+
                 context_strs.append(table_info)
 
         tables_desc_str = "\n\n".join(context_strs)


### PR DESCRIPTION
# Description

Adapted `_get_table_context` member method of class `SQLTableRetrieverQueryEngine` to simply append `context_str` (if it exists) to the returned string.

Fixes #6886

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [none necessary] I have commented my code, particularly in hard-to-understand areas
- [none necessary] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
