### PR TITLE
Fix a typo (avoiding the use of hardcoded constants) in recursive_retriever_nodes.ipynb

### DIFF
--- a/docs/examples/retrievers/recursive_retriever_nodes.ipynb
+++ b/docs/examples/retrievers/recursive_retriever_nodes.ipynb
@@ -1052,7 +1052,7 @@
     }
    ],
    "source": [
-    "base_retriever = base_index.as_retriever(similarity_top_k=10)\n",
+    "base_retriever = base_index.as_retriever(similarity_top_k=top_k)\n",
     "retriever_evaluator = RetrieverEvaluator.from_metric_names(\n",
     "    [\"mrr\", \"hit_rate\"], retriever=base_retriever\n",
     ")\n",


### PR DESCRIPTION
# Description
![image](https://github.com/run-llama/llama_index/assets/5459870/00c1faa1-fe8d-4591-8c48-6d1c37c520d4)

This PR fixes a typo by removing the use of hardcoded constants in `recursive_retriever_nodes.ipynb`.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
