### PR TITLE
Fix bug with `to_tool_list`

### DIFF
--- a/llama_index/tools/tool_spec/base.py
+++ b/llama_index/tools/tool_spec/base.py
@@ -56,9 +56,9 @@ class BaseToolSpec:
         """Convert tool spec to list of tools."""
         func_to_metadata_mapping = func_to_metadata_mapping or {}
         tool_list = []
-        func_sync = None
-        func_async = None
         for func_spec in self.spec_functions:
+            func_sync = None
+            func_async = None
             if isinstance(func_spec, str):
                 func = getattr(self, func_spec)
                 if asyncio.iscoroutinefunction(func):
@@ -99,6 +99,8 @@ class BaseToolSpec:
 
 
 def patch_sync(func_async: AsyncCallable) -> Callable:
+    """Patch sync function from async function."""
+
     def patched_sync(*args: Any, **kwargs: Any) -> Any:
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(func_async(*args, **kwargs))


### PR DESCRIPTION
# Description

BaseToolSpec has a `to_tool_list` function that converts function specifications into a list of FunctionTools. This method is general purpose enough and is written to handle combinations of sync and async functions in a single tool spec. 

The resultant FunctionTool contains both sync and async methods, even if the actual tool spec did not contain a sync version of the function. This is achieved by patching a sync version from the async version.

**Issue**:  The `func_sync` and `func_async` variables are not reset inside the loop every time. This makes it such that if there is a combination of sync and async function specifications, the "sync" version of the function tool actually points to a different function.

**Proposed fix**: Resets func_sync and func_async variables every time a new function specification is being processed.

Fixes # (issue)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense (also used this fix in another repo that I maintain)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
