### PR TITLE
Adding support more filters pinecone

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,7 @@ repos:
       - id: codespell
         additional_dependencies: [tomli]
         exclude: llama_index/_static
+        args: ["--ignore-words-list", "nin"]
   - repo: https://github.com/srstevenson/nb-clean
     rev: 3.1.0
     hooks:

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -1,4 +1,5 @@
-"""Pinecone Vector store index.
+"""
+Pinecone Vector store index.
 
 An index that that is built on top of an existing vector store.
 
@@ -61,6 +62,8 @@ def _transform_pinecone_filter_operator(operator: str) -> str:
         return "$lte"
     elif operator == "in":
         return "$in"
+    elif operator == "nin":
+        return "$nin"
     else:
         raise ValueError(f"Filter operator {operator} not supported")
 

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -69,6 +69,7 @@ class FilterOperator(str, Enum):
     GTE = ">="  # greater than or equal to (int, float)
     LTE = "<="  # less than or equal to (int, float)
     IN = "in"  # In array (string or number)
+    NIN = "nin"  # Not in array (string or number)
 
 
 class FilterCondition(str, Enum):


### PR DESCRIPTION
# Description

Added support for a new filtering method called `nin` means not in array for `pinecone` vector store.

Note:
* Ignore a word `nin` which makes pylint fails



## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
