### PR TITLE
add `iter_data()` method to SimpleDirectoryReader

### DIFF
--- a/docs/examples/data_connectors/simple_directory_reader.ipynb
+++ b/docs/examples/data_connectors/simple_directory_reader.ipynb
@@ -52,15 +52,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index import SimpleDirectoryReader"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -72,10 +63,67 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.\n",
+      "ERROR: could not open HSTS store at '/home/loganm/.wget-hsts'. HSTS will be disabled.\n",
+      "--2023-12-21 16:34:53--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 75042 (73K) [text/plain]\n",
+      "Saving to: ‘data/paul_graham/paul_graham_essay1.txt’\n",
+      "\n",
+      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.04s   \n",
+      "\n",
+      "2023-12-21 16:34:53 (1.81 MB/s) - ‘data/paul_graham/paul_graham_essay1.txt’ saved [75042/75042]\n",
+      "\n",
+      "Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.\n",
+      "ERROR: could not open HSTS store at '/home/loganm/.wget-hsts'. HSTS will be disabled.\n",
+      "--2023-12-21 16:34:53--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 75042 (73K) [text/plain]\n",
+      "Saving to: ‘data/paul_graham/paul_graham_essay2.txt’\n",
+      "\n",
+      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.04s   \n",
+      "\n",
+      "2023-12-21 16:34:53 (1.78 MB/s) - ‘data/paul_graham/paul_graham_essay2.txt’ saved [75042/75042]\n",
+      "\n",
+      "Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.\n",
+      "ERROR: could not open HSTS store at '/home/loganm/.wget-hsts'. HSTS will be disabled.\n",
+      "--2023-12-21 16:34:54--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 75042 (73K) [text/plain]\n",
+      "Saving to: ‘data/paul_graham/paul_graham_essay3.txt’\n",
+      "\n",
+      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.04s   \n",
+      "\n",
+      "2023-12-21 16:34:54 (1.80 MB/s) - ‘data/paul_graham/paul_graham_essay3.txt’ saved [75042/75042]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "!mkdir -p 'data/paul_graham/'\n",
-    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay1.txt'\n",
+    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay2.txt'\n",
+    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay3.txt'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index import SimpleDirectoryReader"
    ]
   },
   {
@@ -93,7 +141,7 @@
    "outputs": [],
    "source": [
     "reader = SimpleDirectoryReader(\n",
-    "    input_files=[\"./data/paul_graham/paul_graham_essay.txt\"]\n",
+    "    input_files=[\"./data/paul_graham/paul_graham_essay1.txt\"]\n",
     ")"
    ]
   },
@@ -129,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reader = SimpleDirectoryReader(input_dir=\"../../end_to_end_tutorials/\")"
+    "reader = SimpleDirectoryReader(input_dir=\"./data/paul_graham/\")"
    ]
   },
   {
@@ -141,7 +189,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded 72 docs\n"
+      "Loaded 3 docs\n"
      ]
     }
    ],
@@ -164,11 +212,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!mkdir -p 'data/paul_graham/nested'\n",
+    "!echo \"This is a nested file\" > 'data/paul_graham/nested/nested_file.md'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# only load markdown files\n",
     "required_exts = [\".md\"]\n",
     "\n",
     "reader = SimpleDirectoryReader(\n",
-    "    input_dir=\"../../end_to_end_tutorials\",\n",
+    "    input_dir=\"./data\",\n",
     "    required_exts=required_exts,\n",
     "    recursive=True,\n",
     ")"
@@ -183,13 +241,49 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded 174 docs\n"
+      "Loaded 1 docs\n"
      ]
     }
    ],
    "source": [
     "docs = reader.load_data()\n",
     "print(f\"Loaded {len(docs)} docs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an iterator to load files and process them as they load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4\n"
+     ]
+    }
+   ],
+   "source": [
+    "reader = SimpleDirectoryReader(\n",
+    "    input_dir=\"./data\",\n",
+    "    recursive=True,\n",
+    ")\n",
+    "\n",
+    "all_docs = []\n",
+    "for docs in reader.iter_data():\n",
+    "    for doc in docs:\n",
+    "        # do something with the doc\n",
+    "        doc.text = doc.text.upper()\n",
+    "        all_docs.append(doc)\n",
+    "\n",
+    "print(len(all_docs))"
    ]
   },
   {

--- a/docs/module_guides/loading/simpledirectoryreader.md
+++ b/docs/module_guides/loading/simpledirectoryreader.md
@@ -40,6 +40,18 @@ By default, `SimpleDirectoryReader` will only read files in the top level of the
 SimpleDirectoryReader(input_dir="path/to/directory", recursive=True)
 ```
 
+### Iterating over files as they load
+
+You can also use the `iter_data()` method to iterate over and process files as they load
+
+```python
+reader = SimpleDirectoryReader(input_dir="path/to/directory", recursive=True)
+all_docs = []
+for docs in reader.iter_data():
+    # <do something with the documents per file>
+    all_docs.extend(docs)
+```
+
 ### Restricting the files loaded
 
 Instead of all files you can pass a list of file paths:


### PR DESCRIPTION
# Description

Adds functionality to iterate over documents as the load with `SimpleDirectoryReader`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new notebook (that tests end-to-end)

