### PR TITLE
[fix] Doc de-duplication might exclude valid documents

### DIFF
--- a/tests/indices/vector_store/utils.py
+++ b/tests/indices/vector_store/utils.py
@@ -53,6 +53,7 @@ class MockPineconeIndex:
             match = MagicMock()
             match.metadata = tup["metadata"]
             match.id = tup["id"]
+            match.values = tup["values"]
             matches.append(match)
 
         response = MagicMock()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -28,3 +28,18 @@ def test_node_with_score_passthrough(node_with_score: NodeWithScore) -> None:
     _ = node_with_score.get_text()
     _ = node_with_score.get_content()
     _ = node_with_score.get_embedding()
+
+
+def test_text_node_hash() -> None:
+    node = TextNode(text="hello", metadata={"foo": "bar"})
+    assert (
+        node.hash == "aa158bf3388f103cef4bd85b2ca93f343ad8f5e50f58ae4141a35d75a2f21fb0"
+    )
+    node.set_content("world")
+    assert (
+        node.hash == "ce6a3cefc3451ecb1ff41ec41a7d7e24354983520d8b2d6f5447be0b6b9b6b99"
+    )
+    node2 = TextNode(text="world", metadata={"foo": "bar"})
+    assert node2.hash == node.hash
+    node3 = TextNode(text="world", metadata={"foo": "baz"})
+    assert node3.hash != node.hash

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -39,7 +39,12 @@ def test_text_node_hash() -> None:
     assert (
         node.hash == "ce6a3cefc3451ecb1ff41ec41a7d7e24354983520d8b2d6f5447be0b6b9b6b99"
     )
-    node2 = TextNode(text="world", metadata={"foo": "bar"})
+
+    node.text = "new"
+    assert (
+        node.hash == "bef8ff82498c9aa7d9f9751f441da9a1a1c4e9941bd03c57caa4a602cd5cadd0"
+    )
+    node2 = TextNode(text="new", metadata={"foo": "bar"})
     assert node2.hash == node.hash
-    node3 = TextNode(text="world", metadata={"foo": "baz"})
+    node3 = TextNode(text="new", metadata={"foo": "baz"})
     assert node3.hash != node.hash


### PR DESCRIPTION
# Description

The ´TextNode´ class calculate an internal hash of the node that is eventually used to de-duplicated docuements retrieved from a retriever/vstore.
The hash is calculated once, over the text and metadata. The problem is the text field is mutable.

This could leads to lose documents with the same metadata in some cases. 
An example is in the Cassandra vector store, whereas the TextNode#text value is set after the object creation. The net 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests
