### PR TITLE
Fixed: React Agent only accept "input keyword" in Action Input, other keyword would raise TypeError

### DIFF
--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -155,7 +155,7 @@ class ReActAgent(BaseAgent):
                 EventPayload.TOOL: tool.metadata,
             },
         ) as event:
-            tool_output = tool.call(input=reasoning_step.action_input)
+            tool_output = tool.call(**reasoning_step.action_input)
             event.on_end(payload={EventPayload.FUNCTION_OUTPUT: str(tool_output)})
 
         observation_step = ObservationReasoningStep(observation=str(tool_output))

--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -155,7 +155,7 @@ class ReActAgent(BaseAgent):
                 EventPayload.TOOL: tool.metadata,
             },
         ) as event:
-            tool_output = tool.call(**reasoning_step.action_input)
+            tool_output = tool.call(input=reasoning_step.action_input)
             event.on_end(payload={EventPayload.FUNCTION_OUTPUT: str(tool_output)})
 
         observation_step = ObservationReasoningStep(observation=str(tool_output))

--- a/llama_index/tools/query_engine.py
+++ b/llama_index/tools/query_engine.py
@@ -55,17 +55,17 @@ class QueryEngineTool(AsyncBaseTool):
         return ToolOutput(
             content=str(response),
             tool_name=self.metadata.name,
-            raw_input={"input": input},
+            raw_input={"kwargs": kwargs},
             raw_output=response,
         )
 
-    async def acall(self, input: Any) -> ToolOutput:
+    async def acall(self, **kwargs: Any) -> ToolOutput:
         query_str = cast(str, input)
         response = await self._query_engine.aquery(query_str)
         return ToolOutput(
             content=str(response),
             tool_name=self.metadata.name,
-            raw_input={"input": input},
+            raw_input={"kwargs": kwargs},
             raw_output=response,
         )
 

--- a/llama_index/tools/query_engine.py
+++ b/llama_index/tools/query_engine.py
@@ -49,8 +49,8 @@ class QueryEngineTool(AsyncBaseTool):
     def metadata(self) -> ToolMetadata:
         return self._metadata
 
-    def call(self, input: Any) -> ToolOutput:
-        query_str = str(input)
+    def call(self, **kwargs: Any) -> ToolOutput:
+        query_str = str(kwargs)
         response = self._query_engine.query(query_str)
         return ToolOutput(
             content=str(response),

--- a/llama_index/tools/query_engine.py
+++ b/llama_index/tools/query_engine.py
@@ -50,7 +50,7 @@ class QueryEngineTool(AsyncBaseTool):
         return self._metadata
 
     def call(self, input: Any) -> ToolOutput:
-        query_str = cast(str, input)
+        query_str = str(input)
         response = self._query_engine.query(query_str)
         return ToolOutput(
             content=str(response),

--- a/llama_index/tools/query_engine.py
+++ b/llama_index/tools/query_engine.py
@@ -49,23 +49,23 @@ class QueryEngineTool(AsyncBaseTool):
     def metadata(self) -> ToolMetadata:
         return self._metadata
 
-    def call(self, **kwargs: Any) -> ToolOutput:
+    def call(self, *args: Any, **kwargs: Any) -> ToolOutput:
         query_str = str(kwargs)
         response = self._query_engine.query(query_str)
         return ToolOutput(
             content=str(response),
             tool_name=self.metadata.name,
-            raw_input={"kwargs": kwargs},
+            raw_input={"args": args, "kwargs": kwargs},
             raw_output=response,
         )
 
-    async def acall(self, **kwargs: Any) -> ToolOutput:
+    async def acall(self, *args: Any, **kwargs: Any) -> ToolOutput:
         query_str = cast(str, input)
         response = await self._query_engine.aquery(query_str)
         return ToolOutput(
             content=str(response),
             tool_name=self.metadata.name,
-            raw_input={"kwargs": kwargs},
+            raw_input={"args": args, "kwargs": kwargs},
             raw_output=response,
         )
 

--- a/llama_index/tools/types.py
+++ b/llama_index/tools/types.py
@@ -124,13 +124,13 @@ class AsyncBaseTool(BaseTool):
         return self.call(*args, **kwargs)
 
     @abstractmethod
-    def call(self, input: Any) -> ToolOutput:
+    def call(self, *args: Any, **kwargs: Any) -> ToolOutput:
         """
         This is the method that should be implemented by the tool developer.
         """
 
     @abstractmethod
-    async def acall(self, input: Any) -> ToolOutput:
+    async def acall(self, *args: Any, **kwargs: Any) -> ToolOutput:
         """
         This is the async version of the call method.
         Should also be implemented by the tool developer as an


### PR DESCRIPTION
- change cast to str() because cast do not cast data type in runtime

# Description

In react agent, `action input` should have various of keys as shown in prompt template`{{"text": "hello, world ", "num_beams": 5}}`.

If you to create such useful action input, following error will be raised:
```shell
  File "/Users/azure/Documents/Workspace/Datasci/lib/python3.10/site-packages/llama_index/agent/react/base.py", line 158, in _process_actions
    tool_output = tool.call(**reasoning_step.action_input)
TypeError: QueryEngineTool.call() got an unexpected keyword argument 'University'
```

### Fixes 
Allow react agent pass full action input into queryEngine. while fixed another bug that fail to cast data type

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
