### PR TITLE
Remove /doc prefix from multiple docs links

### DIFF
--- a/docs/changes/deprecated_terms.md
+++ b/docs/changes/deprecated_terms.md
@@ -10,24 +10,24 @@ This has been renamed to `VectorStoreIndex`, as well as unifying all vector inde
 
 Please see the following links for more details on usage.
 
-- [Index Usage Pattern](/docs/module_guides/evaluating/usage_pattern.md)
-- [Vector Store Guide](/docs/module_guides/indexing/vector_store_guide.ipynb)
-- [Vector Store Integrations](/docs/community/integrations/vector_stores.md)
+- [Index Usage Pattern](/module_guides/evaluating/usage_pattern.md)
+- [Vector Store Guide](/module_guides/indexing/vector_store_guide.ipynb)
+- [Vector Store Integrations](/community/integrations/vector_stores.md)
 
 ## GPTVectorStoreIndex
 
 This has been renamed to `VectorStoreIndex`, but it is only a cosmetic change. Please see the following links for more details on usage.
 
-- [Index Usage Pattern](/docs/module_guides/evaluating/usage_pattern.md)
-- [Vector Store Guide](/docs/module_guides/indexing/vector_store_guide.ipynb)
-- [Vector Store Integrations](/docs/community/integrations/vector_stores.md)
+- [Index Usage Pattern](/module_guides/evaluating/usage_pattern.md)
+- [Vector Store Guide](/module_guides/indexing/vector_store_guide.ipynb)
+- [Vector Store Integrations](/community/integrations/vector_stores.md)
 
 ## LLMPredictor
 
 The `LLMPredictor` object is no longer intended to be used by users. Instead, you can setup an LLM directly and pass it into the `ServiceContext`. The `LLM` class itself has similar attributes and methods as the `LLMPredictor`.
 
-- [LLMs in LlamaIndex](/docs/module_guides/models/llms.md)
-- [Setting LLMs in the ServiceContext](/docs/module_guides/supporting_modules/service_context.md)
+- [LLMs in LlamaIndex](/module_guides/models/llms.md)
+- [Setting LLMs in the ServiceContext](/module_guides/supporting_modules/service_context.md)
 
 ## PromptHelper and max_input_size/
 
@@ -37,5 +37,5 @@ The `PromptHelper` in general has been deprecated in favour of specifying parame
 
 See the following links for more details.
 
-- [Configuring settings in the Service Context](/docs/module_guides/supporting_modules/service_context.md)
-- [Parsing Documents into Nodes](/docs/module_guides/loading/node_parsers/root.md)
+- [Configuring settings in the Service Context](/module_guides/supporting_modules/service_context.md)
+- [Parsing Documents into Nodes](/module_guides/loading/node_parsers/root.md)

--- a/docs/module_guides/evaluating/root.md
+++ b/docs/module_guides/evaluating/root.md
@@ -49,7 +49,7 @@ The core retrieval evaluation steps revolve around the following:
 
 We also integrate with community evaluation tools.
 
-- [DeepEval](/docs/community/integrations/deepeval.md)
+- [DeepEval](/community/integrations/deepeval.md)
 - [Ragas](https://github.com/explodinggradients/ragas/blob/main/docs/howtos/integrations/llamaindex.ipynb)
 
 ## Usage Pattern

--- a/docs/understanding/understanding.md
+++ b/docs/understanding/understanding.md
@@ -10,11 +10,11 @@ If you've already read our [high-level concepts](/getting_started/concepts.md) p
 
 There are a series of key steps involved in building any LLM-powered application, whether it's answering questions about your data, creating a chatbot, or an autonomous agent. Throughout our documentation, you'll notice sections are arranged roughly in the order you'll perform these steps while building your app. You'll learn about:
 
-- **[Using LLMs](/docs/understanding/using_llms/using_llms.md)**: whether it's OpenAI or any number of hosted LLMs or a locally-run model of your own, LLMs are used at every step of the way, from indexing and storing to querying and parsing your data. LlamaIndex comes with a huge number of reliable, tested prompts and we'll also show you how to customize your own.
+- **[Using LLMs](/understanding/using_llms/using_llms.md)**: whether it's OpenAI or any number of hosted LLMs or a locally-run model of your own, LLMs are used at every step of the way, from indexing and storing to querying and parsing your data. LlamaIndex comes with a huge number of reliable, tested prompts and we'll also show you how to customize your own.
 
-- **[Loading](/docs/understanding/loading/loading.md)**: getting your data from wherever it lives, whether that's unstructured text, PDFs, databases, or APIs to other applications. LlamaIndex has hundreds of connectors to every data source over at [LlamaHub](https://llamahub.ai/).
+- **[Loading](/understanding/loading/loading.md)**: getting your data from wherever it lives, whether that's unstructured text, PDFs, databases, or APIs to other applications. LlamaIndex has hundreds of connectors to every data source over at [LlamaHub](https://llamahub.ai/).
 
-- **[Indexing](/docs/understanding/indexing/indexing.md)**: once you've got your data there are an infinite number of ways to structure access to that data to ensure your applications is always working with the most relevant data. LlamaIndex has a huge number of these strategies built-in and can help you select the best ones.
+- **[Indexing](/understanding/indexing/indexing.md)**: once you've got your data there are an infinite number of ways to structure access to that data to ensure your applications is always working with the most relevant data. LlamaIndex has a huge number of these strategies built-in and can help you select the best ones.
 
 - **[Storing](/understanding/storing/storing.md)**: you will probably find it more efficient to store your data in indexed form, or pre-processed summaries provided by an LLM, often in a specialized database known as a `Vector Store` (see below). You can also store your indexes, metadata and more.
 

--- a/docs/use_cases/chatbots.md
+++ b/docs/use_cases/chatbots.md
@@ -6,11 +6,11 @@ LlamaIndex gives you the tools to build knowledge-augmented chatbots and agents.
 
 Here are some relevant resources:
 
-- [Building a chatbot](/docs/understanding/putting_it_all_together/chatbots/building_a_chatbot.md) tutorial
+- [Building a chatbot](/understanding/putting_it_all_together/chatbots/building_a_chatbot.md) tutorial
 - [create-llama](https://blog.llamaindex.ai/create-llama-a-command-line-tool-to-generate-llamaindex-apps-8f7683021191), a command line tool that generates a full-stack chatbot application for you
 - [SECinsights.ai](https://www.secinsights.ai/), an open-source application that uses LlamaIndex to build a chatbot that answers questions about SEC filings
 - [RAGs](https://blog.llamaindex.ai/introducing-rags-your-personalized-chatgpt-experience-over-your-data-2b9d140769b1), a project inspired by OpenAI's GPTs that lets you build a low-code chatbot over your data using Streamlit
-- Our [OpenAI agents](/docs/module_guides/deploying/agents/modules.md) are all chat bots in nature
+- Our [OpenAI agents](/module_guides/deploying/agents/modules.md) are all chat bots in nature
 
 ## External sources
 


### PR DESCRIPTION
# Description

Remove the `/doc` prefix from multiple documentations links.

I think this is what causes several links in the documentation to be broken.

Fixes #9684 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

