### PR TITLE
Remove unneeded where clause in postgres hybrid search query

### DIFF
--- a/llama_index/vector_stores/postgres.py
+++ b/llama_index/vector_stores/postgres.py
@@ -416,14 +416,10 @@ class PGVectorStore(BasePydanticVectorStore):
         ts_query = func.plainto_tsquery(
             type_coerce(self.text_search_config, REGCONFIG), query_str
         )
-        stmt = (
-            select(  # type: ignore
-                self._table_class,
-                func.ts_rank(self._table_class.text_search_tsv, ts_query).label("rank"),
-            )
-            .where(self._table_class.text_search_tsv.op("@@")(ts_query))
-            .order_by(text("rank desc"))
-        )
+        stmt = select(  # type: ignore
+            self._table_class,
+            func.ts_rank(self._table_class.text_search_tsv, ts_query).label("rank"),
+        ).order_by(text("rank desc"))
 
         # type: ignore
         return self._apply_filters_and_limit(stmt, limit, metadata_filters)


### PR DESCRIPTION
# Description

I think the hybrid search postgres query does not need the additional where clause, as it massively restricts the volume of returned rows. Mostly for my case, the number of returned rows is 0.

Ranking and limiting is already performed in the circumference of the query generation, which should be sufficient enough to get good results.
If the query stays as is, that basically means that every (normalised) word needs to be existent in the node/db row that is currently evaluated. 

Even the current example (https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/vector_stores/postgres.ipynb) fails for me when setting similarity_top_k to 0.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
