### PR TITLE
Fix: The _indices of KnowledgeGraphIndex method does not update storage context index

### DIFF
--- a/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
@@ -240,6 +240,9 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
                     rel_embedding = self._embed_model.get_text_embedding(triplet_str)
                     self._index_struct.add_to_embedding_dict(triplet_str, rel_embedding)
 
+        # Update the storage context's index_store
+        self._storage_context.index_store.add_index_struct(self._index_struct)
+
     def upsert_triplet(self, triplet: Tuple[str, str, str]) -> None:
         """Insert triplets.
 


### PR DESCRIPTION
Fix: The _indices of KnowledgeGraphIndex method adds a new node to the index, but does not persit it as it does not update the storage context's index. Added a line to updated the storage context index at the end of the _insert function to fix this issue.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
