### PR TITLE
Fix an issue where download_loader could crash if no __init__.py pre-exist in the download directory

### DIFF
--- a/llama_index/download/module.py
+++ b/llama_index/download/module.py
@@ -139,7 +139,9 @@ def download_module_and_reqs(
         if extra_file == "__init__.py":
             loader_exports = get_exports(extra_file_raw_content)
             existing_exports = []
-            with open(local_dir_path / "__init__.py", "r+") as f:
+            init_file_path = local_dir_path / "__init__.py"
+            mode = "w" if not os.path.exists(init_file_path) else "r+"
+            with open(init_file_path, mode) as f:
                 f.write(f"from .{module_id} import {', '.join(loader_exports)}")
                 existing_exports = get_exports(f.read())
             rewrite_exports(existing_exports + loader_exports, str(local_dir_path))

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -148,7 +148,7 @@ class CorrectnessEvaluator(BaseEvaluator):
 
         # a regexp to remove the score from the response
         reasoning_str = re.sub(r"\[SCORE:(.*?)\]", "", eval_response)
-        reasoning = reasoning_str.lstrip("\n")
+        reasoning = re.sub(r"\[SCORE:(.*?)\]", "", eval_response).lstrip()
 
         return EvaluationResult(
             query=query,

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -1,5 +1,6 @@
 """Correctness evaluation."""
 import asyncio
+import re
 from typing import Any, Optional, Sequence, Union
 
 from llama_index.evaluation.base import BaseEvaluator, EvaluationResult
@@ -23,7 +24,7 @@ You are given the following information:
 
 Your job is to judge the relevance and correctness of the generated answer.
 Output a single score that represents a holistic evaluation.
-You must return your response in a line with only the score.
+You must return your response in a line with only the score using the format [SCORE:2.0].
 Do not return answers in any other format.
 On a separate line provide your reasoning for the score as well.
 
@@ -37,7 +38,7 @@ you should give a score between 2 and 3.
 you should give a score between 4 and 5.
 
 Example Response:
-4.0
+[SCORE:4.0]
 The generated answer has the exact same metrics as the reference answer, \
     but it is not as concise.
 
@@ -134,8 +135,19 @@ class CorrectnessEvaluator(BaseEvaluator):
         )
 
         # Extract from response
-        score_str, reasoning_str = eval_response.split("\n", 1)
+        print(eval_response)
+        # use a regexp to match [SCORE:0.2] in the response
+        match = re.search(r"\[SCORE:(.*?)\]", eval_response)
+        if match:
+            score_str = match.group(1)
+        else:
+            # no score found, maybe retry?
+            pass
+
         score = float(score_str)
+
+        # a regexp to remove the score from the response
+        reasoning_str = re.sub(r"\[SCORE:(.*?)\]", "", eval_response)
         reasoning = reasoning_str.lstrip("\n")
 
         return EvaluationResult(

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -38,7 +38,7 @@ you should give a score between 2 and 3.
 you should give a score between 4 and 5.
 
 Example Response:
-[SCORE:4.0]
+[SCORE:4.2]
 The generated answer has the exact same metrics as the reference answer, \
     but it is not as concise.
 

--- a/llama_index/evaluation/correctness.py
+++ b/llama_index/evaluation/correctness.py
@@ -147,7 +147,6 @@ class CorrectnessEvaluator(BaseEvaluator):
         score = float(score_str)
 
         # a regexp to remove the score from the response
-        reasoning_str = re.sub(r"\[SCORE:(.*?)\]", "", eval_response)
         reasoning = re.sub(r"\[SCORE:(.*?)\]", "", eval_response).lstrip()
 
         return EvaluationResult(

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -1,0 +1,6 @@
+from llama_index import download_loader
+
+
+def test_download_loader_do_not_crash_on_missing_init() -> None:
+    download_loader("GithubRepositoryReader")
+    assert True


### PR DESCRIPTION
# Description

Bug: 
When using  download_loader, sometime llama_index raise an error if the __init__.py file did not exist in the llama_index/download repository. (Reproduced here: https://colab.research.google.com/drive/1DyESezohL-buXGn8DwpLHL2NlN172ZcZ?usp=sharing) 

The propose fix check if the __init_.py file exist before opening it with "r+".

A test to check that the download loader function work and do not crash was added.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Added new unit/integration tests
- I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
