### PR TITLE
passing max_tokens to the `Cohere` llm

### DIFF
--- a/llama_index/llms/cohere.py
+++ b/llama_index/llms/cohere.py
@@ -35,6 +35,7 @@ class Cohere(LLM):
     additional_kwargs: Dict[str, Any] = Field(
         default_factory=dict, description="Additional kwargs for the Cohere API."
     )
+    max_tokens: int = Field(description="The maximum number of tokens to generate.")
 
     _client: Any = PrivateAttr()
     _aclient: Any = PrivateAttr()

--- a/llama_index/llms/cohere.py
+++ b/llama_index/llms/cohere.py
@@ -70,6 +70,7 @@ class Cohere(LLM):
             max_retries=max_retries,
             model=model,
             callback_manager=callback_manager,
+            max_tokens=max_tokens,
         )
 
     @classmethod


### PR DESCRIPTION
# Description

The `Cohere` llm did not have `max_tokens` defined and did not pass the `max_tokens` param from the client instantiation to the constructor. This PR adds it to the constructor init. 

Fixes # https://github.com/run-llama/llama_index/issues/8671 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code/made the bug fix and don't have the `AttributeError` anymore 

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
