### PR TITLE
add source nodes to sub_q engine

### DIFF
--- a/llama_index/query_engine/sub_question_query_engine.py
+++ b/llama_index/query_engine/sub_question_query_engine.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, Optional, Sequence, cast
 
 from llama_index.async_utils import run_async_tasks
-from llama_index.bridge.pydantic import BaseModel
+from llama_index.bridge.pydantic import BaseModel, Field
 from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.indices.query.base import BaseQueryEngine
@@ -28,7 +28,7 @@ class SubQuestionAnswerPair(BaseModel):
 
     sub_q: SubQuestion
     answer: Optional[str] = None
-    sources: Optional[List[NodeWithScore]] = None
+    sources: List[NodeWithScore] = Field(default_factory=list)
 
 
 class SubQuestionQueryEngine(BaseQueryEngine):
@@ -148,9 +148,11 @@ class SubQuestionQueryEngine(BaseQueryEngine):
 
             nodes = [self._construct_node(pair) for pair in qa_pairs]
 
+            source_nodes = [node for qa_pair in qa_pairs for node in qa_pair.sources]
             response = self._response_synthesizer.synthesize(
                 query=query_bundle,
                 nodes=nodes,
+                additional_source_nodes=source_nodes,
             )
 
             query_event.on_end(payload={EventPayload.RESPONSE: response})
@@ -183,9 +185,11 @@ class SubQuestionQueryEngine(BaseQueryEngine):
 
             nodes = [self._construct_node(pair) for pair in qa_pairs]
 
+            source_nodes = [node for qa_pair in qa_pairs for node in qa_pair.sources]
             response = await self._response_synthesizer.asynthesize(
                 query=query_bundle,
                 nodes=nodes,
+                additional_source_nodes=source_nodes,
             )
 
             query_event.on_end(payload={EventPayload.RESPONSE: response})


### PR DESCRIPTION
# Description

Small change to propagate source nodes to the final response object in the sub-question query engine.

Fixes #7978

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
