### PR TITLE
Backdoor to defeat MPS backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## Unreleased
+
+### New Features
+
+- New env var `LLAMA_INDEX_NO_MPS_BACKEND` to disable inference of when to use
+  the MPS backend (#8274)
+
 ## [0.8.49] - 2023-10-23
 
 ### New Features

--- a/llama_index/utils.py
+++ b/llama_index/utils.py
@@ -418,6 +418,8 @@ def infer_torch_device() -> str:
         has_cuda = torch.cuda.is_available()
     if has_cuda:
         return "cuda"
-    if torch.backends.mps.is_available():
+    # Set LLAMA_INDEX_NO_MPS_BACKEND to a truthy value to disable inference of MPS
+    dont_use_mps = os.getenv("LLAMA_INDEX_NO_MPS_BACKEND", default="")
+    if not dont_use_mps and torch.backends.mps.is_available():
         return "mps"
     return "cpu"


### PR DESCRIPTION
# Description

PyTorch's MPS backend is a WIP: https://github.com/pytorch/pytorch/issues/77764

Thus, let's add a backdoor to use CPU backend over MPS for macOS

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
