### PR TITLE
Added support for multiple docs in SentenceTransformersFinetuneEngine. Resolves Issue #10297

### DIFF
--- a/llama_index/finetuning/embeddings/sentence_transformer.py
+++ b/llama_index/finetuning/embeddings/sentence_transformer.py
@@ -35,11 +35,9 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         self.model_output_path = model_output_path
         self.model = SentenceTransformer(model_id)
 
-
         examples: Any = []
         for query_id, query in dataset.queries.items():
-            for doc in dataset.relevant_docs[query_id]:
-                node_id = doc
+            for node_id in dataset.relevant_docs[query_id]:
                 text = dataset.corpus[node_id]
                 example = InputExample(texts=[query, text])
                 examples.append(example)

--- a/llama_index/finetuning/embeddings/sentence_transformer.py
+++ b/llama_index/finetuning/embeddings/sentence_transformer.py
@@ -35,13 +35,14 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         self.model_output_path = model_output_path
         self.model = SentenceTransformer(model_id)
 
-        # TODO: support more than 1 doc per query
+
         examples: Any = []
         for query_id, query in dataset.queries.items():
-            node_id = dataset.relevant_docs[query_id][0]
-            text = dataset.corpus[node_id]
-            example = InputExample(texts=[query, text])
-            examples.append(example)
+            for doc in dataset.relevant_docs[query_id]:
+                node_id = doc
+                text = dataset.corpus[node_id]
+                example = InputExample(texts=[query, text])
+                examples.append(example)
         self.examples = examples
 
         self.loader: DataLoader = DataLoader(examples, batch_size=batch_size)


### PR DESCRIPTION
# Description
In the SentenceTransformersFinetuneEngine, only the first document corresponding to a query was included in the examples. In the changes made, all the documents will considered. The intution is that if all the (query, relevant_doc) pairs are considered as positive samples, it might result in better embeddings.

Fixes #10297 

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
