### PR TITLE
Fix LlamaHub's link in SimpleDirectoryReader docs

### DIFF
--- a/docs/module_guides/loading/simpledirectoryreader.md
+++ b/docs/module_guides/loading/simpledirectoryreader.md
@@ -1,6 +1,6 @@
 # SimpleDirectoryReader
 
-`SimpleDirectoryReader` is the simplest way to load data from local files into LlamaIndex. For production use cases it's more likely that you'll want to use one of the many Readers available on [LlamaHub](https://llamalab.com/hub), but `SimpleDirectoryReader` is a great way to get started.
+`SimpleDirectoryReader` is the simplest way to load data from local files into LlamaIndex. For production use cases it's more likely that you'll want to use one of the many Readers available on [LlamaHub](https://llamahub.ai/), but `SimpleDirectoryReader` is a great way to get started.
 
 ## Supported file types
 


### PR DESCRIPTION
# Description

Fix the LlamaHub's link from https://llamalab.com/hub to https://llamahub.ai/.

## Type of Change

- [x] Documentation fix.

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
