### PR TITLE
`codespell` in `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,8 @@ repos:
     rev: v0.23.1
     hooks:
       - id: toml-sort-fix
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased
+
+### New Features
+- Moves `codespell` to `pre-commit` (#8040)
+
 ## [0.8.43] - 2023-10-10
 
 ### New Features

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:	## Show all Makefile targets.
 format:	## Run code autoformatters (black).
 	black .
 
-lint: ## Run linters: black, codespell, ruff, mypy
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	pre-commit install && pre-commit run --all-files
 	mypy .
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,9 @@ help:	## Show all Makefile targets.
 format:	## Run code autoformatters (black).
 	black .
 
-lint: ## Run linters: mypy, black, codespell, ruff
+lint: ## Run linters: black, codespell, ruff, mypy
 	pre-commit install && pre-commit run --all-files
 	mypy .
-	codespell .
 
 test:	## Run tests via pytest.
 	pytest tests

--- a/examples/multimodal/data/llama/index_guide.md
+++ b/examples/multimodal/data/llama/index_guide.md
@@ -17,7 +17,7 @@ The summary index simply stores Nodes as a sequential chain.
 ### Querying
 
 During query time, if no other query parameters are specified, LlamaIndex simply loads all Nodes in the list into
-our Reponse Synthesis module.
+our Response Synthesis module.
 
 ![](/docs/_static/indices/list_query.png)
 

--- a/experimental/openai_fine_tuning/validate_json.py
+++ b/experimental/openai_fine_tuning/validate_json.py
@@ -165,7 +165,7 @@ def validate_json(data_path: str) -> None:
         f"~{n_epochs * n_billing_tokens_in_dataset} tokens"
     )
 
-    print("As of Augest 22, 2023, fine-tuning gpt-3.5-turbo is $0.008 / 1K Tokens.")
+    print("As of August 22, 2023, fine-tuning gpt-3.5-turbo is $0.008 / 1K Tokens.")
     print(
         "This means your total cost for training will be "
         f"${n_billing_tokens_in_dataset * 0.008 / 1000} per epoch."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["poetry-core"]
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-ignore-words-list = "ot,gallary,rouge,narl"
+ignore-words-list = "astroid,gallary,momento,narl,ot,rouge"
 # Feel free to un-skip examples, and experimental, you will just need to
 # work through many typos (--write-changes and --interactive will help)
 skip = "./examples,./experimental,*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,9 @@ requires = ["poetry-core"]
 check-filenames = true
 check-hidden = true
 ignore-words-list = "ot,gallary,rouge,narl"
-# Remove .git and venv skips when integrated with pre-commit
 # Feel free to un-skip examples, and experimental, you will just need to
 # work through many typos (--write-changes and --interactive will help)
-skip = "poetry.lock,./.git,./*venv,./examples,./experimental,*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+skip = "./examples,./experimental,*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ types-setuptools==67.1.0.0
 
 # linting
 black[jupyter]==23.9.1
-codespell[toml]>=v2.2.6
 mypy==0.991
 pre-commit==3.2.0
 pylint==2.15.10


### PR DESCRIPTION
# Description

- Moves `codespell` to be run and version managed by `pre-commit`
- Fixes more typos

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
