### PR TITLE
add `is_chat_model` to replicate

### DIFF
--- a/llama_index/llms/replicate.py
+++ b/llama_index/llms/replicate.py
@@ -50,7 +50,7 @@ class Replicate(CustomLLM):
         messages_to_prompt: Optional[Callable] = None,
         completion_to_prompt: Optional[Callable] = None,
         callback_manager: Optional[CallbackManager] = None,
-        is_chat_model: bool = False
+        is_chat_model: bool = False,
     ) -> None:
         self._messages_to_prompt = messages_to_prompt or generic_messages_to_prompt
         self._completion_to_prompt = completion_to_prompt or (lambda x: x)
@@ -62,7 +62,7 @@ class Replicate(CustomLLM):
             context_window=context_window,
             prompt_key=prompt_key,
             callback_manager=callback_manager,
-            is_chat_model=is_chat_model
+            is_chat_model=is_chat_model,
         )
 
     @classmethod
@@ -76,7 +76,7 @@ class Replicate(CustomLLM):
             context_window=self.context_window,
             num_output=DEFAULT_NUM_OUTPUTS,
             model_name=self.model,
-            is_chat_model=self.is_chat_model
+            is_chat_model=self.is_chat_model,
         )
 
     @property

--- a/llama_index/llms/replicate.py
+++ b/llama_index/llms/replicate.py
@@ -33,6 +33,9 @@ class Replicate(CustomLLM):
     additional_kwargs: Dict[str, Any] = Field(
         default_factory=dict, description="Additional kwargs for the Replicate API."
     )
+    is_chat_model: bool = Field(
+        default=False, description="Whether the model is a chat model."
+    )
 
     _messages_to_prompt: Callable = PrivateAttr()
     _completion_to_prompt: Callable = PrivateAttr()
@@ -47,6 +50,7 @@ class Replicate(CustomLLM):
         messages_to_prompt: Optional[Callable] = None,
         completion_to_prompt: Optional[Callable] = None,
         callback_manager: Optional[CallbackManager] = None,
+        is_chat_model: bool = False
     ) -> None:
         self._messages_to_prompt = messages_to_prompt or generic_messages_to_prompt
         self._completion_to_prompt = completion_to_prompt or (lambda x: x)
@@ -58,6 +62,7 @@ class Replicate(CustomLLM):
             context_window=context_window,
             prompt_key=prompt_key,
             callback_manager=callback_manager,
+            is_chat_model=is_chat_model
         )
 
     @classmethod
@@ -71,6 +76,7 @@ class Replicate(CustomLLM):
             context_window=self.context_window,
             num_output=DEFAULT_NUM_OUTPUTS,
             model_name=self.model,
+            is_chat_model=self.is_chat_model
         )
 
     @property


### PR DESCRIPTION
was playing around with some replicate models, we should allow user to specify which models are chat models to use the chat-based prompts 