### PR TITLE
use proper metadata str for node parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Simplified `LocalAI.__init__` preserving the same behaviors (#7982)
 
 ### Bug Fixes / Nits
+- Use longest metadata string for metadata aware text splitting (#7987)
 - Handle lists of strings in mongodb reader (#8002)
 - Removes `OpenAI.class_type` as it was dead code (#7983)
 - Fixing `HuggingFaceLLM.device_map` type hint (#7989)

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -121,9 +121,18 @@ def get_nodes_from_node(
     """Get nodes from document."""
     if include_metadata:
         if isinstance(text_splitter, MetadataAwareTextSplitter):
+            embed_metadata_str = node.get_metadata_str(mode=MetadataMode.EMBED)
+            llm_metadata_str = node.get_metadata_str(mode=MetadataMode.LLM)
+
+            # use the longest metadata str for splitting
+            if len(embed_metadata_str) > len(llm_metadata_str):
+                embed_str = embed_metadata_str
+            else:
+                embed_str = llm_metadata_str
+
             text_splits = text_splitter.split_text_metadata_aware(
                 text=node.get_content(metadata_mode=MetadataMode.NONE),
-                metadata_str=node.get_metadata_str(),
+                metadata_str=embed_str,
             )
         else:
             logger.warning(

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -126,13 +126,13 @@ def get_nodes_from_node(
 
             # use the longest metadata str for splitting
             if len(embed_metadata_str) > len(llm_metadata_str):
-                embed_str = embed_metadata_str
+                metadata_str = embed_metadata_str
             else:
-                embed_str = llm_metadata_str
+                metadata_str = llm_metadata_str
 
             text_splits = text_splitter.split_text_metadata_aware(
                 text=node.get_content(metadata_mode=MetadataMode.NONE),
-                metadata_str=embed_str,
+                metadata_str=metadata_str,
             )
         else:
             logger.warning(


### PR DESCRIPTION
# Description

We should be using the `metadata_str` that is the longest we splitting nodes into chunks. Otherwise, LLM errors occur, or text is truncated by embeddings.

Fixes #7980

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense