### PR TITLE
fix beam search for vllm: add missing parameter

### DIFF
--- a/llama_index/llms/vllm.py
+++ b/llama_index/llms/vllm.py
@@ -203,6 +203,7 @@ class Vllm(LLM):
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
             "use_beam_search": self.use_beam_search,
+            "best_of": self.best_of,
             "ignore_eos": self.ignore_eos,
             "stop": self.stop,
             "logprobs": self.logprobs,


### PR DESCRIPTION
# Description

Fix to prevent the following buggy behavior:

`
  File "/...../.venv/lib/python3.11/site-packages/vllm/sampling_params.py", line 198, in _verify_beam_search
    raise ValueError("best_of must be greater than 1 when using beam "
ValueError: best_of must be greater than 1 when using beam search. Got 1.
`

Argument best_of was just simply missed in _model_kwargs getter.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings