### PR TITLE
fix: out of index get latest tool call

### DIFF
--- a/llama_index/agent/openai/step.py
+++ b/llama_index/agent/openai/step.py
@@ -8,13 +8,19 @@ from threading import Thread
 from typing import Any, Dict, List, Optional, Tuple, Union, cast, get_args
 
 from llama_index.agent.openai.utils import resolve_tool_choice
-from llama_index.agent.types import (BaseAgentWorker, Task, TaskStep,
-                                     TaskStepOutput)
-from llama_index.callbacks import (CallbackManager, CBEventType, EventPayload,
-                                   trace_method)
-from llama_index.chat_engine.types import (AGENT_CHAT_RESPONSE_TYPE,
-                                           AgentChatResponse, ChatResponseMode,
-                                           StreamingAgentChatResponse)
+from llama_index.agent.types import BaseAgentWorker, Task, TaskStep, TaskStepOutput
+from llama_index.callbacks import (
+    CallbackManager,
+    CBEventType,
+    EventPayload,
+    trace_method,
+)
+from llama_index.chat_engine.types import (
+    AGENT_CHAT_RESPONSE_TYPE,
+    AgentChatResponse,
+    ChatResponseMode,
+    StreamingAgentChatResponse,
+)
 from llama_index.llms.base import ChatMessage, ChatResponse
 from llama_index.llms.llm import LLM
 from llama_index.llms.openai import OpenAI

--- a/llama_index/agent/openai/step.py
+++ b/llama_index/agent/openai/step.py
@@ -8,24 +8,13 @@ from threading import Thread
 from typing import Any, Dict, List, Optional, Tuple, Union, cast, get_args
 
 from llama_index.agent.openai.utils import resolve_tool_choice
-from llama_index.agent.types import (
-    BaseAgentWorker,
-    Task,
-    TaskStep,
-    TaskStepOutput,
-)
-from llama_index.callbacks import (
-    CallbackManager,
-    CBEventType,
-    EventPayload,
-    trace_method,
-)
-from llama_index.chat_engine.types import (
-    AGENT_CHAT_RESPONSE_TYPE,
-    AgentChatResponse,
-    ChatResponseMode,
-    StreamingAgentChatResponse,
-)
+from llama_index.agent.types import (BaseAgentWorker, Task, TaskStep,
+                                     TaskStepOutput)
+from llama_index.callbacks import (CallbackManager, CBEventType, EventPayload,
+                                   trace_method)
+from llama_index.chat_engine.types import (AGENT_CHAT_RESPONSE_TYPE,
+                                           AgentChatResponse, ChatResponseMode,
+                                           StreamingAgentChatResponse)
 from llama_index.llms.base import ChatMessage, ChatResponse
 from llama_index.llms.llm import LLM
 from llama_index.llms.openai import OpenAI
@@ -245,10 +234,11 @@ class OpenAIAgentWorker(BaseAgentWorker):
         )
 
     def get_latest_tool_calls(self, task: Task) -> Optional[List[OpenAIToolCall]]:
+        chat_history: List[ChatMessage] = task.extra_state["new_memory"].get_all()
         return (
-            task.extra_state["new_memory"]
-            .get_all()[-1]
-            .additional_kwargs.get("tool_calls", None)
+            chat_history[-1].additional_kwargs.get("tool_calls", None)
+            if chat_history
+            else None
         )
 
     def _get_llm_chat_kwargs(


### PR DESCRIPTION
Signed-off-by: San Nguyen <vinhsannguyen91@gmail.com>

# Description

Fix out of index error when chat history is empty for new AgentRunner

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
