### PR TITLE
Fix Multi Modal Image to Text encoder bug

### DIFF
--- a/llama_index/indices/multi_modal/base.py
+++ b/llama_index/indices/multi_modal/base.py
@@ -317,7 +317,7 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
 
         # embed all nodes as text - incclude image nodes that have text attached
         text_nodes = self._get_node_with_embedding(
-            text_nodes, show_progress, is_image=False
+            text_nodes, show_progress, is_image=False, is_image_to_text=False
         )
         new_text_ids = self.storage_context.vector_stores[DEFAULT_VECTOR_STORE].add(
             text_nodes, **insert_kwargs
@@ -325,9 +325,8 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
 
         # embed image nodes as images directly
         # check if we should use text embedding for images instead of default
-        is_image_to_text = all(node.text for node in image_nodes)
         image_nodes = self._get_node_with_embedding(
-            image_nodes, show_progress, is_image=True, is_image_to_text=is_image_to_text
+            image_nodes, show_progress, is_image=True, is_image_to_text=False
         )
         new_img_ids = self.storage_context.vector_stores[self.image_namespace].add(
             image_nodes, **insert_kwargs

--- a/llama_index/indices/multi_modal/base.py
+++ b/llama_index/indices/multi_modal/base.py
@@ -265,16 +265,15 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
 
         # embed all nodes as text - incclude image nodes that have text attached
         text_nodes = await self._aget_node_with_embedding(
-            text_nodes, show_progress, is_image=False
+            text_nodes, show_progress, is_image=False, is_image_to_text=False
         )
         new_text_ids = await self.storage_context.vector_stores[
             DEFAULT_VECTOR_STORE
         ].async_add(text_nodes, **insert_kwargs)
 
         # embed image nodes as images directly
-        is_image_to_text = all(node.text for node in image_nodes)
         image_nodes = await self._aget_node_with_embedding(
-            image_nodes, show_progress, is_image=True, is_image_to_text=is_image_to_text
+            image_nodes, show_progress, is_image=True, is_image_to_text=False
         )
         new_img_ids = await self.storage_context.vector_stores[
             self.image_namespace


### PR DESCRIPTION
# Description


issue: ```is_image_to_text = all(node.text for node in image_nodes)```
Sometime this line will become True   even we don't want to encode image into text embedding
we should 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
