### PR TITLE
fix: missing template vars when logging template data

### DIFF
--- a/llama_index/llm_predictor/base.py
+++ b/llama_index/llm_predictor/base.py
@@ -2,6 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
+from collections import ChainMap
 from typing import Any, List, Optional
 
 from llama_index.bridge.pydantic import BaseModel, PrivateAttr
@@ -118,7 +119,7 @@ class LLMPredictor(BaseLLMPredictor):
     ) -> None:
         template_vars = {
             k: v
-            for k, v in {**prompt.kwargs, **prompt_args}.items()
+            for k, v in ChainMap(prompt.kwargs, prompt_args).items()
             if k in prompt.template_vars
         }
         with self.callback_manager.event(

--- a/llama_index/llm_predictor/base.py
+++ b/llama_index/llm_predictor/base.py
@@ -116,11 +116,16 @@ class LLMPredictor(BaseLLMPredictor):
     def _log_template_data(
         self, prompt: BasePromptTemplate, **prompt_args: Any
     ) -> None:
+        template_vars = {
+            k: v
+            for k, v in {**prompt.kwargs, **prompt_args}.items()
+            if k in prompt.template_vars
+        }
         with self.callback_manager.event(
             CBEventType.TEMPLATING,
             payload={
                 EventPayload.TEMPLATE: prompt.get_template(llm=self._llm),
-                EventPayload.TEMPLATE_VARS: prompt_args,
+                EventPayload.TEMPLATE_VARS: template_vars,
                 EventPayload.SYSTEM_PROMPT: self.system_prompt,
                 EventPayload.QUERY_WRAPPER_PROMPT: self.query_wrapper_prompt,
             },


### PR DESCRIPTION
# Description

Add to the payload of `CBEventType.TEMPLATING` the template vars that have been partially filled out.

Screenshot below shows the template vars being in two different places. This PR unites them.

<img width="884" alt="Screenshot 2023-10-05 at 3 32 02 PM" src="https://github.com/run-llama/llama_index/assets/80478925/67873a3e-799a-4ba4-a6a7-3700ef9f85e9">


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
