### PR TITLE
Fix get_content method in Mbox reader

### DIFF
--- a/llama_index/readers/file/mbox_reader.py
+++ b/llama_index/readers/file/mbox_reader.py
@@ -84,7 +84,7 @@ class MboxReader(BaseReader):
 
                 # Parse message HTML content and remove unneeded whitespace
                 soup = BeautifulSoup(content)
-                stripped_content = " ".join(soup.get_content().split())
+                stripped_content = " ".join(soup.get_text().split())
                 # Format message to include date, sender, receiver and subject
                 msg_string = self.message_format.format(
                     _date=msg["date"],


### PR DESCRIPTION
# Description

 - change get_content to get_text on the BeautifulSoup object
 - get_content doesn't exist on soup object

Fixes # (issue)
Parsing issue for Mbox format

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
- [x] Tested on a Mbox exported from gmail


