### PR TITLE
move agent module guide up one-level

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,7 @@ Currently, we support security patches by committing changes and bumping the ver
 ## Reporting a Vulnerability
 
 Found a vulnerability? Email us:
+
 - logan@llamaindex.ai
 - andrei@llamaindex.ai
 - simon@llamaindex.ai

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,6 @@ Currently, we support security patches by committing changes and bumping the ver
 
 ## Reporting a Vulnerability
 
-
 Found a vulnerability? Please email us:
 
 - logan@llamaindex.ai

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,7 @@ Associated projects
    module_guides/indexing/indexing.md
    module_guides/storing/storing.md
    module_guides/querying/querying.md
+   module_guides/deploying/agents/root.md
    module_guides/observability/observability.md
    module_guides/evaluating/root.md
    module_guides/supporting_modules/supporting_modules.md

--- a/docs/module_guides/deploying/agents/root.md
+++ b/docs/module_guides/deploying/agents/root.md
@@ -1,4 +1,4 @@
-# Data Agents
+# Agents
 
 ## Concept
 

--- a/docs/module_guides/querying/querying.md
+++ b/docs/module_guides/querying/querying.md
@@ -1,6 +1,8 @@
 # Querying
 
-Querying is the most important part of your LLM application. To learn more about getting a final product that you can deploy, check out the [query engine](/module_guides/deploying/query_engine/root.md), [chat engine](/module_guides/deploying/chat_engines/root.md) and [agents](/module_guides/deploying/agents/root.md) sections.
+Querying is the most important part of your LLM application. To learn more about getting a final product that you can deploy, check out the [query engine](/module_guides/deploying/query_engine/root.md), [chat engine](/module_guides/deploying/chat_engines/root.md).
+
+If you wish to combine advanced reasoning with tool use, check out our [agents](/module_guides/deploying/agents/root.md) guide.
 
 ## Query Pipeline
 


### PR DESCRIPTION
before a larger docs refactor thought it'd be good to make our agents more discoverable by moving it out of querying

it's sufficiently different enough it doesn't really fall into "just querying" 