### PR TITLE
Feature (#8039): change fixed default variables as function parameters.

### DIFF
--- a/llama_index/llms/openai_utils.py
+++ b/llama_index/llms/openai_utils.py
@@ -149,12 +149,14 @@ def create_retry_decorator(
 def completion_with_retry(
     is_chat_model: bool,
     max_retries: int,
-    min_seconds: int = 4,
-    max_seconds: int = 10,
+    min_seconds: float = 4,
+    max_seconds: float = 10,
     **kwargs: Any,
 ) -> Any:
     """Use tenacity to retry the completion call."""
-    retry_decorator = create_retry_decorator(max_retries=max_retries)
+    retry_decorator = create_retry_decorator(
+        max_retries=max_retries, min_seconds=min_seconds, max_seconds=max_seconds
+    )
 
     @retry_decorator
     def _completion_with_retry(**kwargs: Any) -> Any:
@@ -167,12 +169,14 @@ def completion_with_retry(
 async def acompletion_with_retry(
     is_chat_model: bool,
     max_retries: int,
-    min_seconds: int = 4,
-    max_seconds: int = 10,
+    min_seconds: float = 4,
+    max_seconds: float = 10,
     **kwargs: Any,
 ) -> Any:
     """Use tenacity to retry the async completion call."""
-    retry_decorator = create_retry_decorator(max_retries=max_retries)
+    retry_decorator = create_retry_decorator(
+        max_retries=max_retries, min_seconds=min_seconds, max_seconds=max_seconds
+    )
 
     @retry_decorator
     async def _completion_with_retry(**kwargs: Any) -> Any:

--- a/llama_index/llms/openai_utils.py
+++ b/llama_index/llms/openai_utils.py
@@ -107,10 +107,12 @@ logger = logging.getLogger(__name__)
 CompletionClientType = Union[Type[Completion], Type[ChatCompletion]]
 
 
-def _create_retry_decorator(max_retries: int) -> Callable[[Any], Any]:
-    min_seconds = 4
-    max_seconds = 10
+def _create_retry_decorator(
+    max_retries: int, min_seconds: int = 4, max_seconds: int = 10
+) -> Callable[[Any], Any]:
     # Wait 2^x * 1 second between each retry starting with
+    # min_seconds, then up to max_seconds, then max_seconds afterwards
+    # By default:
     # 4 seconds, then up to 10 seconds, then 10 seconds afterwards
     return retry(
         reraise=True,
@@ -127,9 +129,17 @@ def _create_retry_decorator(max_retries: int) -> Callable[[Any], Any]:
     )
 
 
-def completion_with_retry(is_chat_model: bool, max_retries: int, **kwargs: Any) -> Any:
+def completion_with_retry(
+    is_chat_model: bool,
+    max_retries: int,
+    min_seconds: int = 4,
+    max_seconds: int = 10,
+    **kwargs: Any,
+) -> Any:
     """Use tenacity to retry the completion call."""
-    retry_decorator = _create_retry_decorator(max_retries=max_retries)
+    retry_decorator = _create_retry_decorator(
+        max_retries=max_retries, min_seconds=min_seconds, max_seconds=max_seconds
+    )
 
     @retry_decorator
     def _completion_with_retry(**kwargs: Any) -> Any:
@@ -140,10 +150,16 @@ def completion_with_retry(is_chat_model: bool, max_retries: int, **kwargs: Any) 
 
 
 async def acompletion_with_retry(
-    is_chat_model: bool, max_retries: int, **kwargs: Any
+    is_chat_model: bool,
+    max_retries: int,
+    min_seconds: int = 4,
+    max_seconds: int = 10,
+    **kwargs: Any,
 ) -> Any:
     """Use tenacity to retry the async completion call."""
-    retry_decorator = _create_retry_decorator(max_retries=max_retries)
+    retry_decorator = _create_retry_decorator(
+        max_retries=max_retries, min_seconds=min_seconds, max_seconds=max_seconds
+    )
 
     @retry_decorator
     async def _completion_with_retry(**kwargs: Any) -> Any:


### PR DESCRIPTION
# Feature (#8039): Add min_seconds and max_seconds as a parameter to the _create_retry_decorator function (#8039)

# Description

This PR includes the changes requested in [Feature Request]: Configurable retry time for LLM calls #8039
I changed the min_seconds and max_seconds variables as parameters of the function def _create_retry_decorator().
User can now to configure these values.

Fixes # (8039)

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
