### PR TITLE
fix: continue instead of forcing exception openai astream chat

### DIFF
--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -498,7 +498,7 @@ class OpenAI(LLM):
                 if len(response.choices) > 0:
                     delta = response.choices[0].delta
                 else:
-                    delta = {}
+                    continue
 
                 # check if this chunk is the start of a function call
                 if delta.tool_calls:

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -498,7 +498,7 @@ class OpenAI(LLM):
                 if len(response.choices) > 0:
                     delta = response.choices[0].delta
                 else:
-                    continue
+                    delta = ChoiceDelta()
 
                 # check if this chunk is the start of a function call
                 if delta.tool_calls:


### PR DESCRIPTION
# Description

Fixes Azure OpenAI LLM failure when returning empty delta dictionary. Currently, an exception is forced anytime a response isn't provided through the completions API call.

Fixes #8995

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X] Tested using AzureOpenAI and OpenAI with OpenAIAgent
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
