### PR TITLE
Fix Default Output Parser Assignment in SubQuestionQueryEngine

### DIFF
--- a/llama_index/question_gen/llm_generators.py
+++ b/llama_index/question_gen/llm_generators.py
@@ -59,10 +59,9 @@ class LLMQuestionGenerator(BaseQuestionGenerator):
             output_parser = prompts["question_gen_prompt"].output_parser
             if output_parser is None:
                 output_parser = SubQuestionOutputParser()
-            new_prompt = PromptTemplate(
+            self._prompt = PromptTemplate(
                 prompts["question_gen_prompt"].template_str, output_parser=output_parser
             )
-            self._prompt = new_prompt
 
     def generate(
         self, tools: Sequence[ToolMetadata], query: QueryBundle

--- a/llama_index/question_gen/llm_generators.py
+++ b/llama_index/question_gen/llm_generators.py
@@ -56,7 +56,13 @@ class LLMQuestionGenerator(BaseQuestionGenerator):
     def _update_prompts(self, prompts: PromptDictType) -> None:
         """Update prompts."""
         if "question_gen_prompt" in prompts:
-            self._prompt = prompts["question_gen_prompt"]
+            output_parser = prompts["question_gen_prompt"].output_parser
+            if output_parser is None:
+                output_parser = SubQuestionOutputParser()
+            new_prompt = PromptTemplate(
+                prompts["question_gen_prompt"].template_str, output_parser=output_parser
+            )
+            self._prompt = new_prompt
 
     def generate(
         self, tools: Sequence[ToolMetadata], query: QueryBundle


### PR DESCRIPTION
## Description

**Summary of Change:**  
This PR introduces a crucial update to the SubQuestionQueryEngine in version 0.9.1.post1. It addresses a specific bug where the engine failed to default to the SubQuestionOutputParser when modifying the prompt without explicitly specifying the `output_parser`. This enhancement ensures more reliable and streamlined functionality in prompt handling.

**Context and Motivation:**  
The necessity for this update stems from the observed behavior where, in the absence of an explicitly assigned `output_parser`, the engine did not resort to the default SubQuestionOutputParser. This led to an `AssertionError`, hindering the usability and flexibility of the SubQuestionQueryEngine.

**Dependencies:**  
No additional dependencies are required for this change.

## Steps to Reproduce

1. Define `SubQuestionQueryEngine` with the necessary parameters.
2. Update the query engine's prompt using `PromptTemplate` without specifying `output_parser`.
   Example code snippet:
   ```python
   from llama_index.prompts import PromptTemplate
   from llama_index.question_gen.output_parser import SubQuestionOutputParser

   # Example prompt template string
   new_prompt_tmpl_str = """..."""

   new_prompt_tmpl = PromptTemplate(
       new_prompt_tmpl_str
       # Previously, output_parser was not specified here
   )
   sq_query_engine.update_prompts({"question_gen:question_gen_prompt": new_prompt_tmpl})

## Notice

The absence of `output_parser = SubQuestionOutputParser()` in the prompt update process results in an `AssertionError`.

## Solution

**Implemented Change:**  
The `_update_prompts` function within the `SubQuestionQueryEngine` class has been updated. This change ensures that if the `output_parser` is not explicitly assigned, it will default to `SubQuestionOutputParser`. This modification effectively resolves the issue and ensures the functionality aligns with expected behaviors.

**Developer Interaction:**  
Developers are now able to update prompts without needing to specify the `output_parser` each time. The engine automatically defaults to the appropriate parser, simplifying the development process.

**Code Example of the Change:**
```python
def _update_prompts(self, prompts: PromptDictType) -> None:
    """Update prompts."""
    if "question_gen_prompt" in prompts:
        output_parser = prompts["question_gen_prompt"].output_parser
        if output_parser is None:
            output_parser = SubQuestionOutputParser()
        new_prompt = PromptTemplate(
            prompts["question_gen_prompt"].template_str,
            output_parser=output_parser
        )
        self._prompt = new_prompt



Fixes # (issue) #9759 


## Type of Change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
- [x] I created a notebook that utilizes the SubQuestionQueryEngine and attempted to replicate the bug by not explicitly specifying the output parser in the PromptTemplate. I used the `_update_prompt` method of the SubQuestionQueryEngine object, and now it functions correctly.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
