### PR TITLE
fix(json-path): multiple expressions parsing

### DIFF
--- a/llama_index/indices/struct_store/json_query.py
+++ b/llama_index/indices/struct_store/json_query.py
@@ -36,7 +36,7 @@ DEFAULT_RESPONSE_SYNTHESIS_PROMPT = PromptTemplate(
 )
 
 
-def default_output_processor(llm_output: str, json_value: JSONType) -> Dict[str, Any]:
+def default_output_processor(llm_output: str, json_value: JSONType) -> JSONType:
     """Default output processor that extracts values based on JSON Path expressions."""
     # Split the given string into separate JSON Path expressions
     expressions = [expr.strip() for expr in llm_output.split(",")]

--- a/llama_index/indices/struct_store/json_query.py
+++ b/llama_index/indices/struct_store/json_query.py
@@ -36,16 +36,32 @@ DEFAULT_RESPONSE_SYNTHESIS_PROMPT = PromptTemplate(
 )
 
 
-def default_output_processor(llm_output: str, json_value: JSONType) -> JSONType:
-    """Default output processor that executes the JSON Path query."""
+def default_output_processor(llm_output: str, json_value: JSONType) -> Dict[str, Any]:
+    """Default output processor that extracts values based on JSON Path expressions."""
+    # Split the given string into separate JSON Path expressions
+    expressions = [expr.strip() for expr in llm_output.split(",")]
+
     try:
         from jsonpath_ng.ext import parse
         from jsonpath_ng.jsonpath import DatumInContext
     except ImportError as exc:
+        IMPORT_ERROR_MSG = "You need to install jsonpath-ng to use this function!"
         raise ImportError(IMPORT_ERROR_MSG) from exc
 
-    datum: List[DatumInContext] = parse(llm_output).find(json_value)
-    return [d.value for d in datum]
+    results = {}
+
+    for expression in expressions:
+        try:
+            datum: List[DatumInContext] = parse(expression).find(json_value)
+            if datum:
+                key = expression.split(".")[
+                    -1
+                ]  # Extracting "title" from "$.title", for example
+                results[key] = datum[0].value
+        except Exception as exc:
+            raise ValueError(f"Invalid JSON Path: {expression}") from exc
+
+    return results
 
 
 class JSONQueryEngine(BaseQueryEngine):


### PR DESCRIPTION
# Description

JSON path parse fails sometimes when dealing with multiple expressions, so now iterating over each expression and parsing and accumulating the results

Fixes # https://github.com/run-llama/llama_index/issues/7975 https://github.com/run-llama/llama_index/issues/7747

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
