### PR TITLE
fix/Reintroduce `WHERE` filter to the Sparse Query for PgVectorStore

### DIFF
--- a/llama_index/vector_stores/postgres.py
+++ b/llama_index/vector_stores/postgres.py
@@ -472,10 +472,14 @@ class PGVectorStore(BasePydanticVectorStore):
         ts_query = func.plainto_tsquery(
             type_coerce(self.text_search_config, REGCONFIG), query_str
         )
-        stmt = select(  # type: ignore
-            self._table_class,
-            func.ts_rank(self._table_class.text_search_tsv, ts_query).label("rank"),
-        ).order_by(text("rank desc"))
+        stmt = (
+            select(  # type: ignore
+                self._table_class,
+                func.ts_rank(self._table_class.text_search_tsv, ts_query).label("rank"),
+            )
+            .where(self._table_class.text_search_tsv.op("@@")(ts_query))
+            .order_by(text("rank desc"))
+        )
 
         # type: ignore
         return self._apply_filters_and_limit(stmt, limit, metadata_filters)


### PR DESCRIPTION
# Description

Reintroduce `WHERE` filter to the Sparse query for PgVector (reverting #9400)

The considerations are:
- The `ts_rank` function works by ranking all rows, by not filtering the result we will essentially rank all rows in the table most of which will probably have a ranking of 0. So that's expensive and unnecessary.
- The `ts_query` variable we put on the `SELECT` clause will only compiled to `plainto_tsquery($1, $2::VARCHAR)`, which does not do anything other than convert the query to `tsquery` type. So we still need to put the `WHERE` clause to actually filter the result.

Performance comparison (you can see the execution time is almost 2x faster):

**Without `WHERE` clause:**
```
QUERY PLAN                                                                                                                                                    |
--------------------------------------------------------------------------------------------------------------------------------------------------------------+
Limit  (cost=61005.45..61017.12 rows=100 width=1191) (actual time=627.584..629.058 rows=100 loops=1)                                                          |
  ->  Gather Merge  (cost=61005.45..88736.49 rows=237678 width=1191) (actual time=627.582..629.048 rows=100 loops=1)                                          |
        Workers Planned: 2                                                                                                                                    |
        Workers Launched: 2                                                                                                                                   |
        ->  Sort  (cost=60005.43..60302.53 rows=118839 width=1191) (actual time=624.766..624.770 rows=64 loops=3)                                             |
              Sort Key: (ts_rank(text_search_tsv, '''china'''::tsquery)) DESC                                                                                 |
              Sort Method: top-N heapsort  Memory: 252kB                                                                                                      |
              Worker 0:  Sort Method: top-N heapsort  Memory: 244kB                                                                                           |
              Worker 1:  Sort Method: top-N heapsort  Memory: 270kB                                                                                           |
              ->  Parallel Seq Scan on my_table                   (cost=0.00..55463.49 rows=118839 width=1191) (actual time=0.072..578.646 rows=95071 loops=3)|
Planning Time: 0.094 ms                                                                                                                                       |
Execution Time: 629.090 ms                                                                                                                                    |
```

**With `WHERE` clause:**
```
QUERY PLAN                                                                                                                                               |
---------------------------------------------------------------------------------------------------------------------------------------------------------+
Limit  (cost=55709.26..55709.51 rows=100 width=1191) (actual time=306.273..306.289 rows=100 loops=1)                                                     |
  ->  Sort  (cost=55709.26..55803.64 rows=37753 width=1191) (actual time=306.272..306.278 rows=100 loops=1)                                              |
        Sort Key: (ts_rank(text_search_tsv, '''china'''::tsquery)) DESC                                                                                  |
        Sort Method: top-N heapsort  Memory: 334kB                                                                                                       |
        ->  Bitmap Heap Scan on my_table  (cost=2220.58..54266.37 rows=37753 width=1191) (actual time=9.637..287.518 rows=36933 loops=1)                 |
              Recheck Cond: (text_search_tsv @@ '''china'''::tsquery)                                                                                    |
              Heap Blocks: exact=21136                                                                                                                   |
              ->  Bitmap Index Scan on text_search_tsv_idx  (cost=0.00..2211.15 rows=37753 width=0) (actual time=6.226..6.226 rows=40473 loops=1)        |
                    Index Cond: (text_search_tsv @@ '''china'''::tsquery)                                                                                |
Planning Time: 0.134 ms                                                                                                                                  |
Execution Time: 306.325 ms                                                                                                                               |
```


Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
