### PR TITLE
Changed import path from honeyhive.sdk to honeyhive.utils

### DIFF
--- a/docs/examples/callbacks/HoneyHiveLlamaIndexTracer.ipynb
+++ b/docs/examples/callbacks/HoneyHiveLlamaIndexTracer.ipynb
@@ -133,7 +133,7 @@
     "from llama_index.indices.composability import ComposableGraph\n",
     "from llama_index import load_index_from_storage, load_graph_from_storage\n",
     "from llama_index.llms import OpenAI\n",
-    "from honeyhive.sdk.llamaindex_tracer import HoneyHiveLlamaIndexTracer"
+    "from honeyhive.utils.llamaindex_tracer import HoneyHiveLlamaIndexTracer"
    ]
   },
   {

--- a/docs/module_guides/observability/observability.md
+++ b/docs/module_guides/observability/observability.md
@@ -235,7 +235,7 @@ set_global_handler(
 # NOTE: No need to do the following
 # from llama_index import ServiceContext
 # from llama_index.callbacks import CallbackManager
-# from honeyhive.sdk.llamaindex_tracer import HoneyHiveLlamaIndexTracer
+# from honeyhive.utils.llamaindex_tracer import HoneyHiveLlamaIndexTracer
 # hh_tracer = HoneyHiveLlamaIndexTracer(
 #     project="My HoneyHive Project",
 #     name="My LLM Pipeline Name",

--- a/llama_index/callbacks/honeyhive_callback.py
+++ b/llama_index/callbacks/honeyhive_callback.py
@@ -5,7 +5,7 @@ from llama_index.callbacks.base_handler import BaseCallbackHandler
 
 def honeyhive_callback_handler(**kwargs: Any) -> BaseCallbackHandler:
     try:
-        from honeyhive.sdk.llamaindex_tracer import HoneyHiveLlamaIndexTracer
+        from honeyhive.utils.llamaindex_tracer import HoneyHiveLlamaIndexTracer
     except ImportError:
         raise ImportError("Please install HoneyHive with `pip install honeyhive`")
     return HoneyHiveLlamaIndexTracer(**kwargs)


### PR DESCRIPTION
# Description

The import path of the HoneyHive LlamaIndex tracer changed from `honeyhive.sdk` to `honeyhive.utils`. Just making appropriate changes to reflect that.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# How Has This Been Tested?

I stared at the code and made sure it makes sense.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
