### PR TITLE
Update json and markdown node parser import documentation

### DIFF
--- a/docs/module_guides/loading/node_parsers/modules.md
+++ b/docs/module_guides/loading/node_parsers/modules.md
@@ -39,7 +39,7 @@ nodes = parser.get_nodes_from_documents(html_docs)
 The `JSONNodeParser` parses raw JSON.
 
 ```python
-from llama_index import JSONNodeParser
+from llama_index.node_parser import JSONNodeParser
 
 parser = JSONNodeParser()
 
@@ -51,7 +51,7 @@ nodes = parser.get_nodes_from_documents(json_docs)
 The `MarkdownNodeParser` parses raw markdown text.
 
 ```python
-from llama_index import MarkdownNodeParser
+from llama_index.node_parser import MarkdownNodeParser
 
 parser = MarkdownNodeParser()
 


### PR DESCRIPTION
# Description
If you try to import the node parser as shown in the current documentation, you will receive the following errors:
`ImportError: cannot import name 'HTMLNodeParser' `
`ImportError: cannot import name 'JSONNodeParser'`

## Type of Change

- [x] This is a documentation change