### PR TITLE
Fix AttributeError: 'DataFrame' object has no attribute 'append' in DataFrameRowsOnly.to_df() #9950 

### DIFF
--- a/llama_index/program/predefined/df.py
+++ b/llama_index/program/predefined/df.py
@@ -62,7 +62,7 @@ class DataFrameRowsOnly(BaseModel):
             new_df = pd.DataFrame([row.row_values for row in self.rows])
             new_df.columns = existing_df.columns
             # assume row values are in order of column names
-            return existing_df.append(new_df, ignore_index=True)
+            return pd.concat([existing_df, new_df], ignore_index=True)
 
 
 class DataFrameValuesPerColumn(BaseModel):


### PR DESCRIPTION
# Description

 In the latest version of pandas (2.1.2), the append() method has been removed from the DataFrame object. This caused an AttributeError when trying to append a new DataFrame to an existing one using existing_df.append(new_df, ignore_index=True).

I have updated the to_df() method in the DataFrameRowsOnly class to use the pd.concat() function instead of the append() method. This change ensures compatibility with the latest version of pandas and prevents the AttributeError from occurring.

Fixes # 9950

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
