### PR TITLE
allow skipping module loading in `download_module` and `download_llama_pack` 

### DIFF
--- a/llama_index/download/module.py
+++ b/llama_index/download/module.py
@@ -175,18 +175,6 @@ def download_module_and_reqs(
             )
 
 
-def _convert_path_to_module(path: str) -> str:
-    """Convert directory path to module path."""
-    # Remove the file extension if it exists
-    if path.endswith('.py'):
-        path = path[:-3]
-    elif path.endswith('.pyc'):
-        path = path[:-4]
-
-    # Replace slashes with dots
-    return path.replace('/', '.')
-
-
 def download_llama_module(
     module_class: str,
     llama_hub_url: str = LLAMA_HUB_URL,

--- a/llama_index/download/module.py
+++ b/llama_index/download/module.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 from enum import Enum
-from importlib import util, import_module
+from importlib import util
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -242,20 +242,14 @@ def download_llama_module(
     # loads the module into memory
     if override_path:
         path = f"{dirpath}/{base_file_name}"
-        spec = util.spec_from_file_location(
-            "custom_module", location=path
-        )
+        spec = util.spec_from_file_location("custom_module", location=path)
         if spec is None:
             raise ValueError(f"Could not find file: {path}.")
     else:
         path = f"{dirpath}/{module_id}/{base_file_name}"
-        spec = util.spec_from_file_location(
-            "custom_module", location=path
-        )
+        spec = util.spec_from_file_location("custom_module", location=path)
         if spec is None:
-            raise ValueError(
-                f"Could not find file: {path}."
-            )
+            raise ValueError(f"Could not find file: {path}.")
 
     module = util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore

--- a/llama_index/download/module.py
+++ b/llama_index/download/module.py
@@ -253,40 +253,21 @@ def download_llama_module(
 
     # loads the module into memory
     if override_path:
-        # base_path = str(dirpath)
-        # sys.path.append(base_path)
         path = f"{dirpath}/{base_file_name}"
-        module_path = _convert_path_to_module(path)
-        # module_path = Path(path).stem
         spec = util.spec_from_file_location(
-            module_path, location=path
+            "custom_module", location=path
         )
         if spec is None:
             raise ValueError(f"Could not find file: {path}.")
     else:
-        # base_path = f"{dirpath}/{module_id}"
-        # sys.path.append(base_path)
         path = f"{dirpath}/{module_id}/{base_file_name}"
-        module_path = _convert_path_to_module(path)
-        # module_path = Path(path).stem
         spec = util.spec_from_file_location(
-            module_path, location=path
+            "custom_module", location=path
         )
         if spec is None:
             raise ValueError(
                 f"Could not find file: {path}."
             )
-
-    # instead of using module_from_spec as below, try to import
-    # given that we added to sys.path using importlib
-
-    # module_import_path = Path(base_path).stem + "." + base_file_name[:-3]
-    # print(base_path)
-    # print(module_import_path)
-    # module = import_module(module_import_path)
-
-    # print(path)
-    # print(module_path)
 
     module = util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore

--- a/llama_index/download/module.py
+++ b/llama_index/download/module.py
@@ -175,6 +175,18 @@ def download_module_and_reqs(
             )
 
 
+def _convert_path_to_module(path: str) -> str:
+    """Convert directory path to module path."""
+    # Remove the file extension if it exists
+    if path.endswith('.py'):
+        path = path[:-3]
+    elif path.endswith('.pyc'):
+        path = path[:-4]
+
+    # Replace slashes with dots
+    return path.replace('/', '.')
+
+
 def download_llama_module(
     module_class: str,
     llama_hub_url: str = LLAMA_HUB_URL,
@@ -238,18 +250,22 @@ def download_llama_module(
 
     # loads the module into memory
     if override_path:
+        path = f"{dirpath}/{base_file_name}"
+        module_path = _convert_path_to_module(path)
         spec = util.spec_from_file_location(
-            "custom_module", location=f"{dirpath}/{base_file_name}"
+            module_path, location=path
         )
         if spec is None:
-            raise ValueError(f"Could not find file: {dirpath}/{base_file_name}.")
+            raise ValueError(f"Could not find file: {path}.")
     else:
+        path = f"{dirpath}/{module_id}/{base_file_name}"
+        module_path = _convert_path_to_module(path)
         spec = util.spec_from_file_location(
-            "custom_module", location=f"{dirpath}/{module_id}/{base_file_name}"
+            module_path, location=path
         )
         if spec is None:
             raise ValueError(
-                f"Could not find file: {dirpath}/{module_id}/{base_file_name}."
+                f"Could not find file: {path}."
             )
 
     module = util.module_from_spec(spec)

--- a/llama_index/download/module.py
+++ b/llama_index/download/module.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 from enum import Enum
-from importlib import util
+from importlib import util, import_module
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -198,6 +198,7 @@ def download_llama_module(
     use_gpt_index_import: bool = False,
     disable_library_cache: bool = False,
     override_path: bool = False,
+    skip_load: bool = False,
 ) -> Any:
     """Download a module from LlamaHub.
 
@@ -247,19 +248,27 @@ def download_llama_module(
         base_file_name=base_file_name,
         override_path=override_path,
     )
+    if skip_load:
+        return None
 
     # loads the module into memory
     if override_path:
+        # base_path = str(dirpath)
+        # sys.path.append(base_path)
         path = f"{dirpath}/{base_file_name}"
         module_path = _convert_path_to_module(path)
+        # module_path = Path(path).stem
         spec = util.spec_from_file_location(
             module_path, location=path
         )
         if spec is None:
             raise ValueError(f"Could not find file: {path}.")
     else:
+        # base_path = f"{dirpath}/{module_id}"
+        # sys.path.append(base_path)
         path = f"{dirpath}/{module_id}/{base_file_name}"
         module_path = _convert_path_to_module(path)
+        # module_path = Path(path).stem
         spec = util.spec_from_file_location(
             module_path, location=path
         )
@@ -267,6 +276,17 @@ def download_llama_module(
             raise ValueError(
                 f"Could not find file: {path}."
             )
+
+    # instead of using module_from_spec as below, try to import
+    # given that we added to sys.path using importlib
+
+    # module_import_path = Path(base_path).stem + "." + base_file_name[:-3]
+    # print(base_path)
+    # print(module_import_path)
+    # module = import_module(module_import_path)
+
+    # print(path)
+    # print(module_path)
 
     module = util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore

--- a/llama_index/llama_pack/download.py
+++ b/llama_index/llama_pack/download.py
@@ -1,4 +1,4 @@
-from typing import Type, Optional
+from typing import Optional, Type
 
 from llama_index.download.module import (
     LLAMA_HUB_URL,

--- a/llama_index/llama_pack/download.py
+++ b/llama_index/llama_pack/download.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Optional
 
 from llama_index.download.module import (
     LLAMA_HUB_URL,
@@ -15,7 +15,7 @@ def download_llama_pack(
     llama_hub_url: str = LLAMA_HUB_URL,
     refresh_cache: bool = True,
     skip_load: bool = False,
-) -> Type[BaseLlamaPack]:
+) -> Optional[Type[BaseLlamaPack]]:
     """Download a single LlamaPack from Llama Hub.
 
     Args:
@@ -38,7 +38,10 @@ def download_llama_pack(
         override_path=True,
         skip_load=skip_load,
     )
+    track_download(llama_pack_class, MODULE_TYPE.LLAMAPACK)
+    if pack_cls is None:
+        return None
+
     if not issubclass(pack_cls, BaseLlamaPack):
         raise ValueError(f"Tool class {pack_cls} must be a subclass of BaseToolSpec.")
-    track_download(llama_pack_class, MODULE_TYPE.LLAMAPACK)
     return pack_cls

--- a/llama_index/llama_pack/download.py
+++ b/llama_index/llama_pack/download.py
@@ -13,6 +13,8 @@ def download_llama_pack(
     llama_pack_class: str,
     download_dir: str,
     llama_hub_url: str = LLAMA_HUB_URL,
+    refresh_cache: bool = True,
+    skip_load: bool = False,
 ) -> Type[BaseLlamaPack]:
     """Download a single LlamaPack from Llama Hub.
 
@@ -29,11 +31,12 @@ def download_llama_pack(
     pack_cls = download_llama_module(
         llama_pack_class,
         llama_hub_url=llama_hub_url,
-        refresh_cache=True,
+        refresh_cache=refresh_cache,
         custom_path=download_dir,
         library_path="llama_packs/library.json",
         disable_library_cache=True,
         override_path=True,
+        skip_load=skip_load,
     )
     if not issubclass(pack_cls, BaseLlamaPack):
         raise ValueError(f"Tool class {pack_cls} must be a subclass of BaseToolSpec.")


### PR DESCRIPTION
for some llama packs, especially those with an entire directory of files, loading modules with `util.module_from_spec` doesn't work well without hacks (the only alternative is to modify the system path and do importlib.import_module) 

In that case the options are either to 1) modify the system path and do `importlib.import_module`, or 2) skip the module loading part and let the user figure it out.

I decided to opt for option 2. Let the user download the files somewhere, and have them figure out how to actually import it. 