### PR TITLE
add start-end char idx to node parser

### DIFF
--- a/llama_index/node_parser/interface.py
+++ b/llama_index/node_parser/interface.py
@@ -60,18 +60,30 @@ class NodeParser(TransformComponent, ABC):
         ) as event:
             nodes = self._parse_nodes(documents, show_progress=show_progress, **kwargs)
 
-            if self.include_metadata:
-                for node in nodes:
-                    if (
-                        node.ref_doc_id is not None
-                        and node.ref_doc_id in doc_id_to_document
-                    ):
+            for i, node in enumerate(nodes):
+                if (
+                    node.ref_doc_id is not None
+                    and node.ref_doc_id in doc_id_to_document
+                ):
+                    ref_doc = doc_id_to_document[node.ref_doc_id]
+                    start_char_idx = ref_doc.text.find(
+                        node.get_content(metadata_mode=MetadataMode.NONE)
+                    )
+
+                    # update start/end char idx
+                    if start_char_idx >= 0:
+                        node.start_char_idx = start_char_idx
+                        node.end_char_idx = start_char_idx + len(
+                            node.get_content(metadata_mode=MetadataMode.NONE)
+                        )
+
+                    # update metadata
+                    if self.include_metadata:
                         node.metadata.update(
                             doc_id_to_document[node.ref_doc_id].metadata
                         )
 
-            if self.include_prev_next_rel:
-                for i, node in enumerate(nodes):
+                if self.include_prev_next_rel:
                     if i > 0:
                         node.relationships[NodeRelationship.PREVIOUS] = nodes[
                             i - 1

--- a/tests/text_splitter/test_code_splitter.py
+++ b/tests/text_splitter/test_code_splitter.py
@@ -1,6 +1,8 @@
 """Test text splitter."""
 import os
+from typing import List
 
+from llama_index.schema import Document, MetadataMode, TextNode
 from llama_index.text_splitter import CodeSplitter
 
 
@@ -23,6 +25,26 @@ def baz():
     chunks = code_splitter.split_text(text)
     assert chunks[0].startswith("def foo():")
     assert chunks[1].startswith("def baz():")
+
+
+def test_start_end_char_idx() -> None:
+    text = """\
+def foo():
+    print("bar")
+
+def baz():
+    print("bbq")"""
+    document = Document(text=text)
+    code_splitter = CodeSplitter(
+        language="python", chunk_lines=4, chunk_lines_overlap=1, max_chars=30
+    )
+    nodes: List[TextNode] = code_splitter.get_nodes_from_documents([document])
+    for node in nodes:
+        assert node.start_char_idx is not None
+        assert node.end_char_idx is not None
+        assert node.end_char_idx - node.start_char_idx == len(
+            node.get_content(metadata_mode=MetadataMode.NONE)
+        )
 
 
 def test_typescript_code_splitter() -> None:

--- a/tests/text_splitter/test_sentence_splitter.py
+++ b/tests/text_splitter/test_sentence_splitter.py
@@ -1,5 +1,8 @@
+from typing import List
+
 import tiktoken
 from llama_index.node_parser.text import SentenceSplitter
+from llama_index.schema import Document, MetadataMode, TextNode
 
 
 def test_paragraphs() -> None:
@@ -10,6 +13,18 @@ def test_paragraphs() -> None:
     sentence_split = sentence_text_splitter.split_text(text)
     assert sentence_split[0] == " ".join(["foo"] * 15)
     assert sentence_split[1] == " ".join(["bar"] * 15)
+
+
+def test_start_end_char_idx() -> None:
+    document = Document(text=" ".join(["foo"] * 15) + "\n\n\n" + " ".join(["bar"] * 15))
+    text_splitter = SentenceSplitter(chunk_size=2, chunk_overlap=1)
+    nodes: List[TextNode] = text_splitter.get_nodes_from_documents([document])
+    for node in nodes:
+        assert node.start_char_idx is not None
+        assert node.end_char_idx is not None
+        assert node.end_char_idx - node.start_char_idx == len(
+            node.get_content(metadata_mode=MetadataMode.NONE)
+        )
 
 
 def test_sentences() -> None:

--- a/tests/text_splitter/test_token_splitter.py
+++ b/tests/text_splitter/test_token_splitter.py
@@ -1,7 +1,10 @@
 """Test text splitter."""
+from typing import List
+
 import tiktoken
 from llama_index.node_parser.text import TokenTextSplitter
 from llama_index.node_parser.text.utils import truncate_text
+from llama_index.schema import Document, MetadataMode, TextNode
 
 
 def test_split_token() -> None:
@@ -15,6 +18,18 @@ def test_split_token() -> None:
     text_splitter = TokenTextSplitter(chunk_size=2, chunk_overlap=1)
     chunks = text_splitter.split_text(token)
     assert chunks == ["foo bar", "bar hello", "hello world"]
+
+
+def test_start_end_char_idx() -> None:
+    document = Document(text="foo bar hello world baz bbq")
+    text_splitter = TokenTextSplitter(chunk_size=3, chunk_overlap=1)
+    nodes: List[TextNode] = text_splitter.get_nodes_from_documents([document])
+    for node in nodes:
+        assert node.start_char_idx is not None
+        assert node.end_char_idx is not None
+        assert node.end_char_idx - node.start_char_idx == len(
+            node.get_content(metadata_mode=MetadataMode.NONE)
+        )
 
 
 def test_truncate_token() -> None:


### PR DESCRIPTION
# Description

This actually seems pretty easy to bring this feature back, and seems to work reasonably well.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

