### PR TITLE
add headers to openai embedding clients

### DIFF
--- a/llama_index/embeddings/azure_openai.py
+++ b/llama_index/embeddings/azure_openai.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional, Tuple
 
+import httpx
 from openai import AsyncAzureOpenAI, AzureOpenAI
 
 from llama_index.bridge.pydantic import Field, PrivateAttr, root_validator
@@ -24,6 +25,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
 
     _client: AzureOpenAI = PrivateAttr()
     _aclient: AsyncAzureOpenAI = PrivateAttr()
+    _http_client: Optional[httpx.Client] = PrivateAttr()
 
     def __init__(
         self,
@@ -39,6 +41,8 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
         deployment_name: Optional[str] = None,
         max_retries: int = 10,
         callback_manager: Optional[CallbackManager] = None,
+        # custom httpx client
+        http_client: Optional[httpx.Client] = None,
         **kwargs: Any,
     ):
         azure_endpoint = get_from_param_or_env(
@@ -49,6 +53,10 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             azure_deployment,
             deployment_name,
         )
+
+        # Use the custom httpx client if provided.
+        # Otherwise the value will be None.
+        self._http_client = http_client
 
         super().__init__(
             mode=mode,
@@ -91,6 +99,8 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
             "api_version": self.api_version,
+            "default_headers": self.default_headers,
+            "http_client": self._http_client,
         }
 
     @classmethod


### PR DESCRIPTION
# Description

Currently, we can add custom headers to `llama_index.llms.openai.OpenAI` (see [9082)](https://github.com/run-llama/llama_index/issues/9082) but not to `llama_index.embeddings.openai.OpenAIEmbedding`. I.e.

```
llm = AzureOpenAI(
    ...
    default_headers={
        'key': 'value',
    },
)
```
correctly works, while
```
embed_model = AzureOpenAIEmbedding(
    ...
    default_headers={
        'key': 'value',
    },
)
```
doesn't work.

This PR fixes that and allows users to add custom headers also while using embeddings.

Fixes # [9211](https://github.com/run-llama/llama_index/issues/9211)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x] I ran `make format; make lint` to appease the lint gods
