### PR TITLE
[new feature] Add jsonl for JsonReader Class

### DIFF
--- a/llama_index/readers/json.py
+++ b/llama_index/readers/json.py
@@ -65,6 +65,9 @@ class JSONReader(BaseReader):
           then a would be collapsed into one line, while b would not.
           Recommend starting around 100 and then adjusting from there.
 
+        is_jsonl (Optional[bool]): If True, indicates that the file is in JSONL format.
+        Defaults to False.
+
     """
 
     def __init__(
@@ -72,37 +75,50 @@ class JSONReader(BaseReader):
         levels_back: Optional[int] = None,
         collapse_length: Optional[int] = None,
         ensure_ascii: bool = False,
+        is_jsonl: Optional[bool] = False,
     ) -> None:
         """Initialize with arguments."""
         super().__init__()
         self.levels_back = levels_back
         self.collapse_length = collapse_length
         self.ensure_ascii = ensure_ascii
+        self.is_jsonl = is_jsonl
 
     def load_data(self, input_file: str) -> List[Document]:
         """Load data from the input file."""
         with open(input_file, encoding="utf-8") as f:
-            data = json.load(f)
-            if self.levels_back is None:
-                # If levels_back isn't set, we just format and make each
-                # line an embedding
-                json_output = json.dumps(data, indent=0, ensure_ascii=self.ensure_ascii)
-                lines = json_output.split("\n")
-                useful_lines = [
-                    line for line in lines if not re.match(r"^[{}\[\],]*$", line)
-                ]
-                return [Document(text="\n".join(useful_lines))]
-            elif self.levels_back is not None:
-                # If levels_back is set, we make the embeddings contain the labels
-                # from further up the JSON tree
-                lines = [
-                    *_depth_first_yield(
-                        data,
-                        self.levels_back,
-                        self.collapse_length,
-                        [],
-                        self.ensure_ascii,
+            load_data = []
+            if self.is_jsonl:
+                for line in f:
+                    load_data.append(json.loads(line.strip()))
+            else:
+                load_data = [json.load(f)]
+
+            documents = []
+            for data in load_data:
+                # print(data)
+                if self.levels_back is None:
+                    # If levels_back isn't set, we just format and make each
+                    # line an embedding
+                    json_output = json.dumps(
+                        data, indent=0, ensure_ascii=self.ensure_ascii
                     )
-                ]
-                return [Document(text="\n".join(lines))]
-            return None
+                    lines = json_output.split("\n")
+                    useful_lines = [
+                        line for line in lines if not re.match(r"^[{}\[\],]*$", line)
+                    ]
+                    documents.append(Document(text="\n".join(useful_lines)))
+                elif self.levels_back is not None:
+                    # If levels_back is set, we make the embeddings contain the labels
+                    # from further up the JSON tree
+                    lines = [
+                        *_depth_first_yield(
+                            data,
+                            self.levels_back,
+                            self.collapse_length,
+                            [],
+                            self.ensure_ascii,
+                        )
+                    ]
+                    documents.append(Document(text="\n".join(lines)))
+            return documents

--- a/tests/readers/test_json.py
+++ b/tests/readers/test_json.py
@@ -52,3 +52,21 @@ def test_collapse_length() -> None:
         data2 = reader2.load_data(file_name)
         assert isinstance(data2[0].get_content(), str)
         assert data2[0].get_content().index("a ") is not None
+
+
+def test_jsonl() -> None:
+    """Test JSON reader using the is_jsonl function."""
+    with TemporaryDirectory() as tmp_dir:
+        file_name = f"{tmp_dir}/test4.json"
+        with open(file_name, "w") as f:
+            f.write('{"test1": "test1"}\n{"test2": "test2"}\n{"test3": "test3"}\n')
+
+        reader = JSONReader(is_jsonl=True)
+        data = reader.load_data(file_name)
+        assert len(data) == 3
+        assert isinstance(data[0].get_content(), str)
+        assert data[0].get_content().index("test1") is not None
+        assert isinstance(data[1].get_content(), str)
+        assert data[1].get_content().index("test2") is not None
+        assert isinstance(data[2].get_content(), str)
+        assert data[2].get_content().index("test3") is not None


### PR DESCRIPTION
# Description

Support JsonReader with jsonl so that it can handle multiple lines of json input file

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
