### PR TITLE
Update default embedding batch size for OpenAI embeddings

### DIFF
--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -8,7 +8,7 @@ from openai import AsyncOpenAI, OpenAI
 
 from llama_index.bridge.pydantic import Field, PrivateAttr
 from llama_index.callbacks.base import CallbackManager
-from llama_index.embeddings.base import DEFAULT_EMBED_BATCH_SIZE, BaseEmbedding
+from llama_index.embeddings.base import BaseEmbedding
 from llama_index.llms.openai_utils import (
     create_retry_decorator,
     resolve_openai_credentials,
@@ -256,7 +256,7 @@ class OpenAIEmbedding(BaseEmbedding):
         self,
         mode: str = OpenAIEmbeddingMode.TEXT_SEARCH_MODE,
         model: str = OpenAIEmbeddingModelType.TEXT_EMBED_ADA_002,
-        embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
+        embed_batch_size: int = 100,
         additional_kwargs: Optional[Dict[str, Any]] = None,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,


### PR DESCRIPTION
# Description

based on some benchmarking by @logan-markewich , it seems like 100 is a more suitable default batch size for OpenAI embedding calls.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
