### PR TITLE
Removed the call to name property of the protobuf enum

### DIFF
--- a/llama_index/vector_stores/google/generativeai/genai_extension.py
+++ b/llama_index/vector_stores/google/generativeai/genai_extension.py
@@ -502,7 +502,7 @@ class GenerateAnswerError(Exception):
 
     def __str__(self) -> str:
         return (
-            f"finish_reason: {self.finish_reason.name} "
+            f"finish_reason: {self.finish_reason} "
             f"finish_message: {self.finish_message} "
             f"safety ratings: {self.safety_ratings}"
         )


### PR DESCRIPTION
# Description

The field `finish_reason`, which is a protobuf enum, becomes an `int` externally.

The fix is to simply use Python native string interpolation. Then, it would work as both a protobuf enum field via protobuf's __str__ and as an int, which Python interpolates already.

Fixes # 10211

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
