### PR TITLE
Update the correctness evaluator's default prompt

### DIFF
--- a/docs/examples/evaluation/correctness_eval.ipynb
+++ b/docs/examples/evaluation/correctness_eval.ipynb
@@ -19,6 +19,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "Wx4LCSJ2-u2T",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install nest_asyncio package to run asyncio code in Colab/ Jupyter Notebooks\n",
+    "!pip install nest-asyncio --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pb8oz6IP-yzl",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the below code to enable async functions to work in Colab/ Jupyter Notebooks\n",
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "01b23140-62b5-46f3-97f4-04f4da8aa5c8",
    "metadata": {},
    "outputs": [],
@@ -89,7 +113,7 @@
     {
      "data": {
       "text/plain": [
-       "2.5"
+       "2.0"
       ]
      },
      "execution_count": null,
@@ -109,8 +133,11 @@
    "outputs": [
     {
      "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "string"
+      },
       "text/plain": [
-       "'The generated answer is relevant to the user query as it attempts to explain the theory of relativity proposed by Albert Einstein. However, it contains significant mistakes. The explanation of general relativity is incorrect. General relativity is about the warping of space and time by mass and energy, not magnetic fields. The analogy used in the generated answer is also incorrect as it introduces magnets, which are not part of the original analogy or the theory of general relativity. These errors significantly affect the correctness of the information provided.'"
+       "'The generated answer is relevant to the user query, but there are significant discrepancies in the concepts mentioned. The theory of general relativity is incorrectly described as being related to magnetism and magnetic fields, which is not accurate. The reference answer correctly states that general relativity is about the warping of space and time by mass and energy, not magnetic fields.'"
       ]
      },
      "execution_count": null,
@@ -124,6 +151,9 @@
   }
  ],
  "metadata": {
+  "colab": {
+   "provenance": []
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -28,10 +28,10 @@ On a separate line provide your reasoning for the score as well.
 Follow these guidelines for scoring:
 - Your score has to be between 1 and 5, where 1 is the worst and 5 is the best.
 - If the generated answer is not relevant to the user query, you should give a score of 1.
-- If the generated answer is relevant but there are discrepancies in the names, dates, years, places, concepts or organizations mentioned, and these do not align with either the query or the reference answer, you should assign a score between 2 and 2.5
+- If the generated answer is relevant but there are discrepancies in the names, dates, years, places, concepts or organizations mentioned, and these do not align with either the query or the reference answer, you should give a score between 2 and 2.5
 - If the answer is mostly relevant but lacks some details, give it a score between 2.5 and 3.5 based on how much and how important the missing details are.
 - If the generated answer is relevant and has all the necessary information but has extra details that are not needed, give it a score between 3.5 and 4.
-- If the generated answer is factually similar to the reference answer, is accurate, and doesn't include extra details, it should receive a score of 4 to 5.
+- If the generated answer is factually similar to the reference answer, is accurate, and doesn't include extra details, give it a score between 4 and 5.
 
 Example Response:
 4.0

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -27,18 +27,15 @@ On a separate line provide your reasoning for the score as well.
 
 Follow these guidelines for scoring:
 - Your score has to be between 1 and 5, where 1 is the worst and 5 is the best.
-- If the generated answer is not relevant to the user query, \
-you should give a score of 1.
-- If the generated answer is relevant but contains mistakes, \
-you should give a score between 2 and 3.
-- If the generated answer is relevant and fully correct, \
-you should give a score between 4 and 5.
+- If the generated answer is not relevant to the user query, you should give a score of 1.
+- If the generated answer is relevant but there are discrepancies in the names, dates, years, places, concepts or organizations mentioned, and these do not align with either the query or the reference answer, you should assign a score between 2 and 2.5
+- If the answer is mostly relevant but lacks some details, give it a score between 2.5 and 3.5 based on how much and how important the missing details are.
+- If the generated answer is relevant and has all the necessary information but has extra details that are not needed, give it a score between 3.5 and 4.
+- If the generated answer is factually similar to the reference answer, is accurate, and doesn't include extra details, it should receive a score of 4 to 5.
 
 Example Response:
 4.0
-The generated answer has the exact same metrics as the reference answer, \
-    but it is not as concise.
-
+The generated answer has the exact same metrics as the reference answer, but it is not as concise.
 """
 
 DEFAULT_USER_TEMPLATE = """


### PR DESCRIPTION
# Description
Updates the Correctness Evaluator module's default prompt to bring more concise and detailed rules which more strongly penalizes hallucinations and discrepancies in entities and concepts between generated answer and the reference answer.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.
- [x] Updated an evaluation metric to make it more robust

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] Updated the older notebook and dev tested with respect to the new changes 

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
