### PR TITLE
Error when git repository is listed in `requirements.txt`.

### DIFF
--- a/llama_index/readers/download.py
+++ b/llama_index/readers/download.py
@@ -15,6 +15,7 @@ from typing import List, Optional, Tuple, Type
 
 import pkg_resources
 import requests
+from packaging.requirements import InvalidRequirement
 from pkg_resources import DistributionNotFound
 
 from llama_index.readers.base import BaseReader
@@ -203,7 +204,7 @@ def download_loader(
                 Path(requirements_path).open()
             )
             pkg_resources.require([str(r) for r in requirements])
-        except DistributionNotFound:
+        except (DistributionNotFound, InvalidRequirement):
             subprocess.check_call(
                 [sys.executable, "-m", "pip", "install", "-r", requirements_path]
             )


### PR DESCRIPTION
# Description

## Background
When I contributed with Llama-Hub, there was a complication that I could not register a new pypi account,
I specified a git repository (git+https://github.com/HawkClaws/main_content_extractor.git) in `requirements.txt`.
At that time, the following error occurred


### error log

```log
Exception has occurred: InvalidRequirement       (note: full exception trace is shown but execution is paused at: _run_module_as_main)
Parse error at "'+https:/'": Expected string_end
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\pkg_resources\_vendor\packaging\requirements.py", line 102, in __init__
    req = REQUIREMENT.parseString(requirement_string)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\pkg_resources\_vendor\pyparsing\core.py", line 1141, in parse_string
    raise exc.with_traceback(None)
pkg_resources._vendor.pyparsing.exceptions.ParseException: Expected string_end, found '+'  (at char 3), (line:1, col:4)

During handling of the above exception, another exception occurred:

  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\pkg_resources\_vendor\packaging\requirements.py", line 104, in __init__
    raise InvalidRequirement(
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\pkg_resources\__init__.py", line 3102, in __init__
    super(Requirement, self).__init__(requirement_string)
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\llama_index\download\download_utils.py", line 231, in <listcomp>
    pkg_resources.require([str(r) for r in requirements])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\llama_index\download\download_utils.py", line 231, in download_module_and_reqs
    pkg_resources.require([str(r) for r in requirements])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\llama_index\download\download_utils.py", line 287, in download_llama_module
    download_module_and_reqs(
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\site-packages\llama_index\readers\download.py", line 44, in download_loader
    reader_cls = download_llama_module(
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\XXX\Desktop\TEST\main_content_extractor_test\reader_test.py", line 13, in <module>
    MainContentExtractorReader = download_loader("MainContentExtractorReader")
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "C:\Users\XXX\AppData\Local\Programs\Python\Python311\Lib\runpy.py", line 198, in _run_module_as_main (Current frame)
    return _run_code(code, main_globals, None,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pkg_resources.extern.packaging.requirements.InvalidRequirement: Parse error at "'+https:/'": Expected string_end
InvalidRequirement

```

## Fixes

The error occurs in the `pkg_resources.require` part of the following code in `download_utils.py

```python
        try:
            requirements = pkg_resources.parse_requirements(
                Path(requirements_path).open()
            )
            pkg_resources.require([str(r) for r in requirements])
        except (DistributionNotFound, InvalidRequirement):
            subprocess.check_call(
                [sys.executable, "-m", "pip", "install", "-r", requirements_path]
            )
```

The implementation seems to allow `git+https:hogehoge` as well, since it executes `pip install` in case of a `DistributionNotFound` exception, but the error when `git+https:hogehoge` is specified is `packaging.requirements.InvalidRequirement`.
So I fixed it to allow `InvalidRequirement` exceptions as well.


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
