### PR TITLE
Add sleep to fix lag in chat stream

### DIFF
--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -166,8 +166,7 @@ class StreamingAgentChatResponse:
                 yield delta
             except queue.Empty:
                 # Queue is empty, but we're not done yet
-                pass
-            time.sleep(0.01)
+                time.sleep(0.01)
         self.response = self._unformatted_response.strip()
 
     async def async_response_gen(self) -> AsyncGenerator[str, None]:

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -1,7 +1,7 @@
-import time
 import asyncio
 import logging
 import queue
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -142,6 +142,7 @@ class StreamingAgentChatResponse:
                 self._is_function = is_function(chat.message)
                 self.aput_in_queue(chat.delta)
                 final_text += chat.delta or ""
+                self._new_item_event.set()
                 if self._is_function is False:
                     self._is_function_false_event.set()
             if self._is_function is not None:  # if loop has gone through iteration

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -1,3 +1,4 @@
+import time
 import asyncio
 import logging
 import queue
@@ -165,7 +166,8 @@ class StreamingAgentChatResponse:
                 yield delta
             except queue.Empty:
                 # Queue is empty, but we're not done yet
-                continue
+                pass
+            time.sleep(0.01)
         self.response = self._unformatted_response.strip()
 
     async def async_response_gen(self) -> AsyncGenerator[str, None]:


### PR DESCRIPTION
# Description

This is a fix for a bug which I identified while attempting to use Chat Stream from within a thread. Adding a sleep within the loop unblocks the thread allowing the chat to stream as expected.
Without this fix, each iteration severely hangs.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested within my application which uses llamaindex. My application runs in a separate worker thread which runs properly with all other streaming agents outside of llama index. When I use chat_stream with llama index, it hangs. This code fixes the issue.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
