### PR TITLE
fix: llms.AzureOpenAI missing `azure_deployment` arg alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # ChangeLog
 
-## [0.9.8 - 2023-11-26
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Use `azure_deployment` kwarg in `AzureOpenAILLM` (#9174)
+
+## [0.9.8] - 2023-11-26
 
 ### New Features
 

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -79,11 +79,7 @@ class AzureOpenAI(OpenAI):
         **kwargs: Any,
     ) -> None:
         engine = resolve_from_aliases(
-            engine,
-            deployment_name,
-            deployment_id,
-            deployment,
-            azure_deployment
+            engine, deployment_name, deployment_id, deployment, azure_deployment
         )
 
         if engine is None:

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -83,6 +83,7 @@ class AzureOpenAI(OpenAI):
             deployment_name,
             deployment_id,
             deployment,
+            azure_deployment
         )
 
         if engine is None:


### PR DESCRIPTION
Fix for issue #9173 