### PR TITLE
Fusion top k for hybrid search

### DIFF
--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -449,8 +449,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 self.parse_to_query_result(sparse_response[1]),
                 # NOTE: only for hybrid search (0 for sparse search, 1 for dense search)
                 alpha=query.alpha or 0.5,
-                # NOTE: use fusion_top_k if provided, otherwise use similarity_top_k
-                top_k=query.fusion_top_k or query.similarity_top_k,
+                # NOTE: use hybrid_top_k if provided, otherwise use similarity_top_k
+                top_k=query.hybrid_top_k or query.similarity_top_k,
             )
         elif self.enable_hybrid:
             # search for dense vectors only
@@ -546,8 +546,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 self.parse_to_query_result(sparse_response[0]),
                 self.parse_to_query_result(sparse_response[1]),
                 alpha=query.alpha or 0.5,
-                # NOTE: use fusion_top_k if provided, otherwise use similarity_top_k
-                top_k=query.fusion_top_k or query.similarity_top_k,
+                # NOTE: use hybrid_top_k if provided, otherwise use similarity_top_k
+                top_k=query.hybrid_top_k or query.similarity_top_k,
             )
         elif self.enable_hybrid:
             # search for dense vectors only

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -449,7 +449,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 self.parse_to_query_result(sparse_response[1]),
                 # NOTE: only for hybrid search (0 for sparse search, 1 for dense search)
                 alpha=query.alpha or 0.5,
-                top_k=query.similarity_top_k,
+                # NOTE: use fusion_top_k if provided, otherwise use similarity_top_k
+                top_k=query.fusion_top_k or query.similarity_top_k,
             )
         elif self.enable_hybrid:
             # search for dense vectors only
@@ -545,7 +546,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 self.parse_to_query_result(sparse_response[0]),
                 self.parse_to_query_result(sparse_response[1]),
                 alpha=query.alpha or 0.5,
-                top_k=query.similarity_top_k,
+                # NOTE: use fusion_top_k if provided, otherwise use similarity_top_k
+                top_k=query.fusion_top_k or query.similarity_top_k,
             )
         elif self.enable_hybrid:
             # search for dense vectors only

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -238,7 +238,7 @@ class VectorStoreQuery:
     # NOTE: currently only used by postgres hybrid search
     sparse_top_k: Optional[int] = None
     # NOTE: return top k results from hybrid search. similarity_top_k is used for dense search top k
-    fusion_top_k: Optional[int] = None
+    hybrid_top_k: Optional[int] = None
 
 
 @runtime_checkable

--- a/llama_index/vector_stores/types.py
+++ b/llama_index/vector_stores/types.py
@@ -237,6 +237,8 @@ class VectorStoreQuery:
 
     # NOTE: currently only used by postgres hybrid search
     sparse_top_k: Optional[int] = None
+    # NOTE: return top k results from hybrid search. similarity_top_k is used for dense search top k
+    fusion_top_k: Optional[int] = None
 
 
 @runtime_checkable


### PR DESCRIPTION
# Description

Instead of using similarity top k for dense retrieval. Should have fusion top k for hybrid search top k

if dense retrieval return 30 and sparse return 30, better to have a new top k to determine how many fusion results to return
Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
