### PR TITLE
Update link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PyPI:
 
 LlamaIndex.TS (Typescript/Javascript): https://github.com/run-llama/LlamaIndexTS.
 
-Documentation: https://gpt-index.readthedocs.io/.
+Documentation: https://docs.llamaindex.ai/en/stable/.
 
 Twitter: https://twitter.com/llama_index.
 


### PR DESCRIPTION
# Description

The README links to documentation under https://gpt-index.readthedocs.io/ . This PR updates it to https://docs.llamaindex.ai/en/stable/.

## Type of Change

README only.

# How Has This Been Tested?

Manually compared websites under old and new URL and concluded they're the same.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

Not relevant