### PR TITLE
feat: fastembed embedding support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- `FastEmbed` embeddings provider (#9043)
 - More precise testing of `OpenAILike` (#9026)
 - Added callback manager to each retriever (#8871)
 

--- a/docs/examples/embeddings/fastembed.ipynb
+++ b/docs/examples/embeddings/fastembed.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/embeddings/clarifai.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Qdrant FastEmbed Embeddings\n",
+    "\n",
+    "LlamaIndex supports [FastEmbed](https://qdrant.github.io/fastembed/) for embeddings generation."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex 🦙."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use this provider, the `fastembed` package needs to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install fastembed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The list of supported models can be found [here](https://qdrant.github.io/fastembed/examples/Supported_Models/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 76.7M/76.7M [00:18<00:00, 4.23MiB/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.embeddings import FastEmbedEmbedding\n",
+    "\n",
+    "embed_model = FastEmbedEmbedding(model_name=\"BAAI/bge-small-en-v1.5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "384\n",
+      "[-0.04166769981384277, 0.0018720313673838973, 0.02632238157093525, -0.036030545830726624, -0.014812108129262924]\n"
+     ]
+    }
+   ],
+   "source": [
+    "embeddings = embed_model.get_text_embedding(\"Some text to embed.\")\n",
+    "print(len(embeddings))\n",
+    "print(embeddings[:5])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/module_guides/models/embeddings.md
+++ b/docs/module_guides/models/embeddings.md
@@ -199,6 +199,7 @@ maxdepth: 1
 /examples/embeddings/OpenAI.ipynb
 /examples/embeddings/Langchain.ipynb
 /examples/embeddings/cohereai.ipynb
+/examples/embeddings/fastembed.ipynb
 /examples/embeddings/gradient.ipynb
 /examples/customization/llms/AzureOpenAI.ipynb
 /examples/embeddings/custom_embeddings.ipynb

--- a/llama_index/embeddings/__init__.py
+++ b/llama_index/embeddings/__init__.py
@@ -14,6 +14,7 @@ from llama_index.embeddings.elasticsearch import (
     ElasticsearchEmbedding,
     ElasticsearchEmbeddings,
 )
+from llama_index.embeddings.fastembed import FastEmbedEmbedding
 from llama_index.embeddings.google import GoogleUnivSentEncoderEmbedding
 from llama_index.embeddings.google_palm import GooglePaLMEmbedding
 from llama_index.embeddings.gradient import GradientEmbedding
@@ -42,6 +43,7 @@ __all__ = [
     "BaseEmbedding",
     "DEFAULT_HUGGINGFACE_EMBEDDING_MODEL",
     "ElasticsearchEmbedding",
+    "FastEmbedEmbedding",
     "GoogleUnivSentEncoderEmbedding",
     "GradientEmbedding",
     "HuggingFaceInferenceAPIEmbedding",

--- a/llama_index/embeddings/fastembed.py
+++ b/llama_index/embeddings/fastembed.py
@@ -1,0 +1,108 @@
+from typing import Any, List, Literal, Optional
+
+import numpy as np
+from pydantic import Field
+
+from llama_index.bridge.pydantic import PrivateAttr
+from llama_index.embeddings.base import BaseEmbedding
+
+
+class FastEmbedEmbedding(BaseEmbedding):
+    """
+    Qdrant FastEmbedding models.
+    FastEmbed is a lightweight, fast, Python library built for embedding generation.
+    See more documentation at:
+    * https://github.com/qdrant/fastembed/
+    * https://qdrant.github.io/fastembed/.
+
+    To use this class, you must install the `fastembed` Python package.
+
+    `pip install fastembed`
+    Example:
+        from llama_index.embeddings import FastEmbedEmbedding
+        fastembed = FastEmbedEmbedding()
+    """
+
+    model_name: str = Field(
+        "BAAI/bge-small-en-v1.5",
+        description="Name of the FastEmbedding model to use.\n"
+        "Defaults to 'BAAI/bge-small-en-v1.5'.\n"
+        "Find the list of supported models at "
+        "https://qdrant.github.io/fastembed/examples/Supported_Models/",
+    )
+
+    max_length: int = Field(
+        512,
+        description="The maximum number of tokens. Defaults to 512.\n"
+        "Unknown behavior for values > 512.",
+    )
+
+    cache_dir: Optional[str] = Field(
+        None,
+        description="The path to the cache directory.\n"
+        "Defaults to `local_cache` in the parent directory",
+    )
+
+    threads: Optional[int] = Field(
+        None,
+        description="The number of threads single onnxruntime session can use.\n"
+        "Defaults to None",
+    )
+
+    doc_embed_type: Literal["default", "passage"] = Field(
+        "default",
+        description="Type of embedding to use for documents.\n"
+        "'default': Uses FastEmbed's default embedding method.\n"
+        "'passage': Prefixes the text with 'passage' before embedding.\n"
+        "Defaults to 'default'.",
+    )
+
+    _model: Any = PrivateAttr()
+
+    @classmethod
+    def class_name(self) -> str:
+        return "FastEmbedEmbedding"
+
+    def __init__(
+        self,
+        model_name: Optional[str] = "BAAI/bge-small-en-v1.5",
+        max_length: Optional[int] = 512,
+        cache_dir: Optional[str] = None,
+        threads: Optional[int] = None,
+        doc_embed_type: Literal["default", "passage"] = "default",
+    ):
+        super().__init__(
+            model_name=model_name,
+            max_length=max_length,
+            threads=threads,
+            doc_embed_type=doc_embed_type,
+        )
+        try:
+            from fastembed.embedding import FlagEmbedding
+
+            self._model = FlagEmbedding(
+                model_name=model_name,
+                max_length=max_length,
+                cache_dir=cache_dir,
+                threads=threads,
+            )
+        except ImportError as ie:
+            raise ImportError(
+                "Could not import 'fastembed' Python package. "
+                "Please install it with `pip install fastembed`."
+            ) from ie
+
+    def _get_text_embedding(self, text: str) -> List[float]:
+        embeddings: List[np.ndarray]
+        if self.doc_embed_type == "passage":
+            embeddings = list(self._model.passage_embed(text))
+        else:
+            embeddings = list(self._model.embed(text))
+        return embeddings[0].tolist()
+
+    def _get_query_embedding(self, query: str) -> List[float]:
+        query_embeddings: np.ndarray = next(self._model.query_embed(query))
+        return query_embeddings.tolist()
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return self._get_query_embedding(query)

--- a/tests/embeddings/test_fastembed.py
+++ b/tests/embeddings/test_fastembed.py
@@ -1,0 +1,53 @@
+from typing import Literal
+
+import pytest
+from llama_index.embeddings import FastEmbedEmbedding
+
+try:
+    import fastembed
+except ImportError:
+    fastembed = None  # type: ignore
+
+
+@pytest.mark.skipif(fastembed is None, reason="fastembed is not installed")
+@pytest.mark.parametrize(
+    "model_name", ["sentence-transformers/all-MiniLM-L6-v2", "BAAI/bge-small-en-v1.5"]
+)
+@pytest.mark.parametrize("max_length", [50, 512])
+@pytest.mark.parametrize("doc_embed_type", ["default", "passage"])
+@pytest.mark.parametrize("threads", [0, 10])
+def test_fastembed_embedding_texts_batch(
+    model_name: str,
+    max_length: int,
+    doc_embed_type: Literal["default", "passage"],
+    threads: int,
+) -> None:
+    """Test FastEmbed batch embedding."""
+    documents = ["foo bar", "bar foo"]
+    embedding = FastEmbedEmbedding(
+        model_name=model_name,
+        max_length=max_length,
+        doc_embed_type=doc_embed_type,
+        threads=threads,
+    )
+
+    output = embedding.get_text_embedding_batch(documents)
+    assert len(output) == len(documents)
+    assert len(output[0]) == 384
+
+
+@pytest.mark.skipif(fastembed is None, reason="fastembed is not installed")
+@pytest.mark.parametrize(
+    "model_name", ["sentence-transformers/all-MiniLM-L6-v2", "BAAI/bge-small-en-v1.5"]
+)
+@pytest.mark.parametrize("max_length", [50, 512])
+def test_fastembed_query_embedding(model_name: str, max_length: int) -> None:
+    """Test FastEmbed batch embedding."""
+    query = "foo bar"
+    embedding = FastEmbedEmbedding(
+        model_name=model_name,
+        max_length=max_length,
+    )
+
+    output = embedding.get_query_embedding(query)
+    assert len(output) == 384


### PR DESCRIPTION
# Description

This PR intends to add [Qdrant/FastEmbed](https://qdrant.github.io/fastembed/) as a supported embeddings provider, associated tests and documentation.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests have been added to `tests/embeddings/test_fastembed.py`.

- [x] Added new unit/integration tests

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code.
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
