### PR TITLE
Fix incorrect id assignment in MyScale query result

### DIFF
--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -304,13 +304,13 @@ class MyScaleVectorStore(VectorStore):
                 start_char_idx = r["node_info"].get("start", None)
                 end_char_idx = r["node_info"].get("end", None)
             node = TextNode(
-                id_=r["doc_id"],
+                id_=r["id"],
                 text=r["text"],
                 metadata=r["metadata"],
                 start_char_idx=start_char_idx,
                 end_char_idx=end_char_idx,
                 relationships={
-                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id=r["doc_id"])
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id=r["id"])
                 },
             )
 


### PR DESCRIPTION
# Description

This PR addresses the issue of wrong ID references in `MyScale` query results. In the current implementation, `id_=r["doc_id"]` is incorrectly used for `TextNode`, and `node_id=r["doc_id"]` for `RelatedNodeInfo` in `TextNode.relationships`. This PR corrects these assignments to use `r["id"]`, ensuring the IDs accurately reflect the query results.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
