### PR TITLE
remove commonly unpicklable entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes / Nits
 
 - Fix retriever node postprocessors for `CitationQueryEngine` (#8818)
+- Fix `cannot pickle 'builtins.CoreBPE' object` in most scenarios (#8835)
 
 ## [0.8.66] - 2023-11-09
 

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -42,6 +42,14 @@ class BaseComponent(BaseModel):
         name changes.
         """
 
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.dict()
+        # Remove common unpicklable entries
+        state.pop("tokenizer", None)
+        state.pop("tokenizer_fn", None)
+        state.pop("callback_manager", None)
+        return state
+
     def to_dict(self, **kwargs: Any) -> Dict[str, Any]:
         data = self.dict(**kwargs)
         data["class_name"] = self.class_name()

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -47,7 +47,6 @@ class BaseComponent(BaseModel):
         # Remove common unpicklable entries
         state.pop("tokenizer", None)
         state.pop("tokenizer_fn", None)
-        state.pop("callback_manager", None)
         return state
 
     def to_dict(self, **kwargs: Any) -> Dict[str, Any]:


### PR DESCRIPTION
# Description

Tiktoken is famously un-picklable, but it's used all across LlamaIndex.

However, with a sneaky wave of a wand (and relying on `BaseComponent` inheritance), we can fix this by removing unpicklable entries.

This probably won't cover every edge case, but it gets most.

Tested with `pickle.dumps(index)` and `pickle.dumps(index.as_query_engine())`.

Fixes https://github.com/run-llama/llama_index/issues/8835

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

