### PR TITLE
fix: Return the Nodes found by Keywords when No relationship is found…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Bug Fixes / Nits
 
-- In Knowledge Graph Index with hybrid retriever_mode, 
+- In Knowledge Graph Index with hybrid retriever_mode,
   - return the nodes found by keyword search when 'No Relationship found'
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
 - Added default file_metadata to get basic metadata that many postprocessors use, for SimpleDirectoryReader (#8486)
 - Handle metadata with None values in chromadb (#8584)
 
+## [0.8.56] - 2023-10-30
+
+### Bug Fixes / Nits
+
+- In Knowledge Graph Index with hybrid retriever_mode, 
+  - return the nodes found by keyword search when 'No Relationship found' from embedding search.
+
 ## [0.8.55] - 2023-10-29
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,6 @@
 - Added default file_metadata to get basic metadata that many postprocessors use, for SimpleDirectoryReader (#8486)
 - Handle metadata with None values in chromadb (#8584)
 
-
-
-### New Features
-
-- Add Amazon `BedrockEmbedding` (#8550)
-
 ## [0.8.55] - 2023-10-29
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@
 ### Bug Fixes / Nits
 
 - In Knowledge Graph Index with hybrid retriever_mode, 
-  - return the nodes found by keyword search when 'No Relationship found' from embedding search.
+  - return the nodes found by keyword search when 'No Relationship found'
+
+### New Features
+
+- Add Amazon `BedrockEmbedding` (#8550)
 
 ## [0.8.55] - 2023-10-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Bug Fixes / Nits
 
 - Update dataType in Weaviate (#8608)
+- In Knowledge Graph Index with hybrid retriever_mode,
+  - return the nodes found by keyword search when 'No Relationship found'
 
 ## [0.8.56] - 2023-10-30
 
@@ -22,12 +24,7 @@
 - Added default file_metadata to get basic metadata that many postprocessors use, for SimpleDirectoryReader (#8486)
 - Handle metadata with None values in chromadb (#8584)
 
-## [0.8.56] - 2023-10-30
 
-### Bug Fixes / Nits
-
-- In Knowledge Graph Index with hybrid retriever_mode,
-  - return the nodes found by keyword search when 'No Relationship found'
 
 ### New Features
 

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -275,8 +275,8 @@ class KGTableRetriever(BaseRetriever):
             if len(sorted_nodes_with_scores) == 0:
                 logger.info("> No nodes found by keywords, returning empty response.")
                 return [
-                        NodeWithScore(node=TextNode(text="No relationships found."), score=1.0)
-                    ]
+                    NodeWithScore(node=TextNode(text="No relationships found."), score=1.0)
+                ]
             # In else case the sorted_nodes_with_scores is not empty
             # thus returning the nodes found by keywords
             return sorted_nodes_with_scores

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -277,10 +277,11 @@ class KGTableRetriever(BaseRetriever):
                 return [
                         NodeWithScore(node=TextNode(text="No relationships found."), score=1.0)
                     ]
-            else:
-                # In else case the sorted_nodes_with_scores is not empty thus returning the nodes found by keywords
-                logger.info("> No relationship found by embeddings, return the nodes found by keywords.")
-                return sorted_nodes_with_scores
+            
+            # In else case the sorted_nodes_with_scores is not empty 
+            # thus returning the nodes found by keywords
+            logger.info("> No relationships found by embeddings, returning nodes found by keywords.")
+            return sorted_nodes_with_scores
 
         # add relationships as Node
         # TODO: make initial text customizable

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -277,8 +277,7 @@ class KGTableRetriever(BaseRetriever):
                 return [
                         NodeWithScore(node=TextNode(text="No relationships found."), score=1.0)
                     ]
-            
-            # In else case the sorted_nodes_with_scores is not empty 
+            # In else case the sorted_nodes_with_scores is not empty
             # thus returning the nodes found by keywords
             return sorted_nodes_with_scores
 

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -275,7 +275,9 @@ class KGTableRetriever(BaseRetriever):
             if len(sorted_nodes_with_scores) == 0:
                 logger.info("> No nodes found by keywords, returning empty response.")
                 return [
-                    NodeWithScore(node=TextNode(text="No relationships found."), score=1.0)
+                    NodeWithScore(
+                        node=TextNode(text="No relationships found."), score=1.0
+                    )
                 ]
             # In else case the sorted_nodes_with_scores is not empty
             # thus returning the nodes found by keywords

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -280,7 +280,6 @@ class KGTableRetriever(BaseRetriever):
             
             # In else case the sorted_nodes_with_scores is not empty 
             # thus returning the nodes found by keywords
-            logger.info("> No relationships found by embeddings, returning nodes found by keywords.")
             return sorted_nodes_with_scores
 
         # add relationships as Node

--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -274,9 +274,13 @@ class KGTableRetriever(BaseRetriever):
             logger.info("> No relationships found, returning nodes found by keywords.")
             if len(sorted_nodes_with_scores) == 0:
                 logger.info("> No nodes found by keywords, returning empty response.")
-            return [
-                NodeWithScore(node=TextNode(text="No relationships found."), score=1.0)
-            ]
+                return [
+                        NodeWithScore(node=TextNode(text="No relationships found."), score=1.0)
+                    ]
+            else:
+                # In else case the sorted_nodes_with_scores is not empty thus returning the nodes found by keywords
+                logger.info("> No relationship found by embeddings, return the nodes found by keywords.")
+                return sorted_nodes_with_scores
 
         # add relationships as Node
         # TODO: make initial text customizable


### PR DESCRIPTION
… by embeddings in Hybrid retriever_mode

# Description

I was using the KnowledgeGraphIndex in recent days. With `hybrid` retriever_mode in index.as_query_engine() when "No Relationship is found" by `embeddings search`, the nodes found by the `keyword` search are not returned.
This was commented but the code was not in such way.
So just added an else case and **returned the nodes found by Keyword search** when no nodes are found in Embedding search.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-Tested the code with the custom Knowledge Graph that I have created.

# Steps to reproduce the issue
- Have a custom Knowledge Graph and create an index either with SimpleGraphStore or NebulaGraphStore
- Configure the retriever_mode as `hybrid`
- Now ask a query which fetched the relevant triplet with keyword search and not with embedding search
- "No Relationship found" will be the response but the Nodes identified from the "Keyword" search is not returned.
- It is already commented to return the Nodes found by Keywords but not returned
- So I have just added an else case and returned accordingly

Hope this saved your time :-)

# Suggested Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
