### PR TITLE
[Docs] grammar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ LlamaIndex is a data framework for `LLM <https://en.wikipedia.org/wiki/Large_lan
 
 LLMs offer a natural language interface between humans and data. Widely available models come pre-trained on huge amounts of publicly available data like Wikipedia, mailing lists, textbooks, source code and more.
 
-However, while LLMs are trained on a great deal of data, they are not trained on **your** data, which may private or specific to the problem you're trying to solve. It's behind APIs, in SQL databases, or trapped in PDFs and slide decks.
+However, while LLMs are trained on a great deal of data, they are not trained on **your** data, which may be private or specific to the problem you're trying to solve. It's behind APIs, in SQL databases, or trapped in PDFs and slide decks.
 
 LlamaIndex solves this problem by connecting to these data sources and adding your data to the data LLMs already have. This is often called Retrieval-Augmented Generation (RAG). RAG enables you to use LLMs to query your data, transform it, and generate new insights. You can ask questions about your data, create chatbots, build semi-autonomous agents, and more. To learn more, check out our Use Cases on the left.
 


### PR DESCRIPTION
# Description
Just a simple grammar change on the main documentation page
`which may private or specific to the problem you’re trying to solve.` ->
`which may be private or specific to the problem you’re trying to solve.`
