### PR TITLE
Brought back `toml-sort` to `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,8 @@ repos:
     hooks:
       - id: nb-clean
         args: [--preserve-cell-outputs, --remove-empty-cells]
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.23.1
+    hooks:
+      - id: toml-sort-fix
+        exclude: poetry.lock

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format:	## Run code autoformatters (black).
 	pre-commit run black-jupyter --all-files
 
 lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
-	pre-commit install && pre-commit run --all-files
+	pre-commit install && pre-commit run --all-files --show-diff-on-failure
 	mypy .
 
 test:	## Run tests via pytest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,3 +232,6 @@ in_place = true
 spaces_before_inline_comment = 2  # Match Python PEP 8
 spaces_indent_inline_array = 4  # Match Python PEP 8
 trailing_comma_inline_array = true
+
+[tool.tomlsort.overrides."tool.poetry.dependencies"]
+table_keys = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ tiktoken = ">=0.3.3"
 typing-extensions = ">=4.5.0"
 typing-inspect = ">=0.8.0"
 urllib3 = "<2"
-asyncpg = {version = "^0.28.0", optional = true}
+asyncpg = {optional = true, version = "^0.28.0"}
 pgvector = {optional = true, version = "^0.1.0"}
 psycopg-binary = {optional = true, version = "^3.1.12"}
 optimum = {extras = ["onnxruntime"], optional = true, version = "^1.13.2"}
@@ -88,13 +88,13 @@ query_tools = [
     "spacy",
 ]
 
-
 [tool.poetry.group.dev.dependencies]
 beautifulsoup4 = "^4.12.2"  # needed for tests
 black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
 codespell = {extras = ["toml"], version = ">=v2.2.6"}
 google-generativeai = {python = ">=3.9,<3.12", version = "^0.2.1"}
 ipython = "8.10.0"
+jupyter = "^1.0.0"
 mypy = "0.991"
 pre-commit = "3.2.0"
 pylint = "2.15.10"
@@ -111,7 +111,6 @@ types-redis = "4.5.5.0"
 types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 vellum-ai = "^0.0.42"
-jupyter = "^1.0.0"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
# Description

https://github.com/run-llama/llama_index/pull/8236 removed `toml-sort` from `pre-commit` because it was making undesired changes.  It seems the undesired changes were:
- Sorting `tool.poetry.dependencies` in `pyproject.toml`
- Sorting `poetry.lock`

This PR blocks those two areas, and brings `toml-sort` back.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
