### PR TITLE
preserve func info with `trace_method` decorator

### DIFF
--- a/llama_index/callbacks/utils.py
+++ b/llama_index/callbacks/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 from typing import Any, Callable, cast
 
@@ -24,6 +25,8 @@ def trace_method(
     """
 
     def decorator(func: Callable) -> Callable:
+
+        @functools.wraps(func)  # preserve signature, name, etc. of func
         def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
             try:
                 callback_manager = getattr(self, callback_manager_attr)
@@ -38,6 +41,7 @@ def trace_method(
             with callback_manager.as_trace(trace_id):
                 return func(self, *args, **kwargs)
 
+        @functools.wraps(func)  # preserve signature, name, etc. of func
         async def async_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
             try:
                 callback_manager = getattr(self, callback_manager_attr)

--- a/llama_index/callbacks/utils.py
+++ b/llama_index/callbacks/utils.py
@@ -25,7 +25,6 @@ def trace_method(
     """
 
     def decorator(func: Callable) -> Callable:
-
         @functools.wraps(func)  # preserve signature, name, etc. of func
         def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
             try:


### PR DESCRIPTION
# Description

`trace_method` did not preserve decorated method information such as signature, name, etc. This is a problem for tools that need this information. This PR fixes this.

Consider inspecting signature of wrapped method:

```python
import inspect
inspect.signature(chat_engine.chat) # created from index.as_chat_engine()
```

Before change, that outputs:
```
<Signature (*args: Any, **kwargs: Any) -> Any>
```

After change, it outputs:
```
<Signature (message: str, chat_history: Optional[List[llama_index.llms.types.ChatMessage]] = None, tool_choice: Union[str, dict] = 'auto') -> llama_index.chat_engine.types.AgentChatResponse>
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I ran `make format; make lint` to appease the lint gods
