### PR TITLE
:sparkles: adding async support to the docstore

### DIFF
--- a/docs/module_guides/loading/node_parsers/modules.md
+++ b/docs/module_guides/loading/node_parsers/modules.md
@@ -132,7 +132,7 @@ A full example can be found [here in combination with the `MetadataReplacementNo
 
 ### TokenTextSplitter
 
-The `TokenTextSplitter` attempts to split text while respecting the boundaries of sentences.
+The `TokenTextSplitter` attempts to split to a consistent chunk size according to raw token counts.
 
 ```python
 from llama_index.text_splitter import TokenTextSplitter

--- a/llama_index/storage/docstore/keyval_docstore.py
+++ b/llama_index/storage/docstore/keyval_docstore.py
@@ -150,6 +150,91 @@ class KVDocumentStore(BaseDocumentStore):
                         node_key, metadata, collection=self._metadata_collection
                     )
 
+    async def aadd_documents(
+        self,
+        nodes: Sequence[BaseNode],
+        allow_update: bool = True,
+        batch_size: Optional[int] = None,
+        store_text: bool = True,
+    ) -> None:
+        """Add a document to the store.
+
+        Args:
+            docs (List[BaseDocument]): documents
+            allow_update (bool): allow update of docstore from document
+
+        """
+        batch_size = batch_size or self._batch_size
+        if batch_size > 1:
+            if store_text:
+                await self._kvstore.aput_all(
+                    [(node.node_id, doc_to_json(node)) for node in nodes],
+                    collection=self._node_collection,
+                )
+            ref_docs, metadatas = [], []
+            for node in nodes:
+                metadata = {"doc_hash": node.hash}
+                if isinstance(node, TextNode) and node.ref_doc_id is not None:
+                    ref_doc_info = (
+                        await self.aget_ref_doc_info(node.ref_doc_id) or RefDocInfo()
+                    )
+                    if node.node_id not in ref_doc_info.node_ids:
+                        ref_doc_info.node_ids.append(node.node_id)
+                    if not ref_doc_info.metadata:
+                        ref_doc_info.metadata = node.metadata or {}
+                    metadata["ref_doc_id"] = node.ref_doc_id
+                    ref_docs.append((node.node_id, ref_doc_info.to_dict()))
+                metadatas.append((node.node_id, metadata))
+            await self._kvstore.aput_all(
+                ref_docs,
+                collection=self._ref_doc_collection,
+            )
+            await self._kvstore.aput_all(
+                metadatas,
+                collection=self._metadata_collection,
+            )
+        else:
+            for node in nodes:
+                # NOTE: doc could already exist in the store, but we overwrite it
+                if not allow_update and await self.adocument_exists(node.node_id):
+                    raise ValueError(
+                        f"node_id {node.node_id} already exists. "
+                        "Set allow_update to True to overwrite."
+                    )
+                node_key = node.node_id
+                data = doc_to_json(node)
+
+                if store_text:
+                    await self._kvstore.aput(
+                        node_key, data, collection=self._node_collection
+                    )
+
+                # update doc_collection if needed
+                metadata = {"doc_hash": node.hash}
+                if isinstance(node, TextNode) and node.ref_doc_id is not None:
+                    ref_doc_info = (
+                        await self.aget_ref_doc_info(node.ref_doc_id) or RefDocInfo()
+                    )
+                    if node.node_id not in ref_doc_info.node_ids:
+                        ref_doc_info.node_ids.append(node.node_id)
+                    if not ref_doc_info.metadata:
+                        ref_doc_info.metadata = node.metadata or {}
+                    await self._kvstore.aput(
+                        node.ref_doc_id,
+                        ref_doc_info.to_dict(),
+                        collection=self._ref_doc_collection,
+                    )
+
+                    # update metadata with map
+                    metadata["ref_doc_id"] = node.ref_doc_id
+                    await self._kvstore.aput(
+                        node_key, metadata, collection=self._metadata_collection
+                    )
+                else:
+                    await self._kvstore.aput(
+                        node_key, metadata, collection=self._metadata_collection
+                    )
+
     def get_document(self, doc_id: str, raise_error: bool = True) -> Optional[BaseNode]:
         """Get a document from the store.
 
@@ -166,9 +251,45 @@ class KVDocumentStore(BaseDocumentStore):
                 return None
         return json_to_doc(json)
 
+    async def aget_document(
+        self, doc_id: str, raise_error: bool = True
+    ) -> Optional[BaseNode]:
+        """Get a document from the store.
+
+        Args:
+            doc_id (str): document id
+            raise_error (bool): raise error if doc_id not found
+
+        """
+        json = await self._kvstore.aget(doc_id, collection=self._node_collection)
+        if json is None:
+            if raise_error:
+                raise ValueError(f"doc_id {doc_id} not found.")
+            else:
+                return None
+        return json_to_doc(json)
+
     def get_ref_doc_info(self, ref_doc_id: str) -> Optional[RefDocInfo]:
         """Get the RefDocInfo for a given ref_doc_id."""
         ref_doc_info = self._kvstore.get(
+            ref_doc_id, collection=self._ref_doc_collection
+        )
+        if not ref_doc_info:
+            return None
+
+        # TODO: deprecated legacy support
+        if "doc_ids" in ref_doc_info:
+            ref_doc_info["node_ids"] = ref_doc_info.get("doc_ids", [])
+            ref_doc_info.pop("doc_ids")
+
+            ref_doc_info["metadata"] = ref_doc_info.get("extra_info", {})
+            ref_doc_info.pop("extra_info")
+
+        return RefDocInfo(**ref_doc_info)
+
+    async def aget_ref_doc_info(self, ref_doc_id: str) -> Optional[RefDocInfo]:
+        """Get the RefDocInfo for a given ref_doc_id."""
+        ref_doc_info = await self._kvstore.aget(
             ref_doc_id, collection=self._ref_doc_collection
         )
         if not ref_doc_info:
@@ -203,13 +324,42 @@ class KVDocumentStore(BaseDocumentStore):
 
         return all_ref_doc_infos
 
+    async def aget_all_ref_doc_info(self) -> Optional[Dict[str, RefDocInfo]]:
+        """Get a mapping of ref_doc_id -> RefDocInfo for all ingested documents."""
+        ref_doc_infos = await self._kvstore.aget_all(
+            collection=self._ref_doc_collection
+        )
+        if ref_doc_infos is None:
+            return None
+
+        # TODO: deprecated legacy support
+        all_ref_doc_infos = {}
+        for doc_id, ref_doc_info in ref_doc_infos.items():
+            if "doc_ids" in ref_doc_info:
+                ref_doc_info["node_ids"] = ref_doc_info.get("doc_ids", [])
+                ref_doc_info.pop("doc_ids")
+
+                ref_doc_info["metadata"] = ref_doc_info.get("extra_info", {})
+                ref_doc_info.pop("extra_info")
+                all_ref_doc_infos[doc_id] = RefDocInfo(**ref_doc_info)
+
+        return all_ref_doc_infos
+
     def ref_doc_exists(self, ref_doc_id: str) -> bool:
         """Check if a ref_doc_id has been ingested."""
         return self.get_ref_doc_info(ref_doc_id) is not None
 
+    async def aref_doc_exists(self, ref_doc_id: str) -> bool:
+        """Check if a ref_doc_id has been ingested."""
+        return await self.aget_ref_doc_info(ref_doc_id) is not None
+
     def document_exists(self, doc_id: str) -> bool:
         """Check if document exists."""
         return self._kvstore.get(doc_id, self._node_collection) is not None
+
+    async def adocument_exists(self, doc_id: str) -> bool:
+        """Check if document exists."""
+        return await self._kvstore.aget(doc_id, self._node_collection) is not None
 
     def _remove_ref_doc_node(self, doc_id: str) -> None:
         """Helper function to remove node doc_id from ref_doc_collection."""
@@ -241,6 +391,40 @@ class KVDocumentStore(BaseDocumentStore):
 
             self._kvstore.delete(ref_doc_id, collection=self._metadata_collection)
 
+    async def _aremove_ref_doc_node(self, doc_id: str) -> None:
+        """Helper function to remove node doc_id from ref_doc_collection."""
+        metadata = await self._kvstore.aget(
+            doc_id, collection=self._metadata_collection
+        )
+        if metadata is None:
+            return
+
+        ref_doc_id = metadata.get("ref_doc_id", None)
+
+        if ref_doc_id is None:
+            return
+
+        ref_doc_info = await self._kvstore.aget(
+            ref_doc_id, collection=self._ref_doc_collection
+        )
+
+        if ref_doc_info is not None:
+            ref_doc_obj = RefDocInfo(**ref_doc_info)
+
+            ref_doc_obj.node_ids.remove(doc_id)
+
+            # delete ref_doc from collection if it has no more doc_ids
+            if len(ref_doc_obj.node_ids) > 0:
+                await self._kvstore.aput(
+                    ref_doc_id,
+                    ref_doc_obj.to_dict(),
+                    collection=self._ref_doc_collection,
+                )
+
+            await self._kvstore.adelete(
+                ref_doc_id, collection=self._metadata_collection
+            )
+
     def delete_document(
         self, doc_id: str, raise_error: bool = True, remove_ref_doc_node: bool = True
     ) -> None:
@@ -250,6 +434,21 @@ class KVDocumentStore(BaseDocumentStore):
 
         delete_success = self._kvstore.delete(doc_id, collection=self._node_collection)
         _ = self._kvstore.delete(doc_id, collection=self._metadata_collection)
+
+        if not delete_success and raise_error:
+            raise ValueError(f"doc_id {doc_id} not found.")
+
+    async def adelete_document(
+        self, doc_id: str, raise_error: bool = True, remove_ref_doc_node: bool = True
+    ) -> None:
+        """Delete a document from the store."""
+        if remove_ref_doc_node:
+            await self._aremove_ref_doc_node(doc_id)
+
+        delete_success = await self._kvstore.adelete(
+            doc_id, collection=self._node_collection
+        )
+        _ = await self._kvstore.adelete(doc_id, collection=self._metadata_collection)
 
         if not delete_success and raise_error:
             raise ValueError(f"doc_id {doc_id} not found.")
@@ -269,14 +468,46 @@ class KVDocumentStore(BaseDocumentStore):
         self._kvstore.delete(ref_doc_id, collection=self._metadata_collection)
         self._kvstore.delete(ref_doc_id, collection=self._ref_doc_collection)
 
+    async def adelete_ref_doc(self, ref_doc_id: str, raise_error: bool = True) -> None:
+        """Delete a ref_doc and all it's associated nodes."""
+        ref_doc_info = await self.aget_ref_doc_info(ref_doc_id)
+        if ref_doc_info is None:
+            if raise_error:
+                raise ValueError(f"ref_doc_id {ref_doc_id} not found.")
+            else:
+                return
+
+        for doc_id in ref_doc_info.node_ids:
+            await self.adelete_document(
+                doc_id, raise_error=False, remove_ref_doc_node=False
+            )
+
+        await self._kvstore.adelete(ref_doc_id, collection=self._metadata_collection)
+        await self._kvstore.adelete(ref_doc_id, collection=self._ref_doc_collection)
+
     def set_document_hash(self, doc_id: str, doc_hash: str) -> None:
         """Set the hash for a given doc_id."""
         metadata = {"doc_hash": doc_hash}
         self._kvstore.put(doc_id, metadata, collection=self._metadata_collection)
 
+    async def aset_document_hash(self, doc_id: str, doc_hash: str) -> None:
+        """Set the hash for a given doc_id."""
+        metadata = {"doc_hash": doc_hash}
+        await self._kvstore.aput(doc_id, metadata, collection=self._metadata_collection)
+
     def get_document_hash(self, doc_id: str) -> Optional[str]:
         """Get the stored hash for a document, if it exists."""
         metadata = self._kvstore.get(doc_id, collection=self._metadata_collection)
+        if metadata is not None:
+            return metadata.get("doc_hash", None)
+        else:
+            return None
+
+    async def aget_document_hash(self, doc_id: str) -> Optional[str]:
+        """Get the stored hash for a document, if it exists."""
+        metadata = await self._kvstore.aget(
+            doc_id, collection=self._metadata_collection
+        )
         if metadata is not None:
             return metadata.get("doc_hash", None)
         else:
@@ -287,6 +518,17 @@ class KVDocumentStore(BaseDocumentStore):
         hashes = {}
         for doc_id in self._kvstore.get_all(collection=self._metadata_collection):
             hash = self.get_document_hash(doc_id)
+            if hash is not None:
+                hashes[hash] = doc_id
+        return hashes
+
+    async def aget_all_document_hashes(self) -> Dict[str, str]:
+        """Get the stored hash for all documents."""
+        hashes = {}
+        for doc_id in await self._kvstore.aget_all(
+            collection=self._metadata_collection
+        ):
+            hash = await self.aget_document_hash(doc_id)
             if hash is not None:
                 hashes[hash] = doc_id
         return hashes

--- a/llama_index/storage/docstore/types.py
+++ b/llama_index/storage/docstore/types.py
@@ -7,11 +7,11 @@ import fsspec
 from dataclasses_json import DataClassJsonMixin
 
 from llama_index.schema import BaseNode
+from llama_index.storage.kvstore.types import DEFAULT_BATCH_SIZE
 
 DEFAULT_PERSIST_FNAME = "docstore.json"
 DEFAULT_PERSIST_DIR = "./storage"
 DEFAULT_PERSIST_PATH = os.path.join(DEFAULT_PERSIST_DIR, DEFAULT_PERSIST_FNAME)
-DEFAULT_BATCH_SIZE = 1
 
 
 @dataclass
@@ -48,7 +48,7 @@ class BaseDocumentStore(ABC):
         ...
 
     @abstractmethod
-    async def aadd_documents(
+    async def async_add_documents(
         self,
         docs: Sequence[BaseNode],
         allow_update: bool = True,

--- a/llama_index/storage/docstore/types.py
+++ b/llama_index/storage/docstore/types.py
@@ -48,7 +48,23 @@ class BaseDocumentStore(ABC):
         ...
 
     @abstractmethod
+    async def aadd_documents(
+        self,
+        docs: Sequence[BaseNode],
+        allow_update: bool = True,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        store_text: bool = True,
+    ) -> None:
+        ...
+
+    @abstractmethod
     def get_document(self, doc_id: str, raise_error: bool = True) -> Optional[BaseNode]:
+        ...
+
+    @abstractmethod
+    async def aget_document(
+        self, doc_id: str, raise_error: bool = True
+    ) -> Optional[BaseNode]:
         ...
 
     @abstractmethod
@@ -57,7 +73,16 @@ class BaseDocumentStore(ABC):
         ...
 
     @abstractmethod
+    async def adelete_document(self, doc_id: str, raise_error: bool = True) -> None:
+        """Delete a document from the store."""
+        ...
+
+    @abstractmethod
     def document_exists(self, doc_id: str) -> bool:
+        ...
+
+    @abstractmethod
+    async def adocument_exists(self, doc_id: str) -> bool:
         ...
 
     # ===== Hash =====
@@ -66,11 +91,23 @@ class BaseDocumentStore(ABC):
         ...
 
     @abstractmethod
+    async def aset_document_hash(self, doc_id: str, doc_hash: str) -> None:
+        ...
+
+    @abstractmethod
     def get_document_hash(self, doc_id: str) -> Optional[str]:
         ...
 
     @abstractmethod
+    async def aget_document_hash(self, doc_id: str) -> Optional[str]:
+        ...
+
+    @abstractmethod
     def get_all_document_hashes(self) -> Dict[str, str]:
+        ...
+
+    @abstractmethod
+    async def aget_all_document_hashes(self) -> Dict[str, str]:
         ...
 
     # ==== Ref Docs =====
@@ -79,11 +116,23 @@ class BaseDocumentStore(ABC):
         """Get a mapping of ref_doc_id -> RefDocInfo for all ingested documents."""
 
     @abstractmethod
+    async def aget_all_ref_doc_info(self) -> Optional[Dict[str, RefDocInfo]]:
+        """Get a mapping of ref_doc_id -> RefDocInfo for all ingested documents."""
+
+    @abstractmethod
     def get_ref_doc_info(self, ref_doc_id: str) -> Optional[RefDocInfo]:
         """Get the RefDocInfo for a given ref_doc_id."""
 
     @abstractmethod
+    async def aget_ref_doc_info(self, ref_doc_id: str) -> Optional[RefDocInfo]:
+        """Get the RefDocInfo for a given ref_doc_id."""
+
+    @abstractmethod
     def delete_ref_doc(self, ref_doc_id: str, raise_error: bool = True) -> None:
+        """Delete a ref_doc and all it's associated nodes."""
+
+    @abstractmethod
+    async def adelete_ref_doc(self, ref_doc_id: str, raise_error: bool = True) -> None:
         """Delete a ref_doc and all it's associated nodes."""
 
     # ===== Nodes =====
@@ -99,6 +148,21 @@ class BaseDocumentStore(ABC):
         """
         return [self.get_node(node_id, raise_error=raise_error) for node_id in node_ids]
 
+    async def aget_nodes(
+        self, node_ids: List[str], raise_error: bool = True
+    ) -> List[BaseNode]:
+        """Get nodes from docstore.
+
+        Args:
+            node_ids (List[str]): node ids
+            raise_error (bool): raise error if node_id not found
+
+        """
+        return [
+            await self.aget_node(node_id, raise_error=raise_error)
+            for node_id in node_ids
+        ]
+
     def get_node(self, node_id: str, raise_error: bool = True) -> BaseNode:
         """Get node from docstore.
 
@@ -112,6 +176,19 @@ class BaseDocumentStore(ABC):
             raise ValueError(f"Document {node_id} is not a Node.")
         return doc
 
+    async def aget_node(self, node_id: str, raise_error: bool = True) -> BaseNode:
+        """Get node from docstore.
+
+        Args:
+            node_id (str): node id
+            raise_error (bool): raise error if node_id not found
+
+        """
+        doc = await self.aget_document(node_id, raise_error=raise_error)
+        if not isinstance(doc, BaseNode):
+            raise ValueError(f"Document {node_id} is not a Node.")
+        return doc
+
     def get_node_dict(self, node_id_dict: Dict[int, str]) -> Dict[int, BaseNode]:
         """Get node dict from docstore given a mapping of index to node ids.
 
@@ -121,4 +198,16 @@ class BaseDocumentStore(ABC):
         """
         return {
             index: self.get_node(node_id) for index, node_id in node_id_dict.items()
+        }
+
+    async def aget_node_dict(self, node_id_dict: Dict[int, str]) -> Dict[int, BaseNode]:
+        """Get node dict from docstore given a mapping of index to node ids.
+
+        Args:
+            node_id_dict (Dict[int, str]): mapping of index to node ids
+
+        """
+        return {
+            index: await self.aget_node(node_id)
+            for index, node_id in node_id_dict.items()
         }

--- a/llama_index/storage/kvstore/dynamodb_kvstore.py
+++ b/llama_index/storage/kvstore/dynamodb_kvstore.py
@@ -128,22 +128,6 @@ class DynamoDBKVStore(BaseKVStore):
         """
         raise NotImplementedError
 
-    def put_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
-    ) -> None:
-        raise NotImplementedError
-
-    async def aput_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
-    ) -> None:
-        """Put a dictionary of key-value pairs into the store.
-
-        Args:
-            kv_pairs (List[Tuple[str, dict]]): key-value pairs
-            collection (str): collection name
-        """
-        raise NotImplementedError
-
     def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> dict | None:
         """Get a value from the store.
 

--- a/llama_index/storage/kvstore/firestore_kvstore.py
+++ b/llama_index/storage/kvstore/firestore_kvstore.py
@@ -1,6 +1,10 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseKVStore
+from llama_index.storage.kvstore.types import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_COLLECTION,
+    BaseKVStore,
+)
 
 # keyword "_" is reserved in Firestore but referred in llama_index/constants.py.
 FIELD_NAME_REPLACE_SET = {"__data__": "data", "__type__": "type"}
@@ -100,20 +104,26 @@ class FirestoreKVStore(BaseKVStore):
         await doc.set(val, merge=True)
 
     def put_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
+        self,
+        kv_pairs: List[Tuple[str, dict]],
+        collection: str = DEFAULT_COLLECTION,
+        batch_size: int = DEFAULT_BATCH_SIZE,
     ) -> None:
         batch = self._db.batch()
         for i, (key, val) in enumerate(kv_pairs):
             collection_id = self.firestore_collection(collection)
             val = self.replace_field_name_set(val)
             batch.set(self._db.collection(collection_id).document(key), val, merge=True)
-            if i % 500 == 0:
+            if i % batch_size == 0:
                 batch.commit()
                 batch = self._db.batch()
         batch.commit()
 
     async def aput_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
+        self,
+        kv_pairs: List[Tuple[str, dict]],
+        collection: str = DEFAULT_COLLECTION,
+        batch_size: int = DEFAULT_BATCH_SIZE,
     ) -> None:
         """Put a dictionary of key-value pairs into the Firestore collection.
 
@@ -127,7 +137,7 @@ class FirestoreKVStore(BaseKVStore):
             doc = self._adb.collection(collection_id).document(key)
             val = self.replace_field_name_set(val)
             batch.set(doc, val, merge=True)
-            if i % 500 == 0:
+            if i % batch_size == 0:
                 await batch.commit()
                 batch = self._adb.batch()
         await batch.commit()

--- a/llama_index/storage/kvstore/mongodb_kvstore.py
+++ b/llama_index/storage/kvstore/mongodb_kvstore.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, Optional, cast
 
 from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseKVStore
 
@@ -126,30 +126,6 @@ class MongoDBKVStore(BaseKVStore):
         Args:
             key (str): key
             val (dict): value
-            collection (str): collection name
-
-        """
-        raise NotImplementedError
-
-    def put_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
-    ) -> None:
-        """Put a dictionary of key-value pairs into the store.
-
-        Args:
-            kv_pairs (List[Tuple[str, dict]]): key-value pairs
-            collection (str): collection name
-
-        """
-        raise NotImplementedError
-
-    async def aput_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
-    ) -> None:
-        """Put a dictionary of key-value pairs into the store.
-
-        Args:
-            kv_pairs (List[Tuple[str, dict]]): key-value pairs
             collection (str): collection name
 
         """

--- a/llama_index/storage/kvstore/s3_kvstore.py
+++ b/llama_index/storage/kvstore/s3_kvstore.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import PurePath
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseKVStore
 
@@ -92,34 +92,6 @@ class S3DBKVStore(BaseKVStore):
         Args:
             key (str): key
             val (dict): value
-            collection (str): collection name
-
-        """
-        raise NotImplementedError
-
-    def put_all(
-        self,
-        kv_pairs: List[Tuple[str, dict]],
-        collection: str = DEFAULT_COLLECTION,
-    ) -> None:
-        """Put a dictionary of key-value pairs into the store.
-
-        Args:
-            kv_pairs (List[Tuple[str, dict]]): key-value pairs
-            collection (str): collection name
-
-        """
-        raise NotImplementedError
-
-    async def aput_all(
-        self,
-        kv_pairs: List[Tuple[str, dict]],
-        collection: str = DEFAULT_COLLECTION,
-    ) -> None:
-        """Put a dictionary of key-value pairs into the store.
-
-        Args:
-            kv_pairs (List[Tuple[str, dict]]): key-value pairs
             collection (str): collection name
 
         """

--- a/llama_index/storage/kvstore/simple_kvstore.py
+++ b/llama_index/storage/kvstore/simple_kvstore.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional
 
 import fsspec
 
@@ -37,19 +37,6 @@ class SimpleKVStore(BaseInMemoryKVStore):
     ) -> None:
         """Put a key-value pair into the store."""
         self.put(key, val, collection)
-
-    def put_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
-    ) -> None:
-        """Put a dictionary of key-value pairs into the store."""
-        for key, val in kv_pairs:
-            self.put(key, val, collection)
-
-    async def aput_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
-    ) -> None:
-        """Put a dictionary of key-value pairs into the store."""
-        self.put_all(kv_pairs, collection)
 
     def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:
         """Get a value from the store."""

--- a/llama_index/storage/kvstore/types.py
+++ b/llama_index/storage/kvstore/types.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Tuple
 import fsspec
 
 DEFAULT_COLLECTION = "data"
+DEFAULT_BATCH_SIZE = 1
 
 
 class BaseKVStore(ABC):
@@ -19,17 +20,31 @@ class BaseKVStore(ABC):
     ) -> None:
         pass
 
-    @abstractmethod
     def put_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
+        self,
+        kv_pairs: List[Tuple[str, dict]],
+        collection: str = DEFAULT_COLLECTION,
+        batch_size: int = DEFAULT_BATCH_SIZE,
     ) -> None:
-        pass
+        # by default, support a batch size of 1
+        if batch_size != 1:
+            raise NotImplementedError("Batching not supported by this key-value store.")
+        else:
+            for key, val in kv_pairs:
+                self.put(key, val, collection=collection)
 
-    @abstractmethod
     async def aput_all(
-        self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION
+        self,
+        kv_pairs: List[Tuple[str, dict]],
+        collection: str = DEFAULT_COLLECTION,
+        batch_size: int = DEFAULT_BATCH_SIZE,
     ) -> None:
-        pass
+        # by default, support a batch size of 1
+        if batch_size != 1:
+            raise NotImplementedError("Batching not supported by this key-value store.")
+        else:
+            for key, val in kv_pairs:
+                await self.aput(key, val, collection=collection)
 
     @abstractmethod
     def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:

--- a/tests/agent/openai/test_openai_agent.py
+++ b/tests/agent/openai/test_openai_agent.py
@@ -34,6 +34,7 @@ def mock_chat_completion(*args: Any, **kwargs: Any) -> ChatCompletion:
                 ),
                 finish_reason="stop",
                 index=0,
+                logprobs=None,
             )
         ],
     )
@@ -63,6 +64,7 @@ def mock_chat_stream(
                     role="assistant",
                     content="\n\nThis is a test!",
                 ),
+                logprobs=None,
             )
         ],
     )
@@ -99,6 +101,7 @@ async def mock_achat_stream(
                         role="assistant",
                         content="\n\nThis is a test!",
                     ),
+                    logprobs=None,
                 )
             ],
         )

--- a/tests/storage/docstore/test_firestore_docstore.py
+++ b/tests/storage/docstore/test_firestore_docstore.py
@@ -58,8 +58,11 @@ def test_firestore_docstore(
     assert all(isinstance(doc, BaseNode) for doc in ds.docs.values())
 
 
+@pytest.mark.asyncio()
 @pytest.mark.skipif(firestore is None, reason="firestore not installed")
-def test_firestore_docstore_hash(firestore_docstore: FirestoreDocumentStore) -> None:
+async def test_firestore_docstore_hash(
+    firestore_docstore: FirestoreDocumentStore,
+) -> None:
     ds = firestore_docstore
 
     # Test setting hash
@@ -67,9 +70,19 @@ def test_firestore_docstore_hash(firestore_docstore: FirestoreDocumentStore) -> 
     doc_hash = ds.get_document_hash("test_doc_id")
     assert doc_hash == "test_doc_hash"
 
+    # Test setting hash (async)
+    await ds.aset_document_hash("test_doc_id", "test_doc_hash")
+    doc_hash = await ds.aget_document_hash("test_doc_id")
+    assert doc_hash == "test_doc_hash"
+
     # Test updating hash
     ds.set_document_hash("test_doc_id", "test_doc_hash_new")
     doc_hash = ds.get_document_hash("test_doc_id")
+    assert doc_hash == "test_doc_hash_new"
+
+    # Test updating hash (async)
+    await ds.aset_document_hash("test_doc_id", "test_doc_hash_new")
+    doc_hash = await ds.aget_document_hash("test_doc_id")
     assert doc_hash == "test_doc_hash_new"
 
     # Test getting non-existent


### PR DESCRIPTION
# Description

Building on the async support with the KVStore, adding some async support to the docstore.

Its not as clean as the KVStore as there are a lot more methods on the docstore. 

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
