### PR TITLE
Fixing `mypy` for Python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed bug in formatting chat prompt templates when estimating chunk sizes (#9025)
 - Sandboxed Pandas execution, remidiate CVE-2023-39662 (#8890)
+- Restored `mypy` for Python 3.8 (#9031)
 
 ## [0.9.4] - 2023-11-19
 

--- a/llama_index/indices/managed/vectara/base.py
+++ b/llama_index/indices/managed/vectara/base.py
@@ -8,7 +8,7 @@ interfaces a managed service.
 import json
 import logging
 import os
-from typing import Any, Optional, Sequence, Type
+from typing import Any, Dict, Optional, Sequence, Type
 
 import requests
 
@@ -155,7 +155,7 @@ class VectaraIndex(BaseManagedIndex):
         return True
 
     def _index_doc(self, doc: dict) -> str:
-        request: dict[str, Any] = {}
+        request: Dict[str, Any] = {}
         request["customerId"] = self._vectara_customer_id
         request["corpusId"] = self._vectara_corpus_id
         request["document"] = doc

--- a/llama_index/response/notebook_utils.py
+++ b/llama_index/response/notebook_utils.py
@@ -1,7 +1,7 @@
 """Utils for jupyter notebook."""
 import os
 from io import BytesIO
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
 import matplotlib.pyplot as plt
 import requests
@@ -26,7 +26,7 @@ def display_image(img_str: str, size: Tuple[int, int] = DEFAULT_THUMBNAIL_SIZE) 
 
 
 def display_image_uris(
-    image_paths: list[str],
+    image_paths: List[str],
     image_matrix: Tuple[int, int] = DEFAULT_IMAGE_MATRIX,
     top_k: int = DEFAULT_SHOW_TOP_K,
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ disallow_untyped_defs = true
 # Remove venv skip when integrated with pre-commit
 exclude = ["build", "examples", "notebooks", "venv"]
 ignore_missing_imports = true
+python_version = "3.8"
 
 [tool.poetry]
 authors = ["Jerry Liu <jerry@llamaindex.ai>"]


### PR DESCRIPTION
# Description

A bit ago I made https://github.com/run-llama/llama_index/pull/8107.  It looks like again there were typing regressions for 3.8.

This PR ensures this won't happen again by setting `python_version` for `mypy`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
