### PR TITLE
add docstore to ingestion pipeline

### DIFF
--- a/llama_index/ingestion/pipeline.py
+++ b/llama_index/ingestion/pipeline.py
@@ -1,14 +1,20 @@
 import re
 from hashlib import sha256
+from pathlib import Path
 from typing import Any, List, Optional, Sequence
+
+from fsspec import AbstractFileSystem
 
 from llama_index.bridge.pydantic import BaseModel, Field
 from llama_index.embeddings.utils import resolve_embed_model
-from llama_index.ingestion.cache import IngestionCache
+from llama_index.ingestion.cache import DEFAULT_CACHE_NAME, IngestionCache
 from llama_index.node_parser import SentenceSplitter
 from llama_index.readers.base import ReaderConfig
 from llama_index.schema import BaseNode, Document, MetadataMode, TransformComponent
 from llama_index.service_context import ServiceContext
+from llama_index.storage.docstore import BaseDocumentStore, SimpleDocumentStore
+from llama_index.storage.storage_context import DOCSTORE_FNAME
+from llama_index.utils import concat_dirs
 from llama_index.vector_stores.types import BasePydanticVectorStore
 
 
@@ -124,7 +130,18 @@ class IngestionPipeline(BaseModel):
         default_factory=IngestionCache,
         description="Cache to use to store the data",
     )
+    docstore: Optional[BaseDocumentStore] = Field(
+        default=None,
+        description="Document store to use to store the data for de-duping",
+    )
+    dedup_key: Optional[str] = Field(
+        default=None,
+        description="Metadata key to use for de-duping documents. If not specified, will use the ref_doc_id.",
+    )
     disable_cache: bool = Field(default=False, description="Disable the cache")
+
+    class Config:
+        arbitrary_types_allowed = True
 
     def __init__(
         self,
@@ -133,6 +150,8 @@ class IngestionPipeline(BaseModel):
         documents: Optional[Sequence[Document]] = None,
         vector_store: Optional[BasePydanticVectorStore] = None,
         cache: Optional[IngestionCache] = None,
+        docstore: Optional[BaseDocumentStore] = None,
+        dedup_key: Optional[str] = None,
     ) -> None:
         if transformations is None:
             transformations = self._get_default_transformations()
@@ -143,6 +162,8 @@ class IngestionPipeline(BaseModel):
             documents=documents,
             vector_store=vector_store,
             cache=cache or IngestionCache(),
+            docstore=docstore,
+            dedup_key=dedup_key,
         )
 
     @classmethod
@@ -153,6 +174,8 @@ class IngestionPipeline(BaseModel):
         documents: Optional[Sequence[Document]] = None,
         vector_store: Optional[BasePydanticVectorStore] = None,
         cache: Optional[IngestionCache] = None,
+        docstore: Optional[BaseDocumentStore] = None,
+        dedup_key: Optional[str] = None,
     ) -> "IngestionPipeline":
         transformations = [
             *service_context.transformations,
@@ -165,7 +188,54 @@ class IngestionPipeline(BaseModel):
             documents=documents,
             vector_store=vector_store,
             cache=cache,
+            docstore=docstore,
+            dedup_key=dedup_key,
         )
+
+    def persist(
+        self,
+        persist_dir: str = "./pipeline_storage",
+        fs: Optional[AbstractFileSystem] = None,
+        cache_name: str = DEFAULT_CACHE_NAME,
+        docstore_name: str = DOCSTORE_FNAME,
+    ) -> None:
+        """Persist the pipeline to disk."""
+        if fs is not None:
+            persist_dir = str(persist_dir)  # NOTE: doesn't support Windows here
+            docstore_path = concat_dirs(persist_dir, docstore_name)
+            cache_path = concat_dirs(persist_dir, cache_name)
+
+        else:
+            persist_dir = Path(persist_dir)
+            docstore_path = str(persist_dir / docstore_name)
+            cache_path = str(persist_dir / cache_name)
+
+        self.cache.persist(cache_path, fs=fs)
+        if self.docstore is not None:
+            self.docstore.persist(docstore_path, fs=fs)
+
+    def load(
+        self,
+        persist_dir: str = "./pipeline_storage",
+        fs: Optional[AbstractFileSystem] = None,
+        cache_name: str = DEFAULT_CACHE_NAME,
+        docstore_name: str = DOCSTORE_FNAME,
+    ) -> None:
+        """Load the pipeline from disk."""
+        if fs is not None:
+            self.cache = IngestionCache.from_persist_path(
+                concat_dirs(persist_dir, cache_name), fs=fs
+            )
+            self.docstore = SimpleDocumentStore.from_persist_path(
+                concat_dirs(persist_dir, docstore_name), fs=fs
+            )
+        else:
+            self.cache = IngestionCache.from_persist_path(
+                str(Path(persist_dir) / cache_name)
+            )
+            self.docstore = SimpleDocumentStore.from_persist_path(
+                str(Path(persist_dir) / docstore_name)
+            )
 
     def _get_default_transformations(self) -> List[TransformComponent]:
         return [
@@ -173,15 +243,9 @@ class IngestionPipeline(BaseModel):
             resolve_embed_model("default"),
         ]
 
-    def run(
-        self,
-        show_progress: bool = False,
-        documents: Optional[List[Document]] = None,
-        nodes: Optional[List[BaseNode]] = None,
-        cache_collection: Optional[str] = None,
-        in_place: bool = True,
-        **kwargs: Any,
-    ) -> Sequence[BaseNode]:
+    def _prepare_inputs(
+        self, documents: Optional[List[Document]], nodes: Optional[List[BaseNode]]
+    ) -> List[Document]:
         input_nodes: List[BaseNode] = []
         if documents is not None:
             input_nodes += documents
@@ -195,8 +259,54 @@ class IngestionPipeline(BaseModel):
         if self.reader is not None:
             input_nodes += self.reader.read()
 
+        return input_nodes
+
+    def run(
+        self,
+        show_progress: bool = False,
+        documents: Optional[List[Document]] = None,
+        nodes: Optional[List[BaseNode]] = None,
+        cache_collection: Optional[str] = None,
+        in_place: bool = True,
+        **kwargs: Any,
+    ) -> Sequence[BaseNode]:
+        input_nodes = self._prepare_inputs(documents, nodes)
+
+        # check if we need to de-
+        nodes_to_run = []
+        if self.docstore is not None:
+            for node in input_nodes:
+                if self.dedup_key is not None:
+                    doc_key = str(node.metadata.get(self.dedup_key, None))
+                else:
+                    doc_key = node.ref_doc_id or node.id_
+
+                if doc_key and not self.docstore.document_exists(doc_key):
+                    # document doesn't exist, so add it
+                    self.docstore.add_documents(
+                        [node], allow_update=False, ref_doc_key=doc_key
+                    )
+                    self.docstore.set_document_hash(doc_key, node.hash)
+                    nodes_to_run.append(node)
+                elif doc_key and self.docstore.document_exists(doc_key):
+                    existing_hash = self.docstore.get_document_hash(doc_key)
+
+                    # update
+                    if existing_hash != node.hash:
+                        self.docstore.delete_ref_doc(doc_key, raise_error=False)
+
+                        if self.vector_store is not None:
+                            self.vector_store.delete(doc_key)
+
+                        self.docstore.add_documents([node], ref_doc_key=doc_key)
+                        self.docstore.set_document_hash(doc_key, node.hash)
+
+                        nodes_to_run.append(node)
+        else:
+            nodes_to_run = input_nodes
+
         nodes = run_transformations(
-            input_nodes,
+            nodes_to_run,
             self.transformations,
             show_progress=show_progress,
             cache=self.cache if not self.disable_cache else None,
@@ -219,18 +329,7 @@ class IngestionPipeline(BaseModel):
         in_place: bool = True,
         **kwargs: Any,
     ) -> Sequence[BaseNode]:
-        input_nodes: List[BaseNode] = []
-        if documents is not None:
-            input_nodes += documents
-
-        if nodes is not None:
-            input_nodes += nodes
-
-        if self.documents is not None:
-            input_nodes += self.documents
-
-        if self.reader is not None:
-            input_nodes += self.reader.read()
+        input_nodes = self._prepare_inputs(documents, nodes)
 
         nodes = await arun_transformations(
             input_nodes,

--- a/llama_index/storage/docstore/keyval_docstore.py
+++ b/llama_index/storage/docstore/keyval_docstore.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Optional, Sequence
 
-from llama_index.schema import BaseNode, TextNode
+from llama_index.schema import BaseNode
 from llama_index.storage.docstore.types import BaseDocumentStore, RefDocInfo
 from llama_index.storage.docstore.utils import doc_to_json, json_to_doc
 from llama_index.storage.kvstore.types import BaseKVStore
@@ -62,7 +62,10 @@ class KVDocumentStore(BaseDocumentStore):
         return {key: json_to_doc(json) for key, json in json_dict.items()}
 
     def add_documents(
-        self, nodes: Sequence[BaseNode], allow_update: bool = True
+        self,
+        nodes: Sequence[BaseNode],
+        allow_update: bool = True,
+        ref_doc_key: Optional[str] = None,
     ) -> None:
         """Add a document to the store.
 
@@ -84,20 +87,26 @@ class KVDocumentStore(BaseDocumentStore):
 
             # update doc_collection if needed
             metadata = {"doc_hash": node.hash}
-            if isinstance(node, TextNode) and node.ref_doc_id is not None:
-                ref_doc_info = self.get_ref_doc_info(node.ref_doc_id) or RefDocInfo()
+            ref_doc_id = (
+                metadata.get(ref_doc_key, None)
+                if ref_doc_key is not None
+                else node.ref_doc_id
+            )
+
+            if ref_doc_id is not None:
+                ref_doc_info = self.get_ref_doc_info(ref_doc_id) or RefDocInfo()
                 if node.node_id not in ref_doc_info.node_ids:
                     ref_doc_info.node_ids.append(node.node_id)
                 if not ref_doc_info.metadata:
                     ref_doc_info.metadata = node.metadata or {}
                 self._kvstore.put(
-                    node.ref_doc_id,
+                    ref_doc_id,
                     ref_doc_info.to_dict(),
                     collection=self._ref_doc_collection,
                 )
 
                 # update metadata with map
-                metadata["ref_doc_id"] = node.ref_doc_id
+                metadata["ref_doc_id"] = ref_doc_id
                 self._kvstore.put(
                     node_key, metadata, collection=self._metadata_collection
                 )
@@ -198,7 +207,10 @@ class KVDocumentStore(BaseDocumentStore):
             self._kvstore.delete(ref_doc_id, collection=self._metadata_collection)
 
     def delete_document(
-        self, doc_id: str, raise_error: bool = True, remove_ref_doc_node: bool = True
+        self,
+        doc_id: str,
+        raise_error: bool = True,
+        remove_ref_doc_node: bool = True,
     ) -> None:
         """Delete a document from the store."""
         if remove_ref_doc_node:

--- a/llama_index/storage/docstore/types.py
+++ b/llama_index/storage/docstore/types.py
@@ -38,7 +38,10 @@ class BaseDocumentStore(ABC):
 
     @abstractmethod
     def add_documents(
-        self, docs: Sequence[BaseNode], allow_update: bool = True
+        self,
+        docs: Sequence[BaseNode],
+        allow_update: bool = True,
+        ref_doc_key: str = None,
     ) -> None:
         ...
 

--- a/tests/ingestion/test_pipeline.py
+++ b/tests/ingestion/test_pipeline.py
@@ -5,6 +5,14 @@ from llama_index.llms import MockLLM
 from llama_index.node_parser import SentenceSplitter
 from llama_index.readers import ReaderConfig, StringIterableReader
 from llama_index.schema import Document
+from llama_index.storage.docstore import SimpleDocumentStore
+
+
+# clean up folders after tests
+def teardown_function() -> None:
+    import shutil
+
+    shutil.rmtree("./test_pipeline", ignore_errors=True)
 
 
 def test_build_pipeline() -> None:
@@ -39,3 +47,82 @@ def test_run_pipeline() -> None:
 
     assert len(nodes) == 2
     assert len(nodes[0].metadata) > 0
+
+
+def test_save_load_pipeline() -> None:
+    document1 = Document.example()
+    document1.doc_id = "1"
+
+    document2 = Document.example()
+    document2.doc_id = "2"
+
+    document3 = Document.example()
+    document3.doc_id = "1"
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    nodes = pipeline.run(documents=[document1])
+    assert len(nodes) == 19
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 1
+
+    nodes = pipeline.run(documents=[document2])
+    assert len(nodes) == 19
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 2
+
+    # dedup will catch the last set of nodes
+    nodes = pipeline.run(documents=[document3])
+    assert len(nodes) == 0
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 2
+
+    # test save/load
+    pipeline.persist("./test_pipeline")
+
+    pipeline2 = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+    )
+
+    pipeline2.load("./test_pipeline")
+
+    # dedup will catch the last set of nodes
+    nodes = pipeline.run(documents=[document3])
+    assert len(nodes) == 0
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 2
+
+
+def test_pipeline_update() -> None:
+    document1 = Document.example()
+    document1.doc_id = "1"
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    nodes = pipeline.run(documents=[document1])
+    assert len(nodes) == 19
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 1
+
+    # adjust document content
+    document1 = Document(text="test", doc_id="1")
+
+    # run pipeline again
+    nodes = pipeline.run(documents=[document1])
+
+    assert len(nodes) == 1
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 1
+    assert next(iter(pipeline.docstore.docs.values())).text == "test"  # type: ignore


### PR DESCRIPTION
# Description

Attempts to add a more customizable version of de-duping to the docstore.

Very much WIP right now, I'm open to scraping the idea, but it seems work initially :) 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## TODO

- [ ] Clean up logic
- [ ] More testing
- [ ] Add notebook / docs