### PR TITLE
Fix python package name for semantic chunking llama-pack

### DIFF
--- a/llama-index-packs/llama-index-packs-node-parser-semantic-chunking/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-node-parser-semantic-chunking/pyproject.toml
@@ -24,7 +24,7 @@ description = "llama-index packs node_parser integration"
 keywords = ["chunk", "chunking", "embedding", "node", "parser", "semantic"]
 license = "MIT"
 maintainers = ["jerryjliu"]
-name = "llama-index-packs-node-parser"
+name = "llama-index-packs-node-parser-semantic-chunking"
 readme = "README.md"
 version = "0.1.2"
 


### PR DESCRIPTION
# Description

- My automation script didn't treat this edge case well, and named the Python package as `llama-index-node-parser`
- This PR fixes this so that its name (though longer) is the more appropriate `llama-index-node-parser-semantic-chunking` package
- NOTE: This python package has been published already.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

