### PR TITLE
`CompletionResponse` docs on fields

### DIFF
--- a/llama_index/llms/base.py
+++ b/llama_index/llms/base.py
@@ -54,8 +54,10 @@ class CompletionResponse(BaseModel):
     Completion response.
 
     Fields:
-        text: TODOC.
-        additional_kwargs: TODOC.
+        text: Text content of the response if not streaming, or if streaming,
+            the current extent of streamed text.
+        additional_kwargs: Additional information on the response(i.e. token
+            counts, function calling information).
         raw: Optional raw JSON that was parsed to populate text, if relevant.
         delta: New text that just streamed in (only relevant when streaming).
     """

--- a/llama_index/llms/base.py
+++ b/llama_index/llms/base.py
@@ -50,7 +50,15 @@ ChatResponseAsyncGen = AsyncGenerator[ChatResponse, None]
 
 # ===== Generic Model Output - Completion =====
 class CompletionResponse(BaseModel):
-    """Completion response."""
+    """
+    Completion response.
+
+    Fields:
+        text: TODOC.
+        additional_kwargs: TODOC.
+        raw: Optional raw JSON that was parsed to populate text, if relevant.
+        delta: New text that just streamed in (only relevant when streaming).
+    """
 
     text: str
     additional_kwargs: dict = Field(default_factory=dict)


### PR DESCRIPTION
# Description

Adds a docstring to `CompletionResponse` for its fields, coming from https://github.com/run-llama/llama_index/pull/8098#discussion_r1358487181.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
