### PR TITLE
[WIP] Rag CLI

### DIFF
--- a/llama_index/command_line/command_line.py
+++ b/llama_index/command_line/command_line.py
@@ -1,14 +1,18 @@
 import argparse
-import os
 from typing import Any, Optional
 
-from llama_index import SimpleDirectoryReader, VectorStoreIndex
+from llama_index.command_line.rag import RagCLI, default_ragcli_persist_dir
+from llama_index.embeddings import OpenAIEmbedding
+from llama_index.ingestion import IngestionCache, IngestionPipeline
 from llama_index.llama_dataset.download import (
     LLAMA_DATASETS_LFS_URL,
     LLAMA_DATASETS_SOURCE_FILES_GITHUB_TREE_URL,
     download_llama_dataset,
 )
 from llama_index.llama_pack.download import LLAMA_HUB_URL, download_llama_pack
+from llama_index.storage.docstore import SimpleDocumentStore
+from llama_index.text_splitter import SentenceSplitter
+from llama_index.vector_stores import ChromaVectorStore
 
 
 def handle_download_llama_pack(
@@ -52,23 +56,36 @@ def handle_download_llama_dataset(
     print(f"Successfully downloaded {llama_dataset_class} to {download_dir}")
 
 
-def handle_question(
-    file_path: Optional[str] = None,
-    question: Optional[str] = None,
-    **kwargs: Any,
-) -> None:
-    assert file_path is not None
-    assert question is not None
+def default_rag_cli() -> RagCLI:
+    import chromadb
 
-    # check if path is dir
-    if os.path.isdir(file_path):
-        documents = SimpleDirectoryReader(file_path).load_data()
-    else:
-        documents = SimpleDirectoryReader(input_files=[file_path]).load_data()
-    index = VectorStoreIndex.from_documents(documents)
-    query_engine = index.as_query_engine()
-    response = query_engine.query(question)
-    print(response)
+    persist_dir = default_ragcli_persist_dir()
+    chroma_client = chromadb.PersistentClient(path=persist_dir)
+    chroma_collection = chroma_client.create_collection("default", get_or_create=True)
+    vector_store = ChromaVectorStore(
+        chroma_collection=chroma_collection, persist_dir=persist_dir
+    )
+    docstore = SimpleDocumentStore()
+    ingestion_pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), OpenAIEmbedding()],
+        vector_store=vector_store,
+        docstore=docstore,
+        cache=IngestionCache(),
+    )
+    try:
+        ingestion_pipeline.load(persist_dir=persist_dir)
+    except FileNotFoundError:
+        pass
+
+    def persist_chroma(*args: list) -> None:
+        vector_store.persist(persist_dir)
+
+    return RagCLI(
+        ingestion_pipeline=ingestion_pipeline,
+        verbose=False,
+        persist_dir=persist_dir,
+        on_ingestion=persist_chroma,
+    )
 
 
 def main() -> None:
@@ -77,27 +94,12 @@ def main() -> None:
     # Subparsers for the main commands
     subparsers = parser.add_subparsers(title="commands", dest="command", required=True)
 
-    # llama ask command
-    llamaask_parser = subparsers.add_parser(
-        "ask", help="Ask a question to a document / a directory of documents."
+    # llama rag command
+    rag_cli = default_rag_cli()
+    llamarag_parser = subparsers.add_parser(
+        "rag", help="Ask a question to a document / a directory of documents."
     )
-
-    llamaask_parser.add_argument(
-        "file_path",
-        type=str,
-        help=(
-            "The name of the file or directory you want to ask a question about,"
-            "such as `file.pdf`."
-        ),
-    )
-
-    llamaask_parser.add_argument(
-        "-q",
-        "--question",
-        type=str,
-        help="The question you want to ask.",
-    )
-    llamaask_parser.set_defaults(func=lambda args: handle_question(**vars(args)))
+    rag_cli.add_parser_args(llamarag_parser)
 
     # download llamapacks command
     llamapack_parser = subparsers.add_parser(

--- a/llama_index/command_line/rag.py
+++ b/llama_index/command_line/rag.py
@@ -1,0 +1,196 @@
+import asyncio
+import os
+from argparse import ArgumentParser
+from glob import iglob
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union, cast
+
+from llama_index import (
+    PromptTemplate,
+    Response,
+    SimpleDirectoryReader,
+    VectorStoreIndex,
+)
+from llama_index.bridge.pydantic import BaseModel, Field, validator
+from llama_index.core.response.schema import StreamingResponse
+from llama_index.ingestion import IngestionPipeline
+from llama_index.llms import OpenAI
+from llama_index.query_pipeline.query import QueryPipeline
+from llama_index.response_synthesizers import CompactAndRefine
+from llama_index.schema import Document
+from llama_index.utils import get_cache_dir
+
+
+def default_ragcli_persist_dir() -> str:
+    return str(Path(get_cache_dir()) / "rag_cli")
+
+
+class RagCLI(BaseModel):
+    """
+    CLI tool for chatting with output of a IngestionPipeline via a QueryPipeline.
+    """
+
+    ingestion_pipeline: IngestionPipeline = Field(
+        description="Ingestion pipeline to run for RAG ingestion."
+    )
+    verbose: bool = Field(
+        description="Whether to print out verbose information during execution.",
+        default=False,
+    )
+    persist_dir: str = Field(
+        description="Directory to persist ingestion pipeline.",
+        default_factory=default_ragcli_persist_dir,
+    )
+    query_pipeline: Optional[QueryPipeline] = Field(
+        description="Query Pipeline to use for Q&A.",
+        default=None,
+    )
+    on_ingestion: Callable[[List[Document]], None] = Field(
+        description="Callback to run after ingestion.",
+        default=lambda documents: None,
+    )
+
+    @validator("query_pipeline", always=True)
+    def query_pipeline_from_ingestion_pipeline(
+        cls, query_pipeline: Any, values: Dict[str, Any]
+    ) -> Optional[QueryPipeline]:
+        """
+        If query_pipeline is not provided, create one from ingestion_pipeline.
+        """
+        if query_pipeline is not None:
+            return query_pipeline
+
+        ingestion_pipeline = cast(IngestionPipeline, values["ingestion_pipeline"])
+        if ingestion_pipeline.vector_store is None:
+            return None
+        verbose = cast(bool, values["verbose"])
+        prompt_tmpl = PromptTemplate("{question}")
+        retriever = VectorStoreIndex.from_vector_store(
+            ingestion_pipeline.vector_store
+        ).as_retriever(similarity_top_k=5)
+        response_synthesizer = CompactAndRefine(streaming=True)
+        llm = OpenAI(model="gpt-3.5-turbo", streaming=True)
+        # define query pipeline
+        query_pipeline = QueryPipeline(verbose=verbose)
+        query_pipeline.add_modules(
+            {
+                "llm": llm,
+                "prompt_tmpl": prompt_tmpl,
+                "retriever": retriever,
+                "summarizer": response_synthesizer,
+            }
+        )
+        query_pipeline.add_link("prompt_tmpl", "llm")
+        query_pipeline.add_link("llm", "retriever")
+        query_pipeline.add_link("retriever", "summarizer", dest_key="nodes")
+        query_pipeline.add_link("llm", "summarizer", dest_key="query_str")
+        return query_pipeline
+
+    async def handle_cli(
+        self,
+        files: Optional[str] = None,
+        question: Optional[str] = None,
+        chat: bool = False,
+        verbose: bool = False,
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        """
+        Entrypoint for local document RAG CLI tool.
+        """
+        self.verbose = verbose
+        ingestion_pipeline = cast(IngestionPipeline, self.ingestion_pipeline)
+        if self.verbose:
+            print("Saving/Loading from persist_dir: ", self.persist_dir)
+        if files is not None:
+            documents = []
+            for _file in iglob(files, recursive=True):
+                _file = os.path.abspath(_file)
+                if os.path.isdir(_file):
+                    reader = SimpleDirectoryReader(input_dir=_file, filename_as_id=True)
+                else:
+                    reader = SimpleDirectoryReader(
+                        input_files=[_file], filename_as_id=True
+                    )
+
+                documents.extend(reader.load_data(show_progress=verbose))
+
+            await ingestion_pipeline.arun(show_progress=verbose, documents=documents)
+            ingestion_pipeline.persist(persist_dir=self.persist_dir)
+            self.on_ingestion(documents)
+
+        if question is not None:
+            await self.handle_question(question)
+        if chat:
+            await self.start_chat_repl()
+
+    async def handle_question(self, question: str) -> None:
+        if self.query_pipeline is None:
+            raise ValueError("query_pipeline is not defined.")
+        query_pipeline = cast(QueryPipeline, self.query_pipeline)
+        query_pipeline.verbose = self.verbose
+        response = query_pipeline.run(question=question)
+
+        if isinstance(response, StreamingResponse):
+            response.print_response_stream()
+        else:
+            response = cast(Response, response)
+            print(response)
+
+    async def start_chat_repl(self) -> None:
+        """
+        Start a REPL for chatting with the agent.
+        """
+        if self.query_pipeline is None:
+            raise ValueError("query_pipeline is not defined.")
+        while True:
+            question = input("\n(rag) ")
+            await self.handle_question(question.strip())
+
+    def add_parser_args(self, parser: Union[ArgumentParser, Any]) -> None:
+        parser.add_argument(
+            "--q",
+            "--question",
+            type=str,
+            help="The question you want to ask.",
+            required=False,
+        )
+
+        parser.add_argument(
+            "-f",
+            "--files",
+            type=str,
+            help=(
+                "The name of the file or directory you want to ask a question about,"
+                "such as `file.pdf`."
+            ),
+        )
+        parser.add_argument(
+            "-c",
+            "--chat",
+            help="Whether to open a chat REPL.",
+            action="store_true",
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Whether to print out verbose information during execution.",
+            action="store_true",
+        )
+        parser.set_defaults(
+            func=lambda args: asyncio.run(self.handle_cli(**vars(args)))
+        )
+
+    def cli(self) -> None:
+        """
+        Entrypoint for CLI tool.
+        """
+        parser = ArgumentParser(description="LlamaIndex RAG Q&A tool.")
+        subparsers = parser.add_subparsers(
+            title="commands", dest="command", required=True
+        )
+        self.add_parser_args(subparsers)
+        # Parse the command-line arguments
+        args = parser.parse_args()
+
+        # Call the appropriate function based on the command
+        args.func(args)


### PR DESCRIPTION
# Description

Some changes from @hexapode's code
- Adds persistence of vector store, docstore, and ingestion cache.
- Makes use of newly introduced `IngestionPipeline` & `QueryPipeline` modules.
  - Should be educational for those new to these classes
- All CLI setup is in new `RagCLI` class that just takes in a `IngestionPipeline` & a `QueryPipeline`, making it very easy to spin up a custom CLI tool with highly customized configurations for those modules.

**❌** Some sort of issue right now with response synthesis. Seems to always say it can't find an answer.


## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
