### PR TITLE
`react_agent_with_query_engine` more intuitive ordering

### DIFF
--- a/docs/examples/agent/react_agent_with_query_engine.ipynb
+++ b/docs/examples/agent/react_agent_with_query_engine.ipynb
@@ -161,19 +161,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3725fb6a-a627-47fb-949a-4fa7c5bff279",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "llm_instruct = OpenAI(model=\"gpt-3.5-turbo-instruct\")\n",
-    "agent_instruct = ReActAgent.from_tools(\n",
-    "    query_engine_tools, llm=llm_instruct, verbose=True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "70a82471-9226-42ad-bd8a-aebde3530d95",
    "metadata": {},
    "outputs": [
@@ -280,6 +267,19 @@
    "metadata": {},
    "source": [
     "#### Taking a look at a turbo-instruct agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac49a939",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm_instruct = OpenAI(model=\"gpt-3.5-turbo-instruct\")\n",
+    "agent_instruct = ReActAgent.from_tools(\n",
+    "    query_engine_tools, llm=llm_instruct, verbose=True\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
# Description

I got confused by the instruct GPT being next to non-instruct GPT.  The instruct GPT should be introduced later in the notebook, where it actually gets used.

Closes https://github.com/run-llama/llama_index/issues/8127

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
