### PR TITLE
Fix #7515 [Optimization] Speed up the function inside VectorIndexRetriever class

### DIFF
--- a/llama_index/indices/vector_store/retrievers/retriever.py
+++ b/llama_index/indices/vector_store/retrievers/retriever.py
@@ -9,7 +9,7 @@ from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.indices.query.schema import QueryBundle
 from llama_index.indices.utils import log_vector_store_query_result
 from llama_index.indices.vector_store.base import VectorStoreIndex
-from llama_index.schema import NodeWithScore, ObjectType
+from llama_index.schema import ImageNode, IndexNode, NodeWithScore
 from llama_index.vector_stores.types import (
     MetadataFilters,
     VectorStoreQuery,
@@ -121,17 +121,13 @@ class VectorIndexRetriever(BaseRetriever):
             # NOTE: vector store keeps text, returns nodes.
             # Only need to recover image or index nodes from docstore
             for i in range(len(query_result.nodes)):
-                source_node = query_result.nodes[i].source_node
                 if (not self._vector_store.stores_text) or (
-                    source_node is not None and source_node.node_type != ObjectType.TEXT
+                    isinstance(query_result.nodes[i], (ImageNode, IndexNode))
                 ):
                     node_id = query_result.nodes[i].node_id
                     if node_id in self._docstore.docs:
-                        query_result.nodes[
-                            i
-                        ] = self._docstore.get_node(  # type: ignore[index]
-                            node_id
-                        )
+                        query_result.nodes[i] = self._docstore.get_node(node_id)
+                        # type: ignore[index]
 
         log_vector_store_query_result(query_result)
 


### PR DESCRIPTION
# Description

Revise to
```python
if (not self._vector_store.stores_text) or (
    isinstance(query_result.nodes[i], (ImageNode, IndexNode))
):
```
solution as the same in https://github.com/jerryjliu/llama_index/commit/51bec97118c10dbc2fd7e98e3181a69de5b3e302

after revising the code, it became fast and almost finished in 1 second:

![image](https://github.com/jerryjliu/llama_index/assets/9716977/4beb188f-d36c-4b31-b0c1-1c3e9b90d494)


Fixes #7515 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
