### PR TITLE
Fix get_single_table_info schema bug

### DIFF
--- a/llama_index/utilities/sql_wrapper.py
+++ b/llama_index/utilities/sql_wrapper.py
@@ -155,7 +155,7 @@ class SQLDatabase:
             "and foreign keys: {foreign_keys}."
         )
         columns = []
-        for column in self._inspector.get_columns(table_name):
+        for column in self._inspector.get_columns(table_name,schema=self._schema):
             if column.get("comment"):
                 columns.append(
                     f"{column['name']} ({column['type']!s}): "
@@ -166,7 +166,7 @@ class SQLDatabase:
 
         column_str = ", ".join(columns)
         foreign_keys = []
-        for foreign_key in self._inspector.get_foreign_keys(table_name):
+        for foreign_key in self._inspector.get_foreign_keys(table_name,schema=self._schema):
             foreign_keys.append(
                 f"{foreign_key['constrained_columns']} -> "
                 f"{foreign_key['referred_table']}.{foreign_key['referred_columns']}"

--- a/llama_index/utilities/sql_wrapper.py
+++ b/llama_index/utilities/sql_wrapper.py
@@ -155,7 +155,7 @@ class SQLDatabase:
             "and foreign keys: {foreign_keys}."
         )
         columns = []
-        for column in self._inspector.get_columns(table_name,schema=self._schema):
+        for column in self._inspector.get_columns(table_name, schema=self._schema):
             if column.get("comment"):
                 columns.append(
                     f"{column['name']} ({column['type']!s}): "
@@ -166,7 +166,9 @@ class SQLDatabase:
 
         column_str = ", ".join(columns)
         foreign_keys = []
-        for foreign_key in self._inspector.get_foreign_keys(table_name,schema=self._schema):
+        for foreign_key in self._inspector.get_foreign_keys(
+            table_name, schema=self._schema
+        ):
             foreign_keys.append(
                 f"{foreign_key['constrained_columns']} -> "
                 f"{foreign_key['referred_table']}.{foreign_key['referred_columns']}"


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


```python
 sql_database = SQLDatabase(
        fin_engine, schema="city", include_tables=["city_stats"], view_support=True
    )
```
When I use the schema but it tells me the error.

```bash
raise exc.NoSuchTableError(
sqlalchemy.exc.NoSuchTableError: city_stats
```
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
