### PR TITLE
Fix delete in elasticsearch vector store (#8230)

### DIFF
--- a/llama_index/vector_stores/elasticsearch.py
+++ b/llama_index/vector_stores/elasticsearch.py
@@ -404,7 +404,7 @@ class ElasticsearchStore(VectorStore):
             async with self.client as client:
                 res = await client.delete_by_query(
                     index=self.index_name,
-                    query={"term": {"metadata.ref_doc_id": ref_doc_id}},
+                    query={"term": {"metadata.ref_doc_id.keyword": ref_doc_id}},
                     refresh=True,
                     **delete_kwargs,
                 )


### PR DESCRIPTION
# Description

Since we're checking for exact matches of `ref_doc_id`, we should use `.keyword` instead of the field itself. `.keyword` was being used in other places in this module but not for delete. This was causing deletion to be skipped (see #8230).

Fixes #8230

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
