### PR TITLE
Adds mistral 7b instruct v0.1 to available anyscale models

### DIFF
--- a/llama_index/llms/anyscale_utils.py
+++ b/llama_index/llms/anyscale_utils.py
@@ -9,8 +9,13 @@ LLAMA_MODELS = {
     "codellama/CodeLlama-34b-Instruct-hf": 16384,
 }
 
+MISTRAL_MODELS = {
+    "mistralai/Mistral-7B-Instruct-v0.1": 4096,
+}
+
 ALL_AVAILABLE_MODELS = {
     **LLAMA_MODELS,
+    **MISTRAL_MODELS,
 }
 
 DISCONTINUED_MODELS: Dict[str, int] = {}


### PR DESCRIPTION
# Description

Anyscale recently made a `Mistral-7B-Instruct-v0.1` endpoint available. However, it's not possible to use with `llama_index.llms.anyscale` because `anyscale_utils.py` expects the model to be explicitly specified.

See here: https://github.com/run-llama/llama_index/blob/main/llama_index/llms/anyscale_utils.py#L42-L48

Fixes # (issue)

I simply updated the list of models to include the relevant one.

This 
## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
