### PR TITLE
Cater for Open-Source LLMs use of JSON output parsing

### DIFF
--- a/llama_index/question_gen/output_parser.py
+++ b/llama_index/question_gen/output_parser.py
@@ -12,6 +12,12 @@ class SubQuestionOutputParser(BaseOutputParser):
         if not json_dict:
             raise ValueError(f"No valid JSON found in output: {output}")
 
+        # example code includes an 'items' key, which breaks
+        # the parsing from open-source LLMs such as Zephyr.
+        # This get's the actual subquestions and recommended tools directly
+        if 'items' in json_dict:
+            json_dict = json_dict['items']
+
         sub_questions = [SubQuestion.parse_obj(item) for item in json_dict]
         return StructuredOutput(raw_output=output, parsed_output=sub_questions)
 

--- a/llama_index/question_gen/output_parser.py
+++ b/llama_index/question_gen/output_parser.py
@@ -15,8 +15,8 @@ class SubQuestionOutputParser(BaseOutputParser):
         # example code includes an 'items' key, which breaks
         # the parsing from open-source LLMs such as Zephyr.
         # This gets the actual subquestions and recommended tools directly
-        if 'items' in json_dict:
-            json_dict = json_dict['items']
+        if "items" in json_dict:
+            json_dict = json_dict["items"]
 
         sub_questions = [SubQuestion.parse_obj(item) for item in json_dict]
         return StructuredOutput(raw_output=output, parsed_output=sub_questions)

--- a/llama_index/question_gen/output_parser.py
+++ b/llama_index/question_gen/output_parser.py
@@ -14,7 +14,7 @@ class SubQuestionOutputParser(BaseOutputParser):
 
         # example code includes an 'items' key, which breaks
         # the parsing from open-source LLMs such as Zephyr.
-        # This get's the actual subquestions and recommended tools directly
+        # This gets the actual subquestions and recommended tools directly
         if 'items' in json_dict:
             json_dict = json_dict['items']
 


### PR DESCRIPTION
# Description

With open source LLMs such as Zephyr, the subquestions are created as a JSON payload and this then needs to be parsed. For some reason, the dictionary had an 'items' key included, which was valid JSON, but unparseable by the subquestion generator.

This simply checks if this is an output, and redefines the json dictionary as the contained subquestions.

Fixes # (issue)

Test for the presence of an 'items' key and if so, ad redefinition of json_dict to the contained content.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Previous tests without the change would consistently fail across numerous open-source LLMS on the standard lyft/uber subquestion sample code.  After making the change, I tested this on zephyr alpha, zephyr-beta, Open Hermes 2.5 7B, and 

I took the sample code from the 10k analysis scenarios.  With OpenAI the code runs well.  With the same code, the issue manifests once the sub-query engine is called with a query

i.e. - load the lyft/uber pdfs into docs, build indexes and query engines.

Then create the subquery engine as follows:

```
query_engine_tools = [
    QueryEngineTool(
        query_engine=lyft_engine,
        metadata=ToolMetadata(
            name="lyft_10k",
            description="Provides information about Lyft financials for year 2021",
        ),
    ),
    QueryEngineTool(
        query_engine=uber_engine,
        metadata=ToolMetadata(
            name="uber_10k",
            description="Provides information about Uber financials for year 2021",
        ),
    ),
]

s_engine = SubQuestionQueryEngine.from_defaults(
    query_engine_tools=query_engine_tools,
    service_context = service_context
)

response = s_engine.query(
    "Compare and contrast the customer segments and geographies that grew the fastest."
)
```
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
