### PR TITLE
Allow `delete_kwargs` in vector store, use them in WeaviateVectorStore

### DIFF
--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -292,7 +292,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         self, ref_doc_id: str, delete_from_docstore: bool = False, **delete_kwargs: Any
     ) -> None:
         """Delete a document and it's nodes by using ref_doc_id."""
-        self._vector_store.delete(ref_doc_id)
+        self._vector_store.delete(ref_doc_id, **delete_kwargs)
 
         # delete from index_struct only if needed
         if not self._vector_store.stores_text or self._store_nodes_override:

--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -208,6 +208,12 @@ class WeaviateVectorStore(BasePydanticVectorStore):
             "operator": "Equal",
             "valueText": ref_doc_id,
         }
+        if "filter" in delete_kwargs and delete_kwargs["filter"] is not None:
+            where_filter = {
+                "operator": "And",
+                "operands": [where_filter, delete_kwargs["filter"]],  # type: ignore
+            }
+
         query = (
             self._client.query.get(self.index_name)
             .with_additional(["id"])


### PR DESCRIPTION
# Description

This is something I needed to patch in order to implement a feature in an application I'm working on.

Use case: Protect documents not owned by a user from deletion. Ownership info was stored in Weaviate metadata.

"filter" param follows convention from the `query` method in `weaviate.py`.

Mypy complains:
```
llama_index/vector_stores/weaviate.py:214: error: List item 0 has incompatible type "Dict[str, Sequence[str]]"; expected "str"  [list-item]
```
I have silenced it as weaviate client lib says this:

```python
    def with_where(self, content: dict) -> "GetBuilder":
        """
        Set `where` filter.

        Parameters
        ----------
        content : dict
            The content of the `where` filter to set. See examples below.

        Examples
        --------
        The `content` prototype is like this:

        >>> content = {
        ...     'operator': '<operator>',
        ...     'operands': [
        ...         {
        ...             'path': [path],
        ...             'operator': '<operator>'
        ...             '<valueType>': <value>
        ...         },
        ...         {
        ...             'path': [<matchPath>],
        ...             'operator': '<operator>',
        ...             '<valueType>': <value>
        ...         }
        ...     ]
        ... }

```

Which matches what we have here.

If some testing / refinement is needed, please let me know.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

Passes tests in my app. Weaviate vector store in llamaindex doesn't seem to have extensive tests anyway at the moment?

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
