### PR TITLE
fix bedrock client initialisation

### DIFF
--- a/llama_index/embeddings/bedrock.py
+++ b/llama_index/embeddings/bedrock.py
@@ -201,7 +201,7 @@ class BedrockEmbedding(BaseEmbedding):
 
     def _get_embedding(self, payload: str, type: Literal["text", "query"]) -> Embedding:
         if self._client is None:
-            self.set_credentials(self.model_name)
+            self.set_credentials()
 
         if self._client is None:
             raise ValueError("Client not set")


### PR DESCRIPTION
# Description

The first parameter of the `set_credentials` method is the AWS region. The current call leads to an exception `botocore.exceptions.InvalidRegionError: Provided region_name 'amazon.titan-embed-text-v1' doesn't match a supported format.`

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
