### PR TITLE
fix: add VllmServer to __init__.py to fix cannot import name 'VllmSer…

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/__init__.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/__init__.py
@@ -1,3 +1,3 @@
-from llama_index.llms.vllm.base import Vllm
+from llama_index.llms.vllm.base import Vllm, VllmServer
 
-__all__ = ["Vllm"]
+__all__ = ["Vllm", "VllmServer"]


### PR DESCRIPTION
…ver' from 'llama_index.llms.vllm'

# Description

I was receiving "cannot import name 'VllmServer' from 'llama_index.llms.vllm' " error while trying to utilize VllmServer, after adding this class at __init__.py issue is resolved.

I also recommend changing document regarding to this here's a brief explanation about why;

Related document page: https://docs.llamaindex.ai/en/stable/examples/llm/vllm.html

At the "completion Response" section of the document it says correct import syntax is like below;
from llama_index.core.llms.vllm import VllmServer

According to applied fix it should be changed as below;
from llama_index.llms.vllm import VllmServer

Fixes # (issue)

Add VllmServer to __init__.py

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
