### PR TITLE
Discussion#8390 : Added sql_only hook to return only sql without running it 

### DIFF
--- a/llama_index/indices/struct_store/sql_query.py
+++ b/llama_index/indices/struct_store/sql_query.py
@@ -1,7 +1,7 @@
 """Default query for SQLStructStoreIndex."""
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from sqlalchemy import Table
 
@@ -86,17 +86,17 @@ class SQLStructStoreQueryEngine(BaseQueryEngine):
     def _get_prompt_modules(self) -> PromptMixinType:
         """Get prompt modules."""
         return {}
-    
-    def _run_with_sql_only_check(self, sql_query_str):
-        """ don't run sql if sql_only is true, else continue with normal path """
+
+    def _run_with_sql_only_check(self, sql_query_str:str) -> Tuple[str, Dict[str, Any]]:
+        """Don't run sql if sql_only is true, else continue with normal path."""
         if self._sql_only:
-            metadata = {}
+            metadata: Dict[str, Any] = {}
             raw_response_str = sql_query_str
-        else : 
+        else:
             raw_response_str, metadata = self._sql_database.run_sql(sql_query_str)
 
         return raw_response_str, metadata
-    
+
     def _query(self, query_bundle: QueryBundle) -> Response:
         """Answer a query."""
         # NOTE: override query method in order to fetch the right results.
@@ -202,13 +202,13 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
             tables_desc_str = "\n\n".join(table_desc_list)
 
         return tables_desc_str
-    
-    def _run_with_sql_only_check(self, sql_query_str):
-        """ don't run sql if sql_only is true, else continue with normal path """
+
+    def _run_with_sql_only_check(self, sql_query_str: str) -> Tuple[str, Dict]:
+        """Don't run sql if sql_only is true, else continue with normal path."""
         if self._sql_only:
-            metadata = {}
+            metadata: Dict[str, Any] = {}
             raw_response_str = sql_query_str
-        else : 
+        else:
             raw_response_str, metadata = self._sql_database.run_sql(sql_query_str)
 
         return raw_response_str, metadata
@@ -401,7 +401,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
             tables=tables,
             context_str_prefix=context_str_prefix,
             service_context=service_context,
-            sql_only=sql_only
+            sql_only=sql_only,
         )
         super().__init__(
             synthesize_response=synthesize_response,

--- a/llama_index/indices/struct_store/sql_query.py
+++ b/llama_index/indices/struct_store/sql_query.py
@@ -436,6 +436,7 @@ class PGVectorSQLQueryEngine(BaseSQLTableQueryEngine):
         tables: Optional[Union[List[str], List[Table]]] = None,
         service_context: Optional[ServiceContext] = None,
         context_str_prefix: Optional[str] = None,
+        sql_only: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -448,6 +449,7 @@ class PGVectorSQLQueryEngine(BaseSQLTableQueryEngine):
             sql_parser_mode=SQLParserMode.PGVECTOR,
             context_str_prefix=context_str_prefix,
             service_context=service_context,
+            sql_only=sql_only
         )
         super().__init__(
             synthesize_response=synthesize_response,
@@ -486,6 +488,7 @@ class SQLTableRetrieverQueryEngine(BaseSQLTableQueryEngine):
             table_retriever=table_retriever,
             context_str_prefix=context_str_prefix,
             service_context=service_context,
+            sql_only=sql_only
         )
         super().__init__(
             synthesize_response=synthesize_response,

--- a/llama_index/indices/struct_store/sql_query.py
+++ b/llama_index/indices/struct_store/sql_query.py
@@ -87,7 +87,9 @@ class SQLStructStoreQueryEngine(BaseQueryEngine):
         """Get prompt modules."""
         return {}
 
-    def _run_with_sql_only_check(self, sql_query_str:str) -> Tuple[str, Dict[str, Any]]:
+    def _run_with_sql_only_check(
+        self, sql_query_str: str
+    ) -> Tuple[str, Dict[str, Any]]:
         """Don't run sql if sql_only is true, else continue with normal path."""
         if self._sql_only:
             metadata: Dict[str, Any] = {}
@@ -449,7 +451,7 @@ class PGVectorSQLQueryEngine(BaseSQLTableQueryEngine):
             sql_parser_mode=SQLParserMode.PGVECTOR,
             context_str_prefix=context_str_prefix,
             service_context=service_context,
-            sql_only=sql_only
+            sql_only=sql_only,
         )
         super().__init__(
             synthesize_response=synthesize_response,
@@ -488,7 +490,7 @@ class SQLTableRetrieverQueryEngine(BaseSQLTableQueryEngine):
             table_retriever=table_retriever,
             context_str_prefix=context_str_prefix,
             service_context=service_context,
-            sql_only=sql_only
+            sql_only=sql_only,
         )
         super().__init__(
             synthesize_response=synthesize_response,

--- a/llama_index/indices/struct_store/sql_query.py
+++ b/llama_index/indices/struct_store/sql_query.py
@@ -72,6 +72,7 @@ class SQLStructStoreQueryEngine(BaseQueryEngine):
         self,
         index: SQLStructStoreIndex,
         sql_context_container: Optional[SQLContextContainerBuilder] = None,
+        sql_only: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -79,18 +80,29 @@ class SQLStructStoreQueryEngine(BaseQueryEngine):
         self._sql_context_container = (
             sql_context_container or index.sql_context_container
         )
+        self._sql_only = sql_only
         super().__init__(index.service_context.callback_manager)
 
     def _get_prompt_modules(self) -> PromptMixinType:
         """Get prompt modules."""
         return {}
+    
+    def _run_with_sql_only_check(self, sql_query_str):
+        """ don't run sql if sql_only is true, else continue with normal path """
+        if self._sql_only:
+            metadata = {}
+            raw_response_str = sql_query_str
+        else : 
+            raw_response_str, metadata = self._sql_database.run_sql(sql_query_str)
 
+        return raw_response_str, metadata
+    
     def _query(self, query_bundle: QueryBundle) -> Response:
         """Answer a query."""
         # NOTE: override query method in order to fetch the right results.
         # NOTE: since the query_str is a SQL query, it doesn't make sense
         # to use ResponseBuilder anywhere.
-        response_str, metadata = self._sql_database.run_sql(query_bundle.query_str)
+        response_str, metadata = self._run_with_sql_only_check(query_bundle.query_str)
         return Response(response=response_str, metadata=metadata)
 
     async def _aquery(self, query_bundle: QueryBundle) -> Response:
@@ -118,6 +130,8 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
             context query. Defaults to {}.
         synthesize_response (bool): Whether to synthesize a response from the
             query results. Defaults to True.
+        sql_only (bool) : Whether to get only sql and not the sql query result.
+            Default to False.
         response_synthesis_prompt (Optional[BasePromptTemplate]): A
             Response Synthesis BasePromptTemplate to use for the query. Defaults to
             DEFAULT_RESPONSE_SYNTHESIS_PROMPT.
@@ -130,6 +144,7 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
         context_query_kwargs: Optional[dict] = None,
         synthesize_response: bool = True,
         response_synthesis_prompt: Optional[BasePromptTemplate] = None,
+        sql_only: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -145,6 +160,7 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
         )
         self._context_query_kwargs = context_query_kwargs or {}
         self._synthesize_response = synthesize_response
+        self._sql_only = sql_only
         super().__init__(index.service_context.callback_manager)
 
     @property
@@ -186,6 +202,16 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
             tables_desc_str = "\n\n".join(table_desc_list)
 
         return tables_desc_str
+    
+    def _run_with_sql_only_check(self, sql_query_str):
+        """ don't run sql if sql_only is true, else continue with normal path """
+        if self._sql_only:
+            metadata = {}
+            raw_response_str = sql_query_str
+        else : 
+            raw_response_str, metadata = self._sql_database.run_sql(sql_query_str)
+
+        return raw_response_str, metadata
 
     def _query(self, query_bundle: QueryBundle) -> Response:
         """Answer a query."""
@@ -203,7 +229,8 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
 
-        raw_response_str, metadata = self._sql_database.run_sql(sql_query_str)
+        raw_response_str, metadata = self._run_with_sql_only_check(sql_query_str)
+
         metadata["sql_query"] = sql_query_str
 
         if self._synthesize_response:
@@ -234,7 +261,7 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
 
-        response_str, metadata = self._sql_database.run_sql(sql_query_str)
+        response_str, metadata = self._run_with_sql_only_check(sql_query_str)
         metadata["sql_query"] = sql_query_str
         return Response(response=response_str, metadata=metadata)
 
@@ -362,6 +389,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
         tables: Optional[Union[List[str], List[Table]]] = None,
         service_context: Optional[ServiceContext] = None,
         context_str_prefix: Optional[str] = None,
+        sql_only: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -373,6 +401,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
             tables=tables,
             context_str_prefix=context_str_prefix,
             service_context=service_context,
+            sql_only=sql_only
         )
         super().__init__(
             synthesize_response=synthesize_response,
@@ -446,6 +475,7 @@ class SQLTableRetrieverQueryEngine(BaseSQLTableQueryEngine):
         response_synthesis_prompt: Optional[BasePromptTemplate] = None,
         service_context: Optional[ServiceContext] = None,
         context_str_prefix: Optional[str] = None,
+        sql_only: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""

--- a/llama_index/indices/struct_store/sql_retriever.py
+++ b/llama_index/indices/struct_store/sql_retriever.py
@@ -282,9 +282,8 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
 
-        if(self._sql_only):
-            #Return
-            sql_only_node = TextNode(text={sql_query_str})
+        if(self._sql_only):            
+            sql_only_node = TextNode(text=f"{sql_query_str}")
             retrieved_nodes = [NodeWithScore(node=sql_only_node)]
             metadata = {}
         else:  
@@ -326,19 +325,25 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         )
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
-        try:
-            (
-                retrieved_nodes,
-                metadata,
-            ) = await self._sql_retriever.aretrieve_with_metadata(sql_query_str)
-        except BaseException as e:
-            # if handle_sql_errors is True, then return error message
-            if self._handle_sql_errors:
-                err_node = TextNode(text=f"Error: {e!s}")
-                retrieved_nodes = [NodeWithScore(node=err_node)]
-                metadata = {}
-            else:
-                raise
+
+        if(self._sql_only):            
+            sql_only_node = TextNode(text=f"{sql_query_str}")
+            retrieved_nodes = [NodeWithScore(node=sql_only_node)]
+            metadata = {}
+        else: 
+            try:
+                (
+                    retrieved_nodes,
+                    metadata,
+                ) = await self._sql_retriever.aretrieve_with_metadata(sql_query_str)
+            except BaseException as e:
+                # if handle_sql_errors is True, then return error message
+                if self._handle_sql_errors:
+                    err_node = TextNode(text=f"Error: {e!s}")
+                    retrieved_nodes = [NodeWithScore(node=err_node)]
+                    metadata = {}
+                else:
+                    raise
         return retrieved_nodes, {"sql_query": sql_query_str, **metadata}
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:

--- a/llama_index/indices/struct_store/sql_retriever.py
+++ b/llama_index/indices/struct_store/sql_retriever.py
@@ -285,7 +285,7 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         if self._sql_only:
             sql_only_node = TextNode(text=f"{sql_query_str}")
             retrieved_nodes = [NodeWithScore(node=sql_only_node)]
-            metadata = {}
+            metadata = {"result": sql_query_str}
         else:
             try:
                 retrieved_nodes, metadata = self._sql_retriever.retrieve_with_metadata(
@@ -329,7 +329,7 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         if self._sql_only:
             sql_only_node = TextNode(text=f"{sql_query_str}")
             retrieved_nodes = [NodeWithScore(node=sql_only_node)]
-            metadata = {}
+            metadata: Dict[str, Any] = {}
         else:
             try:
                 (

--- a/llama_index/indices/struct_store/sql_retriever.py
+++ b/llama_index/indices/struct_store/sql_retriever.py
@@ -189,7 +189,7 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         return_raw: bool = True,
         handle_sql_errors: bool = True,
         sql_only: bool = False,
-        callback_manager: Optional[CallbackManager] = None,        
+        callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -282,11 +282,11 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
 
-        if(self._sql_only):            
+        if self._sql_only:
             sql_only_node = TextNode(text=f"{sql_query_str}")
             retrieved_nodes = [NodeWithScore(node=sql_only_node)]
             metadata = {}
-        else:  
+        else:
             try:
                 retrieved_nodes, metadata = self._sql_retriever.retrieve_with_metadata(
                     sql_query_str
@@ -326,11 +326,11 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
 
-        if(self._sql_only):            
+        if self._sql_only:
             sql_only_node = TextNode(text=f"{sql_query_str}")
             retrieved_nodes = [NodeWithScore(node=sql_only_node)]
             metadata = {}
-        else: 
+        else:
             try:
                 (
                     retrieved_nodes,

--- a/tests/indices/struct_store/test_sql_query.py
+++ b/tests/indices/struct_store/test_sql_query.py
@@ -15,6 +15,7 @@ from llama_index.utilities.sql_wrapper import SQLDatabase
 from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
 from sqlalchemy.exc import OperationalError
 
+
 def test_sql_index_query(
     mock_service_context: ServiceContext,
     struct_kwargs: Tuple[Dict, Dict],
@@ -39,7 +40,7 @@ def test_sql_index_query(
         docs,
         sql_database=sql_database,
         table_name=table_name,
-        service_context=mock_service_context,        
+        service_context=mock_service_context,
         **index_kwargs
     )
 
@@ -106,7 +107,7 @@ def test_sql_index_async_query(
         service_context=mock_service_context,
         **index_kwargs
     )
-    
+
     sql_to_test = "SELECT user_id, foo FROM test_table"
     # query the index with SQL
     sql_query_engine = SQLStructStoreQueryEngine(index, **query_kwargs)
@@ -125,7 +126,7 @@ def test_sql_index_async_query(
     response = asyncio.run(task)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
 
-    ## sql_only = True  ### 
+    ## sql_only = True  ###
     # query the index with SQL
     sql_query_engine = SQLStructStoreQueryEngine(index, sql_only=True, **query_kwargs)
     task = sql_query_engine.aquery(sql_to_test)

--- a/tests/indices/struct_store/test_sql_query.py
+++ b/tests/indices/struct_store/test_sql_query.py
@@ -15,7 +15,6 @@ from llama_index.utilities.sql_wrapper import SQLDatabase
 from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
 from sqlalchemy.exc import OperationalError
 
-
 def test_sql_index_query(
     mock_service_context: ServiceContext,
     struct_kwargs: Tuple[Dict, Dict],
@@ -40,13 +39,14 @@ def test_sql_index_query(
         docs,
         sql_database=sql_database,
         table_name=table_name,
-        service_context=mock_service_context,
+        service_context=mock_service_context,        
         **index_kwargs
     )
 
     # query the index with SQL
+    sql_to_test = "SELECT user_id, foo FROM test_table"
     sql_query_engine = SQLStructStoreQueryEngine(index, **query_kwargs)
-    response = sql_query_engine.query("SELECT user_id, foo FROM test_table")
+    response = sql_query_engine.query(sql_to_test)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
 
     # query the index with natural language
@@ -61,6 +61,21 @@ def test_sql_index_query(
     with pytest.raises(NotImplementedError, match="invalid SQL") as exc_info:
         sql_query_engine.query("LLM didn't provide SQL at all")
     assert isinstance(exc_info.value.__cause__, OperationalError)
+
+    ## sql_only=True tests
+    # query the index with SQL
+    sql_query_engine = SQLStructStoreQueryEngine(index, sql_only=True, **query_kwargs)
+    response = sql_query_engine.query(sql_to_test)
+    assert str(response) == sql_to_test
+
+    # query the index with natural language
+    nl_query_engine = NLStructStoreQueryEngine(index, sql_only=True, **query_kwargs)
+    response = nl_query_engine.query("test_table:user_id,foo")
+    assert str(response) == sql_to_test
+
+    nl_table_engine = NLSQLTableQueryEngine(index.sql_database, sql_only=True)
+    response = nl_table_engine.query("test_table:user_id,foo")
+    assert str(response) == sql_to_test
 
 
 def test_sql_index_async_query(
@@ -91,10 +106,11 @@ def test_sql_index_async_query(
         service_context=mock_service_context,
         **index_kwargs
     )
-
+    
+    sql_to_test = "SELECT user_id, foo FROM test_table"
     # query the index with SQL
     sql_query_engine = SQLStructStoreQueryEngine(index, **query_kwargs)
-    task = sql_query_engine.aquery("SELECT user_id, foo FROM test_table")
+    task = sql_query_engine.aquery(sql_to_test)
     response = asyncio.run(task)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
 
@@ -108,6 +124,24 @@ def test_sql_index_async_query(
     task = nl_table_engine.aquery("test_table:user_id,foo")
     response = asyncio.run(task)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
+
+    ## sql_only = True  ### 
+    # query the index with SQL
+    sql_query_engine = SQLStructStoreQueryEngine(index, sql_only=True, **query_kwargs)
+    task = sql_query_engine.aquery(sql_to_test)
+    response = asyncio.run(task)
+    assert str(response) == sql_to_test
+
+    # query the index with natural language
+    nl_query_engine = NLStructStoreQueryEngine(index, sql_only=True, **query_kwargs)
+    task = nl_query_engine.aquery("test_table:user_id,foo")
+    response = asyncio.run(task)
+    assert str(response) == sql_to_test
+
+    nl_table_engine = NLSQLTableQueryEngine(index.sql_database, sql_only=True)
+    task = nl_table_engine.aquery("test_table:user_id,foo")
+    response = asyncio.run(task)
+    assert str(response) == sql_to_test
 
 
 def test_default_output_parser() -> None:


### PR DESCRIPTION
# Description

As discussed on [Discussion#8390](https://github.com/run-llama/llama_index/discussions/8390) : Added sql_only hook to return only final sql without running it 

Fixes # [Discussion#8390](https://github.com/run-llama/llama_index/discussions/8390)

## Type of Change

- New feature (non-breaking change which adds functionality) to get only final sql without running it. Default is set to existing behavior of returning final sql and result
- I have added comment for this new flag but **might** require a documentation update in samples

# How Has This Been Tested?

- Added new unit/integration tests
- `pytest tests` passed


# Suggested Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes

