### PR TITLE
fix checking final chunk in ReAct agent

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -340,8 +340,12 @@ class ReActAgentWorker(BaseAgentWorker):
             bool: Boolean on whether the chunk is the start of the final response
         """
         latest_content = chunk.message.content
-        if latest_content and "Answer: " in latest_content:
-            return True
+        if latest_content:
+            # doesn't follow thought-action format
+            if len(latest_content) > 7 and not latest_content.startswith("Thought"):
+                return True
+            elif "Answer: " in latest_content:
+                return True
         return False
 
     def _add_back_chunk_to_stream(

--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -342,7 +342,9 @@ class ReActAgentWorker(BaseAgentWorker):
         latest_content = chunk.message.content
         if latest_content:
             # doesn't follow thought-action format
-            if len(latest_content) > 7 and not latest_content.startswith("Thought"):
+            if len(latest_content) > len("Thought") and not latest_content.startswith(
+                "Thought"
+            ):
                 return True
             elif "Answer: " in latest_content:
                 return True

--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -340,14 +340,8 @@ class ReActAgentWorker(BaseAgentWorker):
             bool: Boolean on whether the chunk is the start of the final response
         """
         latest_content = chunk.message.content
-        if latest_content:
-            if not latest_content.startswith(
-                "Thought"
-            ):  # doesn't follow thought-action format
-                return True
-            else:
-                if "Answer: " in latest_content:
-                    return True
+        if latest_content and "Answer: " in latest_content:
+            return True
         return False
 
     def _add_back_chunk_to_stream(


### PR DESCRIPTION
# Description
This PR to fix a minor issue in ReActAgent.

## The issue:
ReActAgent keeps include internal states ("Though: ", "Action: ", "Observation: ",...) in chat response.

## Preproduce:
I create a ReActAgent with LLama2 model:

```python
agent = ReActAgent.from_llm(llm=llm)
res = agent.stream_chat("What is LlamaIndex?")
for token in res:
    print(token, end="")
```
Response output:
```
Thought: I need to use a tool to help me answer the question.
Action: search_engine (one of the tools)
Action Input: {"query": "LlamaIndex"}

Observation: LlamaIndex is a search engine ranking metric that measures the relevance of a website's content to a specific query. It is used to determine the quality and relevance of a website's content in relation to a user's search query.

Thought: I can answer without using any more tools.
Answer: LlamaIndex is a search engine ranking metric that measures the relevance of a website's content to a specific query.
```

Expected output:
- Should response the "Answer: " chunk only
```
LlamaIndex is a search engine ranking metric that measures the relevance of a website's content to a specific query.
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
