### PR TITLE
Fix Bedrock LLMs

### DIFF
--- a/llama_index/llms/bedrock_utils.py
+++ b/llama_index/llms/bedrock_utils.py
@@ -112,11 +112,12 @@ def completion_to_anthopic_prompt(completion: str) -> str:
 class AnthropicProvider(Provider):
     max_tokens_key = "max_tokens_to_sample"
 
+    def __init__(self) -> None:
+        self.messages_to_prompt = messages_to_anthropic_prompt
+        self.completion_to_prompt = completion_to_anthopic_prompt
+
     def get_text_from_response(self, response: dict) -> str:
         return response["completion"]
-
-    messages_to_prompt = messages_to_anthropic_prompt
-    completion_to_prompt = completion_to_anthopic_prompt
 
 
 class CohereProvider(Provider):
@@ -129,11 +130,12 @@ class CohereProvider(Provider):
 class MetaProvider(Provider):
     max_tokens_key = "max_gen_len"
 
+    def __init__(self) -> None:
+        self.messages_to_prompt = messages_to_llama_prompt
+        self.completion_to_prompt = completion_to_llama_prompt
+
     def get_text_from_response(self, response: dict) -> str:
         return response["generation"]
-
-    messages_to_prompt = messages_to_llama_prompt
-    completion_to_prompt = completion_to_llama_prompt
 
 
 PROVIDERS = {

--- a/llama_index/llms/bedrock_utils.py
+++ b/llama_index/llms/bedrock_utils.py
@@ -149,6 +149,8 @@ PROVIDERS = {
 
 def get_provider(model: str) -> Provider:
     provider_name = model.split(".")[0]
+    if provider_name not in PROVIDERS:
+        raise ValueError(f"Provider {provider_name} for model {model} is not supported")
     return PROVIDERS[provider_name]
 
 

--- a/llama_index/llms/bedrock_utils.py
+++ b/llama_index/llms/bedrock_utils.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Callable, Sequence
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional, Sequence
 
 from tenacity import (
     before_sleep_log,
@@ -9,18 +10,17 @@ from tenacity import (
     wait_exponential,
 )
 
+from llama_index.llms.anthropic_utils import messages_to_anthropic_prompt
 from llama_index.llms.generic_utils import (
-    completion_response_to_chat_response,
-    stream_completion_response_to_chat_response,
+    prompt_to_messages,
 )
-from llama_index.llms.types import (
-    ChatMessage,
-    ChatResponse,
-    ChatResponseGen,
-    CompletionResponse,
-    CompletionResponseGen,
-    MessageRole,
+from llama_index.llms.llama_utils import (
+    completion_to_prompt as completion_to_llama_prompt,
 )
+from llama_index.llms.llama_utils import (
+    messages_to_prompt as messages_to_llama_prompt,
+)
+from llama_index.llms.types import ChatMessage
 
 HUMAN_PREFIX = "\n\nHuman:"
 ASSISTANT_PREFIX = "\n\nAssistant:"
@@ -61,38 +61,96 @@ STREAMING_MODELS = {
     "meta.llama2-13b-chat-v1",
 }
 
-# Each bedrock model specifies parameters with a slightly different name
-# most of these are passed optionally by the user in kwargs but max tokens
-# is a required argument.
-PROVIDER_SPECIFIC_PARAM_NAME = {
-    "amazon": {"max_tokens": "maxTokenCount"},
-    "ai21": {"max_tokens": "maxTokens"},
-    "anthropic": {"max_tokens": "max_tokens_to_sample"},
-    "cohere": {"max_tokens": "max_tokens"},
-    "meta": {"max_tokens": "max_gen_len"},
+
+class Provider(ABC):
+    @property
+    @abstractmethod
+    def max_tokens_key(self) -> str:
+        ...
+
+    @abstractmethod
+    def get_text_from_response(self, response: dict) -> str:
+        ...
+
+    def get_text_from_stream_response(self, response: dict) -> str:
+        return self.get_text_from_response(response)
+
+    def get_request_body(self, prompt: str, inference_parameters: dict) -> dict:
+        return {"prompt": prompt, **inference_parameters}
+
+    messages_to_prompt: Optional[Callable[[Sequence[ChatMessage]], str]] = None
+    completion_to_prompt: Optional[Callable[[str], str]] = None
+
+
+class AmazonProvider(Provider):
+    max_tokens_key = "maxTokenCount"
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["results"][0]["outputText"]
+
+    def get_text_from_stream_response(self, response: dict) -> str:
+        return response["outputText"]
+
+    def get_request_body(self, prompt: str, inference_parameters: dict) -> dict:
+        return {
+            "inputText": prompt,
+            "textGenerationConfig": {**inference_parameters},
+        }
+
+
+class Ai21Provider(Provider):
+    max_tokens_key = "maxTokens"
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["completions"][0]["data"]["text"]
+
+
+def completion_to_anthopic_prompt(completion: str) -> str:
+    return messages_to_anthropic_prompt(prompt_to_messages(completion))
+
+
+class AnthropicProvider(Provider):
+    max_tokens_key = "max_tokens_to_sample"
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["completion"]
+
+    messages_to_prompt = messages_to_anthropic_prompt
+    completion_to_prompt = completion_to_anthopic_prompt
+
+
+class CohereProvider(Provider):
+    max_tokens_key = "max_tokens"
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["generations"][0]["text"]
+
+
+class MetaProvider(Provider):
+    max_tokens_key = "max_gen_len"
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["generation"]
+
+    messages_to_prompt = messages_to_llama_prompt
+    completion_to_prompt = completion_to_llama_prompt
+
+
+PROVIDERS = {
+    "amazon": AmazonProvider(),
+    "ai21": Ai21Provider(),
+    "anthropic": AnthropicProvider(),
+    "cohere": CohereProvider(),
+    "meta": MetaProvider(),
 }
 
-# The response format for each provider is different
-PROVIDER_RESPONSE_LOADER = {
-    "amazon": lambda x: x["results"][0]["outputText"],
-    "ai21": lambda x: x["completions"][0]["data"]["text"],
-    "anthropic": lambda x: x["completion"],
-    "cohere": lambda x: x["generations"][0]["text"],
-    "meta": lambda x: x["generation"],
-}
 
-PROVIDER_STREAM_RESPONSE_LOADER = {
-    "amazon": lambda x: x["outputText"],
-    "anthropic": lambda x: x["completion"],
-    "meta": lambda x: x["generation"],
-}
+def get_provider(model: str) -> Provider:
+    provider_name = model.split(".")[0]
+    return PROVIDERS[provider_name]
+
+
 logger = logging.getLogger(__name__)
-
-
-def bedrock_model_to_param_name(model: str, param_name: str) -> str:
-    provider = model.split(".")[0]
-    model_params = PROVIDER_SPECIFIC_PARAM_NAME[provider]
-    return model_params[param_name]
 
 
 def _create_retry_decorator(client: Any, max_retries: int) -> Callable[[Any], Any]:
@@ -137,80 +195,3 @@ def completion_with_retry(
         return client.invoke_model(modelId=model, body=request_body)
 
     return _completion_with_retry(**kwargs)
-
-
-def _message_to_bedrock_prompt(message: ChatMessage) -> str:
-    if message.role == MessageRole.USER:
-        prompt = f"{HUMAN_PREFIX} {message.content}"
-    elif message.role == MessageRole.ASSISTANT:
-        prompt = f"{ASSISTANT_PREFIX} {message.content}"
-    elif message.role == MessageRole.SYSTEM:
-        prompt = f"{HUMAN_PREFIX} <system>{message.content}</system>"
-    elif message.role == MessageRole.FUNCTION:
-        raise ValueError(f"Message role {MessageRole.FUNCTION} is not supported.")
-    else:
-        raise ValueError(f"Unknown message role: {message.role}")
-
-    return prompt
-
-
-def messages_to_bedrock_prompt(messages: Sequence[ChatMessage]) -> str:
-    if len(messages) == 0:
-        raise ValueError("Got empty list of messages.")
-
-    # NOTE: make sure the prompt ends with the assistant prefix
-    if messages[-1].role != MessageRole.ASSISTANT:
-        messages = [
-            *list(messages),
-            ChatMessage(role=MessageRole.ASSISTANT, content=""),
-        ]
-
-    str_list = [_message_to_bedrock_prompt(message) for message in messages]
-    return "".join(str_list)
-
-
-def get_request_body(provider: str, prompt: str, inference_paramters: dict) -> dict:
-    if provider == "amazon":
-        response_body = {
-            "inputText": prompt,
-            "textGenerationConfig": {**inference_paramters},
-        }
-    else:
-        response_body = {"prompt": prompt, **inference_paramters}
-    return response_body
-
-
-def get_text_from_response(provider: str, response: dict, stream: bool = False) -> str:
-    if stream:
-        return PROVIDER_STREAM_RESPONSE_LOADER[provider](response)
-    return PROVIDER_RESPONSE_LOADER[provider](response)
-
-
-def completion_to_chat_decorator(
-    func: Callable[..., CompletionResponse]
-) -> Callable[..., ChatResponse]:
-    """Convert a completion function to a chat function."""
-
-    def wrapper(messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
-        # normalize input
-        prompt = messages_to_bedrock_prompt(messages)
-        completion_response = func(prompt, **kwargs)
-        # normalize output
-        return completion_response_to_chat_response(completion_response)
-
-    return wrapper
-
-
-def stream_completion_to_chat_decorator(
-    func: Callable[..., CompletionResponseGen]
-) -> Callable[..., ChatResponseGen]:
-    """Convert a completion function to a chat function."""
-
-    def wrapper(messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseGen:
-        # normalize input
-        prompt = messages_to_bedrock_prompt(messages)
-        completion_response = func(prompt, **kwargs)
-        # normalize output
-        return stream_completion_response_to_chat_response(completion_response)
-
-    return wrapper

--- a/tests/llms/test_bedrock.py
+++ b/tests/llms/test_bedrock.py
@@ -2,6 +2,7 @@ import json
 from io import BytesIO
 from typing import Any, Generator
 
+import pytest
 from botocore.response import StreamingBody
 from botocore.stub import Stubber
 from llama_index.llms import Bedrock
@@ -22,20 +23,8 @@ class MockEventStream:
             }
 
 
-def get_invoke_model_response() -> dict:
-    # response for titan model
-    raw_stream_bytes = json.dumps(
-        {
-            "inputTextTokenCount": 3,
-            "results": [
-                {
-                    "tokenCount": 14,
-                    "outputText": "\n\nThis is indeed a test",
-                    "completionReason": "FINISH",
-                }
-            ],
-        }
-    ).encode()
+def get_invoke_model_response(payload: str) -> dict:
+    raw_stream_bytes = payload.encode()
     raw_stream = BytesIO(raw_stream_bytes)
     content_length = len(raw_stream_bytes)
 
@@ -90,9 +79,54 @@ class MockStreamCompletionWithRetry:
         }
 
 
-def test_model_basic() -> None:
+@pytest.mark.parametrize(
+    ("model", "complete_request", "response_body", "chat_request"),
+    [
+        (
+            "amazon.titan-text-express-v1",
+            '{"inputText": "test prompt", "textGenerationConfig": {"temperature": 0.5, "maxTokenCount": 512}}',
+            '{"inputTextTokenCount": 3, "results": [{"tokenCount": 14, "outputText": "\\n\\nThis is indeed a test", "completionReason": "FINISH"}]}',
+            '{"inputText": "user: test prompt\\nassistant: ", "textGenerationConfig": {"temperature": 0.5, "maxTokenCount": 512}}',
+        ),
+        (
+            "ai21.j2-grande-instruct",
+            '{"prompt": "test prompt", "temperature": 0.5, "maxTokens": 512}',
+            '{"completions": [{"data": {"text": "\\n\\nThis is indeed a test"}}]}',
+            '{"prompt": "user: test prompt\\nassistant: ", "temperature": 0.5, "maxTokens": 512}',
+        ),
+        (
+            "cohere.command-text-v14",
+            '{"prompt": "test prompt", "temperature": 0.5, "max_tokens": 512}',
+            '{"generations": [{"text": "\\n\\nThis is indeed a test"}]}',
+            '{"prompt": "user: test prompt\\nassistant: ", "temperature": 0.5, "max_tokens": 512}',
+        ),
+        (
+            "anthropic.claude-instant-v1",
+            '{"prompt": "\\n\\nHuman: test prompt\\n\\nAssistant: ", "temperature": 0.5, "max_tokens_to_sample": 512}',
+            '{"completion": "\\n\\nThis is indeed a test"}',
+            '{"prompt": "\\n\\nHuman: test prompt\\n\\nAssistant: ", "temperature": 0.5, "max_tokens_to_sample": 512}',
+        ),
+        (
+            "meta.llama2-13b-chat-v1",
+            '{"prompt": "<s> [INST] <<SYS>>\\n You are a helpful, respectful and '
+            "honest assistant. Always answer as helpfully as possible and follow "
+            "ALL given instructions. Do not speculate or make up information. Do "
+            "not reference any given instructions or context. \\n<</SYS>>\\n\\n "
+            'test prompt [/INST]", "temperature": 0.5, "max_gen_len": 512}',
+            '{"generation": "\\n\\nThis is indeed a test"}',
+            '{"prompt": "<s> [INST] <<SYS>>\\n You are a helpful, respectful and '
+            "honest assistant. Always answer as helpfully as possible and follow "
+            "ALL given instructions. Do not speculate or make up information. Do "
+            "not reference any given instructions or context. \\n<</SYS>>\\n\\n "
+            'test prompt [/INST]", "temperature": 0.5, "max_gen_len": 512}',
+        ),
+    ],
+)
+def test_model_basic(
+    model: str, complete_request: str, response_body: str, chat_request: str
+) -> None:
     llm = Bedrock(
-        model="amazon.titan-text-express-v1",
+        model=model,
         profile_name=None,
         aws_region_name="us-east-1",
         aws_access_key_id="test",
@@ -103,12 +137,14 @@ def test_model_basic() -> None:
     # response for llm.complete()
     bedrock_stubber.add_response(
         "invoke_model",
-        get_invoke_model_response(),
+        get_invoke_model_response(response_body),
+        {"body": complete_request, "modelId": model},
     )
     # response for llm.chat()
     bedrock_stubber.add_response(
         "invoke_model",
-        get_invoke_model_response(),
+        get_invoke_model_response(response_body),
+        {"body": chat_request, "modelId": model},
     )
 
     bedrock_stubber.activate()


### PR DESCRIPTION
# Description

This PR fixes Bedrock LLMs.
Since https://github.com/run-llama/llama_index/pull/9388, Bedrock+Anthropic doesn't work anymore because the completion is used instead of the chat and the completion has an incorrect format (it passes the completion prompt as-is without adding the `Human: /Assistant: ` prefixes)
This change does the following:
* set `is_chat_model` for CHAT_ONLY_MODELS
* create Provider classes to group behaviors
* use messages_to_prompt and completion_to_prompt to convert to prompt. The order of resolution is:
   * user-defined ones
   * provider specific ones
   * generic ones 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
