### PR TITLE
add support to directly use qdrant filters from qdrant_client

### DIFF
--- a/docs/examples/vector_stores/Qdrant_using_qdrant_filters.ipynb
+++ b/docs/examples/vector_stores/Qdrant_using_qdrant_filters.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "71144bf9",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/vector_stores/pinecone_metadata_filter.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "307804a3-c02b-4a57-ac0d-172c30ddc851",
+   "metadata": {},
+   "source": [
+    "# Qdrant Vector Store - Default Qdrant Filters"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "3ceaf5c9",
+   "metadata": {},
+   "source": [
+    "Example on how to use Filters from the qdrant_client SDK directly in your Retriever / Query Engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9466d0fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 install llama-index qdrant_client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ad14111-0bbb-4c62-906d-6d6253e0cdee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openai\n",
+    "import qdrant_client\n",
+    "from IPython.display import Markdown, display\n",
+    "from llama_index import (\n",
+    "    VectorStoreIndex,\n",
+    ")\n",
+    "from llama_index.storage.storage_context import StorageContext\n",
+    "from llama_index.vector_stores.qdrant import QdrantVectorStore\n",
+    "from qdrant_client.http.models import Filter, FieldCondition, MatchValue\n",
+    "\n",
+    "client = qdrant_client.QdrantClient(location=\":memory:\")\n",
+    "from llama_index.schema import TextNode\n",
+    "\n",
+    "nodes = [\n",
+    "    TextNode(\n",
+    "        text=\"りんごとは\",\n",
+    "        metadata={\"author\": \"Tanaka\", \"fruit\": \"apple\", \"city\": \"Tokyo\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"Was ist Apfel?\",\n",
+    "        metadata={\"author\": \"David\", \"fruit\": \"apple\", \"city\": \"Berlin\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"Orange like the sun\",\n",
+    "        metadata={\"author\": \"Jane\", \"fruit\": \"orange\", \"city\": \"Hong Kong\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"Grape is...\",\n",
+    "        metadata={\"author\": \"Jane\", \"fruit\": \"grape\", \"city\": \"Hong Kong\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"T-dot > G-dot\",\n",
+    "        metadata={\"author\": \"George\", \"fruit\": \"grape\", \"city\": \"Toronto\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"6ix Watermelons\",\n",
+    "        metadata={\n",
+    "            \"author\": \"George\",\n",
+    "            \"fruit\": \"watermelon\",\n",
+    "            \"city\": \"Toronto\",\n",
+    "        },\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "openai.api_key = \"YOUR_API_KEY\"\n",
+    "vector_store = QdrantVectorStore(\n",
+    "    client=client, collection_name=\"fruit_collection\"\n",
+    ")\n",
+    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+    "index = VectorStoreIndex(nodes, storage_context=storage_context)\n",
+    "\n",
+    "\n",
+    "# Use filters directly from qdrant_client python library\n",
+    "# View python examples here for more info https://qdrant.tech/documentation/concepts/filtering/\n",
+    "\n",
+    "filters = Filter(\n",
+    "    should=[\n",
+    "        Filter(\n",
+    "            must=[\n",
+    "                FieldCondition(\n",
+    "                    key=\"fruit\",\n",
+    "                    match=MatchValue(value=\"apple\"),\n",
+    "                ),\n",
+    "                FieldCondition(\n",
+    "                    key=\"city\",\n",
+    "                    match=MatchValue(value=\"Tokyo\"),\n",
+    "                ),\n",
+    "            ]\n",
+    "        ),\n",
+    "        Filter(\n",
+    "            must=[\n",
+    "                FieldCondition(\n",
+    "                    key=\"fruit\",\n",
+    "                    match=MatchValue(value=\"grape\"),\n",
+    "                ),\n",
+    "                FieldCondition(\n",
+    "                    key=\"city\",\n",
+    "                    match=MatchValue(value=\"Toronto\"),\n",
+    "                ),\n",
+    "            ]\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "retriever = index.as_retriever(vector_store_kwargs={\"qdrant_filters\": filters})\n",
+    "\n",
+    "response = retriever.retrieve(\"Who makes grapes?\")\n",
+    "for node in response:\n",
+    "    print(\"node\", node.score)\n",
+    "    print(\"node\", node.text)\n",
+    "    print(\"node\", node.metadata)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -415,6 +415,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         from qdrant_client.http.models import Filter
 
         query_embedding = cast(List[float], query.query_embedding)
+        #  NOTE: users can pass in qdrant_filters (nested/complicated filters) to override the default MetadataFilters
         qdrant_filters = kwargs.get("qdrant_filters")
         if qdrant_filters is not None:
             query_filter = qdrant_filters
@@ -548,10 +549,12 @@ class QdrantVectorStore(BasePydanticVectorStore):
 
         query_embedding = cast(List[float], query.query_embedding)
 
+        #  NOTE: users can pass in qdrant_filters (nested/complicated filters) to override the default MetadataFilters
         qdrant_filters = kwargs.get("qdrant_filters")
         if qdrant_filters is not None:
             query_filter = qdrant_filters
         else:
+            # build metadata filters
             query_filter = cast(Filter, self._build_query_filter(query))
 
         if query.mode == VectorStoreQueryMode.HYBRID and not self.enable_hybrid:

--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -415,7 +415,11 @@ class QdrantVectorStore(BasePydanticVectorStore):
         from qdrant_client.http.models import Filter
 
         query_embedding = cast(List[float], query.query_embedding)
-        query_filter = cast(Filter, self._build_query_filter(query))
+        qdrant_filters = kwargs.get("qdrant_filters")
+        if qdrant_filters is not None:
+            query_filter = qdrant_filters
+        else:
+            query_filter = cast(Filter, self._build_query_filter(query))
 
         if query.mode == VectorStoreQueryMode.HYBRID and not self.enable_hybrid:
             raise ValueError(
@@ -528,7 +532,6 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 limit=query.similarity_top_k,
                 query_filter=query_filter,
             )
-
             return self.parse_to_query_result(response)
 
     async def aquery(
@@ -544,7 +547,12 @@ class QdrantVectorStore(BasePydanticVectorStore):
         from qdrant_client.http.models import Filter
 
         query_embedding = cast(List[float], query.query_embedding)
-        query_filter = cast(Filter, self._build_query_filter(query))
+
+        qdrant_filters = kwargs.get("qdrant_filters")
+        if qdrant_filters is not None:
+            query_filter = qdrant_filters
+        else:
+            query_filter = cast(Filter, self._build_query_filter(query))
 
         if query.mode == VectorStoreQueryMode.HYBRID and not self.enable_hybrid:
             raise ValueError(


### PR DESCRIPTION
# Description

Current Metadata Filters does not support OR / Nested AND/ORs for Qdrant.
By allowing to pass vector store kwargs, I can directly use the Filters provided by qdrant_client sdk.
This allows different combinations of filters nested as seen in the example notebook.

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran this on the example notebook.

- [ ] Added new unit/integration tests
- [Yes] Added new notebook (that tests end-to-end)
- [Yes] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ Yes] I have performed a self-review of my own code
- [ Yes] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ Yes] I have added Google Colab support for the newly added notebooks.
- [ Yes] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [Yes ] I ran `make format; make lint` to appease the lint gods
