### PR TITLE
Fix typo error in CohereAIModelName class: cohere light models was missing v3

### DIFF
--- a/llama_index/embeddings/cohereai.py
+++ b/llama_index/embeddings/cohereai.py
@@ -9,9 +9,9 @@ from llama_index.embeddings.base import DEFAULT_EMBED_BATCH_SIZE, BaseEmbedding
 # Enums for validation and type safety
 class CohereAIModelName(str, Enum):
     ENGLISH_V3 = "embed-english-v3.0"
-    ENGLISH_LIGHT_V3 = "embed-english-light-3.0"
+    ENGLISH_LIGHT_V3 = "embed-english-light-v3.0"
     MULTILINGUAL_V3 = "embed-multilingual-v3.0"
-    MULTILINGUAL_LIGHT_V3 = "embed-multilingual-light-3.0"
+    MULTILINGUAL_LIGHT_V3 = "embed-multilingual-light-v3.0"
 
     ENGLISH_V2 = "embed-english-v2.0"
     ENGLISH_LIGHT_V2 = "embed-english-light-v2.0"


### PR DESCRIPTION
# Description

The current cohere integration does not work with the embed-multilingual-light-v3.0 and embed-english-light-v3.0 because the models lacked the "v" in front of the model name within the CohereAIModelName class. Therefore calling the cohere embedding function yielded the following error "CohereAPIError: model not found, make sure the correct model ID was used and that you have access to the model."

Fixes # (issue)

Changed 

ENGLISH_LIGHT_V3 = "embed-english-light-3.0"
to 
ENGLISH_LIGHT_V3 = "embed-english-light-v3.0"

And

MULTILINGUAL_LIGHT_V3 = "embed-multilingual-light-3.0"
to
MULTILINGUAL_LIGHT_V3 = "embed-multilingual-light-v3.0"


Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] Added new notebook (that tests end-to-end)

After changing naming, the following code was run to verify the model name change:

```python
from llama_index.embeddings.cohereai import CohereEmbedding

# with input_typ='search_query'
embed_model = CohereEmbedding(
    cohere_api_key=COHERE_API_KEY,
    model_name="embed-english-light-v3.0",
    input_type="search_query",
)

embeddings = embed_model.get_text_embedding("Hello CohereAI!")

print(len(embeddings))
print(embeddings[:5])
```

As well as

```python
from llama_index.embeddings.cohereai import CohereEmbedding

# with input_typ='search_query'
embed_model = CohereEmbedding(
    cohere_api_key=COHERE_API_KEY,
    model_name="embed-multilingual-light-v3.0",
    input_type="search_query",
)

embeddings = embed_model.get_text_embedding("Hello CohereAI!")

print(len(embeddings))
print(embeddings[:5])
```