### PR TITLE
Simplifying `ReActAgent` and missing `super()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Improved the `BM25Retriever` interface to accept `BaseNode` objects (#8096)
 - Fixed bug with `BM25Retriever` tokenizer not working as expected (#8096)
 - Brought mypy to pass in Python 3.8 (#8107)
+- `ReActAgent` adding missing `super().__init__` call (#8125)
 
 ## [0.8.44] - 2023-10-12
 

--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -73,11 +73,16 @@ class ReActAgent(BaseAgent):
     def from_tools(
         cls,
         tools: Optional[List[BaseTool]] = None,
+        tool_retriever: Optional[ObjectRetriever[BaseTool]] = None,
         llm: Optional[LLM] = None,
         chat_history: Optional[List[ChatMessage]] = None,
         memory: Optional[BaseMemory] = None,
         memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
+        max_iterations: int = 10,
+        react_chat_formatter: Optional[ReActChatFormatter] = None,
+        output_parser: Optional[ReActOutputParser] = None,
         callback_manager: Optional[CallbackManager] = None,
+        verbose: bool = False,
         **kwargs: Any,
     ) -> "ReActAgent":
         llm = llm or OpenAI(model=DEFAULT_MODEL_NAME)
@@ -88,9 +93,14 @@ class ReActAgent(BaseAgent):
         )
         return cls(
             tools=tools or [],
+            tool_retriever=tool_retriever,
             llm=llm,
             memory=memory,
+            max_iterations=max_iterations,
+            react_chat_formatter=react_chat_formatter,
+            output_parser=output_parser,
             callback_manager=callback_manager,
+            verbose=verbose,
             **kwargs,
         )
 

--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -1,5 +1,3 @@
-# ReAct agent
-
 import asyncio
 from threading import Thread
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, cast
@@ -39,7 +37,6 @@ class ReActAgent(BaseAgent):
     completion endpoints.
 
     Can take in a set of tools that require structured inputs.
-
     """
 
     def __init__(

--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -76,36 +76,25 @@ class ReActAgent(BaseAgent):
     def from_tools(
         cls,
         tools: Optional[List[BaseTool]] = None,
-        tool_retriever: Optional[ObjectRetriever[BaseTool]] = None,
         llm: Optional[LLM] = None,
         chat_history: Optional[List[ChatMessage]] = None,
         memory: Optional[BaseMemory] = None,
         memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
-        max_iterations: int = 10,
-        react_chat_formatter: Optional[ReActChatFormatter] = None,
-        output_parser: Optional[ReActOutputParser] = None,
         callback_manager: Optional[CallbackManager] = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> "ReActAgent":
-        tools = tools or []
-        chat_history = chat_history or []
         llm = llm or OpenAI(model=DEFAULT_MODEL_NAME)
         if callback_manager is not None:
             llm.callback_manager = callback_manager
-
-        memory = memory or memory_cls.from_defaults(chat_history=chat_history, llm=llm)
-
+        memory = memory or memory_cls.from_defaults(
+            chat_history=chat_history or [], llm=llm
+        )
         return cls(
-            tools=tools,
-            tool_retriever=tool_retriever,
+            tools=tools or [],
             llm=llm,
             memory=memory,
-            max_iterations=max_iterations,
-            react_chat_formatter=react_chat_formatter,
-            output_parser=output_parser,
             callback_manager=callback_manager,
-            verbose=verbose,
+            **kwargs,
         )
 
     @property

--- a/llama_index/agent/react/base.py
+++ b/llama_index/agent/react/base.py
@@ -54,12 +54,12 @@ class ReActAgent(BaseAgent):
         verbose: bool = False,
         tool_retriever: Optional[ObjectRetriever[BaseTool]] = None,
     ) -> None:
+        super().__init__(callback_manager=callback_manager or llm.callback_manager)
         self._llm = llm
         self._memory = memory
         self._max_iterations = max_iterations
         self._react_chat_formatter = react_chat_formatter or ReActChatFormatter()
         self._output_parser = output_parser or ReActOutputParser()
-        self.callback_manager = callback_manager or self._llm.callback_manager
         self._verbose = verbose
 
         if len(tools) > 0 and tool_retriever is not None:


### PR DESCRIPTION
# Description

- Added missing `super().__init__` to `ReActAgent` to fix IDE warning
- Less locals in `from_tools` implementation

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
