### PR TITLE
fix: Correct Google GenAI extension import

### DIFF
--- a/llama-index-integrations/response_synthesizers/llama-index-response-synthesizers-google/llama_index/response_synthesizers/google/base.py
+++ b/llama-index-integrations/response_synthesizers/llama-index-response-synthesizers-google/llama_index/response_synthesizers/google/base.py
@@ -68,7 +68,7 @@ class GoogleTextSynthesizer(BaseSynthesizer):
         See `from_defaults` for more documentation.
         """
         try:
-            import llama_index.vector_stores.google as genaix
+            import llama_index.vector_stores.google.genai_extension as genaix
         except ImportError:
             raise ImportError(_import_err_msg)
 
@@ -137,7 +137,7 @@ class GoogleTextSynthesizer(BaseSynthesizer):
             A `SynthesizedResponse` object.
         """
         try:
-            import llama_index.vector_stores.google as genaix
+            import llama_index.vector_stores.google.genai_extension as genaix
 
             import google.ai.generativelanguage as genai
         except ImportError:


### PR DESCRIPTION
# Description

Fixes wrong import in Google Response Synthesizers. Issue was identified by using this notebook:
https://github.com/run-llama/llama_index/blob/main/docs/examples/managed/GoogleDemo.ipynb

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Running GoogleDemo.ipynb gives error 'AttributeError: module 'llama_index.vector_stores.google' has no attribute 'build_generative_service''. I identified that the correct import is import llama_index.vector_stores.google.genai_extension which fixes the issue.

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
