### PR TITLE
Typo fix: Replace all `that that` typos with `that`

### DIFF
--- a/llama_index/indices/managed/base.py
+++ b/llama_index/indices/managed/base.py
@@ -1,6 +1,6 @@
 """Base Managed Service index.
 
-An index that that is built on top of a managed service.
+An index that is built on top of a managed service.
 
 """
 from abc import ABC, abstractmethod

--- a/llama_index/indices/managed/vectara/retriever.py
+++ b/llama_index/indices/managed/vectara/retriever.py
@@ -1,5 +1,5 @@
 """Vectara index.
-An index that that is built on top of Vectara.
+An index that is built on top of Vectara.
 """
 
 import json

--- a/llama_index/indices/multi_modal/base.py
+++ b/llama_index/indices/multi_modal/base.py
@@ -1,6 +1,6 @@
 """Multi Modal Vector Store Index.
 
-An index that that is built on top of multiple vector stores for different modalities.
+An index that is built on top of multiple vector stores for different modalities.
 
 """
 import logging

--- a/llama_index/indices/vector_store/base.py
+++ b/llama_index/indices/vector_store/base.py
@@ -1,6 +1,6 @@
 """Base vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 import logging

--- a/llama_index/vector_stores/azurecosmosmongo.py
+++ b/llama_index/vector_stores/azurecosmosmongo.py
@@ -1,6 +1,6 @@
 """Azure CosmosDB MongoDB vCore Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 import logging

--- a/llama_index/vector_stores/faiss.py
+++ b/llama_index/vector_stores/faiss.py
@@ -1,6 +1,6 @@
 """Faiss Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 

--- a/llama_index/vector_stores/mongodb.py
+++ b/llama_index/vector_stores/mongodb.py
@@ -1,6 +1,6 @@
 """MongoDB Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 

--- a/llama_index/vector_stores/pinecone.py
+++ b/llama_index/vector_stores/pinecone.py
@@ -1,7 +1,7 @@
 """
 Pinecone Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 import logging

--- a/llama_index/vector_stores/redis.py
+++ b/llama_index/vector_stores/redis.py
@@ -1,6 +1,6 @@
 """Redis Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 """
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional

--- a/llama_index/vector_stores/tencentvectordb.py
+++ b/llama_index/vector_stores/tencentvectordb.py
@@ -1,6 +1,6 @@
 """Tencent Vector store index.
 
-An index that that is built with Tencent Vector Database.
+An index that is built with Tencent Vector Database.
 
 """
 import json

--- a/llama_index/vector_stores/txtai.py
+++ b/llama_index/vector_stores/txtai.py
@@ -1,6 +1,6 @@
 """txtai Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 

--- a/llama_index/vector_stores/typesense.py
+++ b/llama_index/vector_stores/typesense.py
@@ -1,6 +1,6 @@
 """Typesense Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 

--- a/llama_index/vector_stores/weaviate.py
+++ b/llama_index/vector_stores/weaviate.py
@@ -1,6 +1,6 @@
 """Weaviate Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 


### PR DESCRIPTION
Replaced all the occurences of `that that` by `that` in `*.py` files.

For some reason, there were a dozen of such cases in the repo.

<img width="1066" alt="image" src="https://github.com/run-llama/llama_index/assets/6030745/e3cf5851-11c3-4b2b-87ec-031dee985aaf">
