### PR TITLE
Update supabase vecs metadata filter function to support multiple fields

### DIFF
--- a/llama_index/vector_stores/supabase.py
+++ b/llama_index/vector_stores/supabase.py
@@ -75,8 +75,12 @@ class SupabaseVectorStore(VectorStore):
     def _to_vecs_filters(self, filters: MetadataFilters) -> Any:
         """Convert llama filters to vecs filters. $eq is the only supported operator."""
         vecs_filter = {}
+        filter_cond = "${}".format(filters.condition.value)
+        vecs_filter[filter_cond] = []
         for f in filters.legacy_filters():
-            vecs_filter[f.key] = {"$eq": f.value}
+            sub_filter = {}
+            sub_filter[f.key] = {"$eq": f.value}
+            vecs_filter[filter_cond].append(sub_filter)
         return vecs_filter
 
     def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:

--- a/llama_index/vector_stores/supabase.py
+++ b/llama_index/vector_stores/supabase.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from collections import defaultdict
 from typing import Any, List
 
 from llama_index.constants import DEFAULT_EMBEDDING_DIM
@@ -74,9 +75,9 @@ class SupabaseVectorStore(VectorStore):
 
     def _to_vecs_filters(self, filters: MetadataFilters) -> Any:
         """Convert llama filters to vecs filters. $eq is the only supported operator."""
-        vecs_filter = {}
-        filter_cond = "${}".format(filters.condition.value)
-        vecs_filter[filter_cond] = []
+        vecs_filter = defaultdict(list)
+        filter_cond = f"${filters.condition}"
+
         for f in filters.legacy_filters():
             sub_filter = {}
             sub_filter[f.key] = {"$eq": f.value}


### PR DESCRIPTION
# Description

https://github.com/supabase/vecs/issues/69

This change fixes a bug where the supabase metadata filtering logic incorrectly formats the vecs query for metadata queries with multiple fields. It works correctly for queries with one field but fails for multiple fields. 

Example:
for query ```{file_name: "x", thread_id: "x"}```, the vecs functions returns ```{'file_name': {'$eq': "x"}, 'thread_id': {'$eq':"x"}}``` which is `incorrect` and leads to an error from vecs: 

```
max 1 entry per filter
```

Vecs expects multiple filter queries to be put in a list conditional format like so.

```
{"$and": [{"file_name": {"$eq": "x"}}, {"thread_id": {"$eq": "x"}}]
```

Fixes # (issue)

The fix updates the `_to_vecs_filters` to use the expected style.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
