### PR TITLE
Fix cleanup process in  _delete_node of document_summary

### DIFF
--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -203,7 +203,7 @@ class BaseIndex(Generic[IS], ABC):
 
     def delete_nodes(
         self,
-        node_ids: List[str],
+        doc_ids: List[str],
         delete_from_docstore: bool = False,
         **delete_kwargs: Any,
     ) -> None:
@@ -213,10 +213,10 @@ class BaseIndex(Generic[IS], ABC):
             doc_ids (List[str]): A list of doc_ids from the nodes to delete
 
         """
-        for node_id in node_ids:
-            self._delete_node(node_id, **delete_kwargs)
+        for doc_id in doc_ids:
+            self._delete_node(doc_id, **delete_kwargs)
             if delete_from_docstore:
-                self.docstore.delete_document(node_id, raise_error=False)
+                self.docstore.delete_document(doc_id, raise_error=False)
 
         self._storage_context.index_store.add_index_struct(self._index_struct)
 
@@ -244,7 +244,7 @@ class BaseIndex(Generic[IS], ABC):
             return
 
         self.delete_nodes(
-            ref_doc_info.node_ids,
+            [ref_doc_id],
             delete_from_docstore=False,
             **delete_kwargs,
         )

--- a/llama_index/indices/base.py
+++ b/llama_index/indices/base.py
@@ -198,8 +198,8 @@ class BaseIndex(Generic[IS], ABC):
             self.docstore.set_document_hash(document.get_doc_id(), document.hash)
 
     @abstractmethod
-    def _delete_node(self, node_id: str, **delete_kwargs: Any) -> None:
-        """Delete a node."""
+    def _delete_node(self, doc_id: str, **delete_kwargs: Any) -> None:
+        """Delete nodes from doc_id."""
 
     def delete_nodes(
         self,

--- a/llama_index/indices/document_summary/base.py
+++ b/llama_index/indices/document_summary/base.py
@@ -219,17 +219,17 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
         """Insert a document."""
         self._add_nodes_to_index(self._index_struct, nodes)
 
-    def _delete_node(self, node_id: str, **delete_kwargs: Any) -> None:
+    def _delete_node(self, doc_id: str, **delete_kwargs: Any) -> None:
         """Delete a node."""
-        if node_id not in self._index_struct.doc_id_to_summary_id:
-            raise ValueError(f"node_id {node_id} not in index")
-        summary_id = self._index_struct.doc_id_to_summary_id[node_id]
+        if doc_id not in self._index_struct.doc_id_to_summary_id:
+            raise ValueError(f"doc_id {doc_id} not in index")
+        summary_id = self._index_struct.doc_id_to_summary_id[doc_id]
 
         # delete summary node from docstore
         self.docstore.delete_document(summary_id)
 
         # delete from index struct
-        self._index_struct.delete(node_id)
+        self._index_struct.delete(doc_id)
 
     @property
     def ref_doc_info(self) -> Dict[str, RefDocInfo]:

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -273,7 +273,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
 
     def delete_nodes(
         self,
-        node_ids: List[str],
+        doc_ids: List[str],
         delete_from_docstore: bool = False,
         **delete_kwargs: Any,
     ) -> None:
@@ -281,6 +281,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
 
         Args:
             doc_ids (List[str]): A list of doc_ids from the nodes to delete
+            delete_from_docstore: delete the document from docstore as well
 
         """
         raise NotImplementedError(


### PR DESCRIPTION
# Description

Cannot remove doc from DocumentSummaryIndex by delete_ref_doc(...)

As designed, the user can remove the nodes from the document summary index according to "doc_id" by delete_ref_doc(...) which will call delete_nodes(...) from BaseIndex to do the work. 
<img width="600" alt="截屏2023-12-10 16 12 57" src="https://github.com/run-llama/llama_index/assets/114048/d1b804fd-9830-4dce-985f-ac39acffcb4d">

However, it passes the related node_ids instead of doc_id itself. 
<img width="692" alt="截屏2023-12-10 16 10 15" src="https://github.com/run-llama/llama_index/assets/114048/68e89cb2-d63d-40cc-adee-1dcec1ee443a">

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
