### PR TITLE
fix: use Answer: instead of Response: in ReAct agent

### DIFF
--- a/llama_index/agent/react/types.py
+++ b/llama_index/agent/react/types.py
@@ -66,10 +66,10 @@ class ResponseReasoningStep(BaseReasoningStep):
         if self.is_streaming:
             return (
                 f"Thought: {self.thought}\n"
-                f"Response (Starts With): {self.response} ..."
+                f"Answer (Starts With): {self.response} ..."
             )
         else:
-            return f"Thought: {self.thought}\n" f"Response: {self.response}"
+            return f"Thought: {self.thought}\n" f"Answer: {self.response}"
 
     @property
     def is_done(self) -> bool:


### PR DESCRIPTION
Signed-off-by: San Nguyen <vinhsannguyen91@gmail.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

When using verbose=True, the response from LLM in Step is logged, but not correctly following the ReAct agent format, which lead to confusion.

This PR will fix that

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
