### PR TITLE
corrected broken link to the How to read these docs page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ To install the library:
 
 ``pip install llama-index``
 
-We recommend starting at `how to read these docs </getting_started/reading.html>`_, which will point you to the right place based on your experience level.
+We recommend starting at `how to read these docs <getting_started/reading.md>`_, which will point you to the right place based on your experience level.
 
 🗺️ Ecosystem
 ************


### PR DESCRIPTION
# Description

This fixes a broken link in the top-level of the LlamaIndex documentation.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
- [x] This is just a documentation change. I made sure that the new documentation renders correctly. 
