### PR TITLE
Error during async streaming of OpenAIAgent & multi tool calls

### DIFF
--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -517,9 +517,9 @@ class OpenAI(LLM):
                     # check if the first chunk has neither content nor tool_calls
                     # this happens when 1106 models end up calling multiple tools
                     if (
-                        response.choices[0].delta.content is None
+                        first_chat_chunk
+                        and response.choices[0].delta.content is None
                         and response.choices[0].delta.tool_calls is None
-                        and first_chat_chunk
                     ):
                         first_chat_chunk = False
                         continue


### PR DESCRIPTION
# Description

Fixes #9205 
- The problem only affect openai async stream chatting _(when calling >1 tool)_.
- The changes are focused on one single function, to quickly fix this special problem.
- If the empty chunk is afterward removed by OpenAI, those changes will not be blocking.
 
Again, this is a fix for a situation only happening during **async streaming of an agent response containing multiple tool calls**.
It is meant to quickly fix that, to not have to wait for a bigger structural change that could fix this _(as the entire logic of the streaming response is to detect if the response will call tools or not)_.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This allows the code in #9205 to run normally.

- [x] I stared at the code and made sure it makes sense

# Checklist:

- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods
