### PR TITLE
JSON path prompt debug facilitation

### DIFF
--- a/llama_index/indices/struct_store/json_query.py
+++ b/llama_index/indices/struct_store/json_query.py
@@ -41,7 +41,7 @@ def default_output_response_parser(llm_output: str) -> str:
     try:
         llm_output_parsed = re.search(pattern="JSONPath:\s+(.*)",string=llm_output).groups()[0]
     except Exception as exc:
-        raise ValueError(f"JSON Path could not be parsed in the LLM response after the 'JSONPath' identifier. Try passing a custom JSON path prompt and processor.") from ecc    
+        raise ValueError(f"JSON Path could not be parsed in the LLM response after the 'JSONPath' identifier. Try passing a custom JSON path prompt and processor.") from exc    
     return llm_output_parsed
 
 

--- a/llama_index/indices/struct_store/json_query.py
+++ b/llama_index/indices/struct_store/json_query.py
@@ -36,6 +36,14 @@ DEFAULT_RESPONSE_SYNTHESIS_PROMPT = PromptTemplate(
     prompt_type=PromptType.SQL_RESPONSE_SYNTHESIS,
 )
 
+def default_output_response_parser(llm_output: str) -> str:
+    '''Attempts to parse the JSON path prompt output. Only applicable if the default prompt is used.'''
+    try:
+        llm_output_parsed = re.search(pattern="JSONPath:\s+(.*)",string=llm_output).groups()[0]
+    except Exception as exc:
+        raise ValueError(f"JSON Path could not be parsed in the LLM response after the 'JSONPath' identifier. Try passing a custom JSON path prompt and processor.") from ecc    
+    return llm_output_parsed
+
 
 def default_output_processor(llm_output: str, json_value: JSONType) -> JSONType:
     """Default output processor that extracts values based on JSON Path expressions."""
@@ -142,6 +150,10 @@ class JSONQueryEngine(BaseQueryEngine):
             query_str=query_bundle.query_str,
         )
 
+        #removes JSONPath: prefix from returned JSON path prompt call
+        if self._json_path_prompt == DEFAULT_JSON_PATH_PROMPT:
+            json_path_response_str = default_output_response_parser(json_path_response_str)            
+
         if self._verbose:
             print_text(
                 f"> JSONPath Instructions:\n" f"```\n{json_path_response_str}\n```\n"
@@ -181,6 +193,10 @@ class JSONQueryEngine(BaseQueryEngine):
             schema=schema,
             query_str=query_bundle.query_str,
         )
+        
+        #removes JSONPath: prefix from returned JSON path prompt call
+        if self._json_path_prompt == DEFAULT_JSON_PATH_PROMPT:
+            json_path_response_str = default_output_response_parser(json_path_response_str)        
 
         if self._verbose:
             print_text(

--- a/llama_index/prompts/default_prompts.py
+++ b/llama_index/prompts/default_prompts.py
@@ -390,8 +390,14 @@ DEFAULT_JSON_PATH_TMPL = (
     "{schema}\n"
     "Given a task, respond with a JSON Path query that "
     "can retrieve data from a JSON value that matches the schema.\n"
+    "Provide the JSON Path query in the following format: 'JSONPath: <JSONPath>'\n"
+    "You must include the value 'JSONPath:' before the provided JSON Path query."
+    "Example Format:\n"
+    "Task: What is John's age?\n"
+    "Response: JSONPath: $.John.age\n"
+    "Let's try this now: \n\n"
     "Task: {query_str}\n"
-    "JSONPath: "
+    "Response: "    
 )
 
 DEFAULT_JSON_PATH_PROMPT = PromptTemplate(


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # https://github.com/run-llama/llama_index/issues/7587

## Type of Change


- [ x] New feature (non-breaking change which adds functionality)

(1) Updates the default JSON path prompt to include an identifier that can be parsed with regex
(2) Adds a regex parsing function that finds the JSONPath prompt. If not found provides clearer error handling for trouble shooting

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x] I stared at the code and made sure it makes sense
- [x] Tested by initializing a JSONQueryEngine initialized with an Azure openAI LLM service context and making various queries to ensure that JSON path was being parsed correctlly from the LLM response.

# Suggested Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
