### PR TITLE
fix token counting for new openai client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ChangeLog
 
+## Unreleased
+
+### New Features
+
+- Add perplexity LLM integration (#8734)
+
+### Bug Fixes / Nits
+
+- Fix token counting for new openai client (#8981)
+- Fix small pydantic bug in postgres vector db (#8962)
+
 ## [0.9.2] - 2023-11-16
 
 ### New Features

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -23,7 +23,11 @@ class TokenCountingEvent:
 def get_llm_token_counts(
     token_counter: TokenCounter, payload: Dict[str, Any], event_id: str = ""
 ) -> TokenCountingEvent:
+    import pdb
+
     from llama_index.llms import ChatMessage
+
+    pdb.set_trace()
 
     if EventPayload.PROMPT in payload:
         prompt = str(payload.get(EventPayload.PROMPT))
@@ -46,10 +50,10 @@ def get_llm_token_counts(
 
         # try getting attached token counts first
         try:
-            usage_dict = response.additional_kwargs  # type: ignore
+            usage = response.raw["usage"]  # type: ignore
 
-            messages_tokens = usage_dict["prompt_tokens"]
-            response_tokens = usage_dict["completion_tokens"]
+            messages_tokens = usage.prompt_tokens
+            response_tokens = usage.completion_tokens
 
             if messages_tokens == 0 or response_tokens == 0:
                 raise ValueError("Invalid token counts!")

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -23,11 +23,7 @@ class TokenCountingEvent:
 def get_llm_token_counts(
     token_counter: TokenCounter, payload: Dict[str, Any], event_id: str = ""
 ) -> TokenCountingEvent:
-    import pdb
-
     from llama_index.llms import ChatMessage
-
-    pdb.set_trace()
 
     if EventPayload.PROMPT in payload:
         prompt = str(payload.get(EventPayload.PROMPT))


### PR DESCRIPTION
# Description

The new openai client changed where to find token counts, causing the token counter to be very bad for OpenAI function calling.

Fixes https://github.com/run-llama/llama_index/issues/8978

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

