### PR TITLE
Fix Neo4jVector handling when multiple indexes are present in the db

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-neo4jvector/llama_index/vector_stores/neo4jvector/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-neo4jvector/llama_index/vector_stores/neo4jvector/base.py
@@ -25,7 +25,7 @@ def sort_by_index_name(
     lst: List[Dict[str, Any]], index_name: str
 ) -> List[Dict[str, Any]]:
     """Sort first element to match the index_name if exists."""
-    return sorted(lst, key=lambda x: x.get("index_name") != index_name)
+    return sorted(lst, key=lambda x: x.get("name") != index_name)
 
 
 def clean_params(params: List[BaseNode]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
We return `name` column when searching for existing indexes in the db and not `index_name` as seen in https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/vector_stores/llama-index-vector-stores-neo4jvector/llama_index/vector_stores/neo4jvector/base.py#L245. Current implementation just returns a random index if multiple are present.