### PR TITLE
[FIX] - SemanticSplitterNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
@@ -227,9 +227,7 @@ class SemanticSplitterNodeParser(NodeParser):
             start_index = 0
 
             for index in indices_above_threshold:
-                end_index = index
-
-                group = sentences[start_index : end_index + 1]
+                group = sentences[start_index : index + 1]
                 combined_text = "".join([d["sentence"] for d in group])
                 chunks.append(combined_text)
 

--- a/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
@@ -227,13 +227,13 @@ class SemanticSplitterNodeParser(NodeParser):
             start_index = 0
 
             for index in indices_above_threshold:
-                end_index = index - 1
+                end_index = index
 
                 group = sentences[start_index : end_index + 1]
                 combined_text = "".join([d["sentence"] for d in group])
                 chunks.append(combined_text)
 
-                start_index = index
+                start_index = index + 1
 
             if start_index < len(sentences):
                 combined_text = "".join(


### PR DESCRIPTION
# Description

- SemanticSplitterNodeParser seems to have a bug that results in nodes not having a `text` property
- This PR addresses that bug:
     - It might be that we are slicing incorrectly and thus chunking incorrect groups


Fixes #11277 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Re ran the example as given in the attached bug report / issue
- [x] I stared at the code and made sure it makes sense
