### PR TITLE
improve multimodal retrieval and delete

### DIFF
--- a/llama_index/indices/multi_modal/base.py
+++ b/llama_index/indices/multi_modal/base.py
@@ -311,21 +311,16 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
     ) -> None:
         """Delete a document and it's nodes by using ref_doc_id."""
         # delete from all vector stores
+
         for vector_store in self._storage_context.vector_stores.values():
             vector_store.delete(ref_doc_id)
 
-            # delete from index_struct only if needed
-            if not self._vector_store.stores_text or self._store_nodes_override:
-                ref_doc_info = self._docstore.get_ref_doc_info(ref_doc_id)
-                if ref_doc_info is not None:
-                    for node_id in ref_doc_info.node_ids:
-                        self._index_struct.delete(node_id)
-                        self._vector_store.delete(node_id)
+        ref_doc_info = self._docstore.get_ref_doc_info(ref_doc_id)
+        if ref_doc_info is not None:
+            for node_id in ref_doc_info.node_ids:
+                self._index_struct.delete(node_id)
+                self._vector_store.delete(node_id)
 
-            # delete from docstore only if needed
-            if (
-                not self._vector_store.stores_text or self._store_nodes_override
-            ) and delete_from_docstore:
-                self._docstore.delete_ref_doc(ref_doc_id, raise_error=False)
+        self._docstore.delete_ref_doc(ref_doc_id, raise_error=False)
 
-            self._storage_context.index_store.add_index_struct(self._index_struct)
+        self._storage_context.index_store.add_index_struct(self._index_struct)

--- a/llama_index/storage/docstore/keyval_docstore.py
+++ b/llama_index/storage/docstore/keyval_docstore.py
@@ -86,7 +86,8 @@ class KVDocumentStore(BaseDocumentStore):
             metadata = {"doc_hash": node.hash}
             if isinstance(node, TextNode) and node.ref_doc_id is not None:
                 ref_doc_info = self.get_ref_doc_info(node.ref_doc_id) or RefDocInfo()
-                ref_doc_info.node_ids.append(node.node_id)
+                if node.node_id not in ref_doc_info.node_ids:
+                    ref_doc_info.node_ids.append(node.node_id)
                 if not ref_doc_info.metadata:
                     ref_doc_info.metadata = node.metadata or {}
                 self._kvstore.put(

--- a/llama_index/vector_stores/utils.py
+++ b/llama_index/vector_stores/utils.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Tuple
 
 from llama_index.schema import (
     BaseNode,
+    ImageNode,
     IndexNode,
     NodeRelationship,
     RelatedNodeInfo,
@@ -50,7 +51,7 @@ def node_to_metadata_dict(
 
     # dump remainder of node_dict to json string
     metadata["_node_content"] = json.dumps(node_dict)
-    metadata["_node_type"] = node.get_type()
+    metadata["_node_type"] = node.class_name()
 
     # store ref doc id at top level to allow metadata filtering
     # kept for backwards compatibility, will consolidate in future
@@ -68,8 +69,10 @@ def metadata_dict_to_node(metadata: dict) -> BaseNode:
     if node_json is None:
         raise ValueError("Node content not found in metadata dict.")
 
-    if node_type == IndexNode.get_type():
+    if node_type == IndexNode.class_name():
         return IndexNode.parse_raw(node_json)
+    elif node_type == ImageNode.class_name():
+        return ImageNode.parse_raw(node_json)
     else:
         return TextNode.parse_raw(node_json)
 


### PR DESCRIPTION
# Description

MultiModalVectorStoreIndex had some issues with retrieval and deletion. This PR fixes both by

- ensuring duplicate node ids are not inserted into ref_doc_info
- ensures the proper node type is loaded when fetching from a vector store
- no longer forces users to use the docstore/index store, since most images should just be paths or URLs anyways (if this is an issue for users, they can always enable the docstore)


