### PR TITLE
Fixe ImageNode.resolve_img() for base64 image strings

### DIFF
--- a/llama_index/schema.py
+++ b/llama_index/schema.py
@@ -475,7 +475,9 @@ class ImageNode(TextNode):
     def resolve_image(self) -> ImageType:
         """Resolve an image such that PIL can read it."""
         if self.image is not None:
-            return self.image
+            import base64
+
+            return BytesIO(base64.b64decode(self.image))
         elif self.image_path is not None:
             return self.image_path
         elif self.image_url is not None:


### PR DESCRIPTION
# Description

Return a bytesIO object instead of raw string, so that pillow can open the iamge

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

