### PR TITLE
Cassandra vector-store notebook updates

### DIFF
--- a/docs/examples/vector_stores/CassandraIndexDemo.ipynb
+++ b/docs/examples/vector_stores/CassandraIndexDemo.ipynb
@@ -22,16 +22,14 @@
    "id": "1e7787c2",
    "metadata": {},
    "source": [
-    "[Apache Cassandra®](https://cassandra.apache.org) is a NoSQL, row-oriented, highly scalable and highly available database.\n",
-    "Newest Cassandra releases natively [support](https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-30%3A+Approximate+Nearest+Neighbor(ANN)+Vector+Search+via+Storage-Attached+Indexes) Vector Similarity Search.\n",
+    "[Apache Cassandra®](https://cassandra.apache.org) is a NoSQL, row-oriented, highly scalable and highly available database. Starting with version 5.0, the database ships with [vector search](https://cassandra.apache.org/doc/trunk/cassandra/vector-search/overview.html) capabilities.\n",
     "\n",
-    "**This notebook shows the basic usage of Cassandra as a Vector Store in LlamaIndex.**\n",
+    "DataStax [Astra DB through CQL](https://docs.datastax.com/en/astra-serverless/docs/vector-search/quickstart.html) is a managed serverless database built on Cassandra, offering the same interface and strengths.\n",
     "\n",
-    "To run this notebook you need either a running Cassandra cluster equipped with Vector \n",
-    "Search capabilities (in pre-release at the time of writing) or a DataStax Astra DB instance\n",
-    " running in the cloud (you can get one for free at [datastax.com](https://astra.datastax.com)).\n",
-    " _This notebook shows the latter choice; check\n",
-    " [cassio.org](https://cassio.org/start_here/) for more information, quickstarts and tutorials._"
+    "**This notebook shows the basic usage of the Cassandra Vector Store in LlamaIndex.**\n",
+    "\n",
+    "To run the full code you need either a running Cassandra cluster equipped with Vector \n",
+    "Search capabilities or a DataStax Astra DB instance."
    ]
   },
   {
@@ -47,17 +45,9 @@
    "execution_count": null,
    "id": "e9f8dbcb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install \"cassio>=0.1.3\""
+    "!pip install --quiet \"astrapy>=0.5.6\""
    ]
   },
   {
@@ -68,6 +58,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "from getpass import getpass\n",
     "\n",
     "from llama_index import (\n",
     "    VectorStoreIndex,\n",
@@ -80,14 +71,75 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7eea233d-9993-4e2f-bbf4-fc335599ed4a",
+   "metadata": {},
+   "source": [
+    "The next step is to initialize CassIO with a global DB connection: this is the only step that is done slightly differently for a Cassandra cluster and Astra DB:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3c692310",
    "metadata": {},
    "source": [
-    "### Please provide database connection parameters and secrets\n",
+    "### Initialization (Cassandra cluster)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ea33832-06ad-46eb-a192-290f246ccdb1",
+   "metadata": {},
+   "source": [
+    "In this case, you first need to create a `cassandra.cluster.Session` object,\n",
+    "as described in the [Cassandra driver documentation](https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster/#module-cassandra.cluster).\n",
+    "The details vary (e.g. with network settings and authentication), but this might be something like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79475469-a765-4881-a97d-ac66c272c572",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cassandra.cluster import Cluster\n",
     "\n",
-    "Now you need a database connection. Make sure you have either a vector-capable running Cassandra cluster or an [Astra DB](https://astra.datastax.com) instance in the cloud.\n",
+    "cluster = Cluster([\"127.0.0.1\"])\n",
+    "session = cluster.connect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bee3cd0-faa1-42c1-9826-1fdea46ea238",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cassio\n",
     "\n",
-    "_In the following, the latter is assumed (see the references at the top for details)._"
+    "CASSANDRA_KEYSPACE = input(\"CASSANDRA_KEYSPACE = \")\n",
+    "\n",
+    "cassio.init(session=session, keyspace=CASSANDRA_KEYSPACE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e0900b8-e0d8-488d-bee5-98c9e76811b8",
+   "metadata": {},
+   "source": [
+    "### Initialization (Astra DB through CQL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cc22cd0-3995-4029-ad9c-edd8d0c7e730",
+   "metadata": {},
+   "source": [
+    "In this case you initialize CassIO with the following connection parameters:\n",
+    "\n",
+    "- the Database ID, e.g. 01234567-89ab-cdef-0123-456789abcdef\n",
+    "- the Token, e.g. AstraCS:6gBhNmsk135.... (it must be a \"Database Administrator\" token)\n",
+    "- Optionally a Keyspace name (if omitted, the default one for the database will be used)"
    ]
   },
   {
@@ -95,34 +147,16 @@
    "execution_count": null,
    "id": "ba118688",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Please enter your Database ID (e.g. '0123abcd...'): 0123abcd-01ab-01ab-01ab-012345abcdef\n",
-      "\n",
-      "Please enter your 'Database Administrator' Token (e.g. 'AstraCS:...'): ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os\n",
-    "import getpass\n",
+    "ASTRA_DB_ID = input(\"ASTRA_DB_ID = \")\n",
+    "ASTRA_DB_TOKEN = getpass(\"ASTRA_DB_TOKEN = \")\n",
     "\n",
-    "database_id = input(\"\\nPlease enter your Database ID (e.g. '0123abcd...'):\")\n",
-    "token = getpass.getpass(\n",
-    "    \"\\nPlease enter your 'Database Administrator' Token (e.g. 'AstraCS:...'):\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3baa9719-556c-457e-9c6d-fe10f653e9b0",
-   "metadata": {},
-   "source": [
-    "This cell sets the database connection as a global `cassio` property for usage later (it is also possible to explicitly supply a DB connection when creating the vector store):"
+    "desired_keyspace = input(\"ASTRA_DB_KEYSPACE (optional, can be left empty) = \")\n",
+    "if desired_keyspace:\n",
+    "    ASTRA_DB_KEYSPACE = desired_keyspace\n",
+    "else:\n",
+    "    ASTRA_DB_KEYSPACE = None"
    ]
   },
   {
@@ -134,7 +168,11 @@
    "source": [
     "import cassio\n",
     "\n",
-    "cassio.init(database_id=database_id, token=token)"
+    "cassio.init(\n",
+    "    database_id=ASTRA_DB_ID,\n",
+    "    token=ASTRA_DB_TOKEN,\n",
+    "    keyspace=ASTRA_DB_KEYSPACE,\n",
+    ")"
    ]
   },
   {
@@ -142,9 +180,9 @@
    "id": "f9b97a89",
    "metadata": {},
    "source": [
-    "### Please provide OpenAI access key\n",
+    "### OpenAI key\n",
     "\n",
-    "In order use embeddings by OpenAI you need to supply an OpenAI API Key:"
+    "In order to use embeddings by OpenAI you need to supply an OpenAI API Key:"
    ]
   },
   {
@@ -152,20 +190,9 @@
    "execution_count": null,
    "id": "0c9f4d21-145a-401e-95ff-ccb259e8ef84",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OpenAI API Key: ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import openai\n",
-    "\n",
-    "OPENAI_API_KEY = getpass.getpass(\"OpenAI API Key:\")\n",
-    "openai.api_key = OPENAI_API_KEY"
+    "os.environ[\"OPENAI_API_KEY\"] = getpass(\"OpenAI API Key:\")"
    ]
   },
   {
@@ -174,7 +201,7 @@
    "id": "174ce56b",
    "metadata": {},
    "source": [
-    "Download data"
+    "### Download data"
    ]
   },
   {
@@ -203,26 +230,7 @@
    "execution_count": null,
    "id": "68cbd239-880e-41a3-98d8-dbb3fab55431",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Total documents: 1\n",
-      "First document, id: 7c966f42-36f4-4ff6-ad75-357978a65381\n",
-      "First document, hash: 2e2d9629223c077019a6dde689049344ff2293d6c52372871420119ec049f25c\n",
-      "First document, text (75014 characters):\n",
-      "====================\n",
-      "\n",
-      "\n",
-      "What I Worked On\n",
-      "\n",
-      "February 2021\n",
-      "\n",
-      "Before college the two main things I worked on, outside of school, were writing and programming. I didn't write essays. I wrote what beginning writers were supposed to write then, and probably still are: short stories. My stories were awful. They had hardly any plot, just characters with strong feelings, which I imagined ma ...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load documents\n",
     "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()\n",
@@ -308,15 +316,7 @@
    "execution_count": null,
    "id": "35369eda",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The author chose to work on AI because they were inspired by a novel called \"The Moon is a Harsh Mistress\" by Heinlein, which featured an intelligent computer called Mike. Additionally, they were influenced by a PBS documentary that showed Terry Winograd using SHRDLU, a program that they believed could be improved by teaching it more words.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query_engine = index.as_query_engine()\n",
     "response = query_engine.query(\"Why did the author choose to work on AI?\")\n",
@@ -338,15 +338,7 @@
    "execution_count": null,
    "id": "eb2054c0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The author chose to work on AI because they believed that it was a field that held promise and potential for advancing the understanding of natural language and intelligence. They were initially drawn to AI because of their fascination with the program SHRDLU, which they considered to be a step towards achieving intelligence. However, as they delved deeper into the field, they realized that the existing approaches to AI, which involved explicit data structures and formal representations, were limited and not capable of truly understanding natural language. Despite this realization, the author still found value in working on AI and decided to focus on Lisp, a programming language associated with AI, as they believed it was interesting in its own right.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query_engine = index.as_query_engine(vector_store_query_mode=\"mmr\")\n",
     "response = query_engine.query(\"Why did the author choose to work on AI?\")\n",
@@ -380,7 +372,7 @@
     ")\n",
     "\n",
     "# now you can do querying, etc:\n",
-    "query_engine = index.as_query_engine(similarity_top_k=5)\n",
+    "query_engine = new_index_instance.as_query_engine(similarity_top_k=5)\n",
     "response = query_engine.query(\n",
     "    \"What did the author study prior to working on AI?\"\n",
     ")"
@@ -391,15 +383,7 @@
    "execution_count": null,
    "id": "1ceec3bf",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The author studied painting and drawing prior to working on AI.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(response.response)"
    ]
@@ -436,32 +420,7 @@
    "execution_count": null,
    "id": "6ae9c6b1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 3 nodes.\n",
-      "    [0] score = 0.42933435561941374\n",
-      "        id    = 7734b895-a738-4c56-a433-d24a80179759\n",
-      "        text  = What I Worked On\n",
-      "\n",
-      "February 2021\n",
-      "\n",
-      "Before college the two main things I worked on, outside o ...\n",
-      "    [1] score = 0.002203557726127847\n",
-      "        id    = fea6c20f-e707-4c66-be3f-f963639def30\n",
-      "        text  = Now all I had to do was learn Italian.\n",
-      "\n",
-      "Only stranieri (foreigners) had to take this entra ...\n",
-      "    [2] score = 0.022935334418004605\n",
-      "        id    = cf09e631-ab10-4355-923a-b9711c197600\n",
-      "        text  = All you had to do was teach SHRDLU more words.\n",
-      "\n",
-      "There weren't any classes in AI at Cornell ...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"Found {len(nodes_with_scores)} nodes.\")\n",
     "for idx, node_with_score in enumerate(nodes_with_scores):\n",
@@ -483,18 +442,7 @@
    "execution_count": null,
    "id": "c52bb601-0838-46bb-8b9f-f2012a1c3f84",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Nodes' ref_doc_id:\n",
-      "7c966f42-36f4-4ff6-ad75-357978a65381\n",
-      "7c966f42-36f4-4ff6-ad75-357978a65381\n",
-      "7c966f42-36f4-4ff6-ad75-357978a65381\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Nodes' ref_doc_id:\")\n",
     "print(\"\\n\".join([nws.node.ref_doc_id for nws in nodes_with_scores]))"
@@ -531,15 +479,7 @@
    "execution_count": null,
    "id": "813276ff",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found 0 nodes.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "nodes_with_scores = retriever.retrieve(\n",
     "    \"What did the author study prior to working on AI?\"\n",
@@ -588,7 +528,7 @@
     "\n",
     "# Load documents and build index\n",
     "md_documents = SimpleDirectoryReader(\n",
-    "    \"../data/paul_graham\", file_metadata=my_file_metadata\n",
+    "    \"./data/paul_graham\", file_metadata=my_file_metadata\n",
     ").load_data()\n",
     "md_index = VectorStoreIndex.from_documents(\n",
     "    md_documents, storage_context=md_storage_context\n",
@@ -597,9 +537,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4d48250",
+   "id": "a0a2a030-5621-4844-8971-2b4928ec2ec0",
    "metadata": {},
    "source": [
+    "\n",
+    "\n",
     "That's it: you can now add filtering to your query engine:"
    ]
   },
@@ -618,15 +560,7 @@
    "execution_count": null,
    "id": "733467f3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "It took the author approximately 5 weeks to write his thesis.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "md_query_engine = md_index.as_query_engine(\n",
     "    filters=MetadataFilters(\n",
@@ -634,7 +568,7 @@
     "    )\n",
     ")\n",
     "md_response = md_query_engine.query(\n",
-    "    \"How long it took the author to write his thesis?\"\n",
+    "    \"did the author appreciate Lisp and painting?\"\n",
     ")\n",
     "print(md_response.response)"
    ]
@@ -663,7 +597,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,

--- a/docs/examples/vector_stores/CassandraIndexDemo.ipynb
+++ b/docs/examples/vector_stores/CassandraIndexDemo.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "e9f8dbcb",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "47264e32",
    "metadata": {},
    "outputs": [],
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "ba118688",
    "metadata": {},
    "outputs": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "20933a07",
    "metadata": {},
    "outputs": [],
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "0c9f4d21-145a-401e-95ff-ccb259e8ef84",
    "metadata": {},
    "outputs": [
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "37cb4f67",
    "metadata": {},
    "outputs": [
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "68cbd239-880e-41a3-98d8-dbb3fab55431",
    "metadata": {},
    "outputs": [
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "afc5c44f",
    "metadata": {},
    "outputs": [],
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "ca205b88",
    "metadata": {},
    "outputs": [],
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "35369eda",
    "metadata": {},
    "outputs": [
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "eb2054c0",
    "metadata": {},
    "outputs": [
@@ -428,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "f0aae26e",
    "metadata": {},
    "outputs": [],
@@ -451,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1ceec3bf",
    "metadata": {},
    "outputs": [
@@ -479,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "75ed7807",
    "metadata": {},
    "outputs": [],
@@ -496,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "6ae9c6b1",
    "metadata": {},
    "outputs": [
@@ -539,7 +539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "c52bb601-0838-46bb-8b9f-f2012a1c3f84",
    "metadata": {},
    "outputs": [
@@ -569,7 +569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "2c7aafa0",
    "metadata": {},
    "outputs": [],
@@ -587,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "813276ff",
    "metadata": {},
    "outputs": [
@@ -621,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "23c6ff1a",
    "metadata": {},
    "outputs": [],
@@ -666,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "d4bfd6f6",
    "metadata": {},
    "outputs": [],
@@ -676,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "733467f3",
    "metadata": {},
    "outputs": [
@@ -724,8 +724,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/vector_stores/CassandraIndexDemo.ipynb
+++ b/docs/examples/vector_stores/CassandraIndexDemo.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "e9f8dbcb",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "47264e32",
    "metadata": {},
    "outputs": [],
@@ -144,10 +144,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "ba118688",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "ASTRA_DB_ID =  01234567-89ab-cdef-0123-456789abcdef\n",
+      "ASTRA_DB_TOKEN =  ········\n",
+      "ASTRA_DB_KEYSPACE (optional, can be left empty) =  \n"
+     ]
+    }
+   ],
    "source": [
     "ASTRA_DB_ID = input(\"ASTRA_DB_ID = \")\n",
     "ASTRA_DB_TOKEN = getpass(\"ASTRA_DB_TOKEN = \")\n",
@@ -161,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "20933a07",
    "metadata": {},
    "outputs": [],
@@ -187,10 +197,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "0c9f4d21-145a-401e-95ff-ccb259e8ef84",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "OpenAI API Key: ········\n"
+     ]
+    }
+   ],
    "source": [
     "os.environ[\"OPENAI_API_KEY\"] = getpass(\"OpenAI API Key:\")"
    ]
@@ -206,10 +224,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "37cb4f67",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--2023-11-10 01:44:05--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.111.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 75042 (73K) [text/plain]\n",
+      "Saving to: ‘data/paul_graham/paul_graham_essay.txt’\n",
+      "\n",
+      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.01s   \n",
+      "\n",
+      "2023-11-10 01:44:06 (4.80 MB/s) - ‘data/paul_graham/paul_graham_essay.txt’ saved [75042/75042]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "!mkdir -p 'data/paul_graham/'\n",
     "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
@@ -227,10 +263,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "68cbd239-880e-41a3-98d8-dbb3fab55431",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total documents: 1\n",
+      "First document, id: 12bc6987-366a-49eb-8de0-7b52340e4958\n",
+      "First document, hash: abe31930a1775c78df5a5b1ece7108f78fedbf5fe4a9cf58d7a21808fccaef34\n",
+      "First document, text (75014 characters):\n",
+      "====================\n",
+      "\n",
+      "\n",
+      "What I Worked On\n",
+      "\n",
+      "February 2021\n",
+      "\n",
+      "Before college the two main things I worked on, outside of school, were writing and programming. I didn't write essays. I wrote what beginning writers were supposed to write then, and probably still are: short stories. My stories were awful. They had hardly any plot, just characters with strong feelings, which I imagined ma ...\n"
+     ]
+    }
+   ],
    "source": [
     "# load documents\n",
     "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()\n",
@@ -255,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "afc5c44f",
    "metadata": {},
    "outputs": [],
@@ -275,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "ca205b88",
    "metadata": {},
    "outputs": [],
@@ -313,10 +368,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "35369eda",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author chose to work on AI because they were inspired by a novel called The Moon is a Harsh Mistress, which featured an intelligent computer, and a PBS documentary that showed Terry Winograd using SHRDLU. These experiences sparked the author's interest in AI and motivated them to pursue it as a field of study and work.\n"
+     ]
+    }
+   ],
    "source": [
     "query_engine = index.as_query_engine()\n",
     "response = query_engine.query(\"Why did the author choose to work on AI?\")\n",
@@ -335,10 +398,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "eb2054c0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author chose to work on AI because they believed that teaching SHRDLU more words would eventually lead to the development of intelligent programs. They were fascinated by the potential of AI and saw it as an opportunity to expand their understanding of programming and push the limits of what could be achieved.\n"
+     ]
+    }
+   ],
    "source": [
     "query_engine = index.as_query_engine(vector_store_query_mode=\"mmr\")\n",
     "response = query_engine.query(\"Why did the author choose to work on AI?\")\n",
@@ -357,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "f0aae26e",
    "metadata": {},
    "outputs": [],
@@ -380,10 +451,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "1ceec3bf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author studied philosophy prior to working on AI.\n"
+     ]
+    }
+   ],
    "source": [
     "print(response.response)"
    ]
@@ -400,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "75ed7807",
    "metadata": {},
    "outputs": [],
@@ -417,10 +496,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "6ae9c6b1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 3 nodes.\n",
+      "    [0] score = 0.4251742327832831\n",
+      "        id    = 7e628668-58fa-4548-9c92-8c31d315dce0\n",
+      "        text  = What I Worked On\n",
+      "\n",
+      "February 2021\n",
+      "\n",
+      "Before college the two main things I worked on, outside o ...\n",
+      "    [1] score = -0.020323897262800816\n",
+      "        id    = aa279d09-717f-4d68-9151-594c5bfef7ce\n",
+      "        text  = This was now only weeks away. My nice landlady let me leave my stuff in her attic. I had s ...\n",
+      "    [2] score = 0.011198131320563909\n",
+      "        id    = 50b9170d-6618-4e8b-aaf8-36632e2801a6\n",
+      "        text  = It seemed only a matter of time before we'd have Mike, and when I saw Winograd using SHRDL ...\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Found {len(nodes_with_scores)} nodes.\")\n",
     "for idx, node_with_score in enumerate(nodes_with_scores):\n",
@@ -439,10 +539,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "c52bb601-0838-46bb-8b9f-f2012a1c3f84",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nodes' ref_doc_id:\n",
+      "12bc6987-366a-49eb-8de0-7b52340e4958\n",
+      "12bc6987-366a-49eb-8de0-7b52340e4958\n",
+      "12bc6987-366a-49eb-8de0-7b52340e4958\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Nodes' ref_doc_id:\")\n",
     "print(\"\\n\".join([nws.node.ref_doc_id for nws in nodes_with_scores]))"
@@ -458,7 +569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "2c7aafa0",
    "metadata": {},
    "outputs": [],
@@ -476,10 +587,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "813276ff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 0 nodes.\n"
+     ]
+    }
+   ],
    "source": [
     "nodes_with_scores = retriever.retrieve(\n",
     "    \"What did the author study prior to working on AI?\"\n",
@@ -502,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "23c6ff1a",
    "metadata": {},
    "outputs": [],
@@ -547,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "d4bfd6f6",
    "metadata": {},
    "outputs": [],
@@ -557,10 +676,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "733467f3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yes, the author appreciated Lisp and painting. They mentioned spending a significant amount of time working on Lisp and even building a new dialect of Lisp called Arc. Additionally, the author mentioned spending most of 2014 painting and experimenting with different techniques.\n"
+     ]
+    }
+   ],
    "source": [
     "md_query_engine = md_index.as_query_engine(\n",
     "    filters=MetadataFilters(\n",
@@ -597,7 +724,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As a twin PR to #8777 (now merged), this PR adapts the dependencies and naming scheme for better clarity over which connectors covers which kind of database/protocol. Additionally, URLs are updated to point to the latest quickstart and landing pages (both Astra and Cassandra), and more details are provided for the case of connecting to a Cassandra cluster.

Thank you!