### PR TITLE
fix retriever in citation query engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fix retriever node postprocessors for `CitationQueryEngine` (#8818)
+
 ## [0.8.66] - 2023-11-09
 
 ### New Features

--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -212,7 +212,7 @@ class CitationQueryEngine(BaseQueryEngine):
 
         return nodes
 
-    async def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+    async def aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         nodes = await self._retriever.aretrieve(query_bundle)
 
         for postprocessor in self._node_postprocessors:

--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -205,7 +205,7 @@ class CitationQueryEngine(BaseQueryEngine):
         return new_nodes
 
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        nodes = self._retriever.aretrieve(query_bundle)
+        nodes = self._retriever.retrieve(query_bundle)
 
         for postprocessor in self._node_postprocessors:
             nodes = postprocessor.postprocess_nodes(nodes, query_bundle=query_bundle)
@@ -213,7 +213,7 @@ class CitationQueryEngine(BaseQueryEngine):
         return nodes
 
     async def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        nodes = self._retriever.aretrieve(query_bundle)
+        nodes = await self._retriever.aretrieve(query_bundle)
 
         for postprocessor in self._node_postprocessors:
             nodes = postprocessor.postprocess_nodes(nodes, query_bundle=query_bundle)

--- a/llama_index/query_engine/citation_query_engine.py
+++ b/llama_index/query_engine/citation_query_engine.py
@@ -205,10 +205,18 @@ class CitationQueryEngine(BaseQueryEngine):
         return new_nodes
 
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        nodes = self._retriever.retrieve(query_bundle)
+        nodes = self._retriever.aretrieve(query_bundle)
 
         for postprocessor in self._node_postprocessors:
-            nodes = postprocessor.postprocess_nodes(nodes)
+            nodes = postprocessor.postprocess_nodes(nodes, query_bundle=query_bundle)
+
+        return nodes
+
+    async def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        nodes = self._retriever.aretrieve(query_bundle)
+
+        for postprocessor in self._node_postprocessors:
+            nodes = postprocessor.postprocess_nodes(nodes, query_bundle=query_bundle)
 
         return nodes
 
@@ -275,7 +283,7 @@ class CitationQueryEngine(BaseQueryEngine):
                 CBEventType.RETRIEVE,
                 payload={EventPayload.QUERY_STR: query_bundle.query_str},
             ) as retrieve_event:
-                nodes = self.retrieve(query_bundle)
+                nodes = await self.aretrieve(query_bundle)
                 nodes = self._create_citation_nodes(nodes)
 
                 retrieve_event.on_end(payload={EventPayload.NODES: nodes})


### PR DESCRIPTION
# Description

The citation query engine was not passing in the query bundle to node-postprocessors. Furthermore, it was missing async retrieval support.

Fixes https://github.com/run-llama/llama_index/issues/8817

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

