### PR TITLE
Update Python requirement to "3.8.1,<4.0" for llama-index-cli

### DIFF
--- a/llama-index-cli/CHANGELOG.MD
+++ b/llama-index-cli/CHANGELOG.MD
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.1.2] - 2024-02-20
+
+- Fix python requirement in pyproject.toml
+
 ## [0.1.1] - 2024-02-20
 
 - Upgrades ported over from core

--- a/llama-index-cli/pyproject.toml
+++ b/llama-index-cli/pyproject.toml
@@ -31,10 +31,10 @@ maintainers = [
 name = "llama-index-cli"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<3.12"
+python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.8.post1"
 llama-index-vector-stores-chroma = "^0.1.1"
 llama-index-embeddings-openai = "^0.1.1"


### PR DESCRIPTION
# Description

- llama-index-cli python requirement is inconsistent with rest of llama-index packages and thus can't be used
- this PR addresses that by changing python req to "3.8.1,<4.0"
- NOTE: this package has been built and published already

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

