### PR TITLE
Add parent_id to on_event_start

### DIFF
--- a/llama_index/callbacks/aim.py
+++ b/llama_index/callbacks/aim.py
@@ -81,6 +81,7 @@ class AimCallback(BaseCallbackHandler):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         """
@@ -88,6 +89,7 @@ class AimCallback(BaseCallbackHandler):
             event_type (CBEventType): event type to store.
             payload (Optional[Dict[str, Any]]): payload to store.
             event_id (str): event id to store.
+            parent_id (str): parent event id.
         """
         return ""
 

--- a/llama_index/callbacks/base.py
+++ b/llama_index/callbacks/base.py
@@ -76,7 +76,7 @@ class CallbackManager(BaseCallbackHandler, ABC):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: Optional[str] = None,
-        parent_id: str = "",
+        parent_id: Optional[str] = None,
         **kwargs: Any,
     ) -> str:
         """Run handlers when an event starts and return id of event."""

--- a/llama_index/callbacks/base.py
+++ b/llama_index/callbacks/base.py
@@ -76,16 +76,23 @@ class CallbackManager(BaseCallbackHandler, ABC):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: Optional[str] = None,
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         """Run handlers when an event starts and return id of event."""
         event_id = event_id or str(uuid.uuid4())
 
-        parent_id = global_stack_trace.get()[-1]
+        parent_id = parent_id or global_stack_trace.get()[-1]
         self._trace_map[parent_id].append(event_id)
         for handler in self.handlers:
             if event_type not in handler.event_starts_to_ignore:
-                handler.on_event_start(event_type, payload, event_id=event_id, **kwargs)
+                handler.on_event_start(
+                    event_type,
+                    payload,
+                    event_id=event_id,
+                    parent_id=parent_id,
+                    **kwargs,
+                )
 
         if event_type not in LEAF_EVENTS:
             # copy the stack trace to prevent conflicts with threads/coroutines

--- a/llama_index/callbacks/base_handler.py
+++ b/llama_index/callbacks/base_handler.py
@@ -27,6 +27,7 @@ class BaseCallbackHandler(ABC):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         """Run when an event starts and return id of event."""

--- a/llama_index/callbacks/finetuning_handler.py
+++ b/llama_index/callbacks/finetuning_handler.py
@@ -29,6 +29,7 @@ class OpenAIFineTuningHandler(BaseCallbackHandler):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         """Run when an event starts and return id of event."""

--- a/llama_index/callbacks/llama_debug.py
+++ b/llama_index/callbacks/llama_debug.py
@@ -56,6 +56,7 @@ class LlamaDebugHandler(BaseCallbackHandler):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         """Store event start data by event type.
@@ -64,6 +65,7 @@ class LlamaDebugHandler(BaseCallbackHandler):
             event_type (CBEventType): event type to store.
             payload (Optional[Dict[str, Any]]): payload to store.
             event_id (str): event id to store.
+            parent_id (str): parent event id.
 
         """
         event = CBEvent(event_type, payload=payload, id_=event_id)

--- a/llama_index/callbacks/open_inference_callback.py
+++ b/llama_index/callbacks/open_inference_callback.py
@@ -187,6 +187,7 @@ class OpenInferenceCallbackHandler(BaseCallbackHandler):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         if payload is not None:

--- a/llama_index/callbacks/simple_llm_handler.py
+++ b/llama_index/callbacks/simple_llm_handler.py
@@ -48,6 +48,7 @@ class SimpleLLMHandler(BaseCallbackHandler):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         return event_id

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -97,6 +97,7 @@ class TokenCountingHandler(BaseCallbackHandler):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         return event_id

--- a/llama_index/callbacks/wandb_callback.py
+++ b/llama_index/callbacks/wandb_callback.py
@@ -175,6 +175,7 @@ class WandbCallbackHandler(BaseCallbackHandler):
         event_type: CBEventType,
         payload: Optional[Dict[str, Any]] = None,
         event_id: str = "",
+        parent_id: str = "",
         **kwargs: Any,
     ) -> str:
         """Store event start data by event type.
@@ -183,6 +184,7 @@ class WandbCallbackHandler(BaseCallbackHandler):
             event_type (CBEventType): event type to store.
             payload (Optional[Dict[str, Any]]): payload to store.
             event_id (str): event id to store.
+            parent_id (str): parent event id.
 
         """
         event = CBEvent(event_type, payload=payload, id_=event_id)


### PR DESCRIPTION
# Description

At `on_event_start`, pass the `parent_id` to the child handlers in the base `CallbackManager`. This allows the handlers to construct their own `TraceMap` if needed. Otherwise the child handlers need to wait for the `end_trace` callback to get the final `TraceMap`. Furthermore, some code paths such LLM [chat](https://github.com/run-llama/llama_index/blob/2af7dacc53def707ccd691fa2e51304b6de7091f/llama_index/llms/base.py#L99C26) does not call the `start_trace` and `end_trace`, so handlers for the LLM event may not know right away whether the LLM event is standalone or part of a larger trace.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
