### PR TITLE
Add node_parser attribute back to service context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed bug with `OpenAIAgent` inserting errors into chat history (#9000)
 - Fixed various bugs with LiteLLM and the new OpenAI client (#9003)
 - Added context window attribute to perplexity llm (#9012)
+- Add `node_parser` attribute back to service context (#9013)
 
 ## [0.9.3] - 2023-11-17
 

--- a/llama_index/service_context.py
+++ b/llama_index/service_context.py
@@ -308,6 +308,14 @@ class ServiceContext:
             raise ValueError("llm_predictor must be an instance of LLMPredictor")
         return self.llm_predictor.llm
 
+    @property
+    def node_parser(self) -> NodeParser:
+        """Get the node parser."""
+        for transform in self.transformations:
+            if isinstance(transform, NodeParser):
+                return transform
+        raise ValueError("No node parser found.")
+
     def to_dict(self) -> dict:
         """Convert service context to dict."""
         llm_dict = self.llm_predictor.llm.to_dict()


### PR DESCRIPTION
# Description

A few code samples rely on `service_context.node_parser` being available, lets add this back

Fixes https://github.com/run-llama/llama_index/issues/8992

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

