### PR TITLE
Update prompts.rst

### DIFF
--- a/docs/api_reference/prompts.rst
+++ b/docs/api_reference/prompts.rst
@@ -13,9 +13,9 @@ Default Prompts
 ^^^^^^^^^^^^^^^^^
 
 
-* `Completion prompt templates <https://github.com/jerryjliu/llama_index/blob/main/llama_index/prompts/default_prompts.py>`_.
-* `Chat prompt templates <https://github.com/jerryjliu/llama_index/blob/main/llama_index/prompts/chat_prompts.py>`_.
-* `Selector prompt templates <https://github.com/jerryjliu/llama_index/blob/main/llama_index/prompts/default_prompt_selectors.py>`_.
+* `Completion prompt templates <https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/prompts/default_prompts.py>`_.
+* `Chat prompt templates <https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/prompts/chat_prompts.py>`_.
+* `Selector prompt templates <https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/prompts/default_prompt_selectors.py>`_.
 
 
 


### PR DESCRIPTION
Fixed links to follow the 0.10.X structure

# Description

Links were broken because they were pointing to jerryliu repository and following the 0.9.X structure. No issue opened to fix them yet.

## Type of Change

Just updated documentation

# How Has This Been Tested?

Checked in my own fork

# Suggested Checklist:

- [x] I have made corresponding changes to the documentation