### PR TITLE
Update evaluation.ipynb fixed refine missing service_context

### DIFF
--- a/docs/examples/low_level/evaluation.ipynb
+++ b/docs/examples/low_level/evaluation.ipynb
@@ -716,6 +716,7 @@
     "\n",
     "    service_context = ServiceContext.from_defaults(llm=llm)\n",
     "    refine = Refine(\n",
+    "        service_context=service_context,\n",
     "        text_qa_template=EVAL_TEMPLATE,\n",
     "        refine_template=EVAL_REFINE_TEMPLATE,\n",
     "    )\n",


### PR DESCRIPTION
faithfullness evaluation was wrong because the Refine() object was missing the ServiceContext
