### PR TITLE
AsyncCallback Iterator To Stream Internal Events

### DIFF
--- a/examples/callbacks/async_iter.ipynb
+++ b/examples/callbacks/async_iter.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jordanparker/.pyenv/versions/3.9.13/lib/python3.9/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Parsing nodes: 100%|██████████| 1/1 [00:00<00:00, 253.80it/s]\n",
+      "Generating embeddings: 100%|██████████| 1/1 [00:00<00:00,  2.68it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../..\")\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "from llama_index.agent import OpenAIAgent\n",
+    "from llama_index.tools import QueryEngineTool, ToolMetadata\n",
+    "from llama_index.callbacks import CallbackManager\n",
+    "from llama_index.schema import Document\n",
+    "from llama_index.indices import VectorStoreIndex\n",
+    "from llama_index.callbacks.async_iter import AsyncIteratorCallbackHandler\n",
+    "\n",
+    "ignore_events = []\n",
+    "stream = AsyncIteratorCallbackHandler(\n",
+    "    event_starts_to_ignore=ignore_events,\n",
+    "    event_ends_to_ignore=ignore_events,\n",
+    "    verbose=False,\n",
+    ")\n",
+    "\n",
+    "callback_manager = CallbackManager(\n",
+    "    handlers=[stream],\n",
+    ")\n",
+    "\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    [\n",
+    "        Document(\n",
+    "            content=\"I went to the shops today.\",\n",
+    "            metadata={\"date\": \"2021-01-01\"},\n",
+    "        ),\n",
+    "    ],\n",
+    "    show_progress=True,\n",
+    ")\n",
+    "\n",
+    "tool = QueryEngineTool(\n",
+    "    query_engine=index.as_query_engine(),\n",
+    "    metadata=ToolMetadata(\n",
+    "        name=\"my_diary\",\n",
+    "        description=\"A tool for looking at my diary.\",\n",
+    "    ),\n",
+    ")\n",
+    "agent = OpenAIAgent.from_tools([tool], callback_manager=callback_manager, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'event': 'agent_step.start', 'event_id': 'ab8644d2-1004-4c42-a0fb-5529d14b07fa', 'parent_id': 'root'}\n",
+      "{\"event\": \"agent_step.start\", \"event_id\": \"ab8644d2-1004-4c42-a0fb-5529d14b07fa\", \"parent_id\": \"root\"}\n",
+      "STARTING TURN 1\n",
+      "---------------\n",
+      "\n",
+      "{'event': 'llm.start', 'event_id': 'f9bf90ca-78d2-4914-948c-86ee9ffe8000', 'parent_id': 'ab8644d2-1004-4c42-a0fb-5529d14b07fa'}\n",
+      "{\"event\": \"llm.start\", \"event_id\": \"f9bf90ca-78d2-4914-948c-86ee9ffe8000\", \"parent_id\": \"ab8644d2-1004-4c42-a0fb-5529d14b07fa\"}\n",
+      "{'event': 'llm.end', 'event_id': 'f9bf90ca-78d2-4914-948c-86ee9ffe8000', 'data': {<EventPayload.MESSAGES: 'messages'>: [ChatMessage(role=<MessageRole.USER: 'user'>, content='What did I do a week ago?', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='What did I do a week ago?', additional_kwargs={})], <EventPayload.RESPONSE: 'response'>: ChatResponse(message=ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content=None, additional_kwargs={'tool_calls': [ChatCompletionMessageToolCall(id='call_MEO00YE0ciwq94i8DRy9JNyr', function=Function(arguments='{\\n  \"input\": \"a week ago\"\\n}', name='my_diary'), type='function')]}), raw={'id': 'chatcmpl-8Pd3d3HjeGR6TXKZTgAVotzNjG7PK', 'choices': [Choice(finish_reason='tool_calls', index=0, message=ChatCompletionMessage(content=None, role='assistant', function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_MEO00YE0ciwq94i8DRy9JNyr', function=Function(arguments='{\\n  \"input\": \"a week ago\"\\n}', name='my_diary'), type='function')]))], 'created': 1701119029, 'model': 'gpt-3.5-turbo-0613', 'object': 'chat.completion', 'system_fingerprint': None, 'usage': CompletionUsage(completion_tokens=18, prompt_tokens=68, total_tokens=86)}, delta=None, additional_kwargs={})}}\n",
+      "{'event': 'agent_step.end', 'event_id': 'ab8644d2-1004-4c42-a0fb-5529d14b07fa'}\n",
+      "{\"event\": \"agent_step.end\", \"event_id\": \"ab8644d2-1004-4c42-a0fb-5529d14b07fa\"}\n"
+     ]
+    },
+    {
+     "ename": "TypeError",
+     "evalue": "Object of type ChatMessage is not JSON serializable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/Users/jordanparker/Programs/llama_index/examples/callbacks/async_iter.ipynb Cell 2\u001b[0m line \u001b[0;36m1\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/jordanparker/Programs/llama_index/examples/callbacks/async_iter.ipynb#W1sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m agent\u001b[39m.\u001b[39;49mchat(\u001b[39m\"\u001b[39;49m\u001b[39mWhat did I do a week ago?\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/callbacks/utils.py:44\u001b[0m, in \u001b[0;36mtrace_method.<locals>.decorator.<locals>.wrapper\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m     42\u001b[0m callback_manager \u001b[39m=\u001b[39m cast(CallbackManager, callback_manager)\n\u001b[1;32m     43\u001b[0m \u001b[39mwith\u001b[39;00m callback_manager\u001b[39m.\u001b[39mas_trace(trace_id):\n\u001b[0;32m---> 44\u001b[0m     \u001b[39mreturn\u001b[39;00m func(\u001b[39mself\u001b[39;49m, \u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/agent/openai_agent.py:438\u001b[0m, in \u001b[0;36mBaseOpenAIAgent.chat\u001b[0;34m(self, message, chat_history, tool_choice)\u001b[0m\n\u001b[1;32m    427\u001b[0m \u001b[39m@trace_method\u001b[39m(\u001b[39m\"\u001b[39m\u001b[39mchat\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    428\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mchat\u001b[39m(\n\u001b[1;32m    429\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    432\u001b[0m     tool_choice: Union[\u001b[39mstr\u001b[39m, \u001b[39mdict\u001b[39m] \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mauto\u001b[39m\u001b[39m\"\u001b[39m,\n\u001b[1;32m    433\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m AgentChatResponse:\n\u001b[1;32m    434\u001b[0m     \u001b[39mwith\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcallback_manager\u001b[39m.\u001b[39mevent(\n\u001b[1;32m    435\u001b[0m         CBEventType\u001b[39m.\u001b[39mAGENT_STEP,\n\u001b[1;32m    436\u001b[0m         payload\u001b[39m=\u001b[39m{EventPayload\u001b[39m.\u001b[39mMESSAGES: [message]},\n\u001b[1;32m    437\u001b[0m     ) \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 438\u001b[0m         chat_response \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_chat(\n\u001b[1;32m    439\u001b[0m             message, chat_history, tool_choice, mode\u001b[39m=\u001b[39;49mChatResponseMode\u001b[39m.\u001b[39;49mWAIT\n\u001b[1;32m    440\u001b[0m         )\n\u001b[1;32m    441\u001b[0m         \u001b[39massert\u001b[39;00m \u001b[39misinstance\u001b[39m(chat_response, AgentChatResponse)\n\u001b[1;32m    442\u001b[0m         e\u001b[39m.\u001b[39mon_end(payload\u001b[39m=\u001b[39m{EventPayload\u001b[39m.\u001b[39mRESPONSE: chat_response})\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/agent/openai_agent.py:360\u001b[0m, in \u001b[0;36mBaseOpenAIAgent._chat\u001b[0;34m(self, message, chat_history, tool_choice, mode)\u001b[0m\n\u001b[1;32m    356\u001b[0m     \u001b[39mprint\u001b[39m(\u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mSTARTING TURN \u001b[39m\u001b[39m{\u001b[39;00mix\u001b[39m}\u001b[39;00m\u001b[39m\\n\u001b[39;00m\u001b[39m---------------\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    357\u001b[0m llm_chat_kwargs \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_get_llm_chat_kwargs(\n\u001b[1;32m    358\u001b[0m     openai_tools, current_tool_choice\n\u001b[1;32m    359\u001b[0m )\n\u001b[0;32m--> 360\u001b[0m agent_chat_response \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_agent_response(mode\u001b[39m=\u001b[39;49mmode, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mllm_chat_kwargs)\n\u001b[1;32m    361\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_should_continue(\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mlatest_tool_calls, n_function_calls):\n\u001b[1;32m    362\u001b[0m     logger\u001b[39m.\u001b[39mdebug(\u001b[39m\"\u001b[39m\u001b[39mBreak: should continue False\u001b[39m\u001b[39m\"\u001b[39m)\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/agent/openai_agent.py:322\u001b[0m, in \u001b[0;36mBaseOpenAIAgent._get_agent_response\u001b[0;34m(self, mode, **llm_chat_kwargs)\u001b[0m\n\u001b[1;32m    318\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_get_agent_response\u001b[39m(\n\u001b[1;32m    319\u001b[0m     \u001b[39mself\u001b[39m, mode: ChatResponseMode, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mllm_chat_kwargs: Any\n\u001b[1;32m    320\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m AGENT_CHAT_RESPONSE_TYPE:\n\u001b[1;32m    321\u001b[0m     \u001b[39mif\u001b[39;00m mode \u001b[39m==\u001b[39m ChatResponseMode\u001b[39m.\u001b[39mWAIT:\n\u001b[0;32m--> 322\u001b[0m         chat_response: ChatResponse \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_llm\u001b[39m.\u001b[39;49mchat(\u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mllm_chat_kwargs)\n\u001b[1;32m    323\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_process_message(chat_response)\n\u001b[1;32m    324\u001b[0m     \u001b[39melif\u001b[39;00m mode \u001b[39m==\u001b[39m ChatResponseMode\u001b[39m.\u001b[39mSTREAM:\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/llms/base.py:208\u001b[0m, in \u001b[0;36mllm_chat_callback.<locals>.wrap.<locals>.wrapped_llm_chat\u001b[0;34m(_self, messages, **kwargs)\u001b[0m\n\u001b[1;32m    206\u001b[0m         \u001b[39mreturn\u001b[39;00m wrapped_gen()\n\u001b[1;32m    207\u001b[0m     \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 208\u001b[0m         callback_manager\u001b[39m.\u001b[39;49mon_event_end(\n\u001b[1;32m    209\u001b[0m             CBEventType\u001b[39m.\u001b[39;49mLLM,\n\u001b[1;32m    210\u001b[0m             payload\u001b[39m=\u001b[39;49m{\n\u001b[1;32m    211\u001b[0m                 EventPayload\u001b[39m.\u001b[39;49mMESSAGES: messages,\n\u001b[1;32m    212\u001b[0m                 EventPayload\u001b[39m.\u001b[39;49mRESPONSE: f_return_val,\n\u001b[1;32m    213\u001b[0m             },\n\u001b[1;32m    214\u001b[0m             event_id\u001b[39m=\u001b[39;49mevent_id,\n\u001b[1;32m    215\u001b[0m         )\n\u001b[1;32m    217\u001b[0m \u001b[39mreturn\u001b[39;00m f_return_val\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/callbacks/base.py:116\u001b[0m, in \u001b[0;36mCallbackManager.on_event_end\u001b[0;34m(self, event_type, payload, event_id, **kwargs)\u001b[0m\n\u001b[1;32m    114\u001b[0m \u001b[39mfor\u001b[39;00m handler \u001b[39min\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mhandlers:\n\u001b[1;32m    115\u001b[0m     \u001b[39mif\u001b[39;00m event_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m handler\u001b[39m.\u001b[39mevent_ends_to_ignore:\n\u001b[0;32m--> 116\u001b[0m         handler\u001b[39m.\u001b[39;49mon_event_end(event_type, payload, event_id\u001b[39m=\u001b[39;49mevent_id, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    118\u001b[0m \u001b[39mif\u001b[39;00m event_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m LEAF_EVENTS:\n\u001b[1;32m    119\u001b[0m     \u001b[39m# copy the stack trace to prevent conflicts with threads/coroutines\u001b[39;00m\n\u001b[1;32m    120\u001b[0m     current_trace_stack \u001b[39m=\u001b[39m global_stack_trace\u001b[39m.\u001b[39mget()\u001b[39m.\u001b[39mcopy()\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/callbacks/async_iter.py:74\u001b[0m, in \u001b[0;36mAsyncIteratorCallbackHandler.on_event_end\u001b[0;34m(self, event_type, payload, event_id, **kwargs)\u001b[0m\n\u001b[1;32m     72\u001b[0m     event[\u001b[39m\"\u001b[39m\u001b[39mdata\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m=\u001b[39m payload\n\u001b[1;32m     73\u001b[0m \u001b[39mprint\u001b[39m(event)\n\u001b[0;32m---> 74\u001b[0m event \u001b[39m=\u001b[39m superjson_dumps(event)\n\u001b[1;32m     75\u001b[0m \u001b[39mprint\u001b[39m(event)\n\u001b[1;32m     76\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mverbose:\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/callbacks/utils.py:87\u001b[0m, in \u001b[0;36msuperjson_dumps\u001b[0;34m(data)\u001b[0m\n\u001b[1;32m     86\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39msuperjson_dumps\u001b[39m(data):\n\u001b[0;32m---> 87\u001b[0m     \u001b[39mreturn\u001b[39;00m json\u001b[39m.\u001b[39;49mdumps(data, \u001b[39mcls\u001b[39;49m\u001b[39m=\u001b[39;49mSuperJSONEncoder)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.9.13/lib/python3.9/json/__init__.py:234\u001b[0m, in \u001b[0;36mdumps\u001b[0;34m(obj, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)\u001b[0m\n\u001b[1;32m    232\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mcls\u001b[39m \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    233\u001b[0m     \u001b[39mcls\u001b[39m \u001b[39m=\u001b[39m JSONEncoder\n\u001b[0;32m--> 234\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mcls\u001b[39;49m(\n\u001b[1;32m    235\u001b[0m     skipkeys\u001b[39m=\u001b[39;49mskipkeys, ensure_ascii\u001b[39m=\u001b[39;49mensure_ascii,\n\u001b[1;32m    236\u001b[0m     check_circular\u001b[39m=\u001b[39;49mcheck_circular, allow_nan\u001b[39m=\u001b[39;49mallow_nan, indent\u001b[39m=\u001b[39;49mindent,\n\u001b[1;32m    237\u001b[0m     separators\u001b[39m=\u001b[39;49mseparators, default\u001b[39m=\u001b[39;49mdefault, sort_keys\u001b[39m=\u001b[39;49msort_keys,\n\u001b[1;32m    238\u001b[0m     \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkw)\u001b[39m.\u001b[39;49mencode(obj)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.9.13/lib/python3.9/json/encoder.py:199\u001b[0m, in \u001b[0;36mJSONEncoder.encode\u001b[0;34m(self, o)\u001b[0m\n\u001b[1;32m    195\u001b[0m         \u001b[39mreturn\u001b[39;00m encode_basestring(o)\n\u001b[1;32m    196\u001b[0m \u001b[39m# This doesn't pass the iterator directly to ''.join() because the\u001b[39;00m\n\u001b[1;32m    197\u001b[0m \u001b[39m# exceptions aren't as detailed.  The list call should be roughly\u001b[39;00m\n\u001b[1;32m    198\u001b[0m \u001b[39m# equivalent to the PySequence_Fast that ''.join() would do.\u001b[39;00m\n\u001b[0;32m--> 199\u001b[0m chunks \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49miterencode(o, _one_shot\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m)\n\u001b[1;32m    200\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39misinstance\u001b[39m(chunks, (\u001b[39mlist\u001b[39m, \u001b[39mtuple\u001b[39m)):\n\u001b[1;32m    201\u001b[0m     chunks \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(chunks)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.9.13/lib/python3.9/json/encoder.py:257\u001b[0m, in \u001b[0;36mJSONEncoder.iterencode\u001b[0;34m(self, o, _one_shot)\u001b[0m\n\u001b[1;32m    252\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    253\u001b[0m     _iterencode \u001b[39m=\u001b[39m _make_iterencode(\n\u001b[1;32m    254\u001b[0m         markers, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdefault, _encoder, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mindent, floatstr,\n\u001b[1;32m    255\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mkey_separator, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mitem_separator, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39msort_keys,\n\u001b[1;32m    256\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mskipkeys, _one_shot)\n\u001b[0;32m--> 257\u001b[0m \u001b[39mreturn\u001b[39;00m _iterencode(o, \u001b[39m0\u001b[39;49m)\n",
+      "File \u001b[0;32m~/Programs/llama_index/examples/callbacks/../../llama_index/callbacks/utils.py:83\u001b[0m, in \u001b[0;36mSuperJSONEncoder.default\u001b[0;34m(self, o)\u001b[0m\n\u001b[1;32m     81\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(o, Generator):\n\u001b[1;32m     82\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m---> 83\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39msuper\u001b[39;49m()\u001b[39m.\u001b[39;49mdefault(o)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.9.13/lib/python3.9/json/encoder.py:179\u001b[0m, in \u001b[0;36mJSONEncoder.default\u001b[0;34m(self, o)\u001b[0m\n\u001b[1;32m    160\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mdefault\u001b[39m(\u001b[39mself\u001b[39m, o):\n\u001b[1;32m    161\u001b[0m     \u001b[39m\"\"\"Implement this method in a subclass such that it returns\u001b[39;00m\n\u001b[1;32m    162\u001b[0m \u001b[39m    a serializable object for ``o``, or calls the base implementation\u001b[39;00m\n\u001b[1;32m    163\u001b[0m \u001b[39m    (to raise a ``TypeError``).\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    177\u001b[0m \n\u001b[1;32m    178\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 179\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mTypeError\u001b[39;00m(\u001b[39mf\u001b[39m\u001b[39m'\u001b[39m\u001b[39mObject of type \u001b[39m\u001b[39m{\u001b[39;00mo\u001b[39m.\u001b[39m\u001b[39m__class__\u001b[39m\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m    180\u001b[0m                     \u001b[39mf\u001b[39m\u001b[39m'\u001b[39m\u001b[39mis not JSON serializable\u001b[39m\u001b[39m'\u001b[39m)\n",
+      "\u001b[0;31mTypeError\u001b[0m: Object of type ChatMessage is not JSON serializable"
+     ]
+    }
+   ],
+   "source": [
+    "agent.chat(\"What did I do a week ago?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async for event in stream.aiter():\n",
+    "    print(event)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/llama_index/callbacks/async_iter.py
+++ b/llama_index/callbacks/async_iter.py
@@ -39,12 +39,13 @@ class AsyncIteratorCallbackHandler(BaseCallbackHandler):
     ) -> str:
         """Run when an event starts and return id of event."""
         event = {
-            "event": event_type,
-            "data": payload,
+            "event": event_type + ".start",
             "event_id": event_id,
             "parent_id": parent_id,
         }
+        print(event)
         event = superjson_dumps(event)
+        print(event)
         if self.verbose:
             logger.debug(
                 event_type,
@@ -64,17 +65,20 @@ class AsyncIteratorCallbackHandler(BaseCallbackHandler):
     ) -> None:
         """Run when an event ends."""
         event = {
-            "event": event_type,
-            "data": payload,
+            "event": event_type + ".end",
             "event_id": event_id,
         }
+        if event_type not in [CBEventType.AGENT_STEP]:
+            event["data"] = payload
+        print(event)
         event = superjson_dumps(event)
+        print(event)
         if self.verbose:
             logger.debug(
                 event_type,
-                payload=payload,
-                event_id=event_id,
-                **kwargs,
+                # payload=payload,
+                # event_id=event_id,
+                # **kwargs,
             )
         self.queue.put_nowait(event)
 
@@ -98,7 +102,7 @@ class AsyncIteratorCallbackHandler(BaseCallbackHandler):
     ) -> None:
         """Run when an overall trace is exited."""
         event = {
-            "event": "trace.start",
+            "event": "trace.end",
             "trace_id": trace_id,
             "trace_map": trace_map,
         }

--- a/llama_index/callbacks/async_iter.py
+++ b/llama_index/callbacks/async_iter.py
@@ -109,6 +109,7 @@ class AsyncIteratorCallbackHandler(BaseCallbackHandler):
                 trace_map=trace_map,
             )
         self.queue.put_nowait(superjson_dumps(event))
+        self.done.set()
 
     async def aiter(self) -> AsyncIterator[str]:
         while not self.queue.empty() or not self.done.is_set():

--- a/llama_index/callbacks/async_iter.py
+++ b/llama_index/callbacks/async_iter.py
@@ -1,0 +1,139 @@
+import asyncio
+import logging
+from typing import Any, AsyncIterator, Dict, List, Literal, Optional, Union, cast
+
+from llama_index.callbacks.base_handler import BaseCallbackHandler
+from llama_index.callbacks.schema import CBEventType
+from llama_index.callbacks.utils import superjson_dumps
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncIteratorCallbackHandler(BaseCallbackHandler):
+    """Callback handler that returns an async iterator."""
+
+    queue: asyncio.Queue[str]
+    done: asyncio.Event
+
+    def __init__(
+        self,
+        event_starts_to_ignore: Optional[List[str]] = [],
+        event_ends_to_ignore: Optional[List[str]] = [],
+        verbose: Optional[bool] = True,
+    ) -> None:
+        super().__init__(
+            event_starts_to_ignore=event_starts_to_ignore,
+            event_ends_to_ignore=event_ends_to_ignore,
+        )
+        self.queue = asyncio.Queue()
+        self.done = asyncio.Event()
+        self.verbose = verbose
+
+    def on_event_start(
+        self,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]] = None,
+        event_id: str = "",
+        parent_id: str = "",
+        **kwargs: Any,
+    ) -> str:
+        """Run when an event starts and return id of event."""
+        event = {
+            "event": event_type,
+            "data": payload,
+            "event_id": event_id,
+            "parent_id": parent_id,
+        }
+        event = superjson_dumps(event)
+        if self.verbose:
+            logger.debug(
+                event_type,
+                payload=payload,
+                event_id=event_id,
+                parent_id=parent_id,
+                **kwargs,
+            )
+        self.queue.put_nowait(event)
+
+    def on_event_end(
+        self,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]] = None,
+        event_id: str = "",
+        **kwargs: Any,
+    ) -> None:
+        """Run when an event ends."""
+        event = {
+            "event": event_type,
+            "data": payload,
+            "event_id": event_id,
+        }
+        event = superjson_dumps(event)
+        if self.verbose:
+            logger.debug(
+                event_type,
+                payload=payload,
+                event_id=event_id,
+                **kwargs,
+            )
+        self.queue.put_nowait(event)
+
+    def start_trace(self, trace_id: Optional[str] = None) -> None:
+        """Run when an overall trace is launched."""
+        event = {
+            "event": "trace.start",
+            "trace_id": trace_id,
+        }
+        if self.verbose:
+            logger.debug(
+                "trace.start",
+                trace_id=trace_id,
+            )
+        self.queue.put_nowait(superjson_dumps(event))
+
+    def end_trace(
+        self,
+        trace_id: Optional[str] = None,
+        trace_map: Optional[Dict[str, List[str]]] = None,
+    ) -> None:
+        """Run when an overall trace is exited."""
+        event = {
+            "event": "trace.start",
+            "trace_id": trace_id,
+            "trace_map": trace_map,
+        }
+        if self.verbose:
+            logger.debug(
+                "trace.start",
+                trace_id=trace_id,
+                trace_map=trace_map,
+            )
+        self.queue.put_nowait(superjson_dumps(event))
+
+    async def aiter(self) -> AsyncIterator[str]:
+        while not self.queue.empty() or not self.done.is_set():
+            # Wait for the next token in the queue,
+            # but stop waiting if the done event is set
+            done, other = await asyncio.wait(
+                [
+                    # NOTE: If you add other tasks here, update the code below,
+                    # which assumes each set has exactly one task each
+                    asyncio.ensure_future(self.queue.get()),
+                    asyncio.ensure_future(self.done.wait()),
+                ],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            # Cancel the other task
+            if other:
+                other.pop().cancel()
+
+            # Extract the value of the first completed task
+            token_or_done = cast(Union[str, Literal[True]], done.pop().result())
+
+            # If the extracted value is the boolean True, the done event was set
+            if token_or_done is True:
+                break
+
+            # Otherwise, the extracted value is a token, which we yield
+            yield token_or_done

--- a/llama_index/callbacks/utils.py
+++ b/llama_index/callbacks/utils.py
@@ -1,6 +1,11 @@
 import asyncio
+import dataclasses
+import json
 import logging
+from datetime import date, datetime
 from typing import Any, Callable, cast
+
+from pydantic import BaseModel
 
 from llama_index.callbacks.base import CallbackManager
 
@@ -55,3 +60,26 @@ def trace_method(
         return async_wrapper if asyncio.iscoroutinefunction(func) else wrapper
 
     return decorator
+
+
+class SuperJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return self.default(dataclasses.asdict(o))
+        if isinstance(o, BaseModel):
+            return o.dict()
+        if isinstance(o, (datetime, date)):
+            return o.isoformat()
+        if isinstance(o, Exception):
+            return str(o)
+        if isinstance(o, str):
+            return o
+        if isinstance(o, list):
+            return [self.default(x) for x in o]
+        if isinstance(o, dict):
+            return {k: self.default(v) for k, v in o.items()}
+        return super().default(o)
+
+
+def superjson_dumps(data):
+    return json.dumps(data, cls=SuperJSONEncoder)

--- a/llama_index/callbacks/utils.py
+++ b/llama_index/callbacks/utils.py
@@ -3,7 +3,7 @@ import dataclasses
 import json
 import logging
 from datetime import date, datetime
-from typing import Any, Callable, cast
+from typing import Any, Callable, Generator, cast
 
 from pydantic import BaseModel
 
@@ -67,7 +67,7 @@ class SuperJSONEncoder(json.JSONEncoder):
         if dataclasses.is_dataclass(o):
             return self.default(dataclasses.asdict(o))
         if isinstance(o, BaseModel):
-            return o.dict()
+            return self.default(o.model_dump())
         if isinstance(o, (datetime, date)):
             return o.isoformat()
         if isinstance(o, Exception):
@@ -78,6 +78,8 @@ class SuperJSONEncoder(json.JSONEncoder):
             return [self.default(x) for x in o]
         if isinstance(o, dict):
             return {k: self.default(v) for k, v in o.items()}
+        if isinstance(o, Generator):
+            return None
         return super().default(o)
 
 


### PR DESCRIPTION
# Description

Llama Index should have an out-of-the-box callback that allows the user to stream all internal events through an async iterator. 

The current streaming misses all the internal events like tool usage and agent actions.

This async iterator should also stream token events as well.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This is still in draft and needs input and fixes.
