### PR TITLE
Add mixtral 8x7b model to anyscale available models

### DIFF
--- a/llama_index/llms/anyscale_utils.py
+++ b/llama_index/llms/anyscale_utils.py
@@ -10,7 +10,8 @@ LLAMA_MODELS = {
 }
 
 MISTRAL_MODELS = {
-    "mistralai/Mistral-7B-Instruct-v0.1": 4096,
+    "mistralai/Mistral-7B-Instruct-v0.1": 16384,
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": 32768,
 }
 
 ALL_AVAILABLE_MODELS = {


### PR DESCRIPTION
# Description

Anyscale recently made a Mixtral-8x7B-Instruct-v0.1 endpoint available. However, it's not possible to use with llama_index.llms.anyscale because anyscale_utils.py expects the model to be explicitly specified. 

Moreover the mistral model also supports extended context length of 16k (see attached screenshot)
<img width="669" alt="image" src="https://github.com/run-llama/llama_index/assets/7935430/b73b3c11-345d-44a5-8692-52a547091219">


Fixes # (issue)
I simply updated the list of models to include the relevant one.
## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
