### PR TITLE
fix(vector_stores): elasticsearch - add missing await

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -239,7 +239,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             index_name: Name of the AsyncElasticsearch index to create.
             dims_length: Length of the embedding vectors.
         """
-        if self.client.indices.exists(index=index_name):
+        if await self.client.indices.exists(index=index_name):
             logger.debug(f"Index {index_name} already exists. Skipping creation.")
 
         else:

--- a/llama-index-legacy/llama_index/legacy/vector_stores/elasticsearch.py
+++ b/llama-index-legacy/llama_index/legacy/vector_stores/elasticsearch.py
@@ -247,7 +247,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             index_name: Name of the AsyncElasticsearch index to create.
             dims_length: Length of the embedding vectors.
         """
-        if self.client.indices.exists(index=index_name):
+        if await self.client.indices.exists(index=index_name):
             logger.debug(f"Index {index_name} already exists. Skipping creation.")
 
         else:

--- a/llama-index-legacy/llama_index/legacy/vector_stores/elasticsearch.py
+++ b/llama-index-legacy/llama_index/legacy/vector_stores/elasticsearch.py
@@ -247,7 +247,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             index_name: Name of the AsyncElasticsearch index to create.
             dims_length: Length of the embedding vectors.
         """
-        if await self.client.indices.exists(index=index_name):
+        if self.client.indices.exists(index=index_name):
             logger.debug(f"Index {index_name} already exists. Skipping creation.")
 
         else:


### PR DESCRIPTION
# Description

`vector_stores` @ elasticsearch - Added missing await for indices.exists function call.
solves: `/llama_index/vector_stores/elasticsearch/base.py:344: RuntimeWarning: coroutine 'IndicesClient.exists' was never awaited` - which causes not creating the ES index.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
