### PR TITLE
Make PromptTemplate.partial_format Idempotent

### DIFF
--- a/llama_index/prompts/base.py
+++ b/llama_index/prompts/base.py
@@ -144,6 +144,7 @@ class PromptTemplate(BasePromptTemplate):
 
         # NOTE: put the output parser back
         prompt.output_parser = output_parser
+        self.output_parser = output_parser
         return prompt
 
     def format(self, llm: Optional[LLM] = None, **kwargs: Any) -> str:


### PR DESCRIPTION
# Description

Re-assigned PromptTemplate.output_parser to self after the deepcopy is performed in PromptTemplate.partial_format.


Fixes # (issue)
https://github.com/run-llama/llama_index/issues/9029

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran existing tests to assure no regressions
- [x] Ran notebook from https://docs.llamaindex.ai/en/stable/examples/output_parsing/GuardrailsDemo.html with additional logs to show GuardrailsOutputParser.parse is now being called

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
