### PR TITLE
`LocalAI` intuitive module-level var names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### New Features
+- `LocalAI` more intuitive module-level var names (#8028)
+
 ## [0.8.41] - 2023-10-07
 
 ### New Features

--- a/llama_index/llms/localai.py
+++ b/llama_index/llms/localai.py
@@ -4,10 +4,10 @@ from llama_index.bridge.pydantic import Field
 from llama_index.constants import DEFAULT_CONTEXT_WINDOW
 from llama_index.llms.openai import OpenAI
 
-DEFAULT_KEY = "fake"
-DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 8080
-DEFAULT_API_BASE = f"{DEFAULT_HOST}{DEFAULT_PORT}"
+DEFAULT_API_KEY = "fake"
+DEFAULT_API_HOST = "localhost"
+DEFAULT_API_PORT = 8080
+DEFAULT_API_BASE = f"{DEFAULT_API_HOST}{DEFAULT_API_PORT}"
 
 
 class LocalAI(OpenAI):
@@ -38,7 +38,7 @@ class LocalAI(OpenAI):
 
     def __init__(
         self,
-        api_key: Optional[str] = DEFAULT_KEY,
+        api_key: Optional[str] = DEFAULT_API_KEY,
         api_base: Optional[str] = DEFAULT_API_BASE,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
# Description

Made the module-level vars in `LocalAI` both more intuitive and matching `OpenAI` namings

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
