### PR TITLE
added callbacks to response streams

### DIFF
--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from threading import Event
-from typing import AsyncGenerator, Generator, List, Optional, Union
+from typing import Any, AsyncGenerator, Callable, Generator, List, Optional, Union
 
 from llama_index.llms.base import ChatMessage, ChatResponseAsyncGen, ChatResponseGen
 from llama_index.memory import BaseMemory
@@ -171,13 +171,23 @@ class StreamingAgentChatResponse:
                 self._new_item_event.clear()  # Clear the event for the next wait
         self.response = self._unformatted_response.strip()
 
-    def print_response_stream(self) -> None:
+    def print_response_stream(
+        self, callback: Optional[Callable[[str], Any]] = None
+    ) -> None:
         for token in self.response_gen:
-            print(token, end="", flush=True)
+            if callback is not None:
+                callback(token)
+            else:
+                print(token, end="", flush=True)
 
-    async def aprint_response_stream(self) -> None:
+    async def aprint_response_stream(
+        self, callback: Optional[Callable[[str], Any]] = None
+    ) -> None:
         async for token in self.async_response_gen():
-            print(token, end="", flush=True)
+            if callback is not None:
+                callback(token)
+            else:
+                print(token, end="", flush=True)
 
 
 AGENT_CHAT_RESPONSE_TYPE = Union[AgentChatResponse, StreamingAgentChatResponse]

--- a/llama_index/response/schema.py
+++ b/llama_index/response/schema.py
@@ -1,7 +1,7 @@
 """Response schema."""
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from llama_index.bridge.pydantic import BaseModel
 from llama_index.schema import NodeWithScore
@@ -115,12 +115,17 @@ class StreamingResponse:
             self.response_txt = response_txt
         return Response(self.response_txt, self.source_nodes, self.metadata)
 
-    def print_response_stream(self) -> None:
+    def print_response_stream(
+        self, callback: Optional[Callable[[str], Any]] = None
+    ) -> None:
         """Print the response stream."""
         if self.response_txt is None and self.response_gen is not None:
             response_txt = ""
             for text in self.response_gen:
-                print(text, end="", flush=True)
+                if callback is not None:
+                    callback(text)
+                else:
+                    print(text, end="", flush=True)
                 response_txt += text
             self.response_txt = response_txt
         else:


### PR DESCRIPTION
# Description

This PR adds the ability to specify a callback function for response streams. This means that when using the package, we can get access to the generated text as it comes rather than just handing control to `print_response_stream()`. The updated function takes in a callback function which takes one parameter of string type.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I also tested it with my own project that I'm building and it works. I've put the example usage down below. I can create a notebook if necessary but the change wasn't too big.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods

# Example Usage

```py
query_engine = index.as_query_engine(streaming=True)
response = query_engine.query(prompt)

response.print_response_stream(lambda text: print(text, end="", flush=True))
```

or you can provide it a separate callback function.
