### PR TITLE
improve auto-retrieval

### DIFF
--- a/docs/examples/vector_stores/pinecone_auto_retriever.ipynb
+++ b/docs/examples/vector_stores/pinecone_auto_retriever.ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "d48af8e1",
    "metadata": {},
    "outputs": [],
@@ -63,6 +63,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
+   "id": "7062610f-8ad0-4ef9-a0e8-aaafc66ad71c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"PINECONE_API_KEY\"] = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "4ad14111-0bbb-4c62-906d-6d6253e0cdee",
    "metadata": {},
@@ -71,7 +82,7 @@
     "import pinecone\n",
     "\n",
     "api_key = os.environ[\"PINECONE_API_KEY\"]\n",
-    "pinecone.init(api_key=api_key, environment=\"eu-west1-gcp\")"
+    "pinecone.init(api_key=api_key, environment=\"gcp-starter\")"
    ]
   },
   {
@@ -86,19 +97,42 @@
     "    pinecone.create_index(\n",
     "        \"quickstart-index\", dimension=1536, metric=\"euclidean\", pod_type=\"p1\"\n",
     "    )\n",
-    "except Exception:\n",
+    "except Exception as e:\n",
     "    # most likely index already exists\n",
+    "    print(e)\n",
     "    pass"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "667f3cb3-ce18-48d5-b9aa-bfc1a1f0f0f6",
    "metadata": {},
    "outputs": [],
    "source": [
     "pinecone_index = pinecone.Index(\"quickstart-index\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e86c7673-5664-4cde-abe3-32fe82169a2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Optional: delete data in your pinecone index\n",
+    "pinecone_index.delete(delete_all=True, namespace=\"test\")"
    ]
   },
   {
@@ -123,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "9ae59590",
    "metadata": {},
    "outputs": [],
@@ -132,59 +166,59 @@
     "\n",
     "nodes = [\n",
     "    TextNode(\n",
-    "        text=(\n",
-    "            \"Michael Jordan is a retired professional basketball player,\"\n",
-    "            \" widely regarded as one of the greatest basketball players of all\"\n",
-    "            \" time.\"\n",
-    "        ),\n",
+    "        text=\"The Shawshank Redemption\",\n",
     "        metadata={\n",
-    "            \"category\": \"Sports\",\n",
-    "            \"country\": \"United States\",\n",
+    "            \"author\": \"Stephen King\",\n",
+    "            \"theme\": \"Friendship\",\n",
+    "            \"year\": 1994,\n",
     "        },\n",
     "    ),\n",
     "    TextNode(\n",
-    "        text=(\n",
-    "            \"Angelina Jolie is an American actress, filmmaker, and\"\n",
-    "            \" humanitarian. She has received numerous awards for her acting\"\n",
-    "            \" and is known for her philanthropic work.\"\n",
-    "        ),\n",
+    "        text=\"The Godfather\",\n",
     "        metadata={\n",
-    "            \"category\": \"Entertainment\",\n",
-    "            \"country\": \"United States\",\n",
+    "            \"director\": \"Francis Ford Coppola\",\n",
+    "            \"theme\": \"Mafia\",\n",
+    "            \"year\": 1972,\n",
     "        },\n",
     "    ),\n",
     "    TextNode(\n",
-    "        text=(\n",
-    "            \"Elon Musk is a business magnate, industrial designer, and\"\n",
-    "            \" engineer. He is the founder, CEO, and lead designer of SpaceX,\"\n",
-    "            \" Tesla, Inc., Neuralink, and The Boring Company.\"\n",
-    "        ),\n",
+    "        text=\"Inception\",\n",
     "        metadata={\n",
-    "            \"category\": \"Business\",\n",
-    "            \"country\": \"United States\",\n",
+    "            \"director\": \"Christopher Nolan\",\n",
+    "            \"theme\": \"Fiction\",\n",
+    "            \"year\": 2010,\n",
     "        },\n",
     "    ),\n",
     "    TextNode(\n",
-    "        text=(\n",
-    "            \"Rihanna is a Barbadian singer, actress, and businesswoman. She\"\n",
-    "            \" has achieved significant success in the music industry and is\"\n",
-    "            \" known for her versatile musical style.\"\n",
-    "        ),\n",
+    "        text=\"To Kill a Mockingbird\",\n",
     "        metadata={\n",
-    "            \"category\": \"Music\",\n",
-    "            \"country\": \"Barbados\",\n",
+    "            \"author\": \"Harper Lee\",\n",
+    "            \"theme\": \"Mafia\",\n",
+    "            \"year\": 1960,\n",
     "        },\n",
     "    ),\n",
     "    TextNode(\n",
-    "        text=(\n",
-    "            \"Cristiano Ronaldo is a Portuguese professional footballer who is\"\n",
-    "            \" considered one of the greatest football players of all time. He\"\n",
-    "            \" has won numerous awards and set multiple records during his\"\n",
-    "            \" career.\"\n",
-    "        ),\n",
+    "        text=\"1984\",\n",
     "        metadata={\n",
-    "            \"category\": \"Sports\",\n",
-    "            \"country\": \"Portugal\",\n",
+    "            \"author\": \"George Orwell\",\n",
+    "            \"theme\": \"Totalitarianism\",\n",
+    "            \"year\": 1949,\n",
+    "        },\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"The Great Gatsby\",\n",
+    "        metadata={\n",
+    "            \"author\": \"F. Scott Fitzgerald\",\n",
+    "            \"theme\": \"The American Dream\",\n",
+    "            \"year\": 1925,\n",
+    "        },\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"Harry Potter and the Sorcerer's Stone\",\n",
+    "        metadata={\n",
+    "            \"author\": \"J.K. Rowling\",\n",
+    "            \"theme\": \"Fiction\",\n",
+    "            \"year\": 1997,\n",
     "        },\n",
     "    ),\n",
     "]"
@@ -192,13 +226,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "ee6eeecb-d54f-4a71-b5fe-0cda8a5c3e10",
    "metadata": {},
    "outputs": [],
    "source": [
     "vector_store = PineconeVectorStore(\n",
-    "    pinecone_index=pinecone_index, namespace=\"test\"\n",
+    "    pinecone_index=pinecone_index, \n",
+    "    namespace=\"test\",\n",
+    "    # this is a hack to allow for blank queries in pinecone\n",
+    "    default_empty_query_vector=[0] * 1536\n",
     ")\n",
     "storage_context = StorageContext.from_defaults(vector_store=vector_store)"
    ]
@@ -208,27 +245,14 @@
    "execution_count": null,
    "id": "cad08884",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "> [build_index_from_nodes] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [build_index_from_nodes] Total embedding token usage: 211 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 211 tokens\n",
-      "> [build_index_from_nodes] Total embedding token usage: 211 tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "index = VectorStoreIndex(nodes, storage_context=storage_context)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "1a57e62f",
    "metadata": {},
    "outputs": [],
@@ -240,122 +264,128 @@
     "\n",
     "\n",
     "vector_store_info = VectorStoreInfo(\n",
-    "    content_info=\"brief biography of celebrities\",\n",
+    "    content_info=\"famous books and movies\",\n",
     "    metadata_info=[\n",
     "        MetadataInfo(\n",
-    "            name=\"category\",\n",
+    "            name=\"directory\",\n",
     "            type=\"str\",\n",
     "            description=(\n",
-    "                \"Category of the celebrity, one of [Sports, Entertainment,\"\n",
-    "                \" Business, Music]\"\n",
+    "                \"Name of the director\"\n",
     "            ),\n",
     "        ),\n",
     "        MetadataInfo(\n",
-    "            name=\"country\",\n",
+    "            name=\"theme\",\n",
     "            type=\"str\",\n",
     "            description=(\n",
-    "                \"Country of the celebrity, one of [United States, Barbados,\"\n",
-    "                \" Portugal]\"\n",
+    "                \"Theme of the book/movie\"\n",
+    "            ),\n",
+    "        ),\n",
+    "        MetadataInfo(\n",
+    "            name=\"year\",\n",
+    "            type=\"int\",\n",
+    "            description=(\n",
+    "                \"Year of the book/movie\"\n",
     "            ),\n",
     "        ),\n",
     "    ],\n",
     ")\n",
     "retriever = VectorIndexAutoRetriever(\n",
-    "    index, vector_store_info=vector_store_info\n",
+    "    index, \n",
+    "    vector_store_info=vector_store_info,\n",
+    "    empty_query_top_k=10\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5c0490d",
+   "id": "e8a0453a-fbc4-446c-879f-340040247f76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodes = retriever.retrieve(\"Tell me about some books/movies after the year 2000\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "eaa3b724-e7a3-464a-962e-8c2c8e6e2e81",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Auto query: celebrities\n",
-      "Auto query: celebrities\n",
-      "Auto query: celebrities\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Auto filter: {'country': 'United States'}\n",
-      "Auto filter: {'country': 'United States'}\n",
-      "Auto filter: {'country': 'United States'}\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Auto top_k: 2\n",
-      "Auto top_k: 2\n",
-      "Auto top_k: 2\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total embedding token usage: 3 tokens\n",
-      "> [retrieve] Total embedding token usage: 3 tokens\n",
-      "> [retrieve] Total embedding token usage: 3 tokens\n"
+      "director: Christopher Nolan\n",
+      "theme: Fiction\n",
+      "year: 2010\n",
+      "\n",
+      "Inception\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[NodeWithScore(node=Node(text='category: Entertainment\\ncountry: United States\\n\\nAngelina Jolie is an American actress, filmmaker, and humanitarian. She has received numerous awards for her acting and is known for her philanthropic work.', doc_id='6821b1fe-e1dc-400c-ad2c-83f7fa683321', embedding=None, doc_hash='4086bd15d984c4f3ee3d4f911f0a347735406351d1936b6060b411707d3e82cc', extra_info={'category': 'Entertainment', 'country': 'United States'}, node_info={}, relationships={}), score=0.80265522),\n",
-       " NodeWithScore(node=Node(text='category: Sports\\ncountry: United States\\n\\nMichael Jordan is a retired professional basketball player, widely regarded as one of the greatest basketball players of all time.', doc_id='4cf176e5-363f-479b-8979-c3e07cfaead8', embedding=None, doc_hash='9aaec18f659138a23ca519f8d6d1f3997d34aae993b8c07443b165c13163b886', extra_info={'category': 'Sports', 'country': 'United States'}, node_info={}, relationships={}), score=0.766244411)]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "retriever.retrieve(\"Tell me about two celebrities from United States\")"
+    "for node in nodes:\n",
+    "    print(node.get_content(metadata_mode=\"all\"))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "3a1a9287",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "nodes = retriever.retrieve(\"Tell me about some books that are Fiction\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "1222e259-3146-4c79-9491-fe8453f0cf40",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Auto query: Sports celebrities\n",
-      "Auto query: Sports celebrities\n",
-      "Auto query: Sports celebrities\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Auto filter: {'category': 'Sports', 'country': 'United States'}\n",
-      "Auto filter: {'category': 'Sports', 'country': 'United States'}\n",
-      "Auto filter: {'category': 'Sports', 'country': 'United States'}\n",
-      "INFO:llama_index.indices.vector_store.auto_retriever.auto_retriever:Auto top_k: 2\n",
-      "Auto top_k: 2\n",
-      "Auto top_k: 2\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "> [retrieve] Total LLM token usage: 0 tokens\n",
-      "INFO:llama_index.token_counter.token_counter:> [retrieve] Total embedding token usage: 2 tokens\n",
-      "> [retrieve] Total embedding token usage: 2 tokens\n",
-      "> [retrieve] Total embedding token usage: 2 tokens\n"
+      "f7b1ad3d-00b9-45e2-951f-ed70f4256e3c\n",
+      "director: Christopher Nolan\n",
+      "theme: Fiction\n",
+      "year: 2010\n",
+      "\n",
+      "Inception\n",
+      "d3b347d6-a4e3-4529-bf8a-0ab92f971044\n",
+      "author: J.K. Rowling\n",
+      "theme: Fiction\n",
+      "year: 1997\n",
+      "\n",
+      "Harry Potter and the Sorcerer's Stone\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[NodeWithScore(node=Node(text='category: Sports\\ncountry: United States\\n\\nMichael Jordan is a retired professional basketball player, widely regarded as one of the greatest basketball players of all time.', doc_id='4cf176e5-363f-479b-8979-c3e07cfaead8', embedding=None, doc_hash='9aaec18f659138a23ca519f8d6d1f3997d34aae993b8c07443b165c13163b886', extra_info={'category': 'Sports', 'country': 'United States'}, node_info={}, relationships={}), score=0.797632515)]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "retriever.retrieve(\"Tell me about Sports celebrities from United States\")"
+    "for node in nodes:\n",
+    "    print(node.id_)\n",
+    "    print(node.get_content(metadata_mode=\"all\"))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a913ea7f-a437-46e9-9be2-79ca53ef6530",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "llama_index_v2",
    "language": "python",
-   "name": "python3"
+   "name": "llama_index_v2"
   },
   "language_info": {
    "codemirror_mode": {
@@ -366,7 +396,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/docs/examples/vector_stores/pinecone_auto_retriever.ipynb
+++ b/docs/examples/vector_stores/pinecone_auto_retriever.ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "d48af8e1",
    "metadata": {},
    "outputs": [],
@@ -63,12 +63,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "7062610f-8ad0-4ef9-a0e8-aaafc66ad71c",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
     "os.environ[\"PINECONE_API_KEY\"] = \"\""
    ]
   },
@@ -105,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "667f3cb3-ce18-48d5-b9aa-bfc1a1f0f0f6",
    "metadata": {},
    "outputs": [],
@@ -115,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "e86c7673-5664-4cde-abe3-32fe82169a2f",
    "metadata": {},
    "outputs": [
@@ -125,7 +126,7 @@
        "{}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -157,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "9ae59590",
    "metadata": {},
    "outputs": [],
@@ -226,16 +227,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "ee6eeecb-d54f-4a71-b5fe-0cda8a5c3e10",
    "metadata": {},
    "outputs": [],
    "source": [
     "vector_store = PineconeVectorStore(\n",
-    "    pinecone_index=pinecone_index, \n",
+    "    pinecone_index=pinecone_index,\n",
     "    namespace=\"test\",\n",
-    "    # this is a hack to allow for blank queries in pinecone\n",
-    "    default_empty_query_vector=[0] * 1536\n",
     ")\n",
     "storage_context = StorageContext.from_defaults(vector_store=vector_store)"
    ]
@@ -252,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "1a57e62f",
    "metadata": {},
    "outputs": [],
@@ -269,30 +268,26 @@
     "        MetadataInfo(\n",
     "            name=\"directory\",\n",
     "            type=\"str\",\n",
-    "            description=(\n",
-    "                \"Name of the director\"\n",
-    "            ),\n",
+    "            description=(\"Name of the director\"),\n",
     "        ),\n",
     "        MetadataInfo(\n",
     "            name=\"theme\",\n",
     "            type=\"str\",\n",
-    "            description=(\n",
-    "                \"Theme of the book/movie\"\n",
-    "            ),\n",
+    "            description=(\"Theme of the book/movie\"),\n",
     "        ),\n",
     "        MetadataInfo(\n",
     "            name=\"year\",\n",
     "            type=\"int\",\n",
-    "            description=(\n",
-    "                \"Year of the book/movie\"\n",
-    "            ),\n",
+    "            description=(\"Year of the book/movie\"),\n",
     "        ),\n",
     "    ],\n",
     ")\n",
     "retriever = VectorIndexAutoRetriever(\n",
-    "    index, \n",
+    "    index,\n",
     "    vector_store_info=vector_store_info,\n",
-    "    empty_query_top_k=10\n",
+    "    empty_query_top_k=10,\n",
+    "    # this is a hack to allow for blank queries in pinecone\n",
+    "    default_empty_query_vector=[0] * 1536,\n",
     ")"
    ]
   },
@@ -303,12 +298,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nodes = retriever.retrieve(\"Tell me about some books/movies after the year 2000\")"
+    "nodes = retriever.retrieve(\n",
+    "    \"Tell me about some books/movies after the year 2000\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "eaa3b724-e7a3-464a-962e-8c2c8e6e2e81",
    "metadata": {},
    "outputs": [
@@ -333,9 +330,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3a1a9287",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nodes = retriever.retrieve(\"Tell me about some books that are Fiction\")"
@@ -343,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "1222e259-3146-4c79-9491-fe8453f0cf40",
    "metadata": {},
    "outputs": [
@@ -371,14 +366,6 @@
     "    print(node.id_)\n",
     "    print(node.get_content(metadata_mode=\"all\"))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a913ea7f-a437-46e9-9be2-79ca53ef6530",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -396,8 +383,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -14,6 +14,7 @@ from llama_index.indices.vector_store.retrievers.auto_retriever.prompts import (
     VectorStoreQueryPrompt,
 )
 from llama_index.output_parsers.base import OutputParserException, StructuredOutput
+from llama_index.prompts.mixin import PromptDictType, PromptMixinType
 from llama_index.schema import NodeWithScore, QueryBundle
 from llama_index.service_context import ServiceContext
 from llama_index.vector_stores.types import (
@@ -22,7 +23,6 @@ from llama_index.vector_stores.types import (
     VectorStoreQueryMode,
     VectorStoreQuerySpec,
 )
-from llama_index.prompts.mixin import PromptDictType, PromptMixin, PromptMixinType
 
 _logger = logging.getLogger(__name__)
 
@@ -53,6 +53,11 @@ class VectorIndexAutoRetriever(BaseRetriever):
             be clamped to this value.
         vector_store_query_mode (str): vector store query mode
             See reference for VectorStoreQueryMode for full list of supported modes.
+        default_empty_query_vector (Optional[List[float]]): default empty query vector.
+            Defaults to None. If not None, then this vector will be used as the query
+            vector if the query is empty.
+        callback_manager (Optional[CallbackManager]): callback manager
+        verbose (bool): verbose mode
     """
 
     def __init__(
@@ -65,6 +70,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
         similarity_top_k: int = DEFAULT_SIMILARITY_TOP_K,
         empty_query_top_k: Optional[int] = 10,
         vector_store_query_mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT,
+        default_empty_query_vector: Optional[List[float]] = None,
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
         **kwargs: Any,
@@ -72,6 +78,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
         self._index = index
         self._vector_store_info = vector_store_info
         self._service_context = service_context or self._index.service_context
+        self._default_empty_query_vector = default_empty_query_vector
 
         # prompt
         prompt_template_str = (
@@ -103,6 +110,16 @@ class VectorIndexAutoRetriever(BaseRetriever):
         if "prompt" in prompts:
             self._prompt = prompts["prompt"]
 
+    def _get_query_bundle(self, query: str) -> QueryBundle:
+        """Get query bundle."""
+        if not query and self._default_empty_query_vector is not None:
+            return QueryBundle(
+                query_str="",
+                embedding=self._default_empty_query_vector,
+            )
+        else:
+            return QueryBundle(query_str=query)
+
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         # prepare input
         info_str = self._vector_store_info.json(indent=4)
@@ -131,8 +148,15 @@ class VectorIndexAutoRetriever(BaseRetriever):
                 top_k=None,
             )
 
+        # construct new query bundle from query_spec
+        # insert 0 vector if query is empty and default_empty_query_vector is not None
+        new_query_bundle = self._get_query_bundle(query_spec.query)
+
         _logger.info(f"Using query str: {query_spec.query}")
-        filter_list = [(filter.key, filter.operator.value, filter.value) for filter in query_spec.filters]
+        filter_list = [
+            (filter.key, filter.operator.value, filter.value)
+            for filter in query_spec.filters
+        ]
         _logger.info(f"Using filters: {filter_list}")
         if self._verbose:
             print(f"Using query str: {query_spec.query}")
@@ -160,4 +184,4 @@ class VectorIndexAutoRetriever(BaseRetriever):
             vector_store_query_mode=self._vector_store_query_mode,
             **self._kwargs,
         )
-        return retriever.retrieve(query_spec.query)
+        return retriever.retrieve(new_query_bundle)

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -14,7 +14,7 @@ from llama_index.indices.vector_store.retrievers.auto_retriever.prompts import (
     VectorStoreQueryPrompt,
 )
 from llama_index.output_parsers.base import OutputParserException, StructuredOutput
-from llama_index.prompts.mixin import PromptDictType, PromptMixinType
+from llama_index.prompts.mixin import PromptDictType
 from llama_index.schema import NodeWithScore, QueryBundle
 from llama_index.service_context import ServiceContext
 from llama_index.vector_stores.types import (

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -22,6 +22,7 @@ from llama_index.vector_stores.types import (
     VectorStoreQueryMode,
     VectorStoreQuerySpec,
 )
+from llama_index.prompts.mixin import PromptDictType, PromptMixin, PromptMixinType
 
 _logger = logging.getLogger(__name__)
 
@@ -91,6 +92,17 @@ class VectorIndexAutoRetriever(BaseRetriever):
         self._verbose = verbose
         super().__init__(callback_manager)
 
+    def _get_prompts(self) -> PromptDictType:
+        """Get prompts."""
+        return {
+            "prompt": self._prompt,
+        }
+
+    def _update_prompts(self, prompts: PromptDictType) -> PromptMixinType:
+        """Get prompt modules."""
+        if "prompt" in prompts:
+            self._prompt = prompts["prompt"]
+
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         # prepare input
         info_str = self._vector_store_info.json(indent=4)
@@ -120,11 +132,11 @@ class VectorIndexAutoRetriever(BaseRetriever):
             )
 
         _logger.info(f"Using query str: {query_spec.query}")
-        filter_dict = {filter.key: filter.value for filter in query_spec.filters}
-        _logger.info(f"Using filters: {filter_dict}")
+        filter_list = [(filter.key, filter.operator.value, filter.value) for filter in query_spec.filters]
+        _logger.info(f"Using filters: {filter_list}")
         if self._verbose:
             print(f"Using query str: {query_spec.query}")
-            print(f"Using filters: {filter_dict}")
+            print(f"Using filters: {filter_list}")
 
         # define similarity_top_k
         # if query is specified, then use similarity_top_k

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -105,7 +105,7 @@ class VectorIndexAutoRetriever(BaseRetriever):
             "prompt": self._prompt,
         }
 
-    def _update_prompts(self, prompts: PromptDictType) -> PromptMixinType:
+    def _update_prompts(self, prompts: PromptDictType) -> None:
         """Get prompt modules."""
         if "prompt" in prompts:
             self._prompt = prompts["prompt"]

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/prompts.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/prompts.py
@@ -4,10 +4,11 @@
 from llama_index.prompts.base import PromptTemplate
 from llama_index.prompts.prompt_type import PromptType
 from llama_index.vector_stores.types import (
-    ExactMatchFilter,
+    MetadataFilter,
     MetadataInfo,
     VectorStoreInfo,
     VectorStoreQuerySpec,
+    FilterOperator
 )
 
 # NOTE: these prompts are inspired from langchain's self-query prompt,
@@ -54,9 +55,46 @@ example_query = "What are songs by Taylor Swift or Katy Perry in the dance pop g
 example_output = VectorStoreQuerySpec(
     query="teenager love",
     filters=[
-        ExactMatchFilter(key="artist", value="Taylor Swift"),
-        ExactMatchFilter(key="artist", value="Katy Perry"),
-        ExactMatchFilter(key="genre", value="pop"),
+        MetadataFilter(key="artist", value="Taylor Swift"),
+        MetadataFilter(key="artist", value="Katy Perry"),
+        MetadataFilter(key="genre", value="pop"),
+    ],
+)
+
+example_info_2 = VectorStoreInfo(
+    content_info="Classic literature",
+    metadata_info=[
+        MetadataInfo(name="author", type="str", description="Author name"),
+        MetadataInfo(
+            name="book_title",
+            type="str",
+            description='Book title',
+        ),
+        MetadataInfo(
+            name="year",
+            type="int",
+            description='Year Published',
+        ),
+        MetadataInfo(
+            name="pages",
+            type="int",
+            description='Number of pages',
+        ),
+        MetadataInfo(
+            name="summary",
+            type="str",
+            description="A short summary of the book",
+        )
+    ],
+)
+
+example_query_2 = "What are some books by Jane Austen published after 1813 that explore the theme of marriage for social standing?"
+
+example_output_2 = VectorStoreQuerySpec(
+    query="Books related to theme of marriage for social standing",
+    filters=[
+        MetadataFilter(key="year", value="1813", operator=FilterOperator.GT),
+        MetadataFilter(key="author", value="Jane Austen"),
     ],
 )
 
@@ -73,6 +111,21 @@ User Query:
 Structured Request:
 ```json
 {example_output.json()}
+
+
+<< Example 2. >>
+Data Source:
+```json
+{example_info_2.json(indent=4)}
+```
+
+User Query:
+{example_query_2}
+
+Structured Request:
+```json
+{example_output_2.json()}
+
 ```
 """.replace(
     "{", "{{"
@@ -82,7 +135,7 @@ Structured Request:
 
 
 SUFFIX = """
-<< Example 2. >>
+<< Example 3. >>
 Data Source:
 ```json
 {info_str}

--- a/llama_index/indices/vector_store/retrievers/auto_retriever/prompts.py
+++ b/llama_index/indices/vector_store/retrievers/auto_retriever/prompts.py
@@ -4,11 +4,11 @@
 from llama_index.prompts.base import PromptTemplate
 from llama_index.prompts.prompt_type import PromptType
 from llama_index.vector_stores.types import (
+    FilterOperator,
     MetadataFilter,
     MetadataInfo,
     VectorStoreInfo,
     VectorStoreQuerySpec,
-    FilterOperator
 )
 
 # NOTE: these prompts are inspired from langchain's self-query prompt,
@@ -68,23 +68,23 @@ example_info_2 = VectorStoreInfo(
         MetadataInfo(
             name="book_title",
             type="str",
-            description='Book title',
+            description="Book title",
         ),
         MetadataInfo(
             name="year",
             type="int",
-            description='Year Published',
+            description="Year Published",
         ),
         MetadataInfo(
             name="pages",
             type="int",
-            description='Number of pages',
+            description="Number of pages",
         ),
         MetadataInfo(
             name="summary",
             type="str",
             description="A short summary of the book",
-        )
+        ),
     ],
 )
 

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -188,7 +188,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
     _pinecone_index: Any = PrivateAttr()
     _tokenizer: Optional[Callable] = PrivateAttr()
-    _default_empty_query_vector: Optional[List[float]] = PrivateAttr()
 
     def __init__(
         self,
@@ -229,7 +228,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
         if tokenizer is None and add_sparse_vector:
             tokenizer = get_default_tokenizer()
         self._tokenizer = tokenizer
-        self._default_empty_query_vector = default_empty_query_vector
 
         super().__init__(
             index_name=index_name,
@@ -382,9 +380,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
             query_embedding = cast(List[float], query.query_embedding)
             if query.alpha is not None:
                 query_embedding = [v * query.alpha for v in query_embedding]
-
-            if not query_embedding and self._default_empty_query_vector is not None:
-                query_embedding = self._default_empty_query_vector
 
         if query.filters is not None:
             if "filter" in kwargs:

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -167,6 +167,9 @@ class PineconeVectorStore(BasePydanticVectorStore):
         insert_kwargs (Optional[Dict]): insert kwargs during `upsert` call.
         add_sparse_vector (bool): whether to add sparse vector to index.
         tokenizer (Optional[Callable]): tokenizer to use to generate sparse
+        default_empty_query_vector (Optional[List[float]]): default empty query vector.
+            Defaults to None. If not None, then this vector will be used as the query
+            vector if the query is empty.
 
     """
 
@@ -185,6 +188,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
     _pinecone_index: Any = PrivateAttr()
     _tokenizer: Optional[Callable] = PrivateAttr()
+    _default_empty_query_vector: Optional[List[float]] = PrivateAttr()
 
     def __init__(
         self,
@@ -199,6 +203,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         text_key: str = DEFAULT_TEXT_KEY,
         batch_size: int = DEFAULT_BATCH_SIZE,
         remove_text_from_metadata: bool = False,
+        default_empty_query_vector: Optional[List[float]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -224,6 +229,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         if tokenizer is None and add_sparse_vector:
             tokenizer = get_default_tokenizer()
         self._tokenizer = tokenizer
+        self._default_empty_query_vector = default_empty_query_vector
 
         super().__init__(
             index_name=index_name,
@@ -250,6 +256,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         text_key: str = DEFAULT_TEXT_KEY,
         batch_size: int = DEFAULT_BATCH_SIZE,
         remove_text_from_metadata: bool = False,
+        default_empty_query_vector: Optional[List[float]] = None,
         **kwargs: Any,
     ) -> "PineconeVectorStore":
         try:
@@ -272,6 +279,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             text_key=text_key,
             batch_size=batch_size,
             remove_text_from_metadata=remove_text_from_metadata,
+            default_empty_query_vector=default_empty_query_vector,
             **kwargs,
         )
 
@@ -374,6 +382,9 @@ class PineconeVectorStore(BasePydanticVectorStore):
             query_embedding = cast(List[float], query.query_embedding)
             if query.alpha is not None:
                 query_embedding = [v * query.alpha for v in query_embedding]
+
+            if not query_embedding and self._default_empty_query_vector is not None:
+                query_embedding = self._default_empty_query_vector
 
         if query.filters is not None:
             if "filter" in kwargs:

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -100,8 +100,8 @@ class MetadataFilter(BaseModel):
         """Create MetadataFilter from dictionary.
 
         Args:
+            filter_dict: Dict with key, value and operator.
 
-        
         """
         return MetadataFilter.parse_obj(filter_dict)
 
@@ -148,16 +148,18 @@ class MetadataFilters(BaseModel):
     ) -> "MetadataFilters":
         """Create MetadataFilters from dicts.
 
-        This takes in a list of individual MetadataFilter objects, along 
+        This takes in a list of individual MetadataFilter objects, along
         with the condition.
 
         Args:
             filter_dicts: List of dicts, each dict is a MetadataFilter.
             condition: FilterCondition to combine different filters.
-        
+
         """
         return cls(
-            filters=[MetadataFilter.from_dict(filter_dict) for filter_dict in filter_dicts],
+            filters=[
+                MetadataFilter.from_dict(filter_dict) for filter_dict in filter_dicts
+            ],
             condition=condition,
         )
 

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -92,12 +92,28 @@ class MetadataFilter(BaseModel):
     value: Union[StrictInt, StrictFloat, StrictStr]
     operator: FilterOperator = FilterOperator.EQ
 
+    @classmethod
+    def from_dict(
+        cls,
+        filter_dict: Dict,
+    ) -> "MetadataFilter":
+        """Create MetadataFilter from dictionary.
 
-# TODO: Deprecate ExactMatchFilter and use MetadataFilter instead
-# Keep class for now so that AutoRetriever can still work with old vector stores
-class ExactMatchFilter(BaseModel):
-    key: str
-    value: Union[StrictInt, StrictFloat, StrictStr]
+        Args:
+
+        
+        """
+        return MetadataFilter.parse_obj(filter_dict)
+
+
+# # TODO: Deprecate ExactMatchFilter and use MetadataFilter instead
+# # Keep class for now so that AutoRetriever can still work with old vector stores
+# class ExactMatchFilter(BaseModel):
+#     key: str
+#     value: Union[StrictInt, StrictFloat, StrictStr]
+
+# set ExactMatchFilter to MetadataFilter
+ExactMatchFilter = MetadataFilter
 
 
 class MetadataFilters(BaseModel):
@@ -125,6 +141,26 @@ class MetadataFilters(BaseModel):
             filters.append(filter)
         return cls(filters=filters)
 
+    def from_dicts(
+        cls,
+        filter_dicts: List[Dict],
+        condition: Optional[FilterCondition] = FilterCondition.AND,
+    ) -> "MetadataFilters":
+        """Create MetadataFilters from dicts.
+
+        This takes in a list of individual MetadataFilter objects, along 
+        with the condition.
+
+        Args:
+            filter_dicts: List of dicts, each dict is a MetadataFilter.
+            condition: FilterCondition to combine different filters.
+        
+        """
+        return cls(
+            filters=[MetadataFilter.from_dict(filter_dict) for filter_dict in filter_dicts],
+            condition=condition,
+        )
+
     def legacy_filters(self) -> List[ExactMatchFilter]:
         """Convert MetadataFilters to legacy ExactMatchFilters."""
         filters = []
@@ -146,7 +182,7 @@ class VectorStoreQuerySpec(BaseModel):
     """
 
     query: str
-    filters: List[ExactMatchFilter]
+    filters: List[MetadataFilter]
     top_k: Optional[int] = None
 
 


### PR DESCRIPTION
- allow it to infer less than/greater than filters in addition to equal
- modified pinecone auto-retrieval notebook to show this 
- added a `default_empty_query_vector` to pinecone to fill in a zero-vector if the query is empty (otherwise it will be null, causing pinecone to error. pinecone doesn't support queries without vectors atm) 

**Potentially Breaking Changes**
- I changed the default prompt for auto-retrieval to include a second example (with <, > operators)
- I removed the original ExactMatchFilter, it's now an alias for MetadataFilter
