### PR TITLE
[Astra DB] Use the "indexing" API option to unlock storage of long document texts in vector store

### DIFF
--- a/tests/vector_stores/test_astra.py
+++ b/tests/vector_stores/test_astra.py
@@ -1,4 +1,5 @@
-import unittest
+import os
+from typing import Iterable
 
 import pytest
 from llama_index.schema import NodeRelationship, RelatedNodeInfo, TextNode
@@ -15,45 +16,54 @@ except ImportError:
     has_astrapy = False
 
 
-def get_astra_db_store() -> AstraDBVectorStore:
-    return AstraDBVectorStore(
-        token="AstraCS:<...>",
-        api_endpoint=f"https://<...>",
+# env variables
+ASTRA_DB_APPLICATION_TOKEN = os.getenv("ASTRA_DB_APPLICATION_TOKEN", "")
+ASTRA_DB_API_ENDPOINT = os.getenv("ASTRA_DB_API_ENDPOINT", "")
+
+
+@pytest.fixture(scope="module")
+def astra_db_store() -> Iterable[AstraDBVectorStore]:
+    store = AstraDBVectorStore(
+        token=ASTRA_DB_APPLICATION_TOKEN,
+        api_endpoint=ASTRA_DB_API_ENDPOINT,
         collection_name="test_collection",
         embedding_dimension=2,
-        namespace="default_keyspace",
-        ttl_seconds=123,
+    )
+    yield store
+
+    store._astra_db.delete_collection("test_collection")
+
+
+@pytest.mark.skipif(not has_astrapy, reason="astrapy not installed")
+@pytest.mark.skipif(
+    ASTRA_DB_APPLICATION_TOKEN == "" or ASTRA_DB_API_ENDPOINT == "",
+    reason="missing Astra DB credentials",
+)
+def test_astra_db_create_and_crud(astra_db_store: AstraDBVectorStore) -> None:
+    astra_db_store.add(
+        [
+            TextNode(
+                text="test node text",
+                id_="test node id",
+                relationships={
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test doc id")
+                },
+                embedding=[0.5, 0.5],
+            )
+        ]
     )
 
+    astra_db_store.delete("test node id")
 
-class TestAstraDBVectorStore(unittest.TestCase):
-    @pytest.mark.skipif(not has_astrapy, reason="astrapy not installed")
-    def test_astra_db_create_and_crud(self) -> None:
-        vector_store = get_astra_db_store()
 
-        vector_store.add(
-            [
-                TextNode(
-                    text="test node text",
-                    id_="test node id",
-                    relationships={
-                        NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test doc id")
-                    },
-                    embedding=[0.5, 0.5],
-                )
-            ]
-        )
+@pytest.mark.skipif(not has_astrapy, reason="astrapy not installed")
+@pytest.mark.skipif(
+    ASTRA_DB_APPLICATION_TOKEN == "" or ASTRA_DB_API_ENDPOINT == "",
+    reason="missing Astra DB credentials",
+)
+def test_astra_db_queries(astra_db_store: AstraDBVectorStore) -> None:
+    query = VectorStoreQuery(query_embedding=[1, 1], similarity_top_k=3)
 
-        vector_store.delete("test node id")
-
-        vector_store.client
-
-    @pytest.mark.skipif(not has_astrapy, reason="astrapy not installed")
-    def test_astra_db_queries(self) -> None:
-        vector_store = get_astra_db_store()
-
-        query = VectorStoreQuery(query_embedding=[1, 1], similarity_top_k=3)
-
-        vector_store.query(
-            query,
-        )
+    astra_db_store.query(
+        query,
+    )


### PR DESCRIPTION
This PR uses the "indexing" options to denylist the note text itself from being indexed, thereby bypassing the max-length limitation on this field. This fixed the occasional `SHRED_DOC_LIMIT_VIOLATION` error from the Astra API when trying to store texts beyond ~8000 characters.

Since the indexing options are set at creation time, care has been taken about backward-compatibility, respecting the existence of preexisting collections with a warning. So, if using a preexisting collection, the user may see either 

> UserWarning: Collection 'created_MATTO' has unexpected 'indexing' settings (options.indexing = {"deny": ["MATTO", "metadata._node_content", "content"]}). This can result in odd behaviour when running  metadata filtering and/or unwarranted limitations on storing long texts. Consider reindexing anew on a fresh collection.

or 

> UserWarning: Collection 'created_old' is detected as legacy and has indexing turned on for all fields. This implies stricter limitations on the amount of text each entry can store. Consider reindexing anew on a fresh collection to be able to store longer texts.

I also took the time to refactor the vector store test suite slightly, allowing for an easier management of database secrets. All tests have passed in my environment.