### PR TITLE
Adding an optional auth token to the TextEmbeddingInference class

### DIFF
--- a/llama_index/embeddings/text_embeddings_inference.py
+++ b/llama_index/embeddings/text_embeddings_inference.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Callable, List, Optional, Union
 
 from llama_index.bridge.pydantic import Field
 from llama_index.callbacks import CallbackManager
@@ -30,6 +30,10 @@ class TextEmbeddingsInference(BaseEmbedding):
     truncate_text: bool = Field(
         default=True,
         description="Whether to truncate text or not when generating embeddings.",
+    )
+    auth_token: Optional[Union[str, Callable[[str], str]]] = Field(
+        default=None,
+        description="Authentication token or authentication token generating function for authenticated requests",
     )
 
     def __init__(
@@ -70,6 +74,11 @@ class TextEmbeddingsInference(BaseEmbedding):
         import httpx
 
         headers = {"Content-Type": "application/json"}
+        if self.auth_token is not None:
+            if callable(self.auth_token):
+                headers["Authorization"] = self.auth_token(self.model_name)
+            else:
+                headers["Authorization"] = self.auth_token
         json_data = {"inputs": texts, "truncate": self.truncate_text}
 
         with httpx.Client() as client:
@@ -86,6 +95,11 @@ class TextEmbeddingsInference(BaseEmbedding):
         import httpx
 
         headers = {"Content-Type": "application/json"}
+        if self.auth_token is not None:
+            if callable(self.auth_token):
+                headers["Authorization"] = self.auth_token(self.model_name)
+            else:
+                headers["Authorization"] = self.auth_token
         json_data = {"inputs": texts, "truncate": self.truncate_text}
 
         async with httpx.AsyncClient() as client:

--- a/llama_index/embeddings/text_embeddings_inference.py
+++ b/llama_index/embeddings/text_embeddings_inference.py
@@ -76,7 +76,7 @@ class TextEmbeddingsInference(BaseEmbedding):
         headers = {"Content-Type": "application/json"}
         if self.auth_token is not None:
             if callable(self.auth_token):
-                headers["Authorization"] = self.auth_token(self.model_name)
+                headers["Authorization"] = self.auth_token(self.base_url)
             else:
                 headers["Authorization"] = self.auth_token
         json_data = {"inputs": texts, "truncate": self.truncate_text}
@@ -97,7 +97,7 @@ class TextEmbeddingsInference(BaseEmbedding):
         headers = {"Content-Type": "application/json"}
         if self.auth_token is not None:
             if callable(self.auth_token):
-                headers["Authorization"] = self.auth_token(self.model_name)
+                headers["Authorization"] = self.auth_token(self.base_url)
             else:
                 headers["Authorization"] = self.auth_token
         json_data = {"inputs": texts, "truncate": self.truncate_text}


### PR DESCRIPTION
# Description

In production use cases people may want to add their own auth token to a TEI container or use services like cloud run where you can secure traffic with authentication out of the box. Adding an optional auth token either as a static string or as generated by an auth generation function would be useful.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

All the existing unit tests are passing

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
