### PR TITLE
Feat/update guidance lib

### DIFF
--- a/llama_index/program/guidance_program.py
+++ b/llama_index/program/guidance_program.py
@@ -1,5 +1,5 @@
-from typing import TYPE_CHECKING, Any, Optional, Type, cast
 from functools import partial
+from typing import TYPE_CHECKING, Any, Optional, Type, cast
 
 from llama_index.bridge.pydantic import BaseModel
 from llama_index.program.llm_prompt_program import BaseLLMFunctionProgram
@@ -10,6 +10,7 @@ from llama_index.prompts.guidance_utils import (
 
 if TYPE_CHECKING:
     from guidance.models import Model as GuidanceLLM
+
 
 class GuidancePydanticProgram(BaseLLMFunctionProgram["GuidanceLLM"]):
     """
@@ -36,20 +37,29 @@ class GuidancePydanticProgram(BaseLLMFunctionProgram["GuidanceLLM"]):
             llm = guidance_llm
         else:
             llm = OpenAI("text-davinci-003")
-        
+
         full_str = prompt_template_str + "\n"
         self._full_str = full_str
         self._guidance_program = partial(self.program, llm=llm, silent=not verbose)
         self._output_cls = output_cls
         self._verbose = verbose
 
-    def program(self, llm: "GuidanceLLM", silent: bool, tools_str: str, query_str: str, **kwargs) -> "GuidanceLLM":
-        """a wrapper to execute the program with new guidance version"""
+    def program(
+        self,
+        llm: "GuidanceLLM",
+        silent: bool,
+        tools_str: str,
+        query_str: str,
+        **kwargs: dict,
+    ) -> "GuidanceLLM":
+        """A wrapper to execute the program with new guidance version."""
         from guidance import gen
 
-        given_query = self._full_str.replace("{{tools_str}}", tools_str).replace("{{query_str}}", query_str) 
+        given_query = self._full_str.replace("{{tools_str}}", tools_str).replace(
+            "{{query_str}}", query_str
+        )
 
-        return llm + given_query + gen(stop='.')
+        return llm + given_query + gen(stop=".")
 
     @classmethod
     def from_defaults(

--- a/llama_index/prompts/guidance_utils.py
+++ b/llama_index/prompts/guidance_utils.py
@@ -148,5 +148,6 @@ def parse_pydantic_from_guidance_program(
     except Exception as e:
         raise OutputParserException(
             "Failed to parse pydantic object from guidance program"
+            ". Probabily the LLM failed to produce data with right json schema"
         ) from e
     return sub_questions

--- a/llama_index/prompts/guidance_utils.py
+++ b/llama_index/prompts/guidance_utils.py
@@ -1,9 +1,8 @@
-from typing import TYPE_CHECKING, Optional, Type, TypeVar
-
-from llama_index.output_parsers.base import OutputParserException
-from llama_index.output_parsers.utils import parse_json_markdown
+from typing import Optional, Type, TypeVar
 
 from llama_index.bridge.pydantic import BaseModel
+from llama_index.output_parsers.base import OutputParserException
+from llama_index.output_parsers.utils import parse_json_markdown
 
 
 def convert_to_handlebars(text: str) -> str:
@@ -148,6 +147,6 @@ def parse_pydantic_from_guidance_program(
     except Exception as e:
         raise OutputParserException(
             "Failed to parse pydantic object from guidance program"
-            ". Probabily the LLM failed to produce data with right json schema"
+            ". Probably the LLM failed to produce data with right json schema"
         ) from e
     return sub_questions

--- a/llama_index/prompts/guidance_utils.py
+++ b/llama_index/prompts/guidance_utils.py
@@ -3,9 +3,6 @@ from typing import TYPE_CHECKING, Optional, Type, TypeVar
 from llama_index.output_parsers.base import OutputParserException
 from llama_index.output_parsers.utils import parse_json_markdown
 
-if TYPE_CHECKING:
-    from guidance import Program
-
 from llama_index.bridge.pydantic import BaseModel
 
 
@@ -127,7 +124,7 @@ Model = TypeVar("Model", bound=BaseModel)
 
 
 def parse_pydantic_from_guidance_program(
-    program: "Program", cls: Type[Model], verbose: bool = False
+    response: str, cls: Type[Model], verbose: bool = False
 ) -> Model:
     """Parse output from guidance program.
 
@@ -141,7 +138,7 @@ def parse_pydantic_from_guidance_program(
           So we call back to manually parsing the final text after program execution
     """
     try:
-        output = program.text.split("```json")[-1]
+        output = response.split("```json")[-1]
         output = "```json" + output
         if verbose:
             print("Raw output:")

--- a/llama_index/question_gen/guidance_generator.py
+++ b/llama_index/question_gen/guidance_generator.py
@@ -16,7 +16,7 @@ from llama_index.schema import QueryBundle
 from llama_index.tools.types import ToolMetadata
 
 if TYPE_CHECKING:
-    from guidance.llms import LLM as GuidanceLLM
+    from guidance.models import Model as GuidanceLLM
 
 DEFAULT_GUIDANCE_SUB_QUESTION_PROMPT_TMPL = convert_to_handlebars(
     DEFAULT_SUB_QUESTION_PROMPT_TMPL

--- a/llama_index/question_gen/prompts.py
+++ b/llama_index/question_gen/prompts.py
@@ -47,7 +47,7 @@ example_output = [
     ),
     SubQuestion(sub_question="What is the EBITDA of Lyft", tool_name="lyft_10k"),
 ]
-example_output_str = json.dumps([x.dict() for x in example_output], indent=4)
+example_output_str = json.dumps({"items": [x.dict() for x in example_output]}, indent=4)
 
 EXAMPLES = f"""\
 # Example 1

--- a/tests/program/test_guidance.py
+++ b/tests/program/test_guidance.py
@@ -1,8 +1,9 @@
 import pytest
 from llama_index.bridge.pydantic import BaseModel
+from llama_index.output_parsers.base import OutputParserException
 
 try:
-    from guidance.llms import Mock as MockLLM
+    from guidance.models import Mock as MockLLM
 except ImportError:
     MockLLM = None  # type: ignore
 from llama_index.program.guidance_program import GuidancePydanticProgram
@@ -21,5 +22,5 @@ def test_guidance_pydantic_program() -> None:
 
     assert program.output_cls == TestModel
 
-    output = program(test_input="test_arg")
-    assert isinstance(output, TestModel)
+    with pytest.raises(OutputParserException):
+        _ = program(tools_str="test_tools", query_str="test_query")

--- a/tests/question_gen/test_guidance_generator.py
+++ b/tests/question_gen/test_guidance_generator.py
@@ -3,10 +3,10 @@ try:
 except ImportError:
     MockLLM = None  # type: ignore
 import pytest
+from llama_index.output_parsers.base import OutputParserException
 from llama_index.question_gen.guidance_generator import GuidanceQuestionGenerator
 from llama_index.schema import QueryBundle
 from llama_index.tools.types import ToolMetadata
-from llama_index.output_parsers.base import OutputParserException
 
 
 @pytest.mark.skipif(MockLLM is None, reason="guidance not installed")

--- a/tests/question_gen/test_guidance_generator.py
+++ b/tests/question_gen/test_guidance_generator.py
@@ -1,12 +1,12 @@
 try:
-    from guidance.llms import Mock as MockLLM
+    from guidance.models import Mock as MockLLM
 except ImportError:
     MockLLM = None  # type: ignore
 import pytest
 from llama_index.question_gen.guidance_generator import GuidanceQuestionGenerator
-from llama_index.question_gen.types import SubQuestion
 from llama_index.schema import QueryBundle
 from llama_index.tools.types import ToolMetadata
+from llama_index.output_parsers.base import OutputParserException
 
 
 @pytest.mark.skipif(MockLLM is None, reason="guidance not installed")
@@ -17,5 +17,5 @@ def test_guidance_question_generator() -> None:
         ToolMetadata(name="test_tool_1", description="test_description_1"),
         ToolMetadata(name="test_tool_2", description="test_description_2"),
     ]
-    output = question_gen.generate(tools=tools, query=QueryBundle("test query"))
-    assert isinstance(output[0], SubQuestion)
+    with pytest.raises(OutputParserException):
+        _ = question_gen.generate(tools=tools, query=QueryBundle("test query"))


### PR DESCRIPTION
# Description
llama-index library wasn't updated with the newer version of guidance lib. We updated the codes and now it can run with `guidance==0.1.10`.

Fixes # (issue)
https://github.com/run-llama/llama_index/issues/9797

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
