### PR TITLE
Add Bedrock LLM

### DIFF
--- a/docs/core_modules/model_modules/llms/modules.md
+++ b/docs/core_modules/model_modules/llms/modules.md
@@ -193,3 +193,12 @@ maxdepth: 1
 ---
 /examples/llm/clarifai.ipynb
 ```
+
+## Bedrock
+
+```{toctree}
+---
+maxdepth: 1
+---
+/examples/llm/bedrock.ipynb
+```

--- a/docs/examples/llm/bedrock.ipynb
+++ b/docs/examples/llm/bedrock.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9e3a8796-edc8-43f2-94ad-fe4fb20d70ed",
+   "metadata": {},
+   "source": [
+    "# Cohere"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b007403c-6b7a-420c-92f1-4171d05ed9bb",
+   "metadata": {},
+   "source": [
+    "## Basic Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ead155e-b8bd-46f9-ab9b-28fc009361dd",
+   "metadata": {},
+   "source": [
+    "#### Call `complete` with a prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60be18ae-c957-4ac2-a58a-0652e18ee6d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import Bedrock\n",
+    "\n",
+    "profile_name = \"Your aws profile name\"\n",
+    "resp = Bedrock(\n",
+    "    model=\"amazon.titan-text-express-v1\", profile_name=profile_name\n",
+    ").complete(\"Paul Graham is \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac2cbebb-a444-4a46-9d85-b265a3483d68",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Paul Graham is a computer scientist and entrepreneur, best known for co-founding the Silicon Valley startup incubator Y Combinator. He is also a prominent writer and speaker on technology and business topics, and his essays have been collected in a book titled \"Hackers & Painters.\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14831268-f90f-499d-9d86-925dbc88292b",
+   "metadata": {},
+   "source": [
+    "#### Call `chat` with a list of messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbe29574-4af1-48d5-9739-f60652b6ce6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import ChatMessage, Bedrock\n",
+    "\n",
+    "messages = [\n",
+    "    ChatMessage(\n",
+    "        role=\"system\", content=\"You are a pirate with a colorful personality\"\n",
+    "    ),\n",
+    "    ChatMessage(role=\"user\", content=\"Tell me a story\"),\n",
+    "]\n",
+    "\n",
+    "resp = Bedrock(\n",
+    "    model=\"amazon.titan-text-express-v1\", profile_name=profile_name\n",
+    ").chat(messages)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cbd550a-0264-4a11-9b2c-a08d8723a5ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "assistant: Alright, matey! Here's a story for you:\n",
+      "\n",
+      "Once upon a time, there was a pirate named Captain Jack Sparrow who sailed the seas in search of his next adventure. He was a notorious rogue with a reputation for being unpredictable and a bit of a scallywag.\n",
+      "\n",
+      "One day, Captain Jack encountered a group of treasure-hunting rivals who were also after the same treasure. The rivals tried to steal the treasure from Captain Jack, but he outsmarted them and managed to keep the treasure for himself.\n",
+      "\n",
+      "However, Captain Jack soon discovered that the treasure he had stolen was cursed. Every time he tried to use it, it would cause him some sort of trouble or inconvenience. For example, whenever he tried to spend it, it would turn into a pile of sand or a bunch of sea turtles.\n",
+      "\n",
+      "Despite the curse, Captain Jack was determined to find a way to break it. He set out on a journey to find a wise old seer who could help him lift the curse. Along the way, he encountered all sorts of strange and magical creatures, including a talking parrot and a sea witch.\n",
+      "\n",
+      "Finally, Captain Jack found the seer and explained his predicament. The seer told him that the only way to break the curse was to return the treasure to its rightful owner.\n",
+      "\n",
+      "Captain Jack was hesitant at first, but he knew that it was the right thing to do. He set out on a new adventure to find the rightful owner of the treasure, and along the way, he discovered that sometimes the greatest treasures are not the ones that can be measured in gold or silver, but the ones that come with a sense of purpose and meaning.\n",
+      "\n",
+      "And so, Captain Jack returned the treasure to its rightful owner, and the curse was lifted. He sailed off into the sunset, a hero who had learned that the true treasure of life is not found in material possessions, but in the experiences and connections we make with others.\n",
+      "\n",
+      "Yarr! Hope you enjoyed that tale, matey!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ed5e894-4597-4911-a623-591560f72b82",
+   "metadata": {},
+   "source": [
+    "## Streaming"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cb7986f-aaed-42e2-abdd-f274f6d4fc59",
+   "metadata": {},
+   "source": [
+    "Using `stream_complete` endpoint "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d43f17a2-0aeb-464b-a7a7-732ba5e8ef24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import Bedrock\n",
+    "\n",
+    "llm = Bedrock(model=\"amazon.titan-text-express-v1\", profile_name=profile_name)\n",
+    "resp = llm.stream_complete(\"Paul Graham is \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0214e911-cf0d-489c-bc48-9bb1d8bf65d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Paul Graham is a computer programmer, entrepreneur, investor, and writer, best known for co-founding the internet firm Y Combinator. He is also the author of several books, including \"The Innovator's Dilemma\" and \"On the Internet.\"\n",
+      "\n",
+      "Graham has been a strong supporter of the startup community and the concept of \"disruption\" in the technology sector. He has written extensively about the challenges faced by early-stage companies and the importance of creating new and innovative products.\n",
+      "\n",
+      "Graham is also known for his contrarian views on a variety of topics, including education, government, and the future of the internet. He has been an outspoken critic of the way higher education is administered in the United States and has advocated for a more experimental and entrepreneurial approach to learning.\n",
+      "\n",
+      "Overall, Paul Graham is a highly influential figure in the technology industry, known for his thoughtful and thought-provoking writing and his support for innovative startups and entrepreneurs."
+     ]
+    }
+   ],
+   "source": [
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40350dd8-3f50-4a2f-8545-5723942039bb",
+   "metadata": {},
+   "source": [
+    "Using `stream_chat` endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc636e65-a67b-4dcd-ac60-b25abc9d8dbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import Bedrock\n",
+    "\n",
+    "llm = Bedrock(model=\"amazon.titan-text-express-v1\", profile_name=profile_name)\n",
+    "messages = [\n",
+    "    ChatMessage(\n",
+    "        role=\"system\", content=\"You are a pirate with a colorful personality\"\n",
+    "    ),\n",
+    "    ChatMessage(role=\"user\", content=\"Tell me a story\"),\n",
+    "]\n",
+    "resp = llm.stream_chat(messages)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4475a6bc-1051-4287-abce-ba83324aeb9e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Once upon a time, there was a pirate with a colorful personality who sailed the high seas in search of adventure. She was known for her boldness, her wit, and her love of all things flashy and fancy. But beneath her swashbuckling exterior, there was a heart full of gold, and a desire to do good in the world.\n",
+      "\n",
+      "One day, while on her usual voyages, the pirate came across a small island in distress. The villagers were suffering from a terrible drought, and their crops were failing. The pirate knew that she had to help them, and so she set out to find a way to bring water to the island.\n",
+      "\n",
+      "After much searching, the pirate discovered a hidden spring deep in the heart of the island. She worked tirelessly to build a system of pipes and aqueducts that would carry the spring water to the villages, and finally, after many long months of hard work, the drought was over, and the people were saved.\n",
+      "\n",
+      "The pirate was hailed as a hero, and the villagers threw a grand celebration in her honor. But she knew that her work was not yet done. She continued to sail the seas, seeking out other ways to help those in need, and to spread joy and happiness wherever she went.\n",
+      "\n",
+      "And so, the pirate with the colorful personality lived out her days in a blaze of glory, inspiring others with her courage, her kindness, and her unquenchable sense of adventure."
+     ]
+    }
+   ],
+   "source": [
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "009d3f1c-ef35-4126-ae82-0b97adb746e3",
+   "metadata": {},
+   "source": [
+    "## Configure Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e973e3d1-a3c9-43b9-bee1-af3e57946ac3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import Bedrock\n",
+    "\n",
+    "llm = Bedrock(model=\"amazon.titan-text-express-v1\", profile_name=profile_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2c9bcf6-c950-4dfc-abdc-598d5bdedf40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.complete(\"Paul Graham is \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de715fea-4878-4fbb-b415-71250215f3a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Paul Graham is a computer scientist, entrepreneur, investor, and writer. He co-founded Viaweb, the first commercial web browser, and was a founder of Y Combinator, a startup accelerator. He is the author of several books, including \"The Art of Computer Programming\" and \"On Lisp.\" He is known for his essays on technology and business, and his perspective on the tech industry.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48c14819-9cff-435f-9578-d7b05694498f",
+   "metadata": {},
+   "source": [
+    "#  Connect to Bedrock with Access Keysfrom llama_index.llms import Bedrock\n",
+    "\n",
+    "llm = Bedrock(model=\"amazon.titan-text-express-v1\",profile_name=profile_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9c80814-6d59-4782-a4bb-cbfcdba6a072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import Bedrock\n",
+    "\n",
+    "llm = Bedrock(\n",
+    "    model=\"amazon.titan-text-express-v1\",\n",
+    "    aws_access_key_id=\"AWS Access Key ID to use\",\n",
+    "    aws_secret_access_key=\"AWS Secret Access Key to use\",\n",
+    "    aws_session_token=\"AWS Session Token to use\",\n",
+    ")\n",
+    "\n",
+    "resp = llm.complete(\"Paul Graham is \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a07982f4-035c-41ca-9dca-49ae6ab3c05a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Paul Graham is an American computer scientist, entrepreneur, investor, and author, best known for co-founding Viaweb, the first commercial web browser. He was a co-founder of Netscape Communications and the creator of the Mozilla Foundation. He was also a Y Combinator partner and a prominent early-stage investor in companies such as Airbnb, Dropbox, Facebook, and Twitter.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(resp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/llm/bedrock.ipynb
+++ b/docs/examples/llm/bedrock.ipynb
@@ -5,7 +5,7 @@
    "id": "9e3a8796-edc8-43f2-94ad-fe4fb20d70ed",
    "metadata": {},
    "source": [
-    "# Cohere"
+    "# Bedrock"
    ]
   },
   {

--- a/llama_index/llms/__init__.py
+++ b/llama_index/llms/__init__.py
@@ -12,6 +12,7 @@ from llama_index.llms.base import (
     LLMMetadata,
     MessageRole,
 )
+from llama_index.llms.bedrock import Bedrock
 from llama_index.llms.clarifai import Clarifai
 from llama_index.llms.cohere import Cohere
 from llama_index.llms.custom import CustomLLM
@@ -37,6 +38,7 @@ __all__ = [
     "Anthropic",
     "Anyscale",
     "AzureOpenAI",
+    "Bedrock",
     "ChatMessage",
     "ChatResponse",
     "ChatResponseAsyncGen",

--- a/llama_index/llms/bedrock.py
+++ b/llama_index/llms/bedrock.py
@@ -1,0 +1,223 @@
+import json
+import warnings
+from typing import Any, Dict, Optional, Sequence
+
+from llama_index.bridge.pydantic import Field, PrivateAttr
+from llama_index.callbacks import CallbackManager
+from llama_index.llms.base import (
+    LLM,
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseAsyncGen,
+    CompletionResponseGen,
+    LLMMetadata,
+    llm_chat_callback,
+    llm_completion_callback,
+)
+from llama_index.llms.bedrock_utils import (
+    BEDROCK_FOUNDATION_LLMS,
+    STREAMING_MODELS,
+    bedrock_model_to_param_name,
+    completion_to_chat_decorator,
+    completion_with_retry,
+    get_request_body,
+    get_text_from_response,
+    stream_completion_to_chat_decorator,
+)
+from llama_index.llms.custom import CustomLLM
+
+
+class Bedrock(LLM):
+    model: str = Field(description="The modelId of the Bedrock model to use.")
+    temperature: float = Field(description="The temperature to use for sampling.")
+    max_tokens: int = Field(description="The maximum number of tokens to generate.")
+    context_size: int = Field("The maximum number of tokens available for input.")
+    profile_name: Optional[str] = Field(
+        description="he name of aws profile to use. If not given, then the default profile is used."
+    )
+    aws_access_key_id: Optional[str] = Field(description="AWS Access Key ID to use")
+    aws_secret_access_key: Optional[str] = Field(
+        description="AWS Secret Access Key to use"
+    )
+    aws_session_token: Optional[str] = Field(description="AWS Session Token to use")
+    max_retries: int = Field(
+        default=10, description="The maximum number of API retries."
+    )
+    additional_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional kwargs for the bedrock invokeModel request.",
+    )
+
+    _client: Any = PrivateAttr()
+    _aclient: Any = PrivateAttr()
+
+    def __init__(
+        self,
+        model: str,
+        temperature: Optional[float] = 0.5,
+        max_tokens: Optional[int] = 512,
+        context_size: Optional[int] = None,
+        profile_name: Optional[str] = None,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
+        timeout: Optional[float] = None,
+        max_retries: Optional[int] = 10,
+        additional_kwargs: Optional[Dict[str, Any]] = None,
+        callback_manager: Optional[CallbackManager] = None,
+    ) -> None:
+        if context_size is None and model not in BEDROCK_FOUNDATION_LLMS:
+            raise ValueError(
+                "`context_size` argument not provided and"
+                "model provided refers to a non-foundation model."
+                " Please specify the context_size"
+            )
+        try:
+            import boto3
+
+            aws_access_key_id
+            aws_secret_access_key
+            if not profile_name and aws_access_key_id:
+                session = boto3.Session(
+                    aws_access_key_id=aws_access_key_id,
+                    aws_secret_access_key=aws_secret_access_key,
+                    aws_session_token=aws_session_token,
+                )
+            else:
+                session = boto3.Session(profile_name=profile_name)
+            # Prior to general availability, custom boto3 wheel files were
+            # distributed that used the bedrock service to invokeModel.
+            # This check prevents any services still using those wheel files
+            # from breaking
+            if "bedrock-runtime" in session.get_available_services():
+                self._client = session.client("bedrock-runtime")
+            else:
+                self._client = session.client("bedrock")
+        except ImportError as e:
+            raise ImportError(
+                "You must install the `boto3` package to use Bedrock."
+                "Please `pip install boto3`"
+            ) from e
+
+        additional_kwargs = additional_kwargs or {}
+        callback_manager = callback_manager or CallbackManager([])
+        context_size = context_size or BEDROCK_FOUNDATION_LLMS[model]
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            context_size=context_size,
+            profile_name=profile_name,
+            timeout=timeout,
+            max_retries=max_retries,
+            additional_kwargs=additional_kwargs,
+            callback_manager=callback_manager,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Get class name."""
+        return "Bedrock_LLM"
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(
+            context_window=self.context_size,
+            num_output=self.max_tokens,
+            is_chat_model=True,
+            model_name=self.model,
+        )
+
+    @property
+    def _model_kwargs(self) -> Dict[str, Any]:
+        max_tokens_key = bedrock_model_to_param_name(
+            model=self.model, param_name="max_tokens"
+        )
+        base_kwargs = {"temperature": self.temperature, max_tokens_key: self.max_tokens}
+        return {
+            **base_kwargs,
+            **self.additional_kwargs,
+        }
+
+    def _get_all_kwargs(self, **kwargs: Any) -> Dict[str, Any]:
+        return {
+            **self._model_kwargs,
+            **kwargs,
+        }
+
+    @llm_completion_callback()
+    def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        all_kwargs = self._get_all_kwargs(**kwargs)
+        provider = self.model.split(".")[0]
+        request_body = get_request_body(provider, prompt, all_kwargs)
+        request_body_str = json.dumps(request_body)
+        response = completion_with_retry(
+            client=self._client,
+            model=self.model,
+            request_body=request_body_str,
+            max_retries=self.max_retries,
+            **all_kwargs,
+        )["body"].read()
+        response = json.loads(response)
+        return CompletionResponse(
+            text=get_text_from_response(provider, response), raw=response
+        )
+
+    @llm_completion_callback()
+    def stream_complete(self, prompt: str, **kwargs: Any) -> CompletionResponseGen:
+        if self.model in BEDROCK_FOUNDATION_LLMS and self.model not in STREAMING_MODELS:
+            raise ValueError(f"Model {self.model} does not support streaming")
+        all_kwargs = self._get_all_kwargs(**kwargs)
+        provider = self.model.split(".")[0]
+        request_body = get_request_body(provider, prompt, all_kwargs)
+        request_body_str = json.dumps(request_body)
+        response = completion_with_retry(
+            client=self._client,
+            model=self.model,
+            request_body=request_body_str,
+            max_retries=self.max_retries,
+            stream=True,
+            **all_kwargs,
+        )["body"]
+
+        def gen() -> CompletionResponseGen:
+            content = ""
+            for r in response:
+                r = json.loads(r["chunk"]["bytes"])
+                content_delta = get_text_from_response(provider, r, stream=True)
+                content += content_delta
+                yield CompletionResponse(text=content, delta=content_delta, raw=r)
+
+        return gen()
+
+    @llm_chat_callback()
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        chat_fn = completion_to_chat_decorator(self.complete)
+        return chat_fn(messages, **kwargs)
+
+    def stream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseGen:
+        stream_chat_fn = stream_completion_to_chat_decorator(self.stream_complete)
+        return stream_chat_fn(messages, **kwargs)
+
+    async def achat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        raise NotImplementedError
+
+    async def acomplete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        raise NotImplementedError
+
+    async def astream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        raise NotImplementedError
+
+    async def astream_complete(
+        self, prompt: str, **kwargs: Any
+    ) -> CompletionResponseAsyncGen:
+        raise NotImplementedError

--- a/llama_index/llms/bedrock.py
+++ b/llama_index/llms/bedrock.py
@@ -36,7 +36,7 @@ class Bedrock(LLM):
     max_tokens: int = Field(description="The maximum number of tokens to generate.")
     context_size: int = Field("The maximum number of tokens available for input.")
     profile_name: Optional[str] = Field(
-        description="he name of aws profile to use. If not given, then the default profile is used."
+        description="The name of aws profile to use. If not given, then the default profile is used."
     )
     aws_access_key_id: Optional[str] = Field(description="AWS Access Key ID to use")
     aws_secret_access_key: Optional[str] = Field(
@@ -78,8 +78,6 @@ class Bedrock(LLM):
         try:
             import boto3
 
-            aws_access_key_id
-            aws_secret_access_key
             if not profile_name and aws_access_key_id:
                 session = boto3.Session(
                     aws_access_key_id=aws_access_key_id,

--- a/llama_index/llms/bedrock_utils.py
+++ b/llama_index/llms/bedrock_utils.py
@@ -1,0 +1,222 @@
+import json
+import logging
+from typing import Any, Callable, Sequence
+
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from llama_index.llms.base import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseGen,
+    MessageRole,
+    llm_chat_callback,
+    llm_completion_callback,
+)
+from llama_index.llms.generic_utils import (
+    completion_response_to_chat_response,
+    stream_completion_response_to_chat_response,
+)
+
+HUMAN_PREFIX = "\n\nHuman:"
+ASSISTANT_PREFIX = "\n\nAssistant:"
+
+# Values taken from https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html#model-parameters-claude
+COMPLETION_MODELS = {
+    "amazon.titan-tg1-large": 8000,
+    "amazon.titan-text-express-v1": 8000,
+    "ai21.j2-grande-instruct": 8000,
+    "ai21.j2-jumbo-instruct": 8000,
+    "ai21.j2-mid": 8000,
+    "ai21.j2-mid-v1": 8000,
+    "ai21.j2-ultra": 8000,
+    "ai21.j2-ultra-v1": 8000,
+    "cohere.command-text-v14": 4096,
+}
+
+# Anthropic models require prompt to start with "Human:" and
+# end with "Assistant:"
+CHAT_ONLY_MODELS = {
+    "anthropic.claude-instant-v1": 100000,
+    "anthropic.claude-v1": 100000,
+    "anthropic.claude-v2": 100000,
+}
+BEDROCK_FOUNDATION_LLMS = {**COMPLETION_MODELS, **CHAT_ONLY_MODELS}
+
+# Only the following models support streaming as
+# per result of Bedrock.Client.list_foundation_models
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/list_foundation_models.html
+STREAMING_MODELS = {
+    "amazon.titan-tg1-large",
+    "amazon.titan-text-express-v1",
+    "anthropic.claude-instant-v1",
+    "anthropic.claude-v1",
+    "anthropic.claude-v2",
+}
+
+# Each bedrock model specifies parameters with a slightly different name
+# most of these are passed optionally by the user in kwargs but max tokens
+# is a required argument.
+PROVIDER_SPECIFIC_PARAM_NAME = {
+    "amazon": {"max_tokens": "maxTokenCount"},
+    "ai21": {"max_tokens": "maxTokens"},
+    "anthropic": {"max_tokens": "max_tokens_to_sample"},
+    "cohere": {"max_tokens": "max_tokens"},
+}
+
+# The response format for each provider is different
+PROVIDER_RESPONSE_LOADER = {
+    "amazon": lambda x: x["results"][0]["outputText"],
+    "ai21": lambda x: x["completions"][0]["data"]["text"],
+    "anthropic": lambda x: x["completion"],
+    "cohere": lambda x: x["generations"][0]["text"],
+}
+
+PROVIDER_STREAM_RESPONSE_LOADER = {
+    "amazon": lambda x: x["outputText"],
+    "anthropic": lambda x: x["completion"],
+}
+logger = logging.getLogger(__name__)
+
+
+def bedrock_model_to_param_name(model: str, param_name: str) -> str:
+    provider = model.split(".")[0]
+    model_params = PROVIDER_SPECIFIC_PARAM_NAME[provider]
+    return model_params[param_name]
+
+
+def _create_retry_decorator(client: Any, max_retries: int) -> Callable[[Any], Any]:
+    min_seconds = 4
+    max_seconds = 10
+    # Wait 2^x * 1 second between each retry starting with
+    # 4 seconds, then up to 10 seconds, then 10 seconds afterwards
+    try:
+        import boto3
+    except ImportError as e:
+        raise ImportError(
+            "You must install the `boto3` package to use Bedrock."
+            "Please `pip install boto3`"
+        ) from e
+
+    return retry(
+        reraise=True,
+        stop=stop_after_attempt(max_retries),
+        wait=wait_exponential(multiplier=1, min=min_seconds, max=max_seconds),
+        retry=(
+            retry_if_exception_type(client.exceptions.ThrottlingException)
+            | retry_if_exception_type(client.exceptions.ModelTimeoutException)
+            | retry_if_exception_type(client.exceptions.ModelTimeoutException)
+        ),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+    )
+
+
+def completion_with_retry(
+    client: Any,
+    model: str,
+    request_body: str,
+    max_retries: int,
+    stream: bool = False,
+    **kwargs: Any,
+) -> Any:
+    """Use tenacity to retry the completion call."""
+    if stream:
+        return client.invoke_model_with_response_stream(
+            modelId=model, body=request_body
+        )
+    return client.invoke_model(modelId=model, body=request_body)
+    retry_decorator = _create_retry_decorator(client=client, max_retries=max_retries)
+
+    @retry_decorator
+    def _completion_with_retry(**kwargs: Any) -> Any:
+        if stream:
+            return client.invoke_model_with_response_stream(
+                modelId=model, body=request_body
+            )
+        return client.invoke_model(modelId=model, body=request_body)
+
+    return _completion_with_retry(**kwargs)
+
+
+def _message_to_bedrock_prompt(message: ChatMessage) -> str:
+    if message.role == MessageRole.USER:
+        prompt = f"{HUMAN_PREFIX} {message.content}"
+    elif message.role == MessageRole.ASSISTANT:
+        prompt = f"{ASSISTANT_PREFIX} {message.content}"
+    elif message.role == MessageRole.SYSTEM:
+        prompt = f"{HUMAN_PREFIX} <system>{message.content}</system>"
+    elif message.role == MessageRole.FUNCTION:
+        raise ValueError(f"Message role {MessageRole.FUNCTION} is not supported.")
+    else:
+        raise ValueError(f"Unknown message role: {message.role}")
+
+    return prompt
+
+
+def messages_to_bedrock_prompt(messages: Sequence[ChatMessage]) -> str:
+    if len(messages) == 0:
+        raise ValueError("Got empty list of messages.")
+
+    # NOTE: make sure the prompt ends with the assistant prefix
+    if messages[-1].role != MessageRole.ASSISTANT:
+        messages = [
+            *list(messages),
+            ChatMessage(role=MessageRole.ASSISTANT, content=""),
+        ]
+
+    str_list = [_message_to_bedrock_prompt(message) for message in messages]
+    return "".join(str_list)
+
+
+def get_request_body(provider: str, prompt: str, inference_paramters: dict) -> dict:
+    if provider == "amazon":
+        response_body = {
+            "inputText": prompt,
+            "textGenerationConfig": {**inference_paramters},
+        }
+    else:
+        response_body = {"prompt": prompt, **inference_paramters}
+    return response_body
+
+
+def get_text_from_response(provider: str, response: dict, stream: bool = False) -> str:
+    if stream:
+        return PROVIDER_STREAM_RESPONSE_LOADER[provider](response)
+    return PROVIDER_RESPONSE_LOADER[provider](response)
+
+
+def completion_to_chat_decorator(
+    func: Callable[..., CompletionResponse]
+) -> Callable[..., ChatResponse]:
+    """Convert a completion function to a chat function."""
+
+    def wrapper(messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        # normalize input
+        prompt = messages_to_bedrock_prompt(messages)
+        completion_response = func(prompt, **kwargs)
+        # normalize output
+        return completion_response_to_chat_response(completion_response)
+
+    return wrapper
+
+
+def stream_completion_to_chat_decorator(
+    func: Callable[..., CompletionResponseGen]
+) -> Callable[..., ChatResponseGen]:
+    """Convert a completion function to a chat function."""
+
+    def wrapper(messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseGen:
+        # normalize input
+        prompt = messages_to_bedrock_prompt(messages)
+        completion_response = func(prompt, **kwargs)
+        # normalize output
+        return stream_completion_response_to_chat_response(completion_response)
+
+    return wrapper

--- a/llama_index/llms/loading.py
+++ b/llama_index/llms/loading.py
@@ -1,6 +1,7 @@
 from typing import Dict, Type
 
 from llama_index.llms.base import LLM
+from llama_index.llms.bedrock import Bedrock
 from llama_index.llms.custom import CustomLLM
 from llama_index.llms.gradient import GradientBaseModelLLM, GradientModelAdapterLLM
 from llama_index.llms.huggingface import HuggingFaceLLM
@@ -23,6 +24,7 @@ RECOGNIZED_LLMS: Dict[str, Type[LLM]] = {
     LangChainLLM.class_name(): LangChainLLM,
     PaLM.class_name(): PaLM,
     PredibaseLLM.class_name(): PredibaseLLM,
+    Bedrock.class_name(): Bedrock,
     CustomLLM.class_name(): CustomLLM,
     GradientBaseModelLLM.class_name(): GradientBaseModelLLM,
     GradientModelAdapterLLM.class_name(): GradientModelAdapterLLM,

--- a/tests/llms/test_bedrock.py
+++ b/tests/llms/test_bedrock.py
@@ -1,0 +1,108 @@
+from typing import Any, Generator
+
+import pytest
+from llama_index.llms.base import ChatMessage
+from pytest import MonkeyPatch
+
+try:
+    import boto3
+except ImportError:
+    boto3 = None
+from llama_index.llms import Bedrock
+
+
+class MockStreamingBody:
+    def read(self) -> str:
+        return """{
+        "inputTextTokenCount": 3,
+        "results": [
+        {"tokenCount": 14,
+        "outputText": "\\n\\nThis is indeed a test",
+        "completionReason": "FINISH"
+        }]}
+        """
+
+
+class MockEventStream:
+    def __iter__(self) -> Generator[dict, None, None]:
+        deltas = [b"\\n\\nThis ", b"is indeed", b" a test"]
+        for delta in deltas:
+            yield {
+                "chunk": {
+                    "bytes": b'{"outputText":"' + delta + b'",'
+                    b'"index":0,"totalOutputTextTokenCount":20,'
+                    b'"completionReason":"LENGTH","inputTextTokenCount":7}'
+                }
+            }
+
+
+def mock_completion_with_retry(*args: Any, **kwargs: Any) -> dict:
+    return {
+        "ResponseMetadata": {
+            "HTTPHeaders": {
+                "connection": "keep-alive",
+                "content-length": "246",
+                "content-type": "application/json",
+                "date": "Fri, 20 Oct 2023 08:20:44 GMT",
+                "x-amzn-requestid": "667dq648-fbc3-4a7b-8f0e-4575f1f1f11d",
+            },
+            "HTTPStatusCode": 200,
+            "RequestId": "667dq648-fbc3-4a7b-8f0e-4575f1f1f11d",
+            "RetryAttempts": 0,
+        },
+        "body": MockStreamingBody(),
+        "contentType": "application/json",
+    }
+
+
+def mock_stream_completion_with_retry(*args: Any, **kwargs: Any) -> dict:
+    return {
+        "ResponseMetadata": {
+            "HTTPHeaders": {
+                "connection": "keep-alive",
+                "content-type": "application/vnd.amazon.eventstream",
+                "date": "Fri, 20 Oct 2023 11:59:03 GMT",
+                "transfer-encoding": "chunked",
+                "x-amzn-bedrock-content-type": "application/json",
+                "x-amzn-requestid": "ef9af51b-7ba5-4020-3793-f4733226qb84",
+            },
+            "HTTPStatusCode": 200,
+            "RequestId": "ef9af51b-7ba5-4020-3793-f4733226qb84",
+            "RetryAttempts": 0,
+        },
+        "body": MockEventStream(),
+        "contentType": "application/json",
+    }
+
+
+@pytest.mark.skipif(boto3 is None, reason="bedrock not installed")
+def test_model_basic(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "llama_index.llms.bedrock.completion_with_retry", mock_completion_with_retry
+    )
+    llm = Bedrock(model="amazon.titan-text-express-v1", profile_name=None)
+    test_prompt = "test prompt"
+    response = llm.complete(test_prompt)
+    assert response.text == "\n\nThis is indeed a test"
+
+    message = ChatMessage(role="user", content=test_prompt)
+    chat_response = llm.chat([message])
+    assert chat_response.message.content == "\n\nThis is indeed a test"
+
+
+@pytest.mark.skipif(boto3 is None, reason="bedrock not installed")
+def test_model_streaming(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "llama_index.llms.bedrock.completion_with_retry",
+        mock_stream_completion_with_retry,
+    )
+    llm = Bedrock(model="amazon.titan-text-express-v1", profile_name=None)
+    test_prompt = "test prompt"
+    response_gen = llm.stream_complete(test_prompt)
+    response = list(response_gen)
+    assert response[-1].text == "\n\nThis is indeed a test"
+
+    message = ChatMessage(role="user", content=test_prompt)
+    chat_response_gen = llm.stream_chat([message])
+    chat_response = list(chat_response_gen)
+    assert chat_response[-1].message.content == "\n\nThis is indeed a test"


### PR DESCRIPTION
# Description
This commit adds support for bedrock LLMs. I've added unit tests for basic and streaming functionality.  A couple of notes on some design decisions I've made that you may want done differently:

1. the Anthropic model requires the prompt to start with "Human:" and end with "Assistant:". But boto3 gives very detailed error messages for these cases. So I don't raise an error if `complete` is called when using an Anthropic model, I allow boto3 to raise the error. 
1. In Bedrock.metadata I've set is_chat_model to be False, based on it's definition in the LLMMetadata class. All calls to bedrock models take a string prompt as input, they don't accept a series of messages. But some models(eg. Anthropic) are technically chat models. 

Let me know if either of these are wrong, I'm happy to update the PR

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
