### PR TITLE
Improve `agent.react.output_parser`'s ability in parsing JSONs from Action Inputs

### DIFF
--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -53,6 +53,8 @@ def parse_action_reasoning_step(output: str) -> ActionReasoningStep:
     """
     Parse an action reasoning step from the LLM output.
     """
+    # Weaker LLMs may generate ReActAgent steps whose Action Input are horrible JSON strings.
+    # `dirtyjson` is more lenient than `json` in parsing JSON strings.
     import dirtyjson as json
 
     thought, action, action_input = extract_tool_use(output)

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -50,6 +50,9 @@ def extract_final_response(input_text: str) -> Tuple[str, str]:
 
 
 def parse_action_reasoning_step(output: str) -> ActionReasoningStep:
+    """
+    Parse an action reasoning step from the LLM output.
+    """
     import dirtyjson as json
 
     thought, action, action_input = extract_tool_use(output)

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -16,7 +16,7 @@ from llama_index.types import BaseOutputParser
 
 def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
     pattern = (
-        r"\s*Thought: (.*?)\nAction: ([a-zA-Z0-9_]+).*?\nAction Input: .*?(\{.*?\})"
+        r"\s*Thought: (.*?)\nAction: ([a-zA-Z0-9_]+).*?\nAction Input: .*?(\{.*\})"
     )
 
     match = re.search(pattern, input_text, re.DOTALL)

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -4,8 +4,6 @@
 import re
 from typing import Tuple
 
-import dirtyjson as json
-
 from llama_index.agent.react.types import (
     ActionReasoningStep,
     BaseReasoningStep,
@@ -52,6 +50,8 @@ def extract_final_response(input_text: str) -> Tuple[str, str]:
 
 
 def parse_action_reasoning_step(output: str) -> ActionReasoningStep:
+    import dirtyjson as json
+
     thought, action, action_input = extract_tool_use(output)
     json_str = extract_json_str(action_input)
     # First we try json, if this fails we use ast

--- a/llama_index/agent/react/output_parser.py
+++ b/llama_index/agent/react/output_parser.py
@@ -62,7 +62,7 @@ def parse_action_reasoning_step(output: str) -> ActionReasoningStep:
     # First we try json, if this fails we use ast
     try:
         action_input_dict = json.loads(json_str)
-    except json.JSONDecodeError:
+    except Exception:
         action_input_dict = action_input_parser(json_str)
     return ActionReasoningStep(
         thought=thought, action=action, action_input=action_input_dict

--- a/poetry.lock
+++ b/poetry.lock
@@ -1178,6 +1178,17 @@ files = [
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
+name = "dirtyjson"
+version = "1.0.8"
+description = "JSON decoder for Python that can extract data from the muck"
+optional = false
+python-versions = "*"
+files = [
+    {file = "dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53"},
+    {file = "dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd"},
+]
+
+[[package]]
 name = "diskcache"
 version = "5.6.3"
 description = "Disk Cache -- Disk and file backed persistent cache."
@@ -7811,4 +7822,4 @@ query-tools = ["guidance", "jsonpath-ng", "lm-format-enforcer", "rank-bm25", "sc
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "1ccf014ec22186ffcbec1325d4876089a318f0bec886beadd05b39a145e6a86a"
+content-hash = "6f230242ed4fe799ae5b98f5b64e5f388ad54c304198c6de55bc056be873397c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ spacy = {optional = true, version = "^3.7.1"}
 aiohttp = "^3.8.6"
 networkx = ">=3.0"
 psycopg2-binary = {optional = true, version = "^2.9.9"}
+dirtyjson = "^1.0.8"
 
 [tool.poetry.extras]
 gradientai = [

--- a/tests/agent/react/test_react_output_parser.py
+++ b/tests/agent/react/test_react_output_parser.py
@@ -16,6 +16,18 @@ Action Input: {"a": 1, "b": 1}
     assert action_input == '{"a": 1, "b": 1}'
 
 
+def test_extract_tool_use_with_nested_dicts() -> None:
+    mock_input_text = """\
+Thought: Gotta use a tool.
+Action: tool
+Action Input: {"a": 1, "b": {}}
+"""
+    thought, action, action_input = extract_tool_use(mock_input_text)
+    assert thought == "Gotta use a tool."
+    assert action == "tool"
+    assert action_input == '{"a": 1, "b": {}}'
+
+
 def test_extract_tool_use_() -> None:
     mock_input_text = """\
 Thought: I need to use a tool to help me answer the question.

--- a/tests/agent/react/test_react_output_parser.py
+++ b/tests/agent/react/test_react_output_parser.py
@@ -1,7 +1,21 @@
 from llama_index.agent.react.output_parser import (
     extract_final_response,
     extract_tool_use,
+    parse_action_reasoning_step,
 )
+
+
+def test_parse_action_reasoning_step() -> None:
+    mock_input_text = """\
+Thought: Gotta use a tool.
+Action: tool
+Action Input: {'pages': ['coffee'] /* comment */, 'load_kwargs': {}, 'query_str': ''}, along those lines.
+"""
+    assert parse_action_reasoning_step(mock_input_text).action_input == {
+        "pages": ["coffee"],
+        "load_kwargs": {},
+        "query_str": "",
+    }
 
 
 def test_extract_tool_use() -> None:


### PR DESCRIPTION
# Description

This PR contains a fix and an improvement to `llama_index.agent.react.output_parser`, both targeting at improving the success rate of parsing _Action Input_s.

## Change 1: fix a bug by making regex greedy

As shown in [this comment](https://github.com/run-llama/llama_index/issues/10322#issuecomment-1913988213), when there is a `dict` in the _Action Input_, the regex will fail to extract the JSON string. This is fixed by making the pattern greedy.

## Change 2: improve tolerance to horrible JSONs

Weaker LLMs may generate ReActAgent steps whose _Action Input_ are horrible JSON strings:

```
Thought: Gotta use a tool.
Action: tool
Action Input: {'pages': ['coffee'] /* comment */, 'load_kwargs': {}, 'query_str': ''}
```

Problems that may arise:

- using single quotes while double quotes should be used.
- in-line comments

We can make LlamaIndex tolerant to those problems by using the package [`dirtyjson`](https://github.com/codecobblers/dirtyjson).

Fixes #10322 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
