### PR TITLE
update savepath name for FAISS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fixed save and load for faiss vector store (#9330)
+
 ## [0.9.12] - 2023-12-05
 
 ### New Features

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -13,6 +13,7 @@ import numpy as np
 from fsspec.implementations.local import LocalFileSystem
 
 from llama_index.schema import BaseNode
+from llama_index.vector_stores.simple import DEFAULT_VECTOR_STORE, NAMESPACE_SEP
 from llama_index.vector_stores.types import (
     DEFAULT_PERSIST_DIR,
     DEFAULT_PERSIST_FNAME,
@@ -22,6 +23,10 @@ from llama_index.vector_stores.types import (
 )
 
 logger = logging.getLogger()
+
+DEFAULT_PERSIST_PATH = os.path.join(
+    DEFAULT_PERSIST_DIR, f"{DEFAULT_VECTOR_STORE}{NAMESPACE_SEP}{DEFAULT_PERSIST_FNAME}"
+)
 
 
 class FaissVectorStore(VectorStore):
@@ -62,7 +67,10 @@ class FaissVectorStore(VectorStore):
         persist_dir: str = DEFAULT_PERSIST_DIR,
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "FaissVectorStore":
-        persist_path = os.path.join(persist_dir, DEFAULT_PERSIST_FNAME)
+        persist_path = os.path.join(
+            DEFAULT_PERSIST_DIR,
+            f"{DEFAULT_VECTOR_STORE}{NAMESPACE_SEP}{DEFAULT_PERSIST_FNAME}",
+        )
         # only support local storage for now
         if fs and not isinstance(fs, LocalFileSystem):
             raise NotImplementedError("FAISS only supports local storage for now.")
@@ -117,7 +125,7 @@ class FaissVectorStore(VectorStore):
 
     def persist(
         self,
-        persist_path: str = os.path.join(DEFAULT_PERSIST_DIR, DEFAULT_PERSIST_FNAME),
+        persist_path: str = DEFAULT_PERSIST_PATH,
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Save to file.


### PR DESCRIPTION
# Description

Faiss vector store was not using the correct default vector store name.

Fixes https://github.com/run-llama/llama_index/issues/9110

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

