### PR TITLE
Added call to Llamahub proxy to track download numbers

### DIFF
--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -1,10 +1,10 @@
 """Download."""
-from enum import Enum
-import logging
 import json
+import logging
 import os
 import subprocess
 import sys
+from enum import Enum
 from importlib import util
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -29,11 +29,14 @@ PATH_TYPE = Union[str, Path]
 
 logger = logging.getLogger(__name__)
 LLAMAHUB_ANALYTICS_PROXY_SERVER = "https://llamahub.ai/api/analytics/downloads"
+
+
 class MODULE_TYPE(str, Enum):
     LOADER = "loader"
     TOOL = "tool"
     LLAMAPACK = "llamapack"
     DATASETS = "datasets"
+
 
 def _get_file_content(loader_hub_url: str, path: str) -> Tuple[str, int]:
     """Get the content of a file from the GitHub REST API."""
@@ -353,17 +356,19 @@ def download_llama_module(
         spec.loader.exec_module(module)  # type: ignore
 
         return getattr(module, module_class)
-    
-def track_download(
-    module_class: str,
-    module_type: str
-) -> None:
+
+
+def track_download(module_class: str, module_type: str) -> None:
     """Tracks number of downloads via Llamahub proxy.
+
     Args:
         module_class: The name of the llama module being downloaded, e.g.,`GmailOpenAIAgentPack`.
         module_type: Can be "loader", "tool", "llamapack", or "datasets"
     """
-    try: 
-        requests.post(LLAMAHUB_ANALYTICS_PROXY_SERVER, json={"type": module_type, "plugin": module_class})
-    except Exception as e: 
+    try:
+        requests.post(
+            LLAMAHUB_ANALYTICS_PROXY_SERVER,
+            json={"type": module_type, "plugin": module_class},
+        )
+    except Exception as e:
         logger.info(f"Error tracking downloads for {module_class} : {e}")

--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -7,6 +7,7 @@ import sys
 from importlib import util
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
+from enum import Enum
 
 import pkg_resources
 import requests
@@ -27,10 +28,10 @@ LLAMA_RAG_DATASET_FILENAME = "rag_dataset.json"
 PATH_TYPE = Union[str, Path]
 
 LLAMAHUB_ANALYTICS_PROXY_SERVER = "https://llamahub.ai/api/analytics/download"
-class MODULE_TYPE(Enum):
+class MODULE_TYPE(str, Enum):
     LOADER = "loader"
-    TOOL = "tool"
-    LLAMAHUB = "llamahub"
+    AGENT = "agent"
+    LLAMAPACK = "llamapack"
     DATASETS = "datasets"
 
 def _get_file_content(loader_hub_url: str, path: str) -> Tuple[str, int]:
@@ -362,6 +363,6 @@ def track_download(
         module_type: Can be "loader", "tool", "llamapack", or "datasets"
     """
     try: 
-        requests.post(LLAMAHUB_ANALYTICS_PROXY_SERVER, {"type": module_type, "plugin": module_class})
+        requests.post(LLAMAHUB_ANALYTICS_PROXY_SERVER, json={"type": module_type, "plugin": module_class})
     except: 
-        print(f"Error tracking downloads for {{module_class}}")
+        print(f"Error tracking downloads for {module_class}")

--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -26,6 +26,12 @@ LLAMA_RAG_DATASET_FILENAME = "rag_dataset.json"
 
 PATH_TYPE = Union[str, Path]
 
+LLAMAHUB_ANALYTICS_PROXY_SERVER = "https://llamahub.ai/api/analytics/download"
+class MODULE_TYPE(Enum):
+    LOADER = "loader"
+    TOOL = "tool"
+    LLAMAHUB = "llamahub"
+    DATASETS = "datasets"
 
 def _get_file_content(loader_hub_url: str, path: str) -> Tuple[str, int]:
     """Get the content of a file from the GitHub REST API."""
@@ -345,3 +351,17 @@ def download_llama_module(
         spec.loader.exec_module(module)  # type: ignore
 
         return getattr(module, module_class)
+    
+def track_download(
+    module_class: str,
+    module_type: str
+) -> None:
+    """Tracks number of downloads via Llamahub proxy
+    Args:
+        module_class: The name of the llama module being downloaded, e.g.,`GmailOpenAIAgentPack`.
+        module_type: Can be "loader", "tool", "llamapack", or "datasets"
+    """
+    try: 
+        requests.post(LLAMAHUB_ANALYTICS_PROXY_SERVER, {"type": module_type, "plugin": module_class})
+    except: 
+        print(f"Error tracking downloads for {{module_class}}")

--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -358,12 +358,12 @@ def track_download(
     module_class: str,
     module_type: str
 ) -> None:
-    """Tracks number of downloads via Llamahub proxy
+    """Tracks number of downloads via Llamahub proxy.
     Args:
         module_class: The name of the llama module being downloaded, e.g.,`GmailOpenAIAgentPack`.
         module_type: Can be "loader", "tool", "llamapack", or "datasets"
     """
     try: 
         requests.post(LLAMAHUB_ANALYTICS_PROXY_SERVER, json={"type": module_type, "plugin": module_class})
-    except: 
-        logger.info(f"Error tracking downloads for {module_class}")
+    except Exception as e: 
+        logger.info(f"Error tracking downloads for {module_class} : {e}")

--- a/llama_index/download/download_utils.py
+++ b/llama_index/download/download_utils.py
@@ -1,5 +1,6 @@
 """Download."""
-
+from enum import Enum
+import logging
 import json
 import os
 import subprocess
@@ -7,7 +8,6 @@ import sys
 from importlib import util
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
-from enum import Enum
 
 import pkg_resources
 import requests
@@ -27,10 +27,11 @@ LLAMA_RAG_DATASET_FILENAME = "rag_dataset.json"
 
 PATH_TYPE = Union[str, Path]
 
-LLAMAHUB_ANALYTICS_PROXY_SERVER = "https://llamahub.ai/api/analytics/download"
+logger = logging.getLogger(__name__)
+LLAMAHUB_ANALYTICS_PROXY_SERVER = "https://llamahub.ai/api/analytics/downloads"
 class MODULE_TYPE(str, Enum):
     LOADER = "loader"
-    AGENT = "agent"
+    TOOL = "tool"
     LLAMAPACK = "llamapack"
     DATASETS = "datasets"
 
@@ -365,4 +366,4 @@ def track_download(
     try: 
         requests.post(LLAMAHUB_ANALYTICS_PROXY_SERVER, json={"type": module_type, "plugin": module_class})
     except: 
-        print(f"Error tracking downloads for {module_class}")
+        logger.info(f"Error tracking downloads for {module_class}")

--- a/llama_index/llama_dataset/download.py
+++ b/llama_index/llama_dataset/download.py
@@ -4,9 +4,9 @@ from llama_index import Document
 from llama_index.download.download_utils import (
     LLAMA_DATASETS_URL,
     LLAMA_HUB_URL,
+    MODULE_TYPE,
     download_llama_module,
     track_download,
-    MODULE_TYPE
 )
 from llama_index.llama_dataset.base import BaseLlamaDataset
 from llama_index.llama_dataset.rag import LabelledRagDataset

--- a/llama_index/llama_dataset/download.py
+++ b/llama_index/llama_dataset/download.py
@@ -5,6 +5,8 @@ from llama_index.download.download_utils import (
     LLAMA_DATASETS_URL,
     LLAMA_HUB_URL,
     download_llama_module,
+    track_download,
+    MODULE_TYPE
 )
 from llama_index.llama_dataset.base import BaseLlamaDataset
 from llama_index.llama_dataset.rag import LabelledRagDataset
@@ -41,7 +43,7 @@ def download_llama_dataset(
         override_path=True,
     )
     rag_dataset_filename, source_filenames = filenames
-
+    track_download(llama_dataset_class, MODULE_TYPE.DATASETS)
     return (
         LabelledRagDataset.from_json(rag_dataset_filename),
         SimpleDirectoryReader(input_files=source_filenames).load_data(),

--- a/llama_index/llama_pack/download.py
+++ b/llama_index/llama_pack/download.py
@@ -37,5 +37,5 @@ def download_llama_pack(
     )
     if not issubclass(pack_cls, BaseLlamaPack):
         raise ValueError(f"Tool class {pack_cls} must be a subclass of BaseToolSpec.")
-    track_download(llama_pack_class, MODULE_TYPE.LLAMAHUB)
+    track_download(llama_pack_class, MODULE_TYPE.LLAMAPACK)
     return pack_cls

--- a/llama_index/llama_pack/download.py
+++ b/llama_index/llama_pack/download.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module
+from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module, track_download, MODULE_TYPE
 from llama_index.llama_pack.base import BaseLlamaPack
 
 
@@ -32,5 +32,5 @@ def download_llama_pack(
     )
     if not issubclass(pack_cls, BaseLlamaPack):
         raise ValueError(f"Tool class {pack_cls} must be a subclass of BaseToolSpec.")
-
+    track_download(llama_pack_class, MODULE_TYPE.LLAMAHUB)
     return pack_cls

--- a/llama_index/llama_pack/download.py
+++ b/llama_index/llama_pack/download.py
@@ -1,6 +1,11 @@
 from typing import Type
 
-from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module, track_download, MODULE_TYPE
+from llama_index.download.download_utils import (
+    LLAMA_HUB_URL,
+    MODULE_TYPE,
+    download_llama_module,
+    track_download,
+)
 from llama_index.llama_pack.base import BaseLlamaPack
 
 

--- a/llama_index/readers/download.py
+++ b/llama_index/readers/download.py
@@ -7,9 +7,8 @@ Please do `pip install llama-hub` instead.
 
 from typing import Optional, Type
 
-from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module
+from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module, track_download, MODULE_TYPE
 from llama_index.readers.base import BaseReader
-
 
 def download_loader(
     loader_class: str,
@@ -53,4 +52,5 @@ def download_loader(
         raise ValueError(
             f"Loader class {loader_class} must be a subclass of BaseReader."
         )
+    track_download(loader_class,MODULE_TYPE.LOADER)
     return reader_cls

--- a/llama_index/readers/download.py
+++ b/llama_index/readers/download.py
@@ -7,8 +7,14 @@ Please do `pip install llama-hub` instead.
 
 from typing import Optional, Type
 
-from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module, track_download, MODULE_TYPE
+from llama_index.download.download_utils import (
+    LLAMA_HUB_URL,
+    MODULE_TYPE,
+    download_llama_module,
+    track_download,
+)
 from llama_index.readers.base import BaseReader
+
 
 def download_loader(
     loader_class: str,
@@ -52,5 +58,5 @@ def download_loader(
         raise ValueError(
             f"Loader class {loader_class} must be a subclass of BaseReader."
         )
-    track_download(loader_class,MODULE_TYPE.LOADER)
+    track_download(loader_class, MODULE_TYPE.LOADER)
     return reader_cls

--- a/llama_index/tools/download.py
+++ b/llama_index/tools/download.py
@@ -34,5 +34,5 @@ def download_tool(
     )
     if not issubclass(tool_cls, BaseToolSpec):
         raise ValueError(f"Tool class {tool_class} must be a subclass of BaseToolSpec.")
-    track_download(tool_class, MODULE_TYPE.tool)
+    track_download(tool_class, MODULE_TYPE.AGENT)
     return tool_cls

--- a/llama_index/tools/download.py
+++ b/llama_index/tools/download.py
@@ -2,7 +2,12 @@
 
 from typing import Optional, Type
 
-from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module, track_download, MODULE_TYPE
+from llama_index.download.download_utils import (
+    LLAMA_HUB_URL,
+    MODULE_TYPE,
+    download_llama_module,
+    track_download,
+)
 from llama_index.tools.tool_spec.base import BaseToolSpec
 
 

--- a/llama_index/tools/download.py
+++ b/llama_index/tools/download.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Type
 
-from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module
+from llama_index.download.download_utils import LLAMA_HUB_URL, download_llama_module, track_download, MODULE_TYPE
 from llama_index.tools.tool_spec.base import BaseToolSpec
 
 
@@ -34,5 +34,5 @@ def download_tool(
     )
     if not issubclass(tool_cls, BaseToolSpec):
         raise ValueError(f"Tool class {tool_class} must be a subclass of BaseToolSpec.")
-
+    track_download(tool_class, MODULE_TYPE.tool)
     return tool_cls

--- a/llama_index/tools/download.py
+++ b/llama_index/tools/download.py
@@ -34,5 +34,5 @@ def download_tool(
     )
     if not issubclass(tool_cls, BaseToolSpec):
         raise ValueError(f"Tool class {tool_class} must be a subclass of BaseToolSpec.")
-    track_download(tool_class, MODULE_TYPE.AGENT)
+    track_download(tool_class, MODULE_TYPE.TOOL)
     return tool_cls


### PR DESCRIPTION
# Description
Added tracking code in following functions
* download_loader
* download_tool
* download_llama_pack
* download_lllama_datasets

Fixes # (issue)
NA 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Using python shell. Verified that Llama proxy is hit successfully & download count is updated for each of the four plugin types. 

# Todo
How can we track the downloads when download-utils is not called, i.e., when users directly imports a package.
