### PR TITLE
Add `BaseChatStore` and `SimpleChatStore` for storing conversation history

### DIFF
--- a/docs/examples/query_engine/sec_tables/tesla_10q_table.ipynb
+++ b/docs/examples/query_engine/sec_tables/tesla_10q_table.ipynb
@@ -314,7 +314,7 @@
     "from llama_index.retrievers import RecursiveRetriever\n",
     "\n",
     "recursive_retriever = RecursiveRetriever(\n",
-    "    \"vector\",SentenceSplitter\n",
+    "    \"vector\",\n",
     "    retriever_dict={\"vector\": vector_retriever},\n",
     "    node_dict=node_mappings_2021,\n",
     "    verbose=True,\n",

--- a/docs/module_guides/storing/chat_stores.md
+++ b/docs/module_guides/storing/chat_stores.md
@@ -1,0 +1,48 @@
+# Chat Stores
+
+A chat store serves as a centralized interface to store your chat history. Chat history is unique to other storage formats, since the order of messages is important to maintining an overall conversation.
+
+Chat stores can be organize sequences of chat messages by keys (like `user_ids` or other unique identifiable strings), and handle `delete`, `insert`, and `get` operations.
+
+## SimpleChatStore
+
+The most basic chat store is `SimpleChatStore`, which stores messages in memory and saves to/from disk, or can be serlized and stored somewhere else.
+
+Typically, you will insansiate a chat store and give it to a memory module. Memory modules that use chat stores will default to using `SimpleChatStore` if not provided.
+
+```python
+from llama_index.storage.chat_stores import SimpleChatStore
+from llama_index.memory import ChatMemoryBuffer
+
+chat_store = SimpleChatStore(chat_store_)
+
+chat_memory = ChatMemoryBuffer.from_defaults(
+    token_limit=3000,
+    chat_store=chat_store,
+    chat_store_key="user1",
+)
+```
+
+Once you have the memory created, you might include it in an agent or chat engine:
+
+```python
+agent = OpenAIAgent.from_tools(tools, memory=memory)
+# OR
+chat_engine = index.as_chat_engine(memory=memory)
+```
+
+To save the chat store for later, you can either save/load from disk
+
+```python
+chat_store.persist(persist_path="chat_store.json")
+loaded_chat_store = SimpleChatStore.from_persist_path(
+    persist_path="chat_store.json"
+)
+```
+
+Or you can convert to/from a string, saving the string somewhere else along the way
+
+```python
+chat_store_string = chat_store.json()
+loaded_chat_store = SimpleChatStore.parse_raw(chat_store_string)
+```

--- a/docs/module_guides/storing/storing.md
+++ b/docs/module_guides/storing/storing.md
@@ -10,6 +10,7 @@ Under the hood, LlamaIndex also supports swappable **storage components** that a
 - **Index stores**: where index metadata are stored,
 - **Vector stores**: where embedding vectors are stored.
 - **Graph stores**: where knowledge graphs are stored (i.e. for `KnowledgeGraphIndex`).
+- **Chat Stores**: where chat messages are stored and organized.
 
 The Document/Index stores rely on a common Key-Value store abstraction, which is also detailed below.
 
@@ -85,4 +86,5 @@ docstores.md
 index_stores.md
 kv_stores.md
 /community/integrations/graph_stores.md
+chat_stores.md
 ```

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -1,9 +1,11 @@
+import json
 from typing import Any, Callable, Dict, List, Optional
 
 from llama_index.bridge.pydantic import Field, root_validator
 from llama_index.llms.llm import LLM
 from llama_index.llms.types import ChatMessage, MessageRole
-from llama_index.memory.types import BaseMemory
+from llama_index.memory.types import DEFAULT_CHAT_STORE_KEY, BaseMemory
+from llama_index.storage.chat_store import BaseChatStore, SimpleChatStore
 from llama_index.utils import get_tokenizer
 
 DEFUALT_TOKEN_LIMIT_RATIO = 0.75
@@ -19,7 +21,8 @@ class ChatMemoryBuffer(BaseMemory):
         default_factory=get_tokenizer,
         exclude=True,
     )
-    chat_history: List[ChatMessage] = Field(default_factory=list)
+    chat_store: BaseChatStore = Field(default_factory=SimpleChatStore)
+    chat_store_key: str = Field(default=DEFAULT_CHAT_STORE_KEY)
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.dict()
@@ -29,7 +32,7 @@ class ChatMemoryBuffer(BaseMemory):
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
         super().__init__(
-            token_limit=state["token_limit"], chat_history=state["chat_history"]
+            token_limit=state["token_limit"], chat_store=state["chat_store"]
         )
 
     @root_validator(pre=True)
@@ -51,6 +54,8 @@ class ChatMemoryBuffer(BaseMemory):
         cls,
         chat_history: Optional[List[ChatMessage]] = None,
         llm: Optional[LLM] = None,
+        chat_store: Optional[BaseChatStore] = None,
+        chat_store_key: str = DEFAULT_CHAT_STORE_KEY,
         token_limit: Optional[int] = None,
         tokenizer_fn: Optional[Callable[[str], List]] = None,
     ) -> "ChatMemoryBuffer":
@@ -61,10 +66,14 @@ class ChatMemoryBuffer(BaseMemory):
         elif token_limit is None:
             token_limit = DEFAULT_TOKEN_LIMIT
 
+        if chat_history is not None:
+            chat_store = chat_store or SimpleChatStore()
+            chat_store.set_messages(chat_store_key, chat_history)
+
         return cls(
             token_limit=token_limit,
             tokenizer_fn=tokenizer_fn or get_tokenizer(),
-            chat_history=chat_history or [],
+            chat_store=chat_store or SimpleChatStore(),
         )
 
     def to_string(self) -> str:
@@ -73,7 +82,9 @@ class ChatMemoryBuffer(BaseMemory):
 
     @classmethod
     def from_string(cls, json_str: str) -> "ChatMemoryBuffer":
-        return cls.parse_raw(json_str)
+        """Create a chat memory buffer from a string."""
+        dict_obj = json.loads(json_str)
+        return cls.from_dict(dict_obj)
 
     def to_dict(self) -> dict:
         """Convert memory to dict."""
@@ -81,21 +92,35 @@ class ChatMemoryBuffer(BaseMemory):
 
     @classmethod
     def from_dict(cls, json_dict: dict) -> "ChatMemoryBuffer":
-        return cls.parse_obj(json_dict)
+        from llama_index.storage.chat_store.loading import load_chat_store
+
+        # NOTE: this handles backwards compatibility with the old chat history
+        if "chat_history" in json_dict:
+            chat_history = json_dict.pop("chat_history")
+            chat_store = SimpleChatStore(store={DEFAULT_CHAT_STORE_KEY: chat_history})
+            json_dict["chat_store"] = chat_store
+        elif "chat_store" in json_dict:
+            chat_store = json_dict.pop("chat_store")
+            chat_store = load_chat_store(chat_store)
+            json_dict["chat_store"] = chat_store
+
+        return cls(**json_dict)
 
     def get(self, initial_token_count: int = 0, **kwargs: Any) -> List[ChatMessage]:
         """Get chat history."""
+        chat_history = self.get_all()
+
         if initial_token_count > self.token_limit:
             raise ValueError("Initial token count exceeds token limit")
 
-        message_count = len(self.chat_history)
+        message_count = len(chat_history)
         token_count = (
             self._token_count_for_message_count(message_count) + initial_token_count
         )
 
         while token_count > self.token_limit and message_count > 1:
             message_count -= 1
-            if self.chat_history[-message_count].role == MessageRole.ASSISTANT:
+            if chat_history[-message_count].role == MessageRole.ASSISTANT:
                 # we cannot have an assistant message at the start of the chat history
                 # if after removal of the first, we have an assistant message,
                 # we need to remove the assistant message too
@@ -109,26 +134,28 @@ class ChatMemoryBuffer(BaseMemory):
         if token_count > self.token_limit or message_count <= 0:
             return []
 
-        return self.chat_history[-message_count:]
+        return chat_history[-message_count:]
 
     def get_all(self) -> List[ChatMessage]:
         """Get all chat history."""
-        return self.chat_history
+        return self.chat_store.get_messages(self.chat_store_key)
 
     def put(self, message: ChatMessage) -> None:
         """Put chat history."""
-        self.chat_history.append(message)
+        self.chat_store.add_message(self.chat_store_key, message)
 
     def set(self, messages: List[ChatMessage]) -> None:
         """Set chat history."""
-        self.chat_history = messages
+        self.chat_store.set_messages(self.chat_store_key, messages)
 
     def reset(self) -> None:
         """Reset chat history."""
-        return self.chat_history.clear()
+        return self.chat_store.delete_messages(self.chat_store_key)
 
     def _token_count_for_message_count(self, message_count: int) -> int:
         if message_count <= 0:
             return 0
-        msg_str = " ".join(str(m.content) for m in self.chat_history[-message_count:])
+
+        chat_history = self.get_all()
+        msg_str = " ".join(str(m.content) for m in chat_history[-message_count:])
         return len(self.tokenizer_fn(msg_str))

--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -144,7 +144,7 @@ class ChatMemoryBuffer(BaseMemory):
 
     def reset(self) -> None:
         """Reset chat history."""
-        return self.chat_store.delete_messages(self.chat_store_key)
+        self.chat_store.delete_messages(self.chat_store_key)
 
     def _token_count_for_message_count(self, message_count: int) -> int:
         if message_count <= 0:

--- a/llama_index/memory/types.py
+++ b/llama_index/memory/types.py
@@ -1,18 +1,23 @@
 from abc import abstractmethod
 from typing import Any, List, Optional
 
-from llama_index.bridge.pydantic import BaseModel
 from llama_index.llms.llm import LLM
 from llama_index.llms.types import ChatMessage
+from llama_index.schema import BaseComponent
 
 DEFAULT_CHAT_STORE_KEY = "chat_history"
 
 
-class BaseMemory(BaseModel):
+class BaseMemory(BaseComponent):
     """Base class for all memory types.
 
     NOTE: The interface for memory is not yet finalized and is subject to change.
     """
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Get class name."""
+        return "BaseMemory"
 
     @classmethod
     @abstractmethod

--- a/llama_index/memory/types.py
+++ b/llama_index/memory/types.py
@@ -5,6 +5,8 @@ from llama_index.bridge.pydantic import BaseModel
 from llama_index.llms.llm import LLM
 from llama_index.llms.types import ChatMessage
 
+DEFAULT_CHAT_STORE_KEY = "chat_history"
+
 
 class BaseMemory(BaseModel):
     """Base class for all memory types.

--- a/llama_index/storage/chat_store/__init__.py
+++ b/llama_index/storage/chat_store/__init__.py
@@ -1,0 +1,4 @@
+from llama_index.storage.chat_store.base import BaseChatStore
+from llama_index.storage.chat_store.simple_chat_store import SimpleChatStore
+
+__all__ = ["BaseChatStore", "SimpleChatStore"]

--- a/llama_index/storage/chat_store/base.py
+++ b/llama_index/storage/chat_store/base.py
@@ -1,0 +1,43 @@
+"""Base interface class for storing chat history per user."""
+from abc import abstractmethod
+from typing import List, Optional
+
+from llama_index.llms import ChatMessage
+from llama_index.schema import BaseComponent
+
+
+class BaseChatStore(BaseComponent):
+    @classmethod
+    def class_name(cls) -> str:
+        """Get class name."""
+        return "BaseChatStore"
+
+    @abstractmethod
+    def set_messages(self, key: str, messages: List[ChatMessage]) -> None:
+        """Set messages for a key."""
+        ...
+
+    @abstractmethod
+    def get_messages(self, key: str) -> List[ChatMessage]:
+        """Get messages for a key."""
+        ...
+
+    @abstractmethod
+    def add_message(self, key: str, message: ChatMessage) -> None:
+        """Add a message for a key."""
+        ...
+
+    @abstractmethod
+    def delete_messages(self, key: str) -> None:
+        """Delete messages for a key."""
+        ...
+
+    @abstractmethod
+    def undo_last_message(self, key: str) -> Optional[ChatMessage]:
+        """Undo last message for a key."""
+        ...
+
+    @abstractmethod
+    def get_keys(self) -> List[str]:
+        """Get all keys."""
+        ...

--- a/llama_index/storage/chat_store/base.py
+++ b/llama_index/storage/chat_store/base.py
@@ -28,13 +28,18 @@ class BaseChatStore(BaseComponent):
         ...
 
     @abstractmethod
-    def delete_messages(self, key: str) -> None:
+    def delete_messages(self, key: str) -> Optional[List[ChatMessage]]:
         """Delete messages for a key."""
         ...
 
     @abstractmethod
-    def undo_last_message(self, key: str) -> Optional[ChatMessage]:
-        """Undo last message for a key."""
+    def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
+        """Delete specific message for a key."""
+        ...
+
+    @abstractmethod
+    def delete_last_message(self, key: str) -> Optional[ChatMessage]:
+        """Delete last message for a key."""
         ...
 
     @abstractmethod

--- a/llama_index/storage/chat_store/loading.py
+++ b/llama_index/storage/chat_store/loading.py
@@ -1,0 +1,18 @@
+from llama_index.storage.chat_store.base import BaseChatStore
+from llama_index.storage.chat_store.simple_chat_store import SimpleChatStore
+
+RECOGNIZED_CHAT_STORES = {
+    SimpleChatStore.class_name(): SimpleChatStore,
+}
+
+
+def load_chat_store(data: dict) -> BaseChatStore:
+    """Load a chat store from a dict."""
+    chat_store_name = data.get("class_name", None)
+    if chat_store_name is None:
+        raise ValueError("ChatStore loading requires a class_name")
+
+    if chat_store_name not in RECOGNIZED_CHAT_STORES:
+        raise ValueError(f"Invalid ChatStore name: {chat_store_name}")
+
+    return RECOGNIZED_CHAT_STORES[chat_store_name].from_dict(data)

--- a/llama_index/storage/chat_store/simple_chat_store.py
+++ b/llama_index/storage/chat_store/simple_chat_store.py
@@ -1,0 +1,72 @@
+import json
+import os
+from typing import Dict, List, Optional
+
+import fsspec
+
+from llama_index.bridge.pydantic import Field
+from llama_index.llms import ChatMessage
+from llama_index.storage.chat_store.base import BaseChatStore
+
+
+class SimpleChatStore(BaseChatStore):
+    """Simple chat store."""
+
+    store: Dict[str, List[ChatMessage]] = Field(default_factory=dict)
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Get class name."""
+        return "SimpleChatStore"
+
+    def set_messages(self, key: str, messages: List[ChatMessage]) -> None:
+        """Set messages for a key."""
+        self.store[key] = messages
+
+    def get_messages(self, key: str) -> List[ChatMessage]:
+        """Get messages for a key."""
+        return self.store.get(key, [])
+
+    def add_message(self, key: str, message: ChatMessage) -> None:
+        """Add a message for a key."""
+        self.store.setdefault(key, []).append(message)
+
+    def delete_messages(self, key: str) -> None:
+        """Delete messages for a key."""
+        self.store.pop(key, None)
+
+    def undo_last_message(self, key: str) -> Optional[ChatMessage]:
+        """Undo last message for a key."""
+        return self.store.get(key, []).pop()
+
+    def get_keys(self) -> List[str]:
+        """Get all keys."""
+        return list(self.store.keys())
+
+    def persist(
+        self,
+        persist_path: str = "chat_store.json",
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> None:
+        """Persist the docstore to a file."""
+        fs = fs or fsspec.filesystem("file")
+        dirpath = os.path.dirname(persist_path)
+        if not fs.exists(dirpath):
+            fs.makedirs(dirpath)
+
+        with fs.open(persist_path, "w") as f:
+            f.write(json.dumps(self.store))
+
+    @classmethod
+    def from_persist_path(
+        cls,
+        persist_path: str = "chat_store.json",
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> "SimpleChatStore":
+        """Create a SimpleChatStore from a persist path."""
+        fs = fs or fsspec.filesystem("file")
+        if not fs.exists(persist_path):
+            return cls()
+        with fs.open(persist_path, "r") as f:
+            store = json.load(f)
+        return cls(store=store)

--- a/llama_index/storage/chat_store/simple_chat_store.py
+++ b/llama_index/storage/chat_store/simple_chat_store.py
@@ -27,17 +27,34 @@ class SimpleChatStore(BaseChatStore):
         """Get messages for a key."""
         return self.store.get(key, [])
 
-    def add_message(self, key: str, message: ChatMessage) -> None:
+    def add_message(
+        self, key: str, message: ChatMessage, idx: Optional[int] = None
+    ) -> None:
         """Add a message for a key."""
-        self.store.setdefault(key, []).append(message)
+        if idx is None:
+            self.store.setdefault(key, []).append(message)
+        else:
+            self.store.setdefault(key, []).insert(idx, message)
 
-    def delete_messages(self, key: str) -> None:
+    def delete_messages(self, key: str) -> Optional[List[ChatMessage]]:
         """Delete messages for a key."""
-        self.store.pop(key, None)
+        if key not in self.store:
+            return None
+        return self.store.pop(key)
 
-    def undo_last_message(self, key: str) -> Optional[ChatMessage]:
-        """Undo last message for a key."""
-        return self.store.get(key, []).pop()
+    def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
+        """Delete specific message for a key."""
+        if key not in self.store:
+            return None
+        if idx >= len(self.store[key]):
+            return None
+        return self.store[key].pop(idx)
+
+    def delete_last_message(self, key: str) -> Optional[ChatMessage]:
+        """Delete last message for a key."""
+        if key not in self.store:
+            return None
+        return self.store[key].pop()
 
     def get_keys(self) -> List[str]:
         """Get all keys."""

--- a/tests/storage/chat_store/test_simple_chat_store.py
+++ b/tests/storage/chat_store/test_simple_chat_store.py
@@ -1,0 +1,55 @@
+from llama_index.llms import ChatMessage
+from llama_index.storage.chat_store import SimpleChatStore
+
+
+def test_add_messages() -> None:
+    """Test adding messages to a chat store."""
+    chat_store = SimpleChatStore()
+
+    chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
+    chat_store.add_message("user1", ChatMessage(role="user", content="world"))
+    chat_store.add_message("user2", ChatMessage(role="user", content="hello"))
+    chat_store.add_message("user2", ChatMessage(role="user", content="world"))
+
+    assert chat_store.get_messages("user1") == [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="user", content="world"),
+    ]
+    assert chat_store.get_messages("user2") == [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="user", content="world"),
+    ]
+
+    assert chat_store.get_keys() == ["user1", "user2"]
+
+
+def test_delete_chat_message() -> None:
+    """Test deleting messages from a chat store."""
+    chat_store = SimpleChatStore()
+
+    chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
+    chat_store.add_message("user1", ChatMessage(role="user", content="world"))
+    chat_store.add_message("user2", ChatMessage(role="user", content="hello"))
+    chat_store.add_message("user2", ChatMessage(role="user", content="world"))
+
+    chat_store.delete_messages("user1")
+
+    assert chat_store.get_messages("user1") == []
+    assert chat_store.get_messages("user2") == [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="user", content="world"),
+    ]
+
+
+def test_undo_chat_message() -> None:
+    """Test undoing messages from a chat store."""
+    chat_store = SimpleChatStore()
+
+    chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
+    chat_store.add_message("user1", ChatMessage(role="user", content="world"))
+
+    chat_store.undo_last_message("user1")
+
+    assert chat_store.get_messages("user1") == [
+        ChatMessage(role="user", content="hello"),
+    ]

--- a/tests/storage/chat_store/test_simple_chat_store.py
+++ b/tests/storage/chat_store/test_simple_chat_store.py
@@ -22,8 +22,15 @@ def test_add_messages() -> None:
 
     assert chat_store.get_keys() == ["user1", "user2"]
 
+    chat_store.add_message("user1", ChatMessage(role="user", content="hello"), idx=0)
+    assert chat_store.get_messages("user1") == [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="user", content="world"),
+    ]
 
-def test_delete_chat_message() -> None:
+
+def test_delete_chat_messages() -> None:
     """Test deleting messages from a chat store."""
     chat_store = SimpleChatStore()
 
@@ -41,15 +48,29 @@ def test_delete_chat_message() -> None:
     ]
 
 
-def test_undo_chat_message() -> None:
+def test_delete_chat_message() -> None:
     """Test undoing messages from a chat store."""
     chat_store = SimpleChatStore()
 
     chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
     chat_store.add_message("user1", ChatMessage(role="user", content="world"))
 
-    chat_store.undo_last_message("user1")
+    chat_store.delete_last_message("user1")
 
     assert chat_store.get_messages("user1") == [
         ChatMessage(role="user", content="hello"),
+    ]
+
+
+def test_delete_chat_message_idx() -> None:
+    """Test undoing messages from a chat store at a specific idx."""
+    chat_store = SimpleChatStore()
+
+    chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
+    chat_store.add_message("user1", ChatMessage(role="user", content="world"))
+
+    chat_store.delete_message("user1", 0)
+
+    assert chat_store.get_messages("user1") == [
+        ChatMessage(role="user", content="world"),
     ]


### PR DESCRIPTION
# Description

A PR adding support for saving chat history to redis exposed the need to separate the storage of chat history from the actual memory. 

This way, we are not implementing the same sliding window logic for each new storage backend.

A few notes on the implementation:
- Langchain also has a similar division of responsibilities (`BaseChatMemory` vs. `BaseChatMessageHistory`)
- For memory modules that leverage existing modules that have storage (i.e. vector indexes, knowledge graphs, etc.) a chat store would not be required
- However, those other implementations described above could include a method to initialize from an existing chat store

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Todo
- [x] add tests
- [ ] add docs
