### PR TITLE
Fix incorrect LLAMA_HUB_CONTENTS_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes / Nits
 
+- Fix bug in `download_utils.py` with pointing to wrong repo (#9215)
 - Use `azure_deployment` kwarg in `AzureOpenAILLM` (#9174)
 - Fix similarity score return for `AstraDBVectorStore` Integration (#9193)
 

--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -12,9 +12,7 @@ import pkg_resources
 import requests
 from pkg_resources import DistributionNotFound
 
-LLAMA_HUB_CONTENTS_URL = (
-    f"https://raw.githubusercontent.com/run-llama/llama-hub/datasets"
-)
+LLAMA_HUB_CONTENTS_URL = f"https://raw.githubusercontent.com/run-llama/llama-hub/main"
 LLAMA_HUB_PATH = "/llama_hub"
 LLAMA_HUB_URL = LLAMA_HUB_CONTENTS_URL + LLAMA_HUB_PATH
 


### PR DESCRIPTION
# Description

This PR fixes a bug that I introduced in `download_utils.py` when developing `LlamaDatasets`. I forgot to point the `LLAMA_HUB_URL` back to the correct branch, namely `main`.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
