### PR TITLE
Added option to fine tune on one query to doc pair or all query to doc pairs

### DIFF
--- a/llama_index/finetuning/embeddings/sentence_transformer.py
+++ b/llama_index/finetuning/embeddings/sentence_transformer.py
@@ -24,6 +24,7 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         epochs: int = 2,
         show_progress_bar: bool = True,
         evaluation_steps: int = 50,
+        use_all_docs: bool = False,
     ) -> None:
         """Init params."""
         from sentence_transformers import InputExample, SentenceTransformer, losses
@@ -35,12 +36,21 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         self.model_output_path = model_output_path
         self.model = SentenceTransformer(model_id)
 
+        self.use_all_docs = use_all_docs
+
         examples: Any = []
         for query_id, query in dataset.queries.items():
-            for node_id in dataset.relevant_docs[query_id]:
+            if use_all_docs:
+                for node_id in dataset.relevant_docs[query_id]:
+                    text = dataset.corpus[node_id]
+                    example = InputExample(texts=[query, text])
+                    examples.append(example)
+            else:
+                node_id = dataset.relevant_docs[query_id][0]
                 text = dataset.corpus[node_id]
                 example = InputExample(texts=[query, text])
                 examples.append(example)
+
         self.examples = examples
 
         self.loader: DataLoader = DataLoader(examples, batch_size=batch_size)


### PR DESCRIPTION
# Description

In the SentenceTransformersFinetuneEngine, all the documents corresponding to a query were included in the examples. In the changes made, an option will be given to the user to either finetune on only one ```(query, doc)``` pair or all ```(query, doc)``` pairs. The intution is that if all the (query, relevant_doc) pairs are considered as positive samples, it might result in better embeddings.
The default is to use only one ```(query, doc)``` pair.

Fixes #10298 

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change may require a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
