### PR TITLE
Update PDFReader

### DIFF
--- a/llama_index/readers/file/docs_reader.py
+++ b/llama_index/readers/file/docs_reader.py
@@ -15,6 +15,12 @@ from llama_index.schema import Document
 class PDFReader(BaseReader):
     """PDF parser."""
 
+    def __init__(self, return_full_document: Optional[bool] = False) -> None:
+        """
+        Initialize PDFReader.
+        """
+        self.return_full_document = return_full_document
+
     def load_data(
         self, file: Path, extra_info: Optional[Dict] = None
     ) -> List[Document]:
@@ -32,18 +38,35 @@ class PDFReader(BaseReader):
             # Get the number of pages in the PDF document
             num_pages = len(pdf.pages)
 
-            # Iterate over every page
             docs = []
-            for page in range(num_pages):
-                # Extract the text from the page
-                page_text = pdf.pages[page].extract_text()
-                page_label = pdf.page_labels[page]
 
-                metadata = {"page_label": page_label, "file_name": file.name}
-                if extra_info is not None:
-                    metadata.update(extra_info)
+            # This block returns a whole PDF as a single Document
+            if self.return_full_document:
+                text = ""
+                metadata = {"file_name": fp.name}
 
-                docs.append(Document(text=page_text, metadata=metadata))
+                for page in range(num_pages):
+                    # Extract the text from the page
+                    page_text = pdf.pages[page].extract_text()
+                    text += page_text
+
+                docs.append(Document(text=text, metadata=metadata))
+
+            # This block returns each page of a PDF as its own Document
+            else:
+                # Iterate over every page
+
+                for page in range(num_pages):
+                    # Extract the text from the page
+                    page_text = pdf.pages[page].extract_text()
+                    page_label = pdf.page_labels[page]
+
+                    metadata = {"page_label": page_label, "file_name": fp.name}
+                    if extra_info is not None:
+                        metadata.update(extra_info)
+
+                    docs.append(Document(text=page_text, metadata=metadata))
+
             return docs
 
 


### PR DESCRIPTION


# Description

Add to PDFReader so that a user can specify if they want the PDF read in as one whole Document, or each page as a Document. Lacking the functionality to read in a PDF as a whole document, so then a user can split how they see fit, was annoying.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested by loading in a local PDF with and without the return_full_document argument set to True. When set to True, returned one Document. When set to false, returned 32 Documents. 

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
