### PR TITLE
remove unnecessary transformers requirement

### DIFF
--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -132,7 +132,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
     batch_size: int
 
     _pinecone_index: Any = PrivateAttr()
-    _tokenizer: Callable = PrivateAttr()
+    _tokenizer: Optional[Callable] = PrivateAttr()
 
     def __init__(
         self,
@@ -247,7 +247,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
                 VECTOR_KEY: node.get_embedding(),
                 METADATA_KEY: metadata,
             }
-            if self.add_sparse_vector:
+            if self.add_sparse_vector and self._tokenizer is not None:
                 sparse_vector = generate_sparse_vectors(
                     [node.get_content(metadata_mode=MetadataMode.EMBED)],
                     self._tokenizer,
@@ -293,7 +293,10 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
         """
         sparse_vector = None
-        if query.mode in (VectorStoreQueryMode.SPARSE, VectorStoreQueryMode.HYBRID):
+        if (
+            query.mode in (VectorStoreQueryMode.SPARSE, VectorStoreQueryMode.HYBRID)
+            and self._tokenizer is not None
+        ):
             if query.query_str is None:
                 raise ValueError(
                     "query_str must be specified if mode is SPARSE or HYBRID."

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -168,7 +168,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
         insert_kwargs = insert_kwargs or {}
 
-        if tokenizer is None:
+        if tokenizer is None and add_sparse_vector:
             tokenizer = get_default_tokenizer()
         self._tokenizer = tokenizer
 


### PR DESCRIPTION
# Description

This PR removes the unnecessary need for transformers dependency when `add_sparse_vector=False` (which is the default value) in `PineconeVectorStore` class.

Fixes https://github.com/run-llama/llama_index/issues/7999

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
