### PR TITLE
Fix MetadataInfo import

### DIFF
--- a/docs/examples/vector_stores/chroma_auto_retriever.ipynb
+++ b/docs/examples/vector_stores/chroma_auto_retriever.ipynb
@@ -268,7 +268,7 @@
    "outputs": [],
    "source": [
     "from llama_index.core.retrievers import VectorIndexAutoRetriever\n",
-    "from llama_index.core.vector_stores import MetadataInfo, VectorStoreInfo\n",
+    "from llama_index.core.vector_stores.types import MetadataInfo, VectorStoreInfo\n",
     "\n",
     "\n",
     "vector_store_info = VectorStoreInfo(\n",


### PR DESCRIPTION
# Description

The MetadataInfo class is located at llama_index.core.vector_stores.types instead of llama_index.core.vector_stores

## Type of Change

Please delete options that are not relevant.
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
