### PR TITLE
Fix milvus delete with ref_doc_ids when they don't exist

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -221,9 +221,10 @@ class MilvusVectorStore(VectorStore):
             collection_name=self.collection_name,
             filter=f"{self.doc_id_field} in [{','.join(doc_ids)}]",
         )
-        ids = [entry["id"] for entry in entries]
-        self.milvusclient.delete(collection_name=self.collection_name, pks=ids)
-        logger.debug(f"Successfully deleted embedding with doc_id: {doc_ids}")
+        if len(entries) > 0:
+            ids = [entry["id"] for entry in entries]
+            self.milvusclient.delete(collection_name=self.collection_name, pks=ids)
+            logger.debug(f"Successfully deleted embedding with doc_id: {doc_ids}")
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes.


### PR DESCRIPTION
# Description

The milvus vector-store calls delete(ref_doc_id) when using update_ref_doc. Since that ref_doc_id won't exist on first insert it always fails with the message: "Failed to delete primary keys in collection: <collectionname>"

Fixes # (issue)
11314

## Type of Change
Skip delete if search for primary keys to delete return zero results.

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ X] My changes generate no new warnings

