### PR TITLE
Fixed embeddings `__all__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fixed missing import for `embeddings.__all__` (#8779)
+
 ## [0.8.64] - 2023-11-06
 
 ### New Features

--- a/llama_index/embeddings/__init__.py
+++ b/llama_index/embeddings/__init__.py
@@ -19,6 +19,7 @@ from llama_index.embeddings.gradient import GradientEmbedding
 from llama_index.embeddings.huggingface import (
     HuggingFaceEmbedding,
     HuggingFaceInferenceAPIEmbedding,
+    HuggingFaceInferenceAPIEmbeddings,
 )
 from llama_index.embeddings.huggingface_optimum import OptimumEmbedding
 from llama_index.embeddings.huggingface_utils import DEFAULT_HUGGINGFACE_EMBEDDING_MODEL


### PR DESCRIPTION
# Description

My IDE was warning me about `HuggingFaceInferenceAPIEmbeddings` not being imported in `__init__.py`.  Looks like this was missed in https://github.com/run-llama/llama_index/pull/8565.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
