### PR TITLE
patch global service context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # ChangeLog
 
+## Unreleased
+
+### New Features
+
+- Added Cohere Reranker fine-tuning (#8859)
+- Support for custom httpx client in `AzureOpenAI` LLM (#8920)
+
+### Bug Fixes / Nits
+
+- Fixed issue with `set_global_service_context` not propagating settings (#8940)
+- Fixed issue with building index with Google Palm embeddings (#8936)
+- Fixed small issue with parsing ImageDocuments/Nodes that have no text (#8938)
+- Optimize `QueryEngineTool` for agents (#8933)
+
 ## [0.9.0] - 2023-11-15
 
 ### New Features / Breaking Changes / Deprecations

--- a/llama_index/service_context.py
+++ b/llama_index/service_context.py
@@ -272,6 +272,7 @@ class ServiceContext:
         for transform in service_context.transformations:
             if isinstance(transform, NodeParser):
                 node_parser_found = True
+                node_parser = transform
                 break
 
         if text_splitter is not None and node_parser is not None:
@@ -287,7 +288,8 @@ class ServiceContext:
                     callback_manager=callback_manager,
                 )
             )
-            transformations = [node_parser, *transformations]
+
+        transformations = transformations or service_context.transformations
 
         llama_logger = llama_logger or service_context.llama_logger
 


### PR DESCRIPTION
# Description

The global service context was not passing down it's transformations properly, causing the transformations list to be empty when setting a global service context.

Fixes https://github.com/run-llama/llama_index/issues/8939

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

