### PR TITLE
remove metadata extractors from platform

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/transformations.py
+++ b/llama-index-core/llama_index/core/ingestion/transformations.py
@@ -6,12 +6,6 @@ from enum import Enum
 from typing import Generic, Sequence, Type, TypeVar
 
 from llama_index.core.bridge.pydantic import BaseModel, Field, GenericModel
-from llama_index.core.extractors import (
-    KeywordExtractor,
-    QuestionsAnsweredExtractor,
-    SummaryExtractor,
-    TitleExtractor,
-)
 from llama_index.core.node_parser import (
     CodeSplitter,
     HTMLNodeParser,
@@ -60,12 +54,6 @@ class TransformationCategory(BaseModel):
 class TransformationCategories(Enum):
     """Supported transformation categories."""
 
-    METADATA_EXTRACTOR = TransformationCategory(
-        name="MetadataExtractor",
-        description="Applies a function to extract metadata from nodes",
-        input_type=TransformationIOTypes.NODES.value,
-        output_type=TransformationIOTypes.NODES.value,
-    )
     NODE_PARSER = TransformationCategory(
         name="NodeParser",
         description="Applies a function to parse nodes from documents",
@@ -129,51 +117,6 @@ def build_configurable_transformation_enum():
             )
 
     enum_members = []
-
-    # Metadata extractors
-    enum_members.append(
-        (
-            "KEYWORD_EXTRACTOR",
-            ConfigurableTransformation(
-                name="Keyword Extractor",
-                transformation_category=TransformationCategories.METADATA_EXTRACTOR,
-                component_type=KeywordExtractor,
-            ),
-        )
-    )
-
-    enum_members.append(
-        (
-            "TITLE_EXTRACTOR",
-            ConfigurableTransformation(
-                name="Title Extractor",
-                transformation_category=TransformationCategories.METADATA_EXTRACTOR,
-                component_type=TitleExtractor,
-            ),
-        )
-    )
-
-    enum_members.append(
-        (
-            "SUMMARY_EXTRACTOR",
-            ConfigurableTransformation(
-                name="Summary Extractor",
-                transformation_category=TransformationCategories.METADATA_EXTRACTOR,
-                component_type=SummaryExtractor,
-            ),
-        )
-    )
-
-    enum_members.append(
-        (
-            "QUESTIONS_ANSWERED_EXTRACTOR",
-            ConfigurableTransformation(
-                name="Questions Answered Extractor",
-                transformation_category=TransformationCategories.METADATA_EXTRACTOR,
-                component_type=QuestionsAnsweredExtractor,
-            ),
-        )
-    )
 
     # Node parsers
     enum_members.append(


### PR DESCRIPTION
# Description

just removing metadata extractions from the `ConfigurableTransformation` dynamic enum

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
