### PR TITLE
Add FunctionComponent alias

### DIFF
--- a/llama-index-core/llama_index/core/query_pipeline/__init__.py
+++ b/llama-index-core/llama_index/core/query_pipeline/__init__.py
@@ -1,4 +1,5 @@
 """Init file."""
+
 from llama_index.core.query_pipeline.components.agent import (
     AgentFnComponent,
     AgentInputComponent,
@@ -6,7 +7,10 @@ from llama_index.core.query_pipeline.components.agent import (
     QueryComponent,
 )
 from llama_index.core.query_pipeline.components.argpacks import ArgPackComponent
-from llama_index.core.query_pipeline.components.function import FnComponent
+from llama_index.core.query_pipeline.components.function import (
+    FnComponent,
+    FunctionComponent,
+)
 from llama_index.core.query_pipeline.components.input import InputComponent
 from llama_index.core.query_pipeline.components.router import RouterComponent
 from llama_index.core.query_pipeline.components.tool_runner import ToolRunnerComponent
@@ -25,6 +29,7 @@ __all__ = [
     "AgentInputComponent",
     "ArgPackComponent",
     "FnComponent",
+    "FunctionComponent",
     "InputComponent",
     "RouterComponent",
     "ToolRunnerComponent",

--- a/llama-index-core/llama_index/core/query_pipeline/components/function.py
+++ b/llama-index-core/llama_index/core/query_pipeline/components/function.py
@@ -114,3 +114,7 @@ class FnComponent(QueryComponent):
     def output_keys(self) -> OutputKeys:
         """Output keys."""
         return OutputKeys.from_keys({self.output_key})
+
+
+# alias
+FunctionComponent = FnComponent


### PR DESCRIPTION
# Description

- Add `FunctionComponent` alias for `FnComponent`
- Missing from legacy, but going to add this alias in any case since it was published in a YouTube video of ours.

Fixes #10672

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
