### PR TITLE
added error msg when llm is not explicitly passed

### DIFF
--- a/llama_index/finetuning/embeddings/common.py
+++ b/llama_index/finetuning/embeddings/common.py
@@ -67,7 +67,6 @@ context information provided."
 # generate queries as a convenience function
 def generate_qa_embedding_pairs(
     nodes: List[TextNode],
-    llm: Optional[LLMType] = "default",
     qa_generate_prompt_tmpl: str = DEFAULT_QA_GENERATE_PROMPT_TMPL,
     num_questions_per_chunk: int = 2,
 ) -> EmbeddingQAFinetuneDataset:
@@ -76,8 +75,6 @@ def generate_qa_embedding_pairs(
         node.node_id: node.get_content(metadata_mode=MetadataMode.NONE)
         for node in nodes
     }
-
-    llm = resolve_llm(llm)
 
     queries = {}
     relevant_docs = {}

--- a/llama_index/finetuning/embeddings/common.py
+++ b/llama_index/finetuning/embeddings/common.py
@@ -2,12 +2,12 @@
 import json
 import re
 import uuid
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from tqdm import tqdm
 
 from llama_index.bridge.pydantic import BaseModel
-from llama_index.llms.utils import LLMType
+from llama_index.llms.utils import LLM
 from llama_index.schema import MetadataMode, TextNode
 
 
@@ -67,7 +67,7 @@ context information provided."
 # generate queries as a convenience function
 def generate_qa_embedding_pairs(
     nodes: List[TextNode],
-    llm: Optional[LLMType],
+    llm: LLM,
     qa_generate_prompt_tmpl: str = DEFAULT_QA_GENERATE_PROMPT_TMPL,
     num_questions_per_chunk: int = 2,
 ) -> EmbeddingQAFinetuneDataset:

--- a/llama_index/finetuning/embeddings/common.py
+++ b/llama_index/finetuning/embeddings/common.py
@@ -7,9 +7,9 @@ from typing import Dict, List, Optional, Tuple
 from tqdm import tqdm
 
 from llama_index.bridge.pydantic import BaseModel
-from llama_index.llms.base import LLM
-from llama_index.llms.openai import OpenAI
+from llama_index.llms.utils import LLMType, resolve_llm
 from llama_index.schema import MetadataMode, TextNode
+
 
 class EmbeddingQAFinetuneDataset(BaseModel):
     """Embedding QA Finetuning Dataset.
@@ -67,7 +67,7 @@ context information provided."
 # generate queries as a convenience function
 def generate_qa_embedding_pairs(
     nodes: List[TextNode],
-    llm: Optional[LLM] = None,
+    llm: Optional[LLMType] = "default",
     qa_generate_prompt_tmpl: str = DEFAULT_QA_GENERATE_PROMPT_TMPL,
     num_questions_per_chunk: int = 2,
 ) -> EmbeddingQAFinetuneDataset:
@@ -77,16 +77,7 @@ def generate_qa_embedding_pairs(
         for node in nodes
     }
 
-    # if we don't pass in default llm then error is not raised
-    #llm = llm or OpenAI(model="gpt-3.5-turbo")
-    if llm == None:
-        raise ValueError(
-            "\n******\n"
-                "llm must be passed!" 
-            "\n******\n"
-            )
-    else:
-        llm = llm
+    llm = resolve_llm(llm)
 
     queries = {}
     relevant_docs = {}

--- a/llama_index/finetuning/embeddings/common.py
+++ b/llama_index/finetuning/embeddings/common.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple
 from tqdm import tqdm
 
 from llama_index.bridge.pydantic import BaseModel
-from llama_index.llms.utils import LLMType, resolve_llm
+from llama_index.llms.utils import LLMType
 from llama_index.schema import MetadataMode, TextNode
 
 

--- a/llama_index/finetuning/embeddings/common.py
+++ b/llama_index/finetuning/embeddings/common.py
@@ -11,7 +11,6 @@ from llama_index.llms.base import LLM
 from llama_index.llms.openai import OpenAI
 from llama_index.schema import MetadataMode, TextNode
 
-
 class EmbeddingQAFinetuneDataset(BaseModel):
     """Embedding QA Finetuning Dataset.
 
@@ -78,7 +77,16 @@ def generate_qa_embedding_pairs(
         for node in nodes
     }
 
-    llm = llm or OpenAI(model="gpt-3.5-turbo")
+    # if we don't pass in default llm then error is not raised
+    #llm = llm or OpenAI(model="gpt-3.5-turbo")
+    if llm == None:
+        raise ValueError(
+            "\n******\n"
+                "llm must be passed!" 
+            "\n******\n"
+            )
+    else:
+        llm = llm
 
     queries = {}
     relevant_docs = {}

--- a/llama_index/finetuning/embeddings/common.py
+++ b/llama_index/finetuning/embeddings/common.py
@@ -67,6 +67,7 @@ context information provided."
 # generate queries as a convenience function
 def generate_qa_embedding_pairs(
     nodes: List[TextNode],
+    llm: Optional[LLMType],
     qa_generate_prompt_tmpl: str = DEFAULT_QA_GENERATE_PROMPT_TMPL,
     num_questions_per_chunk: int = 2,
 ) -> EmbeddingQAFinetuneDataset:


### PR DESCRIPTION
# Description

If llm was not explicitly passed then code was trying to make request through Open Ai gpt3.5 turbo by default which may not be available and will throw an authentication error. It is hard to diagnose the problem without proper error message.
We didn't use the resolve_llm function from utils.py because it can roll down to mock LLM which won't help us in this question generation task.

Fixes # (issue)
we added None check, and if LLM is not explicitly passed then we will raise an error to pass the llm
## Type of Change
added None check
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
I tested by installing locally and by passing and not passing the llm object
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
