### PR TITLE
feat: extract title for nodes based on refId

### DIFF
--- a/llama_index/extractors/metadata_extractors.py
+++ b/llama_index/extractors/metadata_extractors.py
@@ -19,7 +19,6 @@ The prompts used to generate the metadata are specifically aimed to help
 disambiguate the document or subsection from other similar documents or subsections.
 (similar with contrastive learning)
 """
-from functools import reduce
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, cast
 
 from llama_index.async_utils import DEFAULT_NUM_WORKERS, run_jobs
@@ -100,45 +99,60 @@ class TitleExtractor(BaseExtractor):
         return "TitleExtractor"
 
     async def aextract(self, nodes: Sequence[BaseNode]) -> List[Dict]:
-        nodes_to_extract_title: List[BaseNode] = []
+        nodes_to_extract_title = self.filter_nodes(nodes)
 
+        if not nodes_to_extract_title:
+            return []
+
+        nodes_by_doc_id = self.separate_nodes_by_ref_id(nodes_to_extract_title)
+        titles_by_doc_id = await self.extract_titles(nodes_by_doc_id)
+
+        return [{"document_title": titles_by_doc_id[node.ref_doc_id]} for node in nodes]
+
+    def filter_nodes(self, nodes: Sequence[BaseNode]) -> List[BaseNode]:
+        filtered_nodes: List[BaseNode] = []
         for node in nodes:
-            if len(nodes_to_extract_title) >= self.nodes:
+            if len(filtered_nodes) >= self.nodes:
                 break
             if self.is_text_node_only and not isinstance(node, TextNode):
                 continue
-            nodes_to_extract_title.append(node)
+            filtered_nodes.append(node)
+        return filtered_nodes
 
-        if len(nodes_to_extract_title) == 0:
-            # Could not extract title
-            return []
+    def separate_nodes_by_ref_id(self, nodes: Sequence[BaseNode]) -> Dict:
+        separated_items: Dict[Optional[str], List[BaseNode]] = {}
 
+        for node in nodes:
+            key = node.ref_doc_id
+            if key not in separated_items:
+                separated_items[key] = []
+
+            separated_items[key].append(node)
+
+        return separated_items
+
+    async def extract_titles(self, nodes_by_doc_id: Dict) -> Dict:
+        titles_by_doc_id = {}
+        for key, nodes in nodes_by_doc_id.items():
+            title_candidates = await self.get_title_candidates(nodes)
+            combined_titles = ", ".join(title_candidates)
+            titles_by_doc_id[key] = await self.llm.apredict(
+                PromptTemplate(template=self.combine_template),
+                context_str=combined_titles,
+            )
+        return titles_by_doc_id
+
+    async def get_title_candidates(self, nodes: List[BaseNode]) -> List[str]:
         title_jobs = [
             self.llm.apredict(
                 PromptTemplate(template=self.node_template),
                 context_str=cast(TextNode, node).text,
             )
-            for node in nodes_to_extract_title
+            for node in nodes
         ]
-        title_candidates = await run_jobs(
+        return await run_jobs(
             title_jobs, show_progress=self.show_progress, workers=self.num_workers
         )
-
-        if len(nodes_to_extract_title) > 1:
-            titles = reduce(
-                lambda x, y: x + "," + y, title_candidates[1:], title_candidates[0]
-            )
-
-            title = await self.llm.apredict(
-                PromptTemplate(template=self.combine_template),
-                context_str=titles,
-            )
-        else:
-            title = title_candidates[
-                0
-            ]  # if single node, just use the title from that node
-
-        return [{"document_title": title.strip(' \t\n\r"')} for _ in nodes]
 
 
 class KeywordExtractor(BaseExtractor):


### PR DESCRIPTION
# Description

Before titles was extracted as the same for all ingested documents, now titles are generated based on ref_doc_id and combined to one

big s/o to @yisding for find the incorrect behavior

# Output example

```json
[
   {
      "title":"Exploring the Diverse Entities and Themes in Paul Graham's Essays",
      "id":"12739816-68ea-451a-aa84-fbb9ce158189",
      "ref_id":"d96bb0f0-1f81-4f0a-9b20-90494a1f07b7"
   },
   {
      "title":"Exploring the Diverse Entities and Themes in Paul Graham's Essays",
      "id":"3fa56b2c-4df9-4679-8052-e4991a662dbc",
      "ref_id":"d96bb0f0-1f81-4f0a-9b20-90494a1f07b7"
   },
   {
      "title":"\"The Enigmatic Blue Dog: Unveiling Uniqueness, Mystery, and Intrigue - The Joyful Canine: A Tale of Happiness and Contentment\"",
      "id":"8f0f7382-f017-4b93-8295-5f27177c5daa",
      "ref_id":"ca8c0567-3524-4b10-ace6-e85f0bee8e53"
   },
   {
      "title":"\"The Enigmatic Blue Dog: Unveiling Uniqueness, Mystery, and Intrigue - The Joyful Canine: A Tale of Happiness and Contentment\"",
      "id":"2ccf7593-1de1-4845-b77f-ec5536806828",
      "ref_id":"ca8c0567-3524-4b10-ace6-e85f0bee8e53"
   },
   {
      "title":"\"The Avian World: A Comprehensive Exploration of the Diversity, Wonders, and Fascinating Aspects of Birds\"",
      "id":"12015ec7-b532-4cc7-8513-1d06a2aa9c98",
      "ref_id":"88497d58-d62d-4976-857c-a4523908afec"
   },
   {
      "title":"\"The Avian World: A Comprehensive Exploration of the Diversity, Wonders, and Fascinating Aspects of Birds\"",
      "id":"9539e607-24c6-4590-891b-e9f64b2a948d",
      "ref_id":"88497d58-d62d-4976-857c-a4523908afec"
   }
]
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
