### PR TITLE
Add support for extra partitioning parameters for partition_html used in UnstructuredElementNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
@@ -1,6 +1,9 @@
 """Unstructured element node parser."""
 
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional, Dict
+
+
+from llama_index.core.bridge.pydantic import Field
 
 import pandas as pd
 from llama_index.core.callbacks.base import CallbackManager
@@ -45,11 +48,17 @@ class UnstructuredElementNodeParser(BaseElementNodeParser):
 
     """
 
+    partitioning_parameters: Optional[Dict[str, Any]] = Field(
+        default={},
+        description="Extra dictionary representing parameters of the partitioning process.",
+    )
+
     def __init__(
         self,
         callback_manager: Optional[CallbackManager] = None,
         llm: Optional[Any] = None,
         summary_query_str: str = DEFAULT_SUMMARY_QUERY_STR,
+        partitioning_parameters: Optional[Dict[str, Any]] = {},
     ) -> None:
         """Initialize."""
         try:
@@ -66,6 +75,7 @@ class UnstructuredElementNodeParser(BaseElementNodeParser):
             callback_manager=callback_manager,
             llm=llm,
             summary_query_str=summary_query_str,
+            partitioning_parameters=partitioning_parameters,
         )
 
     @classmethod
@@ -91,7 +101,7 @@ class UnstructuredElementNodeParser(BaseElementNodeParser):
         from unstructured.partition.html import partition_html  # pants: no-infer-dep
 
         table_filters = table_filters or []
-        elements = partition_html(text=text)
+        elements = partition_html(text=text, **self.partitioning_parameters)
         output_els = []
         for idx, element in enumerate(elements):
             if "unstructured.documents.html.HTMLTable" in str(type(element)):


### PR DESCRIPTION
# Description

Add support for extra parameters for partition_html used in UnstructuredElementNodeParser. 
Thanks to this it's possible to customize chunking parameters.

`
node_parser = UnstructuredElementNodeParser(llm=llm, partitioning_parameters={"chunking_strategy": "by_title"})
`

## Type of Change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- I stared at the code and made sure it makes sense
- I tested the code locally

# Suggested Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- New and existing unit tests pass locally with my changes
- I ran `make format; make lint` to appease the lint gods
