### PR TITLE
Remove OPENAI key dependency

### DIFF
--- a/llama_index/indices/managed/vectara/base.py
+++ b/llama_index/indices/managed/vectara/base.py
@@ -64,7 +64,10 @@ class VectaraIndex(BaseManagedIndex):
         )
 
         super().__init__(
-            show_progress=show_progress, index_struct=index_struct, **kwargs
+            show_progress=show_progress,
+            index_struct=index_struct,
+            service_context=ServiceContext.from_defaults(llm=None, llm_predictor=None),
+            **kwargs,
         )
         self._vectara_customer_id = vectara_customer_id or os.environ.get(
             "VECTARA_CUSTOMER_ID"


### PR DESCRIPTION
# Description

Currently if the OPENAI_API_KEY is not available in the env, the call to VectaraIndex fails.
Here the call to service_context.from_defaults() explicitly uses None for llm and llm_predictor to prevent that dependency (which is not needed).

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I ran `make format; make lint` to appease the lint gods
