### PR TITLE
Bug: Prefix was not removed after retreived.

### DIFF
--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -299,7 +299,7 @@ class RedisVectorStore(BasePydanticVectorStore):
                         NodeRelationship.SOURCE: RelatedNodeInfo(node_id=doc.doc_id)
                     },
                 )
-            ids.append(doc.id.replace(self._prefix + "_", "")
+            ids.append(doc.id.replace(self._prefix + "_", ""))
             nodes.append(node)
             scores.append(1 - float(doc.vector_score))
         _logger.info(f"Found {len(nodes)} results for query with id {ids}")

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -299,7 +299,7 @@ class RedisVectorStore(BasePydanticVectorStore):
                         NodeRelationship.SOURCE: RelatedNodeInfo(node_id=doc.doc_id)
                     },
                 )
-            ids.append(doc.id)
+            ids.append(doc.id.replace(self._prefix + "_", "")
             nodes.append(node)
             scores.append(1 - float(doc.vector_score))
         _logger.info(f"Found {len(nodes)} results for query with id {ids}")


### PR DESCRIPTION
# Description

Very simple change to remove the prefix. Motivated by not being able to load the index. Error happened when the saved index was a DocummentSummaryIndex.


## Type of Change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```
import redis

from llama_index import (
    StorageContext,
    DocumentSummaryIndex,
    load_index_from_storage,
    ServiceContext,
)

from llama_index.storage.docstore import RedisDocumentStore
from llama_index.storage.index_store import RedisIndexStore
from llama_index.vector_stores import RedisVectorStore
from llama_index.embeddings import HuggingFaceEmbedding
from llama_index.schema import Document


REDIS_DB_HOST = "localhost"
REDIS_DB_PASSWORD = ""
REDIS_DB_PORT = 6380

redis_client = redis.Redis(
    host=REDIS_DB_HOST, password=REDIS_DB_PASSWORD, port=REDIS_DB_PORT, db=0
)


docstore = RedisDocumentStore.from_redis_client(
    redis_client=redis_client,
    namespace="Fail_doc_store",
)
index_store = RedisIndexStore.from_redis_client(
    redis_client=redis_client,
    namespace="Fail_index_store",
)
vector_store = RedisVectorStore(
    redis_url=f"redis://:{REDIS_DB_PASSWORD}@{REDIS_DB_HOST}:{REDIS_DB_PORT}/0",
    index_name="Fail_vector_store",
    index_prefix="llama",
    overwrite=True,
)
storage_context = StorageContext.from_defaults(
    docstore=docstore, index_store=index_store, vector_store=vector_store
)

service_context = ServiceContext.from_defaults(
    llm=<SOME_LLM_MODEL>,
    embed_model=HuggingFaceEmbedding(
        model_name="intfloat/multilingual-e5-large",
    ),
)

document = Document(text="This is a test document", id="test_id")
index = DocumentSummaryIndex.from_documents(
    documents=[document],
    storage_context=storage_context,
    service_context=service_context,
)
index_id = index.index_id
index2 = load_index_from_storage(
    index_id=index_id, storage_context=storage_context, service_context=service_context
)
query_engine = index2.as_query_engine().query("This is a test query")
```
- Run in debug mode
- [x ] I stared at the code and made sure it makes sense
