### PR TITLE
Fix HuggingFaceInferenceAPIEmbedding with sentence transformers

### DIFF
--- a/llama_index/embeddings/huggingface.py
+++ b/llama_index/embeddings/huggingface.py
@@ -236,7 +236,10 @@ class HuggingFaceInferenceAPIEmbedding(HuggingFaceInferenceAPI, BaseEmbedding): 
         return "HuggingFaceInferenceAPIEmbedding"
 
     async def _async_embed_single(self, text: str) -> Embedding:
-        embedding = (await self._async_client.feature_extraction(text)).squeeze(axis=0)
+        embedding = await self._async_client.feature_extraction(text)
+        if len(embedding.shape) == 1:
+            return embedding.tolist()
+        embedding = embedding.squeeze(axis=0)
         if len(embedding.shape) == 1:  # Some models pool internally
             return embedding.tolist()
         try:

--- a/tests/embeddings/test_huggingface.py
+++ b/tests/embeddings/test_huggingface.py
@@ -78,6 +78,26 @@ class TestHuggingFaceInferenceAPIEmbeddings:
         )
         mock_feature_extraction.assert_awaited_once_with("test")
 
+    def test_embed_query_one_dimension(
+        self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
+    ) -> None:
+        raw_single_embedding = np.random.default_rng().random(1024, dtype=np.float32)
+
+        with patch.object(
+            hf_inference_api_embedding._async_client,
+            "feature_extraction",
+            AsyncMock(return_value=raw_single_embedding),
+        ) as mock_feature_extraction:
+            embedding = hf_inference_api_embedding.get_query_embedding("test")
+        assert isinstance(embedding, list)
+        assert len(embedding) == 1024
+        assert isinstance(embedding[0], float)
+        assert np.all(
+            np.array(embedding, dtype=raw_single_embedding.dtype)
+            == raw_single_embedding
+        )
+        mock_feature_extraction.assert_awaited_once_with("test")
+
     def test_serialization(
         self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
     ) -> None:


### PR DESCRIPTION
# Description

Huggingface inference API used with sentence transformers such as `sentence-transformers/all-MiniLM-l6-v2` returns a one dimension np.array.
Currently it makes `_async_embed_single` fail because `squeeze(axis=0)` is called on that array.
The change is to return the array directly if it has only one dimension.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
