### PR TITLE
LlamaIndex support for Amazon Bedrock Llama 2 Chat 13b

### DIFF
--- a/llama_index/llms/bedrock_utils.py
+++ b/llama_index/llms/bedrock_utils.py
@@ -44,6 +44,7 @@ CHAT_ONLY_MODELS = {
     "anthropic.claude-instant-v1": 100000,
     "anthropic.claude-v1": 100000,
     "anthropic.claude-v2": 100000,
+    "meta.llama2-13b-chat-v1": 2048,
 }
 BEDROCK_FOUNDATION_LLMS = {**COMPLETION_MODELS, **CHAT_ONLY_MODELS}
 
@@ -56,6 +57,7 @@ STREAMING_MODELS = {
     "anthropic.claude-instant-v1",
     "anthropic.claude-v1",
     "anthropic.claude-v2",
+    "meta.llama2-13b-chat-v1",
 }
 
 # Each bedrock model specifies parameters with a slightly different name
@@ -66,6 +68,7 @@ PROVIDER_SPECIFIC_PARAM_NAME = {
     "ai21": {"max_tokens": "maxTokens"},
     "anthropic": {"max_tokens": "max_tokens_to_sample"},
     "cohere": {"max_tokens": "max_tokens"},
+    "meta": {"max_tokens": "max_gen_len"},
 }
 
 # The response format for each provider is different
@@ -74,11 +77,13 @@ PROVIDER_RESPONSE_LOADER = {
     "ai21": lambda x: x["completions"][0]["data"]["text"],
     "anthropic": lambda x: x["completion"],
     "cohere": lambda x: x["generations"][0]["text"],
+    "meta": lambda x: x["generation"],
 }
 
 PROVIDER_STREAM_RESPONSE_LOADER = {
     "amazon": lambda x: x["outputText"],
     "anthropic": lambda x: x["completion"],
+    "meta": lambda x: x["generation"],
 }
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

Llama Index now supports Llama 2 LLM available on Amazon Bedrock.
Bedrock Model identifier for Llama 2 chat 13b: `meta.llama2-13b-chat-v1`
Implementation covers support for
- `complete` endpoint response,
-  Chat messages `ChatMessage` and
- Streaming support for `stream_complete` endpoint


References: [Amazon Bedrock now provides access to Meta’s Llama 2 Chat 13B model](https://aws.amazon.com/blogs/aws/amazon-bedrock-now-provides-access-to-llama-2-chat-13b-model/)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
