### PR TITLE
Updated the Attribute name in llm_generators 

### DIFF
--- a/llama_index/question_gen/llm_generators.py
+++ b/llama_index/question_gen/llm_generators.py
@@ -60,7 +60,7 @@ class LLMQuestionGenerator(BaseQuestionGenerator):
             if output_parser is None:
                 output_parser = SubQuestionOutputParser()
             self._prompt = PromptTemplate(
-                prompts["question_gen_prompt"].template_str, output_parser=output_parser
+                prompts["question_gen_prompt"].template, output_parser=output_parser
             )
 
     def generate(


### PR DESCRIPTION
# Description

This PR updates the attribute name used in the function `_update_prompts`, the PromptTemplate class has no attribute `template_str` so changed it to `template` without changing the context. 

With the old code i was getting `AttributeError: 'PromptTemplate' object has no attribute 'template_str'` when trying to update the prompt in SubQuestionQueryEngine with LangchainLLM.

```
new_prompt_tmpl = PromptTemplate(
    new_prompt_tmpl_str
)

query_engine.update_prompts(
    {"question_gen:question_gen_prompt": new_prompt_tmpl}
)
```
Fixes # (issue)

## Type of Change

Please delete options that are not relevant,

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
