### PR TITLE
fix(chromadb): queries without embeddings result in program crash

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
@@ -311,9 +311,6 @@ class ChromaVectorStore(BasePydanticVectorStore):
             **kwargs,
         )
 
-        print(f"QUERY RES: {results}")
-        print(f"EMBEDDINGS: {query_embeddings}")
-
         logger.debug(f"> Top {len(results['documents'])} nodes:")
         nodes = []
         similarities = []
@@ -361,8 +358,6 @@ class ChromaVectorStore(BasePydanticVectorStore):
             where=where,
             **kwargs,
         )
-        # results = self._collection.get()
-        print(f"COLLECTIONs: {results}")
 
         logger.debug(f"> Top {len(results['documents'])} nodes:")
         nodes = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
@@ -291,12 +291,28 @@ class ChromaVectorStore(BasePydanticVectorStore):
         else:
             where = kwargs.pop("where", {})
 
-        results = self._collection.query(
+        if not query.query_embedding:
+            return self._get(limit=query.similarity_top_k, where=where, **kwargs)
+
+        return self._query(
             query_embeddings=query.query_embedding,
             n_results=query.similarity_top_k,
             where=where,
             **kwargs,
         )
+
+    def _query(
+        self, query_embeddings: List["float"], n_results: int, where: dict, **kwargs
+    ) -> VectorStoreQueryResult:
+        results = self._collection.query(
+            query_embeddings=query_embeddings,
+            n_results=n_results,
+            where=where,
+            **kwargs,
+        )
+
+        print(f"QUERY RES: {results}")
+        print(f"EMBEDDINGS: {query_embeddings}")
 
         logger.debug(f"> Top {len(results['documents'])} nodes:")
         nodes = []
@@ -338,3 +354,50 @@ class ChromaVectorStore(BasePydanticVectorStore):
             ids.append(node_id)
 
         return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
+
+    def _get(self, limit: int, where: dict, **kwargs) -> VectorStoreQueryResult:
+        results = self._collection.get(
+            limit=limit,
+            where=where,
+            **kwargs,
+        )
+        # results = self._collection.get()
+        print(f"COLLECTIONs: {results}")
+
+        logger.debug(f"> Top {len(results['documents'])} nodes:")
+        nodes = []
+        ids = []
+
+        if not results["ids"]:
+            results["ids"] = [[]]
+
+        for node_id, text, metadata in zip(
+            results["ids"][0], results["documents"], results["metadatas"]
+        ):
+            try:
+                node = metadata_dict_to_node(metadata)
+                node.set_content(text)
+            except Exception:
+                # NOTE: deprecated legacy logic for backward compatibility
+                metadata, node_info, relationships = legacy_metadata_dict_to_node(
+                    metadata
+                )
+
+                node = TextNode(
+                    text=text,
+                    id_=node_id,
+                    metadata=metadata,
+                    start_char_idx=node_info.get("start", None),
+                    end_char_idx=node_info.get("end", None),
+                    relationships=relationships,
+                )
+
+            nodes.append(node)
+
+            logger.debug(
+                f"> [Node {node_id}] [Similarity score: N/A - using get()] "
+                f"{truncate_text(str(text), 100)}"
+            )
+            ids.append(node_id)
+
+        return VectorStoreQueryResult(nodes=nodes, ids=ids)


### PR DESCRIPTION
# Description

When using `VectorStoreQuery` to query _chromadb_ by metadata only, without an embedding, it results in 
a program crash with the following error message: 

```ValueError: You must provide one of query_embeddings, query_texts, query_images, or query_uris.```

# Why is this a problem?

When using the `VectorIndexAutoRetriever`, it will sometimes suggest a metadata only search, without an embedding, 
and this will cause a program crash with the above error message.

This fix is to use the chromadb collection's `get()` method instead of `query()` for cases where a metadata only search is required.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a new test ```test_add_to_chromadb_and_query_by_metafilters_only``` into `test_chromadb.py`.
Run it with:

```sh
pytest llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/tests/test_chromadb.py
```

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
