### PR TITLE
Minor agent updates

### DIFF
--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -233,6 +233,7 @@ class ReActAgent(BaseAgent):
         """Chat."""
         # get tools
         # TODO: do get tools dynamically at every iteration of the agent loop
+        self.sources = []
         tools = self.get_tools(message)
 
         if chat_history is not None:
@@ -271,6 +272,7 @@ class ReActAgent(BaseAgent):
     ) -> AgentChatResponse:
         # get tools
         # TODO: do get tools dynamically at every iteration of the agent loop
+        self.sources = []
         tools = self.get_tools(message)
 
         if chat_history is not None:
@@ -309,6 +311,7 @@ class ReActAgent(BaseAgent):
     ) -> StreamingAgentChatResponse:
         # get tools
         # TODO: do get tools dynamically at every iteration of the agent loop
+        self.sources = []
         tools = self.get_tools(message)
 
         if chat_history is not None:
@@ -363,6 +366,7 @@ class ReActAgent(BaseAgent):
     ) -> StreamingAgentChatResponse:
         # get tools
         # TODO: do get tools dynamically at every iteration of the agent loop
+        self.sources = []
         tools = self.get_tools(message)
 
         if chat_history is not None:

--- a/llama_index/agent/types.py
+++ b/llama_index/agent/types.py
@@ -19,7 +19,9 @@ class BaseAgent(BaseChatEngine, BaseQueryEngine):
             query_bundle.query_str,
             chat_history=[],
         )
-        return Response(response=str(agent_response))
+        return Response(
+            response=str(agent_response), source_nodes=agent_response.source_nodes
+        )
 
     @trace_method("query")
     async def _aquery(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
@@ -27,7 +29,9 @@ class BaseAgent(BaseChatEngine, BaseQueryEngine):
             query_bundle.query_str,
             chat_history=[],
         )
-        return Response(response=str(agent_response))
+        return Response(
+            response=str(agent_response), source_nodes=agent_response.source_nodes
+        )
 
     def stream_chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None


### PR DESCRIPTION
# Description

This PR includes changes that fix issue #8085 and implement feature #8084. The changes involve modifications to the `BaseAgent` and `ReActAgent` classes to handle `sources` correctly. `ReActAgent` now returns `sources` with its response. Agents now correctly return source_nodes when they are used as `QueryEngineTool`s using their `query` and `aquery` methods from the `BaseAgent` class.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Fixes #8085, Implements #8084

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
