### PR TITLE
vector_stores/weaviate: run get_node_similarity before to_node

### DIFF
--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -294,9 +294,9 @@ class WeaviateVectorStore(BasePydanticVectorStore):
 
         for i, entry in enumerate(entries):
             if i < query.similarity_top_k:
+                similarities.append(get_node_similarity(entry, similarity_key))
                 nodes.append(to_node(entry, text_key=self.text_key))
                 node_idxs.append(str(i))
-                similarities.append(get_node_similarity(entry, similarity_key))
             else:
                 break
 


### PR DESCRIPTION
# Description

to_node pops `_additional` from the entry dict, thus get_node_similarity fails to find it later on. The fix is to execute get_node_similarity first and only then run to_node.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
