### PR TITLE
docs(one-click): add proper titles for arize-phoenix integrations

### DIFF
--- a/docs/end_to_end_tutorials/one_click_observability.md
+++ b/docs/end_to_end_tutorials/one_click_observability.md
@@ -1,19 +1,20 @@
 (one-click-observability)=
 
-#  One-Click Observability
+# One-Click Observability
 
-LlamaIndex provides **one-click observability**  🔭 to allow you to build principled LLM applications in a production setting.
+LlamaIndex provides **one-click observability** 🔭 to allow you to build principled LLM applications in a production setting.
 
 A key requirement for principled development of LLM applications over your data (RAG systems, agents) is being able to observe, debug, and evaluate
 your system - both as a whole and for each component.
 
 This feature allows you to seamlessly integrate the LlamaIndex library with powerful observability/evaluation tools offered by our partners.
 Configure a variable once, and you'll be able to do things like the following:
-- View LLM/prompt inputs/outputs
-- Ensure that the outputs of any component (LLMs, embeddings) are performing as expected
-- View call traces for both indexing and querying
 
-Each provider has similarities and differences. Take a look below for the full set of guides for each one! 
+-   View LLM/prompt inputs/outputs
+-   Ensure that the outputs of any component (LLMs, embeddings) are performing as expected
+-   View call traces for both indexing and querying
+
+Each provider has similarities and differences. Take a look below for the full set of guides for each one!
 
 ## Usage Pattern
 
@@ -53,7 +54,6 @@ llama_index.set_global_handler("simple")
 
 We offer a rich set of integrations with our partners. A short description + usage pattern, and guide is provided for each partner.
 
-
 ### Weights and Biases Prompts
 
 Prompts allows users to log/trace/inspect the execution flow of LlamaIndex during index construction and querying. It also allows users to version-control their indices.
@@ -87,6 +87,7 @@ storage_context = llama_index.global_handler.load_storage_context(
 ![](/_static/integrations/wandb.png)
 
 #### Guides
+
 ```{toctree}
 ---
 maxdepth: 1
@@ -98,13 +99,13 @@ maxdepth: 1
 
 Arize [Phoenix](https://github.com/Arize-ai/phoenix): LLMOps insights at lightning speed with zero-config observability. Phoenix provides a notebook-first experience for monitoring your models and LLM Applications by providing:
 
-- LLM Traces - Trace through the execution of your LLM Application to understand the internals of your LLM Application and to troubleshoot problems related to things like retrieval and tool execution.
-- LLM Evals - Leverage the power of large language models to evaluate your generative model or application's relevance, toxicity, and more.
+-   LLM Traces - Trace through the execution of your LLM Application to understand the internals of your LLM Application and to troubleshoot problems related to things like retrieval and tool execution.
+-   LLM Evals - Leverage the power of large language models to evaluate your generative model or application's relevance, toxicity, and more.
 
 #### Usage Pattern
 
 ```python
-# Phoenix can display in real time the traces automatically 
+# Phoenix can display in real time the traces automatically
 # collected from your LlamaIndex application.
 import phoenix as px
 # Look for a URL in the output to open the App in a browser.
@@ -123,11 +124,12 @@ llama_index.set_global_handler("arize_phoenix")
 ![](/_static/integrations/arize_phoenix.png)
 
 #### Guides
+
 ```{toctree}
 ---
 maxdepth: 1
 ---
-LlamaIndex Tracing Tutorial <https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/tracing/llama_index_tracing_tutorial.ipynb>
+Arize-Phoenix Tracing Tutorial <https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/tracing/llama_index_tracing_tutorial.ipynb>
 ```
 
 ### OpenInference
@@ -163,14 +165,14 @@ query_dataframe = as_dataframe(query_data_buffer)
 **NOTE**: To unlock capabilities of Phoenix, you will need to define additional steps to feed in query/ context dataframes. See below!
 
 #### Guides
+
 ```{toctree}
 ---
 maxdepth: 1
 ---
 /examples/callbacks/OpenInferenceCallback.ipynb
-Evaluating and Improving a LlamaIndex Search and Retrieval Application <https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/llama_index_search_and_retrieval_tutorial.ipynb>
+Evaluating Search and Retrieval with Arize Phoenix <https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/llama_index_search_and_retrieval_tutorial.ipynb>
 ```
-
 
 ### TruEra TruLens
 
@@ -183,10 +185,11 @@ TruLens allows users to instrument/evaluate LlamaIndex applications, through fea
 from trulens_eval import TruLlama
 tru_query_engine = TruLlama(query_engine)
 
-# query 
+# query
 tru_query_engine.query("What did the author do growing up?")
 
 ```
+
 ![](/_static/integrations/trulens.png)
 
 #### Guides

--- a/docs/end_to_end_tutorials/one_click_observability.md
+++ b/docs/end_to_end_tutorials/one_click_observability.md
@@ -129,7 +129,7 @@ llama_index.set_global_handler("arize_phoenix")
 ---
 maxdepth: 1
 ---
-Arize-Phoenix Tracing Tutorial <https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/tracing/llama_index_tracing_tutorial.ipynb>
+Arize Phoenix Tracing Tutorial <https://colab.research.google.com/github/Arize-ai/phoenix/blob/main/tutorials/tracing/llama_index_tracing_tutorial.ipynb>
 ```
 
 ### OpenInference

--- a/docs/examples/callbacks/OpenInferenceCallback.ipynb
+++ b/docs/examples/callbacks/OpenInferenceCallback.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# OpenInference Callback Handler\n",
+    "# OpenInference Callback Handler + Arize Phoenix\n",
     "\n",
     "[OpenInference](https://github.com/Arize-ai/open-inference-spec) is an open standard for capturing and storing AI model inferences. It enables production LLMapp servers to seamlessly integrate with LLM observability solutions such as [Arize](https://arize.com/) and [Phoenix](https://github.com/Arize-ai/phoenix).\n",
     "\n",


### PR DESCRIPTION
# Description

The one-click integrations for arize-phoenix lacked proper titles, causing the side-nav to be a bit vague and hard to search. This adds explicit titles to the guides so that the nav is cleaner and easier to parse.

<img width="260" alt="Screenshot 2023-10-02 at 11 35 41 AM" src="https://github.com/run-llama/llama_index/assets/5640648/d17a0f0c-cfe7-455f-9bd5-795fb43e9ca4">


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
