### PR TITLE
Adds support for using message metadata.

### DIFF
--- a/llama_index/readers/discord_reader.py
+++ b/llama_index/readers/discord_reader.py
@@ -136,6 +136,7 @@ class DiscordReader(BasePydanticReader):
             limit (Optional[int]): Maximum number of messages to read.
             oldest_first (bool): Whether to read oldest messages first.
                 Defaults to `True`.
+            complete_metadata (bool): Whether to return the complete message metadata in the List.
 
         Returns:
             List[Document]: List of documents.

--- a/llama_index/readers/discord_reader.py
+++ b/llama_index/readers/discord_reader.py
@@ -68,7 +68,8 @@ async def read_channel(
     client = CustomClient(intents=intents)
     await client.start(discord_token)
 
-    # Wraps each message in a Document containing the text as well as some useful metadata properties.
+    ### Wraps each message in a Document containing the text \
+    # as well as some useful metadata properties.
     return list(
         map(
             lambda msg: Document(

--- a/llama_index/readers/discord_reader.py
+++ b/llama_index/readers/discord_reader.py
@@ -45,12 +45,10 @@ async def read_channel(
                 thread_dict = {}
                 for thread in channel.threads:
                     thread_dict[thread.id] = thread
-                # print(f"channel: {channel}")
                 async for msg in channel.history(
                     limit=limit, oldest_first=oldest_first
                 ):
                     messages.append(msg)
-                    # print(f"message: {msg}")
                     if msg.id in thread_dict:
                         thread = thread_dict[msg.id]
                         async for thread_msg in thread.history(

--- a/llama_index/readers/discord_reader.py
+++ b/llama_index/readers/discord_reader.py
@@ -15,6 +15,7 @@ from llama_index.schema import Document
 
 logger = logging.getLogger(__name__)
 
+
 async def read_channel(
     discord_token: str, channel_id: int, limit: Optional[int], oldest_first: bool,
 ) -> List[Document]:

--- a/llama_index/readers/discord_reader.py
+++ b/llama_index/readers/discord_reader.py
@@ -8,8 +8,6 @@ discord.py module.
 import asyncio
 import logging
 import os
-from functools import reduce
-
 from typing import List, Optional
 
 from llama_index.readers.base import BasePydanticReader
@@ -18,7 +16,7 @@ from llama_index.schema import Document
 logger = logging.getLogger(__name__)
 
 async def read_channel(
-    discord_token: str, channel_id: int, limit: Optional[int], oldest_first: bool, complete_metadata: bool = False,
+    discord_token: str, channel_id: int, limit: Optional[int], oldest_first: bool,
 ) -> List[Document]:
     """Async read channel.
 
@@ -66,13 +64,12 @@ async def read_channel(
     client = CustomClient(intents=intents)
     await client.start(discord_token)
 
-    # return a list of documents per message and include message metadata on a per-document basis
+    # Wraps each message in a Document containing the text as well as some useful metadata properties.
     return list(map(lambda msg: Document(text=msg.content, metadata={
         "message_id": msg.id,
         "username": msg.author.name,
         "created_at": msg.created_at,
         "edited_at": msg.edited_at,
-        "reactions": reduce(lambda reaction: f"{reaction.emoji} {reaction.count}; ", msg.reactions)
     }), messages))
 
 
@@ -138,7 +135,6 @@ class DiscordReader(BasePydanticReader):
             limit (Optional[int]): Maximum number of messages to read.
             oldest_first (bool): Whether to read oldest messages first.
                 Defaults to `True`.
-            complete_metadata (bool): Whether to return the complete message metadata in the List.
 
         Returns:
             List[Document]: List of documents.

--- a/llama_index/readers/discord_reader.py
+++ b/llama_index/readers/discord_reader.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 async def read_channel(
-    discord_token: str, channel_id: int, limit: Optional[int], oldest_first: bool,
+    discord_token: str,
+    channel_id: int,
+    limit: Optional[int],
+    oldest_first: bool,
 ) -> List[Document]:
     """Async read channel.
 
@@ -66,12 +69,20 @@ async def read_channel(
     await client.start(discord_token)
 
     # Wraps each message in a Document containing the text as well as some useful metadata properties.
-    return list(map(lambda msg: Document(text=msg.content, metadata={
-        "message_id": msg.id,
-        "username": msg.author.name,
-        "created_at": msg.created_at,
-        "edited_at": msg.edited_at,
-    }), messages))
+    return list(
+        map(
+            lambda msg: Document(
+                text=msg.content,
+                metadata={
+                    "message_id": msg.id,
+                    "username": msg.author.name,
+                    "created_at": msg.created_at,
+                    "edited_at": msg.edited_at,
+                },
+            ),
+            messages,
+        )
+    )
 
 
 class DiscordReader(BasePydanticReader):
@@ -113,7 +124,6 @@ class DiscordReader(BasePydanticReader):
 
     def _read_channel(
         self, channel_id: int, limit: Optional[int] = None, oldest_first: bool = True
-
     ) -> List[Document]:
         """Read channel."""
         result = asyncio.get_event_loop().run_until_complete(
@@ -149,7 +159,8 @@ class DiscordReader(BasePydanticReader):
                     f"not {type(channel_id)}."
                 )
             channel_documents = self._read_channel(
-                channel_id, limit=limit, oldest_first=oldest_first)
+                channel_id, limit=limit, oldest_first=oldest_first
+            )
             results += channel_documents
         return results
 


### PR DESCRIPTION
# Description
Modifies the `load_data` method of the Discord Reader class with an additional optional parameter to return complete message metadata, namely by way of a boolean value `complete_metadata` (defaulted to false). 

This change is needed for users who wish to query information about the users and allows for further advanced filtering (such as NSFW content, among others). This change requires no dependency changes.


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran a modified version of the [Discord Reader Demo](https://gpt-index.readthedocs.io/en/stable/examples/data_connectors/DiscordDemo.html) locally both with and without the flag and queried the index/engine for a list of users who sent messages in the specified channel (query: `list all users who posted to the channel` produced an output similar to `There is no information provided about the users who posted ideas to the channel.` with the flag set to `False`, and produced an accurate list when the metadata was provided by way of the override flag.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
