### PR TITLE
add support for ChromaDB PersistentClient

### DIFF
--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -71,6 +71,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
     port: Optional[str]
     ssl: bool
     headers: Optional[Dict[str, str]]
+    persist_dir: Optional[str]
     collection_kwargs: Dict[str, Any] = Field(default_factory=dict)
 
     _collection: Any = PrivateAttr()

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -113,7 +113,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
         ssl: bool = False,
         headers: Optional[Dict[str, str]] = None,
         persist_dir: Optional[str] = None,
-        collection_kwargs: Optional[dict] = None,
+        collection_kwargs: Optional[dict] = {},
         **kwargs: Any,
     ) -> "ChromaVectorStore":
         try:

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -82,6 +82,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
         port: Optional[str] = None,
         ssl: bool = False,
         headers: Optional[Dict[str, str]] = None,
+        persist_dir: Optional[str] = None,
         collection_kwargs: Optional[dict] = None,
         **kwargs: Any,
     ) -> None:
@@ -99,6 +100,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
             port=port,
             ssl=ssl,
             headers=headers,
+            persist_dir=persist_dir,
             collection_kwargs=collection_kwargs or {},
         )
 
@@ -110,6 +112,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
         port: Optional[str] = None,
         ssl: bool = False,
         headers: Optional[Dict[str, str]] = None,
+        persist_dir: Optional[str] = None,
         collection_kwargs: Optional[dict] = None,
         **kwargs: Any,
     ) -> "ChromaVectorStore":
@@ -117,18 +120,23 @@ class ChromaVectorStore(BasePydanticVectorStore):
             import chromadb
         except ImportError:
             raise ImportError(import_err_msg)
-
-        client = chromadb.HttpClient(host=host, port=port, ssl=ssl, headers=headers)
-        collection = client.get_or_create_collection(
-            name=collection_name, **collection_kwargs
-        )
-
+        if persist_dir:
+            client = chromadb.PersistentClient(path=persist_dir)
+            collection = client.get_or_create_collection(
+                name=collection_name, **collection_kwargs
+            )
+        else:
+            client = chromadb.HttpClient(host=host, port=port, ssl=ssl, headers=headers)
+            collection = client.get_or_create_collection(
+                name=collection_name, **collection_kwargs
+            )
         return cls(
             chroma_collection=collection,
             host=host,
             port=port,
             ssl=ssl,
             headers=headers,
+            persist_dir=persist_dir,
             collection_kwargs=collection_kwargs,
             **kwargs,
         )

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -126,10 +126,14 @@ class ChromaVectorStore(BasePydanticVectorStore):
             collection = client.get_or_create_collection(
                 name=collection_name, **collection_kwargs
             )
-        else:
+        elif host and port:
             client = chromadb.HttpClient(host=host, port=port, ssl=ssl, headers=headers)
             collection = client.get_or_create_collection(
                 name=collection_name, **collection_kwargs
+            )
+        else:
+            raise ValueError(
+                "Either `persist_dir` or (`host`,`port`) must be specified"
             )
         return cls(
             chroma_collection=collection,


### PR DESCRIPTION
# Description
The existing ChromaDb vector store only had support for the HttpClient. This PR adds support for the PersistentClient with the optional arguement persist_dir.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
