### PR TITLE
fix F1 score definition, update copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ with open("../llama_index/VERSION") as f:
 
 
 project = "LlamaIndex 🦙"
-copyright = "2022, Jerry Liu"
+copyright = "2023, Jerry Liu"
 author = "Jerry Liu"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/optimizing/evaluation/evaluation.md
+++ b/docs/optimizing/evaluation/evaluation.md
@@ -52,9 +52,9 @@ Typically, generation-heavy, open-ended tasks and requiring judgement or opinion
 Against annotated datasets, whether your own data or an academic benchmark, there are a number of standard metrics that it helps to be aware of:
 
 1. **Exact Match (EM):** The percentage of queries that are answered exactly correctly.
-2. **F1:** The percentage of queries that are answered exactly correctly or with a small edit distance (e.g. 1-2 words).
-3. **Recall:** The percentage of queries that are answered correctly, regardless of the number of answers returned.
-4. **Precision:** The percentage of queries that are answered correctly, divided by the number of answers returned.
+2. **Recall:** The percentage of queries that are answered correctly, regardless of the number of answers returned.
+3. **Precision:** The percentage of queries that are answered correctly, divided by the number of answers returned.
+4. **F1:** The F1 score is the harmonic mean of precision and recall. It thus symmetrically represents both precision and recall in one metric, considering both false positives and false negatives.
 
 This [towardsdatascience article](https://towardsdatascience.com/ranking-evaluation-metrics-for-recommender-systems-263d0a66ef54) covers more technical metrics like NDCG, MAP and MRR in greater depth.
 


### PR DESCRIPTION
# Description

F1 is not at all a metric about edit distance. This commit explains F1 using the previous precision and recall definitions.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

This is just a documentation change.

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
