### PR TITLE
add a device in optimum

### DIFF
--- a/llama_index/embeddings/huggingface_optimum.py
+++ b/llama_index/embeddings/huggingface_optimum.py
@@ -4,6 +4,7 @@ from llama_index.bridge.pydantic import Field, PrivateAttr
 from llama_index.callbacks import CallbackManager
 from llama_index.embeddings.base import DEFAULT_EMBED_BATCH_SIZE, BaseEmbedding
 from llama_index.embeddings.huggingface_utils import format_query, format_text
+from llama_index.utils import infer_torch_device
 
 
 class OptimumEmbedding(BaseEmbedding):
@@ -52,7 +53,7 @@ class OptimumEmbedding(BaseEmbedding):
 
         self._model = model or ORTModelForFeatureExtraction.from_pretrained(folder_name)
         self._tokenizer = tokenizer or AutoTokenizer.from_pretrained(folder_name)
-        self._device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self._device = device or infer_torch_device()
 
         if max_length is None:
             try:


### PR DESCRIPTION
# Description

When you try to use mean pooling with an OptimumEmbedding using a model backed by a `CUDAExecutionProvider` we get:

```
  File "/usr/local/lib/python3.10/site-packages/llama_index/embeddings/huggingface_optimum.py", line 141, in _embed
    embeddings = self._mean_pooling(
  File "/usr/local/lib/python3.10/site-packages/llama_index/embeddings/huggingface_optimum.py", line 119, in _mean_pooling
    return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

HuggingFace seems to encourage you to use their `pipeline` abstraction and attach a device to that, and it will automatically make sure the results from the tokenizer and the model are on the same device. Since we don't do any of that here, I think it makes sense for a consumer to pass in a `device` and have tensors moved there.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
