### PR TITLE
BugFix: Instantiate ChatMemoryBuffer with chat_store_key using from_defaults.

### DIFF
--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -69,6 +69,7 @@ class ChatMemoryBuffer(BaseMemory):
             token_limit=token_limit,
             tokenizer_fn=tokenizer_fn or get_tokenizer(),
             chat_store=chat_store or SimpleChatStore(),
+            chat_store_key=chat_store_key,
         )
 
     def to_string(self) -> str:


### PR DESCRIPTION
# Description

Fixes the bug where ChatMemoryBuffer.from_defaults did not pass the chat_store_key argument to ChatMemoryBuffer constructor.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've tested it manually and confirmed that it now uses the chat_store_key value that was passed in instead of the default one.

# Suggested Checklist:
- [x] I ran `make format; make lint` to appease the lint gods

Unfortunately, the `make test` fails on my machine with and without this change. The output is below:
```
FAILED tests/query_engine/test_pandas.py::test_default_output_processor_e2e - assert "Import of module 'os' is not allowed" in 'There was an error running the output as Python code. Error message: Execution of code containing references to private or dunder methods i...
```
