### PR TITLE
Remove unsupported deployment_name arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix returning zero nodes in elastic search vector store (#8746)
 - Add try/except for `SimpleDirectoryReader` loop to avoid crashing on a single document (#8744)
+- Fix for `deployment_name` in async embeddings (#8748)
 
 ## [0.8.63] - 2023-11-05
 

--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -350,6 +350,5 @@ class OpenAIEmbedding(BaseEmbedding):
             self._aclient,
             texts,
             engine=self._text_engine,
-            deployment_id=self.deployment_name,
             **self.additional_kwargs,
         )


### PR DESCRIPTION
# Description

This broke Vectorstore Async embedding support broke after #8712 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
