### PR TITLE
I'm encountering the `object has no attribute '__fields_set__'` error with pydantic.

### DIFF
--- a/llama_index/readers/twitter.py
+++ b/llama_index/readers/twitter.py
@@ -30,8 +30,6 @@ class TwitterTweetReader(BasePydanticReader):
         num_tweets: Optional[int] = 100,
     ) -> None:
         """Initialize with parameters."""
-        self.bearer_token = bearer_token
-        self.num_tweets = num_tweets
         super().__init__(
             num_tweets=num_tweets,
             bearer_token=bearer_token,


### PR DESCRIPTION
# Description

I'm encountering the `object has no attribute '__fields_set__'` error with pydantic.

Here's the code snippet:

```python
self.bearer_token = bearer_token
self.num_tweets = num_tweets
super().__init__(
    num_tweets=num_tweets,
    bearer_token=bearer_token,
)
```

It seems that the object is being initialized twice, and the first initialization is unnecessary. Additionally, during the first initialization, I'm encountering the object has no attribute '__fields_set__' error with pydantic.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
