### PR TITLE
Remove use of not-launched finish_message

### DIFF
--- a/llama_index/vector_stores/google/generativeai/genai_extension.py
+++ b/llama_index/vector_stores/google/generativeai/genai_extension.py
@@ -542,9 +542,10 @@ def generate_answer(
     )
 
     if response.answer.finish_reason != genai.Candidate.FinishReason.STOP:
+        finish_message = _get_finish_message(response.answer)
         raise GenerateAnswerError(
             finish_reason=response.answer.finish_reason,
-            finish_message=response.answer.finish_message,
+            finish_message=finish_message,
             safety_ratings=response.answer.safety_ratings,
         )
 
@@ -561,6 +562,22 @@ def generate_answer(
         ],
         answerable_probability=response.answerable_probability,
     )
+
+
+# TODO: restore to using candidate.finish_message when this field is launched.
+# For now, we derive this message from existing fields.
+def _get_finish_message(candidate: genai.Candidate) -> str:
+    finish_messages: Dict[int, str] = {
+        genai.Candidate.FinishReason.MAX_TOKENS: "Maximum token in context window reached.",
+        genai.Candidate.FinishReason.SAFETY: "Blocked because of safety",
+        genai.Candidate.FinishReason.RECITATION: "Blocked because of recitation",
+    }
+
+    finish_reason = candidate.finish_reason
+    if finish_reason not in finish_messages:
+        return "Unexpected generation error"
+
+    return finish_messages[finish_reason]
 
 
 def _convert_to_metadata(metadata: Dict[str, Any]) -> List[genai.CustomMetadata]:

--- a/llama_index/vector_stores/google/generativeai/genai_extension.py
+++ b/llama_index/vector_stores/google/generativeai/genai_extension.py
@@ -564,8 +564,8 @@ def generate_answer(
     )
 
 
-# TODO: restore to using candidate.finish_message when this field is launched.
-# For now, we derive this message from existing fields.
+# TODO: Use candidate.finish_message when that field is launched.
+# For now, we derive this message from other existing fields.
 def _get_finish_message(candidate: genai.Candidate) -> str:
     finish_messages: Dict[int, str] = {
         genai.Candidate.FinishReason.MAX_TOKENS: "Maximum token in context window reached.",

--- a/tests/response_synthesizers/test_google.py
+++ b/tests/response_synthesizers/test_google.py
@@ -181,3 +181,119 @@ def test_synthesize(mock_generate_answer: MagicMock) -> None:
 
     assert response.metadata is not None
     assert response.metadata.get("answerable_probability", None) == pytest.approx(0.9)
+
+
+@pytest.mark.skipif(not has_google, reason=SKIP_TEST_REASON)
+@patch("google.ai.generativelanguage.GenerativeServiceClient.generate_answer")
+def test_synthesize_with_max_token_blocking(mock_generate_answer: MagicMock) -> None:
+    # Arrange
+    mock_generate_answer.return_value = genai.GenerateAnswerResponse(
+        answer=genai.Candidate(
+            content=genai.Content(parts=[]),
+            grounding_attributions=[],
+            finish_reason=genai.Candidate.FinishReason.MAX_TOKENS,
+        ),
+    )
+
+    # Act
+    synthesizer = GoogleTextSynthesizer.from_defaults()
+    with pytest.raises(Exception) as e:
+        synthesizer.synthesize(
+            query="What is the meaning of life?",
+            nodes=[
+                NodeWithScore(
+                    node=TextNode(text="It's 42"),
+                    score=0.5,
+                ),
+            ],
+        )
+
+    # Assert
+    assert "Maximum token" in str(e.value)
+
+
+@pytest.mark.skipif(not has_google, reason=SKIP_TEST_REASON)
+@patch("google.ai.generativelanguage.GenerativeServiceClient.generate_answer")
+def test_synthesize_with_safety_blocking(mock_generate_answer: MagicMock) -> None:
+    # Arrange
+    mock_generate_answer.return_value = genai.GenerateAnswerResponse(
+        answer=genai.Candidate(
+            content=genai.Content(parts=[]),
+            grounding_attributions=[],
+            finish_reason=genai.Candidate.FinishReason.SAFETY,
+        ),
+    )
+
+    # Act
+    synthesizer = GoogleTextSynthesizer.from_defaults()
+    with pytest.raises(Exception) as e:
+        synthesizer.synthesize(
+            query="What is the meaning of life?",
+            nodes=[
+                NodeWithScore(
+                    node=TextNode(text="It's 42"),
+                    score=0.5,
+                ),
+            ],
+        )
+
+    # Assert
+    assert "safety" in str(e.value)
+
+
+@pytest.mark.skipif(not has_google, reason=SKIP_TEST_REASON)
+@patch("google.ai.generativelanguage.GenerativeServiceClient.generate_answer")
+def test_synthesize_with_recitation_blocking(mock_generate_answer: MagicMock) -> None:
+    # Arrange
+    mock_generate_answer.return_value = genai.GenerateAnswerResponse(
+        answer=genai.Candidate(
+            content=genai.Content(parts=[]),
+            grounding_attributions=[],
+            finish_reason=genai.Candidate.FinishReason.RECITATION,
+        ),
+    )
+
+    # Act
+    synthesizer = GoogleTextSynthesizer.from_defaults()
+    with pytest.raises(Exception) as e:
+        synthesizer.synthesize(
+            query="What is the meaning of life?",
+            nodes=[
+                NodeWithScore(
+                    node=TextNode(text="It's 42"),
+                    score=0.5,
+                ),
+            ],
+        )
+
+    # Assert
+    assert "recitation" in str(e.value)
+
+
+@pytest.mark.skipif(not has_google, reason=SKIP_TEST_REASON)
+@patch("google.ai.generativelanguage.GenerativeServiceClient.generate_answer")
+def test_synthesize_with_unknown_blocking(mock_generate_answer: MagicMock) -> None:
+    # Arrange
+    mock_generate_answer.return_value = genai.GenerateAnswerResponse(
+        answer=genai.Candidate(
+            content=genai.Content(parts=[]),
+            grounding_attributions=[],
+            finish_reason=genai.Candidate.FinishReason.OTHER,
+        ),
+    )
+
+    # Act
+    synthesizer = GoogleTextSynthesizer.from_defaults()
+    with pytest.raises(Exception) as e:
+        synthesizer.synthesize(
+            query="What is the meaning of life?",
+            nodes=[
+                NodeWithScore(
+                    node=TextNode(text="It's 42"),
+                    score=0.5,
+                ),
+            ],
+        )
+
+    # Assert
+    assert "Unexpected" in str(e.value)


### PR DESCRIPTION
# Description

The field finish_message has not been launched yet. So, the public API cannot reference it. When user encounters a generation error, they would see the error message in the attachment.
<img width="1277" alt="Screenshot 2024-01-18 at 10 56 09 PM" src="https://github.com/pikalaw/llama_index/assets/144591/9cadcc3f-251d-464c-b1a2-b5beda357e79">

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
