### PR TITLE
fix pickling again

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -43,11 +43,16 @@ class BaseComponent(BaseModel):
         """
 
     def __getstate__(self) -> Dict[str, Any]:
+        # using super().__getstate__() would also include problematic private variables
         state = self.dict()
+
         # Remove common unpicklable entries
         state.pop("tokenizer", None)
         state.pop("tokenizer_fn", None)
         return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
 
     def to_dict(self, **kwargs: Any) -> Dict[str, Any]:
         data = self.dict(**kwargs)


### PR DESCRIPTION
Another [PR](https://github.com/run-llama/llama_index/pull/8880) pointed out that the original pickling support change was causing pickled data to be un-loadable.

While their change fixed some immediate issues, the larger pickling issue remains. 

In order to support pickling indexes, chat engines, and query engines, I introduce this improved fix