### PR TITLE
Add an hotpatch to remove the listener on 'D' on readthedocs

### DIFF
--- a/docs/_static/js/readTheDocPatch.js
+++ b/docs/_static/js/readTheDocPatch.js
@@ -1,0 +1,10 @@
+function killTheBug() {
+  let elements = document.querySelectorAll("readthedocs-hotkeys");
+  if (elements.length) {
+    for (el of elements) {
+      el.docDiffHotKeyEnabled = false;
+    }
+  }
+}
+// try to remove the 'd' handler every seconds
+setInterval(killTheBug, 1000);

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,7 @@ html_js_files = [
         {"defer": "defer"},
     ),
     ("js/algolia.js", {"defer": "defer"}),
+    "js/readTheDocPatch.js",
 ]
 
 nb_execution_mode = "off"


### PR DESCRIPTION
# Description

When browsing the Llama index doc on readthedocs, it is not possible to type the letter 'd' in the search bar (ctrl + K). This is a patch that deactivate the buggy functionality on readthedocs (ability to use hotkeys when browsing diff of docs).

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested
- [X] I stared at the code and made sure it makes sense
- [X] I build the doc and tested it
- 
# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I ran `make format; make lint` to appease the lint gods
