### PR TITLE
Linking `OpenAILike` in doc's LLM Implementations

### DIFF
--- a/docs/api_reference/llms.rst
+++ b/docs/api_reference/llms.rst
@@ -14,20 +14,21 @@ LLM Implementations
    :maxdepth: 1
    :caption: LLM Implementations
 
-   llms/openai.rst
+   llms/anthropic.rst
    llms/azure_openai.rst
    llms/huggingface.rst
    llms/langchain.rst
-   llms/anthropic.rst
    llms/gradient_base_model.rst
    llms/gradient_model_adapter.rst
    llms/litellm.rst
    llms/llama_cpp.rst
+   llms/openai.rst
+   llms/openai_like.rst
+   llms/openllm.rst
    llms/palm.rst
    llms/predibase.rst
    llms/replicate.rst
    llms/xinference.rst
-   llms/openllm.rst
 
 LLM Interface
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description

https://github.com/run-llama/llama_index/pull/9151 added `openai_like.rst` but didn't link it.

Also, the list wasn't alphabetized, so I alphabetized it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
