### PR TITLE
fix mix up b/w 'formatted' and 'format' params for ollama api call

### DIFF
--- a/llama_index/llms/ollama.py
+++ b/llama_index/llms/ollama.py
@@ -90,7 +90,9 @@ class Ollama(CustomLLM):
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
         prompt = self.messages_to_prompt(messages)
-        completion_response = self.stream_complete(prompt, prompt_formatted=True, **kwargs)
+        completion_response = self.stream_complete(
+            prompt, prompt_formatted=True, **kwargs
+        )
         return stream_completion_response_to_chat_response(completion_response)
 
     @llm_completion_callback()

--- a/llama_index/llms/ollama.py
+++ b/llama_index/llms/ollama.py
@@ -87,7 +87,7 @@ class Ollama(CustomLLM):
 
     @llm_chat_callback()
     def stream_chat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
+            self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
         prompt = self.messages_to_prompt(messages)
         completion_response = self.stream_complete(prompt, formatted=True, **kwargs)
@@ -111,28 +111,18 @@ class Ollama(CustomLLM):
                 "Please install requests with `pip install requests`"
             )
         all_kwargs = self._get_all_kwargs(**kwargs)
-        del all_kwargs["formatted"]  # ollama throws 400 if it receives this option
 
-        if not kwargs.get("formatted", False):
+        if not kwargs.pop("formatted", False):
             prompt = self.completion_to_prompt(prompt)
-
-        ollama_request_json: Dict[str, Any] = {
-            "prompt": prompt,
-            "model": self.model,
-            "options": all_kwargs,
-        }
-        if all_kwargs.get("system"):
-            ollama_request_json["system"] = all_kwargs["system"]
-            del all_kwargs["system"]
-
-        if all_kwargs.get("formatted"):
-            ollama_request_json["format"] = "json" if all_kwargs["formatted"] else None
-            del all_kwargs["formatted"]
 
         response = requests.post(
             url=f"{self.base_url}/api/generate/",
             headers={"Content-Type": "application/json"},
-            json=ollama_request_json,
+            json={
+                "prompt": prompt,
+                "model": self.model,
+                **all_kwargs,
+            },
             stream=True,
         )
         response.encoding = "utf-8"

--- a/llama_index/llms/ollama.py
+++ b/llama_index/llms/ollama.py
@@ -82,15 +82,15 @@ class Ollama(CustomLLM):
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
         prompt = self.messages_to_prompt(messages)
-        completion_response = self.complete(prompt, formatted=True, **kwargs)
+        completion_response = self.complete(prompt, prompt_formatted=True, **kwargs)
         return completion_response_to_chat_response(completion_response)
 
     @llm_chat_callback()
     def stream_chat(
-            self, messages: Sequence[ChatMessage], **kwargs: Any
+        self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
         prompt = self.messages_to_prompt(messages)
-        completion_response = self.stream_complete(prompt, formatted=True, **kwargs)
+        completion_response = self.stream_complete(prompt, prompt_formatted=True, **kwargs)
         return stream_completion_response_to_chat_response(completion_response)
 
     @llm_completion_callback()
@@ -112,7 +112,7 @@ class Ollama(CustomLLM):
             )
         all_kwargs = self._get_all_kwargs(**kwargs)
 
-        if not kwargs.pop("formatted", False):
+        if not kwargs.pop("prompt_formatted", False):
             prompt = self.completion_to_prompt(prompt)
 
         response = requests.post(


### PR DESCRIPTION
# Description

There was an error in the PR #9558, with `formatted` and `format` params getting mixed up. The `formatted` param is an internal param for the ollama llama-index client while the `format` param is for the ollama API (see [here](https://github.com/jmorganca/ollama/blob/86b0dd4b165497e08ec331e3c2c2aa229beb09db/docs/api.md#generate-a-completion)

This PR fixes this issue. Also some code refactoring was done to the ollama client code. All ollama API params needs to be passed in the `additional_kwargs` param as is now removing any confusion of where and how to pass additonal params.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
