### PR TITLE
[Docs] Fix link in /node_parsers/root.md

### DIFF
--- a/docs/module_guides/loading/node_parsers/root.md
+++ b/docs/module_guides/loading/node_parsers/root.md
@@ -1,6 +1,6 @@
 # Node Parser Usage Pattern
 
-Node parsers are a simple abstraction that take a list of documents, and chunk them into `Node` objects, such that each node is a specific chunk of the parent document. When a document is broken into nodes, all of it's attributes are inherited to the children nodes (i.e. `metadata`, text and metadata templates, etc.). You can read more about `Node` and `Document` properties [here](/core_modules/data_modules/documents_and_nodes/root.md).
+Node parsers are a simple abstraction that take a list of documents, and chunk them into `Node` objects, such that each node is a specific chunk of the parent document. When a document is broken into nodes, all of it's attributes are inherited to the children nodes (i.e. `metadata`, text and metadata templates, etc.). You can read more about `Node` and `Document` properties [here](/module_guides/loading/documents_and_nodes/root.md).
 
 ## Getting Started
 


### PR DESCRIPTION
# Description

The link in node_parsers/root.md:
https://docs.llamaindex.ai/en/stable/module_guides/loading/node_parsers/root.html

> You can read more about `Node` and `Document` properties here.
 
Its not working.

I think that the correct link would be to:

> /module_guides/loading/documents_and_nodes/root.md https://docs.llamaindex.ai/en/stable/module_guides/loading/documents_and_nodes/root.html

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

