### PR TITLE
bug fix - make sure no embedding is required with OpenAI

### DIFF
--- a/llama_index/indices/managed/vectara/base.py
+++ b/llama_index/indices/managed/vectara/base.py
@@ -70,7 +70,9 @@ class VectaraIndex(BaseManagedIndex):
         super().__init__(
             show_progress=show_progress,
             index_struct=index_struct,
-            service_context=ServiceContext.from_defaults(llm=None, llm_predictor=None),
+            service_context=ServiceContext.from_defaults(
+                llm=None, llm_predictor=None, embed_model=None
+            ),
             **kwargs,
         )
         self._vectara_customer_id = vectara_customer_id or os.environ.get(


### PR DESCRIPTION
# Description

Bug found during the Rag-a-thon, where if OpenAI key is not available, the VectaraIndex still uses serviceContext where embed_model is not None. This fixes this issue

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
