### PR TITLE
Supporting `mypy` local usage with `venv`

### DIFF
--- a/experimental/splitter_playground/app.py
+++ b/experimental/splitter_playground/app.py
@@ -7,6 +7,8 @@ import tiktoken
 from langchain.text_splitter import (
     CharacterTextSplitter,
     RecursiveCharacterTextSplitter,
+)
+from langchain.text_splitter import (
     TextSplitter as LCSplitter,
 )
 from langchain.text_splitter import TokenTextSplitter as LCTokenTextSplitter
@@ -29,7 +31,6 @@ assert isinstance(n_cols, int)
 @st.cache_resource(ttl="1h")
 def load_document(uploaded_files: List[UploadedFile]) -> List[Document]:
     # Read documents
-    docs = []
     temp_dir = tempfile.TemporaryDirectory()
     for file in uploaded_files:
         temp_filepath = os.path.join(temp_dir.name, file.name)
@@ -37,8 +38,7 @@ def load_document(uploaded_files: List[UploadedFile]) -> List[Document]:
             f.write(file.getvalue())
 
     reader = SimpleDirectoryReader(input_dir=temp_dir.name)
-    docs = reader.load_data()
-    return docs
+    return reader.load_data()
 
 
 if uploaded_files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [tool.mypy]
-ignore_missing_imports = "True"
-disallow_untyped_defs = "True"
-exclude = ["notebooks", "build", "examples"]
+disallow_untyped_defs = true
+# Remove venv skip when integrated with pre-commit
+exclude = ["build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
# Description

- Ignores `venv` for local `mypy` usage
- Fixes error being raised by `mypy` locally when you remove extra `docs` local

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
