### PR TITLE
remove exporter from arize-phoenix global callback handler

### DIFF
--- a/llama_index/callbacks/arize_phoenix_callback.py
+++ b/llama_index/callbacks/arize_phoenix_callback.py
@@ -5,12 +5,9 @@ from llama_index.callbacks.base_handler import BaseCallbackHandler
 
 def arize_phoenix_callback_handler(**kwargs: Any) -> BaseCallbackHandler:
     try:
-        from phoenix.trace.exporter import HttpExporter
         from phoenix.trace.llama_index import OpenInferenceTraceCallbackHandler
     except ImportError:
         raise ImportError(
             "Please install Arize Phoenix with `pip install -q arize-phoenix`"
         )
-    if "exporter" not in kwargs:
-        kwargs = {"exporter": HttpExporter(), **kwargs}
     return OpenInferenceTraceCallbackHandler(**kwargs)


### PR DESCRIPTION
# Description

We have migrated our callback handler to OpenTelemetry, and as part of that change, are now encouraging the use of environment variables to set the host, port, or endpoint of the Phoenix instance that collects spans and traces, and are deprecating the `HttpExporter` argument that was previously passed in by default when running `set_global_handler("arize_phoenix")`. This change should not be visible to most users, and if a user is passing in one an instance of our legacy `HttpExporter` via `set_global_handler("arize_phoenix", exporter=HttpExporter())`, they will see a deprecation warning on upcoming versions of Phoenix.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
- [ ] Test it out manually

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
