### PR TITLE
Fix the perf issue in building nodes from splits.

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/node_utils.py
+++ b/llama-index-core/llama_index/core/node_parser/node_utils.py
@@ -41,9 +41,7 @@ def build_nodes_from_splits(
     """Calling as_related_node_info() on a document recomputes the hash for the whole text and metadata"""
     """It is not that bad, when creating relationships between the nodes, but is terrible when adding a relationship"""
     """between the node and a document, hence we create the relationship only once here and pass it to the nodes"""
-    relationships = {
-      NodeRelationship.SOURCE: ref_doc.as_related_node_info()
-    }
+    relationships = {NodeRelationship.SOURCE: ref_doc.as_related_node_info()}
     for i, text_chunk in enumerate(text_splits):
         logger.debug(f"> Adding chunk: {truncate_text(text_chunk, 50)}")
 

--- a/llama-index-core/llama_index/core/node_parser/node_utils.py
+++ b/llama-index-core/llama_index/core/node_parser/node_utils.py
@@ -38,6 +38,12 @@ def build_nodes_from_splits(
     ref_doc = ref_doc or document
     id_func = id_func or default_id_func
     nodes: List[TextNode] = []
+    """Calling as_related_node_info() on a document recomputes the hash for the whole text and metadata"""
+    """It is not that bad, when creating relationships between the nodes, but is terrible when adding a relationship"""
+    """between the node and a document, hence we create the relationship only once here and pass it to the nodes"""
+    relationships = {
+      NodeRelationship.SOURCE: ref_doc.as_related_node_info()
+    }
     for i, text_chunk in enumerate(text_splits):
         logger.debug(f"> Adding chunk: {truncate_text(text_chunk, 50)}")
 
@@ -54,7 +60,7 @@ def build_nodes_from_splits(
                 metadata_seperator=document.metadata_seperator,
                 metadata_template=document.metadata_template,
                 text_template=document.text_template,
-                relationships={NodeRelationship.SOURCE: ref_doc.as_related_node_info()},
+                relationships=relationships,
             )
             nodes.append(image_node)  # type: ignore
         elif isinstance(document, Document):
@@ -67,7 +73,7 @@ def build_nodes_from_splits(
                 metadata_seperator=document.metadata_seperator,
                 metadata_template=document.metadata_template,
                 text_template=document.text_template,
-                relationships={NodeRelationship.SOURCE: ref_doc.as_related_node_info()},
+                relationships=relationships,
             )
             nodes.append(node)
         elif isinstance(document, TextNode):
@@ -80,7 +86,7 @@ def build_nodes_from_splits(
                 metadata_seperator=document.metadata_seperator,
                 metadata_template=document.metadata_template,
                 text_template=document.text_template,
-                relationships={NodeRelationship.SOURCE: ref_doc.as_related_node_info()},
+                relationships=relationships,
             )
             nodes.append(node)
         else:


### PR DESCRIPTION
# Description

Create the `relationships` object only once. Otherwise, it recomputes the whole text's hash for every node. It is very inefficient for long text.

An alternative approach would be to cache the hash property. However, it wasn't so straightforward as `Document` isn't a cacheable type. I also do not know Python very well, maybe it would be enough to store a simple null and if it isn't null, then don't recompute? However, the most important reason is I'm not sure about the side effects and the existing assumption that the node is mutable and the hash always reflects the state during the call (unless we modify the object in multiple threads). This change doesn't break any assumptions. If the document was modified while we were creating nodes extracted from it, something would be very wrong.

Fixes #10554

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local benchmarks taken on a document attached to the bug:

Before: Execution time for build_nodes_from_splits: 53.69 seconds

After: Execution time for build_nodes_from_splits: 0.18 seconds


- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
