### PR TITLE
filter out negative indexes from faiss query

### DIFF
--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -189,6 +189,16 @@ class FaissVectorStore(BasePydanticVectorStore):
             return VectorStoreQueryResult(similarities=[], ids=[])
 
         # returned dimension is 1 x k
-        node_idxs = [str(i) for i in indices[0]]
+        node_idxs = indices[0]
 
-        return VectorStoreQueryResult(similarities=dists, ids=node_idxs)
+        filtered_dists = []
+        filtered_node_idxs = []
+        for dist, idx in zip(dists, node_idxs):
+            if idx < 0:
+                continue
+            filtered_dists.append(dist)
+            filtered_node_idxs.append(str(idx))
+
+        return VectorStoreQueryResult(
+            similarities=filtered_dists, ids=filtered_node_idxs
+        )


### PR DESCRIPTION
# Description

Faiss will return negative indexes if the top k is higher than the node count.

Fixes https://github.com/run-llama/llama_index/issues/9882

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
