### PR TITLE
:bug: summary index not carrying over excluded metadata keys

### DIFF
--- a/llama_index/llama_dataset/generator.py
+++ b/llama_index/llama_dataset/generator.py
@@ -145,6 +145,9 @@ class RagDatasetGenerator(PromptMixin):
                     Document(
                         text=node.get_content(metadata_mode=self._metadata_mode),
                         metadata=node.metadata,
+                        excluded_llm_metadata_keys=node.excluded_llm_metadata_keys,
+                        excluded_embed_metadata_keys=node.excluded_embed_metadata_keys,
+                        relationships=node.relationships,
                     )
                 ],
                 service_context=self.service_context,


### PR DESCRIPTION
# Description

There is a bug with the Document init as its not passing on the other required fields.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I ran `make format; make lint` to appease the lint gods
