### PR TITLE
update link in vector_stores/MongoDBAtlasVectorSearch.html docs

### DIFF
--- a/docs/examples/vector_stores/MongoDBAtlasVectorSearch.ipynb
+++ b/docs/examples/vector_stores/MongoDBAtlasVectorSearch.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "Note: For MongoDB Atlas, you have to additionally create an Atlas Search Index.\n",
     "\n",
-    "[Mongo DB Docs | How to Index Vector Embeddings for Vector Search](https://www.mongodb.com/docs/atlas/atlas-search/field-types/knn-vector/)"
+    "[MongoDB Docs | Create an Atlas Vector Search Index](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/)"
    ]
   }
  ],


### PR DESCRIPTION
# Description

The link at the bottom of https://docs.llamaindex.ai/en/stable/examples/vector_stores/MongoDBAtlasVectorSearch.html is outdated. Updated to use the most recent page.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

built the docs locally and tested link

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
