### PR TITLE
fix: add back support for python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/run-llama/llama_index"
 version = "0.10.3"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<3.12"
+python = ">=3.8.1,<4.0"
 llama-index-legacy = "^0.9.48"
 llama-index-llms-openai = "^0.1.0"
 llama-index-embeddings-openai = "^0.1.0"


### PR DESCRIPTION
# Description

Fixes #10689

https://github.com/run-llama/llama_index/pull/9304 seems to be reverted while moving to 0.10.x

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

