### PR TITLE
Fix Qdrant Race Condition

### DIFF
--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -334,7 +334,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 )
         except ValueError as exc:
             if "already exists" not in str(exc):
-                raise exc
+                raise exc  # noqa: TRY201
             logger.warning(
                 "Collection %s already exists, skipping collection creation.",
                 collection_name,
@@ -371,7 +371,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 )
         except ValueError as exc:
             if "already exists" not in str(exc):
-                raise exc
+                raise exc  # noqa: TRY201
             logger.warning(
                 "Collection %s already exists, skipping collection creation.",
                 collection_name,

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -308,28 +308,36 @@ class QdrantVectorStore(BasePydanticVectorStore):
         """Create a Qdrant collection."""
         from qdrant_client.http import models as rest
 
-        if self.enable_hybrid:
-            self._client.create_collection(
-                collection_name=collection_name,
-                vectors_config={
-                    "text-dense": rest.VectorParams(
+        try:
+            if self.enable_hybrid:
+                self._client.create_collection(
+                    collection_name=collection_name,
+                    vectors_config={
+                        "text-dense": rest.VectorParams(
+                            size=vector_size,
+                            distance=rest.Distance.COSINE,
+                        )
+                    },
+                    sparse_vectors_config={
+                        "text-sparse": rest.SparseVectorParams(
+                            index=rest.SparseIndexParams()
+                        )
+                    },
+                )
+            else:
+                self._client.create_collection(
+                    collection_name=collection_name,
+                    vectors_config=rest.VectorParams(
                         size=vector_size,
                         distance=rest.Distance.COSINE,
-                    )
-                },
-                sparse_vectors_config={
-                    "text-sparse": rest.SparseVectorParams(
-                        index=rest.SparseIndexParams()
-                    )
-                },
-            )
-        else:
-            self._client.create_collection(
-                collection_name=collection_name,
-                vectors_config=rest.VectorParams(
-                    size=vector_size,
-                    distance=rest.Distance.COSINE,
-                ),
+                    ),
+                )
+        except ValueError as exc:
+            if "already exists" not in str(exc):
+                raise exc
+            logger.warning(
+                "Collection %s already exists, skipping collection creation.",
+                collection_name,
             )
         self._collection_initialized = True
 
@@ -337,28 +345,36 @@ class QdrantVectorStore(BasePydanticVectorStore):
         """Asynchronous method to create a Qdrant collection."""
         from qdrant_client.http import models as rest
 
-        if self.enable_hybrid:
-            await self._aclient.create_collection(
-                collection_name=collection_name,
-                vectors_config={
-                    "text-dense": rest.VectorParams(
+        try:
+            if self.enable_hybrid:
+                await self._aclient.create_collection(
+                    collection_name=collection_name,
+                    vectors_config={
+                        "text-dense": rest.VectorParams(
+                            size=vector_size,
+                            distance=rest.Distance.COSINE,
+                        )
+                    },
+                    sparse_vectors_config={
+                        "text-sparse": rest.SparseVectorParams(
+                            index=rest.SparseIndexParams()
+                        )
+                    },
+                )
+            else:
+                await self._aclient.create_collection(
+                    collection_name=collection_name,
+                    vectors_config=rest.VectorParams(
                         size=vector_size,
                         distance=rest.Distance.COSINE,
-                    )
-                },
-                sparse_vectors_config={
-                    "text-sparse": rest.SparseVectorParams(
-                        index=rest.SparseIndexParams()
-                    )
-                },
-            )
-        else:
-            await self._aclient.create_collection(
-                collection_name=collection_name,
-                vectors_config=rest.VectorParams(
-                    size=vector_size,
-                    distance=rest.Distance.COSINE,
-                ),
+                    ),
+                )
+        except ValueError as exc:
+            if "already exists" not in str(exc):
+                raise exc
+            logger.warning(
+                "Collection %s already exists, skipping collection creation.",
+                collection_name,
             )
         self._collection_initialized = True
 

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -309,7 +309,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         from qdrant_client.http import models as rest
 
         if self.enable_hybrid:
-            self._client.recreate_collection(
+            self._client.create_collection(
                 collection_name=collection_name,
                 vectors_config={
                     "text-dense": rest.VectorParams(
@@ -324,7 +324,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 },
             )
         else:
-            self._client.recreate_collection(
+            self._client.create_collection(
                 collection_name=collection_name,
                 vectors_config=rest.VectorParams(
                     size=vector_size,
@@ -338,7 +338,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         from qdrant_client.http import models as rest
 
         if self.enable_hybrid:
-            await self._aclient.recreate_collection(
+            await self._aclient.create_collection(
                 collection_name=collection_name,
                 vectors_config={
                     "text-dense": rest.VectorParams(
@@ -353,7 +353,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 },
             )
         else:
-            await self._aclient.recreate_collection(
+            await self._aclient.create_collection(
                 collection_name=collection_name,
                 vectors_config=rest.VectorParams(
                     size=vector_size,

--- a/tests/storage/kvstore/mock_mongodb.py
+++ b/tests/storage/kvstore/mock_mongodb.py
@@ -66,6 +66,19 @@ class MockMongoCollection:
         insert_result.inserted_ids = inserted_ids
         return insert_result
 
+    def bulk_write(self, operations: List[dict]) -> Any:
+        for operation in operations:
+            if operation["name"] == "insertOne":
+                self.insert_one(operation["document"])
+            elif operation["name"] == "updateOne":
+                self.update_one(operation["filter"], operation["update"])
+            elif operation["name"] == "replaceOne":
+                self.replace_one(operation["filter"], operation["replacement"])
+            elif operation["name"] == "deleteOne":
+                self.delete_one(operation["filter"])
+            else:
+                raise NotImplementedError
+
 
 class MockMongoDB:
     def __init__(self) -> None:

--- a/tests/storage/kvstore/mock_mongodb.py
+++ b/tests/storage/kvstore/mock_mongodb.py
@@ -66,19 +66,6 @@ class MockMongoCollection:
         insert_result.inserted_ids = inserted_ids
         return insert_result
 
-    def bulk_write(self, operations: List[dict]) -> Any:
-        for operation in operations:
-            if operation["name"] == "insertOne":
-                self.insert_one(operation["document"])
-            elif operation["name"] == "updateOne":
-                self.update_one(operation["filter"], operation["update"])
-            elif operation["name"] == "replaceOne":
-                self.replace_one(operation["filter"], operation["replacement"])
-            elif operation["name"] == "deleteOne":
-                self.delete_one(operation["filter"])
-            else:
-                raise NotImplementedError
-
 
 class MockMongoDB:
     def __init__(self) -> None:

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -58,6 +58,21 @@ def test_add_stores_data(node_embeddings: List[TextNode]) -> None:
 
 
 @pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
+def test_add_stores_data_multiple_connections(node_embeddings: List[TextNode]) -> None:
+    client = qdrant_client.QdrantClient(":memory:")
+    qdrant_vector_store_a = QdrantVectorStore(collection_name="test", client=client)
+    qdrant_vector_store_b = QdrantVectorStore(collection_name="test", client=client)
+
+    with pytest.raises(ValueError):
+        client.count("test")  # That indicates the collection does not exist
+
+    qdrant_vector_store_a.add([node_embeddings[0]])
+    qdrant_vector_store_b.add([node_embeddings[1]])
+
+    assert client.count("test").count == 2
+
+
+@pytest.mark.skipif(qdrant_client is None, reason="qdrant-client not installed")
 def test_build_query_filter_returns_none() -> None:
     client = qdrant_client.QdrantClient(":memory:")
     qdrant_vector_store = QdrantVectorStore(collection_name="test", client=client)


### PR DESCRIPTION
# Description

The Qdrant Vector DB integration was using `recreate_collection` instead of `create_collection`.

The `recreate_collection` *deletes* the collection if it already exists and creates an empty new collection. This is fine in cases where you're just running a notebook since you just have one thread writing into the vector store. Thats because this integration does its own check to see if the collection already exists before calling `recreate_collection`. However, if you are in a situation with multiple writers each doing parallel writes, this becomes problematic since there could be a race condition where they both check if the collection exist at the same time, but then one writer inserts nodes after that only for them to get wiped out by the other writer that does `recreate_collection`. Probably a highly improbable race condition but easy to handle properly.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
