### PR TITLE
Fix node parser modules bug

### DIFF
--- a/docs/module_guides/loading/node_parsers/modules.md
+++ b/docs/module_guides/loading/node_parsers/modules.md
@@ -11,8 +11,9 @@ The simplest flow is to combine the `FlatFileReader` with the `SimpleFileNodePar
 ```python
 from llama_index.node_parser.file import SimpleFileNodeParser
 from llama_index.readers.file.flat_reader import FlatReader
+from pathlib import Path
 
-md_docs = FlatReader().load_data("./test.md")
+md_docs = FlatReader().load_data(Path("./test.md"))
 
 parser = SimpleFileNodeParser()
 md_nodes = parser.get_nodes_from_documents(md_docs)


### PR DESCRIPTION
# Description

Fix node parser modules bug

from pathlib import Path
md_docs = FlatReader().load_data(Path("./test.md"))
parser = SimpleFileNodeParser()
md_nodes =parser.get_nodes_from_documents(md_docs)

```text
--------------------------------------------------------------------------
llamaIndex_wk/demo/venv/lib/python3.9/site-packages/llama_index/readers/file/flat_reader.py:31)     metadata = {**metadata, **extra_info}

AttributeError: 'str' object has no attribute 'name'
```

docs/module_guides/loading/node_parsers/modules.md

```python
from llama_index.node_parser.file import SimpleFileNodeParser
from llama_index.readers.file.flat_reader import FlatReader
from pathlib import Path

md_docs = FlatReader().load_data("./test.md")
md_docs = FlatReader().load_data(Path("./test.md"))

parser = SimpleFileNodeParser()
md_nodes = parser.get_nodes_from_documents(md_docs)
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
