### PR TITLE
Loading the default service_context in SubQuestionQueryEngine

### DIFF
--- a/llama_index/query_engine/sub_question_query_engine.py
+++ b/llama_index/query_engine/sub_question_query_engine.py
@@ -93,18 +93,19 @@ class SubQuestionQueryEngine(BaseQueryEngine):
             callback_manager = service_context.callback_manager
         elif len(query_engine_tools) > 0:
             callback_manager = query_engine_tools[0].query_engine.callback_manager
+
         service_context = service_context or ServiceContext.from_defaults()
         if question_gen is None:
-                # try to use OpenAI function calling based question generator.
-                # if incompatible, use general LLM question generator
-                try:
-                    question_gen = OpenAIQuestionGenerator.from_defaults(
-                        llm=service_context.llm
-                    )
-                except ValueError:
-                    question_gen = LLMQuestionGenerator.from_defaults(
-                        service_context=service_context
-                    )
+            # try to use OpenAI function calling based question generator.
+            # if incompatible, use general LLM question generator
+            try:
+                question_gen = OpenAIQuestionGenerator.from_defaults(
+                    llm=service_context.llm
+                )
+            except ValueError:
+                question_gen = LLMQuestionGenerator.from_defaults(
+                    service_context=service_context
+                )
 
         synth = response_synthesizer or get_response_synthesizer(
             callback_manager=callback_manager,

--- a/llama_index/query_engine/sub_question_query_engine.py
+++ b/llama_index/query_engine/sub_question_query_engine.py
@@ -93,12 +93,8 @@ class SubQuestionQueryEngine(BaseQueryEngine):
             callback_manager = service_context.callback_manager
         elif len(query_engine_tools) > 0:
             callback_manager = query_engine_tools[0].query_engine.callback_manager
-
+        service_context = service_context or ServiceContext.from_defaults()
         if question_gen is None:
-            if service_context is None:
-                # use default openai model that supports function calling API
-                question_gen = OpenAIQuestionGenerator.from_defaults()
-            else:
                 # try to use OpenAI function calling based question generator.
                 # if incompatible, use general LLM question generator
                 try:


### PR DESCRIPTION
# Description

The default service_context is not loaded in SubQuestionQueryEngine if the service_context is not passed as the parameter to the api. Issue raised #9757 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
