### PR TITLE
Return the object along with the subject when extracting the keywords

### DIFF
--- a/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
@@ -173,6 +173,10 @@ class KGTableRetriever(BaseRetriever):
             keyword = rel_text.split(",")[0]
             if keyword:
                 keywords.append(keyword.strip("(\"'"))
+            # Return the Object as well
+            keyword = rel_text.split(",")[2]
+            if keyword:
+                keywords.append(keyword.strip(" ()\"'"))
         return keywords
 
     def _retrieve(


### PR DESCRIPTION
During the Knowledge graph retrieval process, keywords are extracted from the matched triplets in the _extract_rel_text_keywords method. I find that only the subject is fetched and returned as keywords, whereas I believe both subject and object should be returned as the match is for the triplet and not for the subject alone. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
