### PR TITLE
return actual node ids in weaviate

### DIFF
--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -336,17 +336,17 @@ class WeaviateVectorStore(BasePydanticVectorStore):
         entries = parsed_result[self.index_name]
 
         similarities = []
-        nodes = []
-        node_idxs = []
+        nodes: List[BaseNode] = []
+        node_ids = []
 
         for i, entry in enumerate(entries):
             if i < query.similarity_top_k:
                 similarities.append(get_node_similarity(entry, similarity_key))
                 nodes.append(to_node(entry, text_key=self.text_key))
-                node_idxs.append(str(i))
+                node_ids.append(nodes[-1].node_id)
             else:
                 break
 
         return VectorStoreQueryResult(
-            nodes=nodes, ids=node_idxs, similarities=similarities
+            nodes=nodes, ids=node_ids, similarities=similarities
         )


### PR DESCRIPTION
# Description

Weaviate, for some reason, was not using the actual node ids in the `VectorStoreQueryResult` object, causing issues in downstream tools like the `DocumentSummaryIndex`

Fixes https://github.com/run-llama/llama_index/issues/9850

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

