### PR TITLE
Nerdai/feature 8728 objectindex persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### New Features
+
+- Add `persist` and `persist_from_dir` methods to `ObjectIndex` that are able to support it (#9064)
+
 ## [0.9.7] - 2023-11-24
 
 ### New Features

--- a/docs/examples/objects/object_index.ipynb
+++ b/docs/examples/objects/object_index.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2f43c205",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/jerryjliu/llama_index/blob/main/docs/examples/objects/object_index.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f062ba1-0049-472c-8300-64f83d405ffc",
+   "metadata": {},
+   "source": [
+    "# The `ObjectIndex` Class\n",
+    "\n",
+    "The `ObjectIndex` class is one that allows for the indexing of arbitrary Python objects. As such, it is quite flexible and applicable to a wide-range of use cases. As examples:\n",
+    "- [Use an `ObjectIndex` to index Tool objects to then be used by an agent.](https://docs.llamaindex.ai/en/stable/examples/agent/openai_agent_retrieval.html#building-an-object-index)\n",
+    "- [Use an `ObjectIndex` to index a SQLTableSchema objects](https://docs.llamaindex.ai/en/stable/examples/index_structs/struct_indices/SQLIndexDemo.html#part-2-query-time-retrieval-of-tables-for-text-to-sql)\n",
+    "\n",
+    "To construct an `ObjectIndex`, we require an index as well as another abstraction, namely `ObjectNodeMapping`. This mapping, as its name suggests, provides the means to go between node and the associated object, and vice versa. Alternatively, there exists a `from_objects()` class method, that can conveniently construct an `ObjectIndex` from a set of objects.\n",
+    "\n",
+    "In this notebook, we'll quickly cover how you can build an `ObjectIndex` using a `SimpleObjectNodeMapping`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b46bc95b-e154-48e8-9475-350d2446e297",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index import VectorStoreIndex\n",
+    "from llama_index.objects import ObjectIndex, SimpleObjectNodeMapping\n",
+    "\n",
+    "# some really arbitrary objects\n",
+    "obj1 = {\"input\": \"Hey, how's it going\"}\n",
+    "obj2 = [\"a\", \"b\", \"c\", \"d\"]\n",
+    "obj3 = \"llamaindex is an awesome library!\"\n",
+    "arbitrary_objects = [obj1, obj2, obj3]\n",
+    "\n",
+    "# object-node mapping\n",
+    "obj_node_mapping = SimpleObjectNodeMapping.from_objects(arbitrary_objects)\n",
+    "nodes = obj_node_mapping.to_nodes(arbitrary_objects)\n",
+    "\n",
+    "# object index\n",
+    "object_index = ObjectIndex(\n",
+    "    index=VectorStoreIndex(nodes=nodes), object_node_mapping=obj_node_mapping\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd9b90c3-4e72-46b9-b545-a816d4b9ed75",
+   "metadata": {},
+   "source": [
+    "### As a retriever\n",
+    "With the `object_index` in hand, we can use it as a retriever, to retrieve against the index objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8ed16df-5ea3-47bf-81a9-d9917c31d48f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['llamaindex is an awesome library!']"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "object_retriever = object_index.as_retriever(similarity_top_k=1)\n",
+    "object_retriever.retrieve(\"llamaindex\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0032d0e7-815d-414d-9fcc-384709b59484",
+   "metadata": {},
+   "source": [
+    "## Persisting `ObjectIndex`\n",
+    "\n",
+    "When it comes to persisting the `ObjectIndex`, we have to handle both the index as well as the object-node mapping. Persisting the index is straightforward and can be handled by usual means (e.g., see this [guide](https://docs.llamaindex.ai/en/stable/module_guides/storing/save_load.html#persisting-loading-data)). However, it's a bit of a different story when it comes to persisting the `ObjectNodeMapping`. Since we're indexing aribtrary Python objects with the `ObjectIndex`, it may be the case (and perhaps more often than we'd like), that the arbitrary objects are not serializable. In those cases, you can persist the index, but the user would have to maintain a way to re-construct the `ObjectNodeMapping` to be able to re-construct the `ObjectIndex`. For convenience, there are the `persist` and `from_persist_dir` methods on the `ObjectIndex` that will attempt to persist and load a previously saved `ObjectIndex`, respectively."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10053dbc-e9c2-4a54-9b04-a7c66af80860",
+   "metadata": {},
+   "source": [
+    "### Happy example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ad58419-35b5-4010-ae3f-42f96e6c7226",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# persist to disk (no path provided will persist to the default path ./storage)\n",
+    "object_index.persist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3aedfc02-a94b-4f0a-8e8b-a22bf76515fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# re-loading (no path provided will attempt to load from the default path ./storage)\n",
+    "reloaded_object_index = ObjectIndex.from_persist_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ec0c2ba-ef26-41fb-b2ae-df946abac01c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{7981070310142320670: {'input': \"Hey, how's it going\"},\n",
+       " -5984737625581842527: ['a', 'b', 'c', 'd'],\n",
+       " -8305186196625446821: 'llamaindex is an awesome library!'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reloaded_object_index._object_node_mapping.obj_node_mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34107c44-d51c-42a9-a802-fba67deba8d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{7981070310142320670: {'input': \"Hey, how's it going\"},\n",
+       " -5984737625581842527: ['a', 'b', 'c', 'd'],\n",
+       " -8305186196625446821: 'llamaindex is an awesome library!'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "object_index._object_node_mapping.obj_node_mapping"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8078b5ff-0047-4a0c-96ea-a9a768e060ae",
+   "metadata": {},
+   "source": [
+    "### Example of when it doesn't work"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b19b0c3-3bfb-4ed8-bcf0-d04615afbbd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.function_tool import FunctionTool\n",
+    "from llama_index.indices.list.base import SummaryIndex\n",
+    "from llama_index.objects import SimpleToolNodeMapping\n",
+    "\n",
+    "\n",
+    "def add(a: int, b: int) -> int:\n",
+    "    \"\"\"Add two integers and returns the result integer\"\"\"\n",
+    "    return a + b\n",
+    "\n",
+    "\n",
+    "def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiple two integers and returns the result integer\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "multiply_tool = FunctionTool.from_defaults(fn=multiply)\n",
+    "add_tool = FunctionTool.from_defaults(fn=add)\n",
+    "\n",
+    "object_mapping = SimpleToolNodeMapping.from_objects([add_tool, multiply_tool])\n",
+    "object_index = ObjectIndex.from_objects(\n",
+    "    [add_tool, multiply_tool], object_mapping\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63c777a2-d73b-4916-96c4-794fe5ebcac5",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "Subclasses should implement this!",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[4], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# trying to persist the object_mapping directly will raise an error\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mobject_mapping\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpersist\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Projects/llama_index/llama_index/objects/tool_node_mapping.py:47\u001b[0m, in \u001b[0;36mBaseToolNodeMapping.persist\u001b[0;34m(self, persist_dir, obj_node_mapping_fname)\u001b[0m\n\u001b[1;32m     43\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mpersist\u001b[39m(\n\u001b[1;32m     44\u001b[0m     \u001b[38;5;28mself\u001b[39m, persist_dir: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m, obj_node_mapping_fname: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m\n\u001b[1;32m     45\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     46\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Persist objs.\"\"\"\u001b[39;00m\n\u001b[0;32m---> 47\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSubclasses should implement this!\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mNotImplementedError\u001b[0m: Subclasses should implement this!"
+     ]
+    }
+   ],
+   "source": [
+    "# trying to persist the object_mapping directly will raise an error\n",
+    "object_mapping.persist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de77bbca-9ba8-46f9-a66d-60cf1ce143ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/0g/wd11bmkd791fz7hvgy1kqyp00000gn/T/ipykernel_77363/46708458.py:2: UserWarning: Unable to persist ObjectNodeMapping. You will need to reconstruct the same object node mapping to build this ObjectIndex\n",
+      "  object_index.persist()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# try to persist the object index here will throw a Warning to the user\n",
+    "object_index.persist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee002c84-fe00-43e5-b0cb-53f6fb547b13",
+   "metadata": {},
+   "source": [
+    "**In this case, only the index has been persisted.** In order to re-construct the `ObjectIndex` as mentioned above, we will need to manually re-construct `ObjectNodeMapping` and supply that to the `ObjectIndex.from_persist_dir` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbc69da5-d2f0-4feb-9527-436cd0d0a54b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reloaded_object_index = ObjectIndex.from_persist_dir(\n",
+    "    object_node_mapping=object_mapping  # without this, an error will be thrown\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index_3.10",
+   "language": "python",
+   "name": "llama_index_3.10"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/module_guides/indexing/modules.md
+++ b/docs/module_guides/indexing/modules.md
@@ -17,4 +17,5 @@ REBEL + Wikipedia Filtering </examples/index_structs/knowledge_graph/knowledge_g
 SQL Index </examples/index_structs/struct_indices/SQLIndexDemo.ipynb>
 /examples/index_structs/struct_indices/duckdb_sql_query.ipynb
 /examples/index_structs/doc_summary/DocSummary.ipynb
+/examples/objects/object_index.ipynb
 ```

--- a/llama_index/objects/base.py
+++ b/llama_index/objects/base.py
@@ -100,42 +100,12 @@ class ObjectIndex(Generic[OT]):
         else:
             # try to load object_node_mapping
             try:
-                object_node_mapping = cls._resolve_object_node_mapping()
-            except (NotImplementedError, pickle.PickleError) as err:
-                raise ValueError(
+                object_node_mapping = BaseObjectNodeMapping.from_persist_dir(
+                    persist_dir=persist_dir
+                )
+            except Exception as err:
+                raise Exception(
                     "Unable to load from persist dir. The object_node_mapping cannot be loaded."
                 ) from err
             else:
                 return cls(index=index, object_node_mapping=object_node_mapping)
-
-    @staticmethod
-    def _resolve_object_node_mapping(
-        persist_dir: str = DEFAULT_PERSIST_DIR,
-    ) -> Type[BaseObjectNodeMapping]:
-        from llama_index.objects import (
-            SimpleObjectNodeMapping,
-            SimpleQueryToolNodeMapping,
-            SimpleToolNodeMapping,
-            SQLTableNodeMapping,
-        )
-
-        object_node_mapping = None
-        error = None
-        for object_node_mapping_type in [
-            SimpleObjectNodeMapping,
-            SimpleToolNodeMapping,
-            SimpleQueryToolNodeMapping,
-            SQLTableNodeMapping,
-        ]:
-            try:
-                object_node_mapping = object_node_mapping_type.from_persist_dir(
-                    persist_dir=persist_dir
-                )
-                break
-            except (NotImplementedError, pickle.PickleError) as err:
-                error = err
-
-        if object_node_mapping:
-            return object_node_mapping
-        else:
-            raise ValueError("Unable to load object_node_mapping.") from error

--- a/llama_index/objects/base.py
+++ b/llama_index/objects/base.py
@@ -8,6 +8,7 @@ from llama_index.core import BaseRetriever
 from llama_index.indices.base import BaseIndex
 from llama_index.indices.vector_store.base import VectorStoreIndex
 from llama_index.objects.base_node_mapping import (
+    DEFAULT_PERSIST_FNAME,
     BaseObjectNodeMapping,
     SimpleObjectNodeMapping,
 )
@@ -71,17 +72,20 @@ class ObjectIndex(Generic[OT]):
     def persist(
         self,
         persist_dir: str = DEFAULT_PERSIST_DIR,
+        obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
     ) -> None:
         # try to persist object node mapping
         try:
-            self._object_node_mapping.persist(persist_dir=persist_dir)
+            self._object_node_mapping.persist(
+                persist_dir=persist_dir, obj_node_mapping_fname=obj_node_mapping_fname
+            )
         except (NotImplementedError, pickle.PickleError) as err:
             warnings.warn(
                 (
                     "Unable to persist ObjectNodeMapping. You will need to "
                     "reconstruct the same object node mapping to build this ObjectIndex"
                 ),
-                DeprecationWarning,
+                stacklevel=2,
             )
         self._index._storage_context.persist(persist_dir=persist_dir)
 

--- a/llama_index/objects/base.py
+++ b/llama_index/objects/base.py
@@ -103,8 +103,10 @@ class ObjectIndex(Generic[OT]):
             return cls(index=index, object_node_mapping=object_node_mapping)
         else:
             # try to load object_node_mapping
+            # assume SimpleObjectNodeMapping for simplicity as its only subclass
+            # that supports this method
             try:
-                object_node_mapping = BaseObjectNodeMapping.from_persist_dir(
+                object_node_mapping = SimpleObjectNodeMapping.from_persist_dir(
                     persist_dir=persist_dir
                 )
             except Exception as err:

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -80,7 +80,6 @@ class BaseObjectNodeMapping(Generic[OT]):
         )
 
     @classmethod
-    @abstractmethod
     def from_persist_dir(
         cls,
         persist_dir: str = DEFAULT_PERSIST_DIR,
@@ -143,7 +142,7 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
         obj_node_mapping_path = concat_dirs(persist_dir, obj_node_mapping_fname)
         try:
             with open(obj_node_mapping_path, "wb") as f:
-                pickle.dump(self._objs, f)
+                pickle.dump(self.__dict__, f)
         except pickle.PickleError as err:
             raise ValueError("Objs is not pickleable") from err
 
@@ -156,10 +155,11 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
         obj_node_mapping_path = concat_dirs(persist_dir, obj_node_mapping_fname)
         try:
             with open(obj_node_mapping_path, "rb") as f:
-                objs = pickle.load(f)
+                tmp_dict = pickle.load(f)
         except pickle.PickleError as err:
             raise ValueError("Objs cannot be loaded.") from err
 
         simple_object_node_mapping = cls(None)
-        simple_object_node_mapping.obj_node_mapping = objs
+        simple_object_node_mapping.__dict__.clear()
+        simple_object_node_mapping.__dict__.update(tmp_dict)
         return simple_object_node_mapping

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -133,6 +133,11 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
         persist_dir: str = DEFAULT_PERSIST_DIR,
         obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
     ) -> None:
+        """Persist object node mapping.
+
+        NOTE: This may fail depending on whether the object types are
+        pickle-able.
+        """
         if not os.path.exists(persist_dir):
             os.makedirs(persist_dir)
         obj_node_mapping_path = concat_dirs(persist_dir, obj_node_mapping_fname)

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -42,6 +42,11 @@ class BaseObjectNodeMapping(Generic[OT]):
         self.validate_object(obj)
         self._add_object(obj)
 
+    @property
+    @abstractmethod
+    def obj_node_mapping(self) -> Dict[int, Any]:
+        """The mapping data structure between node and object."""
+
     @abstractmethod
     def _add_object(self, obj: OT) -> None:
         """Add object.
@@ -107,15 +112,15 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
     @classmethod
     def from_objects(
         cls, objs: Sequence[Any], *args: Any, **kwargs: Any
-    ) -> "BaseObjectNodeMapping":
+    ) -> "SimpleObjectNodeMapping":
         return cls(objs)
 
     @property
-    def obj_node_mapping(self):
+    def obj_node_mapping(self) -> Dict[int, Any]:
         return self._objs
 
     @obj_node_mapping.setter
-    def obj_node_mapping(self, mapping: Dict[int, Any]):
+    def obj_node_mapping(self, mapping: Dict[int, Any]) -> None:
         self._objs = mapping
 
     def _add_object(self, obj: Any) -> None:

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -75,6 +75,9 @@ class BaseObjectNodeMapping(Generic[OT]):
         obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
     ) -> None:
         """Persist objs."""
+        raise NotImplementedError(
+            "This object node mapping does not support persist method."
+        )
 
     @classmethod
     @abstractmethod
@@ -84,6 +87,9 @@ class BaseObjectNodeMapping(Generic[OT]):
         obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
     ) -> "BaseObjectNodeMapping":
         """Load from serialization."""
+        raise NotImplementedError(
+            "This object node mapping does not support from_persist_dir method."
+        )
 
 
 class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
@@ -110,7 +116,7 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
         return self._objs
 
     @obj_node_mapping.setter
-    def obj_node_mapping(self, mapping: Dict[int:Any]):
+    def obj_node_mapping(self, mapping: Dict[int, Any]):
         self._objs = mapping
 
     def _add_object(self, obj: Any) -> None:
@@ -132,7 +138,7 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
         obj_node_mapping_path = concat_dirs(persist_dir, obj_node_mapping_fname)
         try:
             with open(obj_node_mapping_path, "wb") as f:
-                pickle.dump(self._objs)
+                pickle.dump(self._objs, f)
         except pickle.PickleError as err:
             raise ValueError("Objs is not pickleable") from err
 

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -44,7 +44,7 @@ class BaseObjectNodeMapping(Generic[OT]):
 
     @property
     @abstractmethod
-    def obj_node_mapping(self) -> Dict[int, Any]:
+    def obj_node_mapping(self) -> Dict[Any, Any]:
         """The mapping data structure between node and object."""
 
     @abstractmethod
@@ -80,9 +80,6 @@ class BaseObjectNodeMapping(Generic[OT]):
         obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
     ) -> None:
         """Persist objs."""
-        raise NotImplementedError(
-            "This object node mapping does not support persist method."
-        )
 
     @classmethod
     def from_persist_dir(
@@ -95,7 +92,10 @@ class BaseObjectNodeMapping(Generic[OT]):
         errors = []
         for cls in BaseObjectNodeMapping.__subclasses__():  # type: ignore[misc]
             try:
-                obj_node_mapping = cls.from_persist_dir(persist_dir=persist_dir)
+                obj_node_mapping = cls.from_persist_dir(
+                    persist_dir=persist_dir,
+                    obj_node_mapping_fname=obj_node_mapping_fname,
+                )
                 break
             except (NotImplementedError, pickle.PickleError) as err:
                 # raise unhandled exception otherwise

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -11,7 +11,7 @@ from llama_index.utils import concat_dirs
 
 DEFAULT_PERSIST_FNAME = "object_node_mapping.pickle"
 
-OT = TypeVar("OT", bound=object)
+OT = TypeVar("OT")
 
 
 class BaseObjectNodeMapping(Generic[OT]):
@@ -93,7 +93,7 @@ class BaseObjectNodeMapping(Generic[OT]):
         """Load from serialization."""
         obj_node_mapping = None
         errors = []
-        for cls in BaseObjectNodeMapping.__subclasses__():
+        for cls in BaseObjectNodeMapping.__subclasses__():  # type: ignore[misc]
             try:
                 obj_node_mapping = cls.from_persist_dir(persist_dir=persist_dir)
                 break

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -89,9 +89,9 @@ class BaseObjectNodeMapping(Generic[OT]):
         cls,
         persist_dir: str = DEFAULT_PERSIST_DIR,
         obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
-    ) -> "BaseObjectNodeMapping":
+    ) -> "BaseObjectNodeMapping[OT]":
         """Load from serialization."""
-        obj_node_mapping = None
+        obj_node_mapping: BaseObjectNodeMapping[OT] = None
         errors = []
         for cls in BaseObjectNodeMapping.__subclasses__():
             try:

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -91,7 +91,7 @@ class BaseObjectNodeMapping(Generic[OT]):
         obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
     ) -> "BaseObjectNodeMapping[OT]":
         """Load from serialization."""
-        obj_node_mapping: BaseObjectNodeMapping[OT] = None
+        obj_node_mapping = None
         errors = []
         for cls in BaseObjectNodeMapping.__subclasses__():
             try:

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -3,7 +3,7 @@
 import os
 import pickle
 from abc import abstractmethod
-from typing import Any, Dict, Generic, Optional, Sequence, Type, TypeVar
+from typing import Any, Dict, Generic, Optional, Sequence, TypeVar
 
 from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.storage.storage_context import DEFAULT_PERSIST_DIR
@@ -89,7 +89,7 @@ class BaseObjectNodeMapping(Generic[OT]):
         cls,
         persist_dir: str = DEFAULT_PERSIST_DIR,
         obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
-    ) -> Type["BaseObjectNodeMapping"]:
+    ) -> "BaseObjectNodeMapping":
         """Load from serialization."""
         obj_node_mapping = None
         errors = []

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -157,7 +157,7 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
         obj_node_mapping_path = concat_dirs(persist_dir, obj_node_mapping_fname)
         try:
             with open(obj_node_mapping_path, "wb") as f:
-                pickle.dump(self.__dict__, f)
+                pickle.dump(self, f)
         except pickle.PickleError as err:
             raise ValueError("Objs is not pickleable") from err
 
@@ -170,11 +170,7 @@ class SimpleObjectNodeMapping(BaseObjectNodeMapping[Any]):
         obj_node_mapping_path = concat_dirs(persist_dir, obj_node_mapping_fname)
         try:
             with open(obj_node_mapping_path, "rb") as f:
-                tmp_dict = pickle.load(f)
+                simple_object_node_mapping = pickle.load(f)
         except pickle.PickleError as err:
             raise ValueError("Objs cannot be loaded.") from err
-
-        simple_object_node_mapping = cls(None)
-        simple_object_node_mapping.__dict__.clear()
-        simple_object_node_mapping.__dict__.update(tmp_dict)
         return simple_object_node_mapping

--- a/llama_index/objects/base_node_mapping.py
+++ b/llama_index/objects/base_node_mapping.py
@@ -11,7 +11,7 @@ from llama_index.utils import concat_dirs
 
 DEFAULT_PERSIST_FNAME = "object_node_mapping.pickle"
 
-OT = TypeVar("OT")
+OT = TypeVar("OT", bound=object)
 
 
 class BaseObjectNodeMapping(Generic[OT]):

--- a/llama_index/objects/table_node_mapping.py
+++ b/llama_index/objects/table_node_mapping.py
@@ -3,7 +3,11 @@
 from typing import Any, Optional, Sequence
 
 from llama_index.bridge.pydantic import BaseModel
-from llama_index.objects.base_node_mapping import BaseObjectNodeMapping
+from llama_index.objects.base_node_mapping import (
+    DEFAULT_PERSIST_DIR,
+    DEFAULT_PERSIST_FNAME,
+    BaseObjectNodeMapping,
+)
 from llama_index.schema import BaseNode, TextNode
 from llama_index.utilities.sql_wrapper import SQLDatabase
 
@@ -66,4 +70,14 @@ class SQLTableNodeMapping(BaseObjectNodeMapping[SQLTableSchema]):
             raise ValueError("Metadata must be set")
         return SQLTableSchema(
             table_name=node.metadata["name"], context_str=node.metadata["context"]
+        )
+
+    @classmethod
+    def from_persist_dir(
+        cls,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
+    ) -> "SQLTableNodeMapping":
+        raise NotImplementedError(
+            "This object node mapping does not support persist method."
         )

--- a/llama_index/objects/table_node_mapping.py
+++ b/llama_index/objects/table_node_mapping.py
@@ -1,6 +1,6 @@
 """Table node mapping."""
 
-from typing import Any, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from llama_index.bridge.pydantic import BaseModel
 from llama_index.objects.base_node_mapping import (
@@ -71,6 +71,17 @@ class SQLTableNodeMapping(BaseObjectNodeMapping[SQLTableSchema]):
         return SQLTableSchema(
             table_name=node.metadata["name"], context_str=node.metadata["context"]
         )
+
+    @property
+    def obj_node_mapping(self) -> Dict[int, Any]:
+        """The mapping data structure between node and object."""
+        raise NotImplementedError("Subclasses should implement this!")
+
+    def persist(
+        self, persist_dir: str = ..., obj_node_mapping_fname: str = ...
+    ) -> None:
+        """Persist objs."""
+        raise NotImplementedError("Subclasses should implement this!")
 
     @classmethod
     def from_persist_dir(

--- a/llama_index/objects/tool_node_mapping.py
+++ b/llama_index/objects/tool_node_mapping.py
@@ -35,6 +35,16 @@ class BaseToolNodeMapping(BaseObjectNodeMapping[BaseTool]):
         if not isinstance(obj, BaseTool):
             raise ValueError(f"Object must be of type {BaseTool}")
 
+    @classmethod
+    def from_persist_dir(
+        cls,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
+    ) -> "BaseToolNodeMapping":
+        raise NotImplementedError(
+            "This object node mapping does not support persist method."
+        )
+
 
 class SimpleToolNodeMapping(BaseToolNodeMapping):
     """Simple Tool mapping.
@@ -71,6 +81,16 @@ class SimpleToolNodeMapping(BaseToolNodeMapping):
 class BaseQueryToolNodeMapping(BaseObjectNodeMapping[QueryEngineTool]):
     """Base query tool node mapping."""
 
+    @classmethod
+    def from_persist_dir(
+        cls,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
+    ) -> "BaseQueryToolNodeMapping":
+        raise NotImplementedError(
+            "This object node mapping does not support persist method."
+        )
+
 
 class SimpleQueryToolNodeMapping(BaseQueryToolNodeMapping):
     """Simple query tool mapping."""
@@ -103,13 +123,3 @@ class SimpleQueryToolNodeMapping(BaseQueryToolNodeMapping):
         if node.metadata is None:
             raise ValueError("Metadata must be set")
         return self._tools[node.metadata["name"]]
-
-    @classmethod
-    def from_persist_dir(
-        cls,
-        persist_dir: str = DEFAULT_PERSIST_DIR,
-        obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
-    ) -> "SimpleQueryToolNodeMapping":
-        raise NotImplementedError(
-            "This object node mapping does not support persist method."
-        )

--- a/llama_index/objects/tool_node_mapping.py
+++ b/llama_index/objects/tool_node_mapping.py
@@ -1,6 +1,6 @@
 """Tool mapping."""
 
-from typing import Any, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from llama_index.objects.base_node_mapping import (
     DEFAULT_PERSIST_DIR,
@@ -34,6 +34,17 @@ class BaseToolNodeMapping(BaseObjectNodeMapping[BaseTool]):
     def validate_object(self, obj: BaseTool) -> None:
         if not isinstance(obj, BaseTool):
             raise ValueError(f"Object must be of type {BaseTool}")
+
+    @property
+    def obj_node_mapping(self) -> Dict[int, Any]:
+        """The mapping data structure between node and object."""
+        raise NotImplementedError("Subclasses should implement this!")
+
+    def persist(
+        self, persist_dir: str = ..., obj_node_mapping_fname: str = ...
+    ) -> None:
+        """Persist objs."""
+        raise NotImplementedError("Subclasses should implement this!")
 
     @classmethod
     def from_persist_dir(
@@ -90,6 +101,17 @@ class BaseQueryToolNodeMapping(BaseObjectNodeMapping[QueryEngineTool]):
         raise NotImplementedError(
             "This object node mapping does not support persist method."
         )
+
+    @property
+    def obj_node_mapping(self) -> Dict[int, Any]:
+        """The mapping data structure between node and object."""
+        raise NotImplementedError("Subclasses should implement this!")
+
+    def persist(
+        self, persist_dir: str = ..., obj_node_mapping_fname: str = ...
+    ) -> None:
+        """Persist objs."""
+        raise NotImplementedError("Subclasses should implement this!")
 
 
 class SimpleQueryToolNodeMapping(BaseQueryToolNodeMapping):

--- a/llama_index/objects/tool_node_mapping.py
+++ b/llama_index/objects/tool_node_mapping.py
@@ -2,7 +2,11 @@
 
 from typing import Any, Optional, Sequence
 
-from llama_index.objects.base_node_mapping import BaseObjectNodeMapping
+from llama_index.objects.base_node_mapping import (
+    DEFAULT_PERSIST_DIR,
+    DEFAULT_PERSIST_FNAME,
+    BaseObjectNodeMapping,
+)
 from llama_index.schema import BaseNode, TextNode
 from llama_index.tools.query_engine import QueryEngineTool
 from llama_index.tools.types import BaseTool
@@ -99,3 +103,13 @@ class SimpleQueryToolNodeMapping(BaseQueryToolNodeMapping):
         if node.metadata is None:
             raise ValueError("Metadata must be set")
         return self._tools[node.metadata["name"]]
+
+    @classmethod
+    def from_persist_dir(
+        cls,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        obj_node_mapping_fname: str = DEFAULT_PERSIST_FNAME,
+    ) -> "SimpleQueryToolNodeMapping":
+        raise NotImplementedError(
+            "This object node mapping does not support persist method."
+        )

--- a/tests/objects/test_base.py
+++ b/tests/objects/test_base.py
@@ -22,6 +22,36 @@ def test_object_index(mock_service_context: ServiceContext) -> None:
     assert obj_index.as_retriever().retrieve("test") == ["a", "b", "c", "d"]
 
 
+def test_object_index_persist(mock_service_context: ServiceContext) -> None:
+    """Test object index persist/load."""
+    object_mapping = SimpleObjectNodeMapping.from_objects(["a", "b", "c"])
+    obj_index = ObjectIndex.from_objects(
+        ["a", "b", "c"], object_mapping, index_cls=SummaryIndex
+    )
+    obj_index.persist()
+
+    reloaded_obj_index = ObjectIndex.from_persist_dir(
+        object_node_mapping_type=SimpleObjectNodeMapping
+    )
+    assert obj_index._index.index_id == reloaded_obj_index._index.index_id
+    assert obj_index._index.index_struct == reloaded_obj_index._index.index_struct
+    assert (
+        obj_index._object_node_mapping.obj_node_mapping
+        == reloaded_obj_index._object_node_mapping.obj_node_mapping
+    )
+
+    # version where user passes in the object_node_mapping
+    reloaded_obj_index = ObjectIndex.from_persist_dir(
+        object_node_mapping=object_mapping
+    )
+    assert obj_index._index.index_id == reloaded_obj_index._index.index_id
+    assert obj_index._index.index_struct == reloaded_obj_index._index.index_struct
+    assert (
+        obj_index._object_node_mapping.obj_node_mapping
+        == reloaded_obj_index._object_node_mapping.obj_node_mapping
+    )
+
+
 def test_object_index_with_tools(mock_service_context: ServiceContext) -> None:
     """Test object index with tools."""
     tool1 = FunctionTool.from_defaults(fn=lambda x: x, name="test_tool")

--- a/tests/objects/test_base.py
+++ b/tests/objects/test_base.py
@@ -29,7 +29,6 @@ def test_object_index_persist(mock_service_context: ServiceContext) -> None:
         ["a", "b", "c"], object_mapping, index_cls=SummaryIndex
     )
     obj_index.persist()
-    print(type(object_mapping), flush=True)
 
     reloaded_obj_index = ObjectIndex.from_persist_dir()
     assert obj_index._index.index_id == reloaded_obj_index._index.index_id

--- a/tests/objects/test_base.py
+++ b/tests/objects/test_base.py
@@ -29,10 +29,9 @@ def test_object_index_persist(mock_service_context: ServiceContext) -> None:
         ["a", "b", "c"], object_mapping, index_cls=SummaryIndex
     )
     obj_index.persist()
+    print(type(object_mapping), flush=True)
 
-    reloaded_obj_index = ObjectIndex.from_persist_dir(
-        object_node_mapping_type=SimpleObjectNodeMapping
-    )
+    reloaded_obj_index = ObjectIndex.from_persist_dir()
     assert obj_index._index.index_id == reloaded_obj_index._index.index_id
     assert obj_index._index.index_struct == reloaded_obj_index._index.index_struct
     assert (

--- a/tests/objects/test_node_mapping.py
+++ b/tests/objects/test_node_mapping.py
@@ -43,6 +43,16 @@ def test_simple_object_node_mapping() -> None:
     assert node_mapping.from_node(node_mapping.to_node(objects[0])) == objects[0]
 
 
+def test_simple_object_node_mapping_persist() -> None:
+    """Test persist/load."""
+    strs = ["a", "b", "c"]
+    node_mapping = SimpleObjectNodeMapping.from_objects(strs)
+    node_mapping.persist()
+
+    loaded_node_mapping = SimpleObjectNodeMapping.from_persist_dir()
+    assert node_mapping.obj_node_mapping == loaded_node_mapping.obj_node_mapping
+
+
 def test_tool_object_node_mapping() -> None:
     """Test tool object node mapping."""
     tool1 = FunctionTool.from_defaults(


### PR DESCRIPTION
# Description

Serializing `ObjectIndex` requires handling both the saving and loading of the `index` as well as the `object_node_mapping`. The former is easy and can be done via `storage_context` persist calls. The latter is a bit tricky because, not all objects are serializable.

This PR is the start of this effort, where only `SimpleObjectNodeMapping` has implementations for `persist` and `from_persist_dir`. It attempts to pickle and will raise error if the object type can't be pickled. When being called from `ObjectIndex` however, the error is handled by throwing a "Warning" to the user to let them know that they will have to rebuild the same `object_node_mapping` and supply it to `ObjectIndex.from_persist_dir()` call.


Closes #8728  (though should probably pick up this work in a future PR)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense
