### PR TITLE
Setting event on exception raise to unlock waiting threads

### DIFF
--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -121,6 +121,9 @@ class StreamingAgentChatResponse:
 
         self._is_done = True
 
+        # This act as is_done events for any consumers waiting
+        self._is_function_not_none_thread_event.set()
+
     async def awrite_response_to_history(
         self,
         memory: BaseMemory,


### PR DESCRIPTION
# Description

This PR was motivated when adding a new feature in my app (default message when user's net is disconnected or OpenAI has down-time) and noted that the streaming feature blocked indefinitely in those situations.

- Sets event on exception within `StreamingAgentChatResponse` to allow consumers to continue and not block indefinitely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

You can emulate a net disconnection or OpenAI down time setting `max_retries=0` and `timeout=0` when instantiating a `OpenAI` or `AzureOpenAI` object.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
