### PR TITLE
Add advanced examples of ZillizCloudPipelineIndex in notebook

### DIFF
--- a/docs/examples/managed/zcpDemo.ipynb
+++ b/docs/examples/managed/zcpDemo.ipynb
@@ -84,7 +84,26 @@
    "execution_count": null,
    "id": "97d5c934",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No available pipelines. Please create pipelines first.\n",
+      "Pipelines are automatically created.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'token_usage': 984, 'doc_name': 'milvus_doc_22.md', 'num_chunks': 7}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from llama_index.indices import ZillizCloudPipelineIndex\n",
     "\n",
@@ -133,9 +152,9 @@
     "## Working as Query Engine\n",
     "\n",
     "To conduct semantic search with `ZillizCloudPipelineIndex`, you can use it `as_query_engine()` by specifying a few parameters:\n",
-    "- search_top_k: How many text nodes/chunks to retrieve. Optional, defaults to `DEFAULT_SIMILARITY_TOP_K` (2).\n",
-    "- filters: Metadata filters. Optional, defaults to None.\n",
-    "- output_metadata: What metadata fields to return with the retrieved text node. Optional, defaults to []."
+    "- **search_top_k**: How many text nodes/chunks to retrieve. Optional, defaults to `DEFAULT_SIMILARITY_TOP_K` (2).\n",
+    "- **filters**: Metadata filters. Optional, defaults to None.\n",
+    "- **output_metadata**: What metadata fields to return with the retrieved text node. Optional, defaults to []."
    ]
   },
   {
@@ -145,16 +164,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # If you don't have zcp_index object and have an existing collection, you can construct it by:\n",
-    "#\n",
-    "# from llama_index.indices import ZillizCloudPipelineIndex\n",
-    "# zcp_index = ZillizCloudPipelineIndex(\n",
-    "#         project_id=ZILLIZ_PROJECT_ID,\n",
-    "#         cluster_id=ZILLIZ_CLUSTER_ID,\n",
-    "#         token=ZILLIZ_TOKEN,\n",
-    "#         collection_name=\"zcp_llamalection\"\n",
-    "#     )\n",
-    "\n",
     "from llama_index.vector_stores.types import ExactMatchFilter, MetadataFilters\n",
     "\n",
     "query_engine_milvus23 = zcp_index.as_query_engine(\n",
@@ -188,7 +197,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[NodeWithScore(node=TextNode(id_='447035493899937521', embedding=None, metadata={'version': '2.3'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='6dd1356159a76dacd3559510cb6ce445f1584743cb4a2c4eb98f83cb3095ef8d', text='# Delete Entities\\nThis topic describes how to delete entities in Milvus.  \\nMilvus supports deleting entities by primary key or complex boolean expressions. Deleting entities by primary key is much faster and lighter than deleting them by complex boolean expressions. This is because Milvus executes queries first when deleting data by complex boolean expressions.  \\nDeleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than Strong.\\nEntities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.\\nFrequent deletion operations will impact the system performance.  \\nBefore deleting entities by comlpex boolean expressions, make sure the collection has been loaded.\\nDeleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.\\nDeleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, see Consistency.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.728226900100708), NodeWithScore(node=TextNode(id_='447035493899937524', embedding=None, metadata={'version': '2.3'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='a01306fd8afc7f23f65713e24086c16122293e3c16ce828c624406ae4b724701', text='# Delete Entities\\n## Prepare boolean expression\\n### Complex boolean expression\\nTo filter entities that meet specific conditions, define complex boolean expressions.  \\nFilter entities whose word_count is greater than or equal to 11000:  \\n```python\\nexpr = \"word_count >= 11000\"\\n```  \\nFilter entities whose book_name is not Unknown:  \\n```python\\nexpr = \"book_name != Unknown\"\\n```  \\nFilter entities whose primary key values are greater than 5 and word_count is smaller than or equal to 9999:  \\n```python\\nexpr = \"book_id > 5 && word_count <= 9999\"\\n```', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.687866747379303), NodeWithScore(node=TextNode(id_='447035493899937522', embedding=None, metadata={'version': '2.3'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='449e9c835628a354be9db661e17856d74858393970883131b53b294490c99bcf', text='# Delete Entities\\n## Prepare boolean expression\\nPrepare the boolean expression that filters the entities to delete.  \\nMilvus supports deleting entities by primary key or complex boolean expressions. For more information on expression rules and supported operators, see Boolean Expression Rules.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.6814976334571838)]\n"
+      "[NodeWithScore(node=TextNode(id_='447198459513870883', embedding=None, metadata={'version': '2.3'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, text='# Delete Entities\\nThis topic describes how to delete entities in Milvus.  \\nMilvus supports deleting entities by primary key or complex boolean expressions. Deleting entities by primary key is much faster and lighter than deleting them by complex boolean expressions. This is because Milvus executes queries first when deleting data by complex boolean expressions.  \\nDeleted entities can still be retrieved immediately after the deletion if the consistency level is set lower than Strong.\\nEntities deleted beyond the pre-specified span of time for Time Travel cannot be retrieved again.\\nFrequent deletion operations will impact the system performance.  \\nBefore deleting entities by comlpex boolean expressions, make sure the collection has been loaded.\\nDeleting entities by complex boolean expressions is not an atomic operation. Therefore, if it fails halfway through, some data may still be deleted.\\nDeleting entities by complex boolean expressions is supported only when the consistency is set to Bounded. For details, see Consistency.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.728226900100708), NodeWithScore(node=TextNode(id_='447198459513870886', embedding=None, metadata={'version': '2.3'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, text='# Delete Entities\\n## Prepare boolean expression\\n### Complex boolean expression\\nTo filter entities that meet specific conditions, define complex boolean expressions.  \\nFilter entities whose word_count is greater than or equal to 11000:  \\n```python\\nexpr = \"word_count >= 11000\"\\n```  \\nFilter entities whose book_name is not Unknown:  \\n```python\\nexpr = \"book_name != Unknown\"\\n```  \\nFilter entities whose primary key values are greater than 5 and word_count is smaller than or equal to 9999:  \\n```python\\nexpr = \"book_id > 5 && word_count <= 9999\"\\n```', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.687866747379303), NodeWithScore(node=TextNode(id_='447198459513870884', embedding=None, metadata={'version': '2.3'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, text='# Delete Entities\\n## Prepare boolean expression\\nPrepare the boolean expression that filters the entities to delete.  \\nMilvus supports deleting entities by primary key or complex boolean expressions. For more information on expression rules and supported operators, see Boolean Expression Rules.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.6814976334571838)]\n"
      ]
     }
    ],
@@ -224,12 +233,184 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Yes, users can delete entities by filtering non-primary fields using complex boolean expressions. The context mentions that Milvus supports deleting entities by primary key or complex boolean expressions. Complex boolean expressions allow users to filter entities based on specific conditions, such as filtering entities whose word_count is greater than or equal to a certain value or filtering entities whose book_name is not Unknown. Therefore, users can delete entities by filtering non-primary fields using complex boolean expressions.\n"
+      "Yes, users can delete entities by filtering non-primary fields using complex boolean expressions in Milvus. The complex boolean expressions allow users to define specific conditions to filter entities based on non-primary fields, such as word_count or book_name. By specifying the desired conditions in the boolean expression, users can delete entities that meet those conditions. However, it is important to note that deleting entities by complex boolean expressions is not an atomic operation, and if it fails halfway through, some data may still be deleted.\n"
      ]
     }
    ],
    "source": [
     "response = query_engine_milvus23.query(question)\n",
+    "print(response.response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c3c239b",
+   "metadata": {},
+   "source": [
+    "## Advanced\n",
+    "\n",
+    "You are able to get the managed index without running data ingestion. In order to get ready with Zilliz Cloud Pipelines, you need to provide either pipeline ids or collection name:\n",
+    "\n",
+    "- pipeline_ids: The dictionary of pipeline ids for INGESTION, SEARCH, DELETION. Defaults to None. For example: {\"INGESTION\": \"pipe-xx1\", \"SEARCH\": \"pipe-xx2\", \"DELETION\": \"pipe-xx3\"}.\n",
+    "- collection_name: The collection name, defaults to 'zcp_llamalection'. If no pipeline_ids is given, the index will try to get pipelines with collection_name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "857746c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No available pipelines. Please create pipelines first.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.indices import ZillizCloudPipelineIndex\n",
+    "\n",
+    "\n",
+    "advanced_zcp_index = ZillizCloudPipelineIndex(\n",
+    "    project_id=ZILLIZ_PROJECT_ID,\n",
+    "    cluster_id=ZILLIZ_CLUSTER_ID,\n",
+    "    token=ZILLIZ_TOKEN,\n",
+    "    collection_name=\"zcp_llamalection_advanced\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91f99675",
+   "metadata": {},
+   "source": [
+    "### Customize Pipelines\n",
+    "\n",
+    "If no pipelines are provided or found, then you can manually create and customize pipelines with the following **optional** parameters:\n",
+    "\n",
+    "- **metadata_schema**: A dictionary of metadata schema with field name as key and data type as value. For example, {\"user_id\": \"VarChar\"}.\n",
+    "- **chunkSize**: An integer of chunk size using token as unit. If no chunk size is specified, then Zilliz Cloud Pipeline will use a built-in default chunk size (500 tokens) to split documents.\n",
+    "- **(others)**: Refer to [Zilliz Cloud Pipelines](https://docs.zilliz.com/docs/pipelines) for more available pipeline parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51079a30",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'INGESTION': 'pipe-220572b2597efba9a91ed5',\n",
+       " 'SEARCH': 'pipe-8de59599229631c72d4d2c',\n",
+       " 'DELETION': 'pipe-2813fbf9eb09b352e81efa'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "advanced_zcp_index.create_pipelines(\n",
+    "    metadata_schema={\"user_id\": \"VarChar\"},\n",
+    "    chunkSize=350,\n",
+    "    # other pipeline params\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6efa3b9",
+   "metadata": {},
+   "source": [
+    "### Multi-Tenancy\n",
+    "\n",
+    "With the tenant-specific value (eg. user id) as metadata, the managed index is able to achieve multi-tenancy by applying metadata filters.\n",
+    "\n",
+    "By specifying metadata value, each document is tagged with the tenant-specific field at ingestion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ddd53a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'token_usage': 1247, 'doc_name': 'milvus_doc.md', 'num_chunks': 10}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "advanced_zcp_index.insert_doc_url(\n",
+    "    url=\"https://publicdataset.zillizcloud.com/milvus_doc.md\",\n",
+    "    metadata={\"user_id\": \"user_001\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62a88e50",
+   "metadata": {},
+   "source": [
+    "Then the managed index is able to build a query engine for each tenant by filtering the tenant-specific field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e684e22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.vector_stores.types import ExactMatchFilter, MetadataFilters\n",
+    "\n",
+    "query_engine_for_user_001 = advanced_zcp_index.as_query_engine(\n",
+    "    search_top_k=3,\n",
+    "    filters=MetadataFilters(\n",
+    "        filters=[ExactMatchFilter(key=\"user_id\", value=\"user_001\")]\n",
+    "    ),\n",
+    "    output_metadata=[\"user_id\"],  # optional, display user_id in outputs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eae76dea",
+   "metadata": {},
+   "source": [
+    "> Change `filters` to build query engines with different conditions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea6899f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Yes, you can delete entities by filtering non-primary fields. Milvus supports deleting entities by complex boolean expressions, which allows you to filter entities based on specific conditions on non-primary fields. You can define complex boolean expressions using operators such as greater than or equal to, not equal to, and logical operators like AND and OR. By using these expressions, you can filter entities based on the values of non-primary fields and delete them accordingly.\n"
+     ]
+    }
+   ],
+   "source": [
+    "question = \"Can I delete entities by filtering non-primary fields?\"\n",
+    "\n",
+    "# search_results = query_engine_for_user_001.retrieve(question)\n",
+    "response = query_engine_for_user_001.query(question)\n",
     "print(response.response)"
    ]
   }


### PR DESCRIPTION
# Description

Add advanced examples of ZillizCloudPipelineIndex in notebook:
- customize pipelines (metadata schema, chunk size, etc.)
- multi-tenancy

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Updated the notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
