### PR TITLE
Proposal : Update the evaluation correctness function to be more robust.

### DIFF
--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -148,7 +148,7 @@ class CorrectnessEvaluator(BaseEvaluator):
 
         # a regexp to remove the score from the response
         reasoning_str = re.sub(r"\[SCORE:(.*?)\]", "", eval_response)
-        reasoning = reasoning_str.lstrip("\n")
+        reasoning = re.sub(r"\[SCORE:(.*?)\]", "", eval_response).lstrip()
 
         return EvaluationResult(
             query=query,

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -1,5 +1,6 @@
 """Correctness evaluation."""
 import asyncio
+import re
 from typing import Any, Optional, Sequence, Union
 
 from llama_index.evaluation.base import BaseEvaluator, EvaluationResult
@@ -23,7 +24,7 @@ You are given the following information:
 
 Your job is to judge the relevance and correctness of the generated answer.
 Output a single score that represents a holistic evaluation.
-You must return your response in a line with only the score.
+You must return your response in a line with only the score using the format [SCORE:2.0].
 Do not return answers in any other format.
 On a separate line provide your reasoning for the score as well.
 
@@ -37,7 +38,7 @@ you should give a score between 2 and 3.
 you should give a score between 4 and 5.
 
 Example Response:
-4.0
+[SCORE:4.0]
 The generated answer has the exact same metrics as the reference answer, \
     but it is not as concise.
 
@@ -134,8 +135,19 @@ class CorrectnessEvaluator(BaseEvaluator):
         )
 
         # Extract from response
-        score_str, reasoning_str = eval_response.split("\n", 1)
+        print(eval_response)
+        # use a regexp to match [SCORE:0.2] in the response
+        match = re.search(r"\[SCORE:(.*?)\]", eval_response)
+        if match:
+            score_str = match.group(1)
+        else:
+            # no score found, maybe retry?
+            pass
+
         score = float(score_str)
+
+        # a regexp to remove the score from the response
+        reasoning_str = re.sub(r"\[SCORE:(.*?)\]", "", eval_response)
         reasoning = reasoning_str.lstrip("\n")
 
         return EvaluationResult(

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -38,7 +38,7 @@ you should give a score between 2 and 3.
 you should give a score between 4 and 5.
 
 Example Response:
-[SCORE:4.0]
+[SCORE:4.2]
 The generated answer has the exact same metrics as the reference answer, \
     but it is not as concise.
 

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -147,7 +147,6 @@ class CorrectnessEvaluator(BaseEvaluator):
         score = float(score_str)
 
         # a regexp to remove the score from the response
-        reasoning_str = re.sub(r"\[SCORE:(.*?)\]", "", eval_response)
         reasoning = re.sub(r"\[SCORE:(.*?)\]", "", eval_response).lstrip()
 
         return EvaluationResult(


### PR DESCRIPTION
# Description

Proposal : Update the evaluation correctness function to be more robust.

When using RagEvaluatorPack on a large dataset, sometime GPT3/4 will return a malformated answer, raising an error in correctness.py and interumpting the benchmark (that could be costly).

Such case emerge when the LLM :
 - prefix the answer with ```\n```
 - do not answer correctly such as: ```I'm not sure how to evaluate this case so I will say 3.0```
 - Something in the content made the LLM go off-road
 
To make the parsing more robust, I change the prompt to output the score in the form ```[SCORE:4.2]``` instead of only a number.

I then use a regexp to retrieve the score instead of assuming first line.

I use a regexp to remove the ```[SCORE:2.3]``` pattern from the llm answer to get a reasoning, without relying on line marker.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
