### PR TITLE
Fix ReAct Output Parser for Multi-line action inputs

### DIFF
--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -16,7 +16,7 @@ from llama_index.types import BaseOutputParser
 
 
 def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
-    pattern = r"\s*Thought:(.*?)Action:(.*?)Action Input:(.*?)(?:\n|$)"
+    pattern = r"\s*Thought: (.*?)\nAction: (.*?)\nAction Input: (\{.*?\})"
 
     match = re.search(pattern, input_text, re.DOTALL)
     if not match:

--- a/tests/agent/react/test_react_output_parser.py
+++ b/tests/agent/react/test_react_output_parser.py
@@ -21,7 +21,7 @@ def test_extract_tool_use_multiline_action_input() -> None:
 Thought: I need to use a tool to help me answer the question.
 Action: add
 Action Input: {
-    "a": 1, 
+    "a": 1,
     "b": 1
 }
 """
@@ -32,7 +32,7 @@ Action Input: {
         action_input
         == """\
 {
-    "a": 1, 
+    "a": 1,
     "b": 1
 }"""
     )

--- a/tests/agent/react/test_react_output_parser.py
+++ b/tests/agent/react/test_react_output_parser.py
@@ -16,6 +16,28 @@ Action Input: {"a": 1, "b": 1}
     assert action_input == '{"a": 1, "b": 1}'
 
 
+def test_extract_tool_use_multiline_action_input() -> None:
+    mock_input_text = """\
+Thought: I need to use a tool to help me answer the question.
+Action: add
+Action Input: {
+    "a": 1, 
+    "b": 1
+}
+"""
+    thought, action, action_input = extract_tool_use(mock_input_text)
+    assert thought == "I need to use a tool to help me answer the question."
+    assert action == "add"
+    assert (
+        action_input
+        == """\
+{
+    "a": 1, 
+    "b": 1
+}"""
+    )
+
+
 def test_extract_tool_use_spurious_newlines() -> None:
     mock_input_text = """\
 Thought: I need to use a tool to help me answer the question.


### PR DESCRIPTION
# Description

Changed the regex pattern to work for multi-line action inputs. I also added a test case that is failing on the current main's output parser and green with my regex pattern change.

I've encountered this issue when using custom tools that required more complex inputs. In my tests, most of the time the LLM will respond with a well formatted, multi-line JSON that was always failing in the current output parser.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests
