### PR TITLE
Adjust ReAct system prompt examples to match default `FnSchema`

### DIFF
--- a/llama_index/agent/react/prompts.py
+++ b/llama_index/agent/react/prompts.py
@@ -24,12 +24,12 @@ To answer the question, please use the following format.
 ```
 Thought: I need to use a tool to help me answer the question.
 Action: tool name (one of {tool_names}) if using a tool.
-Action Input: the input to the tool, in a JSON format representing the kwargs (e.g. {{"text": "hello world", "num_beams": 5}})
+Action Input: the input to the tool, in a JSON format representing the kwargs (e.g. {{"input": "hello world", "num_beams": 5}})
 ```
 
 Please ALWAYS start with a Thought.
 
-Please use a valid JSON format for the Action Input. Do NOT do this {{'text': 'hello world', 'num_beams': 5}}.
+Please use a valid JSON format for the Action Input. Do NOT do this {{'input': 'hello world', 'num_beams': 5}}.
 
 If this format is used, the user will respond in the following format:
 


### PR DESCRIPTION
# Description

- REACT_CHAT_SYSTEM_HEADER is the default system prompt for `ReActAgent` and it contains some in-context examples for how LLM should respond to specify a desire to take an action
- The keyword used in those examples is "text", which doesn't match the default `FnSchema` keyword, namely: "input"

Interestingly:
- GPT Models follow the `FnSchema` of the tool that is also included in the prompt, whereas
- Open source models (Llama2 and Zephyr) follow the in-context examples (i.e., use "text")

This is a quick fix to align the default prompt with the default function schema. Though, we should look to add in abilities to customize the system prompt as well as handle prompt selection according to LLM choice in a future PR.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested various notebooks
- [x] I stared at the code and made sure it makes sense
