### PR TITLE
specify tool spec in tool specs

### DIFF
--- a/llama_index/tools/tool_spec/base.py
+++ b/llama_index/tools/tool_spec/base.py
@@ -13,26 +13,35 @@ from llama_index.tools.utils import create_schema_from_function
 AsyncCallable = Callable[..., Awaitable[Any]]
 
 
+# TODO: deprecate the Tuple (there's no use for it)
+SPEC_FUNCTION_TYPE = Union[str, Tuple[str, str]]
+
+
 class BaseToolSpec:
     """Base tool spec class."""
 
     # list of functions that you'd want to convert to spec
-    spec_functions: List[Union[str, Tuple[str, str]]]
+    spec_functions: List[SPEC_FUNCTION_TYPE]
 
-    def get_fn_schema_from_fn_name(self, fn_name: str) -> Optional[Type[BaseModel]]:
+    def get_fn_schema_from_fn_name(
+        self, fn_name: str, spec_functions: Optional[List[SPEC_FUNCTION_TYPE]] = None
+    ) -> Optional[Type[BaseModel]]:
         """Return map from function name.
 
         Return type is Optional, meaning that the schema can be None.
         In this case, it's up to the downstream tool implementation to infer the schema.
 
         """
-        for fn in self.spec_functions:
+        spec_functions = spec_functions or self.spec_functions
+        for fn in spec_functions:
             if fn == fn_name:
                 return create_schema_from_function(fn_name, getattr(self, fn_name))
 
         raise ValueError(f"Invalid function name: {fn_name}")
 
-    def get_metadata_from_fn_name(self, fn_name: str) -> Optional[ToolMetadata]:
+    def get_metadata_from_fn_name(
+        self, fn_name: str, spec_functions: Optional[List[SPEC_FUNCTION_TYPE]] = None
+    ) -> Optional[ToolMetadata]:
         """Return map from function name.
 
         Return type is Optional, meaning that the schema can be None.
@@ -46,17 +55,21 @@ class BaseToolSpec:
         name = fn_name
         docstring = func.__doc__ or ""
         description = f"{name}{signature(func)}\n{docstring}"
-        fn_schema = self.get_fn_schema_from_fn_name(fn_name)
+        fn_schema = self.get_fn_schema_from_fn_name(
+            fn_name, spec_functions=spec_functions
+        )
         return ToolMetadata(name=name, description=description, fn_schema=fn_schema)
 
     def to_tool_list(
         self,
+        spec_functions: Optional[List[SPEC_FUNCTION_TYPE]] = None,
         func_to_metadata_mapping: Optional[Dict[str, ToolMetadata]] = None,
     ) -> List[FunctionTool]:
         """Convert tool spec to list of tools."""
+        spec_functions = spec_functions or self.spec_functions
         func_to_metadata_mapping = func_to_metadata_mapping or {}
         tool_list = []
-        for func_spec in self.spec_functions:
+        for func_spec in spec_functions:
             func_sync = None
             func_async = None
             if isinstance(func_spec, str):

--- a/llama_index/tools/tool_spec/load_and_search/base.py
+++ b/llama_index/tools/tool_spec/load_and_search/base.py
@@ -11,7 +11,7 @@ from llama_index.bridge.pydantic import BaseModel
 from llama_index.indices.base import BaseIndex
 from llama_index.indices.vector_store import VectorStoreIndex
 from llama_index.tools.function_tool import FunctionTool
-from llama_index.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.tool_spec.base import SPEC_FUNCTION_TYPE, BaseToolSpec
 from llama_index.tools.types import ToolMetadata
 from llama_index.tools.utils import create_schema_from_function
 
@@ -115,6 +115,7 @@ class LoadAndSearchToolSpec(BaseToolSpec):
 
     def to_tool_list(
         self,
+        spec_functions: Optional[List[SPEC_FUNCTION_TYPE]] = None,
         func_to_metadata_mapping: Optional[Dict[str, ToolMetadata]] = None,
     ) -> List[FunctionTool]:
         return self._tool_list

--- a/llama_index/tools/tool_spec/notion/base.py
+++ b/llama_index/tools/tool_spec/notion/base.py
@@ -6,7 +6,7 @@ import requests
 
 from llama_index.bridge.pydantic import BaseModel
 from llama_index.readers.notion import NotionPageReader
-from llama_index.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.tool_spec.base import SPEC_FUNCTION_TYPE, BaseToolSpec
 
 SEARCH_URL = "https://api.notion.com/v1/search"
 
@@ -43,7 +43,9 @@ class NotionToolSpec(BaseToolSpec):
         """Initialize with parameters."""
         self.reader = NotionPageReader(integration_token=integration_token)
 
-    def get_fn_schema_from_fn_name(self, fn_name: str) -> Optional[Type[BaseModel]]:
+    def get_fn_schema_from_fn_name(
+        self, fn_name: str, spec_functions: Optional[List[SPEC_FUNCTION_TYPE]] = None
+    ) -> Optional[Type[BaseModel]]:
         """Return map from function name."""
         if fn_name == "load_data":
             return NotionLoadDataSchema

--- a/llama_index/tools/tool_spec/slack/base.py
+++ b/llama_index/tools/tool_spec/slack/base.py
@@ -3,9 +3,8 @@
 import logging
 from datetime import datetime
 from ssl import SSLContext
-from typing import List, Optional, Type
+from typing import List, Optional
 
-from llama_index.bridge.pydantic import BaseModel
 from llama_index.readers.slack import SlackReader
 from llama_index.schema import Document
 from llama_index.tools.tool_spec.base import BaseToolSpec
@@ -32,10 +31,6 @@ class SlackToolSpec(BaseToolSpec):
             earliest_date=earliest_date,
             latest_date=latest_date,
         )
-
-    def get_fn_schema_from_fn_name(self, fn_name: str) -> Optional[Type[BaseModel]]:
-        """Return map from function name."""
-        return None
 
     def load_data(
         self,


### PR DESCRIPTION
can't believe we didn't have this before

just define `spec_functions` when you do to_tool_list to pick the tools you actually want to use 