### PR TITLE
Modify download_utils to allow for PDF downloads in extra_files

### DIFF
--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -28,13 +28,16 @@ LLAMA_RAG_DATASET_FILENAME = "rag_dataset.json"
 PATH_TYPE = Union[str, Path]
 
 
-def _get_file_content(loader_hub_url: str, path: str) -> Tuple[Union[str, bytes], int]:
+def _get_file_content(loader_hub_url: str, path: str) -> Tuple[str, int]:
     """Get the content of a file from the GitHub REST API."""
     resp = requests.get(loader_hub_url + path)
-    if ".pdf" in path:
-        return resp.content, resp.status_code
-    else:
-        return resp.text, resp.status_code
+    return resp.text, resp.status_code
+
+
+def _get_file_content_bytes(loader_hub_url: str, path: str) -> Tuple[bytes, int]:
+    """Get the content of a file from the GitHub REST API."""
+    resp = requests.get(loader_hub_url + path)
+    return resp.content, resp.status_code
 
 
 def get_exports(raw_content: str) -> List:
@@ -212,9 +215,14 @@ def download_module_and_reqs(
         else:
             extra_files_iterator = extra_files
         for extra_file in extra_files_iterator:
-            extra_file_raw_content, _ = _get_file_content(
-                str(remote_dir_path), f"/{module_id}/{extra_file}"
-            )
+            if ".pdf" in extra_file:
+                extra_file_raw_content, _ = _get_file_content_bytes(
+                    str(remote_dir_path), f"/{module_id}/{extra_file}"
+                )
+            else:
+                extra_file_raw_content, _ = _get_file_content(
+                    str(remote_dir_path), f"/{module_id}/{extra_file}"
+                )
             # If the extra file is an __init__.py file, we need to
             # add the exports to the __init__.py file in the modules directory
             if extra_file == "__init__.py":
@@ -230,6 +238,7 @@ def download_module_and_reqs(
                 with open(f"{module_path}/{extra_file}", "wb") as f:
                     f.write(extra_file_raw_content)
             else:
+                extra_file_raw_content = cast(str, extra_file_raw_content)
                 with open(f"{module_path}/{extra_file}", "w") as f:
                     f.write(extra_file_raw_content)
 

--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from importlib import util
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pkg_resources
 import requests
@@ -216,7 +216,7 @@ def download_module_and_reqs(
             extra_files_iterator = extra_files
         for extra_file in extra_files_iterator:
             if ".pdf" in extra_file:
-                extra_file_raw_content, _ = _get_file_content_bytes(
+                extra_file_raw_content_bytes, _ = _get_file_content_bytes(
                     str(remote_dir_path), f"/{module_id}/{extra_file}"
                 )
             else:
@@ -234,11 +234,9 @@ def download_module_and_reqs(
                 rewrite_exports(existing_exports + loader_exports, str(local_dir_path))
 
             if ".pdf" in extra_file:
-                extra_file_raw_content = cast(bytes, extra_file_raw_content)
                 with open(f"{module_path}/{extra_file}", "wb") as f:
-                    f.write(extra_file_raw_content)
+                    f.write(extra_file_raw_content_bytes)
             else:
-                extra_file_raw_content = cast(str, extra_file_raw_content)
                 with open(f"{module_path}/{extra_file}", "w") as f:
                     f.write(extra_file_raw_content)
 

--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from importlib import util
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import pkg_resources
 import requests
@@ -28,7 +28,7 @@ LLAMA_RAG_DATASET_FILENAME = "rag_dataset.json"
 PATH_TYPE = Union[str, Path]
 
 
-def _get_file_content(loader_hub_url: str, path: str) -> Tuple[str, int]:
+def _get_file_content(loader_hub_url: str, path: str) -> Tuple[Union[str, bytes], int]:
     """Get the content of a file from the GitHub REST API."""
     resp = requests.get(loader_hub_url + path)
     if ".pdf" in path:
@@ -226,6 +226,7 @@ def download_module_and_reqs(
                 rewrite_exports(existing_exports + loader_exports, str(local_dir_path))
 
             if ".pdf" in extra_file:
+                extra_file_raw_content = cast(bytes, extra_file_raw_content)
                 with open(f"{module_path}/{extra_file}", "wb") as f:
                     f.write(extra_file_raw_content)
             else:

--- a/llama_index/llama_dataset/download.py
+++ b/llama_index/llama_dataset/download.py
@@ -4,6 +4,7 @@ from llama_index import Document
 from llama_index.download.download_utils import (
     LLAMA_DATASETS_URL,
     LLAMA_HUB_URL,
+    LLAMA_RAG_DATASET_FILENAME,
     download_llama_module,
 )
 from llama_index.llama_dataset.base import BaseLlamaDataset
@@ -16,6 +17,7 @@ def download_llama_dataset(
     download_dir: str,
     llama_hub_url: str = LLAMA_HUB_URL,
     llama_datasets_url: str = LLAMA_DATASETS_URL,
+    show_progress: bool = False,
 ) -> Tuple[Type[BaseLlamaDataset], List[Document]]:
     """Download a single LlamaDataset from Llama Hub.
 
@@ -39,10 +41,13 @@ def download_llama_dataset(
         library_path="llama_datasets/library.json",
         disable_library_cache=True,
         override_path=True,
+        show_progress=show_progress,
     )
     rag_dataset_filename, source_filenames = filenames
 
     return (
         LabelledRagDataset.from_json(rag_dataset_filename),
-        SimpleDirectoryReader(input_files=source_filenames).load_data(),
+        SimpleDirectoryReader(
+            input_dir=download_dir, exclude=[LLAMA_RAG_DATASET_FILENAME, "__init__.py"]
+        ).load_data(show_progress=show_progress),
     )


### PR DESCRIPTION
# Description

Okay, this is getting a bit more hectic. Since `extra_files` is the catch all for all llama-hub artifact's associated files, we need to update this to allow for PDF file downloads as source documents for `LlamaDatasets` may be of this type.

- added ability to download PDF if they are included as `extra_files`
- added `show_progress` kwarg to allow user to see progress of downloading `extra_files` in `llama_dataset` download.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Works in my e2e notebooks for downloading llama datasets that have PDF source files
- [x] I stared at the code and made sure it makes sense
