### PR TITLE
Allow build/search params for MilvusVectorStore

### DIFF
--- a/llama_index/vector_stores/milvus.py
+++ b/llama_index/vector_stores/milvus.py
@@ -67,6 +67,11 @@ class MilvusVectorStore(VectorStore):
             name. Defaults to False.
         text_key (str, optional): What key text is stored in in the passed collection.
             Used when bringing your own collection. Defaults to None.
+        index_config (dict, optional): The configuration used for building the
+            Milvus index. Defaults to None.
+        search_config (dict, optional): The configuration used for searching
+            the Milvus index. Note that this must be compatible with the index
+            type specified by `index_config`. Defaults to None.
 
     Raises:
         ImportError: Unable to import `pymilvus`.

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -118,3 +118,24 @@ def test_search_data_filter(
     )
     assert res.ids is not None and res.ids[0] == "c330d77f-90bd-4c51-9ed2-57d8d693b3b0"
     assert res.nodes is not None and res.nodes[0].metadata["theme"] == "Friendship"
+
+
+@pytest.mark.skipif(milvus_libs is None, reason="Missing milvus packages")
+def test_non_default_index_type(
+    node_embeddings: List[TextNode], embedded_milvus: str
+) -> None:
+    milvus_store = MilvusVectorStore(
+        dim=2,
+        uri=embedded_milvus,
+        collection_name="test",
+        similarity_metric="L2",
+        index_config={"index_type": "IVF_FLAT", "nlist": 64},
+        search_config={"nprobe": 16},
+    )
+    milvus_store.add(node_embeddings)
+
+    res = milvus_store.query(
+        VectorStoreQuery(query_embedding=[3, 3], similarity_top_k=1)
+    )
+    assert res.ids is not None and res.ids[0] == "c3d1e1dd-8fb4-4b8f-b7ea-7fa96038d39d"
+    assert res.nodes is not None and res.nodes[0].metadata["theme"] == "Mafia"


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR introduces the ability to pass index build and search parameters to the MilvusVectorStore. This is valuable for a few reasons:

1. It allows more data to be stored in Milvus on the same hardware by providing access to index types that offer compressed representations of their data.
2. It allows for higher throughput or lower latency for vector store requests by providing access to approximate index types and configurations that allow performance tuning.
3. It allows GPU-acceleration of vector indexing and retrieval through selection of one of Milvus's GPU-accelerated index types.

Fixes #9493 

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests

I have added a test which invokes the MilvusVectorStore with non-default index and search parameters. Specifically, we test with an IVF Flat index type. This can be reproduced with a run of `make test` in an environment with pymilvus available.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] (N/A) I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
