### PR TITLE
fix: remove print call from _llm_extract_triplets

### DIFF
--- a/llama_index/indices/knowledge_graph/base.py
+++ b/llama_index/indices/knowledge_graph/base.py
@@ -123,7 +123,6 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
             self.kg_triple_extract_template,
             text=text,
         )
-        print(response, flush=True)
         return self._parse_triplet_response(
             response, max_length=self._max_object_length
         )


### PR DESCRIPTION
# Description

This removes an extraneous `print` statement  that was introduced in https://github.com/run-llama/llama_index/pull/7493

Fixes #9099 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
