### PR TITLE
Fix 9219: OpenAIAgent using AzureOpenAI not working with stream_chat and astream_chat

### DIFF
--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -13,7 +13,7 @@ from typing import (
 
 import httpx
 import tiktoken
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, AzureOpenAI
 from openai import OpenAI as SyncOpenAI
 from openai.types.chat.chat_completion_chunk import (
     ChatCompletionChunk,
@@ -198,6 +198,9 @@ class OpenAI(LLM):
         elif model_name.startswith("ft:"):
             model_name = model_name.split(":")[1]
         return model_name
+    
+    def _is_azure_client(self) -> bool:
+        return isinstance(self._get_client(), AzureOpenAI)
 
     @classmethod
     def class_name(cls) -> str:
@@ -366,7 +369,10 @@ class OpenAI(LLM):
                 if len(response.choices) > 0:
                     delta = response.choices[0].delta
                 else:
-                    delta = ChoiceDelta()
+                    if self._is_azure_client():
+                        continue
+                    else:
+                        delta = ChoiceDelta()
 
                 # check if this chunk is the start of a function call
                 if delta.tool_calls:
@@ -565,7 +571,10 @@ class OpenAI(LLM):
                         continue
                     delta = response.choices[0].delta
                 else:
-                    delta = ChoiceDelta()
+                    if self._is_azure_client():
+                        continue
+                    else:
+                        delta = ChoiceDelta()
                 first_chat_chunk = False
 
                 # check if this chunk is the start of a function call

--- a/llama_index/llms/openai.py
+++ b/llama_index/llms/openai.py
@@ -198,7 +198,7 @@ class OpenAI(LLM):
         elif model_name.startswith("ft:"):
             model_name = model_name.split(":")[1]
         return model_name
-    
+
     def _is_azure_client(self) -> bool:
         return isinstance(self._get_client(), AzureOpenAI)
 


### PR DESCRIPTION
# Description

When using `AzureOpenAI()` with stream_chat or astream_chat, occasionally the Azure API will return empty responses initially. Adding a check and simply continuing until the next response seems to fix this issue. This issue is described in the following posts:
https://github.com/run-llama/llama_index/issues/9219
https://github.com/run-llama/sec-insights/issues/64
https://github.com/run-llama/sec-insights/issues/78


Fixes #9219

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Used the test code provided by @fchenGT in https://github.com/run-llama/llama_index/issues/9219, and implemented fix in Azure version of https://github.com/run-llama/sec-insights


# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

