### PR TITLE
fix small client bug for edge case where playground pipeline exists with same name as the managed pipeline

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
@@ -60,7 +60,7 @@ class LlamaCloudRetriever(BaseRetriever):
         pipelines = self._client.pipeline.search_pipelines(
             project_name=self.project_name,
             pipeline_name=self.name,
-            pipeline_type=PipelineType.MANAGED,
+            pipeline_type=PipelineType.MANAGED.value,
         )
         if len(pipelines) == 0:
             raise ValueError(
@@ -98,7 +98,7 @@ class LlamaCloudRetriever(BaseRetriever):
         pipelines = await self._aclient.pipeline.search_pipelines(
             project_name=self.project_name,
             pipeline_name=self.name,
-            pipeline_type=PipelineType.MANAGED,
+            pipeline_type=PipelineType.MANAGED.value,
         )
         if len(pipelines) == 0:
             raise ValueError(

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from llama_index_client import TextNodeWithScore
-from llama_index_client.resources.pipeline.client import OMIT
+from llama_index_client.resources.pipeline.client import OMIT, PipelineType
 
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.constants import DEFAULT_PROJECT_NAME
@@ -58,7 +58,9 @@ class LlamaCloudRetriever(BaseRetriever):
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         """Retrieve from the platform."""
         pipelines = self._client.pipeline.search_pipelines(
-            project_name=self.project_name, pipeline_name=self.name
+            project_name=self.project_name,
+            pipeline_name=self.name,
+            pipeline_type=PipelineType.MANAGED,
         )
         if len(pipelines) != 1:
             raise ValueError(
@@ -90,7 +92,9 @@ class LlamaCloudRetriever(BaseRetriever):
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         """Asynchronously retrieve from the platform."""
         pipelines = await self._aclient.pipeline.search_pipelines(
-            project_name=self.project_name, pipeline_name=self.name
+            project_name=self.project_name,
+            pipeline_name=self.name,
+            pipeline_type=PipelineType.MANAGED,
         )
         assert len(pipelines) == 1
         pipeline = pipelines[0]

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
@@ -62,10 +62,14 @@ class LlamaCloudRetriever(BaseRetriever):
             pipeline_name=self.name,
             pipeline_type=PipelineType.MANAGED,
         )
-        if len(pipelines) != 1:
+        if len(pipelines) == 0:
             raise ValueError(
                 f"Unknown index name {self.name}. Please confirm a "
                 "managed index with this name exists."
+            )
+        elif len(pipelines) > 1:
+            raise ValueError(
+                f"Multiple pipelines found with name {self.name} in project {self.project_name}"
             )
         pipeline = pipelines[0]
 
@@ -96,7 +100,15 @@ class LlamaCloudRetriever(BaseRetriever):
             pipeline_name=self.name,
             pipeline_type=PipelineType.MANAGED,
         )
-        assert len(pipelines) == 1
+        if len(pipelines) == 0:
+            raise ValueError(
+                f"Unknown index name {self.name}. Please confirm a "
+                "managed index with this name exists."
+            )
+        elif len(pipelines) > 1:
+            raise ValueError(
+                f"Multiple pipelines found with name {self.name} in project {self.project_name}"
+            )
         pipeline = pipelines[0]
 
         if pipeline.id is None:


### PR DESCRIPTION
# Description

fix small client bug for edge case where playground pipeline exists with same name as the managed pipeline


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
