### PR TITLE
Fix typo in chat_stores doc

### DIFF
--- a/docs/module_guides/storing/chat_stores.md
+++ b/docs/module_guides/storing/chat_stores.md
@@ -11,7 +11,7 @@ The most basic chat store is `SimpleChatStore`, which stores messages in memory 
 Typically, you will insansiate a chat store and give it to a memory module. Memory modules that use chat stores will default to using `SimpleChatStore` if not provided.
 
 ```python
-from llama_index.storage.chat_stores import SimpleChatStore
+from llama_index.storage.chat_store import SimpleChatStore
 from llama_index.memory import ChatMemoryBuffer
 
 chat_store = SimpleChatStore()
@@ -52,7 +52,7 @@ loaded_chat_store = SimpleChatStore.parse_raw(chat_store_string)
 Using `RedisChatStore`, you can store your chat history remotely, without having to worry abouyt manually persisting and loading the chat history.
 
 ```python
-from llama_index.storage.chat_stores import RedisChatStore
+from llama_index.storage.chat_store import RedisChatStore
 from llama_index.memory import ChatMemoryBuffer
 
 chat_store = RedisChatStore(redis_url="redis://localhost:6379", ttl=300)


### PR DESCRIPTION
# Description

Fix typo in chat_stores doc page:

Remove `s` in `chat_stores` code

Fixes #9929 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

