### PR TITLE
Fix pip install commands in LM Format Enforcer notebooks

### DIFF
--- a/docs/examples/output_parsing/lmformatenforcer_pydantic_program.ipynb
+++ b/docs/examples/output_parsing/lmformatenforcer_pydantic_program.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install llama-index lmformatenforcer llama-cpp-python"
+    "!pip install llama-index lm-format-enforcer llama-cpp-python"
    ]
   },
   {

--- a/docs/examples/output_parsing/lmformatenforcer_regular_expressions.ipynb
+++ b/docs/examples/output_parsing/lmformatenforcer_regular_expressions.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install llama-index lmformatenforcer llama-cpp-python"
+    "!pip install llama-index lm-format-enforcer llama-cpp-python"
    ]
   },
   {


### PR DESCRIPTION
# Description

This is a small fix - the pip package name `lm-format-enforcer` was accidentally typed `lmformatenforcer` in the sample notebooks `pip install` commands. This fixes that typo.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

