### PR TITLE
added _node_type to metadata

### DIFF
--- a/llama_index/vector_stores/milvus.py
+++ b/llama_index/vector_stores/milvus.py
@@ -295,7 +295,10 @@ class MilvusVectorStore(VectorStore):
         for hit in res[0]:
             if not self.text_key:
                 node = metadata_dict_to_node(
-                    {"_node_content": hit["entity"].get("_node_content", None)}
+                    {
+                        "_node_content": hit["entity"].get("_node_content", None),
+                        "_node_type": hit["entity"].get("_node_type", None),
+                    }
                 )
             else:
                 try:


### PR DESCRIPTION
# Description

The function meta_data_to_dict takes a metadata_dict that expects both _node_content and _node_type. The current implementation in MilvusVectorStore passes a dictionary with a single key _node_content. My fix simple gets the _node_type from the hit["entity"] and adds it to the metadata dictionary that will be passed to meta_data_to_dict.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I encountered this error using a recursive retriever built on a MilvusVectorStore. The vectorstore only contained IndexNodes but the retriever returned TextNodes. I fixed the problem locally and it works. Also the fix is small so it should be visually verifiable.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
