### PR TITLE
Predibase LLM Integration - prompt method deprecation update

### DIFF
--- a/llama_index/llms/predibase.py
+++ b/llama_index/llms/predibase.py
@@ -87,7 +87,8 @@ class PredibaseLLM(CustomLLM):
             "temperature": self.temperature,
             "max_new_tokens": self.max_new_tokens,
         }
-        results = self._client.prompt(prompt, self.model_name, options=model_kwargs)
+        llm = self._client.LLM(f"pb://deployments/{self.model_name}")
+        results = llm.prompt(prompt, options=model_kwargs)
         return CompletionResponse(
             text=results.loc[0, "response"], additional_kwargs=model_kwargs
         )

--- a/llama_index/llms/predibase.py
+++ b/llama_index/llms/predibase.py
@@ -80,18 +80,11 @@ class PredibaseLLM(CustomLLM):
             model_name=self.model_name,
         )
 
-    # "CompletionResponse"
     @llm_completion_callback()
     def complete(self, prompt: str, **kwargs: Any) -> "CompletionResponse":
-        model_kwargs = {
-            "temperature": self.temperature,
-            "max_new_tokens": self.max_new_tokens,
-        }
         llm = self._client.LLM(f"pb://deployments/{self.model_name}")
-        results = llm.prompt(prompt, options=model_kwargs)
-        return CompletionResponse(
-            text=results.loc[0, "response"], additional_kwargs=model_kwargs
-        )
+        results = llm.prompt(prompt, max_new_tokens=self.max_new_tokens, temperature=self.temperature)
+        return CompletionResponse(text=results.response)
 
     @llm_completion_callback()
     def stream_complete(self, prompt: str, **kwargs: Any) -> "CompletionResponseGen":

--- a/llama_index/llms/predibase.py
+++ b/llama_index/llms/predibase.py
@@ -83,7 +83,9 @@ class PredibaseLLM(CustomLLM):
     @llm_completion_callback()
     def complete(self, prompt: str, **kwargs: Any) -> "CompletionResponse":
         llm = self._client.LLM(f"pb://deployments/{self.model_name}")
-        results = llm.prompt(prompt, max_new_tokens=self.max_new_tokens, temperature=self.temperature)
+        results = llm.prompt(
+            prompt, max_new_tokens=self.max_new_tokens, temperature=self.temperature
+        )
         return CompletionResponse(text=results.response)
 
     @llm_completion_callback()


### PR DESCRIPTION
# Description

We updated the method for prompting an LLM with the latest Predibase SDK release and deprecated the old method. This PR addresses these changes