### PR TITLE
Handle metadata with None values in chromadb

### DIFF
--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -158,11 +158,12 @@ class ChromaVectorStore(BasePydanticVectorStore):
             documents = []
             for node in node_chunk:
                 embeddings.append(node.get_embedding())
-                metadatas.append(
-                    node_to_metadata_dict(
-                        node, remove_text=True, flat_metadata=self.flat_metadata
-                    )
+                metadata_dict = node_to_metadata_dict(
+                    node, remove_text=True, flat_metadata=self.flat_metadata
                 )
+                if "context" in metadata_dict and metadata_dict["context"] is None:
+                    metadata_dict["context"] = ""
+                metadatas.append(metadata_dict)
                 ids.append(node.node_id)
                 documents.append(node.get_content(metadata_mode=MetadataMode.NONE))
 


### PR DESCRIPTION
# Description
This solves #8583 
I think `None` values in metadata only needs to be handled for cases where a llama_index library function internally tries to set `None` values for metadata. If a user passes `None` values they'd understand the issue and should be able to handle the error themselves. Also iterating over every value of a metadata dict for every item passed in would be wasteful.

My solution is to only check if the metadata_dict contains the `context` key and if it is set to None set it to an empty string instead. This is admittedly a bit of a patchwork solution, but I think it solves the problem in the most efficient way. 
The alternative would be to make the default value for `context` an empty string [here](https://github.com/run-llama/llama_index/blob/95e107423664812eeece1af0f162c9dcd4bfe670/llama_index/objects/table_node_mapping.py#L54) but its harder to trace what the downstream consequences of that would be. 


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
