### PR TITLE
Fix SentenceSplitter returning empty list

### DIFF
--- a/llama_index/node_parser/text/sentence.py
+++ b/llama_index/node_parser/text/sentence.py
@@ -170,7 +170,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
         Has a preference for complete sentences, phrases, and minimal overlap.
         """
         if text == "":
-            return []
+            return [text]
 
         with self.callback_manager.event(
             CBEventType.CHUNKING, payload={EventPayload.CHUNKS: [text]}

--- a/llama_index/node_parser/text/token.py
+++ b/llama_index/node_parser/text/token.py
@@ -128,7 +128,7 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
     def _split_text(self, text: str, chunk_size: int) -> List[str]:
         """Split text into chunks up to chunk_size."""
         if text == "":
-            return []
+            return [text]
 
         with self.callback_manager.event(
             CBEventType.CHUNKING, payload={EventPayload.CHUNKS: [text]}


### PR DESCRIPTION
# Description

`SentenceSplitter` returns an empty list when invoking `get_nodes_from_documents` with `ImageDocuments` that have no text.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

