### PR TITLE
fix ollama stream_chat, explicitly raise error in `CondenseQuestionQueryEngine`

### DIFF
--- a/llama_index/chat_engine/condense_question.py
+++ b/llama_index/chat_engine/condense_question.py
@@ -249,7 +249,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
                 sources=[tool_output],
             )
             thread = Thread(
-                target=response.write_response_to_history, args=(self._memory,)
+                target=response.write_response_to_history, args=(self._memory, True)
             )
             thread.start()
         else:

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -98,7 +98,7 @@ class StreamingAgentChatResponse:
         self._aqueue.put_nowait(delta)
         self._new_item_event.set()
 
-    def write_response_to_history(self, memory: BaseMemory) -> None:
+    def write_response_to_history(self, memory: BaseMemory, raise_error: bool = False) -> None:
         if self.chat_stream is None:
             raise ValueError(
                 "chat_stream is None. Cannot write to history without chat_stream."
@@ -117,7 +117,10 @@ class StreamingAgentChatResponse:
                 chat.message.content = final_text.strip()  # final message
                 memory.put(chat.message)
         except Exception as e:
-            logger.warning(f"Encountered exception writing response to history: {e}")
+            if not raise_error:
+                logger.warning(f"Encountered exception writing response to history: {e}")
+            else:
+                raise e
 
         self._is_done = True
 

--- a/llama_index/chat_engine/types.py
+++ b/llama_index/chat_engine/types.py
@@ -98,7 +98,9 @@ class StreamingAgentChatResponse:
         self._aqueue.put_nowait(delta)
         self._new_item_event.set()
 
-    def write_response_to_history(self, memory: BaseMemory, raise_error: bool = False) -> None:
+    def write_response_to_history(
+        self, memory: BaseMemory, raise_error: bool = False
+    ) -> None:
         if self.chat_stream is None:
             raise ValueError(
                 "chat_stream is None. Cannot write to history without chat_stream."
@@ -118,9 +120,11 @@ class StreamingAgentChatResponse:
                 memory.put(chat.message)
         except Exception as e:
             if not raise_error:
-                logger.warning(f"Encountered exception writing response to history: {e}")
+                logger.warning(
+                    f"Encountered exception writing response to history: {e}"
+                )
             else:
-                raise e
+                raise
 
         self._is_done = True
 

--- a/llama_index/llms/ollama.py
+++ b/llama_index/llms/ollama.py
@@ -148,6 +148,8 @@ class Ollama(CustomLLM):
                 for line in response.iter_lines():
                     if line:
                         chunk = json.loads(line)
+                        if "done" in chunk and chunk["done"]:
+                            break
                         message = chunk["message"]
                         delta = message.get("content")
                         text += delta


### PR DESCRIPTION
1. fixed ollama stream_chat, discovered through trying to make ollama work with RAG CLI

2. this took a long time to figure out because the condense chat engine `stream_chat` swallows any errors from underlying LLM in `write_response_to_history` with the blanket try/except. @logan-markewich is there any reason we do this? I added an explicit raise_error flag that's still False by default but can toggle to True by default to make sure all LLM errors are explicitly bubbled up 