### PR TITLE
add add_kwargs to vector stores / vectorstoreindex

### DIFF
--- a/llama_index/vector_stores/astra.py
+++ b/llama_index/vector_stores/astra.py
@@ -88,6 +88,7 @@ class AstraDBVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/awadb.py
+++ b/llama_index/vector_stores/awadb.py
@@ -49,7 +49,7 @@ class AwaDBVectorStore(VectorStore):
         self,
         table_name: str = DEFAULT_TABLE_NAME,
         log_and_data_dir: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Initialize with AwaDB client.
            If table_name is not specified,
@@ -83,6 +83,7 @@ class AwaDBVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to AwaDB.
 

--- a/llama_index/vector_stores/azurecosmosmongo.py
+++ b/llama_index/vector_stores/azurecosmosmongo.py
@@ -123,6 +123,7 @@ class AzureCosmosDBMongoDBVectorSearch(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/bagel.py
+++ b/llama_index/vector_stores/bagel.py
@@ -55,7 +55,7 @@ class BagelVectorStore(VectorStore):
 
         self._collection = collection
 
-    def add(self, nodes: List[BaseNode], **kwargs: Any) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """
         Add a list of nodes with embeddings to the vector store.
 

--- a/llama_index/vector_stores/cassandra.py
+++ b/llama_index/vector_stores/cassandra.py
@@ -122,6 +122,7 @@ class CassandraVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/chatgpt_plugin.py
+++ b/llama_index/vector_stores/chatgpt_plugin.py
@@ -94,6 +94,7 @@ class ChatGPTRetrievalPluginClient(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index."""
         headers = {"Authorization": f"Bearer {self._bearer_token}"}

--- a/llama_index/vector_stores/chroma.py
+++ b/llama_index/vector_stores/chroma.py
@@ -150,7 +150,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
     def class_name(cls) -> str:
         return "ChromaVectorStore"
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to index.
 
         Args:

--- a/llama_index/vector_stores/cogsearch.py
+++ b/llama_index/vector_stores/cogsearch.py
@@ -397,6 +397,7 @@ class CognitiveSearchVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index associated with the configured search client.
 

--- a/llama_index/vector_stores/dashvector.py
+++ b/llama_index/vector_stores/dashvector.py
@@ -73,6 +73,7 @@ class DashVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to vector store.
 

--- a/llama_index/vector_stores/deeplake.py
+++ b/llama_index/vector_stores/deeplake.py
@@ -123,7 +123,7 @@ class DeepLakeVectorStore(VectorStoreBase):
         """
         return self.vectorstore.dataset
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add the embeddings and their nodes into DeepLake.
 
         Args:

--- a/llama_index/vector_stores/docarray/base.py
+++ b/llama_index/vector_stores/docarray/base.py
@@ -96,6 +96,7 @@ class DocArrayVectorStore(VectorStore, ABC):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Adds nodes to the vector store.
 

--- a/llama_index/vector_stores/dynamodb.py
+++ b/llama_index/vector_stores/dynamodb.py
@@ -70,7 +70,7 @@ class DynamoDBVectorStore(VectorStore):
         item = cast(Dict[str, List[float]], item)
         return item[self._key_value]
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to index."""
         response = []
         for node in nodes:

--- a/llama_index/vector_stores/elasticsearch.py
+++ b/llama_index/vector_stores/elasticsearch.py
@@ -270,6 +270,7 @@ class ElasticsearchStore(VectorStore):
         nodes: List[BaseNode],
         *,
         create_index_if_not_exists: bool = True,
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to Elasticsearch index.
 
@@ -296,6 +297,7 @@ class ElasticsearchStore(VectorStore):
         nodes: List[BaseNode],
         *,
         create_index_if_not_exists: bool = True,
+        **add_kwargs: Any,
     ) -> List[str]:
         """Asynchronous method to add nodes to Elasticsearch index.
 

--- a/llama_index/vector_stores/epsilla.py
+++ b/llama_index/vector_stores/epsilla.py
@@ -148,6 +148,7 @@ class EpsillaVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """
         Add nodes to Epsilla vector store.

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -91,6 +91,7 @@ class FaissVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -100,6 +100,7 @@ class LanceDBVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         data = []
         ids = []

--- a/llama_index/vector_stores/metal.py
+++ b/llama_index/vector_stores/metal.py
@@ -111,7 +111,7 @@ class MetalVectorStore(VectorStore):
         """Return Metal client."""
         return self.metal_client
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to index.
 
         Args:

--- a/llama_index/vector_stores/milvus.py
+++ b/llama_index/vector_stores/milvus.py
@@ -151,7 +151,7 @@ class MilvusVectorStore(VectorStore):
         """Get client."""
         return self.milvusclient
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add the embeddings and their nodes into Milvus.
 
         Args:

--- a/llama_index/vector_stores/mongodb.py
+++ b/llama_index/vector_stores/mongodb.py
@@ -102,6 +102,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -214,6 +214,7 @@ class MyScaleVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/neo4jvector.py
+++ b/llama_index/vector_stores/neo4jvector.py
@@ -220,7 +220,7 @@ class Neo4jVectorStore(VectorStore):
             except CypherSyntaxError as e:
                 raise ValueError(f"Cypher Statement is not valid\n{e}")
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         ids = [r.node_id for r in nodes]
         import_query = (
             "UNWIND $data AS row "

--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -363,6 +363,7 @@ class OpensearchVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -231,6 +231,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/postgres.py
+++ b/llama_index/vector_stores/postgres.py
@@ -292,7 +292,7 @@ class PGVectorStore(BasePydanticVectorStore):
             ),
         )
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         self._initialize()
         ids = []
         with self._session() as session, session.begin():

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -120,7 +120,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
     def class_name(cls) -> str:
         return "QdraantVectorStore"
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to index.
 
         Args:

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -126,7 +126,7 @@ class RedisVectorStore(VectorStore):
         """Return the redis client instance."""
         return self._redis_client
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to the index.
 
         Args:

--- a/llama_index/vector_stores/rocksetdb.py
+++ b/llama_index/vector_stores/rocksetdb.py
@@ -123,7 +123,7 @@ class RocksetVectorStore(VectorStore):
     def client(self) -> Any:
         return self.rs
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Stores vectors in the collection.
 
         Args:

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -128,6 +128,7 @@ class SimpleVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index."""
         for node in nodes:

--- a/llama_index/vector_stores/singlestoredb.py
+++ b/llama_index/vector_stores/singlestoredb.py
@@ -122,7 +122,7 @@ class SingleStoreVectorStore(VectorStore):
         finally:
             conn.close()
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to index.
 
         Args:

--- a/llama_index/vector_stores/supabase.py
+++ b/llama_index/vector_stores/supabase.py
@@ -79,7 +79,7 @@ class SupabaseVectorStore(VectorStore):
             vecs_filter[f.key] = {"$eq": f.value}
         return vecs_filter
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to index.
 
         Args:

--- a/llama_index/vector_stores/tair.py
+++ b/llama_index/vector_stores/tair.py
@@ -125,7 +125,7 @@ class TairVectorStore(VectorStore):
         """Return the Tair client instance."""
         return self._tair_client
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to the index.
 
         Args:

--- a/llama_index/vector_stores/tencentvectordb.py
+++ b/llama_index/vector_stores/tencentvectordb.py
@@ -397,6 +397,7 @@ class TencentVectorDB(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/timescalevector.py
+++ b/llama_index/vector_stores/timescalevector.py
@@ -118,15 +118,15 @@ class TimescaleVectorStore(VectorStore):
             node.embedding,
         ]
 
-    def add(self, embedding_results: List[BaseNode]) -> List[str]:
-        rows_to_insert = [self._node_to_row(node) for node in embedding_results]
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
+        rows_to_insert = [self._node_to_row(node) for node in nodes]
         ids = [result[0] for result in rows_to_insert]
         self._sync_client.upsert(rows_to_insert)
         return ids
 
-    async def async_add(self, embedding_results: List[BaseNode]) -> List[str]:
-        rows_to_insert = [self._node_to_row(node) for node in embedding_results]
-        ids = [result.node_id for result in embedding_results]
+    async def async_add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
+        rows_to_insert = [self._node_to_row(node) for node in nodes]
+        ids = [result.node_id for result in nodes]
         await self._async_client.upsert(rows_to_insert)
         return ids
 

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -159,6 +159,7 @@ class VectorStore(Protocol):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes with embedding to vector store."""
         ...
@@ -166,6 +167,7 @@ class VectorStore(Protocol):
     async def async_add(
         self,
         nodes: List[BaseNode],
+        **kwargs: Any,
     ) -> List[str]:
         """
         Asynchronously add nodes with embedding to vector store.

--- a/llama_index/vector_stores/typesense.py
+++ b/llama_index/vector_stores/typesense.py
@@ -130,6 +130,7 @@ class TypesenseVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -167,6 +167,7 @@ class WeaviateVectorStore(BasePydanticVectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to index.
 

--- a/llama_index/vector_stores/zep.py
+++ b/llama_index/vector_stores/zep.py
@@ -121,7 +121,7 @@ class ZepVectorStore(VectorStore):
 
         return docs, ids
 
-    def add(self, nodes: List[BaseNode]) -> List[str]:
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to the collection.
 
         Args:
@@ -147,6 +147,7 @@ class ZepVectorStore(VectorStore):
     async def async_add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Asynchronously add nodes to the collection.
 

--- a/tests/indices/composability/test_utils.py
+++ b/tests/indices/composability/test_utils.py
@@ -25,6 +25,7 @@ class MockVectorStore(VectorStore):
     def add(
         self,
         nodes: List[BaseNode],
+        **add_kwargs: Any,
     ) -> List[str]:
         """Add nodes to vector store."""
         raise NotImplementedError


### PR DESCRIPTION
This PR adds add_kwargs to both the inner `VectorStore` class as well as the outer `VectorStoreIndex` class - we pass any additional kwargs in from_documents towards vector store insert during initialization.

This allows users to specify kwargs when inserting a document/node (whether during `from_documents` or just `insert`) 

Will help with row-level features like access control etc 