### PR TITLE
optimized content of retriever tool and minor bug fix

### DIFF
--- a/llama_index/tools/retriever_tool.py
+++ b/llama_index/tools/retriever_tool.py
@@ -1,6 +1,6 @@
 """Retriever tool."""
 
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.langchain_helpers.agents.tools import LlamaIndexTool

--- a/llama_index/tools/retriever_tool.py
+++ b/llama_index/tools/retriever_tool.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, cast
 
 from llama_index.indices.base_retriever import BaseRetriever
 from llama_index.langchain_helpers.agents.tools import LlamaIndexTool
+from llama_index.schema import MetadataMode
 from llama_index.tools.types import AsyncBaseTool, ToolMetadata, ToolOutput
 
 DEFAULT_NAME = "retriever_tool"
@@ -51,21 +52,50 @@ class RetrieverTool(AsyncBaseTool):
     def metadata(self) -> ToolMetadata:
         return self._metadata
 
-    def call(self, input: Any) -> ToolOutput:
-        query_str = cast(str, input)
+    def call(self, *args: Any, **kwargs: Any) -> ToolOutput:
+        query_str = ""
+        if args is not None:
+            query_str += ", ".join([str(arg) for arg in args]) + "\n"
+        if kwargs is not None:
+            query_str += (
+                ", ".join([f"{k!s} is {v!s}" for k, v in kwargs.items()]) + "\n"
+            )
+        if query_str == "":
+            raise ValueError("Cannot call query engine without inputs")
+
         docs = self._retriever.retrieve(query_str)
+        content = ""
+        for doc in docs:
+            node_copy = doc.node.copy()
+            node_copy.text_template = "{metadata_str}\n{content}"
+            node_copy.metadata_template = "{key} = {value}"
+            content += node_copy.get_content(MetadataMode.LLM) + "\n\n"
         return ToolOutput(
-            content=str(docs),
+            content=content,
             tool_name=self.metadata.name,
             raw_input={"input": input},
             raw_output=docs,
         )
 
-    async def acall(self, input: Any) -> ToolOutput:
-        query_str = cast(str, input)
+    async def acall(self, *args: Any, **kwargs: Any) -> ToolOutput:
+        query_str = ""
+        if args is not None:
+            query_str += ", ".join([str(arg) for arg in args]) + "\n"
+        if kwargs is not None:
+            query_str += (
+                ", ".join([f"{k!s} is {v!s}" for k, v in kwargs.items()]) + "\n"
+            )
+        if query_str == "":
+            raise ValueError("Cannot call query engine without inputs")
         docs = await self._retriever.aretrieve(query_str)
+        content = ""
+        for doc in docs:
+            node_copy = doc.node.copy()
+            node_copy.text_template = "{metadata_str}\n{content}"
+            node_copy.metadata_template = "{key} = {value}"
+            content += node_copy.get_content(MetadataMode.LLM) + "\n\n"
         return ToolOutput(
-            content=str(docs),
+            content=content,
             tool_name=self.metadata.name,
             raw_input={"input": input},
             raw_output=docs,

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -153,12 +153,9 @@ def test_retreiver_tool() -> None:
         ),
     )
     output = vs_ret_tool.call("arg1", "arg2", key1="v1", key2="v2")
-    assert output.content.strip() == (
+    formated_doc = (
         "file_path = /data/personal/essay.md\n"
         "# title1:Hello world.\n"
-        "This is a test.\n"
-        "\n"
-        "file_path = /data/personal/essay.md\n"
-        "# title2:This is another test.\n"
-        "This is a test v2."
+        "This is a test."
     )
+    assert formated_doc in output.content

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -117,3 +117,48 @@ async def test_function_tool_async_defaults() -> None:
     langchain_tool = function_tool.to_langchain_tool()
     result = await langchain_tool.arun("1")
     assert result == "1"
+
+
+from llama_index import (
+    ServiceContext,
+    VectorStoreIndex,
+)
+from llama_index.schema import Document
+from llama_index.token_counter.mock_embed_model import MockEmbedding
+from llama_index.tools import RetrieverTool, ToolMetadata
+
+
+def test_retreiver_tool() -> None:
+    doc1 = Document(
+        text=("# title1:Hello world.\n" "This is a test.\n"),
+        metadata={"file_path": "/data/personal/essay.md"},
+    )
+
+    doc2 = Document(
+        text=("# title2:This is another test.\n" "This is a test v2."),
+        metadata={"file_path": "/data/personal/essay.md"},
+    )
+    service_context = ServiceContext.from_defaults(
+        llm=None, embed_model=MockEmbedding(embed_dim=1)
+    )
+    vs_index = VectorStoreIndex.from_documents(
+        [doc1, doc2], service_context=service_context
+    )
+    vs_retriever = vs_index.as_retriever()
+    vs_ret_tool = RetrieverTool(
+        retriever=vs_retriever,
+        metadata=ToolMetadata(
+            name="knowledgebase",
+            description="test",
+        ),
+    )
+    output = vs_ret_tool.call("arg1", "arg2", key1="v1", key2="v2")
+    assert output.content.strip() == (
+        "file_path = /data/personal/essay.md\n"
+        "# title1:Hello world.\n"
+        "This is a test.\n"
+        "\n"
+        "file_path = /data/personal/essay.md\n"
+        "# title2:This is another test.\n"
+        "This is a test v2."
+    )


### PR DESCRIPTION
# Description

Fixed issues so that retriever can take arbitrary input parameter `args and kwargs` instead of `input = ""`
Optimized content of retriever tool. Before it just str(scored_node), which makes agent really confused

## Change in a Glance
- Considering we have following docs/node to retrieve:
```
[Document(id_='...', embedding=None, metadata={'file_path': '/data/personal/essay.md'}, ..., text='# title1:Hello world.\nThis is a test.\n', ...),
 Document(id_='...', embedding=None, metadata={'file_path': '/data/personal/essay.md'}, ..., text='# title2:This is another test.\nThis is a test v2.', ...)]
```
- Before: retriever.output.content shows simply str(docs), looks like following:
```
"[NodeWithScore(node=TextNode(id_='e8a04fff-8674-44e5-8628-2d1bacafd8c0', embedding=None, metadata={'file_path': '/data/personal/essay.md'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={<NodeRelationship.SOURCE: '1'>: RelatedNodeInfo(node_id='fe85c756-359f-4b41-83a5-8ea623c41c02', node_type=<ObjectType.DOCUMENT: '4'>, metadata={'file_path': '/data/personal/essay.md'}, hash='0c0dad0d2c2a3be7d4cbc156ca42cbfccd2f029eddb69d0ec3af021330648951')}, hash='0c0dad0d2c2a3be7d4cbc156ca42cbfccd2f029eddb69d0ec3af021330648951', text='# title2:This is another test.\\nThis is a test v2.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=1.0), 
NodeWithScore(node=TextNode(id_='f9bb8bd9-a26d-44e4-b2f1-23e239ea32c3', embedding=None, metadata={'file_path': '/data/personal/essay.md'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={<NodeRelationship.SOURCE: '1'>: RelatedNodeInfo(node_id='276c0bbf-7e07-4b81-aac4-98c871b48f42', node_type=<ObjectType.DOCUMENT: '4'>, metadata={'file_path': '/data/personal/essay.md'}, hash='05afed27a3aba61c68c2cd48e140a726d9f0dba877b67b310ccbe614e7f43154')}, hash='21de075519145210f29669b9989036db29e112a7dff15a80f3f5674b23718dac', text='# title1:Hello world.\\nThis is a test.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=1.0)]"
```
- Current: it format the content, and the output looks like this:
```
file_path = [/data/personal/essay.md](https://file+.vscode-resource.vscode-cdn.net/data/personal/essay.md)
# title2:This is another test.
This is a test v2.

file_path = [/data/personal/essay.md](https://file+.vscode-resource.vscode-cdn.net/data/personal/essay.md)
# title1:Hello world.
This is a test.
```
- below is the code that does the formatting :
```python
        content = ""
        for doc in docs:
            node_copy = doc.node.copy()
            node_copy.text_template = "{metadata_str}\n{content}"
            node_copy.metadata_template = "{key} = {value}"
            content += node_copy.get_content(MetadataMode.LLM) + "\n\n"
```
## Validation 
The validation is hard to do in unit test, because it is not like the previous content throw error. The problem is that when I use retriever_tool in REACT AGENT, the agent gets confused by too many object information.
Still, I added a unit test to test the formatting .

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
