### PR TITLE
Improve `Vertex` hints

### DIFF
--- a/docs/examples/llm/vertex.ipynb
+++ b/docs/examples/llm/vertex.ipynb
@@ -9,10 +9,37 @@
     "## Installing Vertex AI \n",
     "To Install Vertex AI you need to follow the following steps\n",
     "* Install Vertex Cloud SDK (https://googleapis.dev/python/aiplatform/latest/index.html)\n",
-    "* Setup your Default Project , credentials , region\n",
+    "* Setup your Default Project, credentials, region\n",
+    "# Basic auth example for service account"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from llama_index.llms.vertex import Vertex\n",
+    "from google.oauth2 import service_account\n",
+    "\n",
+    "filename = \"vertex-407108-37495ce6c303.json\"\n",
+    "credentials: service_account.Credentials = service_account.Credentials.from_service_account_file(filename)\n",
+    "Vertex(model=\"text-bison\", project=credentials.project_id, credentials=credentials)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "3d42f4996210bdc7"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
     "## Basic Usage\n",
     "a Basic call to the text-bison model"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "119bbfb7d84a593d"
   },
   {
    "cell_type": "code",
@@ -33,7 +60,7 @@
    ],
    "source": [
     "from llama_index.llms.vertex import Vertex\n",
-    "from llama_index.llms.base import ChatMessage, MessageRole, CompletionResponse\n",
+    "from llama_index.llms.base import ChatMessage, MessageRole\n",
     "\n",
     "llm = Vertex(model=\"text-bison\", temperature=0, additional_kwargs={})\n",
     "llm.complete(\"Hello this is a sample text\").text"

--- a/docs/examples/llm/vertex.ipynb
+++ b/docs/examples/llm/vertex.ipynb
@@ -16,30 +16,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3d42f4996210bdc7",
+   "metadata": {},
    "outputs": [],
    "source": [
     "from llama_index.llms.vertex import Vertex\n",
     "from google.oauth2 import service_account\n",
     "\n",
     "filename = \"vertex-407108-37495ce6c303.json\"\n",
-    "credentials: service_account.Credentials = service_account.Credentials.from_service_account_file(filename)\n",
-    "Vertex(model=\"text-bison\", project=credentials.project_id, credentials=credentials)"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "3d42f4996210bdc7"
+    "credentials: service_account.Credentials = (\n",
+    "    service_account.Credentials.from_service_account_file(filename)\n",
+    ")\n",
+    "Vertex(\n",
+    "    model=\"text-bison\", project=credentials.project_id, credentials=credentials\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "119bbfb7d84a593d",
+   "metadata": {},
    "source": [
     "## Basic Usage\n",
     "a Basic call to the text-bison model"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "119bbfb7d84a593d"
+   ]
   },
   {
    "cell_type": "code",

--- a/llama_index/llms/vertex.py
+++ b/llama_index/llms/vertex.py
@@ -45,14 +45,14 @@ class Vertex(LLM):
         default=False, description="Flag to determine if current model is a Code Model"
     )
     _client: Any = PrivateAttr()
-    _chatclient: Any = PrivateAttr()
+    _chat_client: Any = PrivateAttr()
 
     def __init__(
         self,
         model: str = "text-bison",
         project: Optional[str] = None,
         location: Optional[str] = None,
-        credential: Optional[str] = None,
+        credentials: Optional[Any] = None,
         examples: Optional[Sequence[ChatMessage]] = None,
         temperature: float = 0.1,
         max_tokens: int = 512,
@@ -61,7 +61,7 @@ class Vertex(LLM):
         additional_kwargs: Optional[Dict[str, Any]] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
-        init_vertexai(project=project, location=location, credentials=credential)
+        init_vertexai(project=project, location=location, credentials=credentials)
 
         additional_kwargs = additional_kwargs or {}
         callback_manager = callback_manager or CallbackManager([])
@@ -69,11 +69,11 @@ class Vertex(LLM):
         if model in CHAT_MODELS:
             from vertexai.language_models import ChatModel
 
-            self._chatclient = ChatModel.from_pretrained(model)
+            self._chat_client = ChatModel.from_pretrained(model)
         elif model in CODE_CHAT_MODELS:
             from vertexai.language_models import CodeChatModel
 
-            self._chatclient = CodeChatModel.from_pretrained(model)
+            self._chat_client = CodeChatModel.from_pretrained(model)
             iscode = True
         elif model in CODE_MODELS:
             from vertexai.language_models import CodeGenerationModel
@@ -148,7 +148,7 @@ class Vertex(LLM):
             )
 
         generation = completion_with_retry(
-            client=self._chatclient,
+            client=self._chat_client,
             prompt=question,
             chat=True,
             stream=False,
@@ -195,7 +195,7 @@ class Vertex(LLM):
             )
 
         response = completion_with_retry(
-            client=self._chatclient,
+            client=self._chat_client,
             prompt=question,
             chat=True,
             stream=True,
@@ -267,7 +267,7 @@ class Vertex(LLM):
                 )
             )
         generation = await acompletion_with_retry(
-            client=self._chatclient,
+            client=self._chat_client,
             prompt=question,
             chat=True,
             params=chat_params,

--- a/llama_index/llms/vertex_utils.py
+++ b/llama_index/llms/vertex_utils.py
@@ -97,7 +97,7 @@ async def acompletion_with_retry(
 def init_vertexai(
     project: Optional[str] = None,
     location: Optional[str] = None,
-    credentials: Optional[str] = None,
+    credentials: Optional[Any] = None,
 ) -> None:
     """Init vertexai.
 


### PR DESCRIPTION
# Description

Refactor `Vertex` llm a little bit to have more correct typehints and naming the same as in client SDK.

**Motivation:**
I was testing Vertex from `llama_index` and then saw that there are wrong (non-similar with the original SDK) names and wrong typehints. That's what I changed. Also added auth example to the `.ipynb`, because only God knows how to do it correctly and with typehints.

## Type of Change

Breaking change in a way that argument name is changed: `credential` -> `credentials`

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Local tests run

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
