### PR TITLE
Define Vertex examples as a Sequence

### DIFF
--- a/llama_index/llms/vertex.py
+++ b/llama_index/llms/vertex.py
@@ -33,7 +33,7 @@ class Vertex(LLM):
     model: str = Field(description="The vertex model to use.")
     temperature: float = Field(description="The temperature to use for sampling.")
     max_tokens: int = Field(description="The maximum number of tokens to generate.")
-    examples: Optional[ChatMessage] = Field(
+    examples: Optional[Sequence[ChatMessage]] = Field(
         description="Example messages for the chat model."
     )
     max_retries: int = Field(default=10, description="The maximum number of retries.")
@@ -53,7 +53,7 @@ class Vertex(LLM):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credential: Optional[str] = None,
-        examples: Optional[ChatMessage] = None,
+        examples: Optional[Sequence[ChatMessage]] = None,
         temperature: float = 0.1,
         max_tokens: int = 512,
         max_retries: int = 10,


### PR DESCRIPTION
# Description

Previous `examples` definition was implying it's an optional `ChatMessage` but in fact it should be an optional Sequence of ChatMessages. [llama_index/llms/vertex_utils.py#L164](https://github.com/run-llama/llama_index/blob/main/llama_index/llms/vertex_utils.py#L164) clearly shows this should be kind of a Sequence, because `len()` is used and later `for` to iterate over the examples. 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've used Vertex integration in my project and using `examples` was yielding errors when a list was provided.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
