### PR TITLE
[FIX] Missing definitions key in `get_params_dict` of QueryPlanTool

### DIFF
--- a/llama_index/tools/types.py
+++ b/llama_index/tools/types.py
@@ -36,7 +36,7 @@ class ToolMetadata:
             parameters = {
                 k: v
                 for k, v in parameters.items()
-                if k in ["type", "properties", "required"]
+                if k in ["type", "properties", "required", "definitions"]
             }
         return parameters
 


### PR DESCRIPTION
# Description

- Adds `definitions` key for `get_parameters_dict` of `ToolMetadata`

Fixes #10348

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
