### PR TITLE
Fix (#9774) service context loading to use global defaults 

### DIFF
--- a/llama_index/evaluation/dataset_generation.py
+++ b/llama_index/evaluation/dataset_generation.py
@@ -12,7 +12,6 @@ from deprecated import deprecated
 from llama_index import Document, ServiceContext, SummaryIndex
 from llama_index.bridge.pydantic import BaseModel, Field
 from llama_index.ingestion import run_transformations
-from llama_index.llms.openai import OpenAI
 from llama_index.postprocessor.node import KeywordNodePostprocessor
 from llama_index.prompts.base import BasePromptTemplate, PromptTemplate
 from llama_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
@@ -28,12 +27,6 @@ Given the context information and not prior knowledge.
 generate only questions based on the below query.
 {query_str}
 """
-
-
-def _get_default_service_context() -> ServiceContext:
-    """Get default service context."""
-    llm = OpenAI(temperature=0, model="gpt-3.5-turbo")
-    return ServiceContext.from_defaults(llm=llm, chunk_size_limit=3000)
 
 
 @deprecated(
@@ -133,7 +126,9 @@ class DatasetGenerator(PromptMixin):
     ) -> None:
         """Init params."""
         if service_context is None:
-            service_context = _get_default_service_context()
+            service_context = service_context or ServiceContext.from_defaults(
+                chunk_size_limit=3000
+            )
         self.service_context = service_context
         self.text_question_template = text_question_template or PromptTemplate(
             DEFAULT_QUESTION_GENERATION_PROMPT
@@ -166,7 +161,9 @@ class DatasetGenerator(PromptMixin):
     ) -> DatasetGenerator:
         """Generate dataset from documents."""
         if service_context is None:
-            service_context = _get_default_service_context()
+            service_context = service_context or ServiceContext.from_defaults(
+                chunk_size_limit=3000
+            )
 
         nodes = run_transformations(
             documents, service_context.transformations, show_progress=show_progress

--- a/llama_index/llama_dataset/generator.py
+++ b/llama_index/llama_dataset/generator.py
@@ -13,7 +13,6 @@ from llama_index.llama_dataset import (
     LabelledRagDataExample,
     LabelledRagDataset,
 )
-from llama_index.llms.openai import OpenAI
 from llama_index.postprocessor.node import KeywordNodePostprocessor
 from llama_index.prompts.base import BasePromptTemplate, PromptTemplate
 from llama_index.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
@@ -30,12 +29,6 @@ Given the context information and not prior knowledge.
 generate only questions based on the below query.
 {query_str}
 """
-
-
-def _get_default_service_context() -> ServiceContext:
-    """Get default service context."""
-    llm = OpenAI(temperature=0, model="gpt-3.5-turbo")
-    return ServiceContext.from_defaults(llm=llm, chunk_size_limit=3000)
 
 
 class RagDatasetGenerator(PromptMixin):
@@ -67,7 +60,9 @@ class RagDatasetGenerator(PromptMixin):
     ) -> None:
         """Init params."""
         if service_context is None:
-            service_context = _get_default_service_context()
+            service_context = service_context or ServiceContext.from_defaults(
+                chunk_size_limit=3000
+            )
         self.service_context = service_context
         self.text_question_template = text_question_template or PromptTemplate(
             DEFAULT_QUESTION_GENERATION_PROMPT
@@ -100,7 +95,9 @@ class RagDatasetGenerator(PromptMixin):
     ) -> RagDatasetGenerator:
         """Generate dataset from documents."""
         if service_context is None:
-            service_context = _get_default_service_context()
+            service_context = service_context or ServiceContext.from_defaults(
+                chunk_size_limit=3000
+            )
 
         nodes = run_transformations(
             documents, service_context.transformations, show_progress=show_progress


### PR DESCRIPTION
Summary of Change:
This PR addresses a critical bug in version 0.9.1.post1 related to the default service context initialization in llama_index. The update ensures that when a service context is not specified, it correctly defaults to the global context using ServiceContext.from_defaults(), replacing the previous erroneous call to _get_default_service_context().

Context and Motivation:
The fix was motivated by the inconsistency and unexpected behavior encountered in the application due to the incorrect initialization of the default service context. This change ensures adherence to the intended default settings, enhancing the reliability of the service context management.

Dependencies:
No additional dependencies are introduced with this change.

Fixes  #9774 


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
- [x] I have tested locally

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
