### PR TITLE
Allow init of stores_text variable for Pinecone vector store

### DIFF
--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -119,9 +119,9 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
     """
 
-    stores_text: bool = True
     flat_metadata: bool = False
 
+    stores_text: bool
     api_key: Optional[str]
     index_name: Optional[str]
     environment: Optional[str]
@@ -146,6 +146,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         tokenizer: Optional[Callable] = None,
         text_key: str = DEFAULT_TEXT_KEY,
         batch_size: int = DEFAULT_BATCH_SIZE,
+        stores_text: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -172,6 +173,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
             tokenizer = get_default_tokenizer()
         self._tokenizer = tokenizer
 
+        self.stores_text = stores_text
+
         super().__init__(
             index_name=index_name,
             environment=environment,
@@ -195,6 +198,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         tokenizer: Optional[Callable] = None,
         text_key: str = DEFAULT_TEXT_KEY,
         batch_size: int = DEFAULT_BATCH_SIZE,
+        stores_text: bool = True,
         **kwargs: Any,
     ) -> "PineconeVectorStore":
         try:
@@ -216,6 +220,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             tokenizer=tokenizer,
             text_key=text_key,
             batch_size=batch_size,
+            stores_text=stores_text,
             **kwargs,
         )
 
@@ -238,8 +243,9 @@ class PineconeVectorStore(BasePydanticVectorStore):
         for node in nodes:
             node_id = node.node_id
 
+            remove_text = not self.stores_text
             metadata = node_to_metadata_dict(
-                node, remove_text=False, flat_metadata=self.flat_metadata
+                node, remove_text=remove_text, flat_metadata=self.flat_metadata
             )
 
             entry = {

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -174,8 +174,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
             tokenizer = get_default_tokenizer()
         self._tokenizer = tokenizer
 
-        self.remove_text_from_metadata = remove_text_from_metadata
-
         super().__init__(
             index_name=index_name,
             environment=environment,
@@ -246,7 +244,9 @@ class PineconeVectorStore(BasePydanticVectorStore):
             node_id = node.node_id
 
             metadata = node_to_metadata_dict(
-                node, remove_text=self.remove_text_from_metadata, flat_metadata=self.flat_metadata
+                node,
+                remove_text=self.remove_text_from_metadata,
+                flat_metadata=self.flat_metadata,
             )
 
             entry = {

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -119,9 +119,9 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
     """
 
+    stores_text: bool = True
     flat_metadata: bool = False
 
-    stores_text: bool
     api_key: Optional[str]
     index_name: Optional[str]
     environment: Optional[str]
@@ -130,6 +130,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
     add_sparse_vector: bool
     text_key: str
     batch_size: int
+    remove_text_from_metadata: bool
 
     _pinecone_index: Any = PrivateAttr()
     _tokenizer: Optional[Callable] = PrivateAttr()
@@ -146,7 +147,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         tokenizer: Optional[Callable] = None,
         text_key: str = DEFAULT_TEXT_KEY,
         batch_size: int = DEFAULT_BATCH_SIZE,
-        stores_text: bool = True,
+        remove_text_from_metadata: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -173,7 +174,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             tokenizer = get_default_tokenizer()
         self._tokenizer = tokenizer
 
-        self.stores_text = stores_text
+        self.remove_text_from_metadata = remove_text_from_metadata
 
         super().__init__(
             index_name=index_name,
@@ -184,6 +185,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             add_sparse_vector=add_sparse_vector,
             text_key=text_key,
             batch_size=batch_size,
+            remove_text_from_metadata=remove_text_from_metadata,
         )
 
     @classmethod
@@ -198,7 +200,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         tokenizer: Optional[Callable] = None,
         text_key: str = DEFAULT_TEXT_KEY,
         batch_size: int = DEFAULT_BATCH_SIZE,
-        stores_text: bool = True,
+        remove_text_from_metadata: bool = False,
         **kwargs: Any,
     ) -> "PineconeVectorStore":
         try:
@@ -220,7 +222,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             tokenizer=tokenizer,
             text_key=text_key,
             batch_size=batch_size,
-            stores_text=stores_text,
+            remove_text_from_metadata=remove_text_from_metadata,
             **kwargs,
         )
 
@@ -243,9 +245,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
         for node in nodes:
             node_id = node.node_id
 
-            remove_text = not self.stores_text
             metadata = node_to_metadata_dict(
-                node, remove_text=remove_text, flat_metadata=self.flat_metadata
+                node, remove_text=self.remove_text_from_metadata, flat_metadata=self.flat_metadata
             )
 
             entry = {


### PR DESCRIPTION
# Description

This allows the the stores_text variable to be initialized with the PineconeVectorStore and used as the flag to determine whether text should be removed from metadata when storing node in Pinecone. 

This is useful for organizations who don't want plaintext document data stored in Pinecone. 

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My code generates no new warnings 
- [x] I ran `make format; make lint` to appease the lint gods
