### PR TITLE
Fix #9612: Set node content for astra db

### DIFF
--- a/llama_index/vector_stores/astra.py
+++ b/llama_index/vector_stores/astra.py
@@ -5,6 +5,7 @@ An index based on a DB table with vector search capabilities,
 powered by the astrapy library
 
 """
+import json
 import logging
 from typing import Any, Dict, List, Optional, cast
 
@@ -272,16 +273,17 @@ class AstraDBVectorStore(VectorStore):
         top_k_ids = []
 
         # Get every match
-        for my_match in matches:
-            # Grab the node information
-            my_match["_node_content"] = "{}"
+        for match in matches:
+            # Check whether we have a llama-generated node content field
+            if "_node_content" not in match["metadata"]:
+                match["metadata"]["_node_content"] = json.dumps(match)
 
-            node = metadata_dict_to_node(my_match["metadata"])
-            node.set_content(my_match["content"])
+            # Create a new node object from the node metadata
+            node = metadata_dict_to_node(match["metadata"], text=match["content"])
 
             # Append to the respective lists
             top_k_nodes.append(node)
-            top_k_ids.append(my_match["_id"])
+            top_k_ids.append(match["_id"])
 
         # return our final result
         return VectorStoreQueryResult(


### PR DESCRIPTION
# Description

Adds a check for the _node_content field for documents that may not have been originally indexed by Llama

Fixes #9612 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
