### PR TITLE
[DRAFT] Audrey pinecone compat

### DIFF
--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -219,6 +219,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
             raise ImportError(import_err_msg)
 
         if pinecone_index is not None:
+            # Cast pinecone_index to pinecone.Index type, which is the expected type of self._pinecone_index
+            # See class docstring: "self._pinecone_index (Optional[pinecone.Index]): Pinecone index instance"
             self._pinecone_index = cast(pinecone.Index, pinecone_index)  # type: ignore[name-defined]
         else:
             if hasattr(pinecone, "version") and pinecone.version >= "3.0.0":

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -4,31 +4,33 @@ Pinecone Vector store index.
 An index that that is built on top of an existing vector store.
 
 """
-
 import logging
 import re
 from collections import Counter
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import List
+from typing import Optional
 
 from packaging import version
 from pkg_resources import get_distribution
 
 from llama_index.bridge.pydantic import PrivateAttr
-from llama_index.schema import BaseNode, MetadataMode, TextNode
-from llama_index.vector_stores.types import (
-    BasePydanticVectorStore,
-    MetadataFilters,
-    VectorStoreQuery,
-    VectorStoreQueryMode,
-    VectorStoreQueryResult,
-)
-from llama_index.vector_stores.utils import (
-    DEFAULT_TEXT_KEY,
-    legacy_metadata_dict_to_node,
-    metadata_dict_to_node,
-    node_to_metadata_dict,
-)
+from llama_index.schema import BaseNode
+from llama_index.schema import MetadataMode
+from llama_index.schema import TextNode
+from llama_index.vector_stores.types import BasePydanticVectorStore
+from llama_index.vector_stores.types import MetadataFilters
+from llama_index.vector_stores.types import VectorStoreQuery
+from llama_index.vector_stores.types import VectorStoreQueryMode
+from llama_index.vector_stores.types import VectorStoreQueryResult
+from llama_index.vector_stores.utils import DEFAULT_TEXT_KEY
+from llama_index.vector_stores.utils import legacy_metadata_dict_to_node
+from llama_index.vector_stores.utils import metadata_dict_to_node
+from llama_index.vector_stores.utils import node_to_metadata_dict
 
 ID_KEY = "id"
 VECTOR_KEY = "values"
@@ -244,7 +246,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
         if pinecone_index is not None:
             # Cast pinecone_index to pinecone.Index type, which is the expected type of self._pinecone_index
             # See class docstring: "self._pinecone_index (Optional[pinecone.Index]): Pinecone index instance"
-            self._pinecone_index = cast(pinecone.Index, pinecone_index)  # type: ignore[name-defined]
+            # type: ignore[name-defined]
+            self._pinecone_index = cast(pinecone.Index, pinecone_index)
         else:
             # Pinecone client version >= 3.0.0 has breaking changes to initialization signature
             if (
@@ -409,7 +412,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
         """
         sparse_vector = None
         if (
-            query.mode in (VectorStoreQueryMode.SPARSE, VectorStoreQueryMode.HYBRID)
+            query.mode in (VectorStoreQueryMode.SPARSE,
+                           VectorStoreQueryMode.HYBRID)
             and self._tokenizer is not None
         ):
             if query.query_str is None:

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -224,8 +224,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             self._pinecone_index = cast(pinecone.Index, pinecone_index)  # type: ignore[name-defined]
         else:
             # Pinecone client version >= 3.0.0 has breaking changes to initialization signature
-            pinecone_client_version = get_distribution("pinecone-client").version[:-5]
-            if version.parse(pinecone_client_version) >= version.parse("3.0.0"):
+            if hasattr(pinecone, "version") and pinecone.version >= "3.0.0":
                 if index_name is None:
                     raise ValueError(
                         "Must specify index_name if not directly passing in client."

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -224,7 +224,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
             self._pinecone_index = cast(pinecone.Index, pinecone_index)  # type: ignore[name-defined]
         else:
             # Pinecone client version >= 3.0.0 has breaking changes to initialization signature
-            if hasattr(pinecone, "version") and pinecone.version >= "3.0.0":
+            pinecone_client_version = get_distribution("pinecone-client").version[:-5]
+            if version.parse(pinecone_client_version) >= version.parse("3.0.0"):
                 if index_name is None:
                     raise ValueError(
                         "Must specify index_name if not directly passing in client."

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -254,7 +254,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         api_key: Optional[str],
         index_name: Optional[str],
         environment: Optional[str],
-        use_pod_based: bool,
+        use_pod_based: Optional[bool],
         **kwargs: Any,
     ) -> Any:
         """Initialize Pinecone client based on version."""

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -5,32 +5,28 @@ An index that that is built on top of an existing vector store.
 
 """
 import logging
-import re
 from collections import Counter
 from functools import partial
-from typing import Any
-from typing import Callable
-from typing import cast
-from typing import Dict
-from typing import List
-from typing import Optional
+from typing import Any, Callable, Dict, List, Optional, cast
 
 from packaging import version
 from pkg_resources import get_distribution
 
 from llama_index.bridge.pydantic import PrivateAttr
-from llama_index.schema import BaseNode
-from llama_index.schema import MetadataMode
-from llama_index.schema import TextNode
-from llama_index.vector_stores.types import BasePydanticVectorStore
-from llama_index.vector_stores.types import MetadataFilters
-from llama_index.vector_stores.types import VectorStoreQuery
-from llama_index.vector_stores.types import VectorStoreQueryMode
-from llama_index.vector_stores.types import VectorStoreQueryResult
-from llama_index.vector_stores.utils import DEFAULT_TEXT_KEY
-from llama_index.vector_stores.utils import legacy_metadata_dict_to_node
-from llama_index.vector_stores.utils import metadata_dict_to_node
-from llama_index.vector_stores.utils import node_to_metadata_dict
+from llama_index.schema import BaseNode, MetadataMode, TextNode
+from llama_index.vector_stores.types import (
+    BasePydanticVectorStore,
+    MetadataFilters,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+    VectorStoreQueryResult,
+)
+from llama_index.vector_stores.utils import (
+    DEFAULT_TEXT_KEY,
+    legacy_metadata_dict_to_node,
+    metadata_dict_to_node,
+    node_to_metadata_dict,
+)
 
 ID_KEY = "id"
 VECTOR_KEY = "values"
@@ -214,7 +210,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
         default_empty_query_vector: Optional[List[float]] = None,
         **kwargs: Any,
     ) -> None:
-
         insert_kwargs = insert_kwargs or {}
 
         if tokenizer is None and add_sparse_vector:
@@ -234,15 +229,21 @@ class PineconeVectorStore(BasePydanticVectorStore):
         )
 
         self._pinecone_index = pinecone_index or self._initialize_pinecone_client(
-            api_key, index_name, environment, **kwargs)
+            api_key, index_name, environment, **kwargs
+        )
 
     @staticmethod
-    def _initialize_pinecone_client(api_key: Optional[str], index_name: Optional[str],
-                                    environment: Optional[str], **kwargs) -> Any:
+    def _initialize_pinecone_client(
+        api_key: Optional[str],
+        index_name: Optional[str],
+        environment: Optional[str],
+        **kwargs,
+    ) -> Any:
         """Initialize Pinecone client based on version."""
         if not index_name:
             raise ValueError(
-                "index_name is required for Pinecone client initialization")
+                "index_name is required for Pinecone client initialization"
+            )
 
         import pinecone
         from packaging.version import parse as parse_version
@@ -252,10 +253,10 @@ class PineconeVectorStore(BasePydanticVectorStore):
             return pinecone_instance.Index(index_name)
 
         if not environment:
-            raise ValueError(
-                "environment is required for Pinecone client < 3.0.0")
-            pinecone.init(api_key=api_key, environment=environment)
-            return pinecone.Index(index_name)
+            raise ValueError("environment is required for Pinecone client < 3.0.0")
+
+        pinecone.init(api_key=api_key, environment=environment)
+        return pinecone.Index(index_name)
 
     @classmethod
     def from_params(
@@ -381,8 +382,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         """
         sparse_vector = None
         if (
-            query.mode in (VectorStoreQueryMode.SPARSE,
-                           VectorStoreQueryMode.HYBRID)
+            query.mode in (VectorStoreQueryMode.SPARSE, VectorStoreQueryMode.HYBRID)
             and self._tokenizer is not None
         ):
             if query.query_str is None:

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -213,7 +213,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
     ) -> None:
         """Initialize params."""
         try:
-            # import pinecone
+            # Dynamic import of pinecone module, needed to simulate different versions of client in tests
             pinecone = __import__("pinecone")
         except ImportError:
             raise ImportError(import_err_msg)

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -168,7 +168,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
     k most similar nodes.
 
     Args:
-        pinecone_index (Optional[pinecone.Index]): Pinecone index instance
+        pinecone_index (Optional[Union[pinecone.Pinecone.Index, pinecone.Index]]): Pinecone index instance,
+        pinecone.Pinecone.Index for clients >= 3.0.0; pinecone.Index for older clients.
         insert_kwargs (Optional[Dict]): insert kwargs during `upsert` call.
         add_sparse_vector (bool): whether to add sparse vector to index.
         tokenizer (Optional[Callable]): tokenizer to use to generate sparse
@@ -196,7 +197,9 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
     def __init__(
         self,
-        pinecone_index: Optional[Any] = None,
+        pinecone_index: Optional[
+            Any
+        ] = None,  # Dynamic import prevents specific type hinting here
         api_key: Optional[str] = None,
         index_name: Optional[str] = None,
         environment: Optional[str] = None,
@@ -237,7 +240,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         api_key: Optional[str],
         index_name: Optional[str],
         environment: Optional[str],
-        **kwargs,
+        **kwargs: Any,
     ) -> Any:
         """Initialize Pinecone client based on version."""
         if not index_name:

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -164,7 +164,9 @@ def apply_regex(input_string: str) -> str:
     """
     Removes any characters in a package's __version__ name after and including the third period.
 
-    >>> apply_regex("3.0.0.dev6")
+    Example:
+    >>> version = apply_regex("3.0.0.dev6")
+    >>> print(version)
     >>> "3.0.0"
 
     Args:

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -223,6 +223,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             # See class docstring: "self._pinecone_index (Optional[pinecone.Index]): Pinecone index instance"
             self._pinecone_index = cast(pinecone.Index, pinecone_index)  # type: ignore[name-defined]
         else:
+            # Pinecone client version >= 3.0.0 has breaking changes to initialization signature
             if hasattr(pinecone, "version") and pinecone.version >= "3.0.0":
                 if index_name is None:
                     raise ValueError(

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -219,6 +219,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
             raise ImportError(import_err_msg)
 
         if pinecone_index is not None:
+            self._pinecone_index = cast(pinecone.Index, pinecone_index)  # type: ignore[name-defined]
+        else:
             if hasattr(pinecone, "version") and pinecone.version >= "3.0.0":
                 if index_name is None:
                     raise ValueError(

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -213,10 +213,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
     batch_size: int
     remove_text_from_metadata: bool
 
-    use_pod_based: bool = (
-        True  # Continue with v3 behavior, unless explicitly overridden
-    )
-
     _pinecone_index: Any = PrivateAttr()
     _tokenizer: Optional[Callable] = PrivateAttr()
 
@@ -236,7 +232,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
         batch_size: int = DEFAULT_BATCH_SIZE,
         remove_text_from_metadata: bool = False,
         default_empty_query_vector: Optional[List[float]] = None,
-        use_pod_based: bool = False,
         **kwargs: Any,
     ) -> None:
         insert_kwargs = insert_kwargs or {}
@@ -275,7 +270,6 @@ class PineconeVectorStore(BasePydanticVectorStore):
         api_key: Optional[str],
         index_name: Optional[str],
         environment: Optional[str],
-        use_pod_based: Optional[bool],
         **kwargs: Any,
     ) -> Any:
         """Initialize Pinecone client based on version."""
@@ -309,11 +303,11 @@ class PineconeVectorStore(BasePydanticVectorStore):
         batch_size: int = DEFAULT_BATCH_SIZE,
         remove_text_from_metadata: bool = False,
         default_empty_query_vector: Optional[List[float]] = None,
-        use_pod_based: bool = False,
         **kwargs: Any,
     ) -> "PineconeVectorStore":
         pinecone_index = cls.initialize_pinecone_client(
-            api_key, index_name, environment, use_pod_based, **kwargs
+            api_key, index_name, environment,
+            **kwargs
         )  # TODO: not sure initialize_pinecone_client should be here
 
         return cls(

--- a/tests/indices/vector_store/utils.py
+++ b/tests/indices/vector_store/utils.py
@@ -61,17 +61,11 @@ class MockPineconeIndex:
 
 
 def get_pinecone_storage_context() -> StorageContext:
-    # NOTE: mock pinecone import
+    # Mocking pinecone module import
     sys.modules["pinecone"] = MagicMock()
-
-    # Can override for newer versions; just need str for pinecone.version comparison in PineconeVectorStore class:
-    sys.modules["pinecone"].version = "2.4.0"  # type: ignore[attr-defined]
-
     return StorageContext.from_defaults(
         vector_store=PineconeVectorStore(
             pinecone_index=MockPineconeIndex(),
-            environment="some env",
-            index_name="some index name",
             tokenizer=mock_tokenizer,
         )
     )

--- a/tests/indices/vector_store/utils.py
+++ b/tests/indices/vector_store/utils.py
@@ -63,8 +63,15 @@ class MockPineconeIndex:
 def get_pinecone_storage_context() -> StorageContext:
     # NOTE: mock pinecone import
     sys.modules["pinecone"] = MagicMock()
+
+    # Can override for newer versions; just need str for pinecone.version comparison in PineconeVectorStore class:
+    sys.modules["pinecone"].version = "2.4.0"  # type: ignore[attr-defined]
+
     return StorageContext.from_defaults(
         vector_store=PineconeVectorStore(
-            pinecone_index=MockPineconeIndex(), tokenizer=mock_tokenizer
+            pinecone_index=MockPineconeIndex(),
+            environment="some env",
+            index_name="some index name",
+            tokenizer=mock_tokenizer,
         )
     )

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -9,7 +9,7 @@ from llama_index.vector_stores.pinecone import (
 
 
 class MockPineconePods:
-    version = "2.9.9"
+    __version__ = "2.2.4"
 
     @staticmethod
     def init(api_key: str, environment: str) -> None:
@@ -21,7 +21,7 @@ class MockPineconePods:
 
 
 class MockPineconeServerless:
-    version = "3.0.0"
+    __version__ = "3.0.0"
 
     class Pinecone:
         def __init__(self, api_key: str) -> None:
@@ -60,3 +60,6 @@ class TestPineconeVectorStore(unittest.TestCase):
         pods_version = False  # type: ignore[name-defined]
         with patch("builtins.__import__", side_effect=mock_import):
             store = PineconeVectorStore(api_key="dummy_key", index_name="dummy_index")
+
+
+# TODO: write test to ensure "__version__" attribute

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -1,12 +1,9 @@
 import builtins
 import unittest
-from typing import Any
-from typing import Callable
-from typing import Type
+from typing import Any, Callable, Type
 from unittest.mock import patch
 
 import pytest
-
 from llama_index.vector_stores.pinecone import (
     PineconeVectorStore,
 )
@@ -73,8 +70,7 @@ class TestPineconeVectorStore(unittest.TestCase):
         global pods_version
         pods_version = True  # type: ignore[name-defined]
         with patch("builtins.__import__", side_effect=mock_import):
-            mocked_version = get_version_attr_from_mock_classes(
-                MockPineconePods)
+            mocked_version = get_version_attr_from_mock_classes(MockPineconePods)
 
             assert mocked_version == "2.2.4"
 
@@ -87,13 +83,11 @@ class TestPineconeVectorStore(unittest.TestCase):
         global pods_version
         pods_version = False  # type: ignore[name-defined]
         with patch("builtins.__import__", side_effect=mock_import):
-            mock_version = get_version_attr_from_mock_classes(
-                MockPineconeServerless)
+            mock_version = get_version_attr_from_mock_classes(MockPineconeServerless)
 
             assert mock_version == "3.0.0"
 
-            store = PineconeVectorStore(
-                api_key="dummy_key", index_name="dummy_index")
+            store = PineconeVectorStore(api_key="dummy_key", index_name="dummy_index")
 
     def test_unversioned_pinecone_client(self) -> None:
         with pytest.raises(

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -43,7 +43,7 @@ class MockUnVersionedPineconeRelease:
             pass
 
 
-def get_version_attr_from_mock_classes(mock_class: Type[Any]) -> None:
+def get_version_attr_from_mock_classes(mock_class: Type[Any]) -> str:
     if not hasattr(mock_class, "__version__"):
         raise AttributeError(
             "The version of pinecone you are using does not contain necessary __version__ attribute."
@@ -53,8 +53,7 @@ def get_version_attr_from_mock_classes(mock_class: Type[Any]) -> None:
 
 def mock_import(name: str, *args: Any, **kwargs: Any) -> Callable:
     if name == "pinecone":
-        # type: ignore[name-defined]
-        return MockPineconePods if pods_version else MockPineconeServerless
+        return MockPineconePods if pods_version else MockPineconeServerless  # type: ignore[name-defined]
     return original_import(name, *args, **kwargs)  # type: ignore[name-defined]
 
 

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -4,9 +4,9 @@ from typing import Any, Callable, Type
 from unittest.mock import patch
 
 import pytest
-from llama_index.vector_stores.pinecone import (
-    PineconeVectorStore,
-)
+from llama_index.vector_stores.pinecone import PineconeVectorStore
+
+original_import = builtins.__import__
 
 
 class MockPineconePods:
@@ -18,6 +18,13 @@ class MockPineconePods:
 
     class Index:
         def __init__(self, index_name: str) -> None:
+            pass
+
+    class Pinecone:
+        def __init__(self, api_key: str) -> None:
+            pass
+
+        def Index(self, index_name: str) -> None:
             pass
 
 
@@ -51,41 +58,42 @@ def get_version_attr_from_mock_classes(mock_class: Type[Any]) -> str:
     return mock_class.__version__
 
 
-def mock_import(name: str, *args: Any, **kwargs: Any) -> Callable:
-    if name == "pinecone":
-        return MockPineconePods if pods_version else MockPineconeServerless  # type: ignore[name-defined]
-    return original_import(name, *args, **kwargs)  # type: ignore[name-defined]
+def make_mock_import(pods_version: bool) -> Callable:
+    def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "pinecone":
+            return MockPineconePods if pods_version else MockPineconeServerless
+        # type: ignore[named-defined]
+        return original_import(name, *args, **kwargs)
+
+    return mock_import
 
 
 class TestPineconeVectorStore(unittest.TestCase):
     def setUp(self) -> None:
-        global original_import
-        original_import = builtins.__import__  # type: ignore[name-defined]
+        super().setUp()
+        self.pods_version = False
+        global original_import  # type: ignore[name-defined]
+        original_import = builtins.__import__
 
     def tearDown(self) -> None:
-        builtins.__import__ = original_import  # type: ignore[name-defined]
+        builtins.__import__ = original_import
 
     def test_pods_version(self) -> None:
-        global pods_version
-        pods_version = True  # type: ignore[name-defined]
-        with patch("builtins.__import__", side_effect=mock_import):
+        self.pods_version = True
+        mock_import_with_context = make_mock_import(self.pods_version)
+        with patch("builtins.__import__", side_effect=mock_import_with_context):
             mocked_version = get_version_attr_from_mock_classes(MockPineconePods)
-
             assert mocked_version == "2.2.4"
-
-            # PineconeVectorStore calls its own init method when instantiated
             store = PineconeVectorStore(
                 api_key="dummy_key", index_name="dummy_index", environment="dummy_env"
             )
 
     def test_serverless_version(self) -> None:
-        global pods_version
-        pods_version = False  # type: ignore[name-defined]
-        with patch("builtins.__import__", side_effect=mock_import):
+        self.pods_version = False
+        mock_import_with_context = make_mock_import(self.pods_version)
+        with patch("builtins.__import__", side_effect=mock_import_with_context):
             mock_version = get_version_attr_from_mock_classes(MockPineconeServerless)
-
             assert mock_version == "3.0.0"
-
             store = PineconeVectorStore(api_key="dummy_key", index_name="dummy_index")
 
     def test_unversioned_pinecone_client(self) -> None:
@@ -94,3 +102,7 @@ class TestPineconeVectorStore(unittest.TestCase):
             match="The version of pinecone you are using does not contain necessary __version__ attribute.",
         ):
             get_version_attr_from_mock_classes(MockUnVersionedPineconeRelease)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -78,6 +78,7 @@ class TestPineconeVectorStore(unittest.TestCase):
 
             assert mocked_version == "2.2.4"
 
+            # PineconeVectorStore calls its own init method when instantiated
             store = PineconeVectorStore(
                 api_key="dummy_key", index_name="dummy_index", environment="dummy_env"
             )

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -1,17 +1,10 @@
-import builtins
 import unittest
-from typing import Any, Callable, Type
 from unittest.mock import patch
 
-import pytest
 from llama_index.vector_stores.pinecone import PineconeVectorStore
-
-original_import = builtins.__import__
 
 
 class MockPineconePods:
-    __version__ = "2.2.4"
-
     @staticmethod
     def init(api_key: str, environment: str) -> None:
         pass
@@ -29,80 +22,42 @@ class MockPineconePods:
 
 
 class MockPineconeServerless:
-    __version__ = "3.0.0"
-
     class Pinecone:
         def __init__(self, api_key: str) -> None:
-            pass
+            self.api_key = api_key
 
-        class Index:
-            def __init__(self, index_name: str) -> None:
-                pass
-
-
-class MockUnVersionedPineconeRelease:
-    @staticmethod
-    def init(api_key: str, environment: str) -> None:
-        pass
+        def Index(self, index_name: str) -> "MockPineconeServerless.Index":
+            return MockPineconeServerless.Index(index_name)
 
     class Index:
         def __init__(self, index_name: str) -> None:
-            pass
-
-
-def get_version_attr_from_mock_classes(mock_class: Type[Any]) -> str:
-    if not hasattr(mock_class, "__version__"):
-        raise AttributeError(
-            "The version of pinecone you are using does not contain necessary __version__ attribute."
-        )
-    return mock_class.__version__
-
-
-def make_mock_import(pods_version: bool) -> Callable:
-    def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
-        if name == "pinecone":
-            return MockPineconePods if pods_version else MockPineconeServerless
-        # type: ignore[named-defined]
-        return original_import(name, *args, **kwargs)
-
-    return mock_import
+            self.index_name = index_name
 
 
 class TestPineconeVectorStore(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.pods_version = False
-        global original_import  # type: ignore[name-defined]
-        original_import = builtins.__import__
-
-    def tearDown(self) -> None:
-        builtins.__import__ = original_import
-
-    def test_pods_version(self) -> None:
-        self.pods_version = True
-        mock_import_with_context = make_mock_import(self.pods_version)
-        with patch("builtins.__import__", side_effect=mock_import_with_context):
-            mocked_version = get_version_attr_from_mock_classes(MockPineconePods)
-            assert mocked_version == "2.2.4"
-            store = PineconeVectorStore(
-                api_key="dummy_key", index_name="dummy_index", environment="dummy_env"
-            )
-
-    def test_serverless_version(self) -> None:
-        self.pods_version = False
-        mock_import_with_context = make_mock_import(self.pods_version)
-        with patch("builtins.__import__", side_effect=mock_import_with_context):
-            mock_version = get_version_attr_from_mock_classes(MockPineconeServerless)
-            assert mock_version == "3.0.0"
-            store = PineconeVectorStore(api_key="dummy_key", index_name="dummy_index")
-
-    def test_unversioned_pinecone_client(self) -> None:
-        with pytest.raises(
-            AttributeError,
-            match="The version of pinecone you are using does not contain necessary __version__ attribute.",
+    def test_with_pod_based_true(self) -> None:
+        # Testing with pod-based configuration
+        with patch(
+            "llama_index.vector_stores.pinecone.PineconeVectorStore._initialize_pinecone_client",
+            return_value=MockPineconePods.Index("dummy_index"),
         ):
-            get_version_attr_from_mock_classes(MockUnVersionedPineconeRelease)
+            store = PineconeVectorStore(
+                api_key="dummy_key",
+                index_name="dummy_index",
+                environment="dummy_env",
+                use_pod_based=True,
+            )
+            self.assertIsInstance(store._pinecone_index, MockPineconePods.Index)
 
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_with_pod_based_false(self) -> None:
+        # Testing with serverless configuration
+        with patch(
+            "llama_index.vector_stores.pinecone.PineconeVectorStore._initialize_pinecone_client",
+            return_value=MockPineconeServerless.Pinecone("dummy_key").Index(
+                "dummy_index"
+            ),
+        ):
+            store = PineconeVectorStore(
+                api_key="dummy_key", index_name="dummy_index", use_pod_based=False
+            )
+            self.assertIsInstance(store._pinecone_index, MockPineconeServerless.Index)

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -1,0 +1,62 @@
+import builtins
+import unittest
+from typing import Any, Callable
+from unittest.mock import patch
+
+from llama_index.vector_stores.pinecone import (
+    PineconeVectorStore,  # Replace with the actual import
+)
+
+
+class MockPineconePods:
+    version = "2.9.9"
+
+    @staticmethod
+    def init(api_key: str, environment: str) -> None:
+        pass
+
+    class Index:
+        def __init__(self, index_name: str) -> None:
+            pass
+
+
+class MockPineconeServerless:
+    version = "3.0.0"
+
+    class Pinecone:
+        def __init__(self, api_key: str) -> None:
+            pass
+
+        class Index:
+            def __init__(self, index_name: str) -> None:
+                pass
+
+
+# Define the mock import function
+def mock_import(name: str, *args: Any, **kwargs: Any) -> Callable:
+    if name == "pinecone":
+        return MockPineconePods if pods_version else MockPineconeServerless  # type: ignore[name-defined]
+    return original_import(name, *args, **kwargs)  # type: ignore[name-defined]
+
+
+class TestPineconeVectorStore(unittest.TestCase):
+    def setUp(self) -> None:
+        global original_import
+        original_import = builtins.__import__  # type: ignore[name-defined]
+
+    def tearDown(self) -> None:
+        builtins.__import__ = original_import  # type: ignore[name-defined]
+
+    def test_pods_version(self) -> None:
+        global pods_version
+        pods_version = True  # type: ignore[name-defined]
+        with patch("builtins.__import__", side_effect=mock_import):
+            store = PineconeVectorStore(
+                api_key="dummy_key", index_name="dummy_index", environment="dummy_env"
+            )
+
+    def test_serverless_version(self) -> None:
+        global pods_version
+        pods_version = False  # type: ignore[name-defined]
+        with patch("builtins.__import__", side_effect=mock_import):
+            store = PineconeVectorStore(api_key="dummy_key", index_name="dummy_index")

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
 from llama_index.vector_stores.pinecone import PineconeVectorStore
 
 
@@ -50,14 +51,59 @@ class TestPineconeVectorStore(unittest.TestCase):
             self.assertIsInstance(store._pinecone_index, MockPineconePods.Index)
 
     def test_with_pod_based_false(self) -> None:
-        # Testing with serverless configuration
+        # Testing with serverless configuration (False is default, so no need to pass param)
         with patch(
             "llama_index.vector_stores.pinecone.PineconeVectorStore._initialize_pinecone_client",
             return_value=MockPineconeServerless.Pinecone("dummy_key").Index(
                 "dummy_index"
             ),
         ):
+            store = PineconeVectorStore(api_key="dummy_key", index_name="dummy_index")
+            self.assertIsInstance(store._pinecone_index, MockPineconeServerless.Index)
+
+    def test_str_value_for_pinecone_index_param_does_not_match_str_value_for_index_name_param(
+        self,
+    ) -> None:
+        str_pinecone_index = "some-string-representing-an-existing-pinecone-index"
+        with patch(
+            "llama_index.vector_stores.pinecone.PineconeVectorStore._initialize_pinecone_client",
+            return_value=MockPineconeServerless.Pinecone("dummy_key").Index(
+                "dummy_index"
+            ),
+        ):  # MockPineconeServerless vs MockPineconePods is arbitrary for this test
+            with pytest.raises(ValueError) as e:
+                store = PineconeVectorStore(
+                    pinecone_index=str_pinecone_index,
+                    api_key="dummy_key",
+                    index_name="dummy_index",
+                    use_pod_based=False,
+                )
+                assert (
+                    e.value.message
+                    == "The string value for `pinecone_index` must match the string value for `index_name`."
+                )
+
+    def test_str_value_for_pinecone_index_param_gets_transformed_into_index_obj(
+        self,
+    ) -> None:
+        str_pinecone_index = "some-string-representing-an-existing-pinecone-index"
+        with patch(
+            "llama_index.vector_stores.pinecone.PineconeVectorStore._initialize_pinecone_client",
+            return_value=MockPineconeServerless.Pinecone("dummy_key").Index(
+                str_pinecone_index
+            ),
+        ):  # MockPineconeServerless vs MockPineconePods is arbitrary for this test
             store = PineconeVectorStore(
-                api_key="dummy_key", index_name="dummy_index", use_pod_based=False
+                pinecone_index=str_pinecone_index,
+                api_key="dummy_key",
+                index_name=str_pinecone_index,
             )
             self.assertIsInstance(store._pinecone_index, MockPineconeServerless.Index)
+
+    def test_pinecone_vector_store_without_passing_index_name(self) -> None:
+        with pytest.raises(ValueError) as e:
+            PineconeVectorStore()
+            assert (
+                e.value.message
+                == "index_name is required for Pinecone client initialization"
+            )


### PR DESCRIPTION
# Description

This branches off of this parallel PR https://github.com/aulorbe/llama_index/pull/3. 

While testing, we found a problem. In the definition of `_initialize_pinecone_client`, we call `init` on `pinecone` (2nd to last line):

```
@staticmethod
def _initialize_pinecone_client(
    api_key: Optional[str],
    index_name: Optional[str],
    environment: Optional[str],
    use_pod_based: Optional[bool],
    **kwargs: Any,
    ) -> Any:
      """Initialize Pinecone client based on version."""
      if not index_name:
          raise ValueError(
              "index_name is required for Pinecone client initialization"
          )
  
      import pinecone
  
      if not use_pod_based:
          pinecone_instance = pinecone.Pinecone(api_key=api_key)
          return pinecone_instance.Index(index_name)
  
      if not environment:
          raise ValueError(
              "environment is required for Pod-based Pinecone client usage"
          )
      pinecone.init(api_key=api_key, environment=environment)
      return pinecone.Index(index_name)
```

However, in versions of `pinecone` > `3.0.0`, regardless of whether it's an official version or a `dev` version, there is no `init` method. So, this current code fails.

It turns out, we need to go back to the bifurcation we had earlier, where we used `version` as an indicator of how to initialize the `pinecone` client.

The folx at Langchain came up with a great logic sequence that we can use to code against: 

>
**1. People using 2.x client:**
    - using pod will be unaffected using pinecone.Index interface
    - using serverless will get an error when they try to do anything
**2. People using 3.0.0.dev6:**
    - using pod will get an error (apparently not implemented yet)
    - using serverless will work using new pinecone.Pinecone() interface
**3. People using 3.0.0 (when released):**
    - will work for both pod and serverless using new pinecone.Pinecone() interface

I am also following their lead by simply not allowing users to pass in a `str` value for `pinecone_index`. Instead, we will go with this block (fitted for Llama):
```
if not isinstance(index, pinecone.Index):
            raise ValueError(
                f"client should be an instance of pinecone.Index, " f"got {type(index)}"
            )
```

****** ❗ NOTE: Unit tests are no longer working.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
