### PR TITLE
Avoiding `pydantic` reinstalls in CI

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r data_requirements.txt
+          pip install -r requirements.txt -r data_requirements.txt
       - name: Run testing
         env:
           CI: true


### PR DESCRIPTION
# Description

In the "Install deps" part of https://github.com/run-llama/llama_index/actions/runs/6400130018/job/17373287211?pr=7889:
1. `requirements.txt` installed pydantic v2
2. `data_requirements.txt` swapped it for pydantic v1

This PR speeds CI by having all dependencies resolved together

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
