### PR TITLE
fix: BedrockEmbeddings.from_credentials always uses the default model

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -311,7 +311,7 @@ class BedrockEmbedding(BaseEmbedding):
             client = session.client("bedrock")
         return cls(
             client=client,
-            model_name=model_name,
+            model=model_name,
             embed_batch_size=embed_batch_size,
             callback_manager=callback_manager,
             verbose=verbose,

--- a/llama-index-legacy/llama_index/legacy/embeddings/bedrock.py
+++ b/llama-index-legacy/llama_index/legacy/embeddings/bedrock.py
@@ -312,7 +312,7 @@ class BedrockEmbedding(BaseEmbedding):
             client = session.client("bedrock")
         return cls(
             client=client,
-            model_name=model_name,
+            model=model_name,
             embed_batch_size=embed_batch_size,
             callback_manager=callback_manager,
             verbose=verbose,


### PR DESCRIPTION
# Description

https://github.com/run-llama/llama_index/pull/10581 reintroduced the method but the model is not passed correctly. 

Context: https://github.com/run-llama/llama_index/issues/10575

## Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
