### PR TITLE
Fix service_context not passed when DocumentSummaryIndex calls Embedd…

### DIFF
--- a/llama_index/indices/document_summary/base.py
+++ b/llama_index/indices/document_summary/base.py
@@ -125,7 +125,8 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
                     "Cannot use embedding retriever if embed_summaries is False"
                 )
 
-            kwargs["service_context"] = self._service_context
+            if "service_context" not in kwargs:
+                kwargs["service_context"] = self._service_context
             return EmbeddingRetriever(self, **kwargs)
         if retriever_mode == _RetrieverMode.LLM:
             return LLMRetriever(self, **kwargs)

--- a/llama_index/indices/document_summary/base.py
+++ b/llama_index/indices/document_summary/base.py
@@ -125,6 +125,7 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
                     "Cannot use embedding retriever if embed_summaries is False"
                 )
 
+            kwargs["service_context"] = self._service_context
             return EmbeddingRetriever(self, **kwargs)
         if retriever_mode == _RetrieverMode.LLM:
             return LLMRetriever(self, **kwargs)


### PR DESCRIPTION
…ingRetriever

# Description

Passes the document summary index's service_context when generating an embedding retriever in _RetrieverMode.EMBEDDING mode.

Note: Anyone who (for whatever reason) relied on explicitly set service_context being ignored in favour of default when in _RetrieverMode.EMBEDDING mode will see a change in behaviour since the explictly set service_context will now be used instead of the default.

Using an explicitly set service_context seems reasonable, but it is a change.

Fixes #8102 

## Type of Change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
