### PR TITLE
Removing context from metadata when None

### DIFF
--- a/llama_index/objects/table_node_mapping.py
+++ b/llama_index/objects/table_node_mapping.py
@@ -45,14 +45,14 @@ class SQLTableNodeMapping(BaseObjectNodeMapping[SQLTableSchema]):
             f"Schema of table {obj.table_name}:\n"
             f"{self._sql_database.get_single_table_info(obj.table_name)}\n"
         )
-        
-        metadata={"name": obj.table_name}
-        
+
+        metadata = {"name": obj.table_name}
+
         if obj.context_str is not None:
             table_text += f"Context of table {obj.table_name}:\n"
             table_text += obj.context_str
             metadata["context"] = obj.context_str
-        
+
         return TextNode(
             text=table_text,
             metadata=metadata,

--- a/tests/objects/test_node_mapping.py
+++ b/tests/objects/test_node_mapping.py
@@ -6,6 +6,7 @@ from llama_index.objects.base_node_mapping import SimpleObjectNodeMapping
 from llama_index.objects.table_node_mapping import SQLTableNodeMapping, SQLTableSchema
 from llama_index.objects.tool_node_mapping import SimpleToolNodeMapping
 from llama_index.tools.function_tool import FunctionTool
+from pytest_mock import MockerFixture
 
 
 class TestObject(BaseModel):
@@ -75,7 +76,7 @@ def test_tool_object_node_mapping() -> None:
     assert node_mapping.from_node(node_mapping.to_node(tool3)) == tool3
 
 
-def test_sql_table_node_mapping_to_node(mocker) -> None:
+def test_sql_table_node_mapping_to_node(mocker: MockerFixture) -> None:
     """Test to add node for sql table node mapping object to ensure no 'None' values in metadata output to avoid issues with nulls when upserting to indexes."""
     mocker.patch(
         "llama_index.utilities.sql_wrapper.SQLDatabase.get_single_table_info",

--- a/tests/objects/test_node_mapping.py
+++ b/tests/objects/test_node_mapping.py
@@ -1,11 +1,11 @@
 """Test node mapping."""
 
+from llama_index import SQLDatabase
 from llama_index.bridge.pydantic import BaseModel
 from llama_index.objects.base_node_mapping import SimpleObjectNodeMapping
+from llama_index.objects.table_node_mapping import SQLTableNodeMapping, SQLTableSchema
 from llama_index.objects.tool_node_mapping import SimpleToolNodeMapping
-from llama_index.objects.table_node_mapping import SQLTableSchema, SQLTableNodeMapping
 from llama_index.tools.function_tool import FunctionTool
-from llama_index import SQLDatabase
 
 
 class TestObject(BaseModel):
@@ -23,9 +23,9 @@ class TestObject(BaseModel):
 
 
 class TestSQLDatabase(SQLDatabase):
-    """Test object for SQL Table Schema Node Mapping"""
+    """Test object for SQL Table Schema Node Mapping."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
 
@@ -75,7 +75,8 @@ def test_tool_object_node_mapping() -> None:
     assert node_mapping.from_node(node_mapping.to_node(tool3)) == tool3
 
 
-def test_sql_table_node_mapping_to_node(mocker):
+def test_sql_table_node_mapping_to_node(mocker) -> None:
+    """Test to add node for sql table node mapping object to ensure no 'None' values in metadata output to avoid issues with nulls when upserting to indexes."""
     mocker.patch(
         "llama_index.utilities.sql_wrapper.SQLDatabase.get_single_table_info",
         return_value="",


### PR DESCRIPTION
# Description

PineconeVectorStore doesn't like None values in metadata and so by removing the context that should resolve errors when upserting.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
