### PR TITLE
AstraDB: handle MetadataFilters and not only ExactMatchFilter

### DIFF
--- a/llama_index/vector_stores/astra.py
+++ b/llama_index/vector_stores/astra.py
@@ -11,11 +11,13 @@ from llama_index.indices.query.embedding_utils import get_top_k_mmr_embeddings
 from llama_index.schema import BaseNode, MetadataMode
 from llama_index.vector_stores.types import (
     ExactMatchFilter,
+    FilterOperator,
+    MetadataFilter,
     MetadataFilters,
     VectorStore,
     VectorStoreQuery,
     VectorStoreQueryMode,
-    VectorStoreQueryResult, FilterOperator, MetadataFilter,
+    VectorStoreQueryResult,
 )
 from llama_index.vector_stores.utils import (
     metadata_dict_to_node,
@@ -164,10 +166,15 @@ class AstraDBVectorStore(VectorStore):
     def _query_filters_to_dict(query_filters: MetadataFilters) -> Dict[str, Any]:
         # Allow only legacy ExactMatchFilter and MetadataFilter with FilterOperator.EQ
         if not all(
-                (isinstance(f, ExactMatchFilter) or
-                 (isinstance(f, MetadataFilter) and f.operator == FilterOperator.EQ))
-                for f in query_filters.filters):
-            raise NotImplementedError("Only filters with operator=FilterOperator.EQ are supported")
+            (
+                isinstance(f, ExactMatchFilter)
+                or (isinstance(f, MetadataFilter) and f.operator == FilterOperator.EQ)
+            )
+            for f in query_filters.filters
+        ):
+            raise NotImplementedError(
+                "Only filters with operator=FilterOperator.EQ are supported"
+            )
         return {f"metadata.{f.key}": f.value for f in query_filters.filters}
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:


### PR DESCRIPTION
# Description

AstraDB Vector store didn't handle generic MetadataFilters, only ExactMatchFilter. 
This patch adds support for ExactMatchFilter with the EQ operator

Fixes #9432

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
