### PR TITLE
one line fix for wrapping of custom function tools to create OpenAI assistant

### DIFF
--- a/llama_index/agent/openai_assistant_agent.py
+++ b/llama_index/agent/openai_assistant_agent.py
@@ -173,7 +173,7 @@ class OpenAIAssistantAgent(BaseAgent):
         openai_tools = openai_tools or []
         tools = tools or []
         tool_fns = [
-            {"type": "function", "function": t.metadata.to_openai_function()}
+            t.metadata.to_openai_function()
             for t in tools
         ]
         all_openai_tools = openai_tools + tool_fns


### PR DESCRIPTION
# Description

Fixes #8853

The custom tools were previously wrapped twice with `{"type": "function", "function": { "type": "function",  "function": ... }`.
Leading to the issue in #8853.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
