### PR TITLE
LanceDBVectorStore bug fixes

### DIFF
--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -187,7 +187,7 @@ class LanceDBVectorStore(VectorStore):
         for _, item in results.iterrows():
             try:
                 node = metadata_dict_to_node(item.metadata)
-                node.embedding = list(item.vector)
+                node.embedding = list(item[self.vector_column_name])
             except Exception:
                 # deprecated legacy logic for backward compatibility
                 _logger.debug(

--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -52,7 +52,8 @@ def _to_llama_similarities(results: DataFrame) -> List[float]:
 
 
 class LanceDBVectorStore(VectorStore):
-    """The LanceDB Vector Store.
+    """
+    The LanceDB Vector Store.
 
     Stores text and embeddings in LanceDB. The vector store will open an existing
         LanceDB dataset or create the dataset if it does not exist.
@@ -174,7 +175,7 @@ class LanceDBVectorStore(VectorStore):
         if self.refine_factor is not None:
             lance_query.refine_factor(self.refine_factor)
 
-        results = lance_query.to_df()
+        results = lance_query.to_pandas()
         nodes = []
         for _, item in results.iterrows():
             try:

--- a/llama_index/vector_stores/lancedb.py
+++ b/llama_index/vector_stores/lancedb.py
@@ -62,6 +62,8 @@ class LanceDBVectorStore(VectorStore):
         uri (str, required): Location where LanceDB will store its files.
         table_name (str, optional): The table name where the embeddings will be stored.
             Defaults to "vectors".
+        vector_column_name (str, optional): The vector column name in the table if different from default.
+            Defaults to "vector", in keeping with lancedb convention.
         nprobes (int, optional): The number of probes used.
             A higher number makes search more accurate but also slower.
             Defaults to 20.
@@ -84,6 +86,7 @@ class LanceDBVectorStore(VectorStore):
         self,
         uri: str,
         table_name: str = "vectors",
+        vector_column_name: str = "vector",
         nprobes: int = 20,
         refine_factor: Optional[int] = None,
         text_key: str = DEFAULT_TEXT_KEY,
@@ -99,6 +102,7 @@ class LanceDBVectorStore(VectorStore):
         self.connection = lancedb.connect(uri)
         self.uri = uri
         self.table_name = table_name
+        self.vector_column_name = vector_column_name
         self.nprobes = nprobes
         self.text_key = text_key
         self.refine_factor = refine_factor
@@ -166,7 +170,10 @@ class LanceDBVectorStore(VectorStore):
 
         table = self.connection.open_table(self.table_name)
         lance_query = (
-            table.search(query.query_embedding)
+            table.search(
+                query=query.query_embedding,
+                vector_column_name=self.vector_column_name,
+            )
             .limit(query.similarity_top_k)
             .where(where)
             .nprobes(self.nprobes)


### PR DESCRIPTION
# Description

In its current form, the `LanceDBVectorStore` class has three issues:

- it prevents the user from working with tables having non-default names for vector columns. 
- call to `to_df()` is deprecated in current and future versions of lancedb.
- the results returned by the query to lancedb is a pandas dataframe, and each item is a `pd.Series`. There is no guarantee that it has a `metadata` dict field: this breaks how a node is constructed from a pd.Series. 

Fixes # (issue)

- Allows parametric specification of `vector_column_name`
- `to_df()` -> `to_pandas()`
- I perform the existence check of a `metadata` key in the query result before constructing the `node` object.

## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
