### PR TITLE
fix(default_prompts): fix prompt

### DIFF
--- a/llama-index-core/llama_index/core/prompts/default_prompts.py
+++ b/llama-index-core/llama_index/core/prompts/default_prompts.py
@@ -411,6 +411,7 @@ DEFAULT_CHOICE_SELECT_PROMPT_TMPL = (
     "as the relevance score. The relevance score is a number from 1-10 based on "
     "how relevant you think the document is to the question.\n"
     "Do not include any documents that are not relevant to the question. \n"
+    "If the question is not answerable with the given documents, respond with the list of documents.\n"
     "Example format: \n"
     "Document 1:\n<summary of document 1>\n\n"
     "Document 2:\n<summary of document 2>\n\n"


### PR DESCRIPTION
# Description

Change One line of the default prompt to reply with the original list is the answer is not related to any docs

Fixes #11092

If you will use LLMRerank class the DEFAULT_CHOICE_SELECT_PROMPT has a problem, the problem is that if the question is a general conversation thing like "great job!", the LLM model reply with something similar that: `['The question "ottimo" is not clear and does not seem to relate to any of the documents provided. Therefore', ' no documents are relevant.']` this will cause another error in this response parser that is: `answer_num = int(line_tokens[0].split(":")[1].strip()) IndexError: list index out of range`. this because for example you choose top 3 docs but the LLM model will reply with only 1

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

i try this fix in my current production project here: https://www.spsitalia.it/

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
