### PR TITLE
fix: Check is usage is None

### DIFF
--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -50,8 +50,8 @@ def get_llm_token_counts(
 
             messages_tokens = 0
             response_tokens = 0
-            
-            if usage is not None:            
+
+            if usage is not None:
                 messages_tokens = usage.prompt_tokens
                 response_tokens = usage.completion_tokens
 

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -48,6 +48,9 @@ def get_llm_token_counts(
         try:
             usage = response.raw["usage"]  # type: ignore
 
+            if usage is None:
+                raise ValueError("Invalid usage!")
+            
             messages_tokens = usage.prompt_tokens
             response_tokens = usage.completion_tokens
 

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -48,11 +48,12 @@ def get_llm_token_counts(
         try:
             usage = response.raw["usage"]  # type: ignore
 
-            if usage is None:
-                raise ValueError("Invalid usage!")
+            messages_tokens = 0
+            response_tokens = 0
             
-            messages_tokens = usage.prompt_tokens
-            response_tokens = usage.completion_tokens
+            if usage is not None:            
+                messages_tokens = usage.prompt_tokens
+                response_tokens = usage.completion_tokens
 
             if messages_tokens == 0 or response_tokens == 0:
                 raise ValueError("Invalid token counts!")


### PR DESCRIPTION
For streamed Azure responses from gpt-3.5-turbo when trying to count the tokens it did not work but also did not fall into the fallback where the token are estimated ourself. This happens when the "usage" field in the raw response is present but None. In comparison with gpt-4 the field is not present.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
