### PR TITLE
Fix retry mechanisms in OpenAI embeddings

### DIFF
--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import openai
 from tenacity import (
     retry,
+    retry_if_exception_type,
     stop_after_attempt,
     stop_after_delay,
     stop_all,
@@ -103,6 +104,13 @@ _TEXT_MODE_MODEL_DICT = {
 @retry(
     wait=wait_random_exponential(min=1, max=20),
     stop=stop_all(stop_after_attempt(6), stop_after_delay(60)),
+    retry=(
+        retry_if_exception_type(openai.error.Timeout)
+        | retry_if_exception_type(openai.error.APIError)
+        | retry_if_exception_type(openai.error.APIConnectionError)
+        | retry_if_exception_type(openai.error.RateLimitError)
+        | retry_if_exception_type(openai.error.ServiceUnavailableError)
+    ),
 )
 def get_embedding(
     text: str, engine: Optional[str] = None, **kwargs: Any
@@ -126,6 +134,13 @@ def get_embedding(
 @retry(
     wait=wait_random_exponential(min=1, max=20),
     stop=stop_all(stop_after_attempt(6), stop_after_delay(60)),
+    retry=(
+        retry_if_exception_type(openai.error.Timeout)
+        | retry_if_exception_type(openai.error.APIError)
+        | retry_if_exception_type(openai.error.APIConnectionError)
+        | retry_if_exception_type(openai.error.RateLimitError)
+        | retry_if_exception_type(openai.error.ServiceUnavailableError)
+    ),
 )
 async def aget_embedding(
     text: str, engine: Optional[str] = None, **kwargs: Any
@@ -149,6 +164,13 @@ async def aget_embedding(
 @retry(
     wait=wait_random_exponential(min=1, max=20),
     stop=stop_all(stop_after_attempt(6), stop_after_delay(60)),
+    retry=(
+        retry_if_exception_type(openai.error.Timeout)
+        | retry_if_exception_type(openai.error.APIError)
+        | retry_if_exception_type(openai.error.APIConnectionError)
+        | retry_if_exception_type(openai.error.RateLimitError)
+        | retry_if_exception_type(openai.error.ServiceUnavailableError)
+    ),
 )
 def get_embeddings(
     list_of_text: List[str], engine: Optional[str] = None, **kwargs: Any
@@ -173,6 +195,13 @@ def get_embeddings(
 @retry(
     wait=wait_random_exponential(min=1, max=20),
     stop=stop_all(stop_after_attempt(6), stop_after_delay(60)),
+    retry=(
+        retry_if_exception_type(openai.error.Timeout)
+        | retry_if_exception_type(openai.error.APIError)
+        | retry_if_exception_type(openai.error.APIConnectionError)
+        | retry_if_exception_type(openai.error.RateLimitError)
+        | retry_if_exception_type(openai.error.ServiceUnavailableError)
+    ),
 )
 async def aget_embeddings(
     list_of_text: List[str], engine: Optional[str] = None, **kwargs: Any


### PR DESCRIPTION
# Description

This issue changes the retry mechanisms in OpenAI embeddings to trigger only for the certain specific errors where there might be a need to retry and not trigger for errors like Authentication error, InvalidRequestError as currently due to the retries sometimes the end user thinks the code is working and in the end gets confused whether it was a retry error or an error on their side( in rare cases where user does not pass OpenAI config or keys properly).

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] Dev tested by calling the respective functions with the specific error codes and checked whether the retry mechanism was working in the cases it should and not working in cases it should not.

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
