### PR TITLE
add resuse_client option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### New Features
+
+- Added an option `reuse_client` to openai/azure to help with async timeouts. Set to `False` to see improvements (#9301)
+
 ## [0.9.11] - 2023-12-03
 
 ### New Features

--- a/llama_index/embeddings/azure_openai.py
+++ b/llama_index/embeddings/azure_openai.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import httpx
 from openai import AsyncAzureOpenAI, AzureOpenAI
@@ -40,6 +40,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
         azure_deployment: Optional[str] = None,
         deployment_name: Optional[str] = None,
         max_retries: int = 10,
+        reuse_client: bool = True,
         callback_manager: Optional[CallbackManager] = None,
         # custom httpx client
         http_client: Optional[httpx.Client] = None,
@@ -68,6 +69,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             azure_endpoint=azure_endpoint,
             azure_deployment=azure_deployment,
             max_retries=max_retries,
+            reuse_client=reuse_client,
             callback_manager=callback_manager,
             **kwargs,
         )
@@ -88,10 +90,21 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
 
         return values
 
-    def _get_clients(self) -> Tuple[AzureOpenAI, AsyncAzureOpenAI]:
-        client = AzureOpenAI(**self._get_credential_kwargs())
-        aclient = AsyncAzureOpenAI(**self._get_credential_kwargs())
-        return client, aclient
+    def _get_client(self) -> AzureOpenAI:
+        if not self.reuse_client:
+            return AzureOpenAI(**self._get_credential_kwargs())
+
+        if self._client is None:
+            self._client = AzureOpenAI(**self._get_credential_kwargs())
+        return self._client
+
+    def _get_aclient(self) -> AsyncAzureOpenAI:
+        if not self.reuse_client:
+            return AsyncAzureOpenAI(**self._get_credential_kwargs())
+
+        if self._aclient is None:
+            self._aclient = AsyncAzureOpenAI(**self._get_credential_kwargs())
+        return self._aclient
 
     def _get_credential_kwargs(self) -> Dict[str, Any]:
         return {

--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -235,14 +235,21 @@ class OpenAIEmbedding(BaseEmbedding):
         default=10, description="Maximum number of retries.", gte=0
     )
     timeout: float = Field(default=60.0, description="Timeout for each request.", gte=0)
-    default_headers: Dict[str, str] = Field(
+    default_headers: Optional[Dict[str, str]] = Field(
         default=None, description="The default headers for API requests."
+    )
+    reuse_client: bool = Field(
+        default=True,
+        description=(
+            "Reuse the OpenAI client between requests. When doing anything with large "
+            "volumes of async API calls, setting this to false can improve stability.",
+        ),
     )
 
     _query_engine: OpenAIEmbeddingModeModel = PrivateAttr()
     _text_engine: OpenAIEmbeddingModeModel = PrivateAttr()
-    _client: OpenAI = PrivateAttr()
-    _aclient: AsyncOpenAI = PrivateAttr()
+    _client: Optional[OpenAI] = PrivateAttr()
+    _aclient: Optional[AsyncOpenAI] = PrivateAttr()
     _http_client: Optional[httpx.Client] = PrivateAttr()
 
     def __init__(
@@ -256,6 +263,7 @@ class OpenAIEmbedding(BaseEmbedding):
         api_version: Optional[str] = None,
         max_retries: int = 10,
         timeout: float = 60.0,
+        reuse_client: bool = True,
         callback_manager: Optional[CallbackManager] = None,
         default_headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.Client] = None,
@@ -280,25 +288,36 @@ class OpenAIEmbedding(BaseEmbedding):
         super().__init__(
             embed_batch_size=embed_batch_size,
             callback_manager=callback_manager,
-            model_name=model,
+            model_name=model_name,
             additional_kwargs=additional_kwargs,
             api_key=api_key,
             api_base=api_base,
             api_version=api_version,
             max_retries=max_retries,
+            reuse_client=reuse_client,
             timeout=timeout,
             default_headers=default_headers,
             **kwargs,
         )
 
-        self._http_client = http_client
-        # NOTE: init after super to use class attributes + helper function
-        self._client, self._aclient = self._get_clients()
+        self._client = None
+        self._aclient = None
 
-    def _get_clients(self) -> Tuple[OpenAI, AsyncOpenAI]:
-        client = OpenAI(**self._get_credential_kwargs())
-        aclient = AsyncOpenAI(**self._get_credential_kwargs())
-        return client, aclient
+    def _get_client(self) -> OpenAI:
+        if not self.reuse_client:
+            return OpenAI(**self._get_credential_kwargs())
+
+        if self._client is None:
+            self._client = OpenAI(**self._get_credential_kwargs())
+        return self._client
+
+    def _get_aclient(self) -> AsyncOpenAI:
+        if not self.reuse_client:
+            return AsyncOpenAI(**self._get_credential_kwargs())
+
+        if self._aclient is None:
+            self._aclient = AsyncOpenAI(**self._get_credential_kwargs())
+        return self._aclient
 
     @classmethod
     def class_name(cls) -> str:
@@ -316,8 +335,9 @@ class OpenAIEmbedding(BaseEmbedding):
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
+        client = self._get_client()
         return get_embedding(
-            self._client,
+            client,
             query,
             engine=self._query_engine,
             **self.additional_kwargs,
@@ -325,8 +345,9 @@ class OpenAIEmbedding(BaseEmbedding):
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
         """The asynchronous version of _get_query_embedding."""
+        aclient = self._get_aclient()
         return await aget_embedding(
-            self._aclient,
+            aclient,
             query,
             engine=self._query_engine,
             **self.additional_kwargs,
@@ -334,8 +355,9 @@ class OpenAIEmbedding(BaseEmbedding):
 
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
+        client = self._get_client()
         return get_embedding(
-            self._client,
+            client,
             text,
             engine=self._text_engine,
             **self.additional_kwargs,
@@ -343,8 +365,9 @@ class OpenAIEmbedding(BaseEmbedding):
 
     async def _aget_text_embedding(self, text: str) -> List[float]:
         """Asynchronously get text embedding."""
+        aclient = self._get_aclient()
         return await aget_embedding(
-            self._aclient,
+            aclient,
             text,
             engine=self._text_engine,
             **self.additional_kwargs,
@@ -357,8 +380,9 @@ class OpenAIEmbedding(BaseEmbedding):
         Can be overridden for batch queries.
 
         """
+        client = self._get_client()
         return get_embeddings(
-            self._client,
+            client,
             texts,
             engine=self._text_engine,
             **self.additional_kwargs,
@@ -366,8 +390,9 @@ class OpenAIEmbedding(BaseEmbedding):
 
     async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Asynchronously get text embeddings."""
+        aclient = self._get_aclient()
         return await aget_embeddings(
-            self._aclient,
+            aclient,
             texts,
             engine=self._text_engine,
             **self.additional_kwargs,

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -63,7 +63,7 @@ class AzureOpenAI(OpenAI):
         additional_kwargs: Optional[Dict[str, Any]] = None,
         max_retries: int = 3,
         timeout: float = 60.0,
-        reuse_client: bool = False,
+        reuse_client: bool = True,
         api_key: Optional[str] = None,
         api_version: Optional[str] = None,
         # azure specific

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import httpx
 from openai import AsyncAzureOpenAI
@@ -63,6 +63,7 @@ class AzureOpenAI(OpenAI):
         additional_kwargs: Optional[Dict[str, Any]] = None,
         max_retries: int = 3,
         timeout: float = 60.0,
+        reuse_client: bool = False,
         api_key: Optional[str] = None,
         api_version: Optional[str] = None,
         # azure specific
@@ -101,6 +102,7 @@ class AzureOpenAI(OpenAI):
             additional_kwargs=additional_kwargs,
             max_retries=max_retries,
             timeout=timeout,
+            reuse_client=reuse_client,
             api_key=api_key,
             azure_endpoint=azure_endpoint,
             azure_deployment=azure_deployment,
@@ -126,14 +128,25 @@ class AzureOpenAI(OpenAI):
 
         return values
 
-    def _get_clients(self, **kwargs: Any) -> Tuple[SyncAzureOpenAI, AsyncAzureOpenAI]:
-        client = SyncAzureOpenAI(
-            **self._get_credential_kwargs(),
-        )
-        aclient = AsyncAzureOpenAI(
-            **self._get_credential_kwargs(),
-        )
-        return client, aclient
+    def _get_client(self) -> SyncAzureOpenAI:
+        if not self.reuse_client:
+            return SyncAzureOpenAI(**self._get_credential_kwargs())
+
+        if self._client is None:
+            self._client = SyncAzureOpenAI(
+                **self._get_credential_kwargs(),
+            )
+        return self._client
+
+    def _get_aclient(self) -> AsyncAzureOpenAI:
+        if not self.reuse_client:
+            return AsyncAzureOpenAI(**self._get_credential_kwargs())
+
+        if self._aclient is None:
+            self._aclient = AsyncAzureOpenAI(
+                **self._get_credential_kwargs(),
+            )
+        return self._aclient
 
     def _get_credential_kwargs(self, **kwargs: Any) -> Dict[str, Any]:
         if self.use_azure_ad:

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -7,7 +7,6 @@ from typing import (
     Optional,
     Protocol,
     Sequence,
-    Tuple,
     cast,
     runtime_checkable,
 )
@@ -101,13 +100,20 @@ class OpenAI(LLM):
     default_headers: Dict[str, str] = Field(
         default=None, description="The default headers for API requests."
     )
+    reuse_client: bool = Field(
+        default=True,
+        description=(
+            "Reuse the OpenAI client between requests. When doing anything with large "
+            "volumes of async API calls, setting this to false can improve stability.",
+        ),
+    )
 
     api_key: str = Field(default=None, description="The OpenAI API key.", exclude=True)
     api_base: str = Field(description="The base URL for OpenAI API.")
     api_version: str = Field(description="The API version for OpenAI API.")
 
-    _client: SyncOpenAI = PrivateAttr()
-    _aclient: AsyncOpenAI = PrivateAttr()
+    _client: Optional[SyncOpenAI] = PrivateAttr()
+    _aclient: Optional[AsyncOpenAI] = PrivateAttr()
     _http_client: Optional[httpx.Client] = PrivateAttr()
 
     def __init__(
@@ -118,6 +124,7 @@ class OpenAI(LLM):
         additional_kwargs: Optional[Dict[str, Any]] = None,
         max_retries: int = 3,
         timeout: float = 60.0,
+        reuse_client: bool = True,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
@@ -145,17 +152,30 @@ class OpenAI(LLM):
             api_version=api_version,
             api_base=api_base,
             timeout=timeout,
+            reuse_client=reuse_client,
             default_headers=default_headers,
             **kwargs,
         )
 
+        self._client = None
+        self._aclient = None
         self._http_client = http_client
-        self._client, self._aclient = self._get_clients()
 
-    def _get_clients(self) -> Tuple[SyncOpenAI, AsyncOpenAI]:
-        client = SyncOpenAI(**self._get_credential_kwargs())
-        aclient = AsyncOpenAI(**self._get_credential_kwargs())
-        return client, aclient
+    def _get_client(self) -> SyncOpenAI:
+        if not self.reuse_client:
+            return SyncOpenAI(**self._get_credential_kwargs())
+
+        if self._client is None:
+            self._client = SyncOpenAI(**self._get_credential_kwargs())
+        return self._client
+
+    def _get_aclient(self) -> AsyncOpenAI:
+        if not self.reuse_client:
+            return AsyncOpenAI(**self._get_credential_kwargs())
+
+        if self._aclient is None:
+            self._aclient = AsyncOpenAI(**self._get_credential_kwargs())
+        return self._aclient
 
     def _get_model_name(self) -> str:
         model_name = self.model
@@ -250,8 +270,9 @@ class OpenAI(LLM):
         return {**base_kwargs, **self.additional_kwargs}
 
     def _chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        client = self._get_client()
         message_dicts = to_openai_message_dicts(messages)
-        response = self._client.chat.completions.create(
+        response = client.chat.completions.create(
             messages=message_dicts,
             stream=False,
             **self._get_model_kwargs(**kwargs),
@@ -314,6 +335,7 @@ class OpenAI(LLM):
     def _stream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
+        client = self._get_client()
         message_dicts = to_openai_message_dicts(messages)
 
         def gen() -> ChatResponseGen:
@@ -321,7 +343,7 @@ class OpenAI(LLM):
             tool_calls: List[ChoiceDeltaToolCall] = []
 
             is_function = False
-            for response in self._client.chat.completions.create(
+            for response in client.chat.completions.create(
                 messages=message_dicts,
                 stream=True,
                 **self._get_model_kwargs(**kwargs),
@@ -360,10 +382,11 @@ class OpenAI(LLM):
         return gen()
 
     def _complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        client = self._get_client()
         all_kwargs = self._get_model_kwargs(**kwargs)
         self._update_max_tokens(all_kwargs, prompt)
 
-        response = self._client.completions.create(
+        response = client.completions.create(
             prompt=prompt,
             stream=False,
             **all_kwargs,
@@ -376,12 +399,13 @@ class OpenAI(LLM):
         )
 
     def _stream_complete(self, prompt: str, **kwargs: Any) -> CompletionResponseGen:
+        client = self._get_client()
         all_kwargs = self._get_model_kwargs(**kwargs)
         self._update_max_tokens(all_kwargs, prompt)
 
         def gen() -> CompletionResponseGen:
             text = ""
-            for response in self._client.completions.create(
+            for response in client.completions.create(
                 prompt=prompt,
                 stream=True,
                 **all_kwargs,
@@ -483,8 +507,9 @@ class OpenAI(LLM):
     async def _achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponse:
+        aclient = self._get_aclient()
         message_dicts = to_openai_message_dicts(messages)
-        response = await self._aclient.chat.completions.create(
+        response = await aclient.chat.completions.create(
             messages=message_dicts, stream=False, **self._get_model_kwargs(**kwargs)
         )
         message_dict = response.choices[0].message
@@ -499,6 +524,7 @@ class OpenAI(LLM):
     async def _astream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
+        aclient = self._get_aclient()
         message_dicts = to_openai_message_dicts(messages)
 
         async def gen() -> ChatResponseAsyncGen:
@@ -507,7 +533,7 @@ class OpenAI(LLM):
 
             is_function = False
             first_chat_chunk = True
-            async for response in await self._aclient.chat.completions.create(
+            async for response in await aclient.chat.completions.create(
                 messages=message_dicts,
                 stream=True,
                 **self._get_model_kwargs(**kwargs),
@@ -556,10 +582,11 @@ class OpenAI(LLM):
         return gen()
 
     async def _acomplete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        aclient = self._get_aclient()
         all_kwargs = self._get_model_kwargs(**kwargs)
         self._update_max_tokens(all_kwargs, prompt)
 
-        response = await self._aclient.completions.create(
+        response = await aclient.completions.create(
             prompt=prompt,
             stream=False,
             **all_kwargs,
@@ -574,12 +601,13 @@ class OpenAI(LLM):
     async def _astream_complete(
         self, prompt: str, **kwargs: Any
     ) -> CompletionResponseAsyncGen:
+        aclient = self._get_aclient()
         all_kwargs = self._get_model_kwargs(**kwargs)
         self._update_max_tokens(all_kwargs, prompt)
 
         async def gen() -> CompletionResponseAsyncGen:
             text = ""
-            async for response in await self._aclient.completions.create(
+            async for response in await aclient.completions.create(
                 prompt=prompt,
                 stream=True,
                 **all_kwargs,


### PR DESCRIPTION
# Description

Frequent LLM/Embddings clients occur during async operation. Hypothesis is that this is due to sharing a single OpenAI client across all API calls.

Fix is to add an option that lets a new client be created for each API call

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

