### PR TITLE
fix: `max_docs` in `SimpleMongoReader`

### DIFF
--- a/llama_index/readers/mongo.py
+++ b/llama_index/readers/mongo.py
@@ -14,7 +14,7 @@ class SimpleMongoReader(BaseReader):
     Args:
         host (str): Mongo host.
         port (int): Mongo port.
-        max_docs (int): Maximum number of documents to load.
+        max_docs (int): Maximum number of documents to load. Defaults to 0 (no limit).
 
     """
 
@@ -23,7 +23,7 @@ class SimpleMongoReader(BaseReader):
         host: Optional[str] = None,
         port: Optional[int] = None,
         uri: Optional[str] = None,
-        max_docs: int = 1000,
+        max_docs: int = 0,
     ) -> None:
         """Initialize with parameters."""
         try:

--- a/llama_index/readers/mongo.py
+++ b/llama_index/readers/mongo.py
@@ -74,10 +74,7 @@ class SimpleMongoReader(BaseReader):
         """
         documents = []
         db = self.client[db_name]
-        if query_dict is None:
-            cursor = db[collection_name].find()
-        else:
-            cursor = db[collection_name].find(query_dict)
+        cursor = db[collection_name].find(filter=query_dict or {}, limit=self.max_docs)
 
         for item in cursor:
             texts = []

--- a/tests/readers/test_mongo.py
+++ b/tests/readers/test_mongo.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -34,7 +35,7 @@ def test_load_data_with_max_docs() -> None:
 
     with patch("pymongo.collection.Collection.find") as mock_find:
 
-        def limit_fn(limit, *args, **kwargs):
+        def limit_fn(limit: int, *_args: Any, **_kwargs: Any) -> list[dict[str, str]]:
             if limit == 0:
                 return mock_cursor
             return mock_cursor[:limit]

--- a/tests/readers/test_mongo.py
+++ b/tests/readers/test_mongo.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 import pytest
@@ -35,7 +35,7 @@ def test_load_data_with_max_docs() -> None:
 
     with patch("pymongo.collection.Collection.find") as mock_find:
 
-        def limit_fn(limit: int, *_args: Any, **_kwargs: Any) -> list[dict[str, str]]:
+        def limit_fn(limit: int, *_args: Any, **_kwargs: Any) -> List[Dict[str, str]]:
             if limit == 0:
                 return mock_cursor
             return mock_cursor[:limit]


### PR DESCRIPTION
# Description

Use `max_docs` as the limit of query. Additionally, refactor the code of invoking `find`.

I am not familiar with `unittest`, so please notify me if there are any issues with the tests I have written.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
