### PR TITLE
add MongoDB Vector Search vector store to docs

### DIFF
--- a/llama_index/vector_stores/__init__.py
+++ b/llama_index/vector_stores/__init__.py
@@ -24,6 +24,7 @@ from llama_index.vector_stores.lancedb import LanceDBVectorStore
 from llama_index.vector_stores.lantern import LanternVectorStore
 from llama_index.vector_stores.metal import MetalVectorStore
 from llama_index.vector_stores.milvus import MilvusVectorStore
+from llama_index.vector_stores.mongodb import MongoDBAtlasVectorSearch
 from llama_index.vector_stores.myscale import MyScaleVectorStore
 from llama_index.vector_stores.neo4jvector import Neo4jVectorStore
 from llama_index.vector_stores.opensearch import (
@@ -99,4 +100,5 @@ __all__ = [
     "AstraDBVectorStore",
     "AzureCosmosDBMongoDBVectorSearch",
     "LanternVectorStore",
+    "MongoDBAtlasVectorSearch",
 ]

--- a/llama_index/vector_stores/mongodb.py
+++ b/llama_index/vector_stores/mongodb.py
@@ -8,8 +8,6 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, cast
 
-from pymongo import MongoClient
-
 from llama_index.schema import BaseNode, MetadataMode, TextNode
 from llama_index.vector_stores.types import (
     MetadataFilters,
@@ -49,7 +47,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
 
     def __init__(
         self,
-        mongodb_client: Optional[MongoClient] = None,
+        mongodb_client: Optional[Any] = None,
         db_name: str = "default_db",
         collection_name: str = "default_collection",
         index_name: str = "default",


### PR DESCRIPTION
# Description

I noticed that the MongoDB vector store was not listed in the [vector store API documentation](https://docs.llamaindex.ai/en/latest/api_reference/storage/vector_store.html). The API reference wasn't available in the docs, either. I'm working on adding this to the MongoDB docs and wanted to be able to link to the llama_index API reference docs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I built the documentation locally and confirmed that the issue is addressed. The API reference for `llama_index.vector_stores.MongoDBAtlasVectorSearch` is now available in the documentation.

![Screenshot 2023-12-15 at 5 47 06 PM](https://github.com/run-llama/llama_index/assets/55147273/83fcfb0e-7d0d-445e-a374-4353d21b2efc)
![Screenshot 2023-12-15 at 5 46 44 PM](https://github.com/run-llama/llama_index/assets/55147273/6ad899c2-b528-40ed-b7ce-bac7581c59c6)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
