### PR TITLE
Fix: Allow `model_name` for `OpenAIEmbedding`

### DIFF
--- a/llama_index/embeddings/openai.py
+++ b/llama_index/embeddings/openai.py
@@ -282,6 +282,7 @@ class OpenAIEmbedding(BaseEmbedding):
 
         if "model_name" in kwargs:
             model_name = kwargs.pop("model_name")
+            self._query_engine = self._text_engine = model_name
         else:
             model_name = model
 


### PR DESCRIPTION
# Description

`OpenAILike` allows us to use non-OpenAI models with an OpenAI-like API, e.g., by calling:
```
 llm = OpenAILike(
        model="my-model",
)   
```
There's no equivalent class for `OpenAIEmbedding`, but we could use `OpenAIEmbedding` and pass a different `model_name`, e.g.:
```
 embed_model = OpenAIEmbedding(
        model_name="paraphrase-multilingual-mpnet-base-v2"
 )
```
There's already some code for passing `model_name`, which currently doesn't work - this PR fixes this.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I stared at the code and made sure it makes sense
