### PR TITLE
Fixed `HuggingFaceLLM` missing f-str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### New Features
 - Moves `codespell` to `pre-commit` (#8040)
 
+### Bug Fixes / Nits
+- Fixed forgotten f-str in `HuggingFaceLLM` (#8075)
+
 ## [0.8.43] - 2023-10-10
 
 ### New Features

--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -140,7 +140,7 @@ class HuggingFaceLLM(CustomLLM):
         if model_context_window and model_context_window < context_window:
             logger.warning(
                 f"Supplied context_window {context_window} is greater "
-                "than the model's max input size {model_context_window}. "
+                f"than the model's max input size {model_context_window}. "
                 "Disable this warning by setting a lower context_window."
             )
             context_window = model_context_window


### PR DESCRIPTION
# Description

Fixing a forgotten f-str in `HuggingFaceLLM`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
