### PR TITLE
add "to-scratch" tutorials for text-to-sql and text-to-pandas

### DIFF
--- a/docs/optimizing/building_rag_from_scratch.md
+++ b/docs/optimizing/building_rag_from_scratch.md
@@ -117,3 +117,18 @@ maxdepth: 1
 ---
 /examples/low_level/fusion_retriever.ipynb
 ```
+
+
+## Building QA over Structured Data from Scratch
+
+RAG as a framework is primarily focused on unstructured data. LlamaIndex also has out of the box support for structured data and semi-structured data as well.
+
+Take a look at our guides below to see how to build text-to-SQL and text-to-Pandas from scratch (using our Query Pipeline syntax).
+
+```{toctree}
+---
+maxdepth: 1
+---
+/examples/pipeline/query_pipeline_sql.ipynb
+/examples/pipeline/query_pipeline_pandas.ipynb
+```

--- a/docs/optimizing/building_rag_from_scratch.md
+++ b/docs/optimizing/building_rag_from_scratch.md
@@ -118,7 +118,6 @@ maxdepth: 1
 /examples/low_level/fusion_retriever.ipynb
 ```
 
-
 ## Building QA over Structured Data from Scratch
 
 RAG as a framework is primarily focused on unstructured data. LlamaIndex also has out of the box support for structured data and semi-structured data as well.


### PR DESCRIPTION
using query pipeline syntax