### PR TITLE
Configurable Node ID Generating Function

### DIFF
--- a/llama_index/node_parser/file/html.py
+++ b/llama_index/node_parser/file/html.py
@@ -123,7 +123,7 @@ class HTMLNodeParser(NodeParser):
         metadata: dict,
     ) -> TextNode:
         """Build node from single text split."""
-        node = build_nodes_from_splits([text_split], node)[0]
+        node = build_nodes_from_splits([text_split], node, id_func=self.id_func)[0]
 
         if self.include_metadata:
             node.metadata = {**node.metadata, **metadata}

--- a/llama_index/node_parser/file/json.py
+++ b/llama_index/node_parser/file/json.py
@@ -64,11 +64,17 @@ class JSONNodeParser(NodeParser):
         json_nodes = []
         if isinstance(data, dict):
             lines = [*self._depth_first_yield(data, 0, [])]
-            json_nodes.extend(build_nodes_from_splits(["\n".join(lines)], node))
+            json_nodes.extend(
+                build_nodes_from_splits(["\n".join(lines)], node, id_func=self.id_func)
+            )
         elif isinstance(data, list):
             for json_object in data:
                 lines = [*self._depth_first_yield(json_object, 0, [])]
-                json_nodes.extend(build_nodes_from_splits(["\n".join(lines)], node))
+                json_nodes.extend(
+                    build_nodes_from_splits(
+                        ["\n".join(lines)], node, id_func=self.id_func
+                    )
+                )
         else:
             raise ValueError("JSON is invalid")
 

--- a/llama_index/node_parser/file/markdown.py
+++ b/llama_index/node_parser/file/markdown.py
@@ -113,7 +113,7 @@ class MarkdownNodeParser(NodeParser):
         metadata: dict,
     ) -> TextNode:
         """Build node from single text split."""
-        node = build_nodes_from_splits([text_split], node)[0]
+        node = build_nodes_from_splits([text_split], node, id_func=self.id_func)[0]
 
         if self.include_metadata:
             node.metadata = {**node.metadata, **metadata}

--- a/llama_index/node_parser/interface.py
+++ b/llama_index/node_parser/interface.py
@@ -1,10 +1,10 @@
 """Node parser interface."""
 from abc import ABC, abstractmethod
-from typing import Any, List, Sequence
+from typing import Any, Callable, List, Sequence
 
 from llama_index.bridge.pydantic import Field
 from llama_index.callbacks import CallbackManager, CBEventType, EventPayload
-from llama_index.node_parser.node_utils import build_nodes_from_splits
+from llama_index.node_parser.node_utils import build_nodes_from_splits, default_id_func
 from llama_index.schema import (
     BaseNode,
     Document,
@@ -26,6 +26,10 @@ class NodeParser(TransformComponent, ABC):
     )
     callback_manager: CallbackManager = Field(
         default_factory=CallbackManager, exclude=True
+    )
+    id_func: Callable[[int, BaseNode], str] = Field(
+        default=default_id_func,
+        description="Function to generate node IDs.",
     )
 
     class Config:
@@ -118,7 +122,9 @@ class TextSplitter(NodeParser):
         for node in nodes_with_progress:
             splits = self.split_text(node.get_content())
 
-            all_nodes.extend(build_nodes_from_splits(splits, node))
+            all_nodes.extend(
+                build_nodes_from_splits(splits, node, id_func=self.id_func)
+            )
 
         return all_nodes
 
@@ -164,6 +170,8 @@ class MetadataAwareTextSplitter(TextSplitter):
                 node.get_content(metadata_mode=MetadataMode.NONE),
                 metadata_str=metadata_str,
             )
-            all_nodes.extend(build_nodes_from_splits(splits, node))
+            all_nodes.extend(
+                build_nodes_from_splits(splits, node, id_func=self.id_func)
+            )
 
         return all_nodes

--- a/llama_index/node_parser/interface.py
+++ b/llama_index/node_parser/interface.py
@@ -1,10 +1,14 @@
 """Node parser interface."""
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List, Sequence
+from typing import Any, List, Sequence
 
 from llama_index.bridge.pydantic import Field
 from llama_index.callbacks import CallbackManager, CBEventType, EventPayload
-from llama_index.node_parser.node_utils import build_nodes_from_splits, default_id_func
+from llama_index.node_parser.node_utils import (
+    IdFuncCallable,
+    build_nodes_from_splits,
+    default_id_func,
+)
 from llama_index.schema import (
     BaseNode,
     Document,
@@ -27,7 +31,7 @@ class NodeParser(TransformComponent, ABC):
     callback_manager: CallbackManager = Field(
         default_factory=CallbackManager, exclude=True
     )
-    id_func: Callable[[int, BaseNode], str] = Field(
+    id_func: IdFuncCallable = Field(
         default=default_id_func,
         description="Function to generate node IDs.",
     )

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -2,7 +2,8 @@
 
 
 import logging
-from typing import List, Optional
+import uuid
+from typing import Callable, List, Optional
 
 from llama_index.schema import (
     BaseNode,
@@ -17,20 +18,26 @@ from llama_index.utils import truncate_text
 logger = logging.getLogger(__name__)
 
 
+def default_id_func(i: int, doc: Document):
+    return str(uuid.uuid4())
+
+
 def build_nodes_from_splits(
     text_splits: List[str],
     document: BaseNode,
     ref_doc: Optional[BaseNode] = None,
+    id_func: Optional[Callable[[int, BaseNode], str]] = None,
 ) -> List[TextNode]:
     """Build nodes from splits."""
     ref_doc = ref_doc or document
-
+    id_func = id_func or default_id_func
     nodes: List[TextNode] = []
     for i, text_chunk in enumerate(text_splits):
         logger.debug(f"> Adding chunk: {truncate_text(text_chunk, 50)}")
 
         if isinstance(document, ImageDocument):
             image_node = ImageNode(
+                id=id_func(i, document),
                 text=text_chunk,
                 embedding=document.embedding,
                 image=document.image,
@@ -46,6 +53,7 @@ def build_nodes_from_splits(
             nodes.append(image_node)  # type: ignore
         elif isinstance(document, Document):
             node = TextNode(
+                id=id_func(i, document),
                 text=text_chunk,
                 embedding=document.embedding,
                 excluded_embed_metadata_keys=document.excluded_embed_metadata_keys,
@@ -58,6 +66,7 @@ def build_nodes_from_splits(
             nodes.append(node)
         elif isinstance(document, TextNode):
             node = TextNode(
+                id=id_func(i, document),
                 text=text_chunk,
                 embedding=document.embedding,
                 excluded_embed_metadata_keys=document.excluded_embed_metadata_keys,

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -18,7 +18,7 @@ from llama_index.utils import truncate_text
 logger = logging.getLogger(__name__)
 
 
-def default_id_func(i: int, doc: Document):
+def default_id_func(i: int, doc: BaseNode) -> str:
     return str(uuid.uuid4())
 
 

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -37,7 +37,7 @@ def build_nodes_from_splits(
 
         if isinstance(document, ImageDocument):
             image_node = ImageNode(
-                id=id_func(i, document),
+                id_=id_func(i, document),
                 text=text_chunk,
                 embedding=document.embedding,
                 image=document.image,
@@ -53,7 +53,7 @@ def build_nodes_from_splits(
             nodes.append(image_node)  # type: ignore
         elif isinstance(document, Document):
             node = TextNode(
-                id=id_func(i, document),
+                id_=id_func(i, document),
                 text=text_chunk,
                 embedding=document.embedding,
                 excluded_embed_metadata_keys=document.excluded_embed_metadata_keys,
@@ -66,7 +66,7 @@ def build_nodes_from_splits(
             nodes.append(node)
         elif isinstance(document, TextNode):
             node = TextNode(
-                id=id_func(i, document),
+                id_=id_func(i, document),
                 text=text_chunk,
                 embedding=document.embedding,
                 excluded_embed_metadata_keys=document.excluded_embed_metadata_keys,

--- a/llama_index/node_parser/node_utils.py
+++ b/llama_index/node_parser/node_utils.py
@@ -3,7 +3,7 @@
 
 import logging
 import uuid
-from typing import Callable, List, Optional
+from typing import List, Optional, Protocol, runtime_checkable
 
 from llama_index.schema import (
     BaseNode,
@@ -18,6 +18,12 @@ from llama_index.utils import truncate_text
 logger = logging.getLogger(__name__)
 
 
+@runtime_checkable
+class IdFuncCallable(Protocol):
+    def __call__(self, i: int, doc: BaseNode) -> str:
+        ...
+
+
 def default_id_func(i: int, doc: BaseNode) -> str:
     return str(uuid.uuid4())
 
@@ -26,7 +32,7 @@ def build_nodes_from_splits(
     text_splits: List[str],
     document: BaseNode,
     ref_doc: Optional[BaseNode] = None,
-    id_func: Optional[Callable[[int, BaseNode], str]] = None,
+    id_func: Optional[IdFuncCallable] = None,
 ) -> List[TextNode]:
     """Build nodes from splits."""
     ref_doc = ref_doc or document

--- a/llama_index/node_parser/text/langchain.py
+++ b/llama_index/node_parser/text/langchain.py
@@ -1,8 +1,10 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from llama_index.bridge.pydantic import PrivateAttr
 from llama_index.callbacks import CallbackManager
 from llama_index.node_parser.interface import TextSplitter
+from llama_index.node_parser.node_utils import default_id_func
+from llama_index.schema import Document
 
 if TYPE_CHECKING:
     from langchain.text_splitter import TextSplitter as LC_TextSplitter
@@ -23,6 +25,7 @@ class LangchainNodeParser(TextSplitter):
         callback_manager: Optional[CallbackManager] = None,
         include_metadata: bool = True,
         include_prev_next_rel: bool = True,
+        id_func: Optional[Callable[[int, Document], str]] = None,
     ):
         """Initialize with parameters."""
         try:
@@ -32,11 +35,13 @@ class LangchainNodeParser(TextSplitter):
                 "Could not run `from langchain.text_splitter import TextSplitter`, "
                 "please run `pip install langchain`"
             )
+        id_func = id_func or default_id_func
 
         super().__init__(
             callback_manager=callback_manager or CallbackManager(),
             include_metadata=include_metadata,
             include_prev_next_rel=include_prev_next_rel,
+            id_func=id_func,
         )
         self._lc_splitter = lc_splitter
 

--- a/llama_index/node_parser/text/sentence.py
+++ b/llama_index/node_parser/text/sentence.py
@@ -7,12 +7,14 @@ from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.constants import DEFAULT_CHUNK_SIZE
 from llama_index.node_parser.interface import MetadataAwareTextSplitter
+from llama_index.node_parser.node_utils import default_id_func
 from llama_index.node_parser.text.utils import (
     split_by_char,
     split_by_regex,
     split_by_sentence_tokenizer,
     split_by_sep,
 )
+from llama_index.schema import Document
 from llama_index.utils import get_tokenizer
 
 SENTENCE_CHUNK_OVERLAP = 200
@@ -71,6 +73,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
         callback_manager: Optional[CallbackManager] = None,
         include_metadata: bool = True,
         include_prev_next_rel: bool = True,
+        id_func: Optional[Callable[[int, Document], str]] = None,
     ):
         """Initialize with parameters."""
         if chunk_overlap > chunk_size:
@@ -78,6 +81,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
                 f"Got a larger chunk overlap ({chunk_overlap}) than chunk size "
                 f"({chunk_size}), should be smaller."
             )
+        id_func = id_func or default_id_func
 
         callback_manager = callback_manager or CallbackManager([])
         self._chunking_tokenizer_fn = (
@@ -105,6 +109,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
             callback_manager=callback_manager,
             include_metadata=include_metadata,
             include_prev_next_rel=include_prev_next_rel,
+            id_func=id_func,
         )
 
     @classmethod

--- a/llama_index/node_parser/text/sentence_window.py
+++ b/llama_index/node_parser/text/sentence_window.py
@@ -102,6 +102,7 @@ class SentenceWindowNodeParser(NodeParser):
             nodes = build_nodes_from_splits(
                 text_splits,
                 doc,
+                id_func=self.id_func,
             )
 
             # add window to each node

--- a/llama_index/node_parser/text/token.py
+++ b/llama_index/node_parser/text/token.py
@@ -7,7 +7,9 @@ from llama_index.callbacks.base import CallbackManager
 from llama_index.callbacks.schema import CBEventType, EventPayload
 from llama_index.constants import DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE
 from llama_index.node_parser.interface import MetadataAwareTextSplitter
+from llama_index.node_parser.node_utils import default_id_func
 from llama_index.node_parser.text.utils import split_by_char, split_by_sep
+from llama_index.schema import Document
 from llama_index.utils import get_tokenizer
 
 _logger = logging.getLogger(__name__)
@@ -49,6 +51,7 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
         backup_separators: Optional[List[str]] = ["\n"],
         include_metadata: bool = True,
         include_prev_next_rel: bool = True,
+        id_func: Optional[Callable[[int, Document], str]] = None,
     ):
         """Initialize with parameters."""
         if chunk_overlap > chunk_size:
@@ -57,7 +60,7 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
                 f"({chunk_size}), should be smaller."
             )
         callback_manager = callback_manager or CallbackManager([])
-
+        id_func = id_func or default_id_func
         self._tokenizer = tokenizer or get_tokenizer()
 
         all_seps = [separator] + (backup_separators or [])
@@ -71,6 +74,7 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
             callback_manager=callback_manager,
             include_metadata=include_metadata,
             include_prev_next_rel=include_prev_next_rel,
+            id_func=id_func,
         )
 
     @classmethod


### PR DESCRIPTION
# Description

It would be ideal to be able to customise the node_id generating function. At the moment it is a function that generates a UUIDv4. It would be great to be able to pass a function as an optional parameter to generate an ID of the users design. The function is accepting the chunk index and the source Document. For example, an id function could be `lambda i, doc:, f"{document.id}__{i}"` allowing the user to create a deterministic Node ID process given a fixed document_id and node_parser configuration. This would be useful for upserts on any pipeline re-runs and help avoiding accidental duplicate inserts.

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have ran all the existing tests and they are passing.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
