### PR TITLE
Introduced action input parser

### DIFF
--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -1,7 +1,6 @@
 """ReAct output parser."""
 
 
-import ast
 import json
 import re
 from typing import Tuple
@@ -29,11 +28,10 @@ def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
 
 
 def action_input_parser(json_str):
-    processed_string = re.sub(r'(?<!\w)\'|\'(?!\w)', '"', json_str)
+    processed_string = re.sub(r"(?<!\w)\'|\'(?!\w)", '"', json_str)
     pattern = r'"(\w+)":\s*"([^"]*)"'
     matches = re.findall(pattern, processed_string)
-    result_dict = {key: value for key, value in matches}
-    return result_dict
+    return dict(matches)
 
 
 def extract_final_response(input_text: str) -> Tuple[str, str]:

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -28,6 +28,14 @@ def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
     return thought, action, action_input
 
 
+def action_input_parser(json_str):
+    processed_string = re.sub(r'(?<!\w)\'|\'(?!\w)', '"', json_str)
+    pattern = r'"(\w+)":\s*"([^"]*)"'
+    matches = re.findall(pattern, processed_string)
+    result_dict = {key: value for key, value in matches}
+    return result_dict
+
+
 def extract_final_response(input_text: str) -> Tuple[str, str]:
     pattern = r"\s*Thought:(.*?)Answer:(.*?)(?:$)"
 
@@ -84,7 +92,7 @@ class ReActOutputParser(BaseOutputParser):
             try:
                 action_input_dict = json.loads(json_str)
             except json.JSONDecodeError:
-                action_input_dict = ast.literal_eval(json_str)
+                action_input_dict = action_input_parser(json_str)
 
             return ActionReasoningStep(
                 thought=thought, action=action, action_input=action_input_dict

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -15,7 +15,9 @@ from llama_index.types import BaseOutputParser
 
 
 def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
-    pattern = r"\s*Thought: (.*?)\nAction: ([a-zA-Z0-9_]+).*?\nAction Input: (\{.*?\})"
+    pattern = (
+        r"\s*Thought: (.*?)\nAction: ([a-zA-Z0-9_]+).*?\nAction Input: .*?(\{.*?\})"
+    )
 
     match = re.search(pattern, input_text, re.DOTALL)
     if not match:

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -29,7 +29,7 @@ def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
     return thought, action, action_input
 
 
-def action_input_parser(json_str):
+def action_input_parser(json_str) -> dict:
     processed_string = re.sub(r"(?<!\w)\'|\'(?!\w)", '"', json_str)
     pattern = r'"(\w+)":\s*"([^"]*)"'
     matches = re.findall(pattern, processed_string)

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -29,7 +29,7 @@ def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
     return thought, action, action_input
 
 
-def action_input_parser(json_str) -> dict:
+def action_input_parser(json_str: str) -> dict:
     processed_string = re.sub(r"(?<!\w)\'|\'(?!\w)", '"', json_str)
     pattern = r'"(\w+)":\s*"([^"]*)"'
     matches = re.findall(pattern, processed_string)

--- a/tests/agent/react/test_react_output_parser.py
+++ b/tests/agent/react/test_react_output_parser.py
@@ -16,6 +16,18 @@ Action Input: {"a": 1, "b": 1}
     assert action_input == '{"a": 1, "b": 1}'
 
 
+def test_extract_tool_use_() -> None:
+    mock_input_text = """\
+Thought: I need to use a tool to help me answer the question.
+Action: add
+Action Input: QueryEngineTool({"a": 1, "b": 1})
+"""
+    thought, action, action_input = extract_tool_use(mock_input_text)
+    assert thought == "I need to use a tool to help me answer the question."
+    assert action == "add"
+    assert action_input == '{"a": 1, "b": 1}'
+
+
 def test_extract_tool_use_extra_action_output() -> None:
     mock_input_text = """\
 Thought: I need to use a tool to help me answer the question.


### PR DESCRIPTION
Potentially avoids many parser misses

# Description

Issue: output parser can easily miss when parsing action input JSON strings to Python dicts. This aims to greatly reduce that, and is only used after json parsing misses.
No additional dependencies.
Regex used can probably be improved too, but it works better than what's there.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense (also ran it locally)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
