### PR TITLE
[Bug]: ChromaReader incorrect indexing of result in create_documents

### DIFF
--- a/llama_index/readers/chroma.py
+++ b/llama_index/readers/chroma.py
@@ -62,16 +62,16 @@ class ChromaReader(BaseReader):
         """
         documents = []
         for result in zip(
-            results["ids"],
-            results["documents"],
-            results["embeddings"],
-            results["metadatas"],
+            results["ids"][0],
+            results["documents"][0],
+            results["embeddings"][0],
+            results["metadatas"][0],
         ):
             document = Document(
-                id_=result[0][0],
-                text=result[1][0],
-                embedding=result[2][0],
-                metadata=result[3][0],
+                id_=result[0],
+                text=result[1],
+                embedding=result[2],
+                metadata=result[3],
             )
             documents.append(document)
 


### PR DESCRIPTION
fix incorrect indexing of result object in chroma.py

# Description

The result of a chroma.query method are key values pairs where the values are nested arrays. In order to appropriately zip/loop through the values you need to first access the list of values themselves.

chroma.query id sample results:
![image](https://github.com/run-llama/llama_index/assets/28288488/e5caf348-2af5-45e5-8469-7264597b88e8)

Currentlly create_documents zips through the unested list, resulting in only one document being returned from the method call.


Fixes # (issue)
#9006 
## Type of Change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] created a notebook and manually tested expected results
