### PR TITLE
BUG fix: read image url field directly from ImageDocument field

### DIFF
--- a/llama_index/multi_modal_llms/openai_utils.py
+++ b/llama_index/multi_modal_llms/openai_utils.py
@@ -33,13 +33,10 @@ def to_openai_multi_modal_payload(
     completion_content = [{"type": "text", "text": prompt}]
     for image_document in image_documents:
         image_content = {}
-        if (
-            "image_url" in image_document.metadata
-            and image_document.metadata["image_url"] != ""
-        ):
+        if image_document.image_url and image_document.image_url != "":
             image_content = {
                 "type": "image_url",
-                "image_url": image_document.metadata["image_url"],
+                "image_url": image_document.image_url,
             }
         elif (
             "file_path" in image_document.metadata

--- a/llama_index/multi_modal_llms/openai_utils.py
+++ b/llama_index/multi_modal_llms/openai_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Sequence
+from typing import Any, Dict, List, Sequence
 
 from openai.types.chat import ChatCompletionMessageParam
 
@@ -32,7 +32,7 @@ def to_openai_multi_modal_payload(
 ) -> List[ChatCompletionMessageParam]:
     completion_content = [{"type": "text", "text": prompt}]
     for image_document in image_documents:
-        image_content = {}
+        image_content: Dict[str, Any] = {}
         if image_document.image_url and image_document.image_url != "":
             image_content = {
                 "type": "image_url",


### PR DESCRIPTION
# Description
The `to_openai_multi_modal_payload` utility function is trying to create `image_content` first by looking for `image_url` within the `metadata` of the `ImageDocument`. However, I believe it should be reading directly from the `image_url` field as the `load_image_urls` loads urls from a list and converts them to `ImageDocuments` with `image_url` being populated.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

