### PR TITLE
Feat/PgVector Support custom hnsw.ef_search and ivfflat.probes

### DIFF
--- a/docs/examples/vector_stores/postgres.ipynb
+++ b/docs/examples/vector_stores/postgres.ipynb
@@ -450,6 +450,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b274ecb",
    "metadata": {},
    "source": [
     "### PgVector Query Options"
@@ -457,6 +458,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a490a0fa",
    "metadata": {},
    "source": [
     "#### IVFFlat Probes\n",
@@ -469,20 +471,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "111a3682",
    "metadata": {},
    "outputs": [],
    "source": [
     "retriever = index.as_retriever(\n",
     "    vector_store_query_mode=query_mode,\n",
     "    similarity_top_k=top_k,\n",
-    "    vector_store_kwargs={\n",
-    "        \"ivfflat_probes\": 10\n",
-    "    },\n",
+    "    vector_store_kwargs={\"ivfflat_probes\": 10},\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "6104ef8d",
    "metadata": {},
    "source": [
     "#### HNSW EF Search\n",
@@ -493,15 +495,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f3a44758",
    "metadata": {},
    "outputs": [],
    "source": [
     "retriever = index.as_retriever(\n",
     "    vector_store_query_mode=query_mode,\n",
     "    similarity_top_k=top_k,\n",
-    "    vector_store_kwargs={\n",
-    "        \"hnsw_ef_search\": 300\n",
-    "    },\n",
+    "    vector_store_kwargs={\"hnsw_ef_search\": 300},\n",
     ")"
    ]
   }

--- a/docs/examples/vector_stores/postgres.ipynb
+++ b/docs/examples/vector_stores/postgres.ipynb
@@ -447,6 +447,63 @@
    "source": [
     "print(hybrid_response)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PgVector Query Options"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### IVFFlat Probes\n",
+    "\n",
+    "Specify the number of [IVFFlat probes](https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options) (1 by default)\n",
+    "\n",
+    "When retrieving from the index, you can specify an appropriate number of IVFFlat probes (higher is better for recall, lower is better for speed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = index.as_retriever(\n",
+    "    vector_store_query_mode=query_mode,\n",
+    "    similarity_top_k=top_k,\n",
+    "    vector_store_kwargs={\n",
+    "        \"ivfflat_probes\": 10\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### HNSW EF Search\n",
+    "\n",
+    "Specify the size of the dynamic [candidate list](https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options-1) for search (40 by default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = index.as_retriever(\n",
+    "    vector_store_query_mode=query_mode,\n",
+    "    similarity_top_k=top_k,\n",
+    "    vector_store_kwargs={\n",
+    "        \"hnsw_ef_search\": 300\n",
+    "    },\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/llama_index/vector_stores/postgres.py
+++ b/llama_index/vector_stores/postgres.py
@@ -393,16 +393,20 @@ class PGVectorStore(BasePydanticVectorStore):
         embedding: Optional[List[float]],
         limit: int = 10,
         metadata_filters: Optional[MetadataFilters] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> List[DBEmbeddingRow]:
         stmt = self._build_query(embedding, limit, metadata_filters)
         with self._session() as session, session.begin():
             from sqlalchemy import text
 
             if kwargs.get("ivfflat_probes"):
-                session.execute(text(f"SET ivfflat.probes = {kwargs.get('ivfflat_probes')}"))
+                session.execute(
+                    text(f"SET ivfflat.probes = {kwargs.get('ivfflat_probes')}")
+                )
             if kwargs.get("hnsw_ef_search"):
-                session.execute(text(f"SET hnsw.ef_search = {kwargs.get('hnsw_ef_search')}"))
+                session.execute(
+                    text(f"SET hnsw.ef_search = {kwargs.get('hnsw_ef_search')}")
+                )
 
             res = session.execute(
                 stmt,
@@ -422,16 +426,20 @@ class PGVectorStore(BasePydanticVectorStore):
         embedding: Optional[List[float]],
         limit: int = 10,
         metadata_filters: Optional[MetadataFilters] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> List[DBEmbeddingRow]:
         stmt = self._build_query(embedding, limit, metadata_filters)
         async with self._async_session() as async_session, async_session.begin():
             from sqlalchemy import text
 
             if kwargs.get("hnsw_ef_search"):
-                await async_session.execute(text(f"SET hnsw.ef_search = {kwargs.get('hnsw_ef_search')}"))
+                await async_session.execute(
+                    text(f"SET hnsw.ef_search = {kwargs.get('hnsw_ef_search')}")
+                )
             if kwargs.get("ivfflat_probes"):
-                await async_session.execute(text(f"SET ivfflat.probes = {kwargs.get('ivfflat_probes')}"))
+                await async_session.execute(
+                    text(f"SET ivfflat.probes = {kwargs.get('ivfflat_probes')}")
+                )
 
             res = await async_session.execute(stmt)
             return [
@@ -536,7 +544,9 @@ class PGVectorStore(BasePydanticVectorStore):
         all_results = dense_results + sparse_results
         return _dedup_results(all_results)
 
-    def _hybrid_query(self, query: VectorStoreQuery, **kwargs: Any) -> List[DBEmbeddingRow]:
+    def _hybrid_query(
+        self, query: VectorStoreQuery, **kwargs: Any
+    ) -> List[DBEmbeddingRow]:
         if query.alpha is not None:
             _logger.warning("postgres hybrid search does not support alpha parameter.")
 


### PR DESCRIPTION
# Description

To improve the retrieval performance on PgVector, it's suggested to use the appropriate `hnsw.ef_search` or `ivfflat.probes`, depending on the index engine you use.

```sql
SET hnsw.ef_search = 100;
-- or
SET ivfflat.probes = 10;
```

This will also fix the https://github.com/run-llama/llama_index/issues/9419 bug

**How to use**
```python
retriever = index.as_retriever(
    vector_store_query_mode=query_mode,
    similarity_top_k=top_k,
    vector_store_kwargs={
        "hnsw_ef_search": 300
    },
)
```

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
