### PR TITLE
Remediate RCE vulnerability CVE-2023-39662 - part 2

### DIFF
--- a/llama_index/exec_utils.py
+++ b/llama_index/exec_utils.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from types import CodeType, ModuleType
 from typing import Any, Dict, Mapping, Sequence, Union
 
@@ -90,6 +91,22 @@ def _get_restricted_globals(__globals: Union[dict, None]) -> Any:
     return restricted_globals
 
 
+def _verify_source_safety(__source: Union[str, bytes, CodeType]) -> None:
+    pattern = r"_{1,2}\w+_{0,2}"
+
+    if isinstance(__source, CodeType):
+        raise TypeError("Direct execution of CodeType is forbidden!")
+    if isinstance(__source, bytes):
+        __source = __source.decode()
+
+    matches = re.findall(pattern, __source)
+
+    if matches:
+        raise RuntimeError(
+            "Execution of code containing references to private or dunder methods is forbidden!"
+        )
+
+
 def safe_eval(
     __source: Union[str, bytes, CodeType],
     __globals: Union[Dict[str, Any], None] = None,
@@ -98,6 +115,7 @@ def safe_eval(
     """
     eval within safe global context.
     """
+    _verify_source_safety(__source)
     return eval(__source, _get_restricted_globals(__globals), __locals)
 
 
@@ -109,4 +127,5 @@ def safe_exec(
     """
     eval within safe global context.
     """
+    _verify_source_safety(__source)
     return exec(__source, _get_restricted_globals(__globals), __locals)

--- a/tests/query_engine/test_pandas.py
+++ b/tests/query_engine/test_pandas.py
@@ -84,6 +84,30 @@ def test_default_output_processor_rce(tmp_path: Path) -> None:
     assert not tmp_file.is_file(), "file has been created via RCE!"
 
 
+def test_default_output_processor_rce2(tmp_path: Path) -> None:
+    """
+    Test that output processor prevents RCE.
+    https://github.com/run-llama/llama_index/issues/7054#issuecomment-1829141330 .
+    """
+    df = pd.DataFrame(
+        {
+            "city": ["Toronto", "Tokyo", "Berlin"],
+            "population": [2930000, 13960000, 3645000],
+        }
+    )
+
+    tmp_file = tmp_path / "pwnnnnn"
+
+    injected_code = "().__class__.__mro__[-1].__subclasses__()[137].__init__.__globals__['system']('ls')"
+
+    output = default_output_processor(injected_code, df)
+
+    assert (
+        "Execution of code containing references to private or dunder methods is forbidden!"
+        in output
+    ), "Injected code executed successfully!"
+
+
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires Python 3.9 or higher")
 def test_default_output_processor_e2e(tmp_path: Path) -> None:
     """

--- a/tests/query_engine/test_pandas.py
+++ b/tests/query_engine/test_pandas.py
@@ -84,6 +84,7 @@ def test_default_output_processor_rce(tmp_path: Path) -> None:
     assert not tmp_file.is_file(), "file has been created via RCE!"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires Python 3.9 or higher")
 def test_default_output_processor_rce2(tmp_path: Path) -> None:
     """
     Test that output processor prevents RCE.


### PR DESCRIPTION
# Description

Adds additional safeguard that prevents RCE of code that contains private / dunder methods as presented in attack from: https://github.com/run-llama/llama_index/issues/7054#issuecomment-1829141330

Fixes #7054

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
