### PR TITLE
Add support for multiline answers in ReActOutputParser (Fixes #7690)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `LocalAI` more intuitive module-level var names (#8028)
 - Enable `codespell` for markdown docs (#7972)
 
+### Bug Fixes / Nits
+- Parse multi-line outputs in react agent answers (#8029)
+
 ## [0.8.41] - 2023-10-07
 
 ### New Features

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -29,7 +29,7 @@ def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
 
 
 def extract_final_response(input_text: str) -> Tuple[str, str]:
-    pattern = r"\s*Thought:(.*?)Answer:(.*?)(?:\n|$)"
+    pattern = r"\s*Thought:(.*?)Answer:(.*?)(?:$)"
 
     match = re.search(pattern, input_text, re.DOTALL)
     if not match:

--- a/tests/agent/react/test_react_output_parser.py
+++ b/tests/agent/react/test_react_output_parser.py
@@ -43,3 +43,25 @@ Answer: 2
     thought, answer = extract_final_response(mock_input_text)
     assert thought == expected_thought
     assert answer == "2"
+
+
+def test_extract_final_response_multiline_answer() -> None:
+    mock_input_text = """\
+Thought: I have enough information to answer the question without using any more tools.
+Answer: Here is the answer:
+
+This is the second line.
+"""
+
+    expected_thought = (
+        "I have enough information to answer the question "
+        "without using any more tools."
+    )
+    thought, answer = extract_final_response(mock_input_text)
+    assert thought == expected_thought
+    assert (
+        answer
+        == """Here is the answer:
+
+This is the second line."""
+    )


### PR DESCRIPTION
# Description

This change fixes issue #7690 and adds support for multiline answers to the ReActAgentOutputParser. This can happen when the agent uses a tool and generates structured output such as html snippets, e.g., the following answer:

```
Here is a list of files in an html table:

<table>
   <tr>
      <td>File1.pdf</td>
   </tr>
   <tr>
      <td>File2.pdf</td>
   </tr>
   <tr>
      <td>File3.pdf</td>
   </tr>
</table>
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
