### PR TITLE
Changes mirroring langchain to allow for serverless open search

### DIFF
--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -74,6 +74,7 @@ def _bulk_ingest_embeddings(
     text_field: str = "content",
     mapping: Optional[Dict] = None,
     max_chunk_bytes: Optional[int] = 1 * 1024 * 1024,
+    is_aoss: bool = False
 ) -> List[str]:
     """Bulk Ingest Embeddings into given index."""
     if not mapping:
@@ -99,12 +100,16 @@ def _bulk_ingest_embeddings(
             vector_field: embeddings[i],
             text_field: text,
             "metadata": metadata,
-            "_id": _id,
         }
+        if is_aoss:
+            request["id"] = _id
+        else:
+            request["_id"] = _id
         requests.append(request)
         return_ids.append(_id)
     bulk(client, requests, max_chunk_bytes=max_chunk_bytes)
-    client.indices.refresh(index=index_name)
+    if not is_aoss:
+        client.indices.refresh(index=index_name)
     return return_ids
 
 
@@ -231,6 +236,17 @@ def _default_painless_scripting_query(
     }
 
 
+def _is_aoss_enabled(http_auth: Any) -> bool:
+    """Check if the service is http_auth is set as `aoss`."""
+    if (
+        http_auth is not None
+        and hasattr(http_auth, "service")
+        and http_auth.service == "aoss"
+    ):
+        return True
+    return False
+
+
 class OpensearchVectorClient:
     """Object encapsulating an Opensearch index that has vector search enabled.
 
@@ -285,6 +301,8 @@ class OpensearchVectorClient:
         self._max_chunk_bytes = max_chunk_bytes
 
         self._search_pipeline = search_pipeline
+        http_auth = kwargs.get("http_auth")
+        self.is_aoss = _is_aoss_enabled(http_auth=http_auth)
         # initialize mapping
         idx_conf = {
             "settings": {"index": {"knn": True, "knn.algo_param.ef_search": 100}},
@@ -329,6 +347,8 @@ class OpensearchVectorClient:
             text_field=self._text_field,
             mapping=None,
             max_chunk_bytes=self._max_chunk_bytes,
+            is_aoss=self.is_aoss
+
         )
 
     def delete_doc_id(self, doc_id: str) -> None:

--- a/llama_index/vector_stores/opensearch.py
+++ b/llama_index/vector_stores/opensearch.py
@@ -74,7 +74,7 @@ def _bulk_ingest_embeddings(
     text_field: str = "content",
     mapping: Optional[Dict] = None,
     max_chunk_bytes: Optional[int] = 1 * 1024 * 1024,
-    is_aoss: bool = False
+    is_aoss: bool = False,
 ) -> List[str]:
     """Bulk Ingest Embeddings into given index."""
     if not mapping:
@@ -347,8 +347,7 @@ class OpensearchVectorClient:
             text_field=self._text_field,
             mapping=None,
             max_chunk_bytes=self._max_chunk_bytes,
-            is_aoss=self.is_aoss
-
+            is_aoss=self.is_aoss,
         )
 
     def delete_doc_id(self, doc_id: str) -> None:


### PR DESCRIPTION
# Description

I was running into an issue trying to utilize the llama-index OpenSearch functionality with my newly provisioned OpenSearch Serverless DB on AWS. See #10042 

`'status': 400, 'error': {'type': 'illegal_argument_exception', 'reason': 'Document ID is not supported in create/index operation request'}`

I discovered that serverless has been made compatible in langchain by detecting whether serverless is being utilized and then:
1. Changing the `_id` key to `id`
2. Not running the refresh functionality on completion of node insertion

So this PR intends to simply mirror those changes

See:
- [Issue raised in opensearch-py library](https://github.com/opensearch-project/opensearch-py/issues/600)
- [Code in langchain library to detect with the serverless version of OpenSearch is being utilized](https://github.com/langchain-ai/langchain/blob/7b084b4cc768a8e5cddc29bfdfb6e5dc1003a5d9/libs/community/langchain_community/vectorstores/opensearch_vector_search.py#L83-L91)



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with the equivalent of the below - connecting to my OpenSearch serverless DB

```
from llama_index.vector_stores import (
    OpensearchVectorStore,
    OpensearchVectorClient,
)
from llama_index.schema import TextNode
client = OpensearchVectorClient(
            endpoint, idx, 1536, embedding_field=embedding_field, text_field=text_field,
            http_auth=auth, use_ssl=True, verify_certs=True, connection_class=RequestsHttpConnection
        )
vector_store = OpensearchVectorStore(client)
nodes = [Node(text='test')]
vector_store.add(nodes)
```

I would appreciate any feedback as to how to more effectively test / provide a set of instructions for maintainers to test

