### PR TITLE
Get a default value if the api doesn't return prompt_tokens

### DIFF
--- a/llama_index/callbacks/token_counting.py
+++ b/llama_index/callbacks/token_counting.py
@@ -53,8 +53,8 @@ def get_llm_token_counts(
                 usage = response.raw.get("usage")  # type: ignore
 
                 if usage is not None:
-                    messages_tokens = usage.prompt_tokens
-                    response_tokens = usage.completion_tokens
+                    messages_tokens = usage.get("prompt_tokens", 0)
+                    response_tokens = usage.get("completion_tokens", 0)
 
                 if messages_tokens == 0 or response_tokens == 0:
                     raise ValueError("Invalid token counts!")


### PR DESCRIPTION
This is consistent with the rest of the codebase

# Description

With anyscale apis, there is a persistent warning originating from `llama_index.chat_engine.types::Encountered exception writing response to history: 'dict' object has no attribute 'prompt_tokens'`

I haven't figured out why this is happening only with anyscale (have tried openai + anthropic as well) but fixing this removes the warning. Moreover this pattern is consistent with the rest of the codebase as can be seen here https://github.com/search?q=repo:run-llama/llama_index%20prompt_tokens&type=code



Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
