### PR TITLE
Implement OpensearchVectorStore document deletion

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -350,13 +350,7 @@ class OpensearchVectorClient:
         Args:
             doc_id (str): document id
         """
-        body = {
-            "query": {
-                "match": {
-                'metadata.ref_doc_id': doc_id
-                }
-            }
-        }
+        body = {"query": {"match": {"metadata.ref_doc_id": doc_id}}}
         self._os_client.delete_by_query(index=self._index, body=body)
 
     def query(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -350,7 +350,14 @@ class OpensearchVectorClient:
         Args:
             doc_id (str): document id
         """
-        self._os_client.delete(index=self._index, id=doc_id)
+        body = {
+            "query": {
+                "match": {
+                'metadata.ref_doc_id': doc_id
+                }
+            }
+        }
+        self._os_client.delete_by_query(index=self._index, body=body)
 
     def query(
         self,


### PR DESCRIPTION
# Description

Implements document deletion by ID for the OpensearchVectorStore. The existing implementation was a placeholder which just errored out when called. Deletion from Opensearch requires using an [Elasticsearch query request body](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html). 

Fixes [Issue 10464](https://github.com/run-llama/llama_index/issues/10464)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense
- [ ] Tested that a `VectorStoreIndex` built over an `OpensearchVectorStore` can successfully invoke its `index.delete_ref_doc()` and `index.update_ref_doc()` methods, and that the documents actually get deleted.

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
