### PR TITLE
make text storage optional on docstore

### DIFF
--- a/llama_index/storage/docstore/keyval_docstore.py
+++ b/llama_index/storage/docstore/keyval_docstore.py
@@ -62,7 +62,10 @@ class KVDocumentStore(BaseDocumentStore):
         return {key: json_to_doc(json) for key, json in json_dict.items()}
 
     def add_documents(
-        self, nodes: Sequence[BaseNode], allow_update: bool = True
+        self,
+        nodes: Sequence[BaseNode],
+        allow_update: bool = True,
+        store_text: bool = True,
     ) -> None:
         """Add a document to the store.
 
@@ -79,8 +82,10 @@ class KVDocumentStore(BaseDocumentStore):
                     "Set allow_update to True to overwrite."
                 )
             node_key = node.node_id
-            data = doc_to_json(node)
-            self._kvstore.put(node_key, data, collection=self._node_collection)
+
+            if store_text:
+                data = doc_to_json(node)
+                self._kvstore.put(node_key, data, collection=self._node_collection)
 
             # update doc_collection if needed
             metadata = {"doc_hash": node.hash}

--- a/llama_index/storage/docstore/types.py
+++ b/llama_index/storage/docstore/types.py
@@ -38,7 +38,10 @@ class BaseDocumentStore(ABC):
 
     @abstractmethod
     def add_documents(
-        self, docs: Sequence[BaseNode], allow_update: bool = True
+        self,
+        docs: Sequence[BaseNode],
+        allow_update: bool = True,
+        store_text: bool = True,
     ) -> None:
         ...
 


### PR DESCRIPTION
# Description

There are cases (like maybe the ingestion pipeline) where you might not want to store documents, since the vector db is already storing the text.

Also, added missing features to the async run endpoint (in preparation for having async docstores)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
