### PR TITLE
make llm completion program more general

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,13 +64,7 @@ repos:
       - id: codespell
         additional_dependencies: [tomli]
         exclude: llama_index/_static
-        args:
-          [
-            "--ignore-words-list",
-            "nin",
-            "--exclude-file",
-            "llama_index/agent/llm_compiler/prompts.py",
-          ]
+        args: ["--ignore-words-list", "nin"]
   - repo: https://github.com/srstevenson/nb-clean
     rev: 3.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,13 @@ repos:
       - id: codespell
         additional_dependencies: [tomli]
         exclude: llama_index/_static
-        args: ["--ignore-words-list", "nin"]
+        args:
+          [
+            "--ignore-words-list",
+            "nin",
+            "--exclude-file",
+            "llama_index/agent/llm_compiler/prompts.py",
+          ]
   - repo: https://github.com/srstevenson/nb-clean
     rev: 3.1.0
     hooks:

--- a/llama_index/program/llm_program.py
+++ b/llama_index/program/llm_program.py
@@ -5,7 +5,7 @@ from llama_index.llms.llm import LLM
 from llama_index.llms.openai import OpenAI
 from llama_index.output_parsers.pydantic import PydanticOutputParser
 from llama_index.prompts.base import BasePromptTemplate, PromptTemplate
-from llama_index.types import BasePydanticProgram
+from llama_index.types import BaseOutputParser, BasePydanticProgram
 
 
 class LLMTextCompletionProgram(BasePydanticProgram[BaseModel]):
@@ -18,12 +18,14 @@ class LLMTextCompletionProgram(BasePydanticProgram[BaseModel]):
 
     def __init__(
         self,
-        output_parser: PydanticOutputParser,
+        output_parser: BaseOutputParser,
+        output_cls: Type[BaseModel],
         prompt: BasePromptTemplate,
         llm: LLM,
         verbose: bool = False,
     ) -> None:
         self._output_parser = output_parser
+        self._output_cls = output_cls
         self._llm = llm
         self._prompt = prompt
         self._verbose = verbose
@@ -33,7 +35,8 @@ class LLMTextCompletionProgram(BasePydanticProgram[BaseModel]):
     @classmethod
     def from_defaults(
         cls,
-        output_parser: PydanticOutputParser,
+        output_parser: BaseOutputParser,
+        output_cls: Optional[Type[BaseModel]] = None,
         prompt_template_str: Optional[str] = None,
         prompt: Optional[PromptTemplate] = None,
         llm: Optional[LLM] = None,
@@ -47,8 +50,16 @@ class LLMTextCompletionProgram(BasePydanticProgram[BaseModel]):
             raise ValueError("Must provide either prompt or prompt_template_str.")
         if prompt_template_str is not None:
             prompt = PromptTemplate(prompt_template_str)
+
+        # decide default output class if not set
+        if output_cls is None:
+            if not isinstance(output_parser, PydanticOutputParser):
+                raise ValueError("Output parser must be PydanticOutputParser.")
+            output_cls = output_parser.output_cls
+
         return cls(
             output_parser,
+            output_cls,
             prompt=cast(PromptTemplate, prompt),
             llm=llm,
             verbose=verbose,
@@ -56,7 +67,7 @@ class LLMTextCompletionProgram(BasePydanticProgram[BaseModel]):
 
     @property
     def output_cls(self) -> Type[BaseModel]:
-        return self._output_parser.output_cls
+        return self._output_cls
 
     @property
     def prompt(self) -> BasePromptTemplate:


### PR DESCRIPTION
before, it only took a pydantic parser

however, other output parsers could also return pydantic objects. let users specify any output parser, and add the option to additionally specify an output class 