### PR TITLE
Allowing `LOCALAI_DEFAULTS` to work with `__ror__`

### DIFF
--- a/llama_index/llms/localai.py
+++ b/llama_index/llms/localai.py
@@ -7,7 +7,7 @@ Source: https://github.com/go-skynet/LocalAI
 
 import warnings
 from types import MappingProxyType
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence
 
 from llama_index.bridge.pydantic import Field
 from llama_index.constants import DEFAULT_CONTEXT_WINDOW
@@ -19,7 +19,8 @@ from llama_index.types import BaseOutputParser, PydanticProgramMode
 
 # Use these as kwargs for OpenAILike to connect to LocalAIs
 DEFAULT_LOCALAI_PORT = 8080
-LOCALAI_DEFAULTS: Mapping[str, Any] = MappingProxyType(
+# TODO: move to MappingProxyType[str, Any] once Python 3.9+
+LOCALAI_DEFAULTS: Dict[str, Any] = MappingProxyType(  # type: ignore[assignment]
     {
         "api_key": "localai_fake",
         "api_type": "localai_fake",


### PR DESCRIPTION
# Description

`mypy==1.7.1` will fail this as of `llama-index==0.9.15`:

```python
from llama_index.llms import LOCALAI_DEFAULTS

overridden = LOCALAI_DEFAULTS | {"api_base": "foo"}
```

The reason is `No overload variant of "__ror__" of "dict" matches argument type "Mapping[str, Any]"  [operator]`

The correct fix here is to use `LOCALAI_DEFAULTS: MappingProxyType[str, Any]`, but that requires Python 3.9+.

This PR takes a second best route, using `Dict[str, Any]` which isn't technically type correct but it's close enough.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
