### PR TITLE
Fix result of BedrockEmbedding with Cohere model

### DIFF
--- a/llama_index/embeddings/bedrock.py
+++ b/llama_index/embeddings/bedrock.py
@@ -27,10 +27,10 @@ class Models(str, Enum):
 
 PROVIDER_SPECIFIC_IDENTIFIERS = {
     PROVIDERS.AMAZON.value: {
-        "embeddings": "embedding",
+        "get_embeddings_func": lambda r: r.get("embedding"),
     },
     PROVIDERS.COHERE.value: {
-        "embeddings": "embeddings",
+        "get_embeddings_func": lambda r: r.get("embeddings")[0],
     },
 }
 
@@ -215,7 +215,7 @@ class BedrockEmbedding(BaseEmbedding):
         identifiers = PROVIDER_SPECIFIC_IDENTIFIERS.get(provider, None)
         if identifiers is None:
             raise ValueError("Provider not supported")
-        return resp.get(identifiers.get("embeddings"))
+        return identifiers["get_embeddings_func"](resp)
 
     def _get_query_embedding(self, query: str) -> Embedding:
         return self._get_embedding(query, "query")

--- a/tests/embeddings/test_bedrock.py
+++ b/tests/embeddings/test_bedrock.py
@@ -72,4 +72,4 @@ class TestBedrockEmbedding(TestCase):
         self.bedrock_stubber.deactivate()
 
         self.bedrock_stubber.assert_no_pending_responses()
-        self.assertEqual(embedding, mock_response["embeddings"])
+        self.assertEqual(embedding, mock_response["embeddings"][0])


### PR DESCRIPTION
# Description

BedrockEmbedding with Cohere model currently returns List[List[float]]. Cohere accepts a list input strings and only one is sent. So the response is a list of embeddings with one element that must be unwrapped.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
