### PR TITLE
Clarify that one needs to explicitly pass custom `persist_dir` to `storage_context.persist`

### DIFF
--- a/docs/getting_started/starter_example.md
+++ b/docs/getting_started/starter_example.md
@@ -95,15 +95,16 @@ from llama_index import (
 )
 
 # check if storage already exists
-if not os.path.exists("./storage"):
+PERSIST_DIR = "./storage"
+if not os.path.exists(PERSIST_DIR):
     # load the documents and create the index
     documents = SimpleDirectoryReader("data").load_data()
     index = VectorStoreIndex.from_documents(documents)
     # store it for later
-    index.storage_context.persist()
+    index.storage_context.persist(persist_dir=PERSIST_DIR)
 else:
     # load the existing index
-    storage_context = StorageContext.from_defaults(persist_dir="./storage")
+    storage_context = StorageContext.from_defaults(persist_dir=PERSIST_DIR)
     index = load_index_from_storage(storage_context)
 
 # either way we can now query the index


### PR DESCRIPTION
# Description

Just a documentation update. I was following the getting-started guide and was confused why data persistence was ignoring the custom path I gave. It took me some time to figure out that the guide was missing a parameter.

## Type of Change

Please delete options that are not relevant.

# How Has This Been Tested?

I also tested it locally end-to-end, but I didn't "add" a new notebook.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
