### PR TITLE
nit: make chainable output parser more exposed in library/docs

### DIFF
--- a/docs/examples/output_parsing/llm_program.ipynb
+++ b/docs/examples/output_parsing/llm_program.ipynb
@@ -251,10 +251,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.types import BaseOutputParser\n",
+    "from llama_index.output_parsers import ChainableOutputParser\n",
     "\n",
     "\n",
-    "class CustomAlbumOutputParser(BaseOutputParser):\n",
+    "class CustomAlbumOutputParser(ChainableOutputParser):\n",
     "    \"\"\"Custom Album output parser.\n",
     "\n",
     "    Assume first line is name and artist.\n",

--- a/docs/optimizing/custom_modules.md
+++ b/docs/optimizing/custom_modules.md
@@ -17,6 +17,7 @@ This guide centralizes all the resources around writing custom modules in LlamaI
 - [Custom Embedding Model](custom_embeddings)
 
 ## Custom Output Parsers
+
 - [Custom Output Parsers](/examples/output_parsing/llm_program.ipynb)
 
 ## Custom Transformations

--- a/docs/optimizing/custom_modules.md
+++ b/docs/optimizing/custom_modules.md
@@ -16,6 +16,9 @@ This guide centralizes all the resources around writing custom modules in LlamaI
 
 - [Custom Embedding Model](custom_embeddings)
 
+## Custom Output Parsers
+- [Custom Output Parsers](/examples/output_parsing/llm_program.ipynb)
+
 ## Custom Transformations
 
 - [Custom Transformations](custom-transformations)

--- a/llama_index/output_parsers/__init__.py
+++ b/llama_index/output_parsers/__init__.py
@@ -1,15 +1,15 @@
 """Output parsers."""
 
+from llama_index.output_parsers.base import ChainableOutputParser
 from llama_index.output_parsers.guardrails import GuardrailsOutputParser
 from llama_index.output_parsers.langchain import LangchainOutputParser
 from llama_index.output_parsers.pydantic import PydanticOutputParser
 from llama_index.output_parsers.selection import SelectionOutputParser
-from llama_index.output_parsers.base import ChainableOutputParser
 
 __all__ = [
     "GuardrailsOutputParser",
     "LangchainOutputParser",
     "PydanticOutputParser",
     "SelectionOutputParser",
-    "ChainableOutputParser"
+    "ChainableOutputParser",
 ]

--- a/llama_index/output_parsers/__init__.py
+++ b/llama_index/output_parsers/__init__.py
@@ -4,10 +4,12 @@ from llama_index.output_parsers.guardrails import GuardrailsOutputParser
 from llama_index.output_parsers.langchain import LangchainOutputParser
 from llama_index.output_parsers.pydantic import PydanticOutputParser
 from llama_index.output_parsers.selection import SelectionOutputParser
+from llama_index.output_parsers.base import ChainableOutputParser
 
 __all__ = [
     "GuardrailsOutputParser",
     "LangchainOutputParser",
     "PydanticOutputParser",
     "SelectionOutputParser",
+    "ChainableOutputParser"
 ]


### PR DESCRIPTION
this should be the class users import to define custom output parsers, so far it's been hidden

there's a broader action item to refactor the output parsing docs 