### PR TITLE
Remove remnant of Pydantic's state in getstate

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -47,8 +47,8 @@ class BaseComponent(BaseModel):
         state = self.dict()
 
         # Remove common unpicklable entries
-        state["__dict__"].pop("tokenizer", None)
-        state["__dict__"].pop("tokenizer_fn", None)
+        state.pop("tokenizer", None)
+        state.pop("tokenizer_fn", None)
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:


### PR DESCRIPTION
# Description

Since we don't subclass Pydantic's `__getstate__`, we will remove the `__dict__` in our `__getstate__` operation as well.
Fixes #8895

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
