### PR TITLE
refactor: list creation in weaviate.py for efficiency

### DIFF
--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -288,11 +288,16 @@ class WeaviateVectorStore(BasePydanticVectorStore):
         parsed_result = parse_get_response(query_result)
         entries = parsed_result[self.index_name]
 
-        similarities = [get_node_similarity(entry, similarity_key) for entry in entries]
-        nodes = [to_node(entry, text_key=self.text_key) for entry in entries]
+        similarities = []
+        nodes = []
+        node_idxs = []
 
-        nodes = nodes[: query.similarity_top_k]
-        node_idxs = [str(i) for i in range(len(nodes))]
+        for i, entry in enumerate(entries):
+            similarities.append(get_node_similarity(entry, similarity_key))
+
+            if i < query.similarity_top_k:
+                nodes.append(to_node(entry, text_key=self.text_key))
+                node_idxs.append(str(i))
 
         return VectorStoreQueryResult(
             nodes=nodes, ids=node_idxs, similarities=similarities

--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -293,11 +293,12 @@ class WeaviateVectorStore(BasePydanticVectorStore):
         node_idxs = []
 
         for i, entry in enumerate(entries):
-            similarities.append(get_node_similarity(entry, similarity_key))
-
             if i < query.similarity_top_k:
                 nodes.append(to_node(entry, text_key=self.text_key))
                 node_idxs.append(str(i))
+                similarities.append(get_node_similarity(entry, similarity_key))
+            else:
+                break
 
         return VectorStoreQueryResult(
             nodes=nodes, ids=node_idxs, similarities=similarities


### PR DESCRIPTION
This commit refactors the way the `similarities`, `nodes`, and `node_idxs` lists are created in the `weaviate.py` file.

Previously, these lists were created by iterating over all `entries`, and then the `nodes` list was sliced to keep only the first `query.similarity_top_k` elements.

In the refactored code, we only add to the `nodes` and `node_idxs` lists if the current index is less than `query.similarity_top_k`. This means we're only creating these lists with the first `query.similarity_top_k` elements to begin with, rather than creating them with all elements and then slicing.

Additionally, I have consolidated three iterations into a single loop.

This change should improve the efficiency of the code, especially when dealing with large `entries` lists.