### PR TITLE
Add maintainers (i.e. authors) and keywords to pyproject.toml from library.json (readers, tools, packs)

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-agent-search/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-agent-search/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers agent_search integration"
 license = "MIT"
+maintainers = ["emrgnt-cmplxty"]
 name = "llama-index-readers-agent-search"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-cdk/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-cdk/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_cdk integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-cdk"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-gong/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-gong/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_gong integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-gong"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-hubspot/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-hubspot/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_hubspot integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-hubspot"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-salesforce/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-salesforce/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_salesforce integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-salesforce"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-shopify/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-shopify/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_shopify integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-shopify"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-stripe/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-stripe/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_stripe integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-stripe"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-typeform/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-typeform/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_typeform integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-typeform"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airbyte-zendesk-support/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airbyte-zendesk-support/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airbyte_zendesk_support integration"
 license = "MIT"
+maintainers = ["flash1293"]
 name = "llama-index-readers-airbyte-zendesk-support"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-airtable/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-airtable/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers airtable integration"
 license = "MIT"
+maintainers = ["smyja"]
 name = "llama-index-readers-airtable"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-apify/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-apify/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers apify integration"
+keywords = ["apify", "crawler", "scraper", "scraping"]
 license = "MIT"
+maintainers = ["drobnikj"]
 name = "llama-index-readers-apify"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-arango-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-arango-db/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers arango db integration"
 license = "MIT"
+maintainers = ["mmaatouk"]
 name = "llama-index-readers-arango-db"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-asana/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-asana/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers asana integration"
 license = "MIT"
+maintainers = ["daveey"]
 name = "llama-index-readers-asana"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-assemblyai/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-assemblyai/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers assemblyai integration"
 license = "MIT"
+maintainers = ["patrickloeber"]
 name = "llama-index-readers-assemblyai"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers astra_db integration"
 license = "MIT"
+maintainers = ["erichare"]
 name = "llama-index-readers-astra-db"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-athena/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-athena/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers athena integration"
+keywords = ["aws athena", "datalake", "sql"]
 license = "MIT"
+maintainers = ["mattick27"]
 name = "llama-index-readers-athena"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-azcognitive-search/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-azcognitive-search/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers azcognitive_search integration"
 license = "MIT"
+maintainers = ["mrcabellom"]
 name = "llama-index-readers-azcognitive-search"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers azstorage_blob integration"
+keywords = ["azure storage", "azure", "blob", "container"]
 license = "MIT"
+maintainers = ["rivms"]
 name = "llama-index-readers-azstorage-blob"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-bagel/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-bagel/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers bagel integration"
+keywords = ["bagelDB", "database", "storage", "vector"]
 license = "MIT"
+maintainers = ["asif"]
 name = "llama-index-readers-bagel"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-bilibili/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-bilibili/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers bilibili integration"
 license = "MIT"
+maintainers = ["alexzhangji"]
 name = "llama-index-readers-bilibili"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-bitbucket/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-bitbucket/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers bitbucket integration"
+keywords = ["bitbucket", "project", "repository"]
 license = "MIT"
+maintainers = ["lejdiprifti"]
 name = "llama-index-readers-bitbucket"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-boarddocs/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-boarddocs/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers boarddocs integration"
+keywords = ["board", "boarddocs"]
 license = "MIT"
+maintainers = ["dweekly"]
 name = "llama-index-readers-boarddocs"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-chatgpt-plugin/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-chatgpt-plugin/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers chatgpt plugin integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-chatgpt-plugin"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-chroma/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-chroma/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers chroma integration"
 license = "MIT"
+maintainers = ["atroyn"]
 name = "llama-index-readers-chroma"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers confluence integration"
 license = "MIT"
+maintainers = ["zywilliamli"]
 name = "llama-index-readers-confluence"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-couchbase/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-couchbase/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers couchbase integration"
+keywords = ["Capella", "Couchbase", "NoSQL"]
 license = "MIT"
+maintainers = ["nithishr"]
 name = "llama-index-readers-couchbase"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-couchdb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-couchdb/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers couchdb integration"
 license = "MIT"
+maintainers = ["technosophy"]
 name = "llama-index-readers-couchdb"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-dad-jokes/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-dad-jokes/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers dad_jokes integration"
+keywords = ["dad jokes", "jokes"]
 license = "MIT"
+maintainers = ["sidu"]
 name = "llama-index-readers-dad-jokes"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-database/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-database/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers database integration"
+keywords = ["aws rds", "postgres", "snowflake", "sql"]
 license = "MIT"
+maintainers = ["kevinqz"]
 name = "llama-index-readers-database"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-deeplake/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-deeplake/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers deeplake integration"
+keywords = ["deeplake"]
 license = "MIT"
+maintainers = ["adolkhan"]
 name = "llama-index-readers-deeplake"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-discord/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-discord/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers discord integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-discord"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-docstring-walker/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-docstring-walker/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers docstring_walker integration"
+keywords = ["code", "docstring", "python", "source code"]
 license = "MIT"
+maintainers = ["Filip Wojcik"]
 name = "llama-index-readers-docstring-walker"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-docugami/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-docugami/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers docugami integration"
+keywords = ["doc", "docugami", "docx", "pdf", "xml"]
 license = "MIT"
+maintainers = ["tjaffri"]
 name = "llama-index-readers-docugami"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-earnings-call-transcript/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-earnings-call-transcript/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers earnings_call_transcript integration"
+keywords = ["Earning calls", "Finance", "Investor"]
 license = "MIT"
+maintainers = ["Athe-kunal"]
 name = "llama-index-readers-earnings-call-transcript"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-elasticsearch/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers elasticsearch integration"
 license = "MIT"
+maintainers = ["jaylmiller"]
 name = "llama-index-readers-elasticsearch"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-faiss/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-faiss/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers faiss integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-faiss"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-feedly-rss/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-feedly-rss/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers feedly_rss integration"
+keywords = ["feedly", "rss"]
 license = "MIT"
+maintainers = ["kychanbp"]
 name = "llama-index-readers-feedly-rss"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-feishu-docs/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-feishu-docs/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers feishu_docs integration"
 license = "MIT"
+maintainers = ["ma-chengcheng"]
 name = "llama-index-readers-feishu-docs"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers file integration"
+keywords = ["10k", "10q", "chart", "eml", "figure", "html", "hwp", "image", "invoice", "ipynb", "jupyter", "notebook", "pdf", "pymupdf", "receipt", "sec", "spreadsheet", "tabular", "unstructured.io", "yaml", "yml"]
 license = "MIT"
+maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
 version = "0.1.2"

--- a/llama-index-integrations/readers/llama-index-readers-firebase-realtimedb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-firebase-realtimedb/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers firebase_realtimedb integration"
+keywords = ["database", "firebase", "realtimedb"]
 license = "MIT"
+maintainers = ["ajay"]
 name = "llama-index-readers-firebase-realtimedb"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-firestore/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-firestore/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers firestore integration"
+keywords = ["datastore", "firestore"]
 license = "MIT"
+maintainers = ["rayzhudev"]
 name = "llama-index-readers-firestore"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers github integration"
+keywords = ["code", "collaborators", "git", "github", "issues", "placeholder", "repository", "source code"]
 license = "MIT"
+maintainers = ["ahmetkca", "moncho", "rwood-97"]
 name = "llama-index-readers-github"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers google integration"
+keywords = ["email", "gmail", "google keep", "google notes"]
 license = "MIT"
+maintainers = ["bbornsztein", "jerryjliu", "ong", "piroz", "pycui", "ravi03071991"]
 name = "llama-index-readers-google"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-gpt-repo/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-gpt-repo/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers gpt_repo integration"
 license = "MIT"
+maintainers = ["mpoon"]
 name = "llama-index-readers-gpt-repo"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-graphdb-cypher/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-graphdb-cypher/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers graphdb_cypher integration"
+keywords = ["cypher", "graph", "neo4j"]
 license = "MIT"
+maintainers = ["jexp"]
 name = "llama-index-readers-graphdb-cypher"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-graphql/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-graphql/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers graphql integration"
+keywords = ["apollo", "gql", "graphql"]
 license = "MIT"
+maintainers = ["jexp"]
 name = "llama-index-readers-graphql"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-guru/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-guru/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers guru integration"
+keywords = ["getguru", "guru", "knowledge base"]
 license = "MIT"
+maintainers = ["mcclain-thiel"]
 name = "llama-index-readers-guru"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-hatena-blog/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-hatena-blog/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers hatena_blog integration"
+keywords = ["blog", "hatena"]
 license = "MIT"
+maintainers = ["Shoya SHIRAKI"]
 name = "llama-index-readers-hatena-blog"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-hive/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-hive/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers hive integration"
+keywords = ["HDFS", "Hadoop", "Hive"]
 license = "MIT"
+maintainers = ["kasen"]
 name = "llama-index-readers-hive"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-hubspot/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-hubspot/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers hubspot integration"
+keywords = ["hubspot"]
 license = "MIT"
+maintainers = ["ykhli"]
 name = "llama-index-readers-hubspot"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-huggingface-fs/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-huggingface-fs/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers huggingface fs integration"
+keywords = ["face", "filesystem", "fs", "hugging", "huggingface"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-huggingface-fs"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-imdb-review/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-imdb-review/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers imdb_review integration"
+keywords = ["IMDB", "movies", "reviews"]
 license = "MIT"
+maintainers = ["Athe-kunal"]
 name = "llama-index-readers-imdb-review"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-intercom/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-intercom/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers intercom integration"
+keywords = ["help center", "intercom", "knowledge base"]
 license = "MIT"
+maintainers = ["bbornsztein"]
 name = "llama-index-readers-intercom"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-jira/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-jira/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers jira integration"
+keywords = ["jira"]
 license = "MIT"
+maintainers = ["bearguy"]
 name = "llama-index-readers-jira"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-joplin/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-joplin/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers joplin integration"
 license = "MIT"
+maintainers = ["alondmnt"]
 name = "llama-index-readers-joplin"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-json/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-json/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers json integration"
 license = "MIT"
+maintainers = ["yisding"]
 name = "llama-index-readers-json"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-kaltura/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-kaltura/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers kaltura e-search integration"
+keywords = ["audio", "events", "image", "kaltura", "library", "media", "portal", "search", "video"]
 license = "MIT"
+maintainers = ["kaltura"]
 name = "llama-index-readers-kaltura-esearch"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-kibela/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-kibela/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers kibela integration"
 license = "MIT"
+maintainers = ["higebu"]
 name = "llama-index-readers-kibela"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-lilac/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-lilac/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers lilac integration"
 license = "MIT"
+maintainers = ["nsthorat"]
 name = "llama-index-readers-lilac"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-linear/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-linear/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers linear integration"
+keywords = ["linear"]
 license = "MIT"
+maintainers = ["Sushmithamallesh"]
 name = "llama-index-readers-linear"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-macrometa-gdn/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-macrometa-gdn/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers macrometa_gdn integration"
+keywords = ["macrometa"]
 license = "MIT"
+maintainers = ["Dain Im"]
 name = "llama-index-readers-macrometa-gdn"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-mangadex/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mangadex/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers mangadex integration"
+keywords = ["anime", "manga"]
 license = "MIT"
+maintainers = ["choombaa"]
 name = "llama-index-readers-mangadex"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-mangoapps-guides/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mangoapps-guides/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers mangoapps_guides integration"
+keywords = ["mangoapps"]
 license = "MIT"
+maintainers = ["mangoapps"]
 name = "llama-index-readers-mangoapps-guides"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-maps/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-maps/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers maps integration"
+keywords = ["geo", "maps", "open maps", "open street maps", "overpass api"]
 license = "MIT"
+maintainers = ["carrotpy"]
 name = "llama-index-readers-maps"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-mbox/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mbox/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers mbox integration"
 license = "MIT"
+maintainers = ["minosvasilias"]
 name = "llama-index-readers-mbox"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-memos/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-memos/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers memos integration"
+keywords = ["memos", "note"]
 license = "MIT"
+maintainers = ["bubu"]
 name = "llama-index-readers-memos"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-metal/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-metal/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers metal integration"
+keywords = ["metal", "retriever", "storage"]
 license = "MIT"
+maintainers = ["getmetal"]
 name = "llama-index-readers-metal"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers microsoft_onedrive integration"
+keywords = ["microsoft 365", "microsoft onedrive", "microsoft365", "onedrive for business", "onedrive personal", "onedrive"]
 license = "MIT"
+maintainers = ["godwin3737"]
 name = "llama-index-readers-microsoft-onedrive"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-outlook/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-outlook/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers microsoft outlook integration"
+keywords = ["calendar", "outlook"]
 license = "MIT"
+maintainers = ["tevslin"]
 name = "llama-index-readers-microsoft-outlook"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers microsoft_sharepoint integration"
+keywords = ["microsoft 365", "microsoft365", "sharepoint"]
 license = "MIT"
+maintainers = ["arun-soliton"]
 name = "llama-index-readers-microsoft-sharepoint"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-milvus/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-milvus/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers milvus integration"
 license = "MIT"
+maintainers = ["filip-halt"]
 name = "llama-index-readers-milvus"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-mondaydotcom/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mondaydotcom/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers mondaydotcom integration"
+keywords = ["monday", "mondaydotcom"]
 license = "MIT"
+maintainers = ["nadavgr"]
 name = "llama-index-readers-mondaydotcom"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers mongodb integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-mongodb"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-notion/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-notion/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers notion integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-notion"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-nougat-ocr/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-nougat-ocr/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers nougat_ocr integration"
+keywords = ["academic papers", "ocr", "pdf"]
 license = "MIT"
+maintainers = ["mdarshad1000"]
 name = "llama-index-readers-nougat-ocr"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-obsidian/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers obsidian integration"
 license = "MIT"
+maintainers = ["hursh-desai"]
 name = "llama-index-readers-obsidian"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-openalex/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-openalex/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers openalex integration"
+keywords = ["academic papers", "open access", "openalex", "scientific papers"]
 license = "MIT"
+maintainers = ["shauryr"]
 name = "llama-index-readers-openalex"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-opendal/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-opendal/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers opendal_reader integration"
+keywords = ["azblob", "gcs", "s3", "storage"]
 license = "MIT"
+maintainers = ["OpenDAL Contributors"]
 name = "llama-index-readers-opendal-reader"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-opensearch/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-opensearch/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers opensearch integration"
 license = "MIT"
+maintainers = ["chnsagitchen"]
 name = "llama-index-readers-opensearch"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-pandas-ai/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-pandas-ai/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers pandas_ai integration"
+keywords = ["ai", "pandas"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-pandas-ai"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers papers integration"
 license = "MIT"
+maintainers = ["thejessezhang"]
 name = "llama-index-readers-papers"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-patentsview/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-patentsview/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers patentsview integration"
+keywords = ["patent"]
 license = "MIT"
+maintainers = ["shao-shuai"]
 name = "llama-index-readers-patentsview"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-pdb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-pdb/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers pdb integration"
+keywords = ["Protein Data Bank", "academic papers", "pdb", "proteins"]
 license = "MIT"
+maintainers = ["joshuakto"]
 name = "llama-index-readers-pdb"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-pdf-table/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-pdf-table/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers pdf_table integration"
+keywords = ["pdf table", "pdf", "table"]
 license = "MIT"
+maintainers = ["yy0867"]
 name = "llama-index-readers-pdf-table"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-pinecone/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-pinecone/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers pinecone integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-pinecone"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-preprocess/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-preprocess/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers preprocess integration"
+keywords = ["chunk", "chunking", "documents", "preprocess"]
 license = "MIT"
+maintainers = ["preprocess"]
 name = "llama-index-readers-preprocess"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-qdrant/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-qdrant/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers qdrant integration"
 license = "MIT"
+maintainers = ["kacperlukawski"]
 name = "llama-index-readers-qdrant"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-rayyan/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-rayyan/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers rayyan integration"
+keywords = ["rayyan", "systematic review"]
 license = "MIT"
+maintainers = ["hammady"]
 name = "llama-index-readers-rayyan"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-readwise/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-readwise/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers readwise integration"
+keywords = ["highlights", "pkm", "reading", "readwise"]
 license = "MIT"
+maintainers = ["alexbowe"]
 name = "llama-index-readers-readwise"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-reddit/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-reddit/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers reddit integration"
+keywords = ["comments", "reddit", "search", "subreddit"]
 license = "MIT"
+maintainers = ["vanessahlyan"]
 name = "llama-index-readers-reddit"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-remote-depth/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-remote-depth/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers remote_depth integration"
+keywords = ["hosted", "multiple", "url"]
 license = "MIT"
+maintainers = ["simonMoisselin"]
 name = "llama-index-readers-remote-depth"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-remote/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-remote/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers remote integration"
+keywords = ["gutenberg", "hosted", "url"]
 license = "MIT"
+maintainers = ["thejessezhang"]
 name = "llama-index-readers-remote"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers s3 integration"
+keywords = ["amazon web services", "aws s3", "bucket"]
 license = "MIT"
+maintainers = ["thejessezhang"]
 name = "llama-index-readers-s3"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers sec_filings integration"
+keywords = ["10-K", "10-Q", "SEC Filings", "finance"]
 license = "MIT"
+maintainers = ["Athe-kunal"]
 name = "llama-index-readers-sec-filings"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-semanticscholar/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-semanticscholar/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers semanticscholar integration"
+keywords = ["paper", "research", "scholar", "semantic"]
 license = "MIT"
+maintainers = ["shauryr"]
 name = "llama-index-readers-semanticscholar"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-singlestore/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-singlestore/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers singlestore integration"
+keywords = ["memsql", "singlestore"]
 license = "MIT"
+maintainers = ["singlestore"]
 name = "llama-index-readers-singlestore"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-slack/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-slack/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers slack integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-slack"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-smart-pdf-loader/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-smart-pdf-loader/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers smart_pdf_loader integration"
+keywords = ["pdf layout", "pdf table", "pdf"]
 license = "MIT"
+maintainers = ["ansukla"]
 name = "llama-index-readers-smart-pdf-loader"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-snowflake/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-snowflake/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers snowflake integration"
+keywords = ["data warehouse", "database", "snowflake", "warehouse"]
 license = "MIT"
+maintainers = ["godwin3737"]
 name = "llama-index-readers-snowflake"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-snscrape-twitter/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-snscrape-twitter/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers snscrape_twitter integration"
 license = "MIT"
+maintainers = ["smyja"]
 name = "llama-index-readers-snscrape-twitter"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-spotify/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-spotify/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers spotify integration"
+keywords = ["music", "spotify"]
 license = "MIT"
+maintainers = ["ong"]
 name = "llama-index-readers-spotify"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-stackoverflow/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-stackoverflow/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers stackoverflow integration"
+keywords = ["answers", "posts", "questions"]
 license = "MIT"
+maintainers = ["allen-munsch"]
 name = "llama-index-readers-stackoverflow"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-steamship/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-steamship/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers steamship integration"
+keywords = ["steamship"]
 license = "MIT"
+maintainers = ["douglas-reid"]
 name = "llama-index-readers-steamship"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-stripe-docs/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-stripe-docs/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers stripe_docs integration"
+keywords = ["documentation", "stripe"]
 license = "MIT"
+maintainers = ["amorriscode"]
 name = "llama-index-readers-stripe-docs"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-telegram/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-telegram/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Dias Kalkamanov <diicellman@gmail.com>"]
 description = "llama-index readers telegram integration"
 license = "MIT"
+maintainers = ["diicell"]
 name = "llama-index-readers-telegram"
 readme = "README.md"
 version = "0.1.2"

--- a/llama-index-integrations/readers/llama-index-readers-trello/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-trello/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers trello integration"
+keywords = ["trello"]
 license = "MIT"
+maintainers = ["bluzir"]
 name = "llama-index-readers-trello"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-twitter/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-twitter/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers twitter integration"
 license = "MIT"
+maintainers = ["ravi03071991"]
 name = "llama-index-readers-twitter"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-weather/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-weather/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers weather integration"
+keywords = ["openweather", "weather"]
 license = "MIT"
+maintainers = ["iamadhee"]
 name = "llama-index-readers-weather"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-weaviate/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-weaviate/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers weaviate integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-weaviate"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers web integration"
+keywords = ["BFS", "article", "atom", "documentation", "feed", "main content extractor", "news", "readthedocs", "rss", "scraper", "selenium", "seo", "sitemap", "substack", "trafilatura", "unstructured.io", "url", "web reader", "web", "website"]
 license = "MIT"
+maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-whatsapp/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-whatsapp/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers whatsapp integration"
+keywords = ["chat", "whatsapp"]
 license = "MIT"
+maintainers = ["batmanscode"]
 name = "llama-index-readers-whatsapp"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-wikipedia/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-wikipedia/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers wikipedia integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-readers-wikipedia"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-wordlift/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-wordlift/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers wordlift integration"
+keywords = ["graphql", "knowledge graph", "seo", "structured data", "wordlift"]
 license = "MIT"
+maintainers = ["msftwarelab"]
 name = "llama-index-readers-wordlift"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers wordpress integration"
+keywords = ["blog", "wordpress"]
 license = "MIT"
+maintainers = ["bbornsztein"]
 name = "llama-index-readers-wordpress"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-youtube-transcript/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-youtube-transcript/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers youtube transcript integration"
+keywords = ["video"]
 license = "MIT"
+maintainers = ["ravi03071991"]
 name = "llama-index-readers-youtube-transcript"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-zendesk/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-zendesk/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers zendesk integration"
+keywords = ["help center", "knowledge base", "zendesk"]
 license = "MIT"
+maintainers = ["bbornsztein"]
 name = "llama-index-readers-zendesk"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-zep/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-zep/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers zep integration"
+keywords = ["memory", "retriever", "storage", "zep"]
 license = "MIT"
+maintainers = ["zep"]
 name = "llama-index-readers-zep"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/readers/llama-index-readers-zulip/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-zulip/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index readers zulip integration"
 license = "MIT"
+maintainers = ["plurigrid"]
 name = "llama-index-readers-zulip"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-arxiv/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-arxiv/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools arxiv integration"
+keywords = ["math", "research", "science"]
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-arxiv"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-azure-cv/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-azure-cv/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools azure_cv integration"
+keywords = ["cv", "image", "vision"]
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-azure-cv"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-azure-speech/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-azure-speech/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools azure_speech integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-azure-speech"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-azure-translate/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-azure-translate/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools azure_translate integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-azure-translate"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-bing-search/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-bing-search/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools bing_search integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-bing-search"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-chatgpt-plugin/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-chatgpt-plugin/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools chatgpt_plugin integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-chatgpt-plugin"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-code-interpreter/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-code-interpreter/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools code_interpreter integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-code-interpreter"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-cogniswitch/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-cogniswitch/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools cogniswitch integration"
+keywords = ["embedding", "graph", "knowledge graph", "neural", "symbolic"]
 license = "MIT"
+maintainers = ["cogniswitch"]
 name = "llama-index-tools-cogniswitch"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-database/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-database/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools database integration"
+keywords = ["aws rds", "postgres", "snowflake", "sql"]
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-database"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-exa/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-exa/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools exa integration"
 license = "MIT"
+maintainers = ["jeffzwang"]
 name = "llama-index-tools-exa"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools google integration"
+keywords = ["email", "gmail"]
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-google"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-graphql/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-graphql/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools graphql integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-graphql"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-ionic-shopping/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-ionic-shopping/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools ionic shopping integration"
 license = "MIT"
+maintainers = ["stewartjarod"]
 name = "llama-index-tools-ionic-shopping"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-metaphor/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-metaphor/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools metaphor integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-metaphor"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-multion/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-multion/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools multion integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-multion"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-neo4j/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-neo4j/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools neo4j integration"
+keywords = ["cypher", "graph", "neo4j"]
 license = "MIT"
+maintainers = ["shahafp"]
 name = "llama-index-tools-neo4j"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-notion/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-notion/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools notion integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-tools-notion"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-openai/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-openai/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools openai_image_generation integration"
+keywords = ["cv", "gpt-3", "image", "openai", "vision"]
 license = "MIT"
+maintainers = ["manelferreira_"]
 name = "llama-index-tools-openai-image-generation"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-openapi/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-openapi/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools openapi integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-openapi"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-playgrounds/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-playgrounds/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools playgrounds integration"
+keywords = ["blockchain", "decentralized", "graphql", "playgroundsapi", "subgraph", "thegraph"]
 license = "MIT"
+maintainers = ["tachi"]
 name = "llama-index-tools-playgrounds"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-python-file/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-python-file/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools python_file integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-python-file"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-requests/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-requests/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools requests integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-requests"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-salesforce/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-salesforce/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools salesforce integration"
+keywords = ["salesforce"]
 license = "MIT"
+maintainers = ["chrispangg"]
 name = "llama-index-tools-salesforce"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-shopify/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-shopify/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools shopify integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-shopify"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-slack/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-slack/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools slack integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-tools-slack"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-tavily-research/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-tavily-research/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools tavily_research integration"
 license = "MIT"
+maintainers = ["rotemweiss57"]
 name = "llama-index-tools-tavily-research"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-text-to-image/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-text-to-image/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools text_to_image integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-text-to-image"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-vector-db/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-vector-db/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools vector_db integration"
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-tools-vector-db"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-waii/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-waii/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools waii integration"
 license = "MIT"
+maintainers = ["wangdatan"]
 name = "llama-index-tools-waii"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-weather/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-weather/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools weather integration"
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-tools-weather"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-wikipedia/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-wikipedia/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools wikipedia integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-wikipedia"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools wolfram_alpha integration"
+keywords = ["math"]
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-wolfram-alpha"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-yelp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-yelp/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools yelp integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-yelp"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-integrations/tools/llama-index-tools-zapier/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-zapier/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index tools zapier integration"
 license = "MIT"
+maintainers = ["ajhofmann"]
 name = "llama-index-tools-zapier"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-agent-search-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-agent-search-retriever/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs agent_search_retriever integration"
+keywords = ["agent", "retriever", "search"]
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-packs-agent-search-retriever"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-agents-llm-compiler/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-agents-llm-compiler/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs agents llm compiler"
+keywords = ["agent", "compiler", "llm"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-agents-llm-compiler"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-amazon-product-extraction/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-amazon-product-extraction/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs amazon_product_extraction integration"
+keywords = ["amazon", "extraction", "product"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-amazon-product-extraction"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-arize-phoenix-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-arize-phoenix-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs arize_phoenix_query_engine integration"
+keywords = ["arize", "engine", "index", "phoenix", "query"]
 license = "MIT"
+maintainers = ["axiomofjoy"]
 name = "llama-index-packs-arize-phoenix-query-engine"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-auto-merging-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-auto-merging-retriever/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs auto_merging_retriever integration"
+keywords = ["auto", "automerging", "index", "merging", "retriever"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-auto-merging-retriever"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-chroma-autoretrieval/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-chroma-autoretrieval/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs chroma_autoretrieval integration"
+keywords = ["chroma", "retrieval", "vector"]
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-packs-chroma-autoretrieval"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-cogniswitch-agent/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-cogniswitch-agent/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs cogniswitch_agent integration"
+keywords = ["embedding", "graph", "knowledge graph", "neural", "symbolic"]
 license = "MIT"
+maintainers = ["cogniswitch"]
 name = "llama-index-packs-cogniswitch-agent"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-deeplake-deepmemory-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-deeplake-deepmemory-retriever/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs deeplake_deepmemory_retriever integration"
+keywords = ["deeplake", "deepmemory", "retriever"]
 license = "MIT"
+maintainers = ["AdkSarsen"]
 name = "llama-index-packs-deeplake-deepmemory-retriever"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-deeplake-multimodal-retrieval/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-deeplake-multimodal-retrieval/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs deeplake_multimodal_retrieval integration"
+keywords = ["deeplake", "multimodal", "retriever"]
 license = "MIT"
+maintainers = ["AdkSarsen"]
 name = "llama-index-packs-deeplake-multimodal-retrieval"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-dense-x-retrieval/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-dense-x-retrieval/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs dense_x_retrieval integration"
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-packs-dense-x-retrieval"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-evaluator-benchmarker/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-evaluator-benchmarker/pyproject.toml
@@ -22,6 +22,7 @@ python_version = "3.8"
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs evaluator_benchmarker integration"
 license = "MIT"
+maintainers = ["nerdai"]
 name = "llama-index-packs-evaluator-benchmarker"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-fusion-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-fusion-retriever/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs fusion_retriever integration"
+keywords = ["fusion", "hybrid", "query", "retriever", "rewriting"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-fusion-retriever"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-fuzzy-citation/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-fuzzy-citation/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs fuzzy_citation integration"
+keywords = ["citation", "cite", "engine", "fuzzy", "index", "query"]
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-packs-fuzzy-citation"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-gmail-openai-agent/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-gmail-openai-agent/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs gmail_openai_agent integration"
+keywords = ["math", "research", "science"]
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-packs-gmail-openai-agent"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-gradio-agent-chat/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-gradio-agent-chat/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs gradio_agent_chat integration"
+keywords = ["agent", "chatbot", "gradio", "tools"]
 license = "MIT"
+maintainers = ["nerdai"]
 name = "llama-index-packs-gradio-agent-chat"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-gradio-react-agent-chatbot/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-gradio-react-agent-chatbot/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs gradio_react_agent_chatbot integration"
+keywords = ["chatbot", "gradio", "react-agent", "tools"]
 license = "MIT"
+maintainers = ["nerdai"]
 name = "llama-index-packs-gradio-react-agent-chatbot"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-infer-retrieve-rerank/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-infer-retrieve-rerank/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs infer retrieve rerank integration"
+keywords = ["infer", "rag", "rerank", "retrieve", "retriever"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-infer-retrieve-rerank"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-llama-dataset-metadata/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-llama-dataset-metadata/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs llama_dataset_metadata integration"
+keywords = ["evaluation", "llamadataset", "rag", "submission"]
 license = "MIT"
+maintainers = ["nerdai"]
 name = "llama-index-packs-llama-dataset-metadata"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-llama-guard-moderator/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-llama-guard-moderator/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs llama_guard_moderator integration"
+keywords = ["llama guard", "llm security", "prompt injection", "purple llama"]
 license = "MIT"
+maintainers = ["wenqiglantz"]
 name = "llama-index-packs-llama-guard-moderator"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-llava-completion/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-llava-completion/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs llava_completion integration"
+keywords = ["image", "llava", "multimodal"]
 license = "MIT"
+maintainers = ["wenqiglantz"]
 name = "llama-index-packs-llava-completion"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-multi-document-agents/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-multi-document-agents/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs multi_document_agents integration"
+keywords = ["agents", "document", "multi"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-multi-document-agents"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-multi-tenancy-rag/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-multi-tenancy-rag/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs multi_tenancy_rag integration"
+keywords = ["multi", "multi-tenancy", "rag", "tenancy"]
 license = "MIT"
+maintainers = ["ravi03071991"]
 name = "llama-index-packs-multi-tenancy-rag"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-multidoc-autoretrieval/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-multidoc-autoretrieval/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs multidoc_autoretrieval integration"
+keywords = ["autoretrieval", "document", "multi", "multidoc", "retrieval"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-multidoc-autoretrieval"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-nebulagraph-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-nebulagraph-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs nebulagraph_query_engine integration"
+keywords = ["knowledge graph", "nebulagraph", "query engine"]
 license = "MIT"
+maintainers = ["wenqiglantz"]
 name = "llama-index-packs-nebulagraph-query-engine"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-neo4j-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-neo4j-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs neo4j_query_engine integration"
+keywords = ["knowledge graph", "neo4j", "query engine"]
 license = "MIT"
+maintainers = ["wenqiglantz"]
 name = "llama-index-packs-neo4j-query-engine"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-node-parser-semantic-chunking/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-node-parser-semantic-chunking/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs node_parser integration"
+keywords = ["chunk", "chunking", "embedding", "node", "parser", "semantic"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-node-parser"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-ollama-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-ollama-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs ollama_query_engine integration"
+keywords = ["engine", "index", "local", "ollama", "query"]
 license = "MIT"
+maintainers = ["chnsagitchen"]
 name = "llama-index-packs-ollama-query-engine"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-panel-chatbot/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-panel-chatbot/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs panel_chatbot integration"
+keywords = ["chatbot", "github", "index", "openai", "panel"]
 license = "MIT"
+maintainers = ["MarcSkovMadsen"]
 name = "llama-index-packs-panel-chatbot"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-rag-cli-local/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-rag-cli-local/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs rag cli local integration"
+keywords = ["cli", "local", "rag"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-rag-cli-local"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-rag-evaluator/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-rag-evaluator/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs rag_evaluator integration"
+keywords = ["benchmarks", "evaluation", "rag"]
 license = "MIT"
+maintainers = ["nerdai"]
 name = "llama-index-packs-rag-evaluator"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-rag-fusion-query-pipeline/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-rag-fusion-query-pipeline/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs query integration"
+keywords = ["fusion", "pipeline", "query", "rag"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-query"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-ragatouille-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-ragatouille-retriever/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs ragatouille_retriever integration"
+keywords = ["rag", "ragatouille", "retriever"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-ragatouille-retriever"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-recursive-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-recursive-retriever/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs recursive_retriever integration"
+keywords = ["big", "embedded", "recursive", "retriever", "small", "tables", "unstructured"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-recursive-retriever"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-redis-ingestion-pipeline/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-redis-ingestion-pipeline/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs redis_ingestion_pipeline integration"
+keywords = ["index", "ingestion", "pipeline", "redis"]
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-packs-redis-ingestion-pipeline"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-resume-screener/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-resume-screener/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs resume_screener integration"
+keywords = ["document", "pdf", "resume", "structured output"]
 license = "MIT"
+maintainers = ["Disiok"]
 name = "llama-index-packs-resume-screener"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-retry-engine-weaviate/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-retry-engine-weaviate/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs retry_engine_weaviate integration"
+keywords = ["engine", "retry", "weaviate"]
 license = "MIT"
+maintainers = ["erika-cardenas"]
 name = "llama-index-packs-retry-engine-weaviate"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-self-rag/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-self-rag/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs self rag integration"
+keywords = ["llm", "self-RAG", "smart-retreiver"]
 license = "MIT"
+maintainers = ["mmaatouk"]
 name = "llama-index-packs-self-rag"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-sentence-window-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-sentence-window-retriever/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs sentence_window_retriever integration"
+keywords = ["retriever", "sentence", "window"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-sentence-window-retriever"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-snowflake-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-snowflake-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs snowflake_query_engine integration"
+keywords = ["engine", "query", "snowflake"]
 license = "MIT"
+maintainers = ["wenqiglantz"]
 name = "llama-index-packs-snowflake-query-engine"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-stock-market-data-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-stock-market-data-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs stock_market_data_query_engine integration"
+keywords = ["data", "engine", "finance", "market", "query", "stock", "yahoo finance", "yahoo"]
 license = "MIT"
+maintainers = ["anoopshrma"]
 name = "llama-index-packs-stock-market-data-query-engine"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-streamlit-chatbot/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-streamlit-chatbot/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs streamlit_chatbot integration"
+keywords = ["chatbot", "snowflake", "streamlit", "wikipedia"]
 license = "MIT"
+maintainers = ["carolinedlu"]
 name = "llama-index-packs-streamlit-chatbot"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-sub-question-weaviate/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-sub-question-weaviate/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs sub_question_weaviate integration"
+keywords = ["index", "query", "weaviate"]
 license = "MIT"
+maintainers = ["erika-cardenas"]
 name = "llama-index-packs-sub-question-weaviate"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-tables/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-tables/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs tables integration"
+keywords = ["chain", "dataframe", "pandas", "table", "tables"]
 license = "MIT"
+maintainers = ["Disiok", "jerryjliu"]
 name = "llama-index-packs-tables"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-timescale-vector-autoretrieval/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-timescale-vector-autoretrieval/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs timescale_vector_autoretrieval integration"
+keywords = ["autoretrieval", "index", "timescale", "vector"]
 license = "MIT"
+maintainers = ["cevian"]
 name = "llama-index-packs-timescale-vector-autoretrieval"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-trulens-eval-packs/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-trulens-eval-packs/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs trulens_eval_packs integration"
+keywords = ["eval", "harmless", "helpful", "rag", "triad", "trulens"]
 license = "MIT"
+maintainers = ["joshreini1"]
 name = "llama-index-packs-trulens-eval-packs"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-vanna/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-vanna/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs vanna integration"
+keywords = ["ai", "sql", "text-to-sql", "vanna"]
 license = "MIT"
+maintainers = ["jerryjliu"]
 name = "llama-index-packs-vanna"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-vectara-rag/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-vectara-rag/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs vectara_rag integration"
+keywords = ["embeddings", "rag", "retrieval", "vectara"]
 license = "MIT"
+maintainers = ["ofermend"]
 name = "llama-index-packs-vectara-rag"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-voyage-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-voyage-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs voyage_query_engine integration"
+keywords = ["embeddings", "query", "retrieval", "voyage"]
 license = "MIT"
+maintainers = ["Liuhong99"]
 name = "llama-index-packs-voyage-query-engine"
 readme = "README.md"
 version = "0.1.1"

--- a/llama-index-packs/llama-index-packs-zephyr-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-zephyr-query-engine/pyproject.toml
@@ -21,7 +21,9 @@ python_version = "3.8"
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
 description = "llama-index packs zephyr_query_engine integration"
+keywords = ["engine", "huggingface", "index", "local", "query", "zephyr"]
 license = "MIT"
+maintainers = ["logan-markewich"]
 name = "llama-index-packs-zephyr-query-engine"
 readme = "README.md"
 version = "0.1.1"


### PR DESCRIPTION
# Description

- This PR ports over the authors/keywords data held in library.json files for readers, tools and packs to the associated pyproject.toml file
- Will patch (bump version of pyproject.toml) and publish each of these packages in a future PR — getting this one in now so that llamahub-ui work is unblocked immediately.