### PR TITLE
Fix duplicated `file_id` on `openai` chat assistant

### DIFF
--- a/llama_index/agent/openai_assistant_agent.py
+++ b/llama_index/agent/openai_assistant_agent.py
@@ -232,7 +232,7 @@ class OpenAIAssistantAgent(BaseAgent):
             instructions=instructions,
             tools=cast(List[Any], all_openai_tools),
             model=model,
-            file_ids=all_file_ids + file_ids,
+            file_ids=all_file_ids,
         )
         return cls(
             client,


### PR DESCRIPTION
# Description

So I was testing how assistant work and found out that even when I specify only one file id, I get 2 at the end.
Code example:
```python
agent = OpenAIAssistantAgent.from_new(
    name="storyteller-12",
    instructions="You are a nice storyteller. Answer questions about the stories and answer questions.",
    openai_tools=[{"type": "retrieval"}],
    model="gpt-4-1106-preview",
    files=[],
    file_ids=[
        "file-gsGm7c4JwG7kYSY2ba66pnjV",
    ],
    api_key=config.openai.api_key,
)
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Locally. Open the chat assistant created with new code and everything correct, only one file. Also, used prints to be sure.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
