### PR TITLE
add passthrough for pinecone_query_filters through retriever

### DIFF
--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -408,13 +408,15 @@ class PineconeVectorStore(BasePydanticVectorStore):
                 query_embedding = [v * query.alpha for v in query_embedding]
 
         if query.filters is not None:
-            if "filter" in kwargs:
+            if "filter" in kwargs or "pinecone_query_filters" in kwargs:
                 raise ValueError(
                     "Cannot specify filter via both query and kwargs. "
                     "Use kwargs only for pinecone specific items that are "
                     "not supported via the generic query interface."
                 )
             filter = _to_pinecone_filter(query.filters)
+        elif "pinecone_query_filters" in kwargs:
+            filter = kwargs.pop("pinecone_query_filters")
         else:
             filter = kwargs.pop("filter", {})
 


### PR DESCRIPTION
# Description

The existing implementation of metadata filtering in our Pinecone Vector Store is limited and does not fully leverage all the capabilities offered by the Pinecone client. To address this, i've introducing a new keyword argument, pinecone_query_filters. This enhancement allows users to directly pass filters in a format compatible with the Pinecone client, enabling more sophisticated and granular query control.



Fixes # (issue)

With pinecone_query_filters, users can apply complex filter criteria that go beyond the current scope of MetadataFilter and MetadataFilters. This new feature is particularly beneficial for advanced use cases where precise control over the query parameters is necessary. I.E `(a $in [...])` or `a $eq b and (a $in [...])`
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I wrote a simple example and tested it by passing in multiple filters, and ensuring i got the correct respone.
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
