### PR TITLE
Fix small bug in string method of NodeWithScore

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -526,7 +526,8 @@ class NodeWithScore(BaseComponent):
     score: Optional[float] = None
 
     def __str__(self) -> str:
-        return f"{self.node}\nScore: {self.score: 0.3f}\n"
+        score_str = "None" if self.score is None else f"{self.score: 0.3f}"
+        return f"{self.node}\nScore: {score_str}\n"
 
     def get_score(self, raise_error: bool = False) -> float:
         """Get score."""


### PR DESCRIPTION
# Description

Avoid exception in __str__ method of NodeWithScore when the optional member variable self.score is None.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
