### PR TITLE
Support Gemini "transport" configuration

### DIFF
--- a/llama_index/llms/gemini.py
+++ b/llama_index/llms/gemini.py
@@ -71,6 +71,7 @@ class Gemini(CustomLLM):
         safety_settings: "genai.types.SafetySettingOptions" = None,
         callback_manager: Optional[CallbackManager] = None,
         api_base: Optional[str] = None,
+        transport: Optional[str] = None,
         **generate_kwargs: Any,
     ):
         """Creates a new Gemini model interface."""
@@ -89,6 +90,9 @@ class Gemini(CustomLLM):
         }
         if api_base:
             config_params["client_options"] = {"api_endpoint": api_base}
+        if transport:
+            config_params["transport"] = transport
+        # transport: A string, one of: [`rest`, `grpc`, `grpc_asyncio`].
         genai.configure(**config_params)
 
         base_gen_config = generation_config if generation_config else {}

--- a/llama_index/multi_modal_llms/gemini.py
+++ b/llama_index/multi_modal_llms/gemini.py
@@ -74,6 +74,7 @@ class GeminiMultiModal(MultiModalLLM):
         generation_config: Optional["genai.types.GenerationConfigDict"] = None,
         safety_settings: "genai.types.SafetySettingOptions" = None,
         api_base: Optional[str] = None,
+        transport: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
         **generate_kwargs: Any,
     ):
@@ -100,6 +101,9 @@ class GeminiMultiModal(MultiModalLLM):
         }
         if api_base:
             config_params["client_options"] = {"api_endpoint": api_base}
+        if transport:
+            config_params["transport"] = transport
+        # transport: A string, one of: [`rest`, `grpc`, `grpc_asyncio`].
         genai.configure(**config_params)
 
         base_gen_config = generation_config if generation_config else {}


### PR DESCRIPTION
Added Gemini transportation method configuration support.

# Description

Gemini models support configuring the transportation method between the client and server.

Types: rest, grpc or grpc_asyncio   (by setting ```genai.configure()``` )

Package Version:
```
google-ai-generativelanguage==0.4.0   (matches the lastest llama index requirement)
  google-auth==2.27.0
  google-generativeai==0.3.2
```

No fixed issue

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
