### PR TITLE
Actually use provided HTTP client when using Azure OpenAI

### DIFF
--- a/llama_index/embeddings/azure_openai.py
+++ b/llama_index/embeddings/azure_openai.py
@@ -25,7 +25,6 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
 
     _client: AzureOpenAI = PrivateAttr()
     _aclient: AsyncAzureOpenAI = PrivateAttr()
-    _http_client: Optional[httpx.Client] = PrivateAttr()
 
     def __init__(
         self,
@@ -55,10 +54,6 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             deployment_name,
         )
 
-        # Use the custom httpx client if provided.
-        # Otherwise the value will be None.
-        self._http_client = http_client
-
         super().__init__(
             mode=mode,
             model=model,
@@ -71,6 +66,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             max_retries=max_retries,
             reuse_client=reuse_client,
             callback_manager=callback_manager,
+            http_client=http_client,
             **kwargs,
         )
 

--- a/llama_index/llms/azure_openai.py
+++ b/llama_index/llms/azure_openai.py
@@ -54,7 +54,6 @@ class AzureOpenAI(OpenAI):
     _azure_ad_token: Any = PrivateAttr()
     _client: SyncAzureOpenAI = PrivateAttr()
     _aclient: AsyncAzureOpenAI = PrivateAttr()
-    _http_client: Optional[httpx.Client] = PrivateAttr()
 
     def __init__(
         self,
@@ -98,10 +97,6 @@ class AzureOpenAI(OpenAI):
             "azure_endpoint", azure_endpoint, "AZURE_OPENAI_ENDPOINT", ""
         )
 
-        # Use the custom httpx client if provided.
-        # Otherwise the value will be None.
-        self._http_client = http_client
-
         super().__init__(
             engine=engine,
             model=model,
@@ -117,6 +112,7 @@ class AzureOpenAI(OpenAI):
             use_azure_ad=use_azure_ad,
             api_version=api_version,
             callback_manager=callback_manager,
+            http_client=http_client,
             system_prompt=system_prompt,
             messages_to_prompt=messages_to_prompt,
             completion_to_prompt=completion_to_prompt,

--- a/tests/embeddings/test_azure_openai.py
+++ b/tests/embeddings/test_azure_openai.py
@@ -5,7 +5,7 @@ from llama_index.embeddings import AzureOpenAIEmbedding
 
 
 @patch("llama_index.embeddings.azure_openai.AzureOpenAI")
-def test_custom_http_client(azure_openai_mock: MagicMock):
+def test_custom_http_client(azure_openai_mock: MagicMock) -> None:
     """
     Verify that a custom http_client set for AzureOpenAIEmbedding.
     Should get passed on to the implementation from OpenAI.

--- a/tests/embeddings/test_azure_openai.py
+++ b/tests/embeddings/test_azure_openai.py
@@ -1,13 +1,15 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
-
 from llama_index.embeddings import AzureOpenAIEmbedding
 
 
 @patch("llama_index.embeddings.azure_openai.AzureOpenAI")
 def test_custom_http_client(azure_openai_mock: MagicMock):
-    """Verify that a custom http_client set for AzureOpenAIEmbedding gets passed on to the implementation from OpenAI"""
+    """
+    Verify that a custom http_client set for AzureOpenAIEmbedding.
+    Should get passed on to the implementation from OpenAI.
+    """
     custom_http_client = httpx.Client()
     embedding = AzureOpenAIEmbedding(http_client=custom_http_client)
     embedding.get_text_embedding(text="foo bar")

--- a/tests/embeddings/test_azure_openai.py
+++ b/tests/embeddings/test_azure_openai.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch, MagicMock
+
+import httpx
+
+from llama_index.embeddings import AzureOpenAIEmbedding
+
+
+@patch("llama_index.embeddings.azure_openai.AzureOpenAI")
+def test_custom_http_client(azure_openai_mock: MagicMock):
+    """Verify that a custom http_client set for AzureOpenAIEmbedding gets passed on to the implementation from OpenAI"""
+    custom_http_client = httpx.Client()
+    embedding = AzureOpenAIEmbedding(http_client=custom_http_client)
+    embedding.get_text_embedding(text="foo bar")
+    azure_openai_mock.assert_called()
+    kwargs = azure_openai_mock.call_args.kwargs
+    assert "http_client" in kwargs
+    assert kwargs["http_client"] == custom_http_client

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import httpx
+
+from llama_index.llms import AzureOpenAI
+from tests.llms.test_openai import mock_chat_completion_v1
+
+
+@patch("llama_index.llms.azure_openai.SyncAzureOpenAI")
+def test_custom_http_client(sync_azure_openai_mock: MagicMock):
+    """Verify that a custom http_client set for AzureOpenAI gets passed on to the implementation from OpenAI"""
+    custom_http_client = httpx.Client()
+    mock_instance = sync_azure_openai_mock.return_value
+    # Valid mocked result required to not run into another error
+    mock_instance.chat.completions.create.return_value = mock_chat_completion_v1()
+    azure_openai = AzureOpenAI(engine="foo bar", http_client=custom_http_client)
+    azure_openai.complete("test prompt")
+    sync_azure_openai_mock.assert_called()
+    kwargs = sync_azure_openai_mock.call_args.kwargs
+    assert "http_client" in kwargs
+    assert kwargs["http_client"] == custom_http_client

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -1,15 +1,17 @@
-from unittest.mock import MagicMock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
-
 from llama_index.llms import AzureOpenAI
+
 from tests.llms.test_openai import mock_chat_completion_v1
 
 
 @patch("llama_index.llms.azure_openai.SyncAzureOpenAI")
 def test_custom_http_client(sync_azure_openai_mock: MagicMock):
-    """Verify that a custom http_client set for AzureOpenAI gets passed on to the implementation from OpenAI"""
+    """
+    Verify that a custom http_client set for AzureOpenAI.
+    Should get passed on to the implementation from OpenAI.
+    """
     custom_http_client = httpx.Client()
     mock_instance = sync_azure_openai_mock.return_value
     # Valid mocked result required to not run into another error

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -7,7 +7,7 @@ from tests.llms.test_openai import mock_chat_completion_v1
 
 
 @patch("llama_index.llms.azure_openai.SyncAzureOpenAI")
-def test_custom_http_client(sync_azure_openai_mock: MagicMock):
+def test_custom_http_client(sync_azure_openai_mock: MagicMock) -> None:
     """
     Verify that a custom http_client set for AzureOpenAI.
     Should get passed on to the implementation from OpenAI.


### PR DESCRIPTION
# Description

There was a bug before that lead to a custom `http_client` (parameter in class `AzureOpenAIEmbedding` and `AzureOpenAI`) being ignored when using Azure OpenAI. By not passing on the provided `http_client` to the base class, its actual value was ignored and None was used instead (from the default paramaters).

The problem can be easily verified by the added unit tests (they fail without the included change to the source files, the `http_client` parameter is then missing in the call to `openai`).

This fixes the bug both for `AzureOpenAIEmbedding` as well as for `AzureOpenAI`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense
