### PR TITLE
Fix: TypeError: chromadb.api.client.Client.get_or_create_collection() argument after ** must be a mapping, not NoneType

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
@@ -1,4 +1,5 @@
 """Chroma vector store."""
+
 import logging
 import math
 from typing import Any, Dict, Generator, List, Optional, cast
@@ -143,6 +144,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
         **kwargs: Any,
     ) -> None:
         """Init params."""
+        collection_kwargs = collection_kwargs or {}
         if chroma_collection is None:
             client = chromadb.HttpClient(host=host, port=port, ssl=ssl, headers=headers)
             self._collection = client.get_or_create_collection(


### PR DESCRIPTION
# Description

Fir for: `TypeError: chromadb.api.client.Client.get_or_create_collection() argument after ** must be a mapping, not NoneType`

raised when:

`
chroma_vector_store = ChromaVectorStore(collection_name="my_collection", host="localhost", port=8000)
`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
