### PR TITLE
Fix broken core link from integration docs to llamma-core folder

### DIFF
--- a/llama-index-integrations/README.md
+++ b/llama-index-integrations/README.md
@@ -1,4 +1,4 @@
 # LlamaIndex Integrations
 
 Building LLM applications with LlamaIndex involves building with LlamaIndex
-[core](https://github.com/run-llamae/llama_index/tree/main/llama-index-core) as well as with the LlamaIndex Integrations required for your application.Integrations are categorized by type and each are their own Python package.
+[core](https://github.com/run-llama/llama_index/tree/main/llama-index-core) as well as with the LlamaIndex Integrations required for your application.Integrations are categorized by type and each are their own Python package.


### PR DESCRIPTION
nitpicky doc issue

Original Link resulted in 404.