### PR TITLE
Fix qdrant aquery hybrid search

### DIFF
--- a/llama_index/vector_stores/qdrant.py
+++ b/llama_index/vector_stores/qdrant.py
@@ -517,7 +517,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                             name="text-dense",
                             vector=query_embedding,
                         ),
-                        limit=sparse_top_k,
+                        limit=query.similarity_top_k,
                         filter=query_filter,
                         with_payload=True,
                     ),


### PR DESCRIPTION
# Description

Fix qdrant aquery hybrid search by correctly passing in top k. 