### PR TITLE
OllamaMultiModal kwargs

### DIFF
--- a/llama_index/multi_modal_llms/ollama.py
+++ b/llama_index/multi_modal_llms/ollama.py
@@ -106,7 +106,7 @@ class OllamaMultiModal(MultiModalLLM):
         import ollama
 
         ollama_messages = _messages_to_dicts(messages)
-        response = ollama.chat(model=self.model, messages=ollama_messages, stream=False)
+        response = ollama.chat(model=self.model, messages=ollama_messages, stream=False, **kwargs)
         return ChatResponse(
             message=ChatMessage(
                 content=response["message"]["content"],
@@ -124,7 +124,7 @@ class OllamaMultiModal(MultiModalLLM):
         import ollama
 
         ollama_messages = _messages_to_dicts(messages)
-        response = ollama.chat(model=self.model, messages=ollama_messages, stream=True)
+        response = ollama.chat(model=self.model, messages=ollama_messages, stream=True, **kwargs)
         text = ""
         for chunk in response:
             if "done" in chunk and chunk["done"]:
@@ -161,6 +161,7 @@ class OllamaMultiModal(MultiModalLLM):
             images=image_documents_to_base64(image_documents),
             stream=False,
             options=self._model_kwargs,
+            **kwargs,
         )
         return CompletionResponse(
             text=response["response"],
@@ -184,6 +185,7 @@ class OllamaMultiModal(MultiModalLLM):
             images=image_documents_to_base64(image_documents),
             stream=True,
             options=self._model_kwargs,
+            **kwargs,
         )
         text = ""
         for chunk in response:

--- a/llama_index/multi_modal_llms/ollama.py
+++ b/llama_index/multi_modal_llms/ollama.py
@@ -106,7 +106,9 @@ class OllamaMultiModal(MultiModalLLM):
         import ollama
 
         ollama_messages = _messages_to_dicts(messages)
-        response = ollama.chat(model=self.model, messages=ollama_messages, stream=False, **kwargs)
+        response = ollama.chat(
+            model=self.model, messages=ollama_messages, stream=False, **kwargs
+        )
         return ChatResponse(
             message=ChatMessage(
                 content=response["message"]["content"],
@@ -124,7 +126,9 @@ class OllamaMultiModal(MultiModalLLM):
         import ollama
 
         ollama_messages = _messages_to_dicts(messages)
-        response = ollama.chat(model=self.model, messages=ollama_messages, stream=True, **kwargs)
+        response = ollama.chat(
+            model=self.model, messages=ollama_messages, stream=True, **kwargs
+        )
         text = ""
         for chunk in response:
             if "done" in chunk and chunk["done"]:


### PR DESCRIPTION
# Description

Allows to pass important options to Ollama while using multimodal models, like "[keep_alive](https://github.com/ollama/ollama/blob/main/docs/api.md#parameters)" and others.

[Ollama class]( https://github.com/run-llama/llama_index/blob/main/llama_index/llms/ollama.py#L137) already features this change, only missing from OllamaMultiModal. kwargs are unused right now.
Example: https://github.com/run-llama/llama_index/blob/main/llama_index/llms/ollama.py#L137

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ollama class already features this change, only missing from OllamaMultiModal. kwargs are unused right now.
Running a local version with this change.

