### PR TITLE
Latest `huggingface_hub`'s recommended model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Properly supporting Hugging Face recommended model (#8784)
+
 ### Bug Fixes / Nits
 
 - Fixed missing import for `embeddings.__all__` (#8779)

--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -387,7 +387,7 @@ class HuggingFaceInferenceAPI(LLM):
             "The model to run inference with. Can be a model id hosted on the Hugging"
             " Face Hub, e.g. bigcode/starcoder or a URL to a deployed Inference"
             " Endpoint. Defaults to None, in which case a recommended model is"
-            " automatically selected for the task."
+            " automatically selected for the task (see Field below)."
         ),
     )
     token: Union[str, bool, None] = Field(
@@ -415,6 +415,13 @@ class HuggingFaceInferenceAPI(LLM):
     )
     cookies: Dict[str, str] = Field(
         default=None, description="Additional cookies to send to the server."
+    )
+    task: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional task to pick Hugging Face's recommended model, used when"
+            " model_name is left as default of None."
+        ),
     )
     _sync_client: "InferenceClient" = PrivateAttr()
     _async_client: "AsyncInferenceClient" = PrivateAttr()
@@ -464,7 +471,6 @@ class HuggingFaceInferenceAPI(LLM):
         Args:
             kwargs: See the class-level Fields.
         """
-        super().__init__(**kwargs)  # Populate pydantic Fields
         try:
             from huggingface_hub import (
                 AsyncInferenceClient,
@@ -476,6 +482,14 @@ class HuggingFaceInferenceAPI(LLM):
                 f"{type(self).__name__} requires huggingface_hub with its inference"
                 " extra, please run `pip install huggingface_hub[inference]>=0.19.0`."
             ) from exc
+        if kwargs.get("model_name") is None:
+            task = kwargs.get("task", "")  # NOTE: empty string leads to error
+            kwargs["model_name"] = InferenceClient.get_recommended_model(task=task)
+            logger.debug(
+                f"Using Hugging Face's recommended model {kwargs['model_name']}"
+                f" given task {task}."
+            )
+        super().__init__(**kwargs)  # Populate pydantic Fields
         self._sync_client = InferenceClient(**self._get_inference_client_kwargs())
         self._async_client = AsyncInferenceClient(**self._get_inference_client_kwargs())
         self._get_model_info = model_info

--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -483,7 +483,9 @@ class HuggingFaceInferenceAPI(LLM):
                 " extra, please run `pip install huggingface_hub[inference]>=0.19.0`."
             ) from exc
         if kwargs.get("model_name") is None:
-            task = kwargs.get("task", "")  # NOTE: empty string leads to error
+            task = kwargs.get("task", "")
+            # NOTE: task being None or empty string leads to ValueError,
+            # which ensures model is present
             kwargs["model_name"] = InferenceClient.get_recommended_model(task=task)
             logger.debug(
                 f"Using Hugging Face's recommended model {kwargs['model_name']}"

--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -474,7 +474,7 @@ class HuggingFaceInferenceAPI(LLM):
         except ModuleNotFoundError as exc:
             raise ImportError(
                 f"{type(self).__name__} requires huggingface_hub with its inference"
-                " extras, please run `pip install huggingface_hub[inference]`."
+                " extra, please run `pip install huggingface_hub[inference]>=0.19.0`."
             ) from exc
         self._sync_client = InferenceClient(**self._get_inference_client_kwargs())
         self._async_client = AsyncInferenceClient(**self._get_inference_client_kwargs())

--- a/tests/embeddings/test_huggingface.py
+++ b/tests/embeddings/test_huggingface.py
@@ -8,22 +8,22 @@ from llama_index.embeddings.pooling import Pooling
 from tests.llms.test_huggingface import STUB_MODEL_NAME
 
 
-@pytest.fixture(name="hf_inference_api_embeddings")
-def fixture_hf_inference_api_embeddings() -> HuggingFaceInferenceAPIEmbedding:
+@pytest.fixture(name="hf_inference_api_embedding")
+def fixture_hf_inference_api_embedding() -> HuggingFaceInferenceAPIEmbedding:
     with patch.dict("sys.modules", huggingface_hub=MagicMock()):
         return HuggingFaceInferenceAPIEmbedding(model_name=STUB_MODEL_NAME)
 
 
 class TestHuggingFaceInferenceAPIEmbeddings:
     def test_class_name(
-        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbedding
+        self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
     ) -> None:
         assert (
             HuggingFaceInferenceAPIEmbedding.class_name()
             == HuggingFaceInferenceAPIEmbedding.__name__
         )
         assert (
-            hf_inference_api_embeddings.class_name()
+            hf_inference_api_embedding.class_name()
             == HuggingFaceInferenceAPIEmbedding.__name__
         )
 
@@ -40,17 +40,17 @@ class TestHuggingFaceInferenceAPIEmbeddings:
         )
 
     def test_embed_query(
-        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbedding
+        self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
     ) -> None:
         raw_single_embedding = np.random.rand(1, 3, 1024)
 
-        hf_inference_api_embeddings.pooling = Pooling.CLS
+        hf_inference_api_embedding.pooling = Pooling.CLS
         with patch.object(
-            hf_inference_api_embeddings._async_client,
+            hf_inference_api_embedding._async_client,
             "feature_extraction",
             AsyncMock(return_value=raw_single_embedding),
         ) as mock_feature_extraction:
-            embedding = hf_inference_api_embeddings.get_query_embedding("test")
+            embedding = hf_inference_api_embedding.get_query_embedding("test")
         assert isinstance(embedding, list)
         assert len(embedding) == 1024
         assert np.all(
@@ -59,13 +59,13 @@ class TestHuggingFaceInferenceAPIEmbeddings:
         )
         mock_feature_extraction.assert_awaited_once_with("test")
 
-        hf_inference_api_embeddings.pooling = Pooling.MEAN
+        hf_inference_api_embedding.pooling = Pooling.MEAN
         with patch.object(
-            hf_inference_api_embeddings._async_client,
+            hf_inference_api_embedding._async_client,
             "feature_extraction",
             AsyncMock(return_value=raw_single_embedding),
         ) as mock_feature_extraction:
-            embedding = hf_inference_api_embeddings.get_query_embedding("test")
+            embedding = hf_inference_api_embedding.get_query_embedding("test")
         assert isinstance(embedding, list)
         assert len(embedding) == 1024
         assert np.all(
@@ -75,9 +75,9 @@ class TestHuggingFaceInferenceAPIEmbeddings:
         mock_feature_extraction.assert_awaited_once_with("test")
 
     def test_serialization(
-        self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbedding
+        self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
     ) -> None:
-        serialized = hf_inference_api_embeddings.to_dict()
+        serialized = hf_inference_api_embedding.to_dict()
         # Check Hugging Face Inference API base class specifics
         assert serialized["model_name"] == STUB_MODEL_NAME
         assert isinstance(serialized["context_window"], int)

--- a/tests/embeddings/test_huggingface.py
+++ b/tests/embeddings/test_huggingface.py
@@ -27,6 +27,18 @@ class TestHuggingFaceInferenceAPIEmbeddings:
             == HuggingFaceInferenceAPIEmbedding.__name__
         )
 
+    def test_using_recommended_model(self) -> None:
+        mock_hub = MagicMock()
+        mock_hub.InferenceClient.get_recommended_model.return_value = (
+            "facebook/bart-base"
+        )
+        with patch.dict("sys.modules", huggingface_hub=mock_hub):
+            embedding = HuggingFaceInferenceAPIEmbedding(task="feature-extraction")
+        assert embedding.model_name == "facebook/bart-base"
+        mock_hub.InferenceClient.get_recommended_model.assert_called_once_with(
+            task="feature-extraction"
+        )
+
     def test_embed_query(
         self, hf_inference_api_embeddings: HuggingFaceInferenceAPIEmbedding
     ) -> None:


### PR DESCRIPTION
# Description

`huggingface_hub==0.19.0` dropped today, which includes `InferenceClient.get_recommended_model` from https://github.com/huggingface/huggingface_hub/pull/1770. This PR makes use of it:

- Adds `task` to `HuggingFaceInferenceAPI` for recommendation of model
- Adds test of new recommended model capability
- Updated test fixture names to correspond with https://github.com/run-llama/llama_index/pull/8565

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
