### PR TITLE
Fixing incorrect spacing in prompt templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add normalization to huggingface embeddings (#8145)
 - Fixed duplicate `FORMAT_STR` being inside prompt (#8171)
+- Fixed inconsistently spaced prompt templates (#8168)
 
 ## [0.8.45] - 2023-10-13
 

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -18,19 +18,25 @@ DEFAULT_SUMMARY_PROMPT_TMPL = (
     "\n"
     'SUMMARY:"""\n'
 )
-
 DEFAULT_SUMMARY_PROMPT = PromptTemplate(
     DEFAULT_SUMMARY_PROMPT_TMPL, prompt_type=PromptType.SUMMARY
 )
 
-# insert prompts
-DEFAULT_INSERT_PROMPT_TMPL = (
-    "Context information is below. It is provided in a numbered list "
-    "(1 to {num_chunks}), "
+
+NUM_LIST_BOILERPLATE = (
+    "It is provided in a numbered list "
+    "(1 to {limit_name}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"
-    "---------------------\n"
+    "\n---------------------\n"
+)
+
+
+# insert prompts
+DEFAULT_INSERT_PROMPT_TMPL = (
+    "Context information is below. "
+    f"{NUM_LIST_BOILERPLATE.replace('limit_name', 'num_chunks')}"
     "Given the context information, here is a new piece of "
     "information: {new_chunk_text}\n"
     "Answer with the number corresponding to the summary that should be updated. "
@@ -43,12 +49,7 @@ DEFAULT_INSERT_PROMPT = PromptTemplate(
 
 
 CHOICES_BOILERPLATE = (
-    "Some choices are given below. It is provided in a numbered list "
-    "(1 to {limit_name}), "
-    "where each item in the list corresponds to a summary.\n"
-    "---------------------\n"
-    "{context_list}"
-    "\n---------------------\n"
+    f"Some choices are given below. {NUM_LIST_BOILERPLATE}"
     "Using only the choices above and not prior knowledge"
 )
 

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -44,7 +44,7 @@ DEFAULT_INSERT_PROMPT = PromptTemplate(
 
 CHOICES_BOILERPLATE = (
     "Some choices are given below. It is provided in a numbered list "
-    "(1 to {num_chunks}), "
+    "(1 to {limit_name}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"
@@ -54,7 +54,7 @@ CHOICES_BOILERPLATE = (
 
 # # single choice
 DEFAULT_QUERY_PROMPT_TMPL = (
-    f"{CHOICES_BOILERPLATE}, "
+    f"{CHOICES_BOILERPLATE.replace('limit_name', 'num_chunks')}, "
     "return the choice that is most relevant to the question: '{query_str}'\n"
     "Provide choice in the following format: 'ANSWER: <number>' and explain why "
     "this summary was selected in relation to the question.\n"
@@ -65,7 +65,7 @@ DEFAULT_QUERY_PROMPT = PromptTemplate(
 
 # multiple choice
 DEFAULT_QUERY_PROMPT_MULTIPLE_TMPL = (
-    f"{CHOICES_BOILERPLATE}, "
+    f"{CHOICES_BOILERPLATE.replace('limit_name', 'num_chunks')}, "
     "return the top choices "
     "(no more than {branching_factor}, ranked by most relevant to least) that "
     "are most relevant to the question: '{query_str}'\n"

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -26,7 +26,7 @@ DEFAULT_SUMMARY_PROMPT = PromptTemplate(
 # insert prompts
 DEFAULT_INSERT_PROMPT_TMPL = (
     "Context information is below. It is provided in a numbered list "
-    "(1 to {num_chunks}),"
+    "(1 to {num_chunks}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"
@@ -42,16 +42,20 @@ DEFAULT_INSERT_PROMPT = PromptTemplate(
 )
 
 
-# # single choice
-DEFAULT_QUERY_PROMPT_TMPL = (
+CHOICES_BOILERPLATE = (
     "Some choices are given below. It is provided in a numbered list "
-    "(1 to {num_chunks}),"
+    "(1 to {num_chunks}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"
     "\n---------------------\n"
-    "Using only the choices above and not prior knowledge, return "
-    "the choice that is most relevant to the question: '{query_str}'\n"
+    "Using only the choices above and not prior knowledge"
+)
+
+# # single choice
+DEFAULT_QUERY_PROMPT_TMPL = (
+    f"{CHOICES_BOILERPLATE}, "
+    "return the choice that is most relevant to the question: '{query_str}'\n"
     "Provide choice in the following format: 'ANSWER: <number>' and explain why "
     "this summary was selected in relation to the question.\n"
 )
@@ -61,13 +65,8 @@ DEFAULT_QUERY_PROMPT = PromptTemplate(
 
 # multiple choice
 DEFAULT_QUERY_PROMPT_MULTIPLE_TMPL = (
-    "Some choices are given below. It is provided in a numbered "
-    "list (1 to {num_chunks}), "
-    "where each item in the list corresponds to a summary.\n"
-    "---------------------\n"
-    "{context_list}"
-    "\n---------------------\n"
-    "Using only the choices above and not prior knowledge, return the top choices "
+    f"{CHOICES_BOILERPLATE}, "
+    "return the top choices "
     "(no more than {branching_factor}, ranked by most relevant to least) that "
     "are most relevant to the question: '{query_str}'\n"
     "Provide choices in the following format: 'ANSWER: <numbers>' and explain why "

--- a/llama_index/selectors/prompts.py
+++ b/llama_index/selectors/prompts.py
@@ -1,4 +1,5 @@
 from llama_index.prompts.base import PromptTemplate
+from llama_index.prompts.default_prompts import CHOICES_BOILERPLATE
 from llama_index.prompts.prompt_type import PromptType
 
 """Single select prompt.
@@ -21,20 +22,11 @@ Required template variables: `num_chunks`, `context_list`, `query_str`,
 """
 MultiSelectPrompt = PromptTemplate
 
-
 # single select
 DEFAULT_SINGLE_SELECT_PROMPT_TMPL = (
-    "Some choices are given below. It is provided in a numbered list "
-    "(1 to {num_choices}),"
-    "where each item in the list corresponds to a summary.\n"
-    "---------------------\n"
-    "{context_list}"
-    "\n---------------------\n"
-    "Using only the choices above and not prior knowledge, return "
-    "the choice that is most relevant to the question: '{query_str}'\n"
+    f"{CHOICES_BOILERPLATE}, "
+    "return the choice that is most relevant to the question: '{query_str}'\n"
 )
-
-
 DEFAULT_SINGLE_SELECT_PROMPT = PromptTemplate(
     template=DEFAULT_SINGLE_SELECT_PROMPT_TMPL, prompt_type=PromptType.SINGLE_SELECT
 )
@@ -42,46 +34,28 @@ DEFAULT_SINGLE_SELECT_PROMPT = PromptTemplate(
 
 # multiple select
 DEFAULT_MULTI_SELECT_PROMPT_TMPL = (
-    "Some choices are given below. It is provided in a numbered "
-    "list (1 to {num_choices}), "
-    "where each item in the list corresponds to a summary.\n"
-    "---------------------\n"
-    "{context_list}"
-    "\n---------------------\n"
-    "Using only the choices above and not prior knowledge, return the top choices "
+    f"{CHOICES_BOILERPLATE}, "
+    "return the top choices "
     "(no more than {max_outputs}, but only select what is needed) that "
     "are most relevant to the question: '{query_str}'\n"
 )
-
-
 DEFAULT_MULTIPLE_SELECT_PROMPT = PromptTemplate(
     template=DEFAULT_MULTI_SELECT_PROMPT_TMPL, prompt_type=PromptType.MULTI_SELECT
 )
 
 # single pydantic select
 DEFAULT_SINGLE_PYD_SELECT_PROMPT_TMPL = (
-    "Some choices are given below. It is provided in a numbered list "
-    "(1 to {num_choices}),"
-    "where each item in the list corresponds to a summary.\n"
-    "---------------------\n"
-    "{context_list}"
-    "\n---------------------\n"
-    "Using only the choices above and not prior knowledge, generate "
-    "the selection object and reason that is most relevant to the "
-    "question: '{query_str}'\n"
+    f"{CHOICES_BOILERPLATE}, "
+    "generate the selection object and reason that is"
+    "most relevant to the question: '{query_str}'\n"
 )
 
 
 # multiple pydantic select
 DEFAULT_MULTI_PYD_SELECT_PROMPT_TMPL = (
-    "Some choices are given below. It is provided in a numbered "
-    "list (1 to {num_choices}), "
-    "where each item in the list corresponds to a summary.\n"
-    "---------------------\n"
-    "{context_list}"
-    "\n---------------------\n"
-    "Using only the choices above and not prior knowledge, return the top choice(s) "
-    "(no more than {max_outputs}, but only select what is needed) by generating "
-    "the selection object and reasons that are most relevant to the "
-    "question: '{query_str}'\n"
+    f"{CHOICES_BOILERPLATE}, "
+    "return the top choice(s) "
+    "(no more than {max_outputs}, but only select what is needed)"
+    "by generating the selection object and reasons"
+    "that are most relevant to the question: '{query_str}'\n"
 )

--- a/llama_index/selectors/prompts.py
+++ b/llama_index/selectors/prompts.py
@@ -24,7 +24,7 @@ MultiSelectPrompt = PromptTemplate
 
 # single select
 DEFAULT_SINGLE_SELECT_PROMPT_TMPL = (
-    f"{CHOICES_BOILERPLATE}, "
+    f"{CHOICES_BOILERPLATE.replace('limit_name', 'num_choices')}, "
     "return the choice that is most relevant to the question: '{query_str}'\n"
 )
 DEFAULT_SINGLE_SELECT_PROMPT = PromptTemplate(
@@ -34,7 +34,7 @@ DEFAULT_SINGLE_SELECT_PROMPT = PromptTemplate(
 
 # multiple select
 DEFAULT_MULTI_SELECT_PROMPT_TMPL = (
-    f"{CHOICES_BOILERPLATE}, "
+    f"{CHOICES_BOILERPLATE.replace('limit_name', 'num_choices')}, "
     "return the top choices "
     "(no more than {max_outputs}, but only select what is needed) that "
     "are most relevant to the question: '{query_str}'\n"
@@ -45,7 +45,7 @@ DEFAULT_MULTIPLE_SELECT_PROMPT = PromptTemplate(
 
 # single pydantic select
 DEFAULT_SINGLE_PYD_SELECT_PROMPT_TMPL = (
-    f"{CHOICES_BOILERPLATE}, "
+    f"{CHOICES_BOILERPLATE.replace('limit_name', 'num_choices')}, "
     "generate the selection object and reason that is"
     "most relevant to the question: '{query_str}'\n"
 )
@@ -53,7 +53,7 @@ DEFAULT_SINGLE_PYD_SELECT_PROMPT_TMPL = (
 
 # multiple pydantic select
 DEFAULT_MULTI_PYD_SELECT_PROMPT_TMPL = (
-    f"{CHOICES_BOILERPLATE}, "
+    f"{CHOICES_BOILERPLATE.replace('limit_name', 'num_choices')}, "
     "return the top choice(s) "
     "(no more than {max_outputs}, but only select what is needed)"
     "by generating the selection object and reasons"


### PR DESCRIPTION
# Description

I observed:
- Some prompts were missing spaces around line wraps
- 6X repeated text in different places

This PR corrects both, without touching prompt content

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
