### PR TITLE
fix: get_from_param_or_env import with old namespace

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -4,7 +4,7 @@ import httpx
 from llama_index.core.base.llms.types import ChatMessage
 from llama_index.core.bridge.pydantic import Field, PrivateAttr, root_validator
 from llama_index.core.callbacks import CallbackManager
-from llama_index.core.base.llms.generic_utils import get_from_param_or_env
+from llama_index.core.llms.generic_utils import get_from_param_or_env
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.llms.azure_openai.utils import (
     refresh_openai_azuread_token,


### PR DESCRIPTION
# Description

This PR address a small but critical error of python package importing when using Azure OpenAI.

The end of the stack trace and the error itself:

```
python-1   |     from llama_index.llms.azure_openai.base import (
python-1   |   File "/usr/local/lib/python3.11/site-packages/llama_index/llms/azure_openai/base.py", line 7, in <module>
python-1   |     from llama_index.core.base.llms.generic_utils import get_from_param_or_env
python-1   | ModuleNotFoundError: No module named 'llama_index.core.base.llms.generic_utils'
```

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

I think static analysis and strong typing are the way to go here?

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
