### PR TITLE
fix: fixes typo in default token limit ratio

### DIFF
--- a/llama_index/memory/chat_memory_buffer.py
+++ b/llama_index/memory/chat_memory_buffer.py
@@ -9,7 +9,7 @@ from llama_index.memory.types import DEFAULT_CHAT_STORE_KEY, BaseMemory
 from llama_index.storage.chat_store import BaseChatStore, SimpleChatStore
 from llama_index.utils import get_tokenizer
 
-DEFUALT_TOKEN_LIMIT_RATIO = 0.75
+DEFAULT_TOKEN_LIMIT_RATIO = 0.75
 DEFAULT_TOKEN_LIMIT = 3000
 
 
@@ -57,7 +57,7 @@ class ChatMemoryBuffer(BaseMemory):
         """Create a chat memory buffer from an LLM."""
         if llm is not None:
             context_window = llm.metadata.context_window
-            token_limit = token_limit or int(context_window * DEFUALT_TOKEN_LIMIT_RATIO)
+            token_limit = token_limit or int(context_window * DEFAULT_TOKEN_LIMIT_RATIO)
         elif token_limit is None:
             token_limit = DEFAULT_TOKEN_LIMIT
 


### PR DESCRIPTION
# Description

Fixes a simple typo I found in the chat_memory_buffer file.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense