### PR TITLE
Docs & code example: Fixed a typo in IngestionPipeline (e was missing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### New Features / Breaking Changes / Deprecations
 
-- New `IngestionPipline` concept for ingesting and transforming data
+- New `IngestionPipeline` concept for ingesting and transforming data
 - Data ingestion and transforms are now automatically cached
 - Updated interface for node parsing/text splitting/metadata extraction modules
 - Changes to the default tokenizer, as well as customizing the tokenizer

--- a/docs/examples/metadata_extraction/EntityExtractionClimate.ipynb
+++ b/docs/examples/metadata_extraction/EntityExtractionClimate.ipynb
@@ -183,9 +183,9 @@
     "# 100 documents takes about 5 minutes on CPU\n",
     "documents = random.sample(documents, 100)\n",
     "\n",
-    "pipline = IngestionPipeline(transformations=transformations)\n",
+    "pipeline = IngestionPipeline(transformations=transformations)\n",
     "\n",
-    "nodes = pipline.run(documents=documents)"
+    "nodes = pipeline.run(documents=documents)"
    ]
   },
   {

--- a/docs/examples/metadata_extraction/PydanticExtractor.ipynb
+++ b/docs/examples/metadata_extraction/PydanticExtractor.ipynb
@@ -182,9 +182,9 @@
     "\n",
     "node_parser = SentenceSplitter(chunk_size=1024)\n",
     "\n",
-    "pipline = IngestionPipeline(transformations=[node_parser, program_extractor])\n",
+    "pipeline = IngestionPipeline(transformations=[node_parser, program_extractor])\n",
     "\n",
-    "orig_nodes = pipline.run(documents=docs)"
+    "orig_nodes = pipeline.run(documents=docs)"
    ]
   },
   {

--- a/docs/module_guides/indexing/metadata_extraction.md
+++ b/docs/module_guides/indexing/metadata_extraction.md
@@ -37,9 +37,9 @@ transformations = [
 Then, we can run our transformations on input documents or nodes:
 
 ```python
-from llama_index.ingestion import IngestionPipline
+from llama_index.ingestion import IngestionPipeline
 
-pipeline = IngestionPipline(transformations=transformations)
+pipeline = IngestionPipeline(transformations=transformations)
 
 nodes = pipeline.run(documents=documents)
 ```


### PR DESCRIPTION
# Description

There where several occasions where "pipeline" was missing an "e" (was pipline)
Notably at `/docs/module_guides/indexing/metadata_extraction.md` where it caused the example to fail.