### PR TITLE
add namespaced vector stores to storage context

### DIFF
--- a/llama_index/storage/storage_context.py
+++ b/llama_index/storage/storage_context.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import fsspec
 
@@ -24,7 +24,11 @@ from llama_index.storage.index_store.types import (
 from llama_index.storage.index_store.types import BaseIndexStore
 from llama_index.utils import concat_dirs
 from llama_index.vector_stores.simple import DEFAULT_PERSIST_FNAME as VECTOR_STORE_FNAME
-from llama_index.vector_stores.simple import SimpleVectorStore
+from llama_index.vector_stores.simple import (
+    DEFAULT_VECTOR_STORE,
+    NAMESPACE_SEP,
+    SimpleVectorStore,
+)
 from llama_index.vector_stores.types import VectorStore
 
 DEFAULT_PERSIST_DIR = "./storage"
@@ -45,7 +49,7 @@ class StorageContext:
 
     docstore: BaseDocumentStore
     index_store: BaseIndexStore
-    vector_store: VectorStore
+    vector_stores: Dict[str, VectorStore]
     graph_store: GraphStore
 
     @classmethod
@@ -54,6 +58,7 @@ class StorageContext:
         docstore: Optional[BaseDocumentStore] = None,
         index_store: Optional[BaseIndexStore] = None,
         vector_store: Optional[VectorStore] = None,
+        vector_stores: Optional[Dict[str, VectorStore]] = None,
         graph_store: Optional[GraphStore] = None,
         persist_dir: Optional[str] = None,
         fs: Optional[fsspec.AbstractFileSystem] = None,
@@ -70,8 +75,12 @@ class StorageContext:
         if persist_dir is None:
             docstore = docstore or SimpleDocumentStore()
             index_store = index_store or SimpleIndexStore()
-            vector_store = vector_store or SimpleVectorStore()
             graph_store = graph_store or SimpleGraphStore()
+
+            if vector_store:
+                vector_stores = {DEFAULT_VECTOR_STORE: vector_store}
+            else:
+                vector_stores = vector_stores, SimpleVectorStore()
         else:
             docstore = docstore or SimpleDocumentStore.from_persist_dir(
                 persist_dir, fs=fs
@@ -79,14 +88,24 @@ class StorageContext:
             index_store = index_store or SimpleIndexStore.from_persist_dir(
                 persist_dir, fs=fs
             )
-            vector_store = vector_store or SimpleVectorStore.from_persist_dir(
-                persist_dir, fs=fs
-            )
             graph_store = graph_store or SimpleGraphStore.from_persist_dir(
                 persist_dir, fs=fs
             )
 
-        return cls(docstore, index_store, vector_store, graph_store)
+            if vector_store:
+                vector_stores = {DEFAULT_VECTOR_STORE: vector_store}
+            else:
+                vector_stores = (
+                    vector_stores
+                    or SimpleVectorStore.from_namespaced_persist_dir(persist_dir, fs=fs)
+                )
+
+        return cls(
+            docstore=docstore,
+            index_store=index_store,
+            vector_stores=vector_stores,
+            graph_store=graph_store,
+        )
 
     def persist(
         self,
@@ -106,39 +125,56 @@ class StorageContext:
             persist_dir = str(persist_dir)  # NOTE: doesn't support Windows here
             docstore_path = concat_dirs(persist_dir, docstore_fname)
             index_store_path = concat_dirs(persist_dir, index_store_fname)
-            vector_store_path = concat_dirs(persist_dir, vector_store_fname)
             graph_store_path = concat_dirs(persist_dir, graph_store_fname)
         else:
             persist_dir = Path(persist_dir)
             docstore_path = str(persist_dir / docstore_fname)
             index_store_path = str(persist_dir / index_store_fname)
-            vector_store_path = str(persist_dir / vector_store_fname)
             graph_store_path = str(persist_dir / graph_store_fname)
 
         self.docstore.persist(persist_path=docstore_path, fs=fs)
         self.index_store.persist(persist_path=index_store_path, fs=fs)
-        self.vector_store.persist(persist_path=vector_store_path, fs=fs)
         self.graph_store.persist(persist_path=graph_store_path, fs=fs)
+
+        # save each vector store under it's namespace
+        for vector_store_name, vector_store in self.vector_stores.items():
+            if fs is not None:
+                vector_store_path = concat_dirs(
+                    persist_dir,
+                    f"{vector_store_name}{NAMESPACE_SEP}{vector_store_fname}",
+                )
+            else:
+                vector_store_path = str(
+                    persist_dir
+                    / f"{vector_store_name}{NAMESPACE_SEP}{vector_store_fname}"
+                )
+
+            vector_store.persist(persist_path=vector_store_path, fs=fs)
 
     def to_dict(self) -> dict:
         all_simple = (
-            isinstance(self.vector_store, SimpleVectorStore)
-            and isinstance(self.docstore, SimpleDocumentStore)
+            isinstance(self.docstore, SimpleDocumentStore)
             and isinstance(self.index_store, SimpleIndexStore)
             and isinstance(self.graph_store, SimpleGraphStore)
+            and all(
+                isinstance(vs, SimpleVectorStore) for vs in self.vector_stores.values()
+            )
         )
         if not all_simple:
             raise ValueError(
                 "to_dict only available when using simple doc/index/vector stores"
             )
 
-        assert isinstance(self.vector_store, SimpleVectorStore)
         assert isinstance(self.docstore, SimpleDocumentStore)
         assert isinstance(self.index_store, SimpleIndexStore)
         assert isinstance(self.graph_store, SimpleGraphStore)
 
         return {
-            VECTOR_STORE_KEY: self.vector_store.to_dict(),
+            VECTOR_STORE_KEY: {
+                key: vector_store.to_dict()
+                for key, vector_store in self.vector_stores.items()
+                if isinstance(vector_store, SimpleVectorStore)
+            },
             DOC_STORE_KEY: self.docstore.to_dict(),
             INDEX_STORE_KEY: self.index_store.to_dict(),
             GRAPH_STORE_KEY: self.graph_store.to_dict(),
@@ -148,12 +184,25 @@ class StorageContext:
     def from_dict(cls, save_dict: dict) -> "StorageContext":
         """Create a StorageContext from dict."""
         docstore = SimpleDocumentStore.from_dict(save_dict[DOC_STORE_KEY])
-        vector_store = SimpleVectorStore.from_dict(save_dict[VECTOR_STORE_KEY])
         index_store = SimpleIndexStore.from_dict(save_dict[INDEX_STORE_KEY])
         graph_store = SimpleGraphStore.from_dict(save_dict[GRAPH_STORE_KEY])
+
+        vector_stores = {}
+        for key, vector_store_dict in save_dict[VECTOR_STORE_KEY].items():
+            vector_stores[key] = SimpleVectorStore.from_dict(vector_store_dict)
+
         return cls(
             docstore=docstore,
             index_store=index_store,
-            vector_store=vector_store,
+            vector_stores=vector_stores,
             graph_store=graph_store,
         )
+
+    @property
+    def vector_store(self) -> VectorStore:
+        """Backwrds compatibility for vector_store property."""
+        return self.vector_stores[DEFAULT_VECTOR_STORE]
+
+    def add_vector_store(self, vector_store: VectorStore, namespace: str) -> None:
+        """Add a vector store to the storage context."""
+        self.vector_stores[namespace] = vector_store

--- a/llama_index/storage/storage_context.py
+++ b/llama_index/storage/storage_context.py
@@ -143,12 +143,12 @@ class StorageContext:
         for vector_store_name, vector_store in self.vector_stores.items():
             if fs is not None:
                 vector_store_path = concat_dirs(
-                    persist_dir,
+                    str(persist_dir),
                     f"{vector_store_name}{NAMESPACE_SEP}{vector_store_fname}",
                 )
             else:
                 vector_store_path = str(
-                    persist_dir
+                    Path(persist_dir)
                     / f"{vector_store_name}{NAMESPACE_SEP}{vector_store_fname}"
                 )
 
@@ -190,7 +190,7 @@ class StorageContext:
         index_store = SimpleIndexStore.from_dict(save_dict[INDEX_STORE_KEY])
         graph_store = SimpleGraphStore.from_dict(save_dict[GRAPH_STORE_KEY])
 
-        vector_stores = {}
+        vector_stores: Dict[str, VectorStore] = {}
         for key, vector_store_dict in save_dict[VECTOR_STORE_KEY].items():
             vector_stores[key] = SimpleVectorStore.from_dict(vector_store_dict)
 

--- a/llama_index/storage/storage_context.py
+++ b/llama_index/storage/storage_context.py
@@ -80,7 +80,9 @@ class StorageContext:
             if vector_store:
                 vector_stores = {DEFAULT_VECTOR_STORE: vector_store}
             else:
-                vector_stores = vector_stores, SimpleVectorStore()
+                vector_stores = vector_stores or {
+                    DEFAULT_VECTOR_STORE: SimpleVectorStore()
+                }
         else:
             docstore = docstore or SimpleDocumentStore.from_persist_dir(
                 persist_dir, fs=fs
@@ -94,10 +96,11 @@ class StorageContext:
 
             if vector_store:
                 vector_stores = {DEFAULT_VECTOR_STORE: vector_store}
+            elif vector_stores:
+                vector_stores = vector_stores
             else:
-                vector_stores = (
-                    vector_stores
-                    or SimpleVectorStore.from_namespaced_persist_dir(persist_dir, fs=fs)
+                vector_stores = SimpleVectorStore.from_namespaced_persist_dir(
+                    persist_dir, fs=fs
                 )
 
         return cls(

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -130,9 +130,9 @@ class SimpleVectorStore(VectorStore):
         cls,
         persist_dir: str = DEFAULT_PERSIST_DIR,
         fs: Optional[fsspec.AbstractFileSystem] = None,
-    ) -> Dict[str, "SimpleVectorStore"]:
+    ) -> Dict[str, VectorStore]:
         """Load from namespaced persist dir."""
-        vector_stores = {}
+        vector_stores: Dict[str, VectorStore] = {}
         for fname in os.listdir(persist_dir):
             if fname.endswith(DEFAULT_PERSIST_FNAME):
                 namespace = fname.split(NAMESPACE_SEP)[0]

--- a/llama_index/vector_stores/simple.py
+++ b/llama_index/vector_stores/simple.py
@@ -37,6 +37,9 @@ LEARNER_MODES = {
 
 MMR_MODE = VectorStoreQueryMode.MMR
 
+NAMESPACE_SEP = "__"
+DEFAULT_VECTOR_STORE = "default"
+
 
 def _build_metadata_filter_fn(
     metadata_lookup_fn: Callable[[str], Mapping[str, Any]],
@@ -107,14 +110,44 @@ class SimpleVectorStore(VectorStore):
     def from_persist_dir(
         cls,
         persist_dir: str = DEFAULT_PERSIST_DIR,
+        namespace: Optional[str] = None,
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "SimpleVectorStore":
         """Load from persist dir."""
-        if fs is not None:
-            persist_path = concat_dirs(persist_dir, DEFAULT_PERSIST_FNAME)
+        if namespace:
+            persist_fname = f"{namespace}{NAMESPACE_SEP}{DEFAULT_PERSIST_FNAME}"
         else:
-            persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
+            persist_fname = DEFAULT_PERSIST_FNAME
+
+        if fs is not None:
+            persist_path = concat_dirs(persist_dir, persist_fname)
+        else:
+            persist_path = os.path.join(persist_dir, persist_fname)
         return cls.from_persist_path(persist_path, fs=fs)
+
+    @classmethod
+    def from_namespaced_persist_dir(
+        cls,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> Dict[str, "SimpleVectorStore"]:
+        """Load from namespaced persist dir."""
+        vector_stores = {}
+        for fname in os.listdir(persist_dir):
+            if fname.endswith(DEFAULT_PERSIST_FNAME):
+                namespace = fname.split(NAMESPACE_SEP)[0]
+
+                # handle backwards compatibility with stores that were persisted
+                if namespace == DEFAULT_PERSIST_FNAME:
+                    vector_stores[DEFAULT_VECTOR_STORE] = cls.from_persist_dir(
+                        persist_dir=persist_dir, fs=fs
+                    )
+                else:
+                    vector_stores[namespace] = cls.from_persist_dir(
+                        persist_dir=persist_dir, namespace=namespace, fs=fs
+                    )
+
+        return vector_stores
 
     @property
     def client(self) -> None:


### PR DESCRIPTION
# Description

There are some scenarios where you may want several vector indexes, and those vector indexes could come from any vector db provider.

This PR updates the storage context to add high-level namespaces for vector stores, to help support future development.

I have personally tested storing/loading old and new indexes for backwards compatibility. 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

