### PR TITLE
`ImportChecker` for standardized import failovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 - Moves `codespell` to `pre-commit` (#8040)
+- Created `ImportChecker` for standardized import failures (#8076)
 
 ## [0.8.43] - 2023-10-10
 

--- a/llama_index/llms/anthropic.py
+++ b/llama_index/llms/anthropic.py
@@ -26,6 +26,7 @@ from llama_index.llms.generic_utils import (
     chat_to_completion_decorator,
     stream_chat_to_completion_decorator,
 )
+from llama_index.utils import ImportChecker
 
 
 class Anthropic(LLM):
@@ -59,13 +60,8 @@ class Anthropic(LLM):
         additional_kwargs: Optional[Dict[str, Any]] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
-        try:
+        with ImportChecker("anthropic", caller=type(self).__name__):
             import anthropic
-        except ImportError as e:
-            raise ImportError(
-                "You must install the `anthropic` package to use Anthropic."
-                "Please `pip install anthropic`"
-            ) from e
 
         additional_kwargs = additional_kwargs or {}
         callback_manager = callback_manager or CallbackManager([])

--- a/llama_index/llms/cohere.py
+++ b/llama_index/llms/cohere.py
@@ -24,6 +24,7 @@ from llama_index.llms.cohere_utils import (
     completion_with_retry,
     messages_to_cohere_history,
 )
+from llama_index.utils import ImportChecker
 
 
 class Cohere(LLM):
@@ -50,13 +51,8 @@ class Cohere(LLM):
         additional_kwargs: Optional[Dict[str, Any]] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
-        try:
+        with ImportChecker("cohere", caller=type(self).__name__):
             import cohere
-        except ImportError as e:
-            raise ImportError(
-                "You must install the `cohere` package to use Cohere."
-                "Please `pip install cohere`"
-            ) from e
         additional_kwargs = additional_kwargs or {}
         callback_manager = callback_manager or CallbackManager([])
 

--- a/llama_index/llms/cohere_utils.py
+++ b/llama_index/llms/cohere_utils.py
@@ -10,6 +10,7 @@ from tenacity import (
 )
 
 from llama_index.llms.base import ChatMessage
+from llama_index.utils import ImportChecker
 
 COMMAND_MODELS = {
     "command": 4096,
@@ -37,13 +38,8 @@ def _create_retry_decorator(max_retries: int) -> Callable[[Any], Any]:
     max_seconds = 10
     # Wait 2^x * 1 second between each retry starting with
     # 4 seconds, then up to 10 seconds, then 10 seconds afterwards
-    try:
+    with ImportChecker("cohere", caller="Cohere"):
         import cohere
-    except ImportError as e:
-        raise ImportError(
-            "You must install the `cohere` package to use Cohere."
-            "Please `pip install cohere`"
-        ) from e
 
     return retry(
         reraise=True,

--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -23,6 +23,7 @@ from llama_index.llms.generic_utils import (
     messages_to_prompt as generic_messages_to_prompt,
 )
 from llama_index.prompts.base import PromptTemplate
+from llama_index.utils import ImportChecker
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,11 @@ class HuggingFaceLLM(CustomLLM):
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
         """Initialize params."""
-        try:
+        with ImportChecker(
+            ["torch", "transformers"],
+            caller=type(self).__name__,
+            pip_install="transformers[torch]",
+        ):
             import torch
             from transformers import (
                 AutoModelForCausalLM,
@@ -121,11 +126,6 @@ class HuggingFaceLLM(CustomLLM):
                 StoppingCriteria,
                 StoppingCriteriaList,
             )
-        except ImportError as exc:
-            raise ImportError(
-                f"{type(self).__name__} requires torch and transformers packages.\n"
-                f"Please install both with `pip install transformers[torch]`."
-            ) from exc
 
         model_kwargs = model_kwargs or {}
         self._model = model or AutoModelForCausalLM.from_pretrained(

--- a/llama_index/llms/llama_api.py
+++ b/llama_index/llms/llama_api.py
@@ -19,6 +19,7 @@ from llama_index.llms.openai_utils import (
     from_openai_message_dict,
     to_openai_message_dicts,
 )
+from llama_index.utils import ImportChecker
 
 
 class LlamaAPI(CustomLLM):
@@ -40,13 +41,8 @@ class LlamaAPI(CustomLLM):
         api_key: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
-        try:
+        with ImportChecker("llamaapi", caller=type(self).__name__):
             from llamaapi import LlamaAPI as Client
-        except ImportError as e:
-            raise ImportError(
-                "llama_api not installed."
-                "Please install it with `pip install llamaapi`."
-            ) from e
 
         self._client = Client(api_key)
 

--- a/llama_index/utils.py
+++ b/llama_index/utils.py
@@ -80,13 +80,8 @@ class GlobalsHelper:
     def tokenizer(self) -> Callable[[str], List]:
         """Get tokenizer."""
         if self._tokenizer is None:
-            tiktoken_import_err = (
-                "`tiktoken` package not found, please run `pip install tiktoken`"
-            )
-            try:
+            with ImportChecker("tiktoken", caller=type(self).__name__):
                 import tiktoken
-            except ImportError:
-                raise ImportError(tiktoken_import_err)
             enc = tiktoken.get_encoding("gpt2")
             self._tokenizer = cast(Callable[[str], List], enc.encode)
             self._tokenizer = partial(self._tokenizer, allowed_special="all")
@@ -96,15 +91,9 @@ class GlobalsHelper:
     def stopwords(self) -> List[str]:
         """Get stopwords."""
         if self._stopwords is None:
-            try:
+            with ImportChecker("nltk", caller=type(self).__name__):
                 import nltk
                 from nltk.corpus import stopwords
-            except ImportError:
-                raise ImportError(
-                    "`nltk` package not found, please run `pip install nltk`"
-                )
-
-            from llama_index.utils import get_cache_dir
 
             cache_dir = get_cache_dir()
             nltk_data_dir = os.environ.get("NLTK_DATA", cache_dir)
@@ -281,12 +270,8 @@ def get_transformer_tokenizer_fn(model_name: str) -> Callable[[str], List[str]]:
         model_name(str): the model name of the tokenizer.
                         For instance, fxmarty/tiny-llama-fast-tokenizer.
     """
-    try:
+    with ImportChecker("transformers"):
         from transformers import AutoTokenizer
-    except ImportError:
-        raise ValueError(
-            "`transformers` package not found, please run `pip install transformers`"
-        )
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     return tokenizer.tokenize
 

--- a/llama_index/utils.py
+++ b/llama_index/utils.py
@@ -45,7 +45,7 @@ class ImportChecker:
     def __enter__(self) -> "ImportChecker":
         return self
 
-    def __exit__(
+    def __exit__(  # type: ignore[exit-return]
         self,
         exc_type: Optional[Type[BaseException]],
         exc_value: Optional[BaseException],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from llama_index.utils import (
     _ANSI_COLORS,
     _LLAMA_INDEX_COLORS,
     ErrorToRetry,
+    ImportChecker,
     _get_colored_text,
     get_color_mapping,
     globals_helper,
@@ -15,6 +16,30 @@ from llama_index.utils import (
     print_text,
     retry_on_exceptions_with_backoff,
 )
+
+
+def test_import_checker() -> None:
+    with ImportChecker("tiktoken"):
+        import tiktoken
+
+    with pytest.raises(ModuleNotFoundError, match="`pip install flake8`") as exc_info:
+        with ImportChecker("flake8"):
+            import flake8
+    assert isinstance(exc_info.value.__cause__, ModuleNotFoundError)
+
+    with pytest.raises(ModuleNotFoundError, match="required by Linter"):
+        with ImportChecker("flake8", "Linter"):
+            import flake8
+
+    with pytest.raises(ModuleNotFoundError, match="`pip install flake8-simplify`"):
+        with ImportChecker("flake8", pip_install="flake8-simplify"):
+            import flake8
+
+    with pytest.raises(
+        ModuleNotFoundError, match="`pip install flake8 flake8-simplify`"
+    ):
+        with ImportChecker(["flake8", "flake8-simplify"]):
+            import flake8
 
 
 def test_tokenizer() -> None:


### PR DESCRIPTION
# Description

Common mistakes in the `try`-`except` about missing pip installs:
- Forgot to use `from` keyword
- Using `ImportError` over `ModuleNotFoundError`
- Not using backtick for readability

This PR makes a context manager to standardize all of this

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
