### PR TITLE
Bugfix: sphinx generation errors

### DIFF
--- a/docs/community/integrations/vector_stores.md
+++ b/docs/community/integrations/vector_stores.md
@@ -761,7 +761,6 @@ maxdepth: 1
 ../../examples/vector_stores/qdrant_hybrid.ipynb
 ../../examples/vector_stores/RocksetIndexDemo.ipynb
 ../../examples/vector_stores/SimpleIndexDemo.ipynb
-../../examples/vector_stores/SingleStoreDemo.ipynb
 ../../examples/vector_stores/SupabaseVectorIndexDemo.ipynb
 ../../examples/vector_stores/TairIndexDemo.ipynb
 ../../examples/vector_stores/TencentVectorDBIndexDemo.ipynb

--- a/docs/module_guides/loading/documents_and_nodes/root.md
+++ b/docs/module_guides/loading/documents_and_nodes/root.md
@@ -57,5 +57,5 @@ maxdepth: 1
 ---
 usage_documents.md
 usage_nodes.md
-/core_modules/data_modules/transformations/root.md
+../ingestion_pipeline/transformations.md
 ```

--- a/docs/module_guides/querying/pipeline/root.md
+++ b/docs/module_guides/querying/pipeline/root.md
@@ -15,6 +15,8 @@ This is centered around our `QueryPipeline` abstraction. Load in a variety of mo
 
 Our query pipelines also propagate callbacks throughout all sub-modules, and these integrate with our [observability partners](/module_guides/observability/observability.md).
 
+![](/_static/query/query_classes.png)
+
 ## Usage Pattern
 
 Here are two simple ways to setup a query pipeline - through a simplified syntax of setting up a sequential chain to setting up a full compute DAG.

--- a/docs/module_guides/querying/pipeline/root.md
+++ b/docs/module_guides/querying/pipeline/root.md
@@ -15,8 +15,6 @@ This is centered around our `QueryPipeline` abstraction. Load in a variety of mo
 
 Our query pipelines also propagate callbacks throughout all sub-modules, and these integrate with our [observability partners](/module_guides/observability/observability.md).
 
-![](/_static/query/pipeline_rag_example.png)
-
 ## Usage Pattern
 
 Here are two simple ways to setup a query pipeline - through a simplified syntax of setting up a sequential chain to setting up a full compute DAG.

--- a/docs/module_guides/storing/vector_stores.md
+++ b/docs/module_guides/storing/vector_stores.md
@@ -87,7 +87,6 @@ maxdepth: 1
 /examples/vector_stores/qdrant_hybrid.ipynb
 /examples/vector_stores/RocksetIndexDemo.ipynb
 /examples/vector_stores/SimpleIndexDemo.ipynb
-/examples/vector_stores/SingleStoreDemo.ipynb
 /examples/vector_stores/SupabaseVectorIndexDemo.ipynb
 /examples/vector_stores/TairIndexDemo.ipynb
 /examples/vector_stores/TencentVectorDBIndexDemo.ipynb

--- a/llama_index/node_parser/relational/hierarchical.py
+++ b/llama_index/node_parser/relational/hierarchical.py
@@ -52,9 +52,9 @@ class HierarchicalNodeParser(NodeParser):
     For instance, this may return a list of nodes like:
     - list of top-level nodes with chunk size 2048
     - list of second-level nodes, where each node is a child of a top-level node,
-        chunk size 512
+      chunk size 512
     - list of third-level nodes, where each node is a child of a second-level node,
-        chunk size 128
+      chunk size 128
     """
 
     chunk_sizes: Optional[List[int]] = Field(

--- a/llama_index/readers/qdrant.py
+++ b/llama_index/readers/qdrant.py
@@ -110,7 +110,7 @@ class QdrantReader(BaseReader):
                  # gte, lte, gt, lt supported
                  rang_search_mapping={"text_field": {"gte": 0.1, "lte": 0.2}},
                  limit=10
-             )
+            )
 
         Returns:
             List[Document]: A list of documents.

--- a/llama_index/vector_stores/cassandra.py
+++ b/llama_index/vector_stores/cassandra.py
@@ -201,7 +201,8 @@ class CassandraVectorStore(VectorStore):
         return {f.key: f.value for f in query_filters.filters}
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
-        """Query index for top k most similar nodes.
+        """
+        Query index for top k most similar nodes.
 
         Supported query modes: 'default' (most similar vectors) and 'mmr'.
 
@@ -221,7 +222,6 @@ class CassandraVectorStore(VectorStore):
                 for prefetch pool size. Defaults to 4.0
             mmr_prefetch_k (Optional[int]): prefetch pool size. This cannot be
                 passed together with mmr_prefetch_factor
-
         """
         _available_query_modes = [
             VectorStoreQueryMode.DEFAULT,


### PR DESCRIPTION
# Description
This PR is contained to fix doc generation issues with sphinx, no functional changes is introduced. The warning/errors list is pretty big so I am breaking down this PR into smaller ones. Will slowly churn through this.

- fix invalid docstring formats
- remove empty references (they aren't showing up on the docs anyway but creating sphinx build errors)
- re-orient references

Fixes # (issue)

## Type of Change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
[before](https://gist.github.com/hackgoofer/3f38b79f90e229026bda54a45e81a477), [after](https://gist.github.com/hackgoofer/b3b0cbce93fc826a025a9e8c25a43a4a)
This only includes errors/warnings before line 60 from the before list

# Suggested Checklist:

- [x] My changes generate no new warnings
- [x] I ran `make html` to check the warnings/errors disappeared
