### PR TITLE
Add ProgressBar for CLI downloads of llama-datasets

### DIFF
--- a/llama_index/command_line/command_line.py
+++ b/llama_index/command_line/command_line.py
@@ -43,6 +43,8 @@ def handle_download_llama_dataset(
         llama_hub_url=llama_hub_url,
         llama_datasets_lfs_url=llama_datasets_lfs_url,
         llama_datasets_source_files_tree_url=llama_datasets_source_files_tree_url,
+        show_progress=True,
+        load_documents=False,
     )
 
     print(f"Successfully downloaded {llama_dataset_class} to {download_dir}")

--- a/llama_index/llama_dataset/download.py
+++ b/llama_index/llama_dataset/download.py
@@ -35,6 +35,7 @@ def download_llama_dataset(
     llama_datasets_lfs_url: str = LLAMA_DATASETS_LFS_URL,
     llama_datasets_source_files_tree_url: str = LLAMA_DATASETS_SOURCE_FILES_GITHUB_TREE_URL,
     show_progress: bool = False,
+    load_documents: bool = True,
 ) -> Tuple[Type[BaseLlamaDataset], List[Document]]:
     """Download dataset from datasets-LFS and llamahub.
 
@@ -78,7 +79,7 @@ def download_llama_dataset(
 
     # for now only rag datasets need to provide the documents
     # in order to build an index over them
-    if "rag_dataset.json" in dataset_filename:
+    if "rag_dataset.json" in dataset_filename and load_documents:
         documents = SimpleDirectoryReader(input_dir=source_files_dir).load_data(
             show_progress=show_progress
         )

--- a/llama_index/llama_dataset/download.py
+++ b/llama_index/llama_dataset/download.py
@@ -55,6 +55,8 @@ def download_llama_dataset(
         disable_library_cache: Boolean to control library cache
         override_path: Boolean to control overriding path
         show_progress: Boolean for showing progress on downloading source files
+        load_documents: Boolean for whether or not source_files for LabelledRagDataset should
+                        be loaded.
 
     Returns:
         a `BaseLlamaDataset` and a `List[Document]`


### PR DESCRIPTION
# Description

- shows progress when downloading source files for a llama-dataset
- changes default behaviour of cli downloads to not load load the download source files into Documents (i.e. cli download just downloads data now)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense (and have a fancy screenshot... see below)

<img width="863" alt="image" src="https://github.com/run-llama/llama_index/assets/92402603/74e35583-9e86-4957-9a06-e038b0ffb6b4">

