### PR TITLE
fix elastic search zero results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fix returning zero nodes in elastic search vector store (#8746)
+- Add try/except for `SimpleDirectoryReader` loop to avoid crashing on a single document (#8744)
+
 ## [0.8.63] - 2023-11-05
 
 ### New Features

--- a/llama_index/vector_stores/elasticsearch.py
+++ b/llama_index/vector_stores/elasticsearch.py
@@ -128,6 +128,9 @@ def _to_elasticsearch_filter(standard_filters: MetadataFilters) -> Dict[str, Any
 
 
 def _to_llama_similarities(scores: List[float]) -> List[float]:
+    if scores is None or len(scores) == 0:
+        return []
+
     scores_to_norm: np.ndarray = np.array(scores)
     return np.exp(scores_to_norm - np.max(scores_to_norm)).tolist()
 


### PR DESCRIPTION
# Description

Simple fix to avoid crashing when zero nodes are returned.

Fixes https://github.com/run-llama/llama_index/issues/8730

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

