### PR TITLE
Repr for JSON conversion errors

### DIFF
--- a/llama_index/output_parsers/selection.py
+++ b/llama_index/output_parsers/selection.py
@@ -92,7 +92,7 @@ class SelectionOutputParser(BaseOutputParser):
             json_obj = [json_obj]
 
         if not json_obj:
-            raise ValueError(f"Failed to convert output to JSON: {output}")
+            raise ValueError(f"Failed to convert output to JSON: {output!r}")
 
         json_output = self._format_output(json_obj)
         answers = [Answer.from_dict(json_dict) for json_dict in json_output]


### PR DESCRIPTION
# Description

Used a `!r` to help make it clear the boundaries of a bad output in JSON conversion.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
