### PR TITLE
A single node passed into compute_scores returns as a float

### DIFF
--- a/llama_index/postprocessor/flag_embedding_reranker.py
+++ b/llama_index/postprocessor/flag_embedding_reranker.py
@@ -66,6 +66,7 @@ class FlagEmbeddingReranker(BaseNodePostprocessor):
         ) as event:
             scores = self._model.compute_score(query_and_nodes)
 
+            # a single node passed into compute_score returns a float
             if isinstance(scores, float):
                 scores = [scores]
             

--- a/llama_index/postprocessor/flag_embedding_reranker.py
+++ b/llama_index/postprocessor/flag_embedding_reranker.py
@@ -69,7 +69,7 @@ class FlagEmbeddingReranker(BaseNodePostprocessor):
             # a single node passed into compute_score returns a float
             if isinstance(scores, float):
                 scores = [scores]
-            
+
             assert len(scores) == len(nodes)
 
             for node, score in zip(nodes, scores):

--- a/llama_index/postprocessor/flag_embedding_reranker.py
+++ b/llama_index/postprocessor/flag_embedding_reranker.py
@@ -66,6 +66,9 @@ class FlagEmbeddingReranker(BaseNodePostprocessor):
         ) as event:
             scores = self._model.compute_score(query_and_nodes)
 
+            if isinstance(scores, float):
+                scores = [scores]
+            
             assert len(scores) == len(nodes)
 
             for node, score in zip(nodes, scores):


### PR DESCRIPTION
# Description

I was reranking NLSQL nodes (dont ask :P) and was getting an exception due to the model returning a float where a list / sequences was expected.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

A unit test for FlagEmbeddingRerank would require downloading the model ya? I skipped this but happy to add...

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
