### PR TITLE
Make HuggingFaceInferenceAPIEmbedding return native floats instead of numpy's float32

### DIFF
--- a/llama_index/embeddings/huggingface.py
+++ b/llama_index/embeddings/huggingface.py
@@ -238,9 +238,9 @@ class HuggingFaceInferenceAPIEmbedding(HuggingFaceInferenceAPI, BaseEmbedding): 
     async def _async_embed_single(self, text: str) -> Embedding:
         embedding = (await self._async_client.feature_extraction(text)).squeeze(axis=0)
         if len(embedding.shape) == 1:  # Some models pool internally
-            return list(embedding)
+            return embedding.tolist()
         try:
-            return list(self.pooling(embedding))  # type: ignore[misc]
+            return self.pooling(embedding).tolist()  # type: ignore[misc]
         except TypeError as exc:
             raise ValueError(
                 f"Pooling is required for {self.model_name} because it returned"

--- a/tests/embeddings/test_huggingface.py
+++ b/tests/embeddings/test_huggingface.py
@@ -42,7 +42,9 @@ class TestHuggingFaceInferenceAPIEmbeddings:
     def test_embed_query(
         self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
     ) -> None:
-        raw_single_embedding = np.random.rand(1, 3, 1024)
+        raw_single_embedding = np.random.default_rng().random(
+            (1, 3, 1024), dtype=np.float32
+        )
 
         hf_inference_api_embedding.pooling = Pooling.CLS
         with patch.object(
@@ -53,6 +55,7 @@ class TestHuggingFaceInferenceAPIEmbeddings:
             embedding = hf_inference_api_embedding.get_query_embedding("test")
         assert isinstance(embedding, list)
         assert len(embedding) == 1024
+        assert isinstance(embedding[0], float)
         assert np.all(
             np.array(embedding, dtype=raw_single_embedding.dtype)
             == raw_single_embedding[0, 0]
@@ -68,6 +71,7 @@ class TestHuggingFaceInferenceAPIEmbeddings:
             embedding = hf_inference_api_embedding.get_query_embedding("test")
         assert isinstance(embedding, list)
         assert len(embedding) == 1024
+        assert isinstance(embedding[0], float)
         assert np.all(
             np.array(embedding, dtype=raw_single_embedding.dtype)
             == raw_single_embedding[0].mean(axis=0)


### PR DESCRIPTION
Fix #9386

# Description

Make HuggingFaceInferenceAPIEmbedding return native floats instead of numpy's float32

Fixes #9386

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
