### PR TITLE
Add IBM WatsonX LLM support

### DIFF
--- a/docs/examples/llm/watsonx.ipynb
+++ b/docs/examples/llm/watsonx.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WatsonX"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Call `complete` with a prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import WatsonX\n",
+    "\n",
+    "credentials = {\n",
+    "    \"url\": \"https://enter.your-ibm.url\",\n",
+    "    \"apikey\": \"insert_your_api_key\",\n",
+    "}\n",
+    "\n",
+    "project_id = \"insert_your_project_id\"\n",
+    "\n",
+    "resp = WatsonX(credentials=credentials, project_id=project_id).complete(\n",
+    "    \"Paul Graham is\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " a programmer, entrepreneur, and author. He is the co-founder of Y Combinator, a startup accelerator. He is also the author of the books Hackers & Painters and On Lisp.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Call `chat` with a list of messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import ChatMessage, WatsonX\n",
+    "\n",
+    "\n",
+    "messages = [\n",
+    "    ChatMessage(\n",
+    "        role=\"system\", content=\"You are a pirate with a colorful personality\"\n",
+    "    ),\n",
+    "    ChatMessage(role=\"user\", content=\"Tell me a story\"),\n",
+    "]\n",
+    "\n",
+    "resp = WatsonX(\n",
+    "    model_id=\"meta-llama/llama-2-70b-chat\",\n",
+    "    credentials=credentials,\n",
+    "    project_id=project_id,\n",
+    ").chat(messages)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "assistant:  Ahoy matey! Yer lookin' fer a tale of the high seas, eh? Well, settle yerself down with a pint o' grog and listen close, for I've got a story that'll make yer timbers shiver!\n",
+      "\n",
+      "It were a dark and stormy night, and me ship, the Black Dragon, were sailin' through treacherous waters. The winds were howlin' like a pack o' wolves and the waves were crashin' against the hull like angry giants. Me and me crew were battle-hardened pirates, but even we were gettin' nervous.\n",
+      "\n",
+      "Suddenly, a great shadow loomed ahead, and we found ourselves face to face with the most fearsome sea monster I'd ever laid eyes on! It were a giant squid, with tentacles as long as me ship and a beak that could snap a man in two.\n",
+      "\n",
+      "Now, I'd never been one to shy away from a fight, but this beast were different. It were a creature of the deep, and it seemed to have a mind of its own. It attacked us with a fury, wrappin' its tentacles around the ship and pullin' us down into the depths.\n",
+      "\n",
+      "We fought with all our might, but it were no use. The squid were too powerful, and it were draggin' us down to a watery grave. I knew that we had to come up with a plan, and fast, or we'd be seein' Davy Jones' locker for ourselves!\n",
+      "\n",
+      "That's when I remembered a trick I'd learned from a wise old sea dog back in port. I told me crew to pour vinegar on the squid's tentacles, and sure enough, it worked like a charm! The squid let out a deafening screech and released its grip on the ship. We were able to sail away, battered but alive.\n",
+      "\n",
+      "And that, me hearty, is the tale of how I, Blackbeak the pirate, defeated the sea monster and saved me crew. Now, if ye'll excuse me, I've got a hankerin' for some grog and a good sea shanty!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Streaming"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " Using `stream_complete` endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import WatsonX\n",
+    "\n",
+    "llm = WatsonX(credentials=credentials, project_id=project_id)\n",
+    "\n",
+    "resp = llm.stream_complete(\"Paul Graham is\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " a programmer, entrepreneur, and writer. He is the co-founder of Y Combinator, a startup accelerator. He is also the author of the essay collection Hackers & Painters."
+     ]
+    }
+   ],
+   "source": [
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using `stream_chat` endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import WatsonX\n",
+    "\n",
+    "llm = WatsonX(\n",
+    "    model_id=\"meta-llama/llama-2-70b-chat\",\n",
+    "    credentials=credentials,\n",
+    "    project_id=project_id,\n",
+    ")\n",
+    "messages = [\n",
+    "    ChatMessage(\n",
+    "        role=\"system\", content=\"You are a pirate with a colorful personality\"\n",
+    "    ),\n",
+    "    ChatMessage(role=\"user\", content=\"Tell me a story\"),\n",
+    "]\n",
+    "\n",
+    "resp = llm.stream_chat(messages)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " Arrrr, me hearty! Listen close and I'll spin ye a yarn of the high seas.\n",
+      "\n",
+      "Ahoy, me name be Captain Blackbeak, the most feared pirate on the seven seas. Me and me crew, the Blackheart Gang, have been sailin' these waters for nigh on 20 years, plunderin' the riches of the landlubbers and bringin' terror to them that dare cross us.\n",
+      "\n",
+      "One dark and stormy night, we came upon a grand ship, the \"Golden Dolphin,\" sailin' the seas with a cargo hold full of gold, silver, and precious jewels. The captain, a foolish man named Captain Redbeard, thought to outrun us, but me and me crew were hot on his tail.\n",
+      "\n",
+      "We battled through the ragin' storm, cannons blazin', swords clashin', and after a fierce fight, we claimed the \"Golden Dolphin\" as our own. The loot was divided among the crew, and we set sail for the nearest port to celebrate our victory.\n",
+      "\n",
+      "But little did we know, Captain Redbeard had a secret weapon, a stowaway on board, a beautiful maiden named Sarah. She was a fierce warrior, skilled in the ways of combat, and she had a plan to take back her ship and its treasure.\n",
+      "\n",
+      "As we docked at the port, Sarah struck, takin' out me crew one by one, and makin' her way to the treasure room. But I, Captain Blackbeak, was ready for her. I challenged her to a duel, and after a fierce battle, I emerged victorious.\n",
+      "\n",
+      "Sarah was impressed by me skill and bravery, and she decided to join me crew. Together, we sailed the seas, plunderin' and pillagin' for years to come. And that, me hearty, be the tale of how I, Captain Blackbeak, defeated the fierce warrior Sarah and claimed the \"Golden Dolphin\" as me own.\n",
+      "\n",
+      "Now, if ye be wantin' to hear another tale of the high seas, just let me know, and I'll be happy to spin ye another yarn."
+     ]
+    }
+   ],
+   "source": [
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms import WatsonX\n",
+    "\n",
+    "llm = WatsonX(\n",
+    "    model_id=\"meta-llama/llama-2-70b-chat\",\n",
+    "    credentials=credentials,\n",
+    "    project_id=project_id,\n",
+    "    temperature=0,\n",
+    "    max_new_tokens=100,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.complete(\"Paul Graham is\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " a well-known entrepreneur, investor, and writer. He is best known for his work in the field of startup accelerators, and for his essays on startup success and entrepreneurship.\n",
+      "\n",
+      "Graham has a background in computer science and philosophy, and has worked in various roles in the tech industry, including as a programmer, software designer, and product manager. He is perhaps best known, however, for his work as a co-founder of Y Com\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(resp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama-index-1zyBTJDh-py3.9",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/llama_index/llms/__init__.py
+++ b/llama_index/llms/__init__.py
@@ -34,6 +34,7 @@ from llama_index.llms.palm import PaLM
 from llama_index.llms.portkey import Portkey
 from llama_index.llms.predibase import PredibaseLLM
 from llama_index.llms.replicate import Replicate
+from llama_index.llms.watsonx import WatsonX
 from llama_index.llms.xinference import Xinference
 
 __all__ = [
@@ -73,5 +74,6 @@ __all__ = [
     "Portkey",
     "PredibaseLLM",
     "Replicate",
+    "WatsonX",
     "Xinference",
 ]

--- a/llama_index/llms/watsonx.py
+++ b/llama_index/llms/watsonx.py
@@ -1,0 +1,200 @@
+from typing import Any, Dict, Optional, Sequence
+
+from llama_index.bridge.pydantic import Field, PrivateAttr
+from llama_index.callbacks import CallbackManager
+from llama_index.llms.base import (
+    LLM,
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseAsyncGen,
+    CompletionResponseGen,
+    LLMMetadata,
+    llm_chat_callback,
+    llm_completion_callback,
+)
+from llama_index.llms.generic_utils import (
+    completion_to_chat_decorator,
+    stream_completion_to_chat_decorator,
+)
+from llama_index.llms.watsonx_utils import (
+    WATSONX_MODELS,
+    get_from_param_or_env_without_error,
+    watsonx_model_to_context_size,
+)
+
+
+class WatsonX(LLM):
+    """IBM WatsonX LLM."""
+
+    model_id: str = Field(description="The Model to use.")
+    max_new_tokens: int = Field(description="The maximum number of tokens to generate.")
+    temperature: float = Field(description="The temperature to use for sampling.")
+    additional_kwargs: Dict[str, Any] = Field(
+        default_factory=dict, description="Additional Kwargs for the WatsonX model"
+    )
+    model_info: Dict[str, Any] = Field(
+        default_factory=dict, description="Details about the selected model"
+    )
+
+    _model = PrivateAttr()
+
+    def __init__(
+        self,
+        credentials: Dict[str, Any],
+        model_id: Optional[str] = "ibm/mpt-7b-instruct2",
+        project_id: Optional[str] = None,
+        space_id: Optional[str] = None,
+        max_new_tokens: Optional[int] = 512,
+        temperature: Optional[float] = 0.1,
+        additional_kwargs: Optional[Dict[str, Any]] = None,
+        callback_manager: Optional[CallbackManager] = None,
+    ) -> None:
+        """Initialize params."""
+        if model_id not in WATSONX_MODELS:
+            raise ValueError(
+                f"Model name {model_id} not found in {WATSONX_MODELS.keys()}"
+            )
+
+        try:
+            from ibm_watson_machine_learning.foundation_models.model import Model
+        except ImportError as e:
+            raise ImportError(
+                "You must install the `ibm_watson_machine_learning` package to use WatsonX"
+                "please `pip install ibm_watson_machine_learning`"
+            ) from e
+
+        additional_kwargs = additional_kwargs or {}
+        callback_manager = callback_manager or CallbackManager([])
+
+        project_id = get_from_param_or_env_without_error(
+            project_id, "IBM_WATSONX_PROJECT_ID"
+        )
+        space_id = get_from_param_or_env_without_error(space_id, "IBM_WATSONX_SPACE_ID")
+
+        if project_id is not None or space_id is not None:
+            self._model = Model(
+                model_id=model_id,
+                credentials=credentials,
+                project_id=project_id,
+                space_id=space_id,
+            )
+        else:
+            raise ValueError(
+                f"Did not find `project_id` or `space_id`, Please pass them as named parameters"
+                f" or as environment variables, `IBM_WATSONX_PROJECT_ID` or `IBM_WATSONX_SPACE_ID`."
+            )
+
+        super().__init__(
+            model_id=model_id,
+            temperature=temperature,
+            max_new_tokens=max_new_tokens,
+            additional_kwargs=additional_kwargs,
+            model_info=self._model.get_details(),
+            callback_manager=callback_manager,
+        )
+
+    @classmethod
+    def class_name(self) -> str:
+        """Get Class Name."""
+        return "WatsonX_LLM"
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(
+            context_window=watsonx_model_to_context_size(self.model_id),
+            num_output=self.max_new_tokens,
+            model_name=self.model_id,
+        )
+
+    @property
+    def sample_model_kwargs(self) -> Dict[str, Any]:
+        """Get a sample of Model kwargs that a user can pass to the model."""
+        try:
+            from ibm_watson_machine_learning.metanames import GenTextParamsMetaNames
+        except ImportError as e:
+            raise ImportError(
+                "You must install the `ibm_watson_machine_learning` package to use WatsonX"
+                "please `pip install ibm_watson_machine_learning`"
+            ) from e
+
+        params = GenTextParamsMetaNames().get_example_values()
+
+        params.pop("return_options")
+
+        return params
+
+    @property
+    def _model_kwargs(self) -> Dict[str, Any]:
+        base_kwargs = {
+            "max_new_tokens": self.max_new_tokens,
+            "temperature": self.temperature,
+        }
+
+        return {**base_kwargs, **self.additional_kwargs}
+
+    def _get_all_kwargs(self, **kwargs: Any) -> Dict[str, Any]:
+        return {**self._model_kwargs, **kwargs}
+
+    @llm_completion_callback()
+    def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        all_kwargs = self._get_all_kwargs(**kwargs)
+
+        response = self._model.generate_text(prompt=prompt, params=all_kwargs)
+
+        return CompletionResponse(text=response)
+
+    @llm_completion_callback()
+    def stream_complete(self, prompt: str, **kwargs: Any) -> CompletionResponseGen:
+        all_kwargs = self._get_all_kwargs(**kwargs)
+
+        stream_response = self._model.generate_text_stream(
+            prompt=prompt, params=all_kwargs
+        )
+
+        def gen() -> CompletionResponseGen:
+            content = ""
+            for stream_delta in stream_response:
+                content += stream_delta
+                yield CompletionResponse(text=content, delta=stream_delta)
+
+        return gen()
+
+    @llm_chat_callback()
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        all_kwargs = self._get_all_kwargs(**kwargs)
+        chat_fn = completion_to_chat_decorator(self.complete)
+
+        return chat_fn(messages, **all_kwargs)
+
+    @llm_chat_callback()
+    def stream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseGen:
+        all_kwargs = self._get_all_kwargs(**kwargs)
+        chat_stream_fn = stream_completion_to_chat_decorator(self.stream_complete)
+
+        return chat_stream_fn(messages, **all_kwargs)
+
+    # Async Functions
+    # IBM Watson Machine Learning Package currently does not have Support for Async calls
+
+    async def acomplete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        raise NotImplementedError
+
+    async def astream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        raise NotImplementedError
+
+    async def achat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        raise NotImplementedError
+
+    async def astream_complete(
+        self, prompt: str, **kwargs: Any
+    ) -> CompletionResponseAsyncGen:
+        raise NotImplementedError

--- a/llama_index/llms/watsonx_utils.py
+++ b/llama_index/llms/watsonx_utils.py
@@ -1,0 +1,44 @@
+import os
+from typing import Optional, Union
+
+WATSONX_MODELS = {
+    "google/flan-t5-xxl": 4096,
+    "google/flan-ul2": 4096,
+    "bigscience/mt0-xxl": 4096,
+    "eleutherai/gpt-neox-20b": 8192,
+    "bigcode/starcoder": 8192,
+    "meta-llama/llama-2-70b-chat": 4096,
+    "ibm/mpt-7b-instruct2": 2048,
+    "ibm/granite-13b-instruct-v1": 8192,
+    "ibm/granite-13b-chat-v1": 8192,
+}
+
+
+def watsonx_model_to_context_size(model_id: str) -> Union[int, None]:
+    """Calculate the maximum number of tokens possible to generate for a model.
+
+    Args:
+        model_id: The model name we want to know the context size for.
+
+    Returns:
+        The maximum context size
+    """
+    token_limit = WATSONX_MODELS.get(model_id, None)
+
+    if token_limit is None:
+        raise ValueError(f"Model name {model_id} not found in {WATSONX_MODELS.keys()}")
+
+    return token_limit
+
+
+def get_from_param_or_env_without_error(
+    param: Optional[str] = None,
+    env_key: Optional[str] = None,
+) -> Union[str, None]:
+    """Get a value from a param or an environment variable without error."""
+    if param is not None:
+        return param
+    elif env_key and env_key in os.environ and os.environ[env_key]:
+        return os.environ[env_key]
+    else:
+        return None

--- a/tests/llms/test_watsonx.py
+++ b/tests/llms/test_watsonx.py
@@ -1,0 +1,96 @@
+import sys
+from typing import Any, Dict, Generator, Optional
+from unittest.mock import MagicMock
+
+import pytest
+from llama_index.llms.base import ChatMessage
+
+try:
+    import ibm_watson_machine_learning
+except ImportError:
+    ibm_watson_machine_learning = None
+
+from llama_index.llms.watsonx import WatsonX
+
+
+class MockStreamResponse:
+    def __iter__(self) -> Generator[str, Any, None]:
+        deltas = ["\n\nThis ", "is indeed", " a test"]
+        yield from deltas
+
+
+class MockIBMModelModule(MagicMock):
+    class Model:
+        def __init__(
+            self,
+            model_id: str,
+            credentials: dict,
+            project_id: Optional[str] = None,
+            space_id: Optional[str] = None,
+        ) -> None:
+            pass
+
+        def get_details(self) -> Dict[str, Any]:
+            return {"model_details": "Mock IBM Watson Model"}
+
+        def generate_text(self, prompt: str, params: Optional[dict] = None) -> str:
+            return "\n\nThis is indeed a test"
+
+        def generate_text_stream(
+            self, prompt: str, params: Optional[dict] = None
+        ) -> MockStreamResponse:
+            return MockStreamResponse()
+
+
+sys.modules[
+    "ibm_watson_machine_learning.foundation_models.model"
+] = MockIBMModelModule()
+
+
+@pytest.mark.skipif(
+    ibm_watson_machine_learning is None,
+    reason="ibm-watson-machine-learning not installed",
+)
+def test_model_basic() -> None:
+    credentials = {"url": "https://thisisa.fake.url/", "apikey": "fake_api_key"}
+    project_id = "fake_project_id"
+
+    test_prompt = "This is a test"
+    llm = WatsonX(
+        model_id="ibm/granite-13b-instruct-v1",
+        credentials=credentials,
+        project_id=project_id,
+    )
+
+    response = llm.complete(test_prompt)
+    assert response.text == "\n\nThis is indeed a test"
+
+    message = ChatMessage(role="user", content=test_prompt)
+    chat_response = llm.chat([message])
+    assert chat_response.message.content == "\n\nThis is indeed a test"
+
+
+@pytest.mark.skipif(
+    ibm_watson_machine_learning is None,
+    reason="ibm-watson-machine-learning not installed",
+)
+def test_model_streaming() -> None:
+    credentials = {"url": "https://thisisa.fake.url/", "apikey": "fake_api_key"}
+    project_id = "fake_project_id"
+
+    test_prompt = "This is a test"
+    llm = WatsonX(
+        model_id="ibm/granite-13b-instruct-v1",
+        credentials=credentials,
+        project_id=project_id,
+    )
+
+    response_gen = llm.stream_complete(test_prompt)
+    response = list(response_gen)
+
+    assert response[-1].text == "\n\nThis is indeed a test"
+
+    message = ChatMessage(role="user", content=test_prompt)
+    chat_response_gen = llm.stream_chat([message])
+    chat_response = list(chat_response_gen)
+    assert chat_response[-1].message.content == "\n\nThis is indeed a test"


### PR DESCRIPTION
# Description

This PR adds support for IBM WatsonX Foundation Models.  I've added unit tests for basic and streaming functionality. 

Just a note regarding the implementation I've done in the tests, where I mocked the `ibm_watson_machine_learning.foundation_models.model` module. I did that because the library makes an API call during initialization to check for credentials' validity. I wasn't able to find an alternative way, to handle this. So I referenced `test_palm.py` and decided to follow that way to Mock the module.

Please let me know if my method is wrong, or if there are any other changes that you'd like in the PR.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
