### PR TITLE
Fix and test chat memory get

### DIFF
--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -153,13 +153,13 @@ class ContextChatEngine(BaseChatEngine):
 
         context_str_template, nodes = self._generate_context(message)
         prefix_messages = self._get_prefix_messages_with_context(context_str_template)
-        initial_token_count = len(
+        prefix_messages_token_count = len(
             self._memory.tokenizer_fn(
                 " ".join([(m.content or "") for m in prefix_messages])
             )
         )
         all_messages = prefix_messages + self._memory.get(
-            initial_token_count=initial_token_count
+            initial_token_count=prefix_messages_token_count
         )
         chat_response = self._llm.chat(all_messages)
         ai_message = chat_response.message

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -88,7 +88,9 @@ class ChatMemoryBuffer(BaseMemory):
             raise ValueError("Initial token count exceeds token limit")
 
         message_count = len(self.chat_history)
-        token_count = self._token_count_for_message_count(message_count) + initial_token_count
+        token_count = (
+            self._token_count_for_message_count(message_count) + initial_token_count
+        )
 
         while token_count > self.token_limit and message_count > 1:
             message_count -= 1
@@ -98,7 +100,9 @@ class ChatMemoryBuffer(BaseMemory):
                 # we need to remove the assistant message too
                 message_count -= 1
 
-            token_count = self._token_count_for_message_count(message_count) + initial_token_count
+            token_count = (
+                self._token_count_for_message_count(message_count) + initial_token_count
+            )
 
         # catch one message longer than token limit
         if token_count > self.token_limit or message_count <= 0:

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -84,6 +84,9 @@ class ChatMemoryBuffer(BaseMemory):
 
     def get(self, initial_token_count: int = 0, **kwargs: Any) -> List[ChatMessage]:
         """Get chat history."""
+        if initial_token_count > self.token_limit:
+            raise ValueError("Initial token count exceeds token limit")
+
         message_count = len(self.chat_history)
         token_count = self._token_count_for_message_count(message_count) + initial_token_count
 

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -85,10 +85,7 @@ class ChatMemoryBuffer(BaseMemory):
     def get(self, initial_token_count: int = 0, **kwargs: Any) -> List[ChatMessage]:
         """Get chat history."""
         message_count = len(self.chat_history)
-        message_str = " ".join(
-            [str(m.content) for m in self.chat_history[-message_count:]]
-        )
-        token_count = initial_token_count + len(self.tokenizer_fn(message_str))
+        token_count = self._token_count_for_message_count(message_count) + initial_token_count
 
         while token_count > self.token_limit and message_count > 1:
             message_count -= 1
@@ -98,13 +95,10 @@ class ChatMemoryBuffer(BaseMemory):
                 # we need to remove the assistant message too
                 message_count -= 1
 
-            message_str = " ".join(
-                [str(m.content) for m in self.chat_history[-message_count:]]
-            )
-            token_count = initial_token_count + len(self.tokenizer_fn(message_str))
+            token_count = self._token_count_for_message_count(message_count) + initial_token_count
 
         # catch one message longer than token limit
-        if token_count > self.token_limit:
+        if token_count > self.token_limit or message_count <= 0:
             return []
 
         return self.chat_history[-message_count:]
@@ -124,3 +118,9 @@ class ChatMemoryBuffer(BaseMemory):
     def reset(self) -> None:
         """Reset chat history."""
         return self.chat_history.clear()
+
+    def _token_count_for_message_count(self, message_count):
+        if message_count <= 0:
+            return 0
+        msg_str = " ".join(str(m.content) for m in self.chat_history[-message_count:])
+        return len(self.tokenizer_fn(msg_str))

--- a/tests/memory/test_chat_memory_buffer.py
+++ b/tests/memory/test_chat_memory_buffer.py
@@ -1,38 +1,148 @@
 import pickle
+import pytest
 
 from llama_index.llms import ChatMessage, MessageRole
 from llama_index.memory.chat_memory_buffer import ChatMemoryBuffer
+from llama_index.utils import GlobalsHelper
 
-USER_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="test message")
-ASSISTANT_CHAT_MESSAGE = ChatMessage(role=MessageRole.ASSISTANT, content="test message")
+tokenizer = GlobalsHelper().tokenizer
+
+USER_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="first message")
+USER_CHAT_MESSAGE_TOKENS = len(tokenizer(USER_CHAT_MESSAGE.content))
+SECOND_USER_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="second message")
+SECOND_USER_CHAT_MESSAGE_TOKENS = len(tokenizer(SECOND_USER_CHAT_MESSAGE.content))
+ASSISTANT_CHAT_MESSAGE = ChatMessage(role=MessageRole.ASSISTANT, content="first answer")
+ASSISTANT_CHAT_MESSAGE_TOKENS = len(tokenizer(ASSISTANT_CHAT_MESSAGE.content))
+SECOND_ASSISTANT_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="second answer")
+SECOND_ASSISTANT_CHAT_MESSAGE_TOKENS = len(tokenizer(SECOND_ASSISTANT_CHAT_MESSAGE.content))
 
 
 def test_put_get() -> None:
-    memory = ChatMemoryBuffer.from_defaults()
+    # Given one message in the memory without limit
+    memory = ChatMemoryBuffer.from_defaults(
+        chat_history=[
+            USER_CHAT_MESSAGE])
 
-    memory.put(USER_CHAT_MESSAGE)
+    # When I get the chat history from the memory
+    history = memory.get()
 
-    assert len(memory.get()) == 1
-    assert memory.get()[0].content == USER_CHAT_MESSAGE.content
-
-
-def test_get_with_initial_tokens_less_than_limit() -> None:
-    memory = ChatMemoryBuffer.from_defaults(token_limit=1000)
-
-    memory.put(USER_CHAT_MESSAGE)
-
-    assert len(memory.get()) == 1
-    assert memory.get()[0].content == USER_CHAT_MESSAGE.content
+    # Then the history should contain the message
+    assert len(history) == 1
+    assert history[0].content == USER_CHAT_MESSAGE.content
 
 
-def test_get_with_initial_tokens_same_as_limit() -> None:
-    limit = 5
-    memory = ChatMemoryBuffer.from_defaults(token_limit=limit)
+def test_get_when_initial_tokens_less_than_limit_returns_history() -> None:
+    # Given some initial tokens much smaller than token_limit and message tokens
+    initial_tokens = 5
 
-    memory.put(USER_CHAT_MESSAGE)
-    memory.put(ASSISTANT_CHAT_MESSAGE)
+    # Given a user message
+    memory = ChatMemoryBuffer.from_defaults(
+        token_limit=1000,
+        chat_history=[
+            USER_CHAT_MESSAGE])
 
-    assert len(memory.get(limit-1)) == 0
+    # When I get the chat history from the memory
+    history = memory.get(initial_tokens)
+
+    # Then the history should contain the message
+    assert len(history) == 1
+    assert USER_CHAT_MESSAGE == history[0]
+
+
+def test_get_when_initial_tokens_exceed_limit_raises_value_error() -> None:
+    # Given some initial tokens exceeding token_limit
+    initial_tokens = 50
+    memory = ChatMemoryBuffer.from_defaults(token_limit=initial_tokens-1)
+
+    # When I get the chat history from the memory
+    with pytest.raises(ValueError) as error:
+        memory.get(initial_tokens)
+
+    # Then a value error should be raised
+    assert str(error.value) == "Initial token count exceeds token limit"
+
+
+def test_get_when_initial_tokens_same_as_limit_removes_message() -> None:
+    # Given some initial tokens equal to the token_limit
+    initial_tokens = 5
+
+    # Given a user message
+    memory = ChatMemoryBuffer.from_defaults(
+        token_limit=initial_tokens,
+        chat_history=[
+            USER_CHAT_MESSAGE])
+
+    # When I get the chat history from the memory
+    history = memory.get(initial_tokens)
+
+    # Then the history should be empty
+    assert len(history) == 0
+
+
+def test_get_when_space_for_assistant_message_removes_assistant_message_at_start_of_history() -> None:
+    # Given some initial tokens equal to the token_limit minus the user message
+    token_limit = 5
+    initial_tokens = token_limit - USER_CHAT_MESSAGE_TOKENS
+
+    # Given a user message and an assistant answer
+    memory = ChatMemoryBuffer.from_defaults(
+        token_limit=token_limit,
+        chat_history=[
+            USER_CHAT_MESSAGE,
+            ASSISTANT_CHAT_MESSAGE])
+
+    # When I get the chat history from the memory
+    history = memory.get(initial_tokens)
+
+    # Then the history should be empty
+    assert len(history) == 0
+
+
+def test_get_when_space_for_second_message_and_answer_removes_only_first_message_and_answer() -> None:
+    # Given some initial tokens equal to the token_limit minus one message and one answer
+    token_limit = 5
+    initial_tokens = token_limit - USER_CHAT_MESSAGE_TOKENS - ASSISTANT_CHAT_MESSAGE_TOKENS
+
+    # Given two user messages and two assistant answers
+    memory = ChatMemoryBuffer.from_defaults(
+        token_limit=token_limit,
+        chat_history=[
+            USER_CHAT_MESSAGE,
+            ASSISTANT_CHAT_MESSAGE,
+            SECOND_USER_CHAT_MESSAGE,
+            SECOND_ASSISTANT_CHAT_MESSAGE])
+
+    # When I get the chat history from the memory
+    history = memory.get(initial_tokens)
+
+    # Then the history should contain the second message and the second answer
+    assert len(history) == 2
+    assert SECOND_USER_CHAT_MESSAGE == history[0]
+    assert SECOND_ASSISTANT_CHAT_MESSAGE == history[1]
+
+
+def test_get_when_space_for_all_but_first_message_removes_first_message_and_answer() -> None:
+    # Given some initial tokens equal to the token_limit minus one message and one answer
+    token_limit = 10
+    history_tokens = ASSISTANT_CHAT_MESSAGE_TOKENS + USER_CHAT_MESSAGE_TOKENS + SECOND_ASSISTANT_CHAT_MESSAGE_TOKENS
+    initial_tokens = token_limit - history_tokens
+
+    # Given two user messages and two assistant answers
+    memory = ChatMemoryBuffer.from_defaults(
+        token_limit=token_limit,
+        chat_history=[
+            USER_CHAT_MESSAGE,
+            ASSISTANT_CHAT_MESSAGE,
+            SECOND_USER_CHAT_MESSAGE,
+            SECOND_ASSISTANT_CHAT_MESSAGE])
+
+    # When I get the chat history from the memory
+    history = memory.get(initial_tokens)
+
+    # Then the history should contain the second message and the second answer
+    assert len(history) == 2
+    assert SECOND_USER_CHAT_MESSAGE == history[0]
+    assert SECOND_ASSISTANT_CHAT_MESSAGE == history[1]
 
 
 def test_set() -> None:

--- a/tests/memory/test_chat_memory_buffer.py
+++ b/tests/memory/test_chat_memory_buffer.py
@@ -4,6 +4,7 @@ from llama_index.llms import ChatMessage, MessageRole
 from llama_index.memory.chat_memory_buffer import ChatMemoryBuffer
 
 USER_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="test message")
+ASSISTANT_CHAT_MESSAGE = ChatMessage(role=MessageRole.ASSISTANT, content="test message")
 
 
 def test_put_get() -> None:
@@ -23,13 +24,15 @@ def test_get_with_initial_tokens_less_than_limit() -> None:
     assert len(memory.get()) == 1
     assert memory.get()[0].content == USER_CHAT_MESSAGE.content
 
+
 def test_get_with_initial_tokens_same_as_limit() -> None:
     limit = 5
     memory = ChatMemoryBuffer.from_defaults(token_limit=limit)
 
     memory.put(USER_CHAT_MESSAGE)
+    memory.put(ASSISTANT_CHAT_MESSAGE)
 
-    assert len(memory.get(limit)) == 0
+    assert len(memory.get(limit-1)) == 0
 
 
 def test_set() -> None:

--- a/tests/memory/test_chat_memory_buffer.py
+++ b/tests/memory/test_chat_memory_buffer.py
@@ -3,38 +3,55 @@ import pickle
 from llama_index.llms import ChatMessage, MessageRole
 from llama_index.memory.chat_memory_buffer import ChatMemoryBuffer
 
-CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="test message")
+USER_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="test message")
 
 
 def test_put_get() -> None:
     memory = ChatMemoryBuffer.from_defaults()
 
-    memory.put(CHAT_MESSAGE)
+    memory.put(USER_CHAT_MESSAGE)
 
     assert len(memory.get()) == 1
-    assert memory.get()[0].content == CHAT_MESSAGE.content
+    assert memory.get()[0].content == USER_CHAT_MESSAGE.content
+
+
+def test_get_with_initial_tokens_less_than_limit() -> None:
+    memory = ChatMemoryBuffer.from_defaults(token_limit=1000)
+
+    memory.put(USER_CHAT_MESSAGE)
+
+    assert len(memory.get()) == 1
+    assert memory.get()[0].content == USER_CHAT_MESSAGE.content
+
+def test_get_with_initial_tokens_same_as_limit() -> None:
+    limit = 5
+    memory = ChatMemoryBuffer.from_defaults(token_limit=limit)
+
+    memory.put(USER_CHAT_MESSAGE)
+
+    assert len(memory.get(limit)) == 0
 
 
 def test_set() -> None:
-    memory = ChatMemoryBuffer.from_defaults(chat_history=[CHAT_MESSAGE])
+    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE])
 
-    memory.put(CHAT_MESSAGE)
+    memory.put(USER_CHAT_MESSAGE)
 
     assert len(memory.get()) == 2
 
-    memory.set([CHAT_MESSAGE])
+    memory.set([USER_CHAT_MESSAGE])
     assert len(memory.get()) == 1
 
 
 def test_max_tokens() -> None:
-    memory = ChatMemoryBuffer.from_defaults(chat_history=[CHAT_MESSAGE], token_limit=5)
+    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE], token_limit=5)
 
-    memory.put(CHAT_MESSAGE)
+    memory.put(USER_CHAT_MESSAGE)
     assert len(memory.get()) == 2
 
     # do we limit properly
-    memory.put(CHAT_MESSAGE)
-    memory.put(CHAT_MESSAGE)
+    memory.put(USER_CHAT_MESSAGE)
+    memory.put(USER_CHAT_MESSAGE)
     assert len(memory.get()) == 2
 
     # does get_all work
@@ -47,7 +64,7 @@ def test_max_tokens() -> None:
 
 
 def test_sting_save_load() -> None:
-    memory = ChatMemoryBuffer.from_defaults(chat_history=[CHAT_MESSAGE], token_limit=5)
+    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE], token_limit=5)
 
     json_str = memory.to_string()
 
@@ -58,7 +75,7 @@ def test_sting_save_load() -> None:
 
 
 def test_dict_save_load() -> None:
-    memory = ChatMemoryBuffer.from_defaults(chat_history=[CHAT_MESSAGE], token_limit=5)
+    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE], token_limit=5)
 
     json_dict = memory.to_dict()
 

--- a/tests/memory/test_chat_memory_buffer.py
+++ b/tests/memory/test_chat_memory_buffer.py
@@ -1,6 +1,6 @@
 import pickle
-import pytest
 
+import pytest
 from llama_index.llms import ChatMessage, MessageRole
 from llama_index.memory.chat_memory_buffer import ChatMemoryBuffer
 from llama_index.utils import GlobalsHelper
@@ -13,15 +13,17 @@ SECOND_USER_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="second me
 SECOND_USER_CHAT_MESSAGE_TOKENS = len(tokenizer(SECOND_USER_CHAT_MESSAGE.content))
 ASSISTANT_CHAT_MESSAGE = ChatMessage(role=MessageRole.ASSISTANT, content="first answer")
 ASSISTANT_CHAT_MESSAGE_TOKENS = len(tokenizer(ASSISTANT_CHAT_MESSAGE.content))
-SECOND_ASSISTANT_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="second answer")
-SECOND_ASSISTANT_CHAT_MESSAGE_TOKENS = len(tokenizer(SECOND_ASSISTANT_CHAT_MESSAGE.content))
+SECOND_ASSISTANT_CHAT_MESSAGE = ChatMessage(
+    role=MessageRole.USER, content="second answer"
+)
+SECOND_ASSISTANT_CHAT_MESSAGE_TOKENS = len(
+    tokenizer(SECOND_ASSISTANT_CHAT_MESSAGE.content)
+)
 
 
 def test_put_get() -> None:
     # Given one message in the memory without limit
-    memory = ChatMemoryBuffer.from_defaults(
-        chat_history=[
-            USER_CHAT_MESSAGE])
+    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE])
 
     # When I get the chat history from the memory
     history = memory.get()
@@ -37,22 +39,21 @@ def test_get_when_initial_tokens_less_than_limit_returns_history() -> None:
 
     # Given a user message
     memory = ChatMemoryBuffer.from_defaults(
-        token_limit=1000,
-        chat_history=[
-            USER_CHAT_MESSAGE])
+        token_limit=1000, chat_history=[USER_CHAT_MESSAGE]
+    )
 
     # When I get the chat history from the memory
     history = memory.get(initial_tokens)
 
     # Then the history should contain the message
     assert len(history) == 1
-    assert USER_CHAT_MESSAGE == history[0]
+    assert history[0] == USER_CHAT_MESSAGE
 
 
 def test_get_when_initial_tokens_exceed_limit_raises_value_error() -> None:
     # Given some initial tokens exceeding token_limit
     initial_tokens = 50
-    memory = ChatMemoryBuffer.from_defaults(token_limit=initial_tokens-1)
+    memory = ChatMemoryBuffer.from_defaults(token_limit=initial_tokens - 1)
 
     # When I get the chat history from the memory
     with pytest.raises(ValueError) as error:
@@ -68,9 +69,8 @@ def test_get_when_initial_tokens_same_as_limit_removes_message() -> None:
 
     # Given a user message
     memory = ChatMemoryBuffer.from_defaults(
-        token_limit=initial_tokens,
-        chat_history=[
-            USER_CHAT_MESSAGE])
+        token_limit=initial_tokens, chat_history=[USER_CHAT_MESSAGE]
+    )
 
     # When I get the chat history from the memory
     history = memory.get(initial_tokens)
@@ -79,7 +79,9 @@ def test_get_when_initial_tokens_same_as_limit_removes_message() -> None:
     assert len(history) == 0
 
 
-def test_get_when_space_for_assistant_message_removes_assistant_message_at_start_of_history() -> None:
+def test_get_when_space_for_assistant_message_removes_assistant_message_at_start_of_history() -> (
+    None
+):
     # Given some initial tokens equal to the token_limit minus the user message
     token_limit = 5
     initial_tokens = token_limit - USER_CHAT_MESSAGE_TOKENS
@@ -87,9 +89,8 @@ def test_get_when_space_for_assistant_message_removes_assistant_message_at_start
     # Given a user message and an assistant answer
     memory = ChatMemoryBuffer.from_defaults(
         token_limit=token_limit,
-        chat_history=[
-            USER_CHAT_MESSAGE,
-            ASSISTANT_CHAT_MESSAGE])
+        chat_history=[USER_CHAT_MESSAGE, ASSISTANT_CHAT_MESSAGE],
+    )
 
     # When I get the chat history from the memory
     history = memory.get(initial_tokens)
@@ -98,10 +99,14 @@ def test_get_when_space_for_assistant_message_removes_assistant_message_at_start
     assert len(history) == 0
 
 
-def test_get_when_space_for_second_message_and_answer_removes_only_first_message_and_answer() -> None:
+def test_get_when_space_for_second_message_and_answer_removes_only_first_message_and_answer() -> (
+    None
+):
     # Given some initial tokens equal to the token_limit minus one message and one answer
     token_limit = 5
-    initial_tokens = token_limit - USER_CHAT_MESSAGE_TOKENS - ASSISTANT_CHAT_MESSAGE_TOKENS
+    initial_tokens = (
+        token_limit - USER_CHAT_MESSAGE_TOKENS - ASSISTANT_CHAT_MESSAGE_TOKENS
+    )
 
     # Given two user messages and two assistant answers
     memory = ChatMemoryBuffer.from_defaults(
@@ -110,21 +115,29 @@ def test_get_when_space_for_second_message_and_answer_removes_only_first_message
             USER_CHAT_MESSAGE,
             ASSISTANT_CHAT_MESSAGE,
             SECOND_USER_CHAT_MESSAGE,
-            SECOND_ASSISTANT_CHAT_MESSAGE])
+            SECOND_ASSISTANT_CHAT_MESSAGE,
+        ],
+    )
 
     # When I get the chat history from the memory
     history = memory.get(initial_tokens)
 
     # Then the history should contain the second message and the second answer
     assert len(history) == 2
-    assert SECOND_USER_CHAT_MESSAGE == history[0]
-    assert SECOND_ASSISTANT_CHAT_MESSAGE == history[1]
+    assert history[0] == SECOND_USER_CHAT_MESSAGE
+    assert history[1] == SECOND_ASSISTANT_CHAT_MESSAGE
 
 
-def test_get_when_space_for_all_but_first_message_removes_first_message_and_answer() -> None:
+def test_get_when_space_for_all_but_first_message_removes_first_message_and_answer() -> (
+    None
+):
     # Given some initial tokens equal to the token_limit minus one message and one answer
     token_limit = 10
-    history_tokens = ASSISTANT_CHAT_MESSAGE_TOKENS + USER_CHAT_MESSAGE_TOKENS + SECOND_ASSISTANT_CHAT_MESSAGE_TOKENS
+    history_tokens = (
+        ASSISTANT_CHAT_MESSAGE_TOKENS
+        + USER_CHAT_MESSAGE_TOKENS
+        + SECOND_ASSISTANT_CHAT_MESSAGE_TOKENS
+    )
     initial_tokens = token_limit - history_tokens
 
     # Given two user messages and two assistant answers
@@ -134,15 +147,17 @@ def test_get_when_space_for_all_but_first_message_removes_first_message_and_answ
             USER_CHAT_MESSAGE,
             ASSISTANT_CHAT_MESSAGE,
             SECOND_USER_CHAT_MESSAGE,
-            SECOND_ASSISTANT_CHAT_MESSAGE])
+            SECOND_ASSISTANT_CHAT_MESSAGE,
+        ],
+    )
 
     # When I get the chat history from the memory
     history = memory.get(initial_tokens)
 
     # Then the history should contain the second message and the second answer
     assert len(history) == 2
-    assert SECOND_USER_CHAT_MESSAGE == history[0]
-    assert SECOND_ASSISTANT_CHAT_MESSAGE == history[1]
+    assert history[0] == SECOND_USER_CHAT_MESSAGE
+    assert history[1] == SECOND_ASSISTANT_CHAT_MESSAGE
 
 
 def test_set() -> None:
@@ -157,7 +172,9 @@ def test_set() -> None:
 
 
 def test_max_tokens() -> None:
-    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE], token_limit=5)
+    memory = ChatMemoryBuffer.from_defaults(
+        chat_history=[USER_CHAT_MESSAGE], token_limit=5
+    )
 
     memory.put(USER_CHAT_MESSAGE)
     assert len(memory.get()) == 2
@@ -177,7 +194,9 @@ def test_max_tokens() -> None:
 
 
 def test_sting_save_load() -> None:
-    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE], token_limit=5)
+    memory = ChatMemoryBuffer.from_defaults(
+        chat_history=[USER_CHAT_MESSAGE], token_limit=5
+    )
 
     json_str = memory.to_string()
 
@@ -188,7 +207,9 @@ def test_sting_save_load() -> None:
 
 
 def test_dict_save_load() -> None:
-    memory = ChatMemoryBuffer.from_defaults(chat_history=[USER_CHAT_MESSAGE], token_limit=5)
+    memory = ChatMemoryBuffer.from_defaults(
+        chat_history=[USER_CHAT_MESSAGE], token_limit=5
+    )
 
     json_dict = memory.to_dict()
 


### PR DESCRIPTION
# Description

- when getting the history from the chat memory buffer then it was possible to have more initial tokens (from long prefix messages) then the token limit. In this case now a value error is raised. 
- Also with negative index slicing the was the possibility that the message count is zero and the get resulting then inn returning the fully history instead of an empty one.
- Refactored method for better readibility
- added tests for "get" with given-when-then schema to test all aspects

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
