### PR TITLE
Replace plain pydantic imports with compat layer

### DIFF
--- a/llama_index/evaluation/dataset_generation.py
+++ b/llama_index/evaluation/dataset_generation.py
@@ -7,9 +7,8 @@ import re
 import uuid
 from typing import Dict, List, Tuple
 
-from pydantic import BaseModel, Field
-
 from llama_index import Document, ServiceContext, SummaryIndex
+from llama_index.bridge.pydantic import BaseModel, Field
 from llama_index.ingestion import run_transformations
 from llama_index.llms.openai import OpenAI
 from llama_index.postprocessor.node import KeywordNodePostprocessor

--- a/llama_index/evaluation/retrieval/metrics_base.py
+++ b/llama_index/evaluation/retrieval/metrics_base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from llama_index.bridge.pydantic import BaseModel, Field
 
 
 class RetrievalMetricResult(BaseModel):

--- a/llama_index/finetuning/rerankers/dataset_gen.py
+++ b/llama_index/finetuning/rerankers/dataset_gen.py
@@ -1,8 +1,7 @@
 import random
 from typing import Any, List, Optional, Tuple
 
-from pydantic import BaseModel
-
+from llama_index.bridge.pydantic import BaseModel
 from llama_index.finetuning import EmbeddingQAFinetuneDataset
 from llama_index.indices.query.embedding_utils import get_top_k_embeddings
 

--- a/llama_index/node_parser/relational/unstructured_element.py
+++ b/llama_index/node_parser/relational/unstructured_element.py
@@ -3,10 +3,9 @@
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 
 import pandas as pd
-from pydantic import BaseModel, ValidationError
 from tqdm import tqdm
 
-from llama_index.bridge.pydantic import Field
+from llama_index.bridge.pydantic import BaseModel, Field, ValidationError
 from llama_index.callbacks.base import CallbackManager
 from llama_index.llms.openai import LLM, OpenAI
 from llama_index.node_parser.interface import NodeParser

--- a/llama_index/param_tuner/base.py
+++ b/llama_index/param_tuner/base.py
@@ -6,9 +6,7 @@ from abc import abstractmethod
 from copy import deepcopy
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-from pydantic import BaseModel, Field
-
-from llama_index.bridge.pydantic import PrivateAttr
+from llama_index.bridge.pydantic import BaseModel, Field, PrivateAttr
 from llama_index.utils import get_tqdm_iterable
 
 

--- a/llama_index/prompts/base.py
+++ b/llama_index/prompts/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
-from pydantic import Field
+from llama_index.bridge.pydantic import Field
 
 if TYPE_CHECKING:
     from llama_index.bridge.langchain import BasePromptTemplate as LangchainTemplate

--- a/llama_index/query_engine/custom.py
+++ b/llama_index/query_engine/custom.py
@@ -3,9 +3,7 @@
 from abc import abstractmethod
 from typing import Union
 
-from pydantic import BaseModel
-
-from llama_index.bridge.pydantic import Field
+from llama_index.bridge.pydantic import BaseModel, Field
 from llama_index.callbacks.base import CallbackManager
 from llama_index.core import BaseQueryEngine
 from llama_index.prompts.mixin import PromptMixinType

--- a/tests/indices/response/test_tree_summarize.py
+++ b/tests/indices/response/test_tree_summarize.py
@@ -4,12 +4,12 @@ from typing import List, Sequence
 from unittest.mock import Mock
 
 import pytest
+from llama_index.bridge.pydantic import BaseModel
 from llama_index.indices.prompt_helper import PromptHelper
 from llama_index.prompts.base import PromptTemplate
 from llama_index.prompts.prompt_type import PromptType
 from llama_index.response_synthesizers import TreeSummarize
 from llama_index.service_context import ServiceContext
-from pydantic import BaseModel
 
 
 @pytest.fixture()

--- a/tests/tools/test_query_engine_tool.py
+++ b/tests/tools/test_query_engine_tool.py
@@ -17,7 +17,7 @@ class MockQueryEngine(CustomQueryEngine):
 
 def test_query_engine_tool() -> None:
     """Test query engine tool."""
-    query_engine = MockQueryEngine()
+    query_engine = MockQueryEngine()  # type: ignore[call-arg]
 
     query_tool = QueryEngineTool.from_defaults(query_engine)
 


### PR DESCRIPTION
# Description

Fixes #8959

I had to add an inline type ignore for a test. The code works at runtime, it passes pytest. I think for the type error to not show up the mypy Pydantic plugin needs to be installed, but I am guessing that is future work, so that's why it is a temporary inline type ignored for now.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I ran mypy
- [x] I ran pytest
