### PR TITLE
`Pooling` in `HuggingFaceEmbedding` with PyTorch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - Add Amazon `BedrockEmbedding` (#8550)
+- Moves `HuggingFaceEmbedding` to center on `Pooling` enum for pooling (#8467)
 
 ## [0.8.55] - 2023-10-29
 

--- a/llama_index/embeddings/huggingface.py
+++ b/llama_index/embeddings/huggingface.py
@@ -75,7 +75,9 @@ class HuggingFaceEmbedding(BaseEmbedding):
                 if model_name is not None
                 else DEFAULT_HUGGINGFACE_EMBEDDING_MODEL
             )
-            model = AutoModel.from_pretrained(model_name, cache_dir=cache_folder, trust_remote_code=trust_remote_code)
+            model = AutoModel.from_pretrained(
+                model_name, cache_dir=cache_folder, trust_remote_code=trust_remote_code
+            )
         elif model_name is None:  # Extract model_name from model
             model_name = model.name_or_path
         self._model = model.to(self._device)

--- a/llama_index/embeddings/pooling.py
+++ b/llama_index/embeddings/pooling.py
@@ -1,6 +1,10 @@
 from enum import Enum
+from typing import TYPE_CHECKING, Union, overload
 
 import numpy as np
+
+if TYPE_CHECKING:
+    import torch
 
 
 class Pooling(str, Enum):
@@ -15,7 +19,19 @@ class Pooling(str, Enum):
         return self.mean_pooling(array)
 
     @classmethod
+    @overload
     def cls_pooling(cls, array: np.ndarray) -> np.ndarray:
+        ...
+
+    @classmethod
+    @overload
+    def cls_pooling(cls, array: "torch.Tensor") -> "torch.Tensor":
+        ...
+
+    @classmethod
+    def cls_pooling(
+        cls, array: "Union[np.ndarray, torch.Tensor]"
+    ) -> "Union[np.ndarray, torch.Tensor]":
         if len(array.shape) == 3:
             return array[:, 0]
         if len(array.shape) == 2:


### PR DESCRIPTION
# Description

- Cleans up `HuggingFaceEmbedding.__init__` to make control flows more explicit
    - Fixes control flow where `model_name` or `tokenizer_name can be left as `None`
- Adds support for `torch.Tensor` in `Pooling.CLS`
- Moves `HuggingFaceEmbedding.pooling` to use the `Pooling` enum
- Removed `torch` dependency for `HuggingFaceEmbedding._mean_pooling`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
