### PR TITLE
Subclass getstate from pydantic's BaseModel to fix cannot pickle and unpickle TextNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fixed bug in loading pickled objects (#8880)
+
 ## [0.8.68] - 2023-11-11
 
 ### New Features

--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -43,10 +43,10 @@ class BaseComponent(BaseModel):
         """
 
     def __getstate__(self) -> Dict[str, Any]:
-        state = self.dict()
+        state = super().__getstate__()
         # Remove common unpicklable entries
-        state.pop("tokenizer", None)
-        state.pop("tokenizer_fn", None)
+        state["__dict__"].pop("tokenizer", None)
+        state["__dict__"].pop("tokenizer_fn", None)
         return state
 
     def to_dict(self, **kwargs: Any) -> Dict[str, Any]:


### PR DESCRIPTION
# Description

Cannot pickle and then unpickle TextNode object. This is due to `BaseComponent`'s `__getstate__` completely overwrites `pydantic.BaseModels`'s `__getstate__`. Example:

```python
import pickle
from llama_index.schema import TextNode

abc = TextNode(text="abc")

# save ok
with open("abc.pkl", "wb") as fo:
    pickle.dump(abc, fo)

# error when load
with open("abc.pkl", "rb") as fi:
    data = pickle.load(fi)
```

Stack trace:
```
File ~/.cache/pypoetry/virtualenvs/llama-index-Jalitqr9-py3.9/lib/python3.9/site-packages/pydantic/main.py:416, in pydantic.main.BaseModel.__setstate__()

KeyError: '__dict__'
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] Test with the snippet above

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
