### PR TITLE
fix: azure ad support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Deepmemory support (#8625)
 - Add CohereAI embeddings (#8650)
+- Add Azure AD (Microsoft Entra ID) support (#8667)
 
 ## [0.8.58] - 2023-11-02
 

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -1,9 +1,12 @@
 from typing import Any, Dict, Optional
 
-from llama_index.bridge.pydantic import Field, root_validator
+from llama_index.bridge.pydantic import Field, PrivateAttr, root_validator
 from llama_index.callbacks import CallbackManager
 from llama_index.llms.openai import OpenAI
-from llama_index.llms.openai_utils import resolve_from_aliases
+from llama_index.llms.openai_utils import (
+    refresh_openai_azuread_token,
+    resolve_from_aliases,
+)
 
 AZURE_OPENAI_API_TYPE = "azure"
 
@@ -27,13 +30,18 @@ class AzureOpenAI(OpenAI):
         This may change in the future.
     - `OPENAI_API_BASE`: your endpoint should look like the following
         https://YOUR_RESOURCE_NAME.openai.azure.com/
-    - `OPENAI_API_KEY`: your API key
+    - `OPENAI_API_KEY`: your API key if the api type is `azure`
 
     More information can be found here:
         https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart?tabs=command-line&pivots=programming-language-python
     """
 
     engine: str = Field(description="The name of the deployed azure engine.")
+    use_azure_ad: bool = Field(
+        description="Indicates if Microsoft Entra ID (former Azure AD) is used for token authentication"
+    )
+
+    _azure_ad_token: Any = PrivateAttr()
 
     def __init__(
         self,
@@ -64,8 +72,11 @@ class AzureOpenAI(OpenAI):
         if engine is None:
             raise ValueError("You must specify an `engine` parameter.")
 
+        use_azure_ad = api_type in ("azuread", "azure_ad")
+
         super().__init__(
             engine=engine,
+            use_azure_ad=use_azure_ad,
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -96,6 +107,14 @@ class AzureOpenAI(OpenAI):
             raise ValueError("You must set OPENAI_API_VERSION for Azure OpenAI.")
 
         return values
+
+    @property
+    def _credential_kwargs(self) -> Dict[str, Any]:
+        if self.use_azure_ad:
+            self._azure_ad_token = refresh_openai_azuread_token(self._azure_ad_token)
+            self.api_key = self._azure_ad_token.token
+
+        return super()._credential_kwargs()
 
     @property
     def _model_kwargs(self) -> Dict[str, Any]:

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -114,7 +114,7 @@ class AzureOpenAI(OpenAI):
             self._azure_ad_token = refresh_openai_azuread_token(self._azure_ad_token)
             self.api_key = self._azure_ad_token.token
 
-        return super()._credential_kwargs()
+        return super()._credential_kwargs
 
     @property
     def _model_kwargs(self) -> Dict[str, Any]:

--- a/llama_index/llms/openai_utils.py
+++ b/llama_index/llms/openai_utils.py
@@ -304,7 +304,7 @@ def resolve_openai_credentials(
     api_type: Optional[str] = None,
     api_base: Optional[str] = None,
     api_version: Optional[str] = None,
-) -> Tuple[str, str, str, str]:
+) -> Tuple[Optional[str], str, str, str]:
     """ "Resolve OpenAI credentials.
 
     The order of precedence is:
@@ -334,8 +334,8 @@ def resolve_openai_credentials(
 
 
 def refresh_openai_azuread_token(
-    azure_ad_token=None,
-) -> "AccessToken":
+    azure_ad_token: Any = None,
+) -> Any:
     """
     Checks the validity of the associated token, if any, and tries to refresh it
     using the credentials available in the current context. Different authentication

--- a/llama_index/llms/openai_utils.py
+++ b/llama_index/llms/openai_utils.py
@@ -335,7 +335,13 @@ def resolve_openai_credentials(
 
 def refresh_openai_azuread_token(
     azure_ad_token=None,
-):
+) -> "AccessToken":
+    """
+    Checks the validity of the associated token, if any, and tries to refresh it
+    using the credentials available in the current context. Different authentication
+    methods are tried, in order, until a successful one is found as defined at the
+    package `azure-indentity`.
+    """
     try:
         from azure.core.exceptions import ClientAuthenticationError
         from azure.identity import DefaultAzureCredential

--- a/llama_index/llms/openai_utils.py
+++ b/llama_index/llms/openai_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import openai
@@ -326,10 +327,36 @@ def resolve_openai_credentials(
     api_base = api_base or openai.api_base or DEFAULT_OPENAI_API_BASE
     api_version = api_version or openai.api_version or DEFAULT_OPENAI_API_VERSION
 
-    if not api_key:
+    if not api_key and api_type not in ("azuread", "azure_ad"):
         raise ValueError(MISSING_API_KEY_ERROR_MESSAGE)
 
     return api_key, api_type, api_base, api_version
+
+
+def refresh_openai_azuread_token(
+    azure_ad_token=None,
+):
+    try:
+        from azure.core.exceptions import ClientAuthenticationError
+        from azure.identity import DefaultAzureCredential
+    except ImportError as ex:
+        raise ValueError(
+            "Using API type `azure_ad` or `azuread` requires the package"
+            " `azure-identity` to be installed."
+        ) from ex
+
+    if not azure_ad_token or azure_ad_token.expires_on < time.time() + 60:
+        try:
+            credential = DefaultAzureCredential()
+            azure_ad_token = credential.get_token(
+                "https://cognitiveservices.azure.com/.default"
+            )
+        except ClientAuthenticationError as err:
+            raise ValueError(
+                "Unable to acquire a valid Microsoft Entra ID (former Azure AD) token for "
+                f"the resource due to the following error: {err.message}"
+            ) from err
+    return azure_ad_token
 
 
 def validate_openai_api_key(api_key: Optional[str] = None) -> None:


### PR DESCRIPTION
# Description

Azure OpenAI LLMs support Microsoft Entra ID (formerly known as Azure Active Directory) tokens to use for authorization instead of relying on keys. This authentication is supported in in LlamaIndex, however, those tokens need to be refreshed since they have a TTL. If not, changes are that authentication errors occur because token is not refreshed.

This PR fixes the support for it.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
