### PR TITLE
Only capture valid python function names in ReAct output

### DIFF
--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -16,7 +16,7 @@ from llama_index.types import BaseOutputParser
 
 
 def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
-    pattern = r"\s*Thought: (.*?)\nAction: (.*?)\nAction Input: (\{.*?\})"
+    pattern = r"\s*Thought: (.*?)\nAction: ([a-zA-Z0-9_]+).*?\nAction Input: (\{.*?\})"
 
     match = re.search(pattern, input_text, re.DOTALL)
     if not match:

--- a/tests/agent/react/test_react_output_parser.py
+++ b/tests/agent/react/test_react_output_parser.py
@@ -16,6 +16,30 @@ Action Input: {"a": 1, "b": 1}
     assert action_input == '{"a": 1, "b": 1}'
 
 
+def test_extract_tool_use_extra_action_output() -> None:
+    mock_input_text = """\
+Thought: I need to use a tool to help me answer the question.
+Action: add (add two numbers)
+Action Input: {"a": 1, "b": 1}
+"""
+    thought, action, action_input = extract_tool_use(mock_input_text)
+    assert thought == "I need to use a tool to help me answer the question."
+    assert action == "add"
+    assert action_input == '{"a": 1, "b": 1}'
+
+
+def test_extract_tool_number() -> None:
+    mock_input_text = """\
+Thought: I need to use a tool to help me answer the question.
+Action: add2
+Action Input: {"a": 1, "b": 1}
+"""
+    thought, action, action_input = extract_tool_use(mock_input_text)
+    assert thought == "I need to use a tool to help me answer the question."
+    assert action == "add2"
+    assert action_input == '{"a": 1, "b": 1}'
+
+
 def test_extract_tool_use_multiline_action_input() -> None:
     mock_input_text = """\
 Thought: I need to use a tool to help me answer the question.


### PR DESCRIPTION
Some LLMs output extra information at the end of the function name and cause llama_index to fail to find the function they want to call. Tighten the regular expression to only accept valid python function names (as used in the lookup) and ignore additional output.

This makes more LLMs work with the ReAct agent, even if they do not follow the instructions exactly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
