### PR TITLE
Fix Cohere system prompt role. (#9881)

### DIFF
--- a/llama_index/chat_engine/condense_plus_context.py
+++ b/llama_index/chat_engine/condense_plus_context.py
@@ -209,7 +209,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             system_message_content = self._system_prompt + "\n" + system_message_content
 
         system_message = ChatMessage(
-            content=system_message_content, role=MessageRole.SYSTEM
+            content=system_message_content, role=self._llm.metadata.system_role
         )
 
         initial_token_count = self._token_counter.estimate_tokens_in_messages(
@@ -256,7 +256,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             system_message_content = self._system_prompt + "\n" + system_message_content
 
         system_message = ChatMessage(
-            content=system_message_content, role=MessageRole.SYSTEM
+            content=system_message_content, role=self._llm.metadata.system_role
         )
 
         initial_token_count = self._token_counter.estimate_tokens_in_messages(

--- a/llama_index/chat_engine/context.py
+++ b/llama_index/chat_engine/context.py
@@ -81,7 +81,7 @@ class ContextChatEngine(BaseChatEngine):
                     "Cannot specify both system_prompt and prefix_messages"
                 )
             prefix_messages = [
-                ChatMessage(content=system_prompt, role=MessageRole.SYSTEM)
+                ChatMessage(content=system_prompt, role=llm.metadata.system_role)
             ]
 
         prefix_messages = prefix_messages or []
@@ -138,7 +138,9 @@ class ContextChatEngine(BaseChatEngine):
 
         context_str_w_sys_prompt = system_prompt.strip() + "\n" + context_str
         return [
-            ChatMessage(content=context_str_w_sys_prompt, role=MessageRole.SYSTEM),
+            ChatMessage(
+                content=context_str_w_sys_prompt, role=self._llm.metadata.system_role
+            ),
             *prefix_messages,
         ]
 

--- a/llama_index/chat_engine/simple.py
+++ b/llama_index/chat_engine/simple.py
@@ -56,7 +56,9 @@ class SimpleChatEngine(BaseChatEngine):
                 raise ValueError(
                     "Cannot specify both system_prompt and prefix_messages"
                 )
-            prefix_messages = [ChatMessage(content=system_prompt, role="system")]
+            prefix_messages = [
+                ChatMessage(content=system_prompt, role=llm.metadata.system_role)
+            ]
 
         prefix_messages = prefix_messages or []
 

--- a/llama_index/core/llms/types.py
+++ b/llama_index/core/llms/types.py
@@ -13,6 +13,7 @@ class MessageRole(str, Enum):
     ASSISTANT = "assistant"
     FUNCTION = "function"
     TOOL = "tool"
+    CHATBOT = "chatbot"
 
 
 # ===== Generic Model Input - Chat =====
@@ -107,4 +108,9 @@ class LLMMetadata(BaseModel):
             " models this can be automatically discerned. For other models, like"
             " locally loaded models, this must be manually specified."
         ),
+    )
+    system_role: MessageRole = Field(
+        default=MessageRole.SYSTEM,
+        description="The role this specific LLM provider"
+        "expects for system prompt. E.g. 'SYSTEM' for OpenAI, 'CHATBOT' for Cohere",
     )

--- a/llama_index/llms/cohere.py
+++ b/llama_index/llms/cohere.py
@@ -99,6 +99,7 @@ class Cohere(LLM):
             num_output=self.max_tokens,
             is_chat_model=True,
             model_name=self.model,
+            system_role=MessageRole.CHATBOT,
         )
 
     @property


### PR DESCRIPTION
# Description
Cohere's system role in chat is now CHATBOT. This broke the chat engines. Fixed by making the system role value LLM specific using LLM metadata. 

Fixes # (issue)
#9881 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested manually.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods