### PR TITLE
fix: retrieve actual content of All the Triplets from KG

### DIFF
--- a/llama_index/indices/knowledge_graph/retrievers.py
+++ b/llama_index/indices/knowledge_graph/retrievers.py
@@ -155,6 +155,9 @@ class KGTableRetriever(BaseRetriever):
                     if node_id in node_visited:
                         continue
 
+                    if self._include_text:
+                        chunk_indices_count[node_id] += 1
+
                     node_visited.add(node_id)
                     if self.use_global_node_triplets:
                         # Get nodes from keyword search, and add them to the subjs
@@ -211,7 +214,7 @@ class KGTableRetriever(BaseRetriever):
             )
             logger.debug(f"Found the following top_k rel_texts: {rel_texts!s}")
             rel_texts.extend(top_rel_texts)
-           
+
         elif len(self._index_struct.embedding_dict) == 0:
             logger.warning(
                 "Index was not constructed with embeddings, skipping embedding usage..."
@@ -231,11 +234,13 @@ class KGTableRetriever(BaseRetriever):
 
             # truncate rel_texts
             rel_texts = rel_texts[: self.max_knowledge_sequence]
-            
-        # When include_text = True just get the actual content of all the nodes 
-        # (Nodes with actual keyord match, Nodes which are found from the depth search and Nodes founnd from top_k similarity)
+
+        # When include_text = True just get the actual content of all the nodes
+        # (Nodes with actual keyword match, Nodes which are found from the depth search and Nodes founnd from top_k similarity)
         if self._include_text:
-            keywords = self._extract_rel_text_keywords(rel_texts) #rel_texts will have all the Triplets retrieved with respect to the Query
+            keywords = self._extract_rel_text_keywords(
+                rel_texts
+            )  # rel_texts will have all the Triplets retrieved with respect to the Query
             nested_node_ids = [
                 self._index_struct.search_node_by_keyword(keyword)
                 for keyword in keywords
@@ -243,7 +248,7 @@ class KGTableRetriever(BaseRetriever):
             node_ids = [_id for ids in nested_node_ids for _id in ids]
             for node_id in node_ids:
                 chunk_indices_count[node_id] += 1
-        
+
         sorted_chunk_indices = sorted(
             chunk_indices_count.keys(),
             key=lambda x: chunk_indices_count[x],


### PR DESCRIPTION
# Description

When dealing with Knowledge Graph retrieval process, I found an issue which is **when `include_text=True` is passed, Only the direct triplet's actual content is fetched while the actual content of the triplets retrieved from the Depth First Search with configured depth is not retrieved.**
So made a common change and now when `include_text=True` is passed then the actual content of every triplet is retrieved from the Keyword:Actual Node ID table which is maintained. [Moved the include_text logic out of `if block` so that a single statement works for all keyword, embedding and hybrid retriever mode]

Hope this change also helps everyone :-)

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested with the sample Knowledge Graph that was build using Simple Knowledge Graph.

# Suggested Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
