### PR TITLE
Make embedding name consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,7 +272,7 @@
 - Updated `KeywordNodePostprocessor` to use spacy to support more languages (#7894)
 - `LocalAI` supporting global or per-query `/chat/completions` vs `/completions` (#7921)
 - Added notebook on using REBEL + Wikipedia filtering for knowledge graphs (#7919)
-- Added support for `ElasticsearchEmbeddings` (#7914)
+- Added support for `ElasticsearchEmbedding` (#7914)
 
 ## [0.8.37] - 2023-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@
 ### New Features
 
 - add response synthesis to text-to-SQL (#8196)
-- Added support for `LLMRailsEmbeddings` (#8169)
+- Added support for `LLMRailsEmbedding` (#8169)
 - Inferring MPS device with PyTorch (#8195)
 - Consolidated query/text prepending (#8189)
 

--- a/docs/examples/embeddings/elasticsearch.ipynb
+++ b/docs/examples/embeddings/elasticsearch.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "# imports\n",
     "\n",
-    "from llama_index.embeddings.elasticsearch import ElasticsearchEmbeddings\n",
+    "from llama_index.embeddings.elasticsearch import ElasticsearchEmbedding\n",
     "from llama_index.vector_stores import ElasticsearchStore\n",
     "from llama_index import ServiceContext, StorageContext, VectorStoreIndex"
    ]
@@ -63,7 +63,7 @@
     "model_id = os.environ.get(\"MODEL_ID\", \"your-model-id\")\n",
     "\n",
     "\n",
-    "embeddings = ElasticsearchEmbeddings.from_credentials(\n",
+    "embeddings = ElasticsearchEmbedding.from_credentials(\n",
     "    model_id=model_id, es_url=host, es_username=username, es_password=password\n",
     ")"
    ]

--- a/docs/examples/embeddings/jina_embeddings.ipynb
+++ b/docs/examples/embeddings/jina_embeddings.ipynb
@@ -47,7 +47,7 @@
    "source": [
     "from llama_index.embeddings import (\n",
     "    HuggingFaceEmbedding,\n",
-    "    HuggingFaceInferenceAPIEmbeddings,\n",
+    "    HuggingFaceInferenceAPIEmbedding,\n",
     "    OpenAIEmbedding,\n",
     ")\n",
     "from llama_index import ServiceContext"
@@ -81,7 +81,7 @@
     "\n",
     "\n",
     "# use inference API on Hugging Face (though you might run into rate limit issues)\n",
-    "# embed_model = HuggingFaceInferenceAPIEmbeddings(\n",
+    "# embed_model = HuggingFaceInferenceAPIEmbedding(\n",
     "#     model_name=\"jinaai/jina-embeddings-v2-base-en\",\n",
     "# )"
    ]

--- a/docs/examples/embeddings/llm_rails.ipynb
+++ b/docs/examples/embeddings/llm_rails.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "# imports\n",
     "\n",
-    "from llama_index.embeddings.llm_rails import LLMRailsEmbeddings"
+    "from llama_index.embeddings.llm_rails import LLMRailsEmbedding"
    ]
   },
   {
@@ -58,7 +58,7 @@
     "model_id = os.environ.get(\"MODEL_ID\", \"your-model-id\")\n",
     "\n",
     "\n",
-    "embed_model = LLMRailsEmbeddings(model_id=model_id, api_key=api_key)\n",
+    "embed_model = LLMRailsEmbedding(model_id=model_id, api_key=api_key)\n",
     "\n",
     "embeddings = embed_model.get_text_embedding(\n",
     "    \"It is raining cats and dogs here!\"\n",

--- a/docs/examples/llm/huggingface.ipynb
+++ b/docs/examples/llm/huggingface.ipynb
@@ -165,12 +165,12 @@
     "If you're curious, other Hugging Face Inference API tasks wrapped are:\n",
     "\n",
     "- `llama_index.llms.HuggingFaceInferenceAPI.chat`: [Conversational task](https://huggingface.co/tasks/conversational)\n",
-    "- `llama_index.embeddings.HuggingFaceInferenceAPIEmbeddings`: [Feature Extraction task](https://huggingface.co/tasks/feature-extraction)\n",
+    "- `llama_index.embeddings.HuggingFaceInferenceAPIEmbedding`: [Feature Extraction task](https://huggingface.co/tasks/feature-extraction)\n",
     "\n",
     "And yes, Hugging Face embedding models are supported with:\n",
     "\n",
     "- `transformers[torch]`: wrapped by `HuggingFaceEmbedding`\n",
-    "- `huggingface_hub[inference]`: wrapped by `HuggingFaceInferenceAPIEmbeddings`\n",
+    "- `huggingface_hub[inference]`: wrapped by `HuggingFaceInferenceAPIEmbedding`\n",
     "\n",
     "Both of the above two subclass `llama_index.embeddings.base.BaseEmbedding`."
    ]

--- a/llama_index/embeddings/__init__.py
+++ b/llama_index/embeddings/__init__.py
@@ -15,7 +15,6 @@ from llama_index.embeddings.gradient import GradientEmbedding
 from llama_index.embeddings.huggingface import (
     HuggingFaceEmbedding,
     HuggingFaceInferenceAPIEmbedding,
-    HuggingFaceInferenceAPIEmbeddings,
 )
 from llama_index.embeddings.huggingface_optimum import OptimumEmbedding
 from llama_index.embeddings.huggingface_utils import DEFAULT_HUGGINGFACE_EMBEDDING_MODEL

--- a/llama_index/embeddings/__init__.py
+++ b/llama_index/embeddings/__init__.py
@@ -6,18 +6,22 @@ from llama_index.embeddings.adapter import (
 )
 from llama_index.embeddings.base import SimilarityMode
 from llama_index.embeddings.clarifai import ClarifaiEmbedding
-from llama_index.embeddings.elasticsearch import ElasticsearchEmbeddings
+from llama_index.embeddings.elasticsearch import (
+    ElasticsearchEmbedding,
+    ElasticsearchEmbeddings,
+)
 from llama_index.embeddings.google import GoogleUnivSentEncoderEmbedding
 from llama_index.embeddings.gradient import GradientEmbedding
 from llama_index.embeddings.huggingface import (
     HuggingFaceEmbedding,
+    HuggingFaceInferenceAPIEmbedding,
     HuggingFaceInferenceAPIEmbeddings,
 )
 from llama_index.embeddings.huggingface_optimum import OptimumEmbedding
 from llama_index.embeddings.huggingface_utils import DEFAULT_HUGGINGFACE_EMBEDDING_MODEL
 from llama_index.embeddings.instructor import InstructorEmbedding
 from llama_index.embeddings.langchain import LangchainEmbedding
-from llama_index.embeddings.llm_rails import LLMRailsEmbeddings
+from llama_index.embeddings.llm_rails import LLMRailsEmbedding, LLMRailsEmbeddings
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.embeddings.pooling import Pooling
 from llama_index.embeddings.text_embeddings_inference import TextEmbeddingsInference
@@ -27,19 +31,23 @@ __all__ = [
     "AdapterEmbeddingModel",
     "ClarifaiEmbedding",
     "DEFAULT_HUGGINGFACE_EMBEDDING_MODEL",
-    "ElasticsearchEmbeddings",
+    "ElasticsearchEmbedding",
     "GoogleUnivSentEncoderEmbedding",
     "GradientEmbedding",
-    "HuggingFaceInferenceAPIEmbeddings",
+    "HuggingFaceInferenceAPIEmbedding",
     "HuggingFaceEmbedding",
     "InstructorEmbedding",
     "LangchainEmbedding",
     "LinearAdapterEmbeddingModel",
-    "LLMRailsEmbeddings",
+    "LLMRailsEmbedding",
     "OpenAIEmbedding",
     "OptimumEmbedding",
     "Pooling",
     "SimilarityMode",
     "TextEmbeddingsInference",
     "resolve_embed_model",
+    # Deprecated, kept for backwards compatibility
+    "LLMRailsEmbeddings",
+    "ElasticsearchEmbeddings",
+    "HuggingFaceInferenceAPIEmbeddings",
 ]

--- a/llama_index/embeddings/elasticsearch.py
+++ b/llama_index/embeddings/elasticsearch.py
@@ -4,7 +4,7 @@ from llama_index.bridge.pydantic import PrivateAttr
 from llama_index.embeddings.base import BaseEmbedding
 
 
-class ElasticsearchEmbeddings(BaseEmbedding):
+class ElasticsearchEmbedding(BaseEmbedding):
     """Elasticsearch embedding models.
 
     This class provides an interface to generate embeddings using a model deployed
@@ -176,3 +176,6 @@ class ElasticsearchEmbeddings(BaseEmbedding):
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
         return self._get_query_embedding(query)
+
+
+ElasticsearchEmbeddings = ElasticsearchEmbedding

--- a/llama_index/embeddings/elasticsearch.py
+++ b/llama_index/embeddings/elasticsearch.py
@@ -24,7 +24,7 @@ class ElasticsearchEmbedding(BaseEmbedding):
 
     @classmethod
     def class_name(self) -> str:
-        return "ElasticsearchEmbeddings"
+        return "ElasticsearchEmbedding"
 
     def __init__(
         self,
@@ -46,10 +46,10 @@ class ElasticsearchEmbedding(BaseEmbedding):
         """
         Instantiate embeddings from an existing Elasticsearch connection.
 
-        This method provides a way to create an instance of the ElasticsearchEmbeddings
+        This method provides a way to create an instance of the ElasticsearchEmbedding
         class using an existing Elasticsearch connection. The connection object is used
         to create an MlClient, which is then used to initialize the
-        ElasticsearchEmbeddings instance.
+        ElasticsearchEmbedding instance.
 
         Args:
         model_id (str): The model_id of the model deployed in the Elasticsearch cluster.
@@ -59,14 +59,14 @@ class ElasticsearchEmbedding(BaseEmbedding):
             in the document. Defaults to 'text_field'.
 
         Returns:
-        ElasticsearchEmbeddings: An instance of the ElasticsearchEmbeddings class.
+        ElasticsearchEmbedding: An instance of the ElasticsearchEmbedding class.
 
         Example:
             .. code-block:: python
 
                 from elasticsearch import Elasticsearch
 
-                from llama_index.embeddings import ElasticsearchEmbeddings
+                from llama_index.embeddings import ElasticsearchEmbedding
 
                 # Define the model ID and input field name (if different from default)
                 model_id = "your_model_id"
@@ -78,8 +78,8 @@ class ElasticsearchEmbedding(BaseEmbedding):
                     hosts=["localhost:9200"], basic_auth=("user", "password")
                 )
 
-                # Instantiate ElasticsearchEmbeddings using the existing connection
-                embeddings = ElasticsearchEmbeddings.from_es_connection(
+                # Instantiate ElasticsearchEmbedding using the existing connection
+                embeddings = ElasticsearchEmbedding.from_es_connection(
                     model_id,
                     es_connection,
                     input_field=input_field,
@@ -119,14 +119,14 @@ class ElasticsearchEmbedding(BaseEmbedding):
         Example:
             .. code-block:: python
 
-                from llama_index.embeddings import ElasticsearchEmbeddings
+                from llama_index.embeddings import ElasticsearchEmbedding
 
                 # Define the model ID and input field name (if different from default)
                 model_id = "your_model_id"
                 # Optional, only if different from 'text_field'
                 input_field = "your_input_field"
 
-                embeddings = ElasticsearchEmbeddings.from_credentials(
+                embeddings = ElasticsearchEmbedding.from_credentials(
                     model_id,
                     input_field=input_field,
                     es_url="foo",

--- a/llama_index/embeddings/huggingface.py
+++ b/llama_index/embeddings/huggingface.py
@@ -220,7 +220,7 @@ class HuggingFaceInferenceAPIEmbedding(HuggingFaceInferenceAPI, BaseEmbedding): 
 
     @classmethod
     def class_name(cls) -> str:
-        return "HuggingFaceInferenceAPIEmbeddings"
+        return "HuggingFaceInferenceAPIEmbedding"
 
     async def _async_embed_single(self, text: str) -> Embedding:
         embedding = (await self._async_client.feature_extraction(text)).squeeze(axis=0)

--- a/llama_index/embeddings/huggingface.py
+++ b/llama_index/embeddings/huggingface.py
@@ -186,7 +186,7 @@ class HuggingFaceEmbedding(BaseEmbedding):
         return self._embed(texts)
 
 
-class HuggingFaceInferenceAPIEmbeddings(HuggingFaceInferenceAPI, BaseEmbedding):  # type: ignore[misc]
+class HuggingFaceInferenceAPIEmbedding(HuggingFaceInferenceAPI, BaseEmbedding):  # type: ignore[misc]
     """
     Wrapper on the Hugging Face's Inference API for embeddings.
 
@@ -292,3 +292,6 @@ class HuggingFaceInferenceAPIEmbeddings(HuggingFaceInferenceAPI, BaseEmbedding):
                 for text in texts
             ]
         )
+
+
+HuggingFaceInferenceAPIEmbeddings = HuggingFaceInferenceAPIEmbedding

--- a/llama_index/embeddings/llm_rails.py
+++ b/llama_index/embeddings/llm_rails.py
@@ -8,7 +8,7 @@ from llama_index.embeddings.base import BaseEmbedding
 logger = logging.getLogger(__name__)
 
 
-class LLMRailsEmbeddings(BaseEmbedding):
+class LLMRailsEmbedding(BaseEmbedding):
     """LLMRails embedding models.
 
     This class provides an interface to generate embeddings using a model deployed
@@ -22,7 +22,7 @@ class LLMRailsEmbeddings(BaseEmbedding):
 
     @classmethod
     def class_name(self) -> str:
-        return "LLMRailsEmbeddings"
+        return "LLMRailsEmbedding"
 
     def __init__(
         self,
@@ -101,3 +101,6 @@ class LLMRailsEmbeddings(BaseEmbedding):
 
     async def _aget_text_embedding(self, query: str) -> List[float]:
         return await self._aget_embedding(query)
+
+
+LLMRailsEmbeddings = LLMRailsEmbedding

--- a/tests/embeddings/test_elasticsearch.py
+++ b/tests/embeddings/test_elasticsearch.py
@@ -1,5 +1,5 @@
 import pytest
-from llama_index.embeddings.elasticsearch import ElasticsearchEmbeddings
+from llama_index.embeddings.elasticsearch import ElasticsearchEmbedding
 
 try:
     import elasticsearch
@@ -36,7 +36,7 @@ def test_elasticsearch_embedding_constructor(
     model_id: str, es_url: str, es_username: str, es_password: str
 ) -> None:
     """Test Elasticsearch embedding query."""
-    ElasticsearchEmbeddings.from_credentials(
+    ElasticsearchEmbedding.from_credentials(
         model_id=model_id,
         es_url=es_url,
         es_username=es_username,

--- a/tests/embeddings/test_huggingface.py
+++ b/tests/embeddings/test_huggingface.py
@@ -2,33 +2,33 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
-from llama_index.embeddings.huggingface import HuggingFaceInferenceAPIEmbeddings
+from llama_index.embeddings.huggingface import HuggingFaceInferenceAPIEmbedding
 from llama_index.embeddings.pooling import Pooling
 
 from tests.llms.test_huggingface import STUB_MODEL_NAME
 
 
 @pytest.fixture(name="hf_inference_api_embeddings")
-def fixture_hf_inference_api_embeddings() -> HuggingFaceInferenceAPIEmbeddings:
+def fixture_hf_inference_api_embeddings() -> HuggingFaceInferenceAPIEmbedding:
     with patch.dict("sys.modules", huggingface_hub=MagicMock()):
-        return HuggingFaceInferenceAPIEmbeddings(model_name=STUB_MODEL_NAME)
+        return HuggingFaceInferenceAPIEmbedding(model_name=STUB_MODEL_NAME)
 
 
 class TestHuggingFaceInferenceAPIEmbeddings:
     def test_class_name(
-        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbeddings
+        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbedding
     ) -> None:
         assert (
-            HuggingFaceInferenceAPIEmbeddings.class_name()
-            == HuggingFaceInferenceAPIEmbeddings.__name__
+            HuggingFaceInferenceAPIEmbedding.class_name()
+            == HuggingFaceInferenceAPIEmbedding.__name__
         )
         assert (
             hf_inference_api_embeddings.class_name()
-            == HuggingFaceInferenceAPIEmbeddings.__name__
+            == HuggingFaceInferenceAPIEmbedding.__name__
         )
 
     def test_embed_query(
-        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbeddings
+        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbedding
     ) -> None:
         raw_single_embedding = np.random.rand(1, 3, 1024)
 
@@ -63,7 +63,7 @@ class TestHuggingFaceInferenceAPIEmbeddings:
         mock_feature_extraction.assert_awaited_once_with("test")
 
     def test_serialization(
-        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbeddings
+        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbedding
     ) -> None:
         serialized = hf_inference_api_embeddings.to_dict()
         # Check Hugging Face Inference API base class specifics

--- a/tests/embeddings/test_llm_rails.py
+++ b/tests/embeddings/test_llm_rails.py
@@ -1,5 +1,5 @@
 import pytest
-from llama_index.embeddings.llm_rails import LLMRailsEmbeddings
+from llama_index.embeddings.llm_rails import LLMRailsEmbedding
 
 
 @pytest.fixture()
@@ -16,4 +16,4 @@ def api_key() -> str:
 
 def test_llm_rails_embedding_constructor(model_id: str, api_key: str) -> None:
     """Test LLMRails embedding constructor."""
-    LLMRailsEmbeddings(model_id=model_id, api_key=api_key)
+    LLMRailsEmbedding(model_id=model_id, api_key=api_key)


### PR DESCRIPTION
# Description

Make embedding name consistent, keep old names as type alias for backward compatibility. 