### PR TITLE
bugfix: added entry for callback to clear _node_data_buffer

### DIFF
--- a/docs/examples/callbacks/OpenInferenceCallback.ipynb
+++ b/docs/examples/callbacks/OpenInferenceCallback.ipynb
@@ -77,6 +77,7 @@
     "from llama_index.callbacks.open_inference_callback import (\n",
     "    as_dataframe,\n",
     "    QueryData,\n",
+    "    NodeData,\n",
     ")\n",
     "from llama_index.node_parser import SimpleNodeParser\n",
     "import pandas as pd\n",
@@ -845,13 +846,18 @@
     "        self._max_buffer_length = max_buffer_length\n",
     "        self._batch_index = 0\n",
     "\n",
-    "    def __call__(self, query_data_buffer: List[QueryData]) -> None:\n",
+    "    def __call__(\n",
+    "        self,\n",
+    "        query_data_buffer: List[QueryData],\n",
+    "        node_data_buffer: List[NodeData],\n",
+    "    ) -> None:\n",
     "        if len(query_data_buffer) > self._max_buffer_length:\n",
     "            query_dataframe = as_dataframe(query_data_buffer)\n",
     "            file_path = self._data_path / f\"log-{self._batch_index}.parquet\"\n",
     "            query_dataframe.to_parquet(file_path)\n",
     "            self._batch_index += 1\n",
-    "            query_data_buffer.clear()  # ⚠️ clear the buffer or it will keep growing forever!"
+    "            query_data_buffer.clear()  # ⚠️ clear the buffer or it will keep growing forever!\n",
+    "            node_data_buffer.clear()  # didn't log node_data_buffer, but still need to clear it"
    ]
   },
   {

--- a/llama_index/callbacks/open_inference_callback.py
+++ b/llama_index/callbacks/open_inference_callback.py
@@ -149,12 +149,12 @@ class OpenInferenceCallbackHandler(BaseCallbackHandler):
 
     def __init__(
         self,
-        callback: Optional[Callable[[List[QueryData]], None]] = None,
+        callback: Optional[Callable[[List[QueryData], List[NodeData]], None]] = None,
     ) -> None:
         """Initializes the OpenInferenceCallbackHandler.
 
         Args:
-            callback (Optional[Callable[[List[QueryData]], None]], optional): A
+            callback (Optional[Callable[[List[QueryData], List[NodeData]], None]], optional): A
             callback function that will be called when a query trace is
             completed, often used for logging or persisting query data.
         """

--- a/llama_index/callbacks/open_inference_callback.py
+++ b/llama_index/callbacks/open_inference_callback.py
@@ -180,7 +180,7 @@ class OpenInferenceCallbackHandler(BaseCallbackHandler):
             self._node_data_buffer.extend(self._trace_data.node_datas)
             self._trace_data = TraceData()
             if self._callback is not None:
-                self._callback(self._query_data_buffer)
+                self._callback(self._query_data_buffer, self._node_data_buffer)
 
     def on_event_start(
         self,


### PR DESCRIPTION
# Description
In `OpenInferenceCallbackHandler`, both `self._query_data_buffer` and `self._node_data_buffer` grows persistently and require manual clearing.
In production env, we need to provide a callback to `OpenInferenceCallbackHandler` for logging and clearing `node_data_buffer`, but `node_data_buffer` is out of access in callback, which leave it grows out of control.
```python
class ParquetCallback:
    ...
    def __call__(
        self,
        query_data_buffer: List[QueryData],
    ) -> None:
        if len(query_data_buffer) > self._max_buffer_length:
            ...
            self._batch_index += 1
            query_data_buffer.clear()  # ⚠️ clear the buffer or it will keep growing forever!
```

# Fixes
pass `self._node_data_buffer` to `callback` function, so it can clear it periodically
```python
    def end_trace(...) -> None:
        if trace_id == "query":
            ...
            if self._callback is not None:
                self._callback(self._query_data_buffer, self._node_data_buffer)
```

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
