### PR TITLE
fix(vllm): make Vllm's 'complete' method behave the same as other LLM class

### DIFF
--- a/llama_index/llms/vllm.py
+++ b/llama_index/llms/vllm.py
@@ -226,20 +226,16 @@ class Vllm(LLM):
         return completion_response_to_chat_response(completion_response)
 
     @llm_completion_callback()
-    def complete(self, prompts: List[str], **kwargs: Any) -> List[CompletionResponse]:
+    def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
         kwargs = kwargs if kwargs else {}
         params = {**self._model_kwargs, **kwargs}
 
         from vllm import SamplingParams
 
-        responses = []
         # build sampling parameters
         sampling_params = SamplingParams(**params)
-        outputs = self._client.generate(prompts, sampling_params)
-        for output in outputs:
-            responses.append(CompletionResponse(text=output.outputs[0].text))
-
-        return responses
+        outputs = self._client.generate([prompt], sampling_params)
+        return CompletionResponse(text=outputs[0].outputs[0].text)
 
     @llm_chat_callback()
     def stream_chat(


### PR DESCRIPTION
# Description

Vllm has a different ```complete``` method signature passing list prompts instead of str prompt, which is incompatible with other LLM like LlamaCPP or HuggingFaceLLM.

This PR makes Vllm's ```complete``` method behave the same as other LLM class.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods