### PR TITLE
TelegramReader fixes not transferred from llama-hub

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-telegram/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-telegram/README.md
@@ -31,7 +31,7 @@ If the `.session` file already existed, it will not login again, so be aware of 
 To use this loader, you simply need to pass in a entity name.
 
 ```python
-from llama_index import download_loader
+from llama_index.core import download_loader
 
 TelegramReader = download_loader("TelegramReader")
 loader = TelegramReader(

--- a/llama-index-integrations/readers/llama-index-readers-telegram/llama_index/readers/telegram/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-telegram/llama_index/readers/telegram/base.py
@@ -1,5 +1,6 @@
 """Telegram reader that reads posts/chats and comments to post from Telegram channel or chat."""
 import asyncio
+import re
 from typing import List, Union
 
 from llama_index.core.readers.base import BaseReader
@@ -47,7 +48,8 @@ class TelegramReader(BaseReader):
         self.api_id = api_id
         self.api_hash = api_hash
         self.phone_number = phone_number
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
 
     def load_data(
         self,
@@ -101,5 +103,15 @@ class TelegramReader(BaseReader):
                 entity_name, reply_to=post_id, limit=limit
             ):
                 if isinstance(message.text, str) and message.text != "":
-                    results.append(Document(text=message.text))
+                    results.append(Document(text=self._remove_links(message.text)))
         return results
+
+    def _remove_links(self, string) -> str:
+        """Removes all URLs from a given string, leaving only the base domain name."""
+
+        def replace_match(match):
+            text = match.group(1)
+            return text if text else ""
+
+        url_pattern = r"https?://(?:www\.)?((?!www\.).)+?"
+        return re.sub(url_pattern, replace_match, string)

--- a/llama-index-integrations/readers/llama-index-readers-telegram/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-telegram/pyproject.toml
@@ -14,7 +14,7 @@ ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = ["Dias Kalkamanov <diicellman@gmail.com>"]
 description = "llama-index readers telegram integration"
 license = "MIT"
 name = "llama-index-readers-telegram"


### PR DESCRIPTION
# Description

Here's some fixes left behind after refactor:

- I encountered this error while using the Telegram Loader in a FastAPI application: "RuntimeError: There is no current event loop in thread 'AnyIO worker thread'." I resolved it by replacing asyncio.get_event_loop() with asyncio.new_event_loop().
- I encountered an issue while loading data from Telegram posts/messages: if there were many links, it wouldn't pass the OpenAI moderation, resulting in the response: "Sorry, I can't answer, there are too many links." Hence, I utilized regular expressions (re) to remove the links, retaining only the domain (as it could be useful) before converting the text into a Document object.
- Updated module imports in readme. 
- Added authorship in pyproject.toml file. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
