### PR TITLE
Extended BaseRetrievalEvaluator to include an optional PostProcessor

### DIFF
--- a/llama_index/evaluation/retrieval/evaluator.py
+++ b/llama_index/evaluation/retrieval/evaluator.py
@@ -42,12 +42,12 @@ class RetrieverEvaluator(BaseRetrievalEvaluator):
         **kwargs: Any,
     ) -> None:
         """Init params."""
-        super().__init__(metrics=metrics, retriever=retriever, **kwargs)
-
-        if "node_postprocessors" in kwargs:
-            self.node_postprocessors = kwargs["node_postprocessors"]
-        else:
-            self.node_postprocessors = node_postprocessors
+        super().__init__(
+            metrics=metrics,
+            retriever=retriever,
+            node_postprocessors=node_postprocessors,
+            **kwargs,
+        )
 
     async def _aget_retrieved_ids_and_texts(
         self, query: str, mode: RetrievalEvalMode = RetrievalEvalMode.TEXT
@@ -92,9 +92,12 @@ class MultiModalRetrieverEvaluator(BaseRetrievalEvaluator):
         **kwargs: Any,
     ) -> None:
         """Init params."""
-        super().__init__(metrics=metrics, retriever=retriever, **kwargs)
-        self.retriever = retriever
-        self.node_postprocessors = node_postprocessors
+        super().__init__(
+            metrics=metrics,
+            retriever=retriever,
+            node_postprocessors=node_postprocessors,
+            **kwargs,
+        )
 
     async def _aget_retrieved_ids_texts(
         self, query: str, mode: RetrievalEvalMode = RetrievalEvalMode.TEXT

--- a/llama_index/evaluation/retrieval/evaluator.py
+++ b/llama_index/evaluation/retrieval/evaluator.py
@@ -1,6 +1,6 @@
 """Retrieval evaluators."""
 
-from typing import Any, List, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 from llama_index.bridge.pydantic import Field
 from llama_index.core.base_retriever import BaseRetriever
@@ -12,6 +12,7 @@ from llama_index.evaluation.retrieval.metrics_base import (
     BaseRetrievalMetric,
 )
 from llama_index.indices.base_retriever import BaseRetriever
+from llama_index.postprocessor.types import BaseNodePostprocessor
 from llama_index.schema import ImageNode, TextNode
 
 
@@ -23,25 +24,42 @@ class RetrieverEvaluator(BaseRetrievalEvaluator):
     Args:
         metrics (List[BaseRetrievalMetric]): Sequence of metrics to evaluate
         retriever: Retriever to evaluate.
+        post_processor (Optional[BaseNodePostprocessor]): Post-processor to apply after retrieval.
+
 
     """
 
     retriever: BaseRetriever = Field(..., description="Retriever to evaluate")
+    post_processor: Optional[BaseNodePostprocessor] = Field(
+        default=None, description="Optional post-processor"
+    )
 
     def __init__(
         self,
         metrics: Sequence[BaseRetrievalMetric],
         retriever: BaseRetriever,
+        post_processor: Optional[BaseNodePostprocessor] = None,
         **kwargs: Any,
     ) -> None:
         """Init params."""
         super().__init__(metrics=metrics, retriever=retriever, **kwargs)
 
+        if "post_processor" in kwargs:
+            self.post_processor = kwargs["post_processor"]
+        else:
+            self.post_processor = post_processor
+
     async def _aget_retrieved_ids_and_texts(
         self, query: str, mode: RetrievalEvalMode = RetrievalEvalMode.TEXT
     ) -> Tuple[List[str], List[str]]:
-        """Get retrieved ids."""
+        """Get retrieved ids and texts, potentially applying a post-processor."""
         retrieved_nodes = await self.retriever.aretrieve(query)
+
+        if self.post_processor:
+            retrieved_nodes = self.post_processor.postprocess_nodes(
+                retrieved_nodes, query_str=query
+            )
+
         return (
             [node.node.node_id for node in retrieved_nodes],
             [node.node.text for node in retrieved_nodes],
@@ -56,19 +74,26 @@ class MultiModalRetrieverEvaluator(BaseRetrievalEvaluator):
     Args:
         metrics (List[BaseRetrievalMetric]): Sequence of metrics to evaluate
         retriever: Retriever to evaluate.
+        post_processor (Optional[BaseNodePostprocessor]): Post-processor to apply after retrieval.
 
     """
 
     retriever: BaseRetriever = Field(..., description="Retriever to evaluate")
+    post_processor: Optional[BaseNodePostprocessor] = Field(
+        default=None, description="Optional post-processor"
+    )
 
     def __init__(
         self,
         metrics: Sequence[BaseRetrievalMetric],
         retriever: BaseRetriever,
+        post_processor: Optional[BaseNodePostprocessor] = None,
         **kwargs: Any,
     ) -> None:
         """Init params."""
         super().__init__(metrics=metrics, retriever=retriever, **kwargs)
+        self.retriever = retriever
+        self.post_processor = post_processor
 
     async def _aget_retrieved_ids_texts(
         self, query: str, mode: RetrievalEvalMode = RetrievalEvalMode.TEXT
@@ -77,6 +102,11 @@ class MultiModalRetrieverEvaluator(BaseRetrievalEvaluator):
         retrieved_nodes = await self.retriever.aretrieve(query)
         image_nodes: List[ImageNode] = []
         text_nodes: List[TextNode] = []
+
+        if self.post_processor:
+            retrieved_nodes = self.post_processor.postprocess_nodes(
+                retrieved_nodes, query_str=query
+            )
 
         for scored_node in retrieved_nodes:
             node = scored_node.node


### PR DESCRIPTION
# Description

RetrieverEvaluator currently only accepts BaseRetriever, but there are cases where one wants to measure the impact of a post processing method applied on retrieval results. This change extends RetrieverEvaluator to include a Postprocessor that gets applied to the retrieved nodes before being evaluated.

Fixes # [10243](https://github.com/run-llama/llama_index/issues/10243) - Extend BaseRetrievalEvaluator to include an optional PostProcessor: 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Confirmed that both 
```
    retriever_evaluator = RetrieverEvaluator(metrics=metrics, retriever=retriever)
    eval_results =asyncio.run(retriever_evaluator.aevaluate_dataset(qa_dataset))
```
and 
```
    retriever_evaluator = RetrieverEvaluator(metrics=metrics, retriever=retriever, post_processor=postprocessor)
    eval_results =asyncio.run(retriever_evaluator.aevaluate_dataset(qa_dataset))
```
showed reasonable outputs with multiple post-processors.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods
