### PR TITLE
Enable passing `tree_sitter` parser instance to `CodeSplitter`

### DIFF
--- a/tests/text_splitter/test_code_splitter.py
+++ b/tests/text_splitter/test_code_splitter.py
@@ -162,3 +162,32 @@ int main() {
     assert chunks[0].startswith("#include <iostream>")
     assert chunks[1].startswith("int main()")
     assert chunks[2].startswith("{\n    std::cout")
+
+
+def test__py_custom_parser_code_splitter() -> None:
+    """Test case for code splitting using custom parser generated from tree_sitter_languages."""
+    if "CI" in os.environ:
+        return
+
+    from tree_sitter_languages import get_parser
+
+    parser = get_parser("python")
+
+    code_splitter = CodeSplitter(
+        language="custom",
+        chunk_lines=4,
+        chunk_lines_overlap=1,
+        max_chars=30,
+        parser=parser,
+    )
+
+    text = """\
+def foo():
+    print("bar")
+
+def baz():
+    print("bbq")"""
+
+    chunks = code_splitter.split_text(text)
+    assert chunks[0].startswith("def foo():")
+    assert chunks[1].startswith("def baz():")


### PR DESCRIPTION
# Description

This adds ability to pass instances from of `tree_sitter` parser to `CodeSplitter`. The default `tree_sitter_languages` has limited number of supported languages, mostly due to licensing restrictions.

We can use any custom tree-sitter instances.

```shell
git clone <tree-sitter-my-language-url> tree-sitter-mylanguage
```

```python
from llama_index.text_splitter import CodeSplitter
from tree_sitter import Language, Parser

Language.build_library(
    # Store the library in the `build` directory
    "build/my-languages.so",
    # Include one or more languages
    ["vendor/tree-sitter-my-language"],
)

MY_LANGUAGE = Language("build/my-languages.so", "mylanguage")

parser = Parser()
parser.set_language(MY_LANGUAGE )

code_splitter = CodeSplitter(
        language="mylanguage", parser=parser )

```


## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
