### PR TITLE
use node.text  instead of node.source_text

### DIFF
--- a/examples/test_wiki/TestNYC-Benchmark-GPT4.ipynb
+++ b/examples/test_wiki/TestNYC-Benchmark-GPT4.ipynb
@@ -185,9 +185,7 @@
     "    def is_correct_source(self) -> bool:\n",
     "        is_correct = True\n",
     "        for answer in self.test.must_contain:\n",
-    "            if all(\n",
-    "                answer not in node.text for node in self.response.source_nodes\n",
-    "            ):\n",
+    "            if all(answer not in node.text for node in self.response.source_nodes):\n",
     "                is_correct = False\n",
     "        return is_correct"
    ]
@@ -352,7 +350,7 @@
     "    outcome: TestOutcome, llm_predictor: LLMPredictor\n",
     ") -> Tuple[bool, bool]:\n",
     "    try:\n",
-    "        source_text = outcome.response.source_nodes[0].source_text\n",
+    "        source_text = outcome.response.source_nodes[0].text\n",
     "    except:\n",
     "        source_text = \"Failed to retrieve any context\"\n",
     "    result_str, _ = llm_predictor.predict(\n",

--- a/examples/test_wiki/TestNYC-Benchmark-GPT4.ipynb
+++ b/examples/test_wiki/TestNYC-Benchmark-GPT4.ipynb
@@ -186,7 +186,7 @@
     "        is_correct = True\n",
     "        for answer in self.test.must_contain:\n",
     "            if all(\n",
-    "                answer not in node.source_text for node in self.response.source_nodes\n",
+    "                answer not in node.text for node in self.response.source_nodes\n",
     "            ):\n",
     "                is_correct = False\n",
     "        return is_correct"


### PR DESCRIPTION
Quick and simple fix for Benchmark notebook. 
Use node.text instead of node.source_text.


