### PR TITLE
Add max_chunk_bytes default arg to OpensearchVectorClient

### DIFF
--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -186,6 +186,7 @@ class OpensearchVectorClient:
         embedding_field: str = "embedding",
         text_field: str = "content",
         method: Optional[dict] = None,
+        max_chunk_bytes: int = 1 * 1024 * 1024,
         **kwargs: Any,
     ):
         """Init params."""
@@ -204,6 +205,7 @@ class OpensearchVectorClient:
         self._dim = dim
         self._index = index
         self._text_field = text_field
+        self._max_chunk_bytes = max_chunk_bytes
         # initialize mapping
         idx_conf = {
             "settings": {"index": {"knn": True, "knn.algo_param.ef_search": 100}},
@@ -237,8 +239,6 @@ class OpensearchVectorClient:
             texts.append(node.get_content(metadata_mode=MetadataMode.NONE))
             metadatas.append(node_to_metadata_dict(node, remove_text=True))
 
-        max_chunk_bytes = kwargs.get("max_chunk_bytes", 1 * 1024 * 1024)
-
         return _bulk_ingest_embeddings(
             self._os_client,
             self._index,
@@ -249,7 +249,7 @@ class OpensearchVectorClient:
             vector_field=self._embedding_field,
             text_field=self._text_field,
             mapping=None,
-            max_chunk_bytes=max_chunk_bytes,
+            max_chunk_bytes=self._max_chunk_bytes,
         )
 
     def delete_doc_id(self, doc_id: str) -> None:


### PR DESCRIPTION
# Description

In `llama_index.vector_stores.opensearch`, [OpensearchVectorClient.index_results](https://github.com/run-llama/llama_index/blob/main/llama_index/vector_stores/opensearch.py#L240) contains a `max_chunk_bytes` arg into `_bulk_ingest_embeddings` that is not accessible from where `OpensearchVectorStore.add` is called in [VectorStoreIndex](https://github.com/run-llama/llama_index/blob/main/llama_index/indices/vector_store/base.py#L187)

This change will allow users to pass a `max_chunk_bytes` arg into `OpensearchVectorClient` so that it can be used when bulk inserting into Opensearch.

Rough example usage:

```
client = OpensearchVectorClient(
    endpoint="https://fake-endpoint.com:443",
    index="fake-index",
    dim=1536,
    max_chunk_bytes=(2 * 1024 * 1024),
)

vector_store = OpensearchVectorStore(client)

storage_context = StorageContext.from_defaults(vector_store=vector_store)

index = VectorStoreIndex.from_vector_store(vector_store=self.storage_context.vector_store)

node_parser = SimpleNodeParser.from_defaults()
nodes = node_parser.get_nodes_from_documents(documents)

index.insert_nodes(nodes)  # changes in PR take effect here
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense