### PR TITLE
Fix context window reference in Lllama-cpp

### DIFF
--- a/llama_index/llms/llama_cpp.py
+++ b/llama_index/llms/llama_cpp.py
@@ -151,7 +151,7 @@ class LlamaCPP(CustomLLM):
     def metadata(self) -> LLMMetadata:
         """LLM metadata."""
         return LLMMetadata(
-            context_window=self._model.context_params.n_ctx,
+            context_window=self._model.params.n_ctx,
             num_output=self.max_new_tokens,
             model_name=self.model_path,
         )


### PR DESCRIPTION
# Description 
The LLama class from LLama-cpp stores its context window argument in `.params.n_ctx` instead of `.context_params.n_ctx`. 

Prior to this PR when attempting to create an index with llama-cpp locally I would get: 

`AttributeError: 'Llama' object has no attribute 'context_params'` 

Upon debugging you can see that the context params are stored as `params`
<img width="576" alt="Screenshot 2023-11-05 at 9 31 56 PM" src="https://github.com/run-llama/llama_index/assets/14863425/c4dfb88c-6323-4c28-82fa-80daf6243451">

Fixes # (issue) 

No current issue. 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

Existing tests pass, I had 7 unrelated tests fail that require `stopwords` from `nltk` as I can not make that download with my corporate proxy setup.  

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
