### PR TITLE
fix(ColbertRerank): calculate ColBERT similarity per token rather than vs pooled query embeds

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/llama_index/postprocessor/colbert_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/llama_index/postprocessor/colbert_rerank/base.py
@@ -53,9 +53,7 @@ class ColbertRerank(BaseNodePostprocessor):
         # Query: [batch_size, query_length, embedding_size] -> [batch_size, query_length, 1, embedding_size]
         # Document: [batch_size, doc_length, embedding_size] -> [batch_size, 1, doc_length, embedding_size]
         query_encoding = self._tokenizer(query, return_tensors="pt")
-        query_embedding = (
-            self._model(**query_encoding).last_hidden_state.mean(dim=1).unsqueeze(0)
-        )
+        query_embedding = self._model(**query_encoding).last_hidden_state
         rerank_score_list = []
 
         for document_text in documents_text_list:


### PR DESCRIPTION
# Description

Fixes the similarity calculation for the ColBERTReranker.

The current approach pools the query representation and performs cosine similarity for each document token against the single-vector query representation, whereas the original ColBERT maxsim implementation does so at the token level (i.e. it compares each query token to each document token).
This PR fixes this slight issue by removing the mean pooling.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
