### PR TITLE
get full node content in KeywordExtractor

### DIFF
--- a/llama_index/extractors/metadata_extractors.py
+++ b/llama_index/extractors/metadata_extractors.py
@@ -192,13 +192,14 @@ class KeywordExtractor(BaseExtractor):
             return {}
 
         # TODO: figure out a good way to allow users to customize keyword template
+        context_str = node.get_content(metadata_mode=self.metadata_mode)
         keywords = await self.llm.apredict(
             PromptTemplate(
                 template=f"""\
 {{context_str}}. Give {self.keywords} unique keywords for this \
 document. Format as comma separated. Keywords: """
             ),
-            context_str=cast(TextNode, node).text,
+            context_str=context_str,
         )
 
         return {"excerpt_keywords": keywords.strip()}


### PR DESCRIPTION
# Description

Use `get_content` like other extractors to allow metadata strategies when using the default `KeywordExtractor`.

Fixes # (issue)

* not being able to include metadata in default keyword extractor

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense
☝️ _entirely this one_

# Suggested Checklist:

- [x] I have performed a self-review of my own code