### PR TITLE
Adds the column name to the text if using the database reader

### DIFF
--- a/llama_index/readers/database.py
+++ b/llama_index/readers/database.py
@@ -92,6 +92,8 @@ class DatabaseReader(BaseReader):
 
             for item in result.fetchall():
                 # fetch each item
-                doc_str = ", ".join([str(entry) for entry in item])
+                doc_str = ", ".join(
+                    [f"{col}: {entry}" for col, entry in zip(result.keys(), item)]
+                )
                 documents.append(Document(text=doc_str))
         return documents


### PR DESCRIPTION
# Description

Currently if using the DatabaseReader `from llama_index.readers.database import DatabaseReader` the column names will get removed in the created text, which will later get embedded. However, this behaviour removes relevant contextual information. 

Fixes: No Issue exists for this

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


The following code creates a sqlite db and adds an entry and then uses DatabaseReader to retrieve the data. Before the change it should be `assert documents[0].text == 'llama'` after the change it should be `assert documents[0].text == 'name: llama'`
```
from llama_index.readers.database import DatabaseReader
from sqlalchemy import create_engine, Column, String
from sqlalchemy.ext.declarative import declarative_base
from sqlalchemy.orm import sessionmaker

# Create an engine that stores data in the local directory's llama_db.sqlite file.
engine = create_engine('sqlite:///llama_db.sqlite')
Base = declarative_base()
class LlamaIndex(Base):
    __tablename__ = 'llama_index'
    name = Column(String, primary_key=True)

Base.metadata.create_all(engine)
Session = sessionmaker(bind=engine)
session = Session()
new_llama = LlamaIndex(name='llama')
session.add(new_llama)
session.commit()
session.close()

# retrieve data and check how it looks like
db = DatabaseReader(
    engine=engine,  # Database Scheme
)
documents = db.load_data("SELECT * FROM llama_index")
assert documents[0].text == 'name: llama'
```

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
