### PR TITLE
bundle nltk tiktoken v2

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,6 +7,10 @@ on:
 
   workflow_dispatch:
 
+env:
+  POETRY_VERSION: "1.6.1"
+  PYTHON_VERSION: "3.9"
+
 jobs:
   build-n-publish:
     name: Build and publish to PyPI
@@ -14,6 +18,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Set up python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+      - name: Install deps
+        shell: bash
+        run: poetry install
+      - name: Cache tiktoken and nltk files
+        shell: bash
+        run: python -c "from llama_index import get_tokenizer; get_tokenizer()"
+      - name: Clean up zip files
+        shell: bash
+        run: rm -rf llama_index/_static/nltk_cache/corpora/stopwords.zip llama_index/_static/nltk_cache/tokenizers/punkt.zip
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v1.17
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,24 +10,30 @@ repos:
       - id: check-merge-conflict
       - id: check-symlinks
       - id: check-toml
+        exclude: llama_index/_static
       - id: check-yaml
+        exclude: llama_index/_static
       - id: detect-private-key
       - id: end-of-file-fixer
+        exclude: llama_index/_static
       - id: mixed-line-ending
+        exclude: llama_index/_static
       - id: trailing-whitespace
+        exclude: llama_index/_static
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.1.5
 
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+        exclude: llama_index/_static
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.10.1
     hooks:
       - id: black-jupyter
         name: black-src
         alias: black
-        exclude: docs/
+        exclude: ^(docs/|llama_index/_static)
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.10.1
     hooks:
@@ -51,11 +57,13 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
+        exclude: llama_index/_static
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
       - id: codespell
         additional_dependencies: [tomli]
+        exclude: llama_index/_static
   - repo: https://github.com/srstevenson/nb-clean
     rev: 3.1.0
     hooks:
@@ -65,4 +73,4 @@ repos:
     rev: v0.23.1
     hooks:
       - id: toml-sort-fix
-        exclude: poetry.lock
+        exclude: ^(poetry.lock|llama_index/_static)

--- a/llama_index/_static/nltk_cache/.gitignore
+++ b/llama_index/_static/nltk_cache/.gitignore
@@ -1,0 +1,2 @@
+# Include this file
+!.gitignore

--- a/llama_index/_static/tiktoken_cache/.gitignore
+++ b/llama_index/_static/tiktoken_cache/.gitignore
@@ -1,0 +1,2 @@
+# Include this file
+!.gitignore

--- a/llama_index/finetuning/cross_encoders/dataset_gen.py
+++ b/llama_index/finetuning/cross_encoders/dataset_gen.py
@@ -3,10 +3,9 @@ import re
 from dataclasses import dataclass
 from typing import List, Optional
 
-import tiktoken
 from tqdm.auto import tqdm
 
-from llama_index import VectorStoreIndex
+from llama_index import VectorStoreIndex, get_tokenizer
 from llama_index.llms import ChatMessage, OpenAI
 from llama_index.llms.llm import LLM
 from llama_index.node_parser import TokenTextSplitter
@@ -46,7 +45,7 @@ def generate_synthetic_queries_over_documents(
         chunk_size=max_chunk_length,
         chunk_overlap=0,
         backup_separators=["\n"],
-        tokenizer=tiktoken.encoding_for_model("gpt-3.5-turbo").encode,
+        tokenizer=get_tokenizer(),
     )
 
     llm = llm or OpenAI(model="gpt-3.5-turbo-16k", temperature=0.3)
@@ -123,7 +122,7 @@ def generate_ce_fine_tuning_dataset(
         chunk_size=max_chunk_length,
         chunk_overlap=0,
         backup_separators=["\n"],
-        tokenizer=tiktoken.encoding_for_model("gpt-3.5-turbo").encode,
+        tokenizer=get_tokenizer(),
     )
 
     # Use logit bias in case of OpenAI for the tokens for Yes and No

--- a/llama_index/indices/keyword_table/utils.py
+++ b/llama_index/indices/keyword_table/utils.py
@@ -29,8 +29,6 @@ def rake_extract_keywords(
     """Extract keywords with RAKE."""
     try:
         import nltk
-
-        nltk.download("punkt")
     except ImportError:
         raise ImportError("Please install nltk: `pip install nltk`")
     try:
@@ -38,7 +36,10 @@ def rake_extract_keywords(
     except ImportError:
         raise ImportError("Please install rake_nltk: `pip install rake_nltk`")
 
-    r = Rake()
+    r = Rake(
+        sentence_tokenizer=nltk.tokenize.sent_tokenize,
+        word_tokenizer=nltk.tokenize.wordpunct_tokenize,
+    )
     r.extract_keywords_from_text(text_chunk)
     keywords = r.get_ranked_phrases()[:max_keywords]
     if expand_with_subtokens:

--- a/llama_index/indices/keyword_table/utils.py
+++ b/llama_index/indices/keyword_table/utils.py
@@ -28,6 +28,10 @@ def rake_extract_keywords(
 ) -> Set[str]:
     """Extract keywords with RAKE."""
     try:
+        import nltk
+    except ImportError:
+        raise ImportError("Please install nltk: `pip install nltk`")
+    try:
         from rake_nltk import Rake
     except ImportError:
         raise ImportError("Please install rake_nltk: `pip install rake_nltk`")

--- a/llama_index/indices/keyword_table/utils.py
+++ b/llama_index/indices/keyword_table/utils.py
@@ -28,10 +28,6 @@ def rake_extract_keywords(
 ) -> Set[str]:
     """Extract keywords with RAKE."""
     try:
-        import nltk
-    except ImportError:
-        raise ImportError("Please install nltk: `pip install nltk`")
-    try:
         from rake_nltk import Rake
     except ImportError:
         raise ImportError("Please install rake_nltk: `pip install rake_nltk`")

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -1,10 +1,10 @@
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional
 
 from llama_index.bridge.pydantic import Field, root_validator
 from llama_index.llms.llm import LLM
 from llama_index.llms.types import ChatMessage, MessageRole
 from llama_index.memory.types import BaseMemory
-from llama_index.utils import GlobalsHelper
+from llama_index.utils import get_tokenizer
 
 DEFUALT_TOKEN_LIMIT_RATIO = 0.75
 DEFAULT_TOKEN_LIMIT = 3000
@@ -16,7 +16,7 @@ class ChatMemoryBuffer(BaseMemory):
     token_limit: int
     tokenizer_fn: Callable[[str], List] = Field(
         # NOTE: mypy does not handle the typing here well, hence the cast
-        default_factory=cast(Callable[[], Any], GlobalsHelper().tokenizer),
+        default_factory=get_tokenizer,
         exclude=True,
     )
     chat_history: List[ChatMessage] = Field(default_factory=list)
@@ -42,7 +42,7 @@ class ChatMemoryBuffer(BaseMemory):
         # Validate tokenizer -- this avoids errors when loading from json/dict
         tokenizer_fn = values.get("tokenizer_fn", None)
         if tokenizer_fn is None:
-            values["tokenizer_fn"] = GlobalsHelper().tokenizer
+            values["tokenizer_fn"] = get_tokenizer()
 
         return values
 
@@ -63,7 +63,7 @@ class ChatMemoryBuffer(BaseMemory):
 
         return cls(
             token_limit=token_limit,
-            tokenizer_fn=tokenizer_fn or GlobalsHelper().tokenizer,
+            tokenizer_fn=tokenizer_fn or get_tokenizer(),
             chat_history=chat_history or [],
         )
 

--- a/llama_index/node_parser/text/utils.py
+++ b/llama_index/node_parser/text/utils.py
@@ -35,30 +35,7 @@ def split_by_char() -> Callable[[str], List[str]]:
 
 
 def split_by_sentence_tokenizer() -> Callable[[str], List[str]]:
-    import os
-
     import nltk
-
-    from llama_index.utils import get_cache_dir
-
-    cache_dir = get_cache_dir()
-    nltk_data_dir = os.environ.get("NLTK_DATA", cache_dir)
-
-    # update nltk path for nltk so that it finds the data
-    if nltk_data_dir not in nltk.data.path:
-        nltk.data.path.append(nltk_data_dir)
-
-    try:
-        nltk.data.find("tokenizers/punkt")
-    except LookupError:
-        try:
-            nltk.download("punkt", download_dir=nltk_data_dir)
-        except FileExistsError:
-            logger.info(
-                "Tried to re-download NLTK files but already exists. "
-                "This could happen in multi-theaded deployments, "
-                "should be benign"
-            )
 
     tokenizer = nltk.tokenize.PunktSentenceTokenizer()
 

--- a/llama_index/postprocessor/optimizer.py
+++ b/llama_index/postprocessor/optimizer.py
@@ -66,23 +66,7 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
         self._embed_model = embed_model or OpenAIEmbedding()
 
         if tokenizer_fn is None:
-            import os
-
             import nltk.data
-
-            from llama_index.utils import get_cache_dir
-
-            cache_dir = get_cache_dir()
-            nltk_data_dir = os.environ.get("NLTK_DATA", cache_dir)
-
-            # update nltk path for nltk so that it finds the data
-            if nltk_data_dir not in nltk.data.path:
-                nltk.data.path.append(nltk_data_dir)
-
-            try:
-                nltk.data.find("tokenizers/punkt")
-            except LookupError:
-                nltk.download("punkt", download_dir=nltk_data_dir)
 
             tokenizer = nltk.data.load("tokenizers/punkt/english.pickle")
             tokenizer_fn = tokenizer.tokenize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ check-hidden = true
 ignore-words-list = "astroid,gallary,momento,narl,ot,rouge"
 # Feel free to un-skip examples, and experimental, you will just need to
 # work through many typos (--write-changes and --interactive will help)
-skip = "./examples,./experimental,*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+skip = "./llama_index/_static,./examples,./experimental,*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.mypy]
 disallow_untyped_defs = true
 # Remove venv skip when integrated with pre-commit
-exclude = ["build", "examples", "notebooks", "venv"]
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
 ignore_missing_imports = true
 python_version = "3.8"
 
@@ -27,6 +27,7 @@ classifiers = [
 description = "Interface between LLMs and your data"
 documentation = "https://docs.llamaindex.ai/en/stable/"
 homepage = "https://llamaindex.ai"
+include = ["llama_index/_static"]
 keywords = ["LLM", "NLP", "RAG", "data", "devtools", "index", "retrieval"]
 license = "MIT"
 maintainers = [
@@ -147,6 +148,7 @@ llamaindex-cli = 'llama_index.command_line.command_line:main'
 
 [tool.ruff]
 exclude = [
+    "_static",
     "examples",
     "notebooks",
 ]

--- a/tests/memory/test_chat_memory_buffer.py
+++ b/tests/memory/test_chat_memory_buffer.py
@@ -3,9 +3,9 @@ import pickle
 import pytest
 from llama_index.llms import ChatMessage, MessageRole
 from llama_index.memory.chat_memory_buffer import ChatMemoryBuffer
-from llama_index.utils import GlobalsHelper
+from llama_index.utils import get_tokenizer
 
-tokenizer = GlobalsHelper().tokenizer
+tokenizer = get_tokenizer()
 
 USER_CHAT_MESSAGE = ChatMessage(role=MessageRole.USER, content="first message")
 USER_CHAT_MESSAGE_TOKENS = len(tokenizer(str(USER_CHAT_MESSAGE.content)))


### PR DESCRIPTION
# Description

The second approach at bundling nltk and tiktoken with the package.

Instead of using LFS (which has actual $$ costs associated with it), we can use a similar approach that will download and cache the tiktoken and nltk packages during publishing

Locally, I tested this with `poetry publish` -- you can try `pip install 0.9.16.dev2` and inspect the installed files -- they will include the cached files in `site_packages/llama_index/llama_index/_static` 

I'm not 100% sure how to test the github workflow without making an actual release, but I think it should work? 🙏🏻 

Fixes https://github.com/run-llama/llama_index/issues/9610

