### PR TITLE
fix: model_name validation error and nomic embed model name

### DIFF
--- a/llama_index/embeddings/nomic.py
+++ b/llama_index/embeddings/nomic.py
@@ -32,7 +32,7 @@ class NomicEmbedding(BaseEmbedding):
 
     def __init__(
         self,
-        model_name: str = "nomic-text-embed-v1",
+        model_name: str = "nomic-embed-text-v1",
         embed_batch_size: int = 32,
         api_key: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
@@ -57,6 +57,7 @@ class NomicEmbedding(BaseEmbedding):
         if api_key is not None:
             nomic.cli.login(api_key)
         super().__init__(
+            model_name=model_name,
             embed_batch_size=embed_batch_size,
             callback_manager=callback_manager,
             _model=embed,


### PR DESCRIPTION
# Description

- Addressing a Pydantic validation error related to the 'model_name' field when utilizing NomicEmbedding from the llama_index.embeddings module.
- Correcting the default name of the Nomic embedding model.

issue : https://github.com/run-llama/llama_index/issues/10420

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
