### PR TITLE
Update flat_metadata to False in PineconeVectorStore

### DIFF
--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -120,7 +120,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
     """
 
     stores_text: bool = True
-    flat_metadata: bool = True
+    flat_metadata: bool = False
 
     api_key: Optional[str]
     index_name: Optional[str]


### PR DESCRIPTION
# Description

Updated default value of flat_metadata = False so that support for metadata to an array of values works without causing any error. It is done only in PineconeVectorStore.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
