### PR TITLE
Adapt Cassandra VectorStore constructor DB connection through cassio.init

### DIFF
--- a/docs/community/integrations/vector_stores.md
+++ b/docs/community/integrations/vector_stores.md
@@ -264,31 +264,22 @@ vector_store = QdrantVectorStore(
 )
 ```
 
-**Cassandra** (covering DataStax Astra DB as well, which is built on Cassandra)
+**Cassandra** (covering DataStax Astra DB cloud instances as well)
 
 ```python
-from cassandra.cluster import Cluster
-from cassandra.auth import PlainTextAuthProvider
 from llama_index.vector_stores import CassandraVectorStore
+import cassio
 
-# for a Cassandra cluster:
+# For an Astra DB cloud instance:
+cassio.init(database_id="1234abcd-...", token="AstraCS:...")
+
+# For a Cassandra cluster:
+from cassandra.cluster import Cluster
 cluster = Cluster(["127.0.0.1"])
-# for an Astra DB cloud instance:
-cluster = Cluster(
-  cloud={"secure_connect_bundle": "/home/USER/secure-bundle.zip"},
-  auth_provider=PlainTextAuthProvider("token", "AstraCS:...")
-)
-#
-session = cluster.connect()
-keyspace = "my_cassandra_keyspace"
+cassio.init(session=cluster.connect(), keyspace="my_keyspace")
 
-vector_store = CassandraVectorStore(
-    session=session,
-    keyspace=keyspace,
-    table="llamaindex_vector_test_1",
-    embedding_dimension=1536,
-    #insertion_batch_size=50,  # optional
-)
+# After the abive `cassio.init(...)`, create a vector store:
+vector_store = CassandraVectorStore(table="cass_v_table", embedding_dimension=1536)
 ```
 
 **Chroma**

--- a/docs/community/integrations/vector_stores.md
+++ b/docs/community/integrations/vector_stores.md
@@ -278,7 +278,7 @@ from cassandra.cluster import Cluster
 cluster = Cluster(["127.0.0.1"])
 cassio.init(session=cluster.connect(), keyspace="my_keyspace")
 
-# After the abive `cassio.init(...)`, create a vector store:
+# After the above `cassio.init(...)`, create a vector store:
 vector_store = CassandraVectorStore(table="cass_v_table", embedding_dimension=1536)
 ```
 

--- a/docs/examples/vector_stores/CassandraIndexDemo.ipynb
+++ b/docs/examples/vector_stores/CassandraIndexDemo.ipynb
@@ -18,7 +18,11 @@
     "\n",
     "**This notebook shows the basic usage of Cassandra as a Vector Store in LlamaIndex.**\n",
     "\n",
-    "To run this notebook you need either a running Cassandra cluster equipped with Vector Search capabilities (in pre-release at the time of writing) or a DataStax Astra DB instance running in the cloud (you can get one for free at [datastax.com](https://astra.datastax.com)). _This notebook covers both choices._ Check [cassio.org](https://cassio.org/start_here/) for more information, quickstarts and tutorials."
+    "To run this notebook you need either a running Cassandra cluster equipped with Vector \n",
+    "Search capabilities (in pre-release at the time of writing) or a DataStax Astra DB instance\n",
+    " running in the cloud (you can get one for free at [datastax.com](https://astra.datastax.com)).\n",
+    " _This notebook shows the latter choice; check\n",
+    " [cassio.org](https://cassio.org/start_here/) for more information, quickstarts and tutorials._"
    ]
   },
   {
@@ -34,9 +38,17 @@
    "execution_count": null,
    "id": "e9f8dbcb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "...\n"
+     ]
+    }
+   ],
    "source": [
-    "!pip install \"cassio>=0.1.0\""
+    "!pip install \"cassio>=0.1.3\""
    ]
   },
   {
@@ -64,9 +76,9 @@
    "source": [
     "### Please provide database connection parameters and secrets\n",
     "\n",
-    "First you need a database connection (a `cassandra.cluster.Session` object).\n",
+    "Now you need a database connection. Make sure you have either a vector-capable running Cassandra cluster or an [Astra DB](https://astra.datastax.com) instance in the cloud.\n",
     "\n",
-    "Make sure you have either a vector-capable running Cassandra cluster or an [Astra DB](https://astra.datastax.com) instance in the cloud."
+    "_In the following, the former is assumed (see the references at the top for details)._"
    ]
   },
   {
@@ -80,12 +92,9 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "(C)assandra or (A)stra DB?  A\n",
+      "Please enter your Database ID (e.g. '0123abcd...'): 0123abcd-01ab-01ab-01ab-012345abcdef\n",
       "\n",
-      "Keyspace name?  llama_index_demo\n",
-      "\n",
-      "Astra DB Token (\"AstraCS:...\")  ········\n",
-      "Full path to your Secure Connect Bundle?  /path/to/secure-connect-DATABASE.zip\n"
+      "Please enter your 'Database Administrator' Token (e.g. 'AstraCS:...'): ········\n"
      ]
     }
    ],
@@ -93,22 +102,18 @@
     "import os\n",
     "import getpass\n",
     "\n",
-    "database_mode = (input(\"\\n(C)assandra or (A)stra DB? \")).upper()\n",
-    "\n",
-    "keyspace_name = input(\"\\nKeyspace name? \")\n",
-    "\n",
-    "if database_mode == \"A\":\n",
-    "    ASTRA_DB_APPLICATION_TOKEN = getpass.getpass(\n",
-    "        '\\nAstra DB Token (\"AstraCS:...\") '\n",
-    "    )\n",
-    "    #\n",
-    "    ASTRA_DB_SECURE_BUNDLE_PATH = input(\n",
-    "        \"Full path to your Secure Connect Bundle? \"\n",
-    "    )\n",
-    "elif database_mode == \"C\":\n",
-    "    CASSANDRA_CONTACT_POINTS = input(\n",
-    "        \"Contact points? (comma-separated, empty for localhost) \"\n",
-    "    ).strip()"
+    "database_id = input(\"\\nPlease enter your Database ID (e.g. '0123abcd...'):\")\n",
+    "token = getpass.getpass(\n",
+    "    \"\\nPlease enter your 'Database Administrator' Token (e.g. 'AstraCS:...'):\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3baa9719-556c-457e-9c6d-fe10f653e9b0",
+   "metadata": {},
+   "source": [
+    "This cell sets the database connection as a global `cassio` property for usage later (it is also possible to explicitly supply a DB connection when creating the vector store):"
    ]
   },
   {
@@ -118,35 +123,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cassandra.cluster import Cluster\n",
-    "from cassandra.auth import PlainTextAuthProvider\n",
+    "import cassio\n",
     "\n",
-    "if database_mode == \"C\":\n",
-    "    if CASSANDRA_CONTACT_POINTS:\n",
-    "        cluster = Cluster(\n",
-    "            [\n",
-    "                cp.strip()\n",
-    "                for cp in CASSANDRA_CONTACT_POINTS.split(\",\")\n",
-    "                if cp.strip()\n",
-    "            ]\n",
-    "        )\n",
-    "    else:\n",
-    "        cluster = Cluster()\n",
-    "    session = cluster.connect()\n",
-    "elif database_mode == \"A\":\n",
-    "    ASTRA_DB_CLIENT_ID = \"token\"\n",
-    "    cluster = Cluster(\n",
-    "        cloud={\n",
-    "            \"secure_connect_bundle\": ASTRA_DB_SECURE_BUNDLE_PATH,\n",
-    "        },\n",
-    "        auth_provider=PlainTextAuthProvider(\n",
-    "            ASTRA_DB_CLIENT_ID,\n",
-    "            ASTRA_DB_APPLICATION_TOKEN,\n",
-    "        ),\n",
-    "    )\n",
-    "    session = cluster.connect()\n",
-    "else:\n",
-    "    raise NotImplementedError"
+    "cassio.init(database_id=database_id, token=token)"
    ]
   },
   {
@@ -201,17 +180,17 @@
      "output_type": "stream",
      "text": [
       "Total documents: 1\n",
-      "First document, id: 5b7489b6-0cca-4088-8f30-6de32d540fdf\n",
-      "First document, hash: 4c702b4df575421e1d1af4b1fd50511b226e0c9863dbfffeccb8b689b8448f35\n",
-      "First document, text (75019 characters):\n",
+      "First document, id: 7c966f42-36f4-4ff6-ad75-357978a65381\n",
+      "First document, hash: 2e2d9629223c077019a6dde689049344ff2293d6c52372871420119ec049f25c\n",
+      "First document, text (75014 characters):\n",
       "====================\n",
-      "\t\t\n",
+      "\n",
       "\n",
       "What I Worked On\n",
       "\n",
       "February 2021\n",
       "\n",
-      "Before college the two main things I worked on, outside of school, were writing and programming. I didn't write essays. I wrote what beginning writers were supposed to write then, and probably still are: short stories. My stories were awful. They had hardly any plot, just characters with strong feelings, which I imagined  ...\n"
+      "Before college the two main things I worked on, outside of school, were writing and programming. I didn't write essays. I wrote what beginning writers were supposed to write then, and probably still are: short stories. My stories were awful. They had hardly any plot, just characters with strong feelings, which I imagined ma ...\n"
      ]
     }
    ],
@@ -245,10 +224,7 @@
    "outputs": [],
    "source": [
     "cassandra_store = CassandraVectorStore(\n",
-    "    session=session,\n",
-    "    keyspace=keyspace_name,\n",
-    "    table=\"cassandra_vector_table_1\",\n",
-    "    embedding_dimension=1536,\n",
+    "    table=\"cass_v_table\", embedding_dimension=1536\n",
     ")"
    ]
   },
@@ -308,8 +284,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "The author chose to work on AI because of his fascination with the novel The Moon is a Harsh Mistress, which featured an intelligent computer called Mike, and a PBS documentary that showed Terry Winograd using SHRDLU. He was also drawn to the idea that AI could be used to explore the ultimate truths that other fields could not.\n"
+      "The author chose to work on AI because they were inspired by a novel called \"The Moon is a Harsh Mistress\" by Heinlein, which featured an intelligent computer called Mike. Additionally, they were influenced by a PBS documentary that showed Terry Winograd using SHRDLU, a program that they believed could be improved by teaching it more words.\n"
      ]
     }
    ],
@@ -339,8 +314,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "The author chose to work on AI because he was impressed and envious of his friend who had built a computer kit and was able to type programs into it. He was also inspired by a novel by Heinlein called The Moon is a Harsh Mistress, which featured an intelligent computer called Mike, and a PBS documentary that showed Terry Winograd using SHRDLU. He was also disappointed with philosophy courses in college, which he found to be boring, and he wanted to work on something that seemed more powerful.\n"
+      "The author chose to work on AI because they believed that it was a field that held promise and potential for advancing the understanding of natural language and intelligence. They were initially drawn to AI because of their fascination with the program SHRDLU, which they considered to be a step towards achieving intelligence. However, as they delved deeper into the field, they realized that the existing approaches to AI, which involved explicit data structures and formal representations, were limited and not capable of truly understanding natural language. Despite this realization, the author still found value in working on AI and decided to focus on Lisp, a programming language associated with AI, as they believed it was interesting in its own right.\n"
      ]
     }
    ],
@@ -368,10 +342,7 @@
    "outputs": [],
    "source": [
     "new_store_instance = CassandraVectorStore(\n",
-    "    session=session,\n",
-    "    keyspace=keyspace_name,\n",
-    "    table=\"cassandra_vector_table_1\",\n",
-    "    embedding_dimension=1536,\n",
+    "    table=\"cass_v_table\", embedding_dimension=1536\n",
     ")\n",
     "\n",
     "# Create index (from preexisting stored vectors)\n",
@@ -396,9 +367,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "\n",
-      "The author studied philosophy and painting, worked on spam filters, and wrote essays prior to working on AI.\n"
+      "The author studied painting and drawing prior to working on AI.\n"
      ]
     }
    ],
@@ -444,19 +413,23 @@
      "output_type": "stream",
      "text": [
       "Found 3 nodes.\n",
-      "    [0] score = 0.42589144520149874\n",
-      "        id    = 05f53f06-9905-461a-bc6d-fa4817e5a776\n",
+      "    [0] score = 0.42933435561941374\n",
+      "        id    = 7734b895-a738-4c56-a433-d24a80179759\n",
       "        text  = What I Worked On\n",
       "\n",
       "February 2021\n",
       "\n",
       "Before college the two main things I worked on, outside o ...\n",
-      "    [1] score = -0.0012061281453193962\n",
-      "        id    = 2f9f843e-6495-4646-a03d-4b844ff7c1ab\n",
-      "        text  = been explored. But all I wanted was to get out of grad school, and my rapidly written diss ...\n",
-      "    [2] score = 0.025454533089838027\n",
-      "        id    = 28ad32da-25f9-4aaa-8487-88390ec13348\n",
-      "        text  = showed Terry Winograd using SHRDLU. I haven't tried rereading The Moon is a Harsh Mistress ...\n"
+      "    [1] score = 0.002203557726127847\n",
+      "        id    = fea6c20f-e707-4c66-be3f-f963639def30\n",
+      "        text  = Now all I had to do was learn Italian.\n",
+      "\n",
+      "Only stranieri (foreigners) had to take this entra ...\n",
+      "    [2] score = 0.022935334418004605\n",
+      "        id    = cf09e631-ab10-4355-923a-b9711c197600\n",
+      "        text  = All you had to do was teach SHRDLU more words.\n",
+      "\n",
+      "There weren't any classes in AI at Cornell ...\n"
      ]
     }
    ],
@@ -487,9 +460,9 @@
      "output_type": "stream",
      "text": [
       "Nodes' ref_doc_id:\n",
-      "5b7489b6-0cca-4088-8f30-6de32d540fdf\n",
-      "5b7489b6-0cca-4088-8f30-6de32d540fdf\n",
-      "5b7489b6-0cca-4088-8f30-6de32d540fdf\n"
+      "7c966f42-36f4-4ff6-ad75-357978a65381\n",
+      "7c966f42-36f4-4ff6-ad75-357978a65381\n",
+      "7c966f42-36f4-4ff6-ad75-357978a65381\n"
      ]
     }
    ],
@@ -567,10 +540,7 @@
    "source": [
     "md_storage_context = StorageContext.from_defaults(\n",
     "    vector_store=CassandraVectorStore(\n",
-    "        session=session,\n",
-    "        keyspace=keyspace_name,\n",
-    "        table=\"cassandra_vector_table_2_md\",\n",
-    "        embedding_dimension=1536,\n",
+    "        table=\"cass_v_table_md\", embedding_dimension=1536\n",
     "    )\n",
     ")\n",
     "\n",
@@ -624,8 +594,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "It took the author five weeks to write his thesis.\n"
+      "It took the author approximately 5 weeks to write his thesis.\n"
      ]
     }
    ],

--- a/tests/vector_stores/test_cassandra.py
+++ b/tests/vector_stores/test_cassandra.py
@@ -27,10 +27,10 @@ class TestCassandraVectorStore(unittest.TestCase):
             sys.modules["cassio"] = mock_cassio
         #
         vector_store = CassandraVectorStore(
-            session=mock_db_session,
-            keyspace="keyspace",
             table="table",
             embedding_dimension=2,
+            session=mock_db_session,
+            keyspace="keyspace",
             ttl_seconds=123,
         )
 
@@ -62,10 +62,10 @@ class TestCassandraVectorStore(unittest.TestCase):
             sys.modules["cassio"] = mock_cassio
         #
         vector_store = CassandraVectorStore(
-            session=mock_db_session,
-            keyspace="keyspace",
             table="table",
             embedding_dimension=2,
+            session=mock_db_session,
+            keyspace="keyspace",
             ttl_seconds=123,
         )
         # q1: default


### PR DESCRIPTION
# Description

The `cassio` library underlying the Cassandra Vector Store integration has gained a global `cassio.init(...)` method that sets a globally-available database connection. This way, for all subsequently created CassIO table abstractions (such as the one behind LlamaIndex's `CassandraVectorStore`, the connection parameters `session` and `keyspace` can be left out entirely, in that case falling back to the global values.

This PR adapts LlamaIndex' class signature to this usage, essentially making the `session` and `keyspace` parameters of `CassandraVectorStore` optional as well.

### A slightly breaking change in the `__init__`

I am aware that this introduces a slight breaking change, limited to former instantiations being done passing _positional_ arguments. That is, keyword-based existing code does not suffer any disturbance, but the (IMO almost nonexistent) positionally-specified constructions such as this one would raise an error with this PR:

```
my_v_store = CassandraVectorStore(
  my_session,
  my_keyspace,
  table="my_table_name",
  ...
)
```

While I think that enabling use of the `cassio.init(...)` handy method, on the long run, vastly overweighs the discomfort of having to revise usages like the above, I took care of:
- rephrasing the docstring for the `__init__` method to make it as clear as possible how the code should be changed to work again;
- enforcing, with the `*` special argument, a keyword-only syntax from now on for the `__init__`. This well matches the keyword-based examples that we provide everywhere and would prevent future similar trouble, and incidentally results in an error message from the occasional legacy positional-based usage that points to the actual proper cause of the error.

I would be happy to discuss the motivation behind this choice in more detail! Thank you for a review!