### PR TITLE
Small chat engine updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Add support for `PGVectoRsStore` (#9087)
 - Enforcing `requests>=2.31` for security, while unpinning `urllib3` (#9108)
 
+### Bug Fixes / Nits
+
+- Increased default memory token limit for context chat engine (#9123)
+- Added system prompt to `CondensePlusContextChatEngine` that gets prepended to the `context_prompt` (#9123)
+
 ## [0.9.6] - 2023-11-22
 
 ### New Features

--- a/llama_index/chat_engine/condense_plus_context.py
+++ b/llama_index/chat_engine/condense_plus_context.py
@@ -63,6 +63,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         memory: BaseMemory,
         context_prompt: Optional[str] = None,
         condense_prompt: Optional[str] = None,
+        system_prompt: Optional[str] = None,
         skip_condense: bool = False,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         callback_manager: Optional[CallbackManager] = None,
@@ -77,6 +78,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         )
         condense_prompt_str = condense_prompt or DEFAULT_CONDENSE_PROMPT_TEMPLATE
         self._condense_prompt_template = PromptTemplate(condense_prompt_str)
+        self._system_prompt = system_prompt
         self._skip_condense = skip_condense
         self._node_postprocessors = node_postprocessors or []
         self.callback_manager = callback_manager or CallbackManager([])
@@ -92,6 +94,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         chat_history: Optional[List[ChatMessage]] = None,
         memory: Optional[BaseMemory] = None,
         memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
+        system_prompt: Optional[str] = None,
         context_prompt: Optional[str] = None,
         condense_prompt: Optional[str] = None,
         skip_condense: bool = False,
@@ -118,6 +121,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             skip_condense=skip_condense,
             callback_manager=service_context.callback_manager,
             node_postprocessors=node_postprocessors,
+            system_prompt=system_prompt,
             verbose=verbose,
         )
 
@@ -203,6 +207,9 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         system_message_content = self._context_prompt_template.format(
             context_str=context_str
         )
+        if self._system_prompt:
+            system_message_content = self._system_prompt + "\n" + system_message_content
+
         system_message = ChatMessage(
             content=system_message_content, role=MessageRole.SYSTEM
         )
@@ -239,6 +246,9 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         system_message_content = self._context_prompt_template.format(
             context_str=context_str
         )
+        if self._system_prompt:
+            system_message_content = self._system_prompt + "\n" + system_message_content
+
         system_message = ChatMessage(
             content=system_message_content, role=MessageRole.SYSTEM
         )

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -1,6 +1,6 @@
 import asyncio
 from threading import Thread
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple
 
 from llama_index.callbacks import CallbackManager, trace_method
 from llama_index.chat_engine.types import (
@@ -60,7 +60,6 @@ class ContextChatEngine(BaseChatEngine):
         service_context: Optional[ServiceContext] = None,
         chat_history: Optional[List[ChatMessage]] = None,
         memory: Optional[BaseMemory] = None,
-        memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
         system_prompt: Optional[str] = None,
         prefix_messages: Optional[List[ChatMessage]] = None,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
@@ -74,7 +73,9 @@ class ContextChatEngine(BaseChatEngine):
         llm = service_context.llm_predictor.llm
 
         chat_history = chat_history or []
-        memory = memory or memory_cls.from_defaults(chat_history=chat_history, llm=llm)
+        memory = memory or ChatMemoryBuffer.from_defaults(
+            chat_history=chat_history, token_limit=llm.metadata.context_window - 256
+        )
 
         if system_prompt is not None:
             if prefix_messages is not None:


### PR DESCRIPTION
# Description

Adds optional system prompt param to `condense_plus_context` chat engine

Increases token limit for `context` chat engine, since the memory is also taking into account the system prompt

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
