### PR TITLE
Support custom prompt formatting for non-chat LLMS

### DIFF
--- a/llama_index/llms/huggingface.py
+++ b/llama_index/llms/huggingface.py
@@ -395,16 +395,6 @@ def chat_messages_to_conversational_kwargs(
     return kwargs
 
 
-def chat_messages_to_completion_prompt(messages: Sequence[ChatMessage]) -> str:
-    """Convert ChatMessages to a completion prompt."""
-    return (
-        "\n".join(
-            f"{message.role.capitalize()}: {message.content}" for message in messages
-        )
-        + "\nAssistant:"
-    )
-
-
 class HuggingFaceInferenceAPI(CustomLLM):
     """
     Wrapper on the Hugging Face's Inference API.
@@ -471,9 +461,6 @@ class HuggingFaceInferenceAPI(CustomLLM):
             " model_name is left as default of None."
         ),
     )
-    completion_prompt_formatter: Callable[
-        [Sequence[ChatMessage]], str
-    ] = chat_messages_to_completion_prompt
 
     _sync_client: "InferenceClient" = PrivateAttr()
     _async_client: "AsyncInferenceClient" = PrivateAttr()
@@ -547,8 +534,6 @@ class HuggingFaceInferenceAPI(CustomLLM):
             task = "conversational"
         else:
             task = kwargs["task"].lower()
-        if kwargs.get("completion_prompt_formatter") is not None:
-            completion_prompt_formatter = kwargs["completion_prompt_formatter"]
 
         super().__init__(**kwargs)  # Populate pydantic Fields
         self._sync_client = InferenceClient(**self._get_inference_client_kwargs())
@@ -602,7 +587,7 @@ class HuggingFaceInferenceAPI(CustomLLM):
             )
         else:
             # try and use text generation
-            prompt = self.completion_prompt_formatter(messages)
+            prompt = self.messages_to_prompt(messages)
             completion = self.complete(prompt)
             return ChatResponse(
                 message=ChatMessage(role=MessageRole.ASSISTANT, content=completion.text)

--- a/tests/llms/test_huggingface.py
+++ b/tests/llms/test_huggingface.py
@@ -74,11 +74,11 @@ class TestHuggingFaceInferenceAPI:
     def test_chat_text_generation(
         self, hf_inference_api: HuggingFaceInferenceAPI
     ) -> None:
-        mock_formatter = MagicMock(
+        mock_message_to_prompt = MagicMock(
             return_value="System: You are an expert movie reviewer\nUser: Which movie is the best?\nAssistant:"
         )
         hf_inference_api.task = "text-generation"
-        hf_inference_api.completion_prompt_formatter = mock_formatter
+        hf_inference_api.messages_to_prompt = mock_message_to_prompt
         messages = [
             ChatMessage(
                 role=MessageRole.SYSTEM, content="You are an expert movie reviewer"
@@ -94,7 +94,7 @@ class TestHuggingFaceInferenceAPI:
         ) as mock_complete:
             response = hf_inference_api.chat(messages=messages)
 
-        mock_formatter.assert_called_once_with(messages)
+        hf_inference_api.messages_to_prompt.assert_called_once_with(messages)
         assert response.message.role == MessageRole.ASSISTANT
         assert response.message.content == conversational_return
         mock_complete.assert_called_once_with(

--- a/tests/llms/test_huggingface.py
+++ b/tests/llms/test_huggingface.py
@@ -74,7 +74,11 @@ class TestHuggingFaceInferenceAPI:
     def test_chat_text_generation(
         self, hf_inference_api: HuggingFaceInferenceAPI
     ) -> None:
+        mock_formatter = MagicMock(
+            return_value="System: You are an expert movie reviewer\nUser: Which movie is the best?\nAssistant:"
+        )
         hf_inference_api.task = "text-generation"
+        hf_inference_api.completion_prompt_formatter = mock_formatter
         messages = [
             ChatMessage(
                 role=MessageRole.SYSTEM, content="You are an expert movie reviewer"
@@ -89,7 +93,8 @@ class TestHuggingFaceInferenceAPI:
             return_value=conversational_return,
         ) as mock_complete:
             response = hf_inference_api.chat(messages=messages)
-            print(response)
+
+        mock_formatter.assert_called_once_with(messages)
         assert response.message.role == MessageRole.ASSISTANT
         assert response.message.content == conversational_return
         mock_complete.assert_called_once_with(


### PR DESCRIPTION
# Description

allows the passing of a function that changes the format of chat messages, this is really helpful when a model doesnt use the "traditional" prompting scheme, like most llama models. I.E.
```
<s>[INST] Hello, how are you? [/INST] I'm doing great. How can I help you today? </s><s>[INST] I'd like to show off how chat templating works! [/INST]
```
## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
