### PR TITLE
normalize embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Add normalization to huggingface embeddings (#8145)
+
 ## [0.8.45] - 2023-10-13
 
 ### New Features

--- a/llama_index/embeddings/huggingface.py
+++ b/llama_index/embeddings/huggingface.py
@@ -15,6 +15,7 @@ class HuggingFaceEmbedding(BaseEmbedding):
     tokenizer_name: str = Field(description="Tokenizer name from HuggingFace.")
     max_length: int = Field(description="Maximum length of input.")
     pooling: str = Field(description="Pooling strategy. One of ['cls', 'mean'].")
+    normalize: str = Field(default=True, description="Normalize embeddings or not.")
     query_instruction: Optional[str] = Field(
         description="Instruction to prepend to query text."
     )
@@ -37,6 +38,7 @@ class HuggingFaceEmbedding(BaseEmbedding):
         max_length: Optional[int] = None,
         query_instruction: Optional[str] = None,
         text_instruction: Optional[str] = None,
+        normalize: bool = True,
         model: Optional[Any] = None,
         tokenizer: Optional[Any] = None,
         embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
@@ -100,6 +102,7 @@ class HuggingFaceEmbedding(BaseEmbedding):
             tokenizer_name=tokenizer_name,
             max_length=max_length,
             pooling=pooling,
+            normalize=normalize,
             query_instruction=query_instruction,
             text_instruction=text_instruction,
         )
@@ -161,11 +164,18 @@ class HuggingFaceEmbedding(BaseEmbedding):
         model_output = self._model(**encoded_input)
 
         if self.pooling == "cls":
-            return self._cls_pooling(model_output).tolist()
+            embeddings = self._cls_pooling(model_output)
         else:
-            return self._mean_pooling(
+            embeddings = self._mean_pooling(
                 model_output, encoded_input["attention_mask"]
-            ).tolist()
+            )
+
+        if self.normalize:
+            import torch
+
+            embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+
+        return embeddings.tolist()
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
@@ -182,7 +192,9 @@ class HuggingFaceEmbedding(BaseEmbedding):
 
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
+        print(text)
         text = self._format_text(text)
+        print(text)
         return self._embed([text])[0]
 
     def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:

--- a/llama_index/embeddings/huggingface_optimum.py
+++ b/llama_index/embeddings/huggingface_optimum.py
@@ -9,6 +9,7 @@ class OptimumEmbedding(BaseEmbedding):
     folder_name: str = Field(description="Folder name to load from.")
     max_length: int = Field(description="Maximum length of input.")
     pooling: str = Field(description="Pooling strategy. One of ['cls', 'mean'].")
+    normalize: str = Field(default=True, description="Normalize embeddings or not.")
     query_instruction: Optional[str] = Field(
         description="Instruction to prepend to query text."
     )
@@ -27,6 +28,7 @@ class OptimumEmbedding(BaseEmbedding):
         folder_name: str,
         pooling: str = "cls",
         max_length: Optional[int] = None,
+        normalize: bool = True,
         query_instruction: Optional[str] = None,
         text_instruction: Optional[str] = None,
         model: Optional[Any] = None,
@@ -65,6 +67,7 @@ class OptimumEmbedding(BaseEmbedding):
             folder_name=folder_name,
             max_length=max_length,
             pooling=pooling,
+            normalize=normalize,
             query_instruction=query_instruction,
             text_instruction=text_instruction,
         )
@@ -140,11 +143,18 @@ class OptimumEmbedding(BaseEmbedding):
         model_output = self._model(**encoded_input)
 
         if self.pooling == "cls":
-            return self._cls_pooling(model_output).tolist()
+            embeddings = self._cls_pooling(model_output)
         else:
-            return self._mean_pooling(
+            embeddings = self._mean_pooling(
                 model_output, encoded_input["attention_mask"]
-            ).tolist()
+            )
+
+        if self.normalize:
+            import torch
+
+            embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+
+        return embeddings.tolist()
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""


### PR DESCRIPTION
# Description

Compared to `sentence-transformers`, we were missing the step of normalizing embeddings.

In some preliminary testing, non-normalized, normalized, and mixed approaches returned the same nodes for various questions on the pg essay.

Fixes #8143

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested in local test-cases
- [x] I stared at the code and made sure it makes sense
