### PR TITLE
feature: adds support for embeddings from gradient.ai

### DIFF
--- a/docs/core_modules/model_modules/embeddings/modules.md
+++ b/docs/core_modules/model_modules/embeddings/modules.md
@@ -8,6 +8,7 @@ maxdepth: 1
 ---
 /examples/embeddings/OpenAI.ipynb
 /examples/embeddings/Langchain.ipynb
+/examples/embeddings/gradient.ipynb
 /examples/customization/llms/AzureOpenAI.ipynb
 /examples/embeddings/custom_embeddings.ipynb
 /examples/embeddings/huggingface.ipynb

--- a/docs/examples/embeddings/gradient.ipynb
+++ b/docs/examples/embeddings/gradient.ipynb
@@ -5,7 +5,9 @@
    "id": "bf9f19f3",
    "metadata": {},
    "source": [
-    "# LlamaIndex / Gradient Integration"
+    "# Gradient Embeddings\n",
+    "\n",
+    "[Gradient](https://gradient.ai) offers embeddings model that can be easily integrated with LlamaIndex. Below is an example of how to use it with LlamaIndex."
    ]
   },
   {
@@ -17,8 +19,20 @@
    },
    "outputs": [],
    "source": [
+    "# Install the required packages\n",
+    "\n",
     "%pip install llama-index --quiet\n",
     "%pip install gradientai --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e314915",
+   "metadata": {},
+   "source": [
+    "Gradient needs an access token and workspaces id for authorization. They can be obtained from:\n",
+    "- [Gradient UI](https://auth.gradient.ai/login), or\n",
+    "- [Gradient CLI](https://docs.gradient.ai/docs/cli-quickstart) with `gradient env` command."
    ]
   },
   {
@@ -35,57 +49,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "9a602a2a",
-   "metadata": {},
-   "source": [
-    "## Example 1: Query Gradient LLM directly"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4baffaa2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index.llms import GradientBaseModelLLM\n",
-    "\n",
-    "# You can also use a model adapter you've trained with GradientModelAdapterLLM\n",
-    "llm = GradientBaseModelLLM(\n",
-    "    base_model_slug=\"llama2-7b-chat\",\n",
-    "    max_tokens=400,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7039a65",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result = llm.complete(\"Can you tell me about large language models?\")\n",
-    "print(result)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1112e828",
-   "metadata": {},
-   "source": [
-    "## Example 2: Retrieval Augmented Generation (RAG) with Gradient embeddings"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cacff36a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index import VectorStoreIndex, SimpleDirectoryReader, ServiceContext\n",
-    "from llama_index.embeddings import GradientEmbedding"
+    "from llama_index.llms import GradientBaseModelLLM\n",
+    "\n",
+    "# NOTE: we use a base model here, you can as well insert your fine-tuned model.\n",
+    "llm = GradientBaseModelLLM(\n",
+    "    base_model_slug=\"llama2-7b-chat\",\n",
+    "    max_tokens=400,\n",
+    ")"
    ]
   },
   {
@@ -103,7 +79,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "documents = SimpleDirectoryReader(\"../paul_graham_essay/data\").load_data()\n",
+    "from llama_index import SimpleDirectoryReader\n",
+    "\n",
+    "documents = SimpleDirectoryReader(\"../data/paul_graham\").load_data()\n",
     "print(f\"Loaded {len(documents)} document(s).\")"
    ]
   },
@@ -122,6 +100,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from llama_index import ServiceContext\n",
+    "from llama_index.embeddings import GradientEmbedding\n",
+    "\n",
     "embed_model = GradientEmbedding(\n",
     "    gradient_access_token=os.environ[\"GRADIENT_ACCESS_TOKEN\"],\n",
     "    gradient_workspace_id=os.environ[\"GRADIENT_WORKSPACE_ID\"],\n",
@@ -148,6 +129,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from llama_index import VectorStoreIndex\n",
+    "\n",
     "index = VectorStoreIndex.from_documents(documents, service_context=service_context)\n",
     "query_engine = index.as_query_engine()"
    ]

--- a/llama_index/embeddings/__init__.py
+++ b/llama_index/embeddings/__init__.py
@@ -8,6 +8,7 @@ from llama_index.embeddings.base import SimilarityMode
 from llama_index.embeddings.clarifai import ClarifaiEmbedding
 from llama_index.embeddings.elasticsearch import ElasticsearchEmbeddings
 from llama_index.embeddings.google import GoogleUnivSentEncoderEmbedding
+from llama_index.embeddings.gradient import GradientEmbedding
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.embeddings.huggingface_optimum import OptimumEmbedding
 from llama_index.embeddings.huggingface_utils import DEFAULT_HUGGINGFACE_EMBEDDING_MODEL
@@ -30,4 +31,5 @@ __all__ = [
     "SimilarityMode",
     "ElasticsearchEmbeddings",
     "ClarifaiEmbedding",
+    "GradientEmbedding",
 ]

--- a/llama_index/embeddings/gradient.py
+++ b/llama_index/embeddings/gradient.py
@@ -1,0 +1,98 @@
+import logging
+from typing import Any, List, Optional
+
+from llama_index.bridge.pydantic import Field, PrivateAttr
+from llama_index.embeddings.base import BaseEmbedding, Embedding
+
+logger = logging.getLogger(__name__)
+
+
+# For bge models that Gradient AI provides, it is suggested to add the instruction for retrieval.
+# Reference: https://huggingface.co/BAAI/bge-large-en-v1.5#model-list
+QUERY_INSTRUCTION_FOR_RETRIEVAL = (
+    "Represent this sentence for searching relevant passages:"
+)
+
+
+class GradientEmbedding(BaseEmbedding):
+    """GradientAI embedding models.
+
+    This class provides an interface to generate embeddings using a model
+    deployed in Gradient AI. At the initialization it requires a model_id
+    of the model deployed in the cluster.
+
+    Note:
+        Requires `gradientai` package to be available in the PYTHONPATH. It can be installed with
+        `pip install gradientai`.
+    """
+
+    _gradient: Any = PrivateAttr()
+    _model: Any = PrivateAttr()
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "GradientEmbedding"
+
+    def __init__(
+        self,
+        *,
+        gradient_model_slug: str,
+        gradient_access_token: Optional[str] = None,
+        gradient_workspace_id: Optional[str] = None,
+        gradient_host: Optional[str] = None,
+        **kwargs,
+    ):
+        """Initializes the GradientEmbedding class.
+
+        During the initialization the `gradientai` package is imported. Using the access token,
+        workspace id and the slug of the model, the model is fetched from Gradient AI and prepared to use.
+
+        Args:
+            gradient_model_slug (str): The model slug of the model in the Gradient AI account.
+            gradient_access_token (str, optional): The access token of the Gradient AI account, if
+                `None` read from the environment variable `GRADIENT_ACCESS_TOKEN`.
+            gradient_workspace_id (str, optional): The workspace ID of the Gradient AI account, if `None`
+                read from the environment variable `GRADIENT_WORKSPACE_ID`.
+            gradient_host (str, optional): The host of the Gradient AI API. Defaults to None, which
+              means the default host is used.
+
+        Raises:
+            ImportError: If the `gradientai` package is not available in the PYTHONPATH.
+            ValueError: If the model cannot be fetched from Gradient AI.
+        """
+        try:
+            import gradientai
+        except ImportError:
+            raise ImportError("GradientEmbedding requires `pip install gradientai`.")
+
+        self._gradient = gradientai.Gradient(
+            access_token=gradient_access_token,
+            workspace_id=gradient_workspace_id,
+            host=gradient_host,
+        )
+
+        try:
+            self._model = self._gradient.get_embeddings_model(slug=gradient_model_slug)
+        except gradientai.openapi.client.exceptions.UnauthorizedException as e:
+            logger.error(f"Error while loading model {gradient_model_slug}.")
+            self._gradient.close()
+            raise ValueError("Unable to fetch the requested embeddings model") from e
+
+        super().__init__(model_name=gradient_model_slug, **kwargs)
+
+    async def _aget_query_embedding(self, query: str) -> Embedding:
+        # Gradient AI doesn't have the proper API for async yet, so we just use the sync version.
+        return self._get_query_embedding(query)
+
+    def _get_text_embedding(self, text: str) -> Embedding:
+        return self._get_text_embeddings([text])[0]
+
+    def _get_text_embeddings(self, texts: List[str]) -> List[Embedding]:
+        inputs = [{"input": text} for text in texts]
+
+        result = self._model.generate_embeddings(inputs=inputs).embeddings
+
+        return [e.embedding for e in result]
+
+    def _get_query_embedding(self, query: str) -> Embedding:
+        return self._get_text_embedding(f"{QUERY_INSTRUCTION_FOR_RETRIEVAL} {query}")

--- a/tests/embeddings/test_gradient.py
+++ b/tests/embeddings/test_gradient.py
@@ -1,0 +1,118 @@
+import pytest
+from llama_index.embeddings.gradient import GradientEmbedding
+
+try:
+    import gradientai
+except ImportError:
+    gradientai = None  # type: ignore
+
+
+@pytest.fixture()
+def gradient_host() -> str:
+    return "https://api.gradient.ai/"
+
+
+@pytest.fixture()
+def gradient_model_slug() -> str:
+    return "bge-large"
+
+
+@pytest.fixture()
+def gradient_access_token() -> str:
+    return "some-access-token"
+
+
+@pytest.fixture()
+def gradient_workspace_id() -> str:
+    return "some-workspace-id"
+
+
+BGE_LARGE_EMBEDDING_SIZE = 1024
+
+
+@pytest.mark.skipif(gradientai is None, reason="gradientai not installed")
+def test_gradientai_embedding_constructor(
+    gradient_access_token: str, gradient_model_slug: str, gradient_workspace_id: str
+) -> None:
+    """Test Gradient AI embedding query."""
+    test_object = GradientEmbedding(
+        gradient_model_slug=gradient_model_slug,
+        gradient_access_token=gradient_access_token,
+        gradient_workspace_id=gradient_workspace_id,
+    )
+    assert test_object is not None
+
+
+@pytest.mark.skipif(
+    gradientai is not None, reason="gradientai is installed, no need to test behavior"
+)
+def test_gradientai_throws_if_not_installed(
+    gradient_access_token: str, gradient_model_slug: str, gradient_workspace_id: str
+) -> None:
+    with pytest.raises(ImportError):
+        GradientEmbedding(
+            gradient_model_slug=gradient_model_slug,
+            gradient_access_token=gradient_access_token,
+            gradient_workspace_id=gradient_workspace_id,
+        )
+
+
+@pytest.mark.skipif(gradientai is None, reason="gradientai is not installed")
+def test_gradientai_throws_without_proper_auth(
+    gradient_model_slug: str, gradient_workspace_id: str
+) -> None:
+    """Test Gradient AI embedding query."""
+    with pytest.raises(ValueError):
+        GradientEmbedding(
+            gradient_model_slug=gradient_model_slug,
+            gradient_access_token="definitely-not-a-valid-token",
+            gradient_workspace_id=gradient_workspace_id,
+        )
+
+
+@pytest.mark.skipif(gradientai is None, reason="gradientai not installed")
+def test_gradientai_can_receive_text_embedding(
+    gradient_access_token: str, gradient_model_slug: str, gradient_workspace_id: str
+) -> None:
+    test_object = GradientEmbedding(
+        gradient_model_slug=gradient_model_slug,
+        gradient_access_token=gradient_access_token,
+        gradient_workspace_id=gradient_workspace_id,
+    )
+
+    result = test_object.get_text_embedding("input")
+
+    assert len(result) == BGE_LARGE_EMBEDDING_SIZE
+
+
+@pytest.mark.skipif(gradientai is None, reason="gradientai not installed")
+def test_gradientai_can_receive_multiple_text_embeddings(
+    gradient_access_token: str, gradient_model_slug: str, gradient_workspace_id: str
+) -> None:
+    test_object = GradientEmbedding(
+        gradient_model_slug=gradient_model_slug,
+        gradient_access_token=gradient_access_token,
+        gradient_workspace_id=gradient_workspace_id,
+    )
+
+    inputs = ["first input", "second input"]
+    result = test_object.get_text_embedding_batch(inputs)
+
+    assert len(result) == len(inputs)
+    assert len(result[0]) == BGE_LARGE_EMBEDDING_SIZE
+    assert len(result[1]) == BGE_LARGE_EMBEDDING_SIZE
+
+
+@pytest.mark.skipif(gradientai is None, reason="gradientai not installed")
+def test_gradientai_can_receive_query_embedding(
+    gradient_access_token: str, gradient_model_slug: str, gradient_workspace_id: str
+) -> None:
+    test_object = GradientEmbedding(
+        gradient_model_slug=gradient_model_slug,
+        gradient_access_token=gradient_access_token,
+        gradient_workspace_id=gradient_workspace_id,
+    )
+
+    result = test_object.get_query_embedding("gradient as the best managed AI platform")
+
+    assert len(result) == BGE_LARGE_EMBEDDING_SIZE

--- a/tests/embeddings/test_gradient.py
+++ b/tests/embeddings/test_gradient.py
@@ -116,3 +116,16 @@ def test_gradientai_can_receive_query_embedding(
     result = test_object.get_query_embedding("gradient as the best managed AI platform")
 
     assert len(result) == BGE_LARGE_EMBEDDING_SIZE
+
+
+@pytest.mark.skipif(gradientai is None, reason="gradientai not installed")
+def test_gradientai_cannot_support_batches_larger_than_100(
+    gradient_access_token: str, gradient_model_slug: str, gradient_workspace_id: str
+) -> None:
+    with pytest.raises(ValueError):
+        GradientEmbedding(
+            embed_batch_size=101,
+            gradient_model_slug=gradient_model_slug,
+            gradient_access_token=gradient_access_token,
+            gradient_workspace_id=gradient_workspace_id,
+        )


### PR DESCRIPTION
# Description

Adds a new module for obtaining embeddings from [Gradient](https://docs.gradient.ai).

> [!NOTE]
> This feature needs [Gradient Python SDK](https://pypi.org/project/gradientai/) installed, with version at least `1.1.0`.



## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

The change is tested with a new unit test `tests/embeddings/test_gradient.py` that obtains some embeddings for simple examples from Gradient, using the [public client](https://pypi.org/project/gradientai/). To work correctly the Gradient SDK needs to be installed:

```
pip install -U gradientai
```

The test requires the change in the fixtures to provide the access token and workspace id. They can be generated from either:

1. [Gradient website](https://auth.gradient.ai) or,
1. [Gradient CLI](https://docs.gradient.ai/docs/cli-quickstart) with `gradient env --json` command.


- [X] Added new unit/integration tests
- [X] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
