### PR TITLE
Allow specifying tool_choice during agent construction

### DIFF
--- a/llama_index/agent/openai/base.py
+++ b/llama_index/agent/openai/base.py
@@ -54,6 +54,7 @@ class OpenAIAgent(AgentRunner):
         prefix_messages: List[ChatMessage],
         verbose: bool = False,
         max_function_calls: int = DEFAULT_MAX_FUNCTION_CALLS,
+        default_tool_choice: str = 'auto',
         callback_manager: Optional[CallbackManager] = None,
         tool_retriever: Optional[ObjectRetriever[BaseTool]] = None,
     ) -> None:
@@ -73,6 +74,7 @@ class OpenAIAgent(AgentRunner):
             memory=memory,
             llm=llm,
             callback_manager=callback_manager,
+            default_tool_choice=default_tool_choice
         )
 
     @classmethod
@@ -86,6 +88,7 @@ class OpenAIAgent(AgentRunner):
         memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
         verbose: bool = False,
         max_function_calls: int = DEFAULT_MAX_FUNCTION_CALLS,
+        default_tool_choice: str = 'auto',
         callback_manager: Optional[CallbackManager] = None,
         system_prompt: Optional[str] = None,
         prefix_messages: Optional[List[ChatMessage]] = None,
@@ -133,4 +136,5 @@ class OpenAIAgent(AgentRunner):
             verbose=verbose,
             max_function_calls=max_function_calls,
             callback_manager=callback_manager,
+            default_tool_choice=default_tool_choice,
         )

--- a/llama_index/agent/runner/base.py
+++ b/llama_index/agent/runner/base.py
@@ -209,6 +209,7 @@ class AgentRunner(BaseAgentRunner):
         callback_manager: Optional[CallbackManager] = None,
         init_task_state_kwargs: Optional[dict] = None,
         delete_task_on_finish: bool = False,
+        default_tool_choice: str = 'auto',
     ) -> None:
         """Initialize."""
         self.agent_worker = agent_worker
@@ -217,6 +218,7 @@ class AgentRunner(BaseAgentRunner):
         self.callback_manager = callback_manager or CallbackManager([])
         self.init_task_state_kwargs = init_task_state_kwargs or {}
         self.delete_task_on_finish = delete_task_on_finish
+        self.default_tool_choice = default_tool_choice
 
     @property
     def chat_history(self) -> List[ChatMessage]:
@@ -477,8 +479,11 @@ class AgentRunner(BaseAgentRunner):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        tool_choice: Union[str, dict] = "auto",
+        tool_choice: Optional[Union[str, dict]] = None,
     ) -> AgentChatResponse:
+        # override tool choice is provided as input.
+        if tool_choice is None:
+            tool_choice = self.default_tool_choice
         with self.callback_manager.event(
             CBEventType.AGENT_STEP,
             payload={EventPayload.MESSAGES: [message]},
@@ -495,8 +500,11 @@ class AgentRunner(BaseAgentRunner):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        tool_choice: Union[str, dict] = "auto",
+        tool_choice: Optional[Union[str, dict]] = None,
     ) -> AgentChatResponse:
+        # override tool choice is provided as input.
+        if tool_choice is None:
+            tool_choice = self.default_tool_choice
         with self.callback_manager.event(
             CBEventType.AGENT_STEP,
             payload={EventPayload.MESSAGES: [message]},
@@ -513,8 +521,11 @@ class AgentRunner(BaseAgentRunner):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        tool_choice: Union[str, dict] = "auto",
+        tool_choice: Optional[Union[str, dict]] = None,
     ) -> StreamingAgentChatResponse:
+        # override tool choice is provided as input.
+        if tool_choice is None:
+            tool_choice = self.default_tool_choice
         with self.callback_manager.event(
             CBEventType.AGENT_STEP,
             payload={EventPayload.MESSAGES: [message]},
@@ -531,8 +542,11 @@ class AgentRunner(BaseAgentRunner):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        tool_choice: Union[str, dict] = "auto",
+        tool_choice: Optional[Union[str, dict]] = None,
     ) -> StreamingAgentChatResponse:
+        # override tool choice is provided as input.
+        if tool_choice is None:
+            tool_choice = self.default_tool_choice
         with self.callback_manager.event(
             CBEventType.AGENT_STEP,
             payload={EventPayload.MESSAGES: [message]},


### PR DESCRIPTION
Rationale for this change:

If we want to construct an agent and force the LLM to make function calls from specific tools only, currently it is only possible through the `chat` api.

However while constructing heirarchical agents, it will be not be possible to force this behavior to a particular agent. 