### PR TITLE
fix: token_counting fails to import ChatMessage

### DIFF
--- a/llama-index-core/llama_index/core/utilities/token_counting.py
+++ b/llama-index-core/llama_index/core/utilities/token_counting.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Callable, Dict, List, Optional
 
-from llama_index.core.llms import ChatMessage, MessageRole
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.utils import get_tokenizer
 
 


### PR DESCRIPTION
# Description

The new import is wrong and it fails to resolve at runtime

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
