### PR TITLE
fix(azure_openai.py): add missing return to subclass override

### DIFF
--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -168,6 +168,8 @@ class AzureOpenAI(OpenAI):
 
         return {
             "api_key": self.api_key,
+            "max_retries": self.max_retries,
+            "timeout": self.timeout,
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
             "api_version": self.api_version,


### PR DESCRIPTION
# Description

As described in #9597, when using azure_openai.py and specifying max_retries and/or timeout, those parameters are not considered by the function _get_credential_kwargs. The function exist in the super class openai.py but is overridden in azure_openai.py, without the propagation of those parameters.

Fixes #9597

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
