### PR TITLE
add prompt template variable mapping

### DIFF
--- a/llama_index/prompts/base.py
+++ b/llama_index/prompts/base.py
@@ -31,9 +31,7 @@ class BasePromptTemplate(BaseModel, ABC):
     def _map_template_vars(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """For keys in template_var_mappings, swap in the right keys."""
         template_var_mappings = self.template_var_mappings or {}
-        return {
-            template_var_mappings.get(k, k): v for k, v in kwargs.items()
-        }
+        return {template_var_mappings.get(k, k): v for k, v in kwargs.items()}
 
     class Config:
         arbitrary_types_allowed = True
@@ -182,7 +180,7 @@ class ChatPromptTemplate(BasePromptTemplate):
                 k: v for k, v in mapped_all_kwargs.items() if k in template_vars
             }
             content_template = message_template.content or ""
-            
+
             # if there's mappings specified, make sure those are used
             content = content_template.format(**relevant_kwargs)
 

--- a/llama_index/prompts/base.py
+++ b/llama_index/prompts/base.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from pydantic import Field
+
 from llama_index.bridge.langchain import BasePromptTemplate as LangchainTemplate
 from llama_index.bridge.langchain import ConditionalPromptSelector as LangchainSelector
 from llama_index.bridge.pydantic import BaseModel
@@ -22,6 +24,14 @@ class BasePromptTemplate(BaseModel, ABC):
     template_vars: List[str]
     kwargs: Dict[str, str]
     output_parser: Optional[BaseOutputParser]
+    template_var_mappings: Dict[str, Any] = Field(
+        default_factory=dict, description="Template variable mappings (Optional)."
+    )
+
+    def _map_template_vars(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            k: kwargs.get(v, v) for k, v in self.template_var_mappings.items()
+        }
 
     class Config:
         arbitrary_types_allowed = True
@@ -54,6 +64,7 @@ class PromptTemplate(BasePromptTemplate):
         prompt_type: str = PromptType.CUSTOM,
         output_parser: Optional[BaseOutputParser] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        template_var_mappings: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         if metadata is None:
@@ -61,6 +72,7 @@ class PromptTemplate(BasePromptTemplate):
         metadata["prompt_type"] = prompt_type
 
         template_vars = get_template_vars(template)
+        template_var_mappings = template_var_mappings or {}
 
         super().__init__(
             template=template,
@@ -68,6 +80,7 @@ class PromptTemplate(BasePromptTemplate):
             kwargs=kwargs,
             metadata=metadata,
             output_parser=output_parser,
+            template_var_mappings=template_var_mappings,
         )
 
     def partial_format(self, **kwargs: Any) -> "PromptTemplate":
@@ -91,7 +104,10 @@ class PromptTemplate(BasePromptTemplate):
             **kwargs,
         }
 
-        prompt = self.template.format(**all_kwargs)
+        # if there's mappings specified, make sure those are used
+        mapped_kwargs = self._map_template_vars(all_kwargs)
+
+        prompt = self.template.format(**mapped_kwargs)
         if self.output_parser is not None:
             prompt = self.output_parser.format(prompt)
         return prompt
@@ -117,6 +133,7 @@ class ChatPromptTemplate(BasePromptTemplate):
         prompt_type: str = PromptType.CUSTOM,
         output_parser: Optional[BaseOutputParser] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        template_var_mappings: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ):
         if metadata is None:
@@ -133,6 +150,7 @@ class ChatPromptTemplate(BasePromptTemplate):
             metadata=metadata,
             output_parser=output_parser,
             template_vars=template_vars,
+            template_var_mappings=template_var_mappings,
         )
 
     def partial_format(self, **kwargs: Any) -> "ChatPromptTemplate":
@@ -162,7 +180,10 @@ class ChatPromptTemplate(BasePromptTemplate):
                 k: v for k, v in all_kwargs.items() if k in template_vars
             }
             content_template = message_template.content or ""
-            content = content_template.format(**relevant_kwargs)
+            
+            # if there's mappings specified, make sure those are used
+            mapped_relevant_kwargs = self._map_template_vars(relevant_kwargs)
+            content = content_template.format(**mapped_relevant_kwargs)
 
             message: ChatMessage = message_template.copy()
             message.content = content
@@ -259,6 +280,7 @@ class LangchainPromptTemplate(BasePromptTemplate):
         output_parser: Optional[BaseOutputParser] = None,
         prompt_type: str = PromptType.CUSTOM,
         metadata: Optional[Dict[str, Any]] = None,
+        template_var_mappings: Optional[Dict[str, Any]] = None,
     ) -> None:
         if selector is None:
             if template is None:
@@ -282,6 +304,7 @@ class LangchainPromptTemplate(BasePromptTemplate):
             kwargs=kwargs,
             template_vars=template_vars,
             output_parser=output_parser,
+            template_var_mappings=template_var_mappings,
         )
 
     def partial_format(self, **kwargs: Any) -> "BasePromptTemplate":
@@ -305,7 +328,9 @@ class LangchainPromptTemplate(BasePromptTemplate):
         else:
             lc_template = self.selector.default_prompt
 
-        return lc_template.format(**kwargs)
+        # if there's mappings specified, make sure those are used
+        mapped_kwargs = self._map_template_vars(kwargs)
+        return lc_template.format(**mapped_kwargs)
 
     def format_messages(
         self, llm: Optional[LLM] = None, **kwargs: Any

--- a/tests/prompts/test_base.py
+++ b/tests/prompts/test_base.py
@@ -194,22 +194,28 @@ Given the context, please answer the final question:
         qa_prompt_tmpl, template_var_mappings=template_var_mappings
     )
     fmt_prompt = qa_prompt.format(query_str="abc", context_str="def")
-    assert fmt_prompt == """\
+    assert (
+        fmt_prompt
+        == """\
 Here's some context:
 def
 Given the context, please answer the final question:
 abc
 """
+    )
     # try partial format
     qa_prompt_partial = qa_prompt.partial_format(query_str="abc2")
     fmt_prompt_partial = qa_prompt_partial.format(context_str="def2")
-    assert fmt_prompt_partial == """\
+    assert (
+        fmt_prompt_partial
+        == """\
 Here's some context:
 def2
 Given the context, please answer the final question:
 abc2
 """
-    
+    )
+
     # try chat prompt template
     # partial template var mapping
     template_var_mappings = {
@@ -235,4 +241,3 @@ abc2
         "user: hello def abc\n"
         "assistant: "
     )
-        

--- a/tests/prompts/test_base.py
+++ b/tests/prompts/test_base.py
@@ -175,3 +175,64 @@ def test_langchain_selector_template() -> None:
     assert isinstance(template, LangchainPromptTemplate)
 
     assert template_fmt.format(llm=mock_llm, text="world") == "hello world bar mock"
+
+
+def test_template_var_mappings() -> None:
+    """Test template variable mappings."""
+    qa_prompt_tmpl = """\
+Here's some context:
+{foo}
+Given the context, please answer the final question:
+{bar}
+"""
+    template_var_mappings = {
+        "context_str": "foo",
+        "query_str": "bar",
+    }
+    # try regular prompt template
+    qa_prompt = PromptTemplate(
+        qa_prompt_tmpl, template_var_mappings=template_var_mappings
+    )
+    fmt_prompt = qa_prompt.format(query_str="abc", context_str="def")
+    assert fmt_prompt == """\
+Here's some context:
+def
+Given the context, please answer the final question:
+abc
+"""
+    # try partial format
+    qa_prompt_partial = qa_prompt.partial_format(query_str="abc2")
+    fmt_prompt_partial = qa_prompt_partial.format(context_str="def2")
+    assert fmt_prompt_partial == """\
+Here's some context:
+def2
+Given the context, please answer the final question:
+abc2
+"""
+    
+    # try chat prompt template
+    # partial template var mapping
+    template_var_mappings = {
+        "context_str": "foo",
+        "query_str": "bar",
+    }
+    chat_template = ChatPromptTemplate(
+        message_templates=[
+            ChatMessage(
+                content="This is a system message with a {sys_param}",
+                role=MessageRole.SYSTEM,
+            ),
+            ChatMessage(content="hello {foo} {bar}", role=MessageRole.USER),
+        ],
+        prompt_type=PromptType.CONVERSATION,
+        template_var_mappings=template_var_mappings,
+    )
+    fmt_prompt = chat_template.format(
+        query_str="abc", context_str="def", sys_param="sys_arg"
+    )
+    assert fmt_prompt == (
+        "system: This is a system message with a sys_arg\n"
+        "user: hello def abc\n"
+        "assistant: "
+    )
+        


### PR DESCRIPTION
# Description

Allows users to specify prompts with other template variable keys, but define a mapping from the "expected" template var names to the var names they actually have in the prompt.
