### PR TITLE
Update LlamaCPP context_params property

### DIFF
--- a/llama_index/llms/llama_cpp.py
+++ b/llama_index/llms/llama_cpp.py
@@ -149,7 +149,7 @@ class LlamaCPP(CustomLLM):
     def metadata(self) -> LLMMetadata:
         """LLM metadata."""
         return LLMMetadata(
-            context_window=self._model.params.n_ctx,
+            context_window=self._model.context_params.n_ctx,
             num_output=self.max_new_tokens,
             model_name=self.model_path,
         )


### PR DESCRIPTION
# Description

Initializing new `ServiceContext` with LlamaCPP model started failing for me after update.  Look like `params` property got renamed in the recent `llama-cpp-python` release:

https://github.com/abetlen/llama-cpp-python/commit/1a1c3dc418a3e55073676ea60b3c5b57117d3421

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense