### PR TITLE
add response synthesis to text-to-SQL 

### DIFF
--- a/llama_index/indices/struct_store/sql_query.py
+++ b/llama_index/indices/struct_store/sql_query.py
@@ -22,10 +22,17 @@ from llama_index.prompts.default_prompts import (
 from llama_index.prompts.prompt_type import PromptType
 from llama_index.response.schema import Response
 from llama_index.utilities.sql_wrapper import SQLDatabase
+from llama_index.response_synthesizers import (
+    BaseSynthesizer,
+    ResponseMode,
+    get_response_synthesizer,
+)
+from llama_index.schema import TextNode, NodeWithScore
 
 logger = logging.getLogger(__name__)
 
 
+# **NOTE**: deprecated (for older versions of sql query engine)
 DEFAULT_RESPONSE_SYNTHESIS_PROMPT_TMPL = (
     "Given an input question, synthesize a response from the query results.\n"
     "Query: {query_str}\n"
@@ -35,6 +42,19 @@ DEFAULT_RESPONSE_SYNTHESIS_PROMPT_TMPL = (
 )
 DEFAULT_RESPONSE_SYNTHESIS_PROMPT = PromptTemplate(
     DEFAULT_RESPONSE_SYNTHESIS_PROMPT_TMPL,
+    prompt_type=PromptType.SQL_RESPONSE_SYNTHESIS,
+)
+
+# **NOTE**: newer version of sql query engine
+DEFAULT_RESPONSE_SYNTHESIS_PROMPT_TMPL_V2 = (
+    "Given an input question, synthesize a response from the query results.\n"
+    "Query: {query_str}\n"
+    "SQL: {sql_query}\n"
+    "SQL Response: {context_str}\n"
+    "Response: "
+)
+DEFAULT_RESPONSE_SYNTHESIS_PROMPT_V2 = PromptTemplate(
+    DEFAULT_RESPONSE_SYNTHESIS_PROMPT_TMPL_V2,
     prompt_type=PromptType.SQL_RESPONSE_SYNTHESIS,
 )
 
@@ -212,6 +232,15 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
         return Response(response=response_str, metadata=metadata)
 
 
+def _validate_prompt(response_synthesis_prompt: BasePromptTemplate) -> None:
+    """Validate prompt."""
+    if response_synthesis_prompt.template_vars != DEFAULT_RESPONSE_SYNTHESIS_PROMPT_V2.template_vars:
+        raise ValueError(
+            "response_synthesis_prompt must have the following template variables: "
+            "query_str, sql_query, context_str"
+        )
+
+
 class BaseSQLTableQueryEngine(BaseQueryEngine):
     def __init__(
         self,
@@ -229,8 +258,11 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
 
         self._text_to_sql_prompt = text_to_sql_prompt or DEFAULT_TEXT_TO_SQL_PROMPT
         self._response_synthesis_prompt = (
-            response_synthesis_prompt or DEFAULT_RESPONSE_SYNTHESIS_PROMPT
+            response_synthesis_prompt or DEFAULT_RESPONSE_SYNTHESIS_PROMPT_V2
         )
+        # do some basic prompt validation
+        _validate_prompt(self._response_synthesis_prompt)
+
         self._context_query_kwargs = context_query_kwargs or {}
         self._synthesize_response = synthesize_response
         super().__init__(self._service_context.callback_manager, **kwargs)
@@ -281,16 +313,23 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
         metadata["sql_query"] = sql_query_str
 
         if self._synthesize_response:
-            response_str = self._service_context.llm_predictor.predict(
-                self._response_synthesis_prompt,
-                query_str=query_bundle.query_str,
+            partial_synthesis_prompt = self._response_synthesis_prompt.partial_format(
                 sql_query=sql_query_str,
-                sql_response_str=raw_response_str,
             )
+            response_synthesizer = get_response_synthesizer(
+                service_context=self._service_context,
+                callback_manager=self._service_context.callback_manager,
+                text_qa_template=partial_synthesis_prompt
+            )
+            response = response_synthesizer.synthesize(
+                query=query_bundle.query_str,
+                nodes=[NodeWithScore(node=TextNode(text=raw_response_str))],
+            )
+            response.metadata.update(metadata)
+            return response
         else:
             response_str = raw_response_str
-
-        return Response(response=response_str, metadata=metadata)
+            return Response(response=response_str, metadata=metadata)
 
     async def _aquery(self, query_bundle: QueryBundle) -> Response:
         """Answer a query."""
@@ -308,9 +347,27 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
 
-        response_str, metadata = self._sql_database.run_sql(sql_query_str)
+        raw_response_str, metadata = self._sql_database.run_sql(sql_query_str)
         metadata["sql_query"] = sql_query_str
-        return Response(response=response_str, metadata=metadata)
+
+        if self._synthesize_response:
+            partial_synthesis_prompt = self._response_synthesis_prompt.partial_format(
+                sql_query=sql_query_str,
+            )
+            response_synthesizer = get_response_synthesizer(
+                service_context=self._service_context,
+                callback_manager=self._service_context.callback_manager,
+                text_qa_template=partial_synthesis_prompt
+            )
+            response = await response_synthesizer.asynthesize(
+                query=query_bundle.query_str,
+                nodes=[NodeWithScore(node=TextNode(raw_response_str))],
+            )
+            response.metadata.update(metadata)
+            return response
+        else:
+            response_str = raw_response_str
+            return Response(response=response_str, metadata=metadata)
 
 
 class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):

--- a/llama_index/utilities/sql_wrapper.py
+++ b/llama_index/utilities/sql_wrapper.py
@@ -198,5 +198,5 @@ class SQLDatabase:
                 ) from exc
             if cursor.returns_rows:
                 result = cursor.fetchall()
-                return str(result), {"result": result}
+                return str(result), {"result": result, "col_keys": list(cursor.keys())}
         return "", {}


### PR DESCRIPTION
This PR is a small attempt towards adding response synthesis capabilities to our text-to-SQL engine.

Leads to mildly breaking changes (replace `sql_response_str` template var with `context_str` template var).

I'm working on a bigger change to separate out SQL Retrieval (text-to-SQL retrieval) from the synthesis portion, making it similar to our other RAG pipelines. draft PR for that incoming 