### PR TITLE
Add aws_region_name parameter to Bedrock LLM

### DIFF
--- a/docs/examples/llm/bedrock.ipynb
+++ b/docs/examples/llm/bedrock.ipynb
@@ -309,12 +309,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48c14819-9cff-435f-9578-d7b05694498f",
+   "id": "1bdd4602-e37c-4230-af82-35af5292f9a0",
    "metadata": {},
    "source": [
-    "#  Connect to Bedrock with Access Keysfrom llama_index.llms import Bedrock\n",
-    "\n",
-    "llm = Bedrock(model=\"amazon.titan-text-express-v1\",profile_name=profile_name)"
+    "# Connect to Bedrock with Access Keys "
    ]
   },
   {
@@ -331,6 +329,7 @@
     "    aws_access_key_id=\"AWS Access Key ID to use\",\n",
     "    aws_secret_access_key=\"AWS Secret Access Key to use\",\n",
     "    aws_session_token=\"AWS Session Token to use\",\n",
+    "    aws_region_name=\"AWS Region to use, eg. us-east-1\",\n",
     ")\n",
     "\n",
     "resp = llm.complete(\"Paul Graham is \")"


### PR DESCRIPTION
# Description

If aws cli is not configured, and you don't specify a region when you try to create a Bedrock client with boto3, it will throw a NoRegionError. This PR adds an optional parameter to the Bedrock LLM that allows the user to specify the region and throws an informative ValueError in case boto3 throws the NoRegionError

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
