### PR TITLE
Update deeplake.py

### DIFF
--- a/llama_index/vector_stores/deeplake.py
+++ b/llama_index/vector_stores/deeplake.py
@@ -18,7 +18,7 @@ from llama_index.vector_stores.utils import (
 )
 
 try:
-    from deeplake.core.vectorstore import VectorStore
+    from deeplake.core.vectorstore.deeplake_vectorstore import VectorStore
 
     DEEPLAKE_INSTALLED = True
 except ImportError:


### PR DESCRIPTION
# Description

I am trying Deep Memory and noticed one issue, this block in deeplake.py is no longer valid:
```
try:
    from deeplake.core.vectorstore import VectorStore
  
    DEEPLAKE_INSTALLED = True
except ImportError:
    DEEPLAKE_INSTALLED = False
```

The latest deeplake release has VectorStore under deeplake.core.vectorstore.deeplake_vectorstore, so that line in try block needs to be updated, otherwise, it keeps complaining import error even if we have deeplake installed.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
