### PR TITLE
Added missing `default=None` to `LLM.system_prompt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+### Bug Fixes / Nits
+
+- Fixed missing `default=None` for `LLM.system_prompt` (#9504)
+
 ## [0.9.15] - 2023-12-13
 
 ### New Features

--- a/llama_index/llms/llm.py
+++ b/llama_index/llms/llm.py
@@ -86,7 +86,9 @@ async def astream_chat_response_to_tokens(
 
 
 class LLM(BaseLLM):
-    system_prompt: Optional[str] = Field(description="System prompt for LLM calls.")
+    system_prompt: Optional[str] = Field(
+        default=None, description="System prompt for LLM calls."
+    )
     messages_to_prompt: MessagesToPromptType = Field(
         description="Function to convert a list of messages to an LLM prompt.",
         default=generic_messages_to_prompt,


### PR DESCRIPTION
# Description

Upgrading to `llama-index==0.9.15`, `mypy==1.7.1` is reporting a lot of type errors for every LLM:

```
scripts/index.py:76:15: error: Missing named argument "system_prompt" for
"Ollama"  [call-arg]
            llm = Ollama(model="llama2:13b")
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

The issue is a missing default for `system_prompt`. This PR fixes that

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
