### PR TITLE
[BUG-FIX] retriever_mode param missing when constructing KGTableRetriever

### DIFF
--- a/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
@@ -138,6 +138,7 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
             object_map=self._object_map,
             llm=self._llm,
             embed_model=embed_model or self._embed_model,
+            retriever_mode=retriever_mode,
             **kwargs,
         )
 

--- a/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
@@ -1,4 +1,5 @@
 """KG Retrievers."""
+
 import logging
 from collections import defaultdict
 from enum import Enum
@@ -120,7 +121,11 @@ class KGTableRetriever(BaseRetriever):
         self.query_keyword_extract_template = query_keyword_extract_template or DQKET
         self.similarity_top_k = similarity_top_k
         self._include_text = include_text
-        self._retriever_mode = KGRetrieverMode(retriever_mode)
+        self._retriever_mode = (
+            KGRetrieverMode(retriever_mode)
+            if retriever_mode
+            else KGRetrieverMode.KEYWORD
+        )
 
         self._llm = llm or llm_from_settings_or_context(Settings, index.service_context)
         self._embed_model = embed_model or embed_model_from_settings_or_context(


### PR DESCRIPTION
# Description

- `retriever_mode` made as explicit param in `KnowledgeGraphIndex.as_retriever()` but was not propagated to `KGTableRetriever`

Fixes #10708 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
