### PR TITLE
Modified the formatting of question_gen_query

### DIFF
--- a/llama_index/llama_dataset/generator.py
+++ b/llama_index/llama_dataset/generator.py
@@ -72,11 +72,7 @@ class RagDatasetGenerator(PromptMixin):
         self.text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT
         self.question_gen_query = (
             question_gen_query
-            or f"You are a Teacher/Professor. Your task is to setup \
-                        {num_questions_per_chunk} questions for an upcoming \
-                        quiz/examination. The questions should be diverse in nature \
-                            across the document. Restrict the questions to the \
-                                context information provided."
+            or f"You are a Teacher/Professor. Your task is to setup {num_questions_per_chunk} questions for an upcoming quiz/examination. The questions should be diverse in nature across the document. Restrict the questions to the context information provided."
         )
         self.nodes = nodes
         self._metadata_mode = metadata_mode


### PR DESCRIPTION
# Description

This PR tries to correct the formatting issue of the default question_gen_query string. Without modification the Query Generation prompt looks like,
```
......
Given the context information and not prior knowledge.
generate only questions based on the below query.
You are a Teacher/Professor. Your task is to setup                         2 questions for an upcoming                         quiz/examination. The questions should be diverse in nature                             across the document. Restrict the questions to the                                 context information provided.
```
The changes result in removing the unwanted tab spaces between the characters.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
