### PR TITLE
Fix MultiModalReActAgetnWorker memory

### DIFF
--- a/llama-index-core/llama_index/core/agent/react_multimodal/step.py
+++ b/llama-index-core/llama_index/core/agent/react_multimodal/step.py
@@ -398,7 +398,7 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
 
         input_chat = self._react_chat_formatter.format(
             tools,
-            chat_history=task.memory.get() + task.extra_state["new_memory"].get_all(),
+            chat_history=task.memory.get_all() + task.extra_state["new_memory"].get_all(),
             current_reasoning=task.extra_state["current_reasoning"],
         )
 
@@ -437,7 +437,7 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
 
         input_chat = self._react_chat_formatter.format(
             tools,
-            chat_history=task.memory.get() + task.extra_state["new_memory"].get_all(),
+            chat_history=task.memory.get_all() + task.extra_state["new_memory"].get_all(),
             current_reasoning=task.extra_state["current_reasoning"],
         )
         # send prompt
@@ -501,7 +501,7 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
     def finalize_task(self, task: Task, **kwargs: Any) -> None:
         """Finalize task, after all the steps are completed."""
         # add new messages to memory
-        task.memory.set(task.memory.get() + task.extra_state["new_memory"].get_all())
+        task.memory.set(task.memory.get_all() + task.extra_state["new_memory"].get_all())
         # reset new memory
         task.extra_state["new_memory"].reset()
 

--- a/llama-index-core/llama_index/core/agent/react_multimodal/step.py
+++ b/llama-index-core/llama_index/core/agent/react_multimodal/step.py
@@ -398,7 +398,8 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
 
         input_chat = self._react_chat_formatter.format(
             tools,
-            chat_history=task.memory.get_all() + task.extra_state["new_memory"].get_all(),
+            chat_history=task.memory.get_all()
+            + task.extra_state["new_memory"].get_all(),
             current_reasoning=task.extra_state["current_reasoning"],
         )
 
@@ -437,7 +438,8 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
 
         input_chat = self._react_chat_formatter.format(
             tools,
-            chat_history=task.memory.get_all() + task.extra_state["new_memory"].get_all(),
+            chat_history=task.memory.get_all()
+            + task.extra_state["new_memory"].get_all(),
             current_reasoning=task.extra_state["current_reasoning"],
         )
         # send prompt
@@ -501,7 +503,9 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
     def finalize_task(self, task: Task, **kwargs: Any) -> None:
         """Finalize task, after all the steps are completed."""
         # add new messages to memory
-        task.memory.set(task.memory.get_all() + task.extra_state["new_memory"].get_all())
+        task.memory.set(
+            task.memory.get_all() + task.extra_state["new_memory"].get_all()
+        )
         # reset new memory
         task.extra_state["new_memory"].reset()
 


### PR DESCRIPTION
# Description

when using `MultimodalReActAgentWorker`, memory did not persist between tasks, meaning that when you create a second task it has no memory of the history from the first task. this fixes it.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

the change just makes sense, also this code began to work after the change

```py
def do_test(user_id: str) -> bool:
    """
    runs the test and returns whether it was successful or not
    """
    return user_id == "f6773f16854cca0f871d10e7cf6c7e84d12f3783bcfa13ccba8d2d0e48ee7cbd"

function_tool = FunctionTool.from_defaults(fn=do_test)
tools = [FunctionTool.from_defaults(fn=f) for f in (do_test,)]
llm = OpenAIMultiModal(model="gpt-4-vision-preview", api_key=OPENAI_API_KEY)
react_step_engine = MultimodalReActAgentWorker.from_tools(tools, llm=llm, verbose=True)
agent = AgentRunner(react_step_engine)

def execute_step(agent: AgentRunner, task: Task):
    step_output = agent.run_step(task.task_id)
    if step_output.is_last:
        response = agent.finalize_response(task.task_id)
        return response
    else:
        return None


def execute_steps(agent: AgentRunner, task: Task):
    response = execute_step(agent, task)
    while response is None:
        response = execute_step(agent, task)
    return response

task = agent.create_task(
    "User ID: f6773f16854cca0f871d10e7cf6c7e84d12f3783bcfa13ccba8d2d0e48ee7cbd\nrun the first test and if it fails describe the image",
    extra_state={"image_docs": [ImageDocument(image_path="/home/finn/Pictures/rhino.jpeg")]},
)

response = execute_steps(agent, task)

task2 = agent.create_task(
    "what is the first word i said to you",
    extra_state={"image_docs": []},
)

response = execute_steps(agent, task2)
```

