### PR TITLE
Fix: `language` used before assignment in `CodeSplitter`

### DIFF
--- a/llama_index/node_parser/text/code.py
+++ b/llama_index/node_parser/text/code.py
@@ -67,7 +67,7 @@ class CodeSplitter(TextSplitter):
                 )
             except Exception:
                 print(
-                    f"Could not get parser for language {self.language}. Check "
+                    f"Could not get parser for language {language}. Check "
                     "https://github.com/grantjenks/py-tree-sitter-languages#license "
                     "for a list of valid languages."
                 )


### PR DESCRIPTION
# Description

As [commented](https://github.com/run-llama/llama_index/pull/9845#issuecomment-1886124362) by @j-yclin there was an edge case bug introduced in #9845.

This patch aims to fix that.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
