### PR TITLE
Fix Docs error due to cross_encoder_finetuning notebook

### DIFF
--- a/docs/examples/finetuning/cross_encoder_finetuning/cross_encoder_finetuning.ipynb
+++ b/docs/examples/finetuning/cross_encoder_finetuning/cross_encoder_finetuning.ipynb
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Process\n",
+    "## Process\n",
     "\n",
     "- Download the QASPER Dataset from HuggingFace Hub using Datasets Library (https://huggingface.co/datasets/allenai/qasper)\n",
     "\n",
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load the Dataset"
+    "## Load the Dataset"
    ]
   },
   {
@@ -114,7 +114,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# QASPER Dataset\n",
+    "## QASPER Dataset\n",
     "* Each row has the below 6 columns\n",
     "    - id: Unique identifier of the research paper\n",
     "\n",
@@ -216,7 +216,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate RAG Eval test data"
+    "### Generate RAG Eval test data"
    ]
   },
   {
@@ -321,7 +321,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate Finetuning Dataset"
+    "### Generate Finetuning Dataset"
    ]
   },
   {
@@ -450,7 +450,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate Reranking Eval test data"
+    "### Generate Reranking Eval test data"
    ]
   },
   {
@@ -563,7 +563,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Finetune Cross-Encoder"
+    "## Finetune Cross-Encoder"
    ]
   },
   {
@@ -690,7 +690,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Reranking Evaluation"
+    "## Reranking Evaluation"
    ]
   },
   {
@@ -1110,7 +1110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Results\n",
+    "### Results\n",
     "\n",
     "As we can see below we get more hits with finetuned_cross_encoder compared to other options."
    ]
@@ -1192,7 +1192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# RAG Evaluation"
+    "## RAG Evaluation"
    ]
   },
   {
@@ -1403,7 +1403,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Baseline Evaluation\n",
+    "### Baseline Evaluation\n",
     "\n",
     "Just using OpenAI Embeddings for retrieval without any re-ranker"
    ]
@@ -1412,7 +1412,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Eval Method:-\n",
+    "#### Eval Method:-\n",
     "1. Iterate over each row of the test dataset:-\n",
     "    1. For the current row being iterated, create a vector index using the paper document provided in the paper column of the dataset\n",
     "    2. Query the vector index with a top_k value of top 3 nodes without any reranker\n",
@@ -1582,7 +1582,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Evaluate with base reranker\n",
+    "### Evaluate with base reranker\n",
     "\n",
     "OpenAI Embeddings +  `cross-encoder/ms-marco-MiniLM-L-12-v2` as reranker"
    ]
@@ -1591,7 +1591,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Eval Method:-\n",
+    "#### Eval Method:-\n",
     "1. Iterate over each row of the test dataset:-\n",
     "    1. For the current row being iterated, create a vector index using the paper document provided in the paper column of the dataset\n",
     "    2. Query the vector index with a top_k value of top 5 nodes.\n",
@@ -1838,7 +1838,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Evaluate with Fine-Tuned re-ranker\n",
+    "### Evaluate with Fine-Tuned re-ranker\n",
     "\n",
     "OpenAI Embeddings + `bpHigh/Cross-Encoder-LLamaIndex-Demo-v2` as reranker"
    ]
@@ -1847,7 +1847,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Eval Method:-\n",
+    "#### Eval Method:-\n",
     "1. Iterate over each row of the test dataset:-\n",
     "    1. For the current row being iterated, create a vector index using the paper document provided in the paper column of the dataset\n",
     "    2. Query the vector index with a top_k value of top 5 nodes.\n",
@@ -2023,7 +2023,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Results\n",
+    "### Results\n",
     "\n",
     "As we can see we get the highest pairwise score with finetuned cross-encoder.\n",
     "\n",


### PR DESCRIPTION
# Description

This change fixes the error in llamaindex docs due to addition of cross_encoder_finetuning notebook.  Due to all major sections being on the same level as the notebook title they are also reflected in the llamaindex docs content sidebar. This change pushes them to sub-section level and reduces the respective level for each subsection.

Fixes # (issue)
https://gpt-index.readthedocs.io/en/latest/examples/finetuning/cross_encoder_finetuning/cross_encoder_finetuning.html
<img width="237" alt="Screenshot 2023-10-14 at 1 07 31 AM" src="https://github.com/run-llama/llama_index/assets/108733252/bf2fc323-ec42-48d7-a053-9a14cf0a19f5">


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
