### PR TITLE
feat: able to concatenate list fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+- Handle lists of strings in mongodb reader (#8002)
+
 ## [0.8.40] - 2023-10-05
 
 ### New Features

--- a/llama_index/readers/mongo.py
+++ b/llama_index/readers/mongo.py
@@ -78,7 +78,8 @@ class SimpleMongoReader(BaseReader):
                     raise ValueError(
                         f"`{field_name}` field not found in Mongo document."
                     )
-                text += item[field_name]
+                field = item[field_name]
+                text += field if isinstance(field, str) else "".join(field)
 
             documents.append(Document(text=text))
 

--- a/tests/readers/test_mongo.py
+++ b/tests/readers/test_mongo.py
@@ -30,9 +30,9 @@ def test_load_data() -> None:
 def test_load_data_with_field_name() -> None:
     """Test Mongo reader using passed in field_names."""
     mock_cursor = [
-        {"first": "first1", "second": "second1", "third": "third1"},
-        {"first": "first2", "second": "second2", "third": "third2"},
-        {"first": "first3", "second": "second3", "third": "third3"},
+        {"first": "first1", "second": ["second1", "second11"], "third": "third1"},
+        {"first": "first2", "second": ["second2", "second22"], "third": "third2"},
+        {"first": "first3", "second": ["second3", "second33"], "third": "third3"},
     ]
 
     with patch("pymongo.collection.Collection.find") as mock_find:
@@ -44,6 +44,6 @@ def test_load_data_with_field_name() -> None:
         )
 
         assert len(documents) == 3
-        assert documents[0].get_content() == "first1second1third1"
-        assert documents[1].get_content() == "first2second2third2"
-        assert documents[2].get_content() == "first3second3third3"
+        assert documents[0].get_content() == "first1second1second11third1"
+        assert documents[1].get_content() == "first2second2second22third2"
+        assert documents[2].get_content() == "first3second3second33third3"


### PR DESCRIPTION
# Description

Sometimes, we store an article splited into paragraphs in MongoDB as a list of string. This PR make it able to concatenate such field.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
