### PR TITLE
Fix exception callback handling

### DIFF
--- a/llama_index/callbacks/base.py
+++ b/llama_index/callbacks/base.py
@@ -160,7 +160,7 @@ class CallbackManager(BaseCallbackHandler, ABC):
             # data already logged to trace?
             if not hasattr(e, "event_added"):
                 payload = {EventPayload.EXCEPTION: e}
-                e.event_added = True
+                e.event_added = True  # type: ignore
                 if not event.finished:
                     event.on_end(payload=payload)
             raise
@@ -182,7 +182,7 @@ class CallbackManager(BaseCallbackHandler, ABC):
                 self.on_event_start(
                     CBEventType.EXCEPTION, payload={EventPayload.EXCEPTION: e}
                 )
-                e.event_added = True
+                e.event_added = True  # type: ignore
 
             raise
         finally:


### PR DESCRIPTION
# Description

Exceptions were not consistently placed in the trace map (sibling vs. child, due to how leaf events work). Furthermore, they were often duplicated.

This PR attempts to fix both issues.

Fixes https://github.com/run-llama/llama_index/issues/9070

Fixes https://github.com/run-llama/llama_index/issues/7799

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested notebooks + provided repro scripts
- [x] I stared at the code and made sure it makes sense

