### PR TITLE
Update openai_utils.py

### DIFF
--- a/llama_index/llms/openai_utils.py
+++ b/llama_index/llms/openai_utils.py
@@ -68,6 +68,8 @@ TURBO_MODELS: Dict[str, int] = {
     # resolves to gpt-3.5-turbo-16k-0613 until 2023-12-11
     # resolves to gpt-3.5-turbo-1106 after
     "gpt-3.5-turbo-16k": 16384,
+    # 0125 (2024) model (JSON mode)
+    "gpt-3.5-turbo-0125": 16385,
     # 1106 model (JSON mode)
     "gpt-3.5-turbo-1106": 16384,
     # 0613 models (function calling):


### PR DESCRIPTION
# Description

Add support for OpenAI "gpt-3.5-turbo-0125" (16,385 tokens)

Note that:

> Customers using the pinned gpt-3.5-turbo model alias will be automatically upgraded from gpt-3.5-turbo-0613 to gpt-3.5-turbo-0125 two weeks after this model launches.
(https://openai.com/blog/new-embedding-models-and-api-updates)

This means that per Feb 8, 2024 the default gpt-3.5-turbo model will point to this model (in which case you'd also want to update the number of tokens that that model supports on line 67).

For the 1106 model, OpenAI lists the number of tokens as 16,385, whereas the code lists it as 16,384. Not sure if that is a bug, or if my change should also use this number.

Aside: I would suggest using Python's `16_385` `_` decimal separator for readability, but I did not do so here for consistency.

## Type of Change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran on 0.9.41 and this used the model, without this change the model name is rejected.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas