### PR TITLE
Add Sparse Embedding to BaseNode Class

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -135,7 +135,10 @@ class BaseNode(BaseComponent):
         default_factory=lambda: str(uuid.uuid4()), description="Unique ID of the node."
     )
     embedding: Optional[List[float]] = Field(
-        default=None, description="Embedding of the node."
+        default=None, description="Dense embedding of the node."
+    )
+    sparse_embedding: Optional[Dict[str, float]] = Field(
+        default=None, description="Sparse embedding of the node."
     )
 
     """"
@@ -279,6 +282,16 @@ class BaseNode(BaseComponent):
         if self.embedding is None:
             raise ValueError("embedding not set.")
         return self.embedding
+    
+    def get_sparse_embedding(self) -> Dict[str, float]:
+        """Get sparse embedding.
+
+        Errors if sparse_embedding is None.
+
+        """
+        if self.sparse_embedding is None:
+            raise ValueError("sparse_embedding not set.")
+        return self.sparse_embedding
 
     def as_related_node_info(self) -> RelatedNodeInfo:
         """Get node as RelatedNodeInfo."""

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -244,9 +244,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
         ids = []
         entries = []
 
-        #check if the LIst of nodes has sparse_embeddings
-        #if it does, then we need to add the sparse_embeddings to the index
-
         contains_sparse_embeddings = check_sparse_embeddings(nodes)
 
         for node in nodes:
@@ -263,12 +260,12 @@ class PineconeVectorStore(BasePydanticVectorStore):
                 VECTOR_KEY: node.get_embedding(),
                 METADATA_KEY: metadata,
             }
-            if self.add_sparse_vector and self._tokenizer is not None:
+            if self.add_sparse_vector:
 
                 if not contains_sparse_embeddings:
                     entry[SPARSE_VECTOR_KEY] = node.sparse_embedding
 
-                else:
+                elif self._tokenizer is not None:
                     sparse_vector = generate_sparse_vectors(
                         [node.get_content(metadata_mode=MetadataMode.EMBED)],
                         self._tokenizer,


### PR DESCRIPTION
# Description

This PR adds an optional parameter to the BaseNode class `sparse_embedding`. This is made to support by default the growing number of RAG systems that include traditional sparse-vector search methods (ex. Okapi BM25). 

To provide extended functionality for this change, I edited the PineconeVectorStore class to support adding nodes with existing sparse vectors in the `add` class method. 

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I ran `make format; make lint` to appease the lint gods
