### PR TITLE
Fix (#9867) sync_to_async to avoid blocking during asynchronous calls

### DIFF
--- a/llama_index/tools/function_tool.py
+++ b/llama_index/tools/function_tool.py
@@ -1,3 +1,5 @@
+from functools import partial
+import asyncio
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, Type
 
@@ -14,7 +16,9 @@ def sync_to_async(fn: Callable[..., Any]) -> AsyncCallable:
     """Sync to async."""
 
     async def _async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:
-        return fn(*args, **kwargs)
+        loop = asyncio.get_running_loop()
+        partial_func = partial(fn, **kwargs)
+        return await loop.run_in_executor(None, partial_func, *args)
 
     return _async_wrapped_fn
 

--- a/llama_index/tools/function_tool.py
+++ b/llama_index/tools/function_tool.py
@@ -1,5 +1,4 @@
 import asyncio
-from functools import partial
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, Type
 
@@ -17,8 +16,7 @@ def sync_to_async(fn: Callable[..., Any]) -> AsyncCallable:
 
     async def _async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:
         loop = asyncio.get_running_loop()
-        partial_func = partial(fn, **kwargs)
-        return await loop.run_in_executor(None, partial_func, *args)
+        return await loop.run_in_executor(None, lambda: fn(*args, **kwargs))
 
     return _async_wrapped_fn
 

--- a/llama_index/tools/function_tool.py
+++ b/llama_index/tools/function_tool.py
@@ -1,5 +1,5 @@
-from functools import partial
 import asyncio
+from functools import partial
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, Type
 


### PR DESCRIPTION
# Description

This PR corrects the ineffective sync_to_async function for converting synchronous to asynchronous, preventing blocking when asynchronous calls trigger tools.

Fixes #9867

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
