### PR TITLE
`OpenAILike` ability to not infer `max_tokens`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - More precise testing of `OpenAILike` (#9026)
 - Added callback manager to each retriever (#8871)
+- Ability to bypass `max_tokens` inference with `OpenAILike` (#9032)
 
 ### Bug Fixes / Nits
 

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -161,7 +161,13 @@ class OpenAI(LLM):
         return "openai_llm"
 
     @property
-    def _tokenizer(self) -> Tokenizer:
+    def _tokenizer(self) -> Optional[Tokenizer]:
+        """
+        Get a tokenizer for this model, or None if a tokenizing method is unknown.
+
+        OpenAI can do this using the tiktoken package, subclasses may not have
+        this convenience.
+        """
         return tiktoken.encoding_for_model(self._get_model_name())
 
     @property
@@ -385,16 +391,17 @@ class OpenAI(LLM):
         return gen()
 
     def _update_max_tokens(self, all_kwargs: Dict[str, Any], prompt: str) -> None:
-        if self.max_tokens is not None:
+        """Infer max_tokens for the payload, if possible."""
+        if self.max_tokens is not None or self._tokenizer is None:
             return
         # NOTE: non-chat completion endpoint requires max_tokens to be set
-        context_window = self.metadata.context_window
-        tokens = self._tokenizer.encode(prompt)
-        max_tokens = context_window - len(tokens)
+        num_tokens = len(self._tokenizer.encode(prompt))
+        max_tokens = self.metadata.context_window - num_tokens
         if max_tokens <= 0:
             raise ValueError(
-                f"The prompt is too long for the model. "
-                f"Please use a prompt that is less than {context_window} tokens."
+                f"The prompt has {num_tokens} tokens, which is too long for"
+                " the model. Please use a prompt that fits within"
+                f" {self.metadata.context_window} tokens."
             )
         all_kwargs["max_tokens"] = max_tokens
 

--- a/llama_index/llms/openai_like.py
+++ b/llama_index/llms/openai_like.py
@@ -8,7 +8,7 @@ from llama_index.llms.openai import OpenAI, Tokenizer
 
 class OpenAILike(OpenAI):
     """
-    OpenAILike is a thin wrapper around the OpenAI model that makes it compatible with \
+    OpenAILike is a thin wrapper around the OpenAI model that makes it compatible with
     3rd party tools that provide an openai-compatible api.
 
     Currently, llama_index prevents using custom models with their OpenAI class
@@ -22,19 +22,25 @@ class OpenAILike(OpenAI):
 
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,
-        description="The maximum number of context tokens for the model.",
+        description=LLMMetadata.__fields__["context_window"].field_info.description,
     )
     is_chat_model: bool = Field(
-        default=False, description="Indicates that the custom model is a chat_model."
+        default=False,
+        description=LLMMetadata.__fields__["is_chat_model"].field_info.description,
     )
     is_function_calling_model: bool = Field(
         default=False,
-        description="Indicates that the custom model is a function calling model.",
+        description=LLMMetadata.__fields__[
+            "is_function_calling_model"
+        ].field_info.description,
     )
     tokenizer: Optional[Tokenizer] = Field(
         default=None,
-        description="An instance of a tokenizer object that has an encode method. "
-        "If not provided, will default to the huggingface tokenizer for the model.",
+        description=(
+            "An instance of a tokenizer object that has an encode method, or the name"
+            " of a tokenizer model from Hugging Face. If left as None, then this"
+            " disables inference of max_tokens."
+        ),
     )
 
     @property

--- a/llama_index/llms/openai_like.py
+++ b/llama_index/llms/openai_like.py
@@ -54,8 +54,8 @@ class OpenAILike(OpenAI):
         )
 
     @property
-    def _tokenizer(self) -> Tokenizer:
-        if not self.tokenizer:
+    def _tokenizer(self) -> Optional[Tokenizer]:
+        if isinstance(self.tokenizer, str):
             try:
                 from transformers import AutoTokenizer
             except ImportError as exc:
@@ -64,9 +64,8 @@ class OpenAILike(OpenAI):
                     "huggingface tokenizers with OpenAILike."
                 ) from exc
 
-            return AutoTokenizer.from_pretrained(self._get_model_name())
-        else:
-            return self.tokenizer
+            return AutoTokenizer.from_pretrained(self.tokenizer)
+        return self.tokenizer
 
     @classmethod
     def class_name(cls) -> str:

--- a/tests/llms/test_openai_like.py
+++ b/tests/llms/test_openai_like.py
@@ -1,5 +1,5 @@
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from llama_index.llms import OpenAILike
 from llama_index.llms.base import ChatMessage, MessageRole
@@ -60,27 +60,48 @@ def mock_completion(text: str) -> Completion:
 
 @patch("llama_index.llms.openai.SyncOpenAI")
 def test_completion(MockSyncOpenAI: MagicMock) -> None:
-    text = "placeholder"
-
     mock_instance = MockSyncOpenAI.return_value
-    mock_instance.completions.create.return_value = mock_completion(text)
+    mock_instance.completions.create.side_effect = [
+        mock_completion("1"),
+        mock_completion("2"),
+    ]
 
     llm = OpenAILike(
         model=STUB_MODEL_NAME,
-        is_chat_model=False,
+        context_window=1024,
+        max_tokens=None,
+    )
+    response = llm.complete("A long time ago in a galaxy far, far away")
+    expected_calls = [
+        # NOTE: has no max_tokens or tokenizer, so won't infer max_tokens
+        call(
+            prompt="A long time ago in a galaxy far, far away",
+            stream=False,
+            model=STUB_MODEL_NAME,
+            temperature=0.1,
+        )
+    ]
+    assert response.text == "1"
+    mock_instance.completions.create.assert_has_calls(expected_calls)
+
+    llm = OpenAILike(
+        model=STUB_MODEL_NAME,
         context_window=1024,
         tokenizer=StubTokenizer(),
     )
-
     response = llm.complete("A long time ago in a galaxy far, far away")
-    assert response.text == text
-    mock_instance.completions.create.assert_called_once_with(
-        prompt="A long time ago in a galaxy far, far away",
-        stream=False,
-        model=STUB_MODEL_NAME,
-        temperature=0.1,
-        max_tokens=1014,
-    )
+    expected_calls += [
+        # NOTE: has tokenizer, so will infer max_tokens
+        call(
+            prompt="A long time ago in a galaxy far, far away",
+            stream=False,
+            model=STUB_MODEL_NAME,
+            temperature=0.1,
+            max_tokens=1014,
+        )
+    ]
+    assert response.text == "2"
+    mock_instance.completions.create.assert_has_calls(expected_calls)
 
 
 @patch("llama_index.llms.openai.SyncOpenAI")


### PR DESCRIPTION
# Description

Part 2 of the decomposition of https://github.com/run-llama/llama_index/pull/8241.
- Ability to not infer `max_tokens` using `OpenAI` or its subclasses
- Cleans up `OpenAILike` docstring and `description`s

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
