### PR TITLE
ollama: strip invalid `formatted` option

### DIFF
--- a/llama_index/llms/ollama.py
+++ b/llama_index/llms/ollama.py
@@ -111,6 +111,7 @@ class Ollama(CustomLLM):
                 "Please install requests with `pip install requests`"
             )
         all_kwargs = self._get_all_kwargs(**kwargs)
+        del all_kwargs["formatted"]  # ollama throws 400 if it receives this option
 
         if not kwargs.get("formatted", False):
             prompt = self.completion_to_prompt(prompt)


### PR DESCRIPTION
# Description

Looks like the `formatted` kwarg is forwarded as a model option, which causes Ollama to return a 400 error.

As far as I can tell, it's only used to check if we should call `completion_to_prompt`, so I deleted it, and it seems to work.

Fixes #9551

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
