### PR TITLE
fix(limit): redis limit should follow top_k

### DIFF
--- a/llama_index/readers/redis/utils.py
+++ b/llama_index/readers/redis/utils.py
@@ -84,7 +84,9 @@ def get_redis_query(
     from redis.commands.search.query import Query
 
     base_query = f"{filters}=>[KNN {top_k} @{vector_field} $vector AS vector_score]"
-    query = Query(base_query).return_fields(*return_fields).dialect(2)
+
+    query = Query(base_query).return_fields(*return_fields).dialect(2).paging(0, top_k)
+
     if sort:
         query.sort_by("vector_score")
     return query


### PR DESCRIPTION
# Description

Redis was set to return 10 results, and breaking retrieval which requested more than 10 top_k results, since the default LIMIT was set to 10, now should follow the top_k limit

Fixes https://github.com/run-llama/llama_index/issues/8553

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
