### PR TITLE
Update rag.py for ServiceContext and Response

### DIFF
--- a/llama-index-core/llama_index/core/command_line/rag.py
+++ b/llama-index-core/llama_index/core/command_line/rag.py
@@ -7,15 +7,14 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union, cast
 
 from llama_index.core import (
-    Response,
-    ServiceContext,
     SimpleDirectoryReader,
     VectorStoreIndex,
 )
 from llama_index.core.base.embeddings.base import BaseEmbedding
-from llama_index.core.base.response.schema import RESPONSE_TYPE, StreamingResponse
+from llama_index.core.base.response.schema import RESPONSE_TYPE, StreamingResponse, Response
 from llama_index.core.bridge.pydantic import BaseModel, Field, validator
 from llama_index.core.chat_engine import CondenseQuestionChatEngine
+from llama_index.core.indices.service_context import ServiceContext
 from llama_index.core.ingestion import IngestionPipeline
 from llama_index.core.llms import LLM
 from llama_index.core.query_engine import CustomQueryEngine

--- a/llama-index-core/llama_index/core/command_line/rag.py
+++ b/llama-index-core/llama_index/core/command_line/rag.py
@@ -11,7 +11,11 @@ from llama_index.core import (
     VectorStoreIndex,
 )
 from llama_index.core.base.embeddings.base import BaseEmbedding
-from llama_index.core.base.response.schema import RESPONSE_TYPE, StreamingResponse, Response
+from llama_index.core.base.response.schema import (
+    RESPONSE_TYPE,
+    StreamingResponse,
+    Response,
+)
 from llama_index.core.bridge.pydantic import BaseModel, Field, validator
 from llama_index.core.chat_engine import CondenseQuestionChatEngine
 from llama_index.core.indices.service_context import ServiceContext


### PR DESCRIPTION
I had a problem using the upgrade CLI, similar to https://github.com/run-llama/llama_index/issues/10634

I wonder if it's because of the old import statements in this file. Please check and see if it's an appropriate patch before moving to Settings

# Description
Similar issues with old ServiceContext and other old import statements. But I am not sure if the Response referred to is the same one as the new one I referred to. However, I couldn't find any other similarly-named "Response" in the docs, so I assumed this was correct.

However, according to this, the ServiceContext should be depreciated fully instead of a quick fix like this - https://docs.llamaindex.ai/en/stable/module_guides/supporting_modules/service_context_migration.html

I might have missed other old imports but I'm not familiar enough to check through it all. I guess we will see if this version errors out and fix it again 😆

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
- [x] In a local copy, the import was successful on the IDE.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
