### PR TITLE
fix: paths treated as hidden

### DIFF
--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -145,6 +145,11 @@ class SimpleDirectoryReader(BaseReader):
         self.file_metadata = file_metadata or default_file_metadata_func
         self.filename_as_id = filename_as_id
 
+    def is_hidden(path):
+        return any(
+            part.startswith(".") and part not in [".", ".."] for part in path.parts
+        )
+
     def _add_files(self, input_dir: Path) -> List[Path]:
         """Add files."""
         all_files = set()
@@ -171,8 +176,7 @@ class SimpleDirectoryReader(BaseReader):
             # Manually check if file is hidden or directory instead of
             # in glob for backwards compatibility.
             is_dir = ref.is_dir()
-            hidden_parts = [part for part in ref.parts if part.startswith(".")]
-            skip_because_hidden = self.exclude_hidden and any(hidden_parts)
+            skip_because_hidden = self.exclude_hidden and self.is_hidden(ref)
             skip_because_bad_ext = (
                 self.required_exts is not None and ref.suffix not in self.required_exts
             )

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -145,7 +145,7 @@ class SimpleDirectoryReader(BaseReader):
         self.file_metadata = file_metadata or default_file_metadata_func
         self.filename_as_id = filename_as_id
 
-    def is_hidden(self, path):
+    def is_hidden(self, path: Path) -> bool:
         return any(
             part.startswith(".") and part not in [".", ".."] for part in path.parts
         )

--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -145,7 +145,7 @@ class SimpleDirectoryReader(BaseReader):
         self.file_metadata = file_metadata or default_file_metadata_func
         self.filename_as_id = filename_as_id
 
-    def is_hidden(path):
+    def is_hidden(self, path):
         return any(
             part.startswith(".") and part not in [".", ".."] for part in path.parts
         )


### PR DESCRIPTION
# Description

Notebooks when using `"../../../img_cache"` is being treated as a hidden file, making it throw an error that the path doesn't have files

How to reproduce:
```py
from llama_index.multi_modal_llms.openai import OpenAIMultiModal
from llama_index import SimpleDirectoryReader

image_documents = SimpleDirectoryReader("../../../img_cache").load_data()
```

Keep any image file in the img_cache directory and run (curiously when have a document it's recognized, images no (before the fix)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I ran `make format; make lint` to appease the lint gods
