### PR TITLE
Fix : VectorStore’s QueryResult always returns saved Node as TextNode

### DIFF
--- a/llama_index/vector_stores/utils.py
+++ b/llama_index/vector_stores/utils.py
@@ -1,7 +1,13 @@
 import json
 from typing import Any, Dict, Tuple
 
-from llama_index.schema import BaseNode, NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    IndexNode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 
 DEFAULT_TEXT_KEY = "text"
 DEFAULT_EMBEDDING_KEY = "embedding"
@@ -44,6 +50,7 @@ def node_to_metadata_dict(
 
     # dump remainder of node_dict to json string
     metadata["_node_content"] = json.dumps(node_dict)
+    metadata["_node_type"] = node.get_type()
 
     # store ref doc id at top level to allow metadata filtering
     # kept for backwards compatibility, will consolidate in future
@@ -54,13 +61,17 @@ def node_to_metadata_dict(
     return metadata
 
 
-def metadata_dict_to_node(metadata: dict) -> TextNode:
+def metadata_dict_to_node(metadata: dict) -> BaseNode:
     """Common logic for loading Node data from metadata dict."""
     node_json = metadata.get("_node_content", None)
+    node_type = metadata.get("_node_type", None)
     if node_json is None:
         raise ValueError("Node content not found in metadata dict.")
 
-    return TextNode.parse_raw(node_json)
+    if node_type == IndexNode.get_type():
+        return IndexNode.parse_raw(node_json)
+    else:
+        return TextNode.parse_raw(node_json)
 
 
 # TODO: Deprecated conversion functions

--- a/tests/vector_stores/test_postgres.py
+++ b/tests/vector_stores/test_postgres.py
@@ -2,7 +2,13 @@ import asyncio
 from typing import Any, Dict, Generator, List, Union, cast
 
 import pytest
-from llama_index.schema import NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.schema import (
+    BaseNode,
+    IndexNode,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+)
 from llama_index.vector_stores import PGVectorStore
 from llama_index.vector_stores.loading import load_vector_store
 from llama_index.vector_stores.types import (
@@ -25,7 +31,6 @@ TEST_DB = "test_vector_db"
 TEST_TABLE_NAME = "lorem_ipsum"
 TEST_SCHEMA_NAME = "test"
 TEST_EMBED_DIM = 2
-
 
 try:
     import asyncpg
@@ -150,6 +155,29 @@ def hybrid_node_embeddings() -> List[TextNode]:
             relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="ddd")},
             extra_info={"test_key": "test_value"},
             embedding=_get_sample_vector(10.0),
+        ),
+    ]
+
+
+@pytest.fixture(scope="session")
+def index_node_embeddings() -> List[TextNode]:
+    return [
+        TextNode(
+            text="lorem ipsum",
+            id_="aaa",
+            embedding=_get_sample_vector(0.1),
+        ),
+        TextNode(
+            text="dolor sit amet",
+            id_="bbb",
+            extra_info={"test_key": "test_value"},
+            embedding=_get_sample_vector(1.0),
+        ),
+        IndexNode(
+            text="The quick brown fox jumped over the lazy dog.",
+            id_="aaa_ref",
+            index_id="aaa",
+            embedding=_get_sample_vector(5.0),
         ),
     ]
 
@@ -439,3 +467,29 @@ def test_hybrid_query_fails_if_no_query_str_provided(
         pg_hybrid.query(q)
 
         assert str(exc) == "query_str must be specified for a sparse vector query."
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_add_to_db_and_query_index_nodes(
+    pg: PGVectorStore, index_node_embeddings: List[BaseNode], use_async: bool
+) -> None:
+    if use_async:
+        await pg.async_add(index_node_embeddings)
+    else:
+        pg.add(index_node_embeddings)
+    assert isinstance(pg, PGVectorStore)
+    assert hasattr(pg, "_engine")
+    q = VectorStoreQuery(query_embedding=_get_sample_vector(5.0), similarity_top_k=2)
+    if use_async:
+        res = await pg.aquery(q)
+    else:
+        res = pg.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 2
+    assert res.nodes[0].node_id == "aaa_ref"
+    assert isinstance(res.nodes[0], IndexNode)
+    assert hasattr(res.nodes[0], "index_id")
+    assert res.nodes[1].node_id == "bbb"
+    assert isinstance(res.nodes[1], TextNode)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The Problem:
* Currently, postgres vector store always returns nodes as `TextNode`. When an IndexNode is added to the vector store, although the IndexNode is stored as raw JSON successfully, it is always returned as a `TextNode`.
* While I have identified this problem using postgres vector store, I assume other vector stores behave similarly, as the function from `vector_stores.utils` consistently returns `TextNode`.
* This problem limits the use of the vector store when implementing advanced RAG strategies, such as handling tabular data with `RecursiveRetriever` or using `UnstructuredElementNodeParser`, as it returns both TextNode and `IndexNode`.

The FIX:
* When saving a node to the vector store, save the node type as `_node_type` along with `_node_content`.
* If `_node_type` exists, check `_node_type` and return the corresponding Node object.

Fixes #8240 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
