### PR TITLE
Implement mongodb kvstore put all method

### DIFF
--- a/llama_index/storage/kvstore/mongodb_kvstore.py
+++ b/llama_index/storage/kvstore/mongodb_kvstore.py
@@ -1,6 +1,10 @@
-from typing import Any, Dict, List, Optional, cast, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
-from llama_index.storage.kvstore.types import DEFAULT_BATCH_SIZE, DEFAULT_COLLECTION, BaseKVStore
+from llama_index.storage.kvstore.types import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_COLLECTION,
+    BaseKVStore,
+)
 
 IMPORT_ERROR_MSG = "`pymongo` package not found, please run `pip install pymongo`"
 
@@ -130,12 +134,20 @@ class MongoDBKVStore(BaseKVStore):
 
         """
         raise NotImplementedError
-    
-    def put_all(self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION, batch_size: int = DEFAULT_BATCH_SIZE) -> None:
+
+    def put_all(
+        self,
+        kv_pairs: List[Tuple[str, dict]],
+        collection: str = DEFAULT_COLLECTION,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
         # Prepare documents with '_id' set to the key for batch insertion
-        docs = [{'_id': key, **value} for key, value in kv_pairs]
+
+        docs = [{"_id": key, **value} for key, value in kv_pairs]
         # Insert documents in batches
-        for batch in (docs[i:i + batch_size] for i in range(0, len(docs), batch_size)):
+        for batch in (
+            docs[i : i + batch_size] for i in range(0, len(docs), batch_size)
+        ):
             self._db[collection].insert_many(batch)
 
     def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:

--- a/llama_index/storage/kvstore/mongodb_kvstore.py
+++ b/llama_index/storage/kvstore/mongodb_kvstore.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast, Tuple
 
-from llama_index.storage.kvstore.types import DEFAULT_COLLECTION, BaseKVStore
+from llama_index.storage.kvstore.types import DEFAULT_BATCH_SIZE, DEFAULT_COLLECTION, BaseKVStore
 
 IMPORT_ERROR_MSG = "`pymongo` package not found, please run `pip install pymongo`"
 
@@ -130,6 +130,13 @@ class MongoDBKVStore(BaseKVStore):
 
         """
         raise NotImplementedError
+    
+    def put_all(self, kv_pairs: List[Tuple[str, dict]], collection: str = DEFAULT_COLLECTION, batch_size: int = DEFAULT_BATCH_SIZE) -> None:
+        # Prepare documents with '_id' set to the key for batch insertion
+        docs = [{'_id': key, **value} for key, value in kv_pairs]
+        # Insert documents in batches
+        for batch in (docs[i:i + batch_size] for i in range(0, len(docs), batch_size)):
+            self._db[collection].insert_many(batch)
 
     def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:
         """Get a value from the store.


### PR DESCRIPTION
# Description

When I assign batch_size greater than 1 for MongoDBstore, it fails because put_all in MongoDBKVStore is not implemented. 

Fixes https://github.com/run-llama/llama_index/issues/9998

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
