### PR TITLE
bugfix: `_verify_source_safety` should detect calls to private functions with AST, not regexes

### DIFF
--- a/llama_index/exec_utils.py
+++ b/llama_index/exec_utils.py
@@ -95,18 +95,18 @@ class DunderVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.has_access_to_private_entity = False
 
-    def visit_Name(self, node):
+    def visit_Name(self, node) -> None:
         if node.id.startswith("_"):
             self.has_access_to_private_entity = True
         self.generic_visit(node)
 
-    def visit_Attribute(self, node):
+    def visit_Attribute(self, node) -> None:
         if node.attr.startswith("_"):
             self.has_access_to_private_entity = True
         self.generic_visit(node)
 
 
-def _contains_protected_access(code):
+def _contains_protected_access(code) -> bool:
     tree = ast.parse(code)
     dunder_visitor = DunderVisitor()
     dunder_visitor.visit(tree)

--- a/llama_index/exec_utils.py
+++ b/llama_index/exec_utils.py
@@ -95,18 +95,18 @@ class DunderVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.has_access_to_private_entity = False
 
-    def visit_Name(self, node) -> None:
+    def visit_Name(self, node: ast.Name) -> None:
         if node.id.startswith("_"):
             self.has_access_to_private_entity = True
         self.generic_visit(node)
 
-    def visit_Attribute(self, node) -> None:
+    def visit_Attribute(self, node: ast.Attribute) -> None:
         if node.attr.startswith("_"):
             self.has_access_to_private_entity = True
         self.generic_visit(node)
 
 
-def _contains_protected_access(code) -> bool:
+def _contains_protected_access(code: str) -> bool:
     tree = ast.parse(code)
     dunder_visitor = DunderVisitor()
     dunder_visitor.visit(tree)

--- a/tests/test_exec_utils.py
+++ b/tests/test_exec_utils.py
@@ -1,9 +1,17 @@
-from llama_index.exec_utils import _contains_dunder_calls
+from llama_index.exec_utils import _contains_protected_access
 
 
-def test_contains_dunder_calls():
-    assert not _contains_dunder_calls(
+def test_contains_protected_access():
+    assert not _contains_protected_access(
         "def _a(b): pass"
     ), "definition of dunder function"
-    assert _contains_dunder_calls("a = _b(c)"), "call to dunder function"
-    assert not _contains_dunder_calls("a = b(c)"), "call to non-dunder function"
+    assert _contains_protected_access("a = _b(c)"), "call to protected function"
+    assert not _contains_protected_access("a = b(c)"), "call to public function"
+    assert _contains_protected_access("_b"), "access to protected name"
+    assert not _contains_protected_access("b"), "access to public name"
+    assert _contains_protected_access("_b[0]"), "subscript access to protected name"
+    assert not _contains_protected_access("b[0]"), "subscript access to public name"
+    assert _contains_protected_access("_a.b"), "access to attribute of a protected name"
+    assert not _contains_protected_access("a.b"), "access to attribute of a public name"
+    assert _contains_protected_access("a._b"), "access to protected attribute of a name"
+    assert not _contains_protected_access("a.b"), "access to public attribute of a name"

--- a/tests/test_exec_utils.py
+++ b/tests/test_exec_utils.py
@@ -1,7 +1,7 @@
 from llama_index.exec_utils import _contains_protected_access
 
 
-def test_contains_protected_access():
+def test_contains_protected_access() -> None:
     assert not _contains_protected_access(
         "def _a(b): pass"
     ), "definition of dunder function"

--- a/tests/test_exec_utils.py
+++ b/tests/test_exec_utils.py
@@ -1,0 +1,9 @@
+from llama_index.exec_utils import _contains_dunder_calls
+
+
+def test_contains_dunder_calls():
+    assert not _contains_dunder_calls(
+        "def _a(b): pass"
+    ), "definition of dunder function"
+    assert _contains_dunder_calls("a = _b(c)"), "call to dunder function"
+    assert not _contains_dunder_calls("a = b(c)"), "call to non-dunder function"


### PR DESCRIPTION
# Description

Matching a regex in a code snippet isn't ideal anyway. If the code snippet contains comments / strings that happen to contain a method name that starts with an underscore (or two, for that matter), `_verify_source_safety` will also raise a false positive.

IMO the only safe way to test whether the code contains a call to a dunder function is by parsing the code from text into an abstract syntax tree (AST).

Fixes #9696

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
