### PR TITLE
Add missing fields for SentenceTransformerRerank

### DIFF
--- a/llama_index/postprocessor/sbert_rerank.py
+++ b/llama_index/postprocessor/sbert_rerank.py
@@ -10,8 +10,16 @@ DEFAULT_SENTENCE_TRANSFORMER_MAX_LENGTH = 512
 
 
 class SentenceTransformerRerank(BaseNodePostprocessor):
-    model: str = Field(ddescription="Sentence transformer model name.")
+    model: str = Field(description="Sentence transformer model name.")
     top_n: int = Field(description="Number of nodes to return sorted by score.")
+    device: str = Field(
+        default="cpu",
+        description="Device to use for sentence transformer.",
+    )
+    keep_retrieval_score: bool = Field(
+        default=False,
+        description="Whether to keep the retrieval score in metadata.",
+    )
     _model: Any = PrivateAttr()
 
     def __init__(


### PR DESCRIPTION
# Description

As a pydantic class SentenceTransformerRerank doesn't define field `device` and `keep_retrieval_score`, we will see following error messages when try to access these fields. Which will cause problems in [this line](https://github.com/run-llama/llama_index/blob/015c59d9f236606e64d0e5ae3e5f6e61eb928a0d/llama_index/postprocessor/sbert_rerank.py#L78).         
```
File ~/.pyenv/versions/3.10.8/lib/python3.10/site-packages/llama_index/postprocessor/sbert_rerank.py:78, in SentenceTransformerRerank._postprocess_nodes(self, nodes, query_bundle)
     75 assert len(scores) == len(nodes)
     77 for node, score in zip(nodes, scores):
---> 78     if self.keep_retrieval_score:
     79         # keep the retrieval score in metadata
     80         node.node.metadata["retrieval_score"] = node.score
     81     node.score = score

AttributeError: 'SentenceTransformerRerank' object has no attribute 'keep_retrieval_score'
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

**To reproduce the issue**: install the latest llamaindex (0.9.36) and then run the example notebook:
https://docs.llamaindex.ai/en/stable/module_guides/querying/node_postprocessors/node_postprocessors.html#sentencetransformerrerank

**Verify the fix**: manually apply the change and rerun the same notebook

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
