### PR TITLE
Changed .complete() to .predict() function in generate_qa_embedding_pairs api

### DIFF
--- a/llama_index/finetuning/embeddings/common.py
+++ b/llama_index/finetuning/embeddings/common.py
@@ -84,7 +84,7 @@ def generate_qa_embedding_pairs(
         query = qa_generate_prompt_tmpl.format(
             context_str=text, num_questions_per_chunk=num_questions_per_chunk
         )
-        response = llm.complete(query)
+        response = llm.predict(query)
 
         result = str(response).strip().split("\n")
         questions = [


### PR DESCRIPTION
Summary of Change:

This PR addresses a bug in version 0.9.1.post1 related to the .complete() function call in generate_qa_embedding_pairs. The update ensures that regardless of LLM wrapper the generate_qa_embedding_pairs doesn't raise any error.

Context and Motivation:
The fix was motivated by the inconsistency and unexpected behavior encountered in the application when using LLMPredictor or LangChainInterface classes. This change ensures adherence to the intended behaviour of the LLM which also holds for the OpenAI and other LLM's as .predict() function is used globally.

Dependencies:
No additional dependencies are introduced with this change.

Fixes #9784 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
