### PR TITLE
Pass down attributes to underlying sentence splitter in Hierarchical node parser

### DIFF
--- a/llama_index/node_parser/relational/hierarchical.py
+++ b/llama_index/node_parser/relational/hierarchical.py
@@ -98,6 +98,8 @@ class HierarchicalNodeParser(NodeParser):
                     chunk_size=chunk_size,
                     callback_manager=callback_manager,
                     chunk_overlap=chunk_overlap,
+                    include_metadata=include_metadata,
+                    include_prev_next_rel=include_prev_next_rel,
                 )
         else:
             if chunk_sizes is not None:


### PR DESCRIPTION
# Description

Fixes https://github.com/run-llama/llama_index/issues/9175

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
