### PR TITLE
Fix Bug in sql wrapper with run_sql method

### DIFF
--- a/llama_index/utilities/sql_wrapper.py
+++ b/llama_index/utilities/sql_wrapper.py
@@ -206,6 +206,8 @@ class SQLDatabase:
         """
         with self._engine.begin() as connection:
             try:
+                if self._schema:
+                    command = command.replace("FROM ", f"FROM {self._schema}.")
                 cursor = connection.execute(text(command))
             except (ProgrammingError, OperationalError) as exc:
                 raise NotImplementedError(


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

When I use schema for `SQLDatabase`, but it's [`run_sql`]( https://github.com/run-llama/llama_index/blob/main/llama_index/utilities/sql_wrapper.py#L201C2-L209C59)
method did not use the schema mode to works well with sql

```python
def run_sql(self, command: str) -> Tuple[str, Dict]:
    """Execute a SQL statement and return a string representing the results.


    If the statement returns rows, a string of the results is returned.
    If the statement returns no rows, an empty string is returned.
    """
    with self._engine.begin() as connection:
        try:
            cursor = connection.execute(text(command))
```


## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
