### PR TITLE
fix prompt helper error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fixed bug in formatting chat prompt templates when estimating chunk sizes (#9025)
+
 ## [0.9.4] - 2023-11-19
 
 ### New Features

--- a/llama_index/indices/prompt_helper.py
+++ b/llama_index/indices/prompt_helper.py
@@ -188,13 +188,18 @@ class PromptHelper(BaseComponent):
                 ]
 
                 # figure out which variables are partially formatted
-                used_vars = {}
+                # if a variable is not formatted, it will be replaced with
+                # the template variable itself
+                used_vars = {
+                    template_var: f"{{{template_var}}}"
+                    for template_var in template_vars
+                }
                 for var_name, val in prompt.kwargs.items():
                     if var_name in template_vars:
                         used_vars[var_name] = val
 
                 # format partial message
-                if len(used_vars) > 0 and partial_message.content is not None:
+                if partial_message.content is not None:
                     partial_message.content = partial_message.content.format(
                         **used_vars
                     )


### PR DESCRIPTION
# Description

When getting the token counts of chat messages, partial formatting causes some issues. If both query_str and context_str are in the same message, but only query_str is formatted, it will attempt to format the message with incomplete args and cause an error.

In the case of this happening, unused vars will get formated with the template var itself (essentially skipping actual formatting).

Fixes https://github.com/run-llama/llama_index/issues/9020

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
