### PR TITLE
Handling the case where the response does not have a "usage" in the token counts function

### DIFF
--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -49,7 +49,7 @@ def get_llm_token_counts(
             messages_tokens = 0
             response_tokens = 0
 
-            if response.raw is not None:
+            if response is not None and response.raw is not None:
                 usage = response.raw.get("usage")  # type: ignore
 
                 if usage is not None:

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -46,29 +46,31 @@ def get_llm_token_counts(
 
         # try getting attached token counts first
         try:
-            usage = response.raw["usage"]  # type: ignore
-
             messages_tokens = 0
             response_tokens = 0
 
-            if usage is not None:
-                messages_tokens = usage.prompt_tokens
-                response_tokens = usage.completion_tokens
+            if response.raw is not None:
+                usage = response.raw.get("usage")  # type: ignore
 
-            if messages_tokens == 0 or response_tokens == 0:
-                raise ValueError("Invalid token counts!")
+                if usage is not None:
+                    messages_tokens = usage.prompt_tokens
+                    response_tokens = usage.completion_tokens
 
-            return TokenCountingEvent(
-                event_id=event_id,
-                prompt=messages_str,
-                prompt_token_count=messages_tokens,
-                completion=response_str,
-                completion_token_count=response_tokens,
-            )
+                if messages_tokens == 0 or response_tokens == 0:
+                    raise ValueError("Invalid token counts!")
+
+                return TokenCountingEvent(
+                    event_id=event_id,
+                    prompt=messages_str,
+                    prompt_token_count=messages_tokens,
+                    completion=response_str,
+                    completion_token_count=response_tokens,
+                )
 
         except (ValueError, KeyError):
             # Invalid token counts, or no token counts attached
             pass
+
 
         # Should count tokens ourselves
         messages_tokens = token_counter.estimate_tokens_in_messages(messages)

--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -71,7 +71,6 @@ def get_llm_token_counts(
             # Invalid token counts, or no token counts attached
             pass
 
-
         # Should count tokens ourselves
         messages_tokens = token_counter.estimate_tokens_in_messages(messages)
         response_tokens = token_counter.get_string_tokens(response_str)


### PR DESCRIPTION
# Description

To code is throwing an exception for "usage" is None when used with AWS Bedrock APIs , QueryFusionRetriever and CondensePlusContextChatEngine . Adjusted the logic to handle cases where "usage" is not be present.

Fixes # (issue) https://github.com/run-llama/llama_index/issues/9276

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
