### PR TITLE
:bug: fixing batch size

### DIFF
--- a/llama_index/storage/kvstore/firestore_kvstore.py
+++ b/llama_index/storage/kvstore/firestore_kvstore.py
@@ -103,7 +103,7 @@ class FirestoreKVStore(BaseKVStore):
         self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
     ) -> None:
         batch = self._db.batch()
-        for i, (key, val) in enumerate(kv_pairs):
+        for i, (key, val) in enumerate(kv_pairs, start=1):
             collection_id = self.firestore_collection(collection)
             val = self.replace_field_name_set(val)
             batch.set(self._db.collection(collection_id).document(key), val, merge=True)

--- a/llama_index/storage/kvstore/firestore_kvstore.py
+++ b/llama_index/storage/kvstore/firestore_kvstore.py
@@ -122,7 +122,7 @@ class FirestoreKVStore(BaseKVStore):
             collection (str): collection name
         """
         batch = self._adb.batch()
-        for i, (key, val) in enumerate(kv_pairs):
+        for i, (key, val) in enumerate(kv_pairs, start=1):
             collection_id = self.firestore_collection(collection)
             doc = self._adb.collection(collection_id).document(key)
             val = self.replace_field_name_set(val)


### PR DESCRIPTION
# Description

Small error with the batch size `i % 500` needs to start from 1 for it to ensure the batch size isn't bigger than 500.

This only pertains to the firestore limitations.
