### PR TITLE
FIX #10736 : Import for ChatMessage fails

### DIFF
--- a/llama-index-core/llama_index/core/utilities/token_counting.py
+++ b/llama-index-core/llama_index/core/utilities/token_counting.py
@@ -3,12 +3,13 @@
 
 from typing import Any, Callable, Dict, List, Optional
 
-from llama_index.core.llms import ChatMessage, MessageRole
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.utils import get_tokenizer
 
 
 class TokenCounter:
-    """Token counter class.
+    """
+    Token counter class.
 
     Attributes:
         model (Optional[str]): The model to use for token counting.
@@ -18,7 +19,8 @@ class TokenCounter:
         self.tokenizer = tokenizer or get_tokenizer()
 
     def get_string_tokens(self, string: str) -> int:
-        """Get the token count for a string.
+        """
+        Get the token count for a string.
 
         Args:
             string (str): The string to count.
@@ -29,7 +31,8 @@ class TokenCounter:
         return len(self.tokenizer(string))
 
     def estimate_tokens_in_messages(self, messages: List[ChatMessage]) -> int:
-        """Estimate token count for a single message.
+        """
+        Estimate token count for a single message.
 
         Args:
             message (OpenAIMessage): The message to estimate the token count for.
@@ -66,7 +69,8 @@ class TokenCounter:
         return tokens
 
     def estimate_tokens_in_functions(self, functions: List[Dict[str, Any]]) -> int:
-        """Estimate token count for the functions.
+        """
+        Estimate token count for the functions.
 
         We take here a list of functions created using the `to_openai_spec` function (or similar).
 


### PR DESCRIPTION
# Description

I believe the import for ChatMessage needs to be updated in the token_counting.py script, after the restructure.

Fixes #10736 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods
