### PR TITLE
Make OpenAIAgent compatible with OpenAILike

### DIFF
--- a/llama_index/agent/openai_agent.py
+++ b/llama_index/agent/openai_agent.py
@@ -20,7 +20,7 @@ from llama_index.chat_engine.types import (
 )
 from llama_index.llms.base import LLM, ChatMessage, ChatResponse, MessageRole
 from llama_index.llms.openai import OpenAI
-from llama_index.llms.openai_utils import OpenAIToolCall, is_function_calling_model
+from llama_index.llms.openai_utils import OpenAIToolCall
 from llama_index.memory import BaseMemory, ChatMemoryBuffer
 from llama_index.objects.base import ObjectRetriever
 from llama_index.tools import BaseTool, ToolOutput, adapt_to_async_tool
@@ -585,7 +585,7 @@ class OpenAIAgent(BaseOpenAIAgent):
 
         memory = memory or memory_cls.from_defaults(chat_history, llm=llm)
 
-        if not is_function_calling_model(llm.model):
+        if not llm.metadata.is_function_calling_model:
             raise ValueError(
                 f"Model name {llm.model} does not support function calling API. "
             )


### PR DESCRIPTION
# Description

I was using an OpenAILike LLM that supports function calling, but it was failing because this line depends specifically on certain OpenAI model names. It looks like `llm.metadata.is_function_calling_model` should be preferred for this check now, and it resolves the issue I was having.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
