### PR TITLE
Fixed bug with duplicate `FORMAT_STR` in prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes / Nits
 
 - Add normalization to huggingface embeddings (#8145)
+- Fixed duplicate `FORMAT_STR` being inside prompt (#8171)
 
 ## [0.8.45] - 2023-10-13
 

--- a/llama_index/output_parsers/selection.py
+++ b/llama_index/output_parsers/selection.py
@@ -16,7 +16,7 @@ def _escape_curly_braces(input_string: str) -> str:
 
 FORMAT_STR = """The output should be ONLY JSON formatted as a JSON instance.
 
-Here's an example:
+Here is an example:
 [
     {
         choice: 1,

--- a/llama_index/selectors/llm_selectors.py
+++ b/llama_index/selectors/llm_selectors.py
@@ -73,9 +73,6 @@ class LLMSingleSelector(BaseSelector):
         prompt_template_str = prompt_template_str or DEFAULT_SINGLE_SELECT_PROMPT_TMPL
         output_parser = output_parser or SelectionOutputParser()
 
-        # add output formatting to prompt template
-        prompt_template_str = output_parser.format(prompt_template_str)
-
         # construct prompt
         prompt = SingleSelectPrompt(
             template=prompt_template_str,

--- a/tests/selectors/test_llm_selectors.py
+++ b/tests/selectors/test_llm_selectors.py
@@ -1,21 +1,27 @@
+from unittest.mock import patch
+
 from llama_index.indices.service_context import ServiceContext
+from llama_index.llms import CompletionResponse
 from llama_index.selectors.llm_selectors import LLMMultiSelector, LLMSingleSelector
 
+from tests.mock_utils.mock_predict import _mock_single_select
 
-def test_llm_single_selector(
-    mock_service_context: ServiceContext,
-) -> None:
-    selector = LLMSingleSelector.from_defaults(service_context=mock_service_context)
 
-    choices = [
-        "apple",
-        "pear",
-        "peach",
-    ]
-    query = "what is the best fruit?"
+def test_llm_single_selector() -> None:
+    service_context = ServiceContext.from_defaults(llm=None, embed_model=None)
+    selector = LLMSingleSelector.from_defaults(service_context=service_context)
 
-    result = selector.select(choices, query)
+    with patch.object(
+        type(service_context.llm),
+        "complete",
+        return_value=CompletionResponse(text=_mock_single_select()),
+    ) as mock_complete:
+        result = selector.select(
+            choices=["apple", "pear", "peach"], query="what is the best fruit?"
+        )
     assert result.ind == 0
+    mock_complete.assert_called_once()
+    assert mock_complete.call_args.args[0].count("Here is an example") <= 1
 
 
 def test_llm_multi_selector(


### PR DESCRIPTION
# Description

This bug is somewhat significant, where I believe for a long time, duplicate `FORMAT_STR` has been used in prompts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
