### PR TITLE
Add `PGVectorStore` schema param.

### DIFF
--- a/tests/vector_stores/test_postgres.py
+++ b/tests/vector_stores/test_postgres.py
@@ -23,6 +23,7 @@ PARAMS: Dict[str, Union[str, int]] = {
 }
 TEST_DB = "test_vector_db"
 TEST_TABLE_NAME = "lorem_ipsum"
+TEST_SCHEMA_NAME = "test"
 TEST_EMBED_DIM = 2
 
 
@@ -77,6 +78,7 @@ def pg(db: None) -> Any:
         **PARAMS,  # type: ignore
         database=TEST_DB,
         table_name=TEST_TABLE_NAME,
+        schema_name=TEST_SCHEMA_NAME,
         embed_dim=TEST_EMBED_DIM,
     )
 
@@ -91,6 +93,7 @@ def pg_hybrid(db: None) -> Any:
         **PARAMS,  # type: ignore
         database=TEST_DB,
         table_name=TEST_TABLE_NAME,
+        schema_name=TEST_SCHEMA_NAME,
         hybrid_search=True,
         embed_dim=TEST_EMBED_DIM,
     )
@@ -158,6 +161,7 @@ async def test_instance_creation(db: None) -> None:
         **PARAMS,  # type: ignore
         database=TEST_DB,
         table_name=TEST_TABLE_NAME,
+        schema_name=TEST_SCHEMA_NAME,
     )
     assert isinstance(pg, PGVectorStore)
     assert not hasattr(pg, "_engine")


### PR DESCRIPTION
# Description

Added option for custom Postgres schema on PGVectorStore instead of only allowing `public` schema. 

Motivation is to allow an extra degree of separation in the DB for generated indexes. In my project for example I am creating many indexes, each of which exist in their own table. Instead of these tables existing alongside my main DB tables, it is advantageous for me to create them all in a `vector_indexes_v1` schema. That way, if I need to drop all indexes and regenerate I can simply drop the schema. I may also want to generate another `vector_indexes_v2` version of my index, in that case each index version could be placed in its own schema.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Exisiting PGVectorStore tests have been modified to take in the new `schema_name` param alongside the existing `table_name` param.

# Suggested Checklist:

I could not find the PGVectorStore docs in the latest version of the website.

- [x] My changes generate no new warnings
- [x] I have `modified` tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
