### PR TITLE
skip empty nodes

### DIFF
--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -11,7 +11,7 @@ from llama_index.core.base_retriever import BaseRetriever
 from llama_index.data_structs.data_structs import IndexDict
 from llama_index.indices.base import BaseIndex
 from llama_index.indices.utils import async_embed_nodes, embed_nodes
-from llama_index.schema import BaseNode, ImageNode, IndexNode
+from llama_index.schema import BaseNode, ImageNode, IndexNode, MetadataMode
 from llama_index.service_context import ServiceContext
 from llama_index.storage.docstore.types import RefDocInfo
 from llama_index.storage.storage_context import StorageContext
@@ -259,6 +259,9 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
             VectorStoreIndex only stores nodes in document store
             if vector store does not store text
         """
+        nodes = [
+            node for node in nodes if node.get_content(metadata_mode=MetadataMode.EMBED)
+        ]
         return self._build_index_from_nodes(nodes, **insert_kwargs)
 
     def _insert(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -259,9 +259,15 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
             VectorStoreIndex only stores nodes in document store
             if vector store does not store text
         """
-        nodes = [
-            node for node in nodes if node.get_content(metadata_mode=MetadataMode.EMBED)
-        ]
+        # raise an error if even one node has no content
+        if any(
+            node.get_content(metadata_mode=MetadataMode.EMBED) == "" for node in nodes
+        ):
+            raise ValueError(
+                "Cannot build index from nodes with no content. "
+                "Please ensure all nodes have content."
+            )
+
         return self._build_index_from_nodes(nodes, **insert_kwargs)
 
     def _insert(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:

--- a/llama_index/node_parser/text/token.py
+++ b/llama_index/node_parser/text/token.py
@@ -108,7 +108,6 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
         """Split text into chunks, reserving space required for metadata str."""
         metadata_len = len(self._tokenizer(metadata_str)) + DEFAULT_METADATA_FORMAT_LEN
         effective_chunk_size = self.chunk_size - metadata_len
-        print(effective_chunk_size, flush=True)
         if effective_chunk_size <= 0:
             raise ValueError(
                 f"Metadata length ({metadata_len}) is longer than chunk size "


### PR DESCRIPTION
# Description

Nodes with no content should be skipped when embedding. This error has come up a few times.

Fixes https://github.com/run-llama/llama_index/issues/9951

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
