### PR TITLE
Fix to SageMakerEmbedding class

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-sagemaker-endpoint/llama_index/embeddings/sagemaker_endpoint/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-sagemaker-endpoint/llama_index/embeddings/sagemaker_endpoint/utils.py
@@ -47,4 +47,4 @@ class IOHandler(BaseIOHandler):
 
     def deserialize_output(self, response: "StreamingBody") -> List[List[float]]:
         response_json = json.loads(response.read().decode("utf-8"))
-        return response_json["vectors"]
+        return response_json

--- a/llama-index-integrations/embeddings/llama-index-embeddings-sagemaker-endpoint/llama_index/embeddings/sagemaker_endpoint/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-sagemaker-endpoint/llama_index/embeddings/sagemaker_endpoint/utils.py
@@ -46,5 +46,4 @@ class IOHandler(BaseIOHandler):
         return request_str.encode("utf-8")
 
     def deserialize_output(self, response: "StreamingBody") -> List[List[float]]:
-        response_json = json.loads(response.read().decode("utf-8"))
-        return response_json
+        return json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
# Description

Fixes #10776 by removing an unused "vectors" key when returning values from a SageMaker endpoint. This is the return format from the model `intfloat/multilingual-e5-large-instruct`.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
