### PR TITLE
Update custom_agent.ipynb

### DIFF
--- a/docs/examples/agent/custom_agent.ipynb
+++ b/docs/examples/agent/custom_agent.ipynb
@@ -86,7 +86,7 @@
     "from llama_index.core.query_engine import RouterQueryEngine\n",
     "from llama_index.core import ChatPromptTemplate, PromptTemplate\n",
     "from llama_index.core.selectors import PydanticSingleSelector\n",
-    "from pydantic import Field, BaseModel"
+    "from llama_index.core.bridge.pydantic import Field, BaseModel"
    ]
   },
   {
@@ -162,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pydantic import PrivateAttr\n",
+    "from llama_index.core.bridge.pydantic import PrivateAttr\n",
     "\n",
     "\n",
     "class RetryAgentWorker(CustomSimpleAgentWorker):\n",


### PR DESCRIPTION
Replacing import source from pydantic to llama_index.core.bridge.pydantic to avoid error explained in issue #10921

# Description

It's just a documentation udpate. Replacing import source from pydantic to llama_index.core.bridge.pydantic to avoid getting the ValueError: "RetryAgentWorker"  object has no field "_router_query_engine".

The error is created because, under the hood, we still use the v1 compatibility imports

Fixes #10921 

## Type of Change

Just documentation chante

# How Has This Been Tested?

I just tested on my machine that the code now works


# Suggested Checklist:

- [x] I have made corresponding changes to the documentation
