### PR TITLE
Vectara summarization

### DIFF
--- a/docs/examples/managed/vectaraDemo.ipynb
+++ b/docs/examples/managed/vectaraDemo.ipynb
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "028833af",
+   "id": "0055f0cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,28 +44,7 @@
    "outputs": [],
    "source": [
     "from llama_index import SimpleDirectoryReader\n",
-    "from llama_index.indices import VectaraIndex\n",
-    "\n",
-    "import textwrap"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eda1e218",
-   "metadata": {},
-   "source": [
-    "### Download Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9d5ae460",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!mkdir -p 'data/paul_graham/'\n",
-    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+    "from llama_index.indices import VectaraIndex"
    ]
   },
   {
@@ -87,13 +66,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Document ID: fe81af94-f315-4e58-a7c6-2625292dc283\n"
+      "documents loaded into 305 document objects\n",
+      "Document ID of first doc is 751bcd41-acc7-4c77-aef1-7845c7ee4965\n"
      ]
     }
    ],
    "source": [
-    "documents = SimpleDirectoryReader(\"../data/10q\").load_data()\n",
-    "print(\"Document ID:\", documents[0].doc_id)"
+    "documents = SimpleDirectoryReader(os.path.abspath(\"../data/10q/\")).load_data()\n",
+    "print(f\"documents loaded into {len(documents)} document objects\")\n",
+    "print(f\"Document ID of first doc is {documents[0].doc_id}\")"
    ]
   },
   {
@@ -134,7 +115,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = \"what are the main risks?\""
+    "# query = \"what are the main risks?\"\n",
+    "# query = \"How does the Didi investment doing?\"\n",
+    "query = \"Is Uber still losing money or have they achieved profitability?\""
    ]
   },
   {
@@ -147,22 +130,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Our ownership in these entities involves significant risks that are outside our control.\n",
+      "The court granted our motion to defer the summary judgment motion on January 12, 2022. Our chances of success on\n",
+      "the merits are still uncertain and any reasonably possible loss or range of loss cannot be estimated. Swiss Social Security Reclassification\n",
+      "Several Swiss administrative bodies have issued decisions in which they classify Drivers as employees of Uber Switzerland, Rasier Operations B.V. or of Uber\n",
+      "B.V. for social security or labor purposes. We are challenging each of them before the Social Security and Administrative Tribunals. In April 2021, a ruling was made that Uber Switzerland could not be held liable for social security contributions.\n",
       "--\n",
-      "Our ownership in these entities involves significant risks that are outside our control.\n",
+      "The court granted our motion to defer the summary judgment motion on January 12, 2022. Our chances of success on\n",
+      "the merits are still uncertain and any reasonably possible loss or range of loss cannot be estimated. Swiss Social Security Reclassification\n",
+      "Several Swiss administrative bodies have issued decisions in which they classify Drivers as employees of Uber Switzerland, Rasier Operations B.V. or of Uber\n",
+      "B.V. for social security or regulatory purposes. We are challenging each of them before the Social Security and Administrative Tribunals. In April 2021, a ruling\n",
+      "was made that Uber Switzerland could not be held liable for social security contributions.\n",
       "--\n",
-      "Our ownership in these entities involves significant risks that are outside our control.\n",
+      "Most jurisdictions in which we operate have laws that govern payment and financial services activities. Regulators in certain jurisdictions may determine that\n",
+      "certain aspects of our business are subject to these laws and could require us to obtain licenses to continue to operate in such jurisdictions. For example, our\n",
+      "subsidiary in the Netherlands, Uber Payments B.V., is registered and authorized by its competent authority, De Nederlandsche Bank, as an electronic money\n",
+      "institution. This authorization permits Uber Payments B.V. to provide payment services (including acquiring and executing payment transactions and money\n",
+      "remittances, as referred to in the Revised Payment Services Directive (2015/2366/EU)) and to issue electronic money in the Netherlands. In addition, Uber\n",
+      "Payments B.V. has notified De Nederlandsche Bank that it will provide such services on a cross-border passport basis into other countries within the EEA.\n",
       "--\n",
-      "Autonomous vehicle technologies involve significant risks and liabilities.\n",
+      "Most jurisdictions in which we operate have laws that govern payment and financial services activities. Regulators in certain jurisdictions may determine that\n",
+      "certain aspects of our business are subject to these laws and could require us to obtain licenses to continue to operate in such jurisdictions. For example, our\n",
+      "subsidiary in the Netherlands, Uber Payments B.V., is registered and authorized by its competent authority, De Nederlandsche Bank, as an electronic money\n",
+      "institution. This authorization permits Uber Payments B.V. to provide payment services (including acquiring and executing payment transactions and money\n",
+      "remittances, as referred to in the Revised Payment Services Directive (2015/2366/EU)) and to issue electronic money in the Netherlands. In addition, Uber\n",
+      "Payments B.V. has notified De Nederlandsche Bank that it will provide such services on a cross-border passport basis into other countries within the EEA.\n",
       "--\n",
-      "We are unable to predict what global or U.S. tax reforms may be proposed or enacted in the future or what effects such future changes would have on our\n",
-      "business.\n"
+      "The court granted our motion to defer the summary judgment motion on January 12, 2022 and summary judgment\n",
+      "papers will be fully briefed by May 31, 2023. Our chances of success on the merits are still uncertain and any reasonably possible loss or range of loss cannot be\n",
+      "estimated. Swiss Social Security Rulings\n",
+      "Several Swiss administrative bodies have issued decisions in which they classify Drivers as employees of Uber Switzerland, Rasier Operations B.V. or of Uber\n",
+      "B.V. for social security or labor purposes. We are challenging each of them before the Social Security and Administrative Tribunals. In April 2021, a ruling was made that Uber Switzerland could not be held liable for social security contributions.\n"
      ]
     }
    ],
    "source": [
     "query_engine = index.as_query_engine(\n",
-    "    similarity_top_k=5, n_sentences_before=0, n_sentences_after=0\n",
+    "    similarity_top_k=5, n_sentences_before=2, n_sentences_after=2\n",
     ")\n",
     "response = query_engine.retrieve(query)\n",
     "texts = [t.node.text for t in response]\n",
@@ -179,13 +182,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The main risks mentioned in the context are significant risks associated with ownership in certain entities that are outside the company's control, as well as significant risks and liabilities related to autonomous vehicle technologies. Additionally, there is a mention of uncertainty regarding future global or U.S. tax reforms and their potential effects on the company's business.\n"
+      "Uber's financial situation remains uncertain, and it is unclear if they have achieved profitability or continue to incur losses [1]. Various administrative bodies in Switzerland have classified Uber drivers as employees, and Uber is challenging these rulings [2]. Additionally, Uber Payments B.V., a subsidiary in the Netherlands, is registered and authorized to provide payment services [3]. However, these details do not directly address Uber's overall financial performance or profitability. Therefore, based on the search results provided, it is not possible to definitively determine if Uber is still losing money or if they have achieved profitability.\n"
      ]
     }
    ],
    "source": [
+    "query_engine = index.as_query_engine(\n",
+    "    similarity_top_k=5,\n",
+    "    n_sentences_before=2,\n",
+    "    n_sentences_after=2,\n",
+    "    summary_enabled=True,\n",
+    ")\n",
     "response = query_engine.query(query)\n",
-    "print(response)"
+    "print(response.response[0][\"text\"])"
    ]
   },
   {
@@ -207,26 +216,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Our ownership in these entities involves significant risks that are outside our control.\n",
+      "Taxing authorities have appealed the orders related to tax issues and plan confirmation but did not\n",
+      "appeal the settlement approval. Uber is not a party to those appeals. The taxing authorities’ chances of success on the merits are still uncertain and any reasonably\n",
+      "possible loss or range of loss is immaterial. Non-Income Tax Matters\n",
+      "We recorded an estimated liability for contingencies related to non-income tax matters and are under audit by various domestic and foreign tax authorities with\n",
+      "regard to such matters. The subject matter of these contingent liabilities and non-income tax audits primarily arises from our transactions with Drivers, as well as\n",
+      "the tax treatment of certain employee benefits and related employment taxes.\n",
       "--\n",
-      "We are unable to predict what global or U.S. tax reforms may be proposed or enacted in the future or what effects such future changes would have on our\n",
-      "business.\n",
+      "We are challenging each of them before the Social Security and Administrative Tribunals. In April 2021, a ruling was made that Uber Switzerland could not be held liable for social security contributions. The litigations with regards to Uber B.V. and\n",
+      "Rasier Operations B.V. are still pending for years 2014 to 2019. In January 2022, the Social Security Tribunal of Zurich reclassified drivers who have used the App\n",
+      "in 2014 as dependent workers of Uber B.V. and Rasier Operations B.V. from a social security standpoint, but this ruling has been appealed before the Federal\n",
+      "Tribunal and has no impact on our current operations. On June 3, 2022, the Federal Tribunal issued two rulings by which both Drivers and Couriers in the canton of\n",
+      "Geneva are classified as employees of Uber B.V. and Uber Switzerland GmbH.\n",
       "--\n",
-      "We are subject to climate change risks, including physical and transitional risks, and if we are unable to manage such risks, our business may be adversely\n",
-      "impacted.\n",
+      "Most jurisdictions in which we operate have laws that govern payment and financial services activities. Regulators in certain jurisdictions may determine that\n",
+      "certain aspects of our business are subject to these laws and could require us to obtain licenses to continue to operate in such jurisdictions. For example, our\n",
+      "subsidiary in the Netherlands, Uber Payments B.V., is registered and authorized by its competent authority, De Nederlandsche Bank, as an electronic money\n",
+      "institution. This authorization permits Uber Payments B.V. to provide payment services (including acquiring and executing payment transactions and money\n",
+      "remittances, as referred to in the Revised Payment Services Directive (2015/2366/EU)) and to issue electronic money in the Netherlands. In addition, Uber\n",
+      "Payments B.V. has notified De Nederlandsche Bank that it will provide such services on a cross-border passport basis into other countries within the EEA.\n",
       "--\n",
-      "Autonomous vehicle technologies involve significant risks and liabilities.\n",
+      "The court granted our motion to defer the summary judgment motion on January 12, 2022. Our chances of success on\n",
+      "the merits are still uncertain and any reasonably possible loss or range of loss cannot be estimated. Swiss Social Security Reclassification\n",
+      "Several Swiss administrative bodies have issued decisions in which they classify Drivers as employees of Uber Switzerland, Rasier Operations B.V. or of Uber\n",
+      "B.V. for social security or labor purposes. We are challenging each of them before the Social Security and Administrative Tribunals. In April 2021, a ruling was made that Uber Switzerland could not be held liable for social security contributions.\n",
       "--\n",
-      "QUANTITATIVE AND QUALITATIVE DISCLOSURES ABOUT MARKET RISK\n",
-      "We are exposed to market risks in the ordinary course of our business.\n"
+      "These investments or strategic transactions, along with other competitive advantages discussed above, may allow our competitors to compete more\n",
+      "effectively against us and continue to lower their prices, offer Driver incentives or consumer discounts and promotions, or otherwise attract Drivers, consumers,\n",
+      "merchants, shippers, and carriers to their platform and away from ours. Such competitive pressures may lead us to maintain or lower fares or service fees or\n",
+      "maintain or increase our Driver incentives and consumer discounts and promotions. Ridesharing and certain other categories in which we compete are relatively\n",
+      "nascent, and we cannot guarantee that they will stabilize at a competitive equilibrium that will allow us to achieve profitability. We have incurred significant losses since inception, including in the United States and other major markets. We expect our operating expenses to increase\n",
+      "significantly in the foreseeable future, and we may not achieve or maintain profitability.\n"
      ]
     }
    ],
    "source": [
     "query_engine = index.as_query_engine(\n",
     "    similarity_top_k=5,\n",
-    "    n_sentences_before=0,\n",
-    "    n_sentences_after=0,\n",
+    "    n_sentences_before=2,\n",
+    "    n_sentences_after=2,\n",
     "    vectara_query_mode=\"mmr\",\n",
     "    vectara_kwargs={\"mmr_k\": 100, \"mmr_diversity_bias\": 1.0},\n",
     ")\n",
@@ -245,35 +273,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "12be9556",
+   "metadata": {},
+   "source": [
+    "The resposne is also better as it includes more risk factors mentioned in the original document"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5dafac23",
+   "id": "10bf0fb9",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The main risks mentioned in the given context are:\n",
-      "1. Risks associated with ownership in certain entities.\n",
-      "2. Uncertainty regarding future global or U.S. tax reforms and their potential impact on the business.\n",
-      "3. Risks related to climate change, including both physical and transitional risks.\n",
-      "4. Risks and liabilities associated with autonomous vehicle technologies.\n",
-      "5. Market risks that the company is exposed to in the ordinary course of its business.\n"
+      "As per the provided search results, Uber is still facing financial challenges and has incurred significant losses since its inception [fifth result]. They are engaged in various legal battles and administrative proceedings, such as tax issues and social security reclassification [first, second, fourth, and seventh results]. While there have been some rulings in favor of Uber, the outcomes are still uncertain and subject to appeals [second and seventh results]. Additionally, Uber is required to comply with evolving laws and regulations related to payment processing and financial services [third and sixth results]. Thus, based on the available information, it can be concluded that Uber has not yet achieved profitability and continues to face financial hurdles.\n"
      ]
     }
    ],
    "source": [
+    "query_engine = index.as_query_engine(\n",
+    "    similarity_top_k=5,\n",
+    "    n_sentences_before=2,\n",
+    "    n_sentences_after=2,\n",
+    "    summary_enabled=True,\n",
+    "    vectara_query_mode=\"mmr\",\n",
+    "    vectara_kwargs={\"mmr_k\": 100, \"mmr_diversity_bias\": 1.0},\n",
+    ")\n",
     "response = query_engine.query(query)\n",
-    "print(response)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12be9556",
-   "metadata": {},
-   "source": [
-    "The resposne is also better as it includes more risk factors mentioned in the original document"
+    "print(response.response[0][\"text\"])"
    ]
   }
  ],

--- a/docs/examples/managed/vectaraDemo.ipynb
+++ b/docs/examples/managed/vectaraDemo.ipynb
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0055f0cb",
+   "id": "6019e01a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
    "metadata": {},
    "source": [
     "### Loading documents\n",
-    "Load the documents stored in the `paul_graham_essay` using the SimpleDirectoryReader"
+    "Load the documents stored in the `Uber 10q` using the SimpleDirectoryReader"
    ]
   },
   {
@@ -67,7 +67,7 @@
      "output_type": "stream",
      "text": [
       "documents loaded into 305 document objects\n",
-      "Document ID of first doc is 751bcd41-acc7-4c77-aef1-7845c7ee4965\n"
+      "Document ID of first doc is 812706e0-f35d-439f-8083-c5a9f7dd5c89\n"
      ]
     }
    ],
@@ -115,9 +115,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# query = \"what are the main risks?\"\n",
-    "# query = \"How does the Didi investment doing?\"\n",
     "query = \"Is Uber still losing money or have they achieved profitability?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52878fd2",
+   "metadata": {},
+   "source": [
+    "First we use the retriever to list the returned documents:"
    ]
   },
   {
@@ -164,12 +170,18 @@
     }
    ],
    "source": [
-    "query_engine = index.as_query_engine(\n",
-    "    similarity_top_k=5, n_sentences_before=2, n_sentences_after=2\n",
-    ")\n",
+    "query_engine = index.as_query_engine(similarity_top_k=5)\n",
     "response = query_engine.retrieve(query)\n",
     "texts = [t.node.text for t in response]\n",
     "print(\"\\n--\\n\".join(texts))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fbf0c93",
+   "metadata": {},
+   "source": [
+    "with the as_query_engine(), we can ask questions and get the responses based on Vectara's full RAG pipeline:"
    ]
   },
   {
@@ -182,19 +194,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Uber's financial situation remains uncertain, and it is unclear if they have achieved profitability or continue to incur losses [1]. Various administrative bodies in Switzerland have classified Uber drivers as employees, and Uber is challenging these rulings [2]. Additionally, Uber Payments B.V., a subsidiary in the Netherlands, is registered and authorized to provide payment services [3]. However, these details do not directly address Uber's overall financial performance or profitability. Therefore, based on the search results provided, it is not possible to definitively determine if Uber is still losing money or if they have achieved profitability.\n"
+      "Uber's financial situation remains uncertain, and it is difficult to estimate their potential losses or achieve profitability [1][5]. They face challenges in various jurisdictions, including reclassification of drivers for social security or labor purposes [1][5]. Uber Payments B.V., their subsidiary in the Netherlands, is authorized to provide payment services [3][4]. However, the search results do not provide a clear and direct answer regarding Uber's current profitability or ongoing losses.\n"
      ]
     }
    ],
    "source": [
-    "query_engine = index.as_query_engine(\n",
-    "    similarity_top_k=5,\n",
-    "    n_sentences_before=2,\n",
-    "    n_sentences_after=2,\n",
-    "    summary_enabled=True,\n",
-    ")\n",
+    "query_engine = index.as_query_engine(similarity_top_k=5)\n",
     "response = query_engine.query(query)\n",
-    "print(response.response[0][\"text\"])"
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc0874ad",
+   "metadata": {},
+   "source": [
+    "Note that the \"response\" object above includes both the summary text but also the source documents used to provide this response (citations)"
    ]
   },
   {
@@ -202,8 +217,8 @@
    "id": "9e49914a",
    "metadata": {},
    "source": [
-    "Vectara supports max-marginal-relevance natively in the backend, and this is available as a query moe. \n",
-    "Let's see an example of how to use MMR: We will run the same query \"What is YC?\" but this time we will use MMR where mmr_diversity_bias=1.0 which maximizes the focus on maximum diversity:"
+    "Vectara supports max-marginal-relevance natively in the backend, and this is available as a query mode. \n",
+    "Let's see an example of how to use MMR: We will run the same query \"Is Uber still losing money or have they achieved profitability?\" but this time we will use MMR where mmr_diversity_bias=1.0 which maximizes the focus on maximum diversity:"
    ]
   },
   {
@@ -241,11 +256,12 @@
       "Several Swiss administrative bodies have issued decisions in which they classify Drivers as employees of Uber Switzerland, Rasier Operations B.V. or of Uber\n",
       "B.V. for social security or labor purposes. We are challenging each of them before the Social Security and Administrative Tribunals. In April 2021, a ruling was made that Uber Switzerland could not be held liable for social security contributions.\n",
       "--\n",
-      "These investments or strategic transactions, along with other competitive advantages discussed above, may allow our competitors to compete more\n",
-      "effectively against us and continue to lower their prices, offer Driver incentives or consumer discounts and promotions, or otherwise attract Drivers, consumers,\n",
-      "merchants, shippers, and carriers to their platform and away from ours. Such competitive pressures may lead us to maintain or lower fares or service fees or\n",
-      "maintain or increase our Driver incentives and consumer discounts and promotions. Ridesharing and certain other categories in which we compete are relatively\n",
-      "nascent, and we cannot guarantee that they will stabilize at a competitive equilibrium that will allow us to achieve profitability. We have incurred significant losses since inception, including in the United States and other major markets. We expect our operating expenses to increase\n",
+      "These investments or strategic\n",
+      "transactions, along with other competitive advantages discussed above, may allow our competitors to compete more effectively against us and continue to lower\n",
+      "their prices, offer Driver incentives or consumer discounts and promotions, or otherwise attract Drivers, consumers, merchants, Shippers, and Carriers to their\n",
+      "platform and away from ours. Such competitive pressures may lead us to maintain or lower fares or service fees or maintain or increase our Driver incentives and\n",
+      "consumer discounts and promotions. Ridesharing and certain other categories in which we compete are relatively nascent, and we cannot guarantee that they will\n",
+      "stabilize at a competitive equilibrium that will allow us to achieve profitability. We have incurred significant losses since inception, including in the United States and other major markets. We expect our operating expenses to increase\n",
       "significantly in the foreseeable future, and we may not achieve or maintain profitability.\n"
      ]
     }
@@ -256,7 +272,7 @@
     "    n_sentences_before=2,\n",
     "    n_sentences_after=2,\n",
     "    vectara_query_mode=\"mmr\",\n",
-    "    vectara_kwargs={\"mmr_k\": 100, \"mmr_diversity_bias\": 1.0},\n",
+    "    vectara_kwargs={\"mmr_k\": 50, \"mmr_diversity_bias\": 1.0},\n",
     ")\n",
     "response = query_engine.retrieve(query)\n",
     "\n",
@@ -269,15 +285,7 @@
    "id": "53e76fd1",
    "metadata": {},
    "source": [
-    "As you can see, the results in this case are much more diverse, and for example do not contain the same text more than once."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12be9556",
-   "metadata": {},
-   "source": [
-    "The resposne is also better as it includes more risk factors mentioned in the original document"
+    "As you can see, the results in this case are much more diverse, and for example do not contain the same text more than once. The response is also better since the LLM had a more diverse set of facts to ground its response on:"
    ]
   },
   {
@@ -290,7 +298,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "As per the provided search results, Uber is still facing financial challenges and has incurred significant losses since its inception [fifth result]. They are engaged in various legal battles and administrative proceedings, such as tax issues and social security reclassification [first, second, fourth, and seventh results]. While there have been some rulings in favor of Uber, the outcomes are still uncertain and subject to appeals [second and seventh results]. Additionally, Uber is required to comply with evolving laws and regulations related to payment processing and financial services [third and sixth results]. Thus, based on the available information, it can be concluded that Uber has not yet achieved profitability and continues to face financial hurdles.\n"
+      "Uber has faced various legal challenges regarding its classification of drivers and social security contributions [2, 4, 7]. While there have been rulings in favor of Uber, such as in Switzerland, other cases are still pending [2, 7]. The company also deals with tax audits and potential tax liabilities [1]. Furthermore, Uber operates under evolving laws and regulations related to payment services and financial activities [3, 6]. Overall, Uber's financial situation remains uncertain, and they have incurred significant losses since inception [5]. It cannot be definitively stated whether Uber has achieved profitability or is still losing money based on the provided information.\n"
      ]
     }
    ],
@@ -301,10 +309,45 @@
     "    n_sentences_after=2,\n",
     "    summary_enabled=True,\n",
     "    vectara_query_mode=\"mmr\",\n",
-    "    vectara_kwargs={\"mmr_k\": 100, \"mmr_diversity_bias\": 1.0},\n",
+    "    vectara_kwargs={\"mmr_k\": 50, \"mmr_diversity_bias\": 1.0},\n",
     ")\n",
     "response = query_engine.query(query)\n",
-    "print(response.response[0][\"text\"])"
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e863b914",
+   "metadata": {},
+   "source": [
+    "So far we've used Vectara's internal summarization capability, which is the best way for most users.\n",
+    "\n",
+    "You can still use Llama-Index's standard VectorStore as_query_engine() method, in which case Vectara's summarization won't be used, and you would be using an external LLM (like OpenAI's GPT-4 or similar) and a cutom prompt from LlamaIndex to generate the summart. For this option just set summary_enabled=False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b0a49d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uber is still losing money and has not achieved profitability.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query_engine = index.as_query_engine(\n",
+    "    similarity_top_k=5,\n",
+    "    summary_enabled=False,\n",
+    "    vectara_query_mode=\"mmr\",\n",
+    "    vectara_kwargs={\"mmr_k\": 50, \"mmr_diversity_bias\": 0.5},\n",
+    ")\n",
+    "response = query_engine.query(query)\n",
+    "print(response)"
    ]
   }
  ],

--- a/llama_index/indices/managed/vectara/base.py
+++ b/llama_index/indices/managed/vectara/base.py
@@ -106,8 +106,8 @@ class VectaraIndex(BaseManagedIndex):
         docs = [
             Document(
                 text=node.get_content(metadata_mode=MetadataMode.NONE),
-                metadata=node.metadata,
-                id_=node.id_,
+                metadata=node.metadata,  # type: ignore
+                id_=node.id_,  # type: ignore
             )
             for node in nodes
         ]
@@ -220,7 +220,9 @@ class VectaraIndex(BaseManagedIndex):
         use_core_api: bool = False,
         allow_update: bool = True,
     ) -> None:
-        nodes = [TextNode(text=doc.text, metadata=doc.metadata) for doc in docs]
+        nodes = [
+            TextNode(text=doc.get_content(), metadata=doc.metadata) for doc in docs  # type: ignore
+        ]
         self._insert(nodes, use_core_api)
 
     def insert_file(
@@ -323,7 +325,7 @@ class VectaraIndex(BaseManagedIndex):
     ) -> IndexType:
         """Build a Vectara index from a sequence of documents."""
         nodes = [
-            TextNode(text=document.text, metadata=document.metadata)
+            TextNode(text=document.get_content(), metadata=document.metadata)  # type: ignore
             for document in documents
         ]
         return cls(

--- a/llama_index/indices/managed/vectara/base.py
+++ b/llama_index/indices/managed/vectara/base.py
@@ -17,6 +17,8 @@ from llama_index.core import BaseQueryEngine, BaseRetriever
 from llama_index.data_structs.data_structs import IndexDict, IndexStructType
 from llama_index.indices.managed.base import BaseManagedIndex, IndexType
 from llama_index.schema import BaseNode, Document, MetadataMode, TextNode
+from llama_index.service_context import ServiceContext
+from llama_index.storage.storage_context import StorageContext
 
 _logger = logging.getLogger(__name__)
 
@@ -301,7 +303,7 @@ class VectaraIndex(BaseManagedIndex):
 
             kwargs["summary_enabled"] = True
             retriever = self.as_retriever(**kwargs)
-            return VectaraQueryEngine.from_args(retriever, **kwargs)
+            return VectaraQueryEngine.from_args(retriever, **kwargs)  # type: ignore
         else:
             from llama_index.query_engine.retriever_query_engine import (
                 RetrieverQueryEngine,
@@ -314,6 +316,8 @@ class VectaraIndex(BaseManagedIndex):
     def from_documents(
         cls: Type[IndexType],
         documents: Sequence[Document],
+        storage_context: Optional[StorageContext] = None,
+        service_context: Optional[ServiceContext] = None,
         show_progress: bool = False,
         **kwargs: Any,
     ) -> IndexType:

--- a/llama_index/indices/managed/vectara/query.py
+++ b/llama_index/indices/managed/vectara/query.py
@@ -29,9 +29,9 @@ class VectaraQueryEngine(BaseQueryEngine):
         if summary_enabled:
             self._summary_kwargs = {
                 "summary_response_lang": summary_kwargs.get(
-                    "summary_response_lang", "en"
+                    "summary_response_lang", "eng"
                 ),
-                "summary_num_results": summary_kwargs.get("summary_num_results", 7),
+                "summary_num_results": summary_kwargs.get("summary_num_results", 5),
                 "summary_prompt_name": summary_kwargs.get(
                     "summary_prompt_name", "vectara-summary-ext-v1.2.0"
                 ),

--- a/llama_index/indices/managed/vectara/query.py
+++ b/llama_index/indices/managed/vectara/query.py
@@ -1,0 +1,105 @@
+from typing import Any, List, Optional
+
+from llama_index.callbacks.base import CallbackManager
+from llama_index.callbacks.schema import CBEventType, EventPayload
+from llama_index.core import BaseQueryEngine, BaseRetriever
+from llama_index.indices.managed.vectara.retriever import VectaraRetriever
+from llama_index.prompts.mixin import PromptDictType, PromptMixinType
+from llama_index.response.schema import RESPONSE_TYPE, Response
+from llama_index.schema import NodeWithScore, QueryBundle
+
+
+class VectaraQueryEngine(BaseQueryEngine):
+    """Retriever query engine for Vectara.
+
+    Args:
+        retriever (VectaraRetriever): A retriever object.
+        summary_kwargs (dict): Additional kwargs to pass to the Vectara summary synthesizer.
+    """
+
+    def __init__(
+        self,
+        retriever: VectaraRetriever,
+        summary_enabled: bool = False,
+        summary_kwargs: Optional[dict] = None,
+        callback_manager: Optional[CallbackManager] = None,
+    ) -> None:
+        self._retriever = retriever
+        self._summary_enabled = summary_enabled
+        if summary_enabled:
+            self._summary_kwargs = {
+                "summary_response_lang": summary_kwargs.get(
+                    "summary_response_lang", "en"
+                ),
+                "summary_num_results": summary_kwargs.get("summary_num_results", 7),
+                "summary_prompt_name": summary_kwargs.get(
+                    "summary_prompt_name", "vectara-summary-ext-v1.2.0"
+                ),
+            }
+        super().__init__(callback_manager=callback_manager)
+
+    @classmethod
+    def from_args(
+        cls,
+        retriever: VectaraRetriever,
+        summary_enabled: bool = False,
+        summary_kwargs: dict = {},
+        **kwargs: Any,
+    ) -> "VectaraQueryEngine":
+        """Initialize a VectaraQueryEngine object.".
+
+        Args:
+            retriever (VectaraRetriever): A Vectara retriever object.
+            summary_kwargs: additional keywords to pass to the Vectara summary synthesizer.
+
+        """
+        return cls(
+            retriever=retriever,
+            summary_enabled=summary_enabled,
+            summary_kwargs=summary_kwargs,
+        )
+
+    def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return self._retriever.retrieve(query_bundle)
+
+    async def aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return await self._retriever.aretrieve(query_bundle)
+
+    def with_retriever(self, retriever: VectaraRetriever) -> "VectaraQueryEngine":
+        return VectaraQueryEngine(
+            retriever=retriever,
+            summary_enabled=self._summary_enabled,
+            summary_kwargs=self._summary_kwargs,
+        )
+
+    def _query(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
+        """Answer a query."""
+        with self.callback_manager.event(
+            CBEventType.QUERY, payload={EventPayload.QUERY_STR: query_bundle.query_str}
+        ) as query_event:
+            nodes, response = self._retriever._vectara_query(
+                query_bundle,
+                kwargs=self._summary_kwargs if self._summary_enabled else {},
+            )
+            query_event.on_end(payload={EventPayload.RESPONSE: response})
+        return Response(response=response, source_nodes=nodes)
+
+    async def _aquery(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
+        return self._query(query_bundle)
+
+    @property
+    def retriever(self) -> BaseRetriever:
+        """Get the retriever object."""
+        return self._retriever
+
+    # required for PromptMixin
+    def _get_prompts(self) -> PromptDictType:
+        """Get prompts."""
+        return {}
+
+    def _get_prompt_modules(self) -> PromptMixinType:
+        """Get prompt modules."""
+        return {}
+
+    def _update_prompts(self, prompts: PromptDictType) -> None:
+        """Update prompts."""

--- a/llama_index/indices/managed/vectara/query.py
+++ b/llama_index/indices/managed/vectara/query.py
@@ -4,6 +4,7 @@ from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.core import BaseQueryEngine, BaseRetriever
 from llama_index.indices.managed.vectara.retriever import VectaraRetriever
+from llama_index.postprocessor.types import BaseNodePostprocessor
 from llama_index.prompts.mixin import PromptDictType, PromptMixinType
 from llama_index.response.schema import RESPONSE_TYPE, Response
 from llama_index.schema import NodeWithScore, QueryBundle
@@ -14,28 +15,27 @@ class VectaraQueryEngine(BaseQueryEngine):
 
     Args:
         retriever (VectaraRetriever): A retriever object.
-        summary_kwargs (dict): Additional kwargs to pass to the Vectara summary synthesizer.
+        summary_response_lang: response language for summary (ISO 639-2 code)
+        summary_num_results: number of results to use for summary generation.
+        summary_prompt_name: name of the prompt to use for summary generation.
     """
 
     def __init__(
         self,
         retriever: VectaraRetriever,
         summary_enabled: bool = False,
-        summary_kwargs: Optional[dict] = None,
+        node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         callback_manager: Optional[CallbackManager] = None,
+        summary_response_lang: str = "eng",
+        summary_num_results: int = 5,
+        summary_prompt_name: str = "vectara-experimental-summary-ext-2023-10-23-small",
     ) -> None:
         self._retriever = retriever
         self._summary_enabled = summary_enabled
-        if summary_enabled:
-            self._summary_kwargs = {
-                "summary_response_lang": summary_kwargs.get(
-                    "summary_response_lang", "eng"
-                ),
-                "summary_num_results": summary_kwargs.get("summary_num_results", 5),
-                "summary_prompt_name": summary_kwargs.get(
-                    "summary_prompt_name", "vectara-summary-ext-v1.2.0"
-                ),
-            }
+        self._summary_response_lang = summary_response_lang
+        self._summary_num_results = summary_num_results
+        self._summary_prompt_name = summary_prompt_name
+        self._node_postprocessors = node_postprocessors or []
         super().__init__(callback_manager=callback_manager)
 
     @classmethod
@@ -43,33 +43,52 @@ class VectaraQueryEngine(BaseQueryEngine):
         cls,
         retriever: VectaraRetriever,
         summary_enabled: bool = False,
-        summary_kwargs: dict = {},
+        summary_response_lang: str = "eng",
+        summary_num_results: int = 5,
+        summary_prompt_name: str = "vectara-experimental-summary-ext-2023-10-23-small",
         **kwargs: Any,
     ) -> "VectaraQueryEngine":
         """Initialize a VectaraQueryEngine object.".
 
         Args:
             retriever (VectaraRetriever): A Vectara retriever object.
-            summary_kwargs: additional keywords to pass to the Vectara summary synthesizer.
+            summary_response_lang: response language for summary (ISO 639-2 code)
+            summary_num_results: number of results to use for summary generation.
+            summary_prompt_name: name of the prompt to use for summary generation.
 
         """
         return cls(
             retriever=retriever,
             summary_enabled=summary_enabled,
-            summary_kwargs=summary_kwargs,
+            summary_response_lang=summary_response_lang,
+            summary_num_results=summary_num_results,
+            summary_prompt_name=summary_prompt_name,
         )
 
+    def _apply_node_postprocessors(
+        self, nodes: List[NodeWithScore], query_bundle: QueryBundle
+    ) -> List[NodeWithScore]:
+        for node_postprocessor in self._node_postprocessors:
+            nodes = node_postprocessor.postprocess_nodes(
+                nodes, query_bundle=query_bundle
+            )
+        return nodes
+
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        return self._retriever.retrieve(query_bundle)
+        nodes = self._retriever.retrieve(query_bundle)
+        return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)
 
     async def aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        return await self._retriever.aretrieve(query_bundle)
+        nodes = await self._retriever.aretrieve(query_bundle)
+        return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)
 
     def with_retriever(self, retriever: VectaraRetriever) -> "VectaraQueryEngine":
         return VectaraQueryEngine(
             retriever=retriever,
             summary_enabled=self._summary_enabled,
-            summary_kwargs=self._summary_kwargs,
+            summary_response_lang=self._summary_response_lang,
+            summary_num_results=self._summary_num_results,
+            summary_prompt_name=self._summary_prompt_name,
         )
 
     def _query(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
@@ -79,7 +98,13 @@ class VectaraQueryEngine(BaseQueryEngine):
         ) as query_event:
             nodes, response = self._retriever._vectara_query(
                 query_bundle,
-                kwargs=self._summary_kwargs if self._summary_enabled else {},
+                kwargs={
+                    "summary_response_lang": self._summary_response_lang,
+                    "summary_num_results": self._summary_num_results,
+                    "summary_prompt_name": self._summary_prompt_name,
+                }
+                if self._summary_enabled
+                else {},
             )
             query_event.on_end(payload={EventPayload.RESPONSE: response})
         return Response(response=response, source_nodes=nodes)

--- a/llama_index/indices/managed/vectara/retriever.py
+++ b/llama_index/indices/managed/vectara/retriever.py
@@ -76,7 +76,7 @@ class VectaraRetriever(BaseRetriever):
 
         if kwargs.get("summary_enabled", False):
             self._summary_enabled = True
-            self._summary_response_lang = kwargs.get("summary_response_lang", "en")
+            self._summary_response_lang = kwargs.get("summary_response_lang", "eng")
             self._summary_num_results = kwargs.get("summary_num_results", 7)
             self._summary_prompt_name = kwargs.get(
                 "summary_prompt_name", "vectara-summary-ext-v1.2.0"
@@ -176,7 +176,7 @@ class VectaraRetriever(BaseRetriever):
                 f"(code {response.status_code}, reason {response.reason}, details "
                 f"{response.text})",
             )
-            return []
+            return [], ""
 
         result = response.json()
 

--- a/llama_index/indices/managed/vectara/retriever.py
+++ b/llama_index/indices/managed/vectara/retriever.py
@@ -201,7 +201,7 @@ class VectaraRetriever(BaseRetriever):
             doc_inx = x["documentIndex"]
             doc_id = documents[doc_inx]["id"]
             node = NodeWithScore(
-                node=TextNode(text=x["text"], id_=doc_id, metadata=md), score=x["score"]
+                node=TextNode(text=x["text"], id_=doc_id, metadata=md), score=x["score"]  # type: ignore
             )
             top_nodes.append(node)
 

--- a/llama_index/indices/managed/vectara/retriever.py
+++ b/llama_index/indices/managed/vectara/retriever.py
@@ -182,7 +182,11 @@ class VectaraRetriever(BaseRetriever):
 
         responses = result["responseSet"][0]["response"]
         documents = result["responseSet"][0]["document"]
-        summary = result["responseSet"][0]["summary"] if self._summary_enabled else None
+        summary = (
+            result["responseSet"][0]["summary"][0]["text"]
+            if self._summary_enabled
+            else None
+        )
 
         metadatas = []
         for x in responses:

--- a/llama_index/indices/managed/vectara/retriever.py
+++ b/llama_index/indices/managed/vectara/retriever.py
@@ -4,7 +4,7 @@ An index that that is built on top of Vectara.
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from llama_index.callbacks.base import CallbackManager
 from llama_index.constants import DEFAULT_SIMILARITY_TOP_K
@@ -40,6 +40,10 @@ class VectaraRetriever(BaseRetriever):
                 of diversity among the results with 0 corresponding
                 to minimum diversity and 1 to maximum diversity.
                 Defaults to 0.3.
+            * summary_enabled: whether to generate summaries or not. Defaults to False.
+            * summary_response_lang: language to use for summary generation.
+            * summary_num_results: number of results to use for summary generation.
+            * summary_prompt_name: name of the prompt to use for summary generation.
     """
 
     def __init__(
@@ -69,6 +73,16 @@ class VectaraRetriever(BaseRetriever):
             self._mmr_diversity_bias = kwargs.get("mmr_diversity_bias", 0.3)
         else:
             self._mmr = False
+
+        if kwargs.get("summary_enabled", False):
+            self._summary_enabled = True
+            self._summary_response_lang = kwargs.get("summary_response_lang", "en")
+            self._summary_num_results = kwargs.get("summary_num_results", 7)
+            self._summary_prompt_name = kwargs.get(
+                "summary_prompt_name", "vectara-summary-ext-v1.2.0"
+            )
+        else:
+            self._summary_enabled = False
         super().__init__(callback_manager)
 
     def _get_post_headers(self) -> dict:
@@ -95,6 +109,18 @@ class VectaraRetriever(BaseRetriever):
         query_bundle: QueryBundle,
         **kwargs: Any,
     ) -> List[NodeWithScore]:
+        """Retrieve top k most similar nodes.
+
+        Args:
+            query: Query Bundle
+        """
+        return self._vectara_query(query_bundle, **kwargs)[0]  # return top_nodes only
+
+    def _vectara_query(
+        self,
+        query_bundle: QueryBundle,
+        **kwargs: Any,
+    ) -> Tuple[List[NodeWithScore], str]:
         """Query Vectara index to get for top k most similar nodes.
 
         Args:
@@ -128,6 +154,15 @@ class VectaraRetriever(BaseRetriever):
                 "mmrConfig": {"diversityBias": self._mmr_diversity_bias},
             }
 
+        if self._summary_enabled:
+            data["query"][0]["summary"] = [
+                {
+                    "responseLang": self._summary_response_lang,
+                    "maxSummarizedResults": self._summary_num_results,
+                    "summarizerPromptName": self._summary_prompt_name,
+                }
+            ]
+
         response = self._index._session.post(
             headers=self._get_post_headers(),
             url="https://api.vectara.io/v1/query",
@@ -144,8 +179,10 @@ class VectaraRetriever(BaseRetriever):
             return []
 
         result = response.json()
+
         responses = result["responseSet"][0]["response"]
         documents = result["responseSet"][0]["document"]
+        summary = result["responseSet"][0]["summary"] if self._summary_enabled else None
 
         metadatas = []
         for x in responses:
@@ -164,4 +201,14 @@ class VectaraRetriever(BaseRetriever):
             )
             top_nodes.append(node)
 
-        return top_nodes[: self._similarity_top_k]
+        return top_nodes[: self._similarity_top_k], summary
+
+    async def _avectara_query(
+        self, query_bundle: QueryBundle
+    ) -> Tuple[List[NodeWithScore], str]:
+        """Asynchronously retrieve nodes given query.
+
+        Implemented by the user.
+
+        """
+        return self._vectara_query(query_bundle)

--- a/tests/indices/managed/test_vectara.py
+++ b/tests/indices/managed/test_vectara.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 import pytest
 from llama_index.indices.managed.vectara.base import VectaraIndex
@@ -14,7 +14,7 @@ from llama_index.schema import Document
 #
 
 
-def get_docs() -> Tuple[List[Document], List[str]]:
+def get_docs() -> List[Document]:
     inputs = [
         {
             "text": "This is test text for Vectara integration with LlamaIndex",

--- a/tests/indices/managed/test_vectara.py
+++ b/tests/indices/managed/test_vectara.py
@@ -36,8 +36,8 @@ def get_docs() -> List[Document]:
     docs: List[Document] = []
     for inp in inputs:
         doc = Document(
-            text=inp["text"],
-            metadata=inp["metadata"],
+            text=str(inp["text"]),
+            metadata=inp["metadata"],  # type: ignore
         )
         docs.append(doc)
     return docs
@@ -59,7 +59,7 @@ def test_simple_retrieval() -> None:
     qe = index.as_retriever(similarity_top_k=1)
     res = qe.retrieve("how will I look?")
     assert len(res) == 1
-    assert res[0].node.text == docs[2].text
+    assert res[0].node.get_content() == docs[2].text
 
     remove_docs(index, index.doc_ids)
 
@@ -84,8 +84,8 @@ def test_mmr_retrieval() -> None:
     )
     res = qe.retrieve("how will I look?")
     assert len(res) == 2
-    assert res[0].node.text == docs[2].text
-    assert res[1].node.text == docs[3].text
+    assert res[0].node.get_content() == docs[2].text
+    assert res[1].node.get_content() == docs[3].text
 
     # test with diversity bias = 1
     qe = index.as_retriever(
@@ -98,8 +98,8 @@ def test_mmr_retrieval() -> None:
     )
     res = qe.retrieve("how will I look?")
     assert len(res) == 2
-    assert res[0].node.text == docs[2].text
-    assert res[1].node.text == docs[0].text
+    assert res[0].node.get_content() == docs[2].text
+    assert res[1].node.get_content() == docs[0].text
 
     remove_docs(index, index.doc_ids)
 
@@ -115,7 +115,7 @@ def test_retrieval_with_filter() -> None:
     qe = index.as_retriever(similarity_top_k=1, filter="doc.test_num = '1'")
     res = qe.retrieve("how will I look?")
     assert len(res) == 1
-    assert res[0].node.text == docs[0].text
+    assert res[0].node.get_content() == docs[0].text
 
     remove_docs(index, index.doc_ids)
 


### PR DESCRIPTION
This PR focused on extending VectaraIndex capabilities to enable Vectara's internal summarization capability, allowing users to avoid the requirement of additional LLM within their LlamaIndex RAG implementation.

In addition, a few other changes:

* Using hash of text as doc_id (instead of node.id_ which resulted in documents being ingested multiple times)
* Cleaned up VectaraDemo and added example of using the Vectara summarization
* Added new test cases
