### PR TITLE
Add support for custom httpx client configuration in AzureOpenAI

### DIFF
--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -147,6 +147,7 @@ class AzureOpenAI(OpenAI):
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
             "api_version": self.api_version,
+            "http_client": self._http_client,
         }
 
     def _get_model_kwargs(self, **kwargs: Any) -> Dict[str, Any]:

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -92,8 +92,8 @@ class AzureOpenAI(OpenAI):
         )
 
         # Use the custom httpx client if provided.
-        # Otherwise a default one will be created.
-        self._http_client = http_client or httpx.Client()
+        # Otherwise the value will be None.
+        self._http_client = http_client
 
         super().__init__(
             engine=engine,

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional, Tuple
 
+import httpx
 from openai import AsyncAzureOpenAI
 from openai import AzureOpenAI as SyncAzureOpenAI
 
@@ -72,6 +73,8 @@ class AzureOpenAI(OpenAI):
         deployment_name: Optional[str] = None,
         deployment_id: Optional[str] = None,
         deployment: Optional[str] = None,
+        # custom httpx client
+        http_client: Optional[httpx.Client] = None,
         **kwargs: Any,
     ) -> None:
         engine = resolve_from_aliases(
@@ -87,6 +90,10 @@ class AzureOpenAI(OpenAI):
         azure_endpoint = get_from_param_or_env(
             "azure_endpoint", azure_endpoint, "AZURE_OPENAI_ENDPOINT", ""
         )
+
+        # Use the custom httpx client if provided.
+        # Otherwise a default one will be created.
+        self._http_client = http_client or httpx.Client()
 
         super().__init__(
             engine=engine,


### PR DESCRIPTION
# Description

This PR includes the changes requested in **[Feature Request]: Support for Custom httpx Client Configuration in AzureOpenAI #8875**

A new attribute, `http_client` , was added to `azure_openai.py` constructor . If a custom one is not provided, a default httpx client will be created.

Fixes #8875 

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
