### PR TITLE
Check if __init__.py file exist in download/module.py to avoid crash when using download_loader

### DIFF
--- a/llama_index/download/module.py
+++ b/llama_index/download/module.py
@@ -139,7 +139,10 @@ def download_module_and_reqs(
         if extra_file == "__init__.py":
             loader_exports = get_exports(extra_file_raw_content)
             existing_exports = []
-            with open(local_dir_path / "__init__.py", "r+") as f:
+            init_file_path = local_dir_path / "__init__.py"
+            # if the __init__.py file do not exists, we need to create it
+            mode = "a+" if not os.path.exists(init_file_path) else "r+"
+            with open(init_file_path, mode) as f:
                 f.write(f"from .{module_id} import {', '.join(loader_exports)}")
                 existing_exports = get_exports(f.read())
             rewrite_exports(existing_exports + loader_exports, str(local_dir_path))

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -1,6 +1,0 @@
-from llama_index import download_loader
-
-
-def test_download_loader_do_not_crash_on_missing_init() -> None:
-    download_loader("GithubRepositoryReader")
-    assert True

--- a/tests/download/test_download.py
+++ b/tests/download/test_download.py
@@ -1,0 +1,6 @@
+from llama_index import download_loader
+
+
+def test_download_loader_do_not_crash_on_missing_init() -> None:
+    download_loader("GithubRepositoryReader")
+    assert True


### PR DESCRIPTION
# Description

When using download_loader, sometime llama_index raise an error if the init.py file did not exist in the llama_index/download repository. (Reproduced here: https://colab.research.google.com/drive/1DyESezohL-buXGn8DwpLHL2NlN172ZcZ?usp=sharing)

The propose fix check if the _init.py file exist before opening it with "r+".

A test to check that the download loader function work and do not crash was added.


Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added new unit/integration tests
I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
