### PR TITLE
Bug fix: QueryEngineTool's chat/achat method returns python built-in input func instead of query_str

### DIFF
--- a/llama_index/tools/query_engine.py
+++ b/llama_index/tools/query_engine.py
@@ -77,7 +77,7 @@ class QueryEngineTool(AsyncBaseTool):
         return ToolOutput(
             content=str(response),
             tool_name=self.metadata.name,
-            raw_input={"input": input},
+            raw_input={"input": query_str},
             raw_output=response,
         )
 
@@ -96,7 +96,7 @@ class QueryEngineTool(AsyncBaseTool):
         return ToolOutput(
             content=str(response),
             tool_name=self.metadata.name,
-            raw_input={"input": input},
+            raw_input={"input": query_str},
             raw_output=response,
         )
 


### PR DESCRIPTION
# Description

`QueryEngineTool`'s `chat`/`achat` method returns python built-in input func instead of `query_str`

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

