### PR TITLE
add missing azure openai model context sizes

### DIFF
--- a/llama_index/llms/openai_utils.py
+++ b/llama_index/llms/openai_utils.py
@@ -50,6 +50,11 @@ GPT4_MODELS: Dict[str, int] = {
 AZURE_TURBO_MODELS: Dict[str, int] = {
     "gpt-35-turbo-16k": 16384,
     "gpt-35-turbo": 4096,
+    # 1106 model (JSON mode)
+    "gpt-35-turbo-1106": 16384,
+    # 0613 models (function calling):
+    "gpt-35-turbo-0613": 4096,
+    "gpt-35-turbo-16k-0613": 16384,
 }
 
 TURBO_MODELS: Dict[str, int] = {


### PR DESCRIPTION
# Description

The latest Azure Openai models needed to be included in the context size lists. This results in incorrect context size calculation.

Check this list: https://github.com/run-llama/llama_index/blob/db22c244bcea6c2f368909b04e33f3e4c96b1489/llama_index/llms/openai_utils.py#L50

Fixes https://github.com/run-llama/llama_index/issues/9781

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods
