### PR TITLE
Make ollama support additional_kwargs correctly

### DIFF
--- a/llama_index/embeddings/ollama_embedding.py
+++ b/llama_index/embeddings/ollama_embedding.py
@@ -83,7 +83,7 @@ class OllamaEmbedding(BaseEmbedding):
         ollama_request_body = {
             "prompt": prompt,
             "model": self.model_name,
-            **self.ollama_additional_kwargs,
+            "options": self.ollama_additional_kwargs,
         }
 
         response = requests.post(

--- a/llama_index/llms/ollama.py
+++ b/llama_index/llms/ollama.py
@@ -63,7 +63,7 @@ class Ollama(CustomLLM):
     def _model_kwargs(self) -> Dict[str, Any]:
         base_kwargs = {
             "temperature": self.temperature,
-            "max_length": self.context_window,
+            "num_ctx": self.context_window,
         }
         return {
             **base_kwargs,
@@ -117,7 +117,7 @@ class Ollama(CustomLLM):
         response = requests.post(
             url=f"{self.base_url}/api/generate/",
             headers={"Content-Type": "application/json"},
-            json={"prompt": prompt, "model": self.model, **all_kwargs},
+            json={"prompt": prompt, "model": self.model, "options": all_kwargs},
             stream=True,
         )
         response.encoding = "utf-8"


### PR DESCRIPTION
# Description

Fix how the options passed to ollama api, so now options like `context_window`, `temperature` works correctly.
the full list of options is [right here](https://github.com/jmorganca/ollama/blob/main/docs/api.md#request-with-options)

I didn't found the doc describing the way to pass options when calling `complete() / stream_complete()`, but according to the code it should be like this?
`llm.stream_complete(message, temperature=temperature)`

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] Try to pass `num_ctx=10` and it triggered ollama to rebuild the model

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
