### PR TITLE
Fix ImportError in MetadataExtractionSEC.ipynb (pypdf missing)

### DIFF
--- a/docs/examples/metadata_extraction/MetadataExtractionSEC.ipynb
+++ b/docs/examples/metadata_extraction/MetadataExtractionSEC.ipynb
@@ -176,6 +176,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2da91ecc-afef-409a-b94a-13e80aab6c6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pypdf is required to read PDF files\n",
+    "!pip install pypdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "38a46bf6-9539-4ac2-ad97-eb909992b94d",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
# Description

Fixes ImportError when running in Google Colab: pypdf is required to read PDF files

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Rerun the notebook in Google Colab

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
