### PR TITLE
fix(graph_stores/nebulagraph):Modify the openCypher syntax to nGql st…

### DIFF
--- a/llama_index/graph_stores/nebulagraph.py
+++ b/llama_index/graph_stores/nebulagraph.py
@@ -18,10 +18,10 @@ logger = logging.getLogger(__name__)
 
 rel_query = Template(
     """
-MATCH ()-[e:`$edge_type`]->()
-  WITH e limit 1
-MATCH (m)-[:`$edge_type`]->(n) WHERE id(m) == src(e) AND id(n) == dst(e)
-RETURN "(:" + tags(m)[0] + ")-[:$edge_type]->(:" + tags(n)[0] + ")" AS rels
+LOOKUP ON $edge_type 
+YIELD src(edge) AS srcVid |
+GO FROM $$-.srcVid OVER $edge_type 
+        YIELD "(:" + tags($$^)[0] + ")-[:$edge_type]->(:" + tags($$$$)[0] + ")" AS rels | limit 1
 """
 )
 


### PR DESCRIPTION
…atements to adapt to the latest version of nebula

# Description

The original nebulastore encountered a openCypher syntax error when using Nebula 3.4.0 due to Nebula openCypher syntax limitations and needs to be changed to Nebula's nGQL syntax
Fixes # (issue)

## Type of Change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

using Nebulastore for text2cipher operation，Initialize KnowledgeGraphQueryEngine and query

# Suggested Checklist:

 I have performed a self-review of my own code
