### PR TITLE
Fixed missing spaces in prompt templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fixed missing spaces in prompt templates (#8190)
+
 ## [0.8.47] - 2023-10-19
 
 ### New Features

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -26,7 +26,7 @@ DEFAULT_SUMMARY_PROMPT = PromptTemplate(
 # insert prompts
 DEFAULT_INSERT_PROMPT_TMPL = (
     "Context information is below. It is provided in a numbered list "
-    "(1 to {num_chunks}),"
+    "(1 to {num_chunks}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"
@@ -45,7 +45,7 @@ DEFAULT_INSERT_PROMPT = PromptTemplate(
 # # single choice
 DEFAULT_QUERY_PROMPT_TMPL = (
     "Some choices are given below. It is provided in a numbered list "
-    "(1 to {num_chunks}),"
+    "(1 to {num_chunks}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"

--- a/llama_index/selectors/prompts.py
+++ b/llama_index/selectors/prompts.py
@@ -25,7 +25,7 @@ MultiSelectPrompt = PromptTemplate
 # single select
 DEFAULT_SINGLE_SELECT_PROMPT_TMPL = (
     "Some choices are given below. It is provided in a numbered list "
-    "(1 to {num_choices}),"
+    "(1 to {num_choices}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"
@@ -61,7 +61,7 @@ DEFAULT_MULTIPLE_SELECT_PROMPT = PromptTemplate(
 # single pydantic select
 DEFAULT_SINGLE_PYD_SELECT_PROMPT_TMPL = (
     "Some choices are given below. It is provided in a numbered list "
-    "(1 to {num_choices}),"
+    "(1 to {num_choices}), "
     "where each item in the list corresponds to a summary.\n"
     "---------------------\n"
     "{context_list}"


### PR DESCRIPTION
# Description

Added missing spaces into prompt templates.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
