### PR TITLE
fix: vertex gemini models should not use Content type directly

### DIFF
--- a/llama_index/llms/vertex_gemini_utils.py
+++ b/llama_index/llms/vertex_gemini_utils.py
@@ -15,7 +15,7 @@ def create_gemini_client(model: str) -> Any:
 
 
 def convert_chat_message_to_gemini_content(
-    message: ChatMessage, is_history: bool
+    message: ChatMessage, is_history: bool = True
 ) -> Any:
     from vertexai.preview.generative_models import Content, Part
 

--- a/llama_index/llms/vertex_gemini_utils.py
+++ b/llama_index/llms/vertex_gemini_utils.py
@@ -14,7 +14,9 @@ def create_gemini_client(model: str) -> Any:
     return GenerativeModel(model_name=model)
 
 
-def convert_chat_message_to_gemini_content(message: ChatMessage) -> Any:
+def convert_chat_message_to_gemini_content(
+    message: ChatMessage, is_history: bool
+) -> Any:
     from vertexai.preview.generative_models import Content, Part
 
     def _convert_gemini_part_to_prompt(part: Union[str, Dict]) -> Part:
@@ -47,7 +49,10 @@ def convert_chat_message_to_gemini_content(message: ChatMessage) -> Any:
     if isinstance(raw_content, str):
         raw_content = [raw_content]
     parts = [_convert_gemini_part_to_prompt(part) for part in raw_content]
-    return Content(
-        role="user" if message.role == MessageRole.USER else "model",
-        parts=parts,
-    )
+    if is_history:
+        return Content(
+            role="user" if message.role == MessageRole.USER else "model",
+            parts=parts,
+        )
+    else:
+        return parts

--- a/llama_index/llms/vertex_utils.py
+++ b/llama_index/llms/vertex_utils.py
@@ -147,7 +147,7 @@ def _parse_message(message: ChatMessage, is_gemini: bool) -> Any:
             convert_chat_message_to_gemini_content,
         )
 
-        return convert_chat_message_to_gemini_content(message)
+        return convert_chat_message_to_gemini_content(message=message, is_history=False)
     else:
         return message.content
 
@@ -179,7 +179,11 @@ def _parse_chat_history(history: Any, is_gemini: bool) -> Any:
                     convert_chat_message_to_gemini_content,
                 )
 
-                vertex_messages.append(convert_chat_message_to_gemini_content(message))
+                vertex_messages.append(
+                    convert_chat_message_to_gemini_content(
+                        message=message, is_history=True
+                    )
+                )
             else:
                 vertex_message = ChatMessage(
                     content=message.content,


### PR DESCRIPTION
# Description

As explained in the [google client](https://github.com/googleapis/python-aiplatform/pull/3226), the ChatSession shouldn't be used with Content as argument, since the role would be ignored and in the future versions there would be a warning.

This change is totally transparent for LlamaIndex users 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests