### PR TITLE
Sleep for 0 seconds to release GIL

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -173,8 +173,8 @@ class StreamingAgentChatResponse:
                 self._unformatted_response += delta
                 yield delta
             except queue.Empty:
-                # Queue is empty, but we're not done yet
-                time.sleep(0.01)
+                # Queue is empty, but we're not done yet. Sleep for 0 secs to release the GIL and allow other threads to run.
+                time.sleep(0)
         self.response = self._unformatted_response.strip()
 
     async def async_response_gen(self) -> AsyncGenerator[str, None]:


### PR DESCRIPTION
# Description
`time.sleep(0)` in some cases to release the GIL and allow other threads to run.

Based on [this article](https://discuss.python.org/t/time-sleep-0-yield-behaviour/27185/9) and [this SO post](https://discord.com/channels/1059199217496772688/1209563309112565790/1209569223828045865), you can sleep for 0 seconds to release the GIL and allow other threads a turn. "Who goes next" is up to the scheduler.

This should yield faster responses overall. The processes will still consume 100% CPU (for their duration) but will be polite and let others have a turn. 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] I read [this article](https://discuss.python.org/t/time-sleep-0-yield-behaviour/27185/9) and [this SO post](https://discord.com/channels/1059199217496772688/1209563309112565790/1209569223828045865) and conferred with co-polit

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
