### PR TITLE
Dedup logic for recursive retriever nodes

### DIFF
--- a/llama_index/retrievers/recursive_retriever.py
+++ b/llama_index/retrievers/recursive_retriever.py
@@ -57,6 +57,21 @@ class RecursiveRetriever(BaseRetriever):
         self._query_response_tmpl = query_response_tmpl or DEFAULT_QUERY_RESPONSE_TMPL
         super().__init__(callback_manager, verbose=verbose)
 
+    def _deduplicate_nodes(
+        self, nodes_with_score: List[NodeWithScore]
+    ) -> List[NodeWithScore]:
+        """Deduplicate nodes according to node id.
+        Keep the node with the highest score/first returned.
+        """
+        node_ids = set()
+        deduplicate_nodes = []
+        for node_with_score in nodes_with_score:
+            node = node_with_score.node
+            if node.id_ not in node_ids:
+                node_ids.add(node.id_)
+                deduplicate_nodes.append(node_with_score)
+        return deduplicate_nodes
+
     def _query_retrieved_nodes(
         self, query_bundle: QueryBundle, nodes_with_score: List[NodeWithScore]
     ) -> Tuple[List[NodeWithScore], List[NodeWithScore]]:
@@ -108,6 +123,10 @@ class RecursiveRetriever(BaseRetriever):
                 cur_additional_nodes = []
             nodes_to_add.extend(cur_retrieved_nodes)
             additional_nodes.extend(cur_additional_nodes)
+
+        # dedup nodes in case some nodes could be retrieved from multiple sources
+        nodes_to_add = self._deduplicate_nodes(nodes_to_add)
+        additional_nodes = self._deduplicate_nodes(additional_nodes)
 
         return nodes_to_add, additional_nodes
 


### PR DESCRIPTION
# Description
In some cases, we need to pass both index nodes and original nodes for recursive retriever. Since index nodes might not be enough to represent all the nodes information.

Then for index, we could have both index nodes and original nodes.
When we do retrieval, we could have the same response node appear multi times from different souces.

We need to add dedup logic after we gather all the nodex

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
