### PR TITLE
Refactor: add AgentRunner.from_llm method

### DIFF
--- a/docs/module_guides/deploying/agents/usage_pattern.md
+++ b/docs/module_guides/deploying/agents/usage_pattern.md
@@ -34,6 +34,14 @@ Example usage:
 agent.chat("What is 2123 * 215123")
 ```
 
+To automatically pick the best agent depending on the LLM, you can use the `from_llm` method to generate an agent.
+
+```python
+from llama_index.agent import AgentRunner
+
+agent = AgentRunner.from_llm([multiply_tool], llm=llm, verbose=True)
+```
+
 ## Defining Tools
 
 ### Query Engine Tools

--- a/llama_index/agent/runner/base.py
+++ b/llama_index/agent/runner/base.py
@@ -27,6 +27,7 @@ from llama_index.llms.base import ChatMessage
 from llama_index.llms.llm import LLM
 from llama_index.memory import BaseMemory, ChatMemoryBuffer
 from llama_index.memory.types import BaseMemory
+from llama_index.tools.types import BaseTool
 
 
 class BaseAgentRunner(BaseAgent):
@@ -219,6 +220,32 @@ class AgentRunner(BaseAgentRunner):
         self.init_task_state_kwargs = init_task_state_kwargs or {}
         self.delete_task_on_finish = delete_task_on_finish
         self.default_tool_choice = default_tool_choice
+
+    @staticmethod
+    def from_llm(
+        tools: Optional[List[BaseTool]] = None,
+        llm: Optional[LLM] = None,
+        **kwargs: Any,
+    ) -> "AgentRunner":
+        from llama_index.llms.openai import OpenAI
+        from llama_index.llms.openai_utils import is_function_calling_model
+
+        if isinstance(llm, OpenAI) and is_function_calling_model(llm.model):
+            from llama_index.agent import OpenAIAgent
+
+            return OpenAIAgent.from_tools(
+                tools=tools,
+                llm=llm,
+                **kwargs,
+            )
+        else:
+            from llama_index.agent import ReActAgent
+
+            return ReActAgent.from_tools(
+                tools=tools,
+                llm=llm,
+                **kwargs,
+            )
 
     @property
     def chat_history(self) -> List[ChatMessage]:

--- a/tests/agent/runner/test_base.py
+++ b/tests/agent/runner/test_base.py
@@ -189,3 +189,16 @@ def test_dag_agent() -> None:
     assert step_outputs[0].is_last is True
     assert step_outputs[1].is_last is True
     assert len(agent_runner.state.task_dict[task.task_id].completed_steps) == 3
+
+
+def test_agent_from_llm() -> None:
+    from llama_index.agent import OpenAIAgent, ReActAgent
+    from llama_index.llms.mock import MockLLM
+    from llama_index.llms.openai import OpenAI
+
+    llm = OpenAI()
+    agent_runner = AgentRunner.from_llm(llm=llm)
+    assert isinstance(agent_runner, OpenAIAgent)
+    llm = MockLLM()
+    agent_runner = AgentRunner.from_llm(llm=llm)
+    assert isinstance(agent_runner, ReActAgent)


### PR DESCRIPTION
# Description

Added `AgentRunner.from_llm` method to create the right `AgentRunner` depending on the LLM.
This simplifies the DX for creating an agent. It would simplify `create-llama` generated code for agents.
Added usage for this factory also in `BaseIndex::as_query_engine` 

Fixes # (issue)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
