### PR TITLE
fix: support other regions for aws s3 storage

### DIFF
--- a/docs/examples/llm/mymagic.ipynb
+++ b/docs/examples/llm/mymagic.ipynb
@@ -66,6 +66,7 @@
     "    session=\"your-session-name\",  # files should be located in this folder on which batch inference will be run\n",
     "    role_arn=\"your-role-arn\",\n",
     "    system_prompt=\"your-system-prompt\",\n",
+    "    region=\"your-bucket-region\",\n",
     ")"
    ]
   },
@@ -123,6 +124,7 @@
     "        session=\"your-session-name\",  # files should be located in this folder on which batch inference will be run\n",
     "        role_arn=\"your-role-arn\",\n",
     "        system_prompt=\"your-system-prompt\",\n",
+    "        region=\"your-bucket-region\",\n",
     "    )\n",
     "    response = await allm.acomplete(\n",
     "        question=\"your-question\",\n",

--- a/llama-index-integrations/llms/llama-index-llms-mymagic/llama_index/llms/mymagic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mymagic/llama_index/llms/mymagic/base.py
@@ -36,7 +36,7 @@ class MyMagicAI(LLM):
         description="The session to use. This is a subfolder in the bucket where your data is located.",
     )
     role_arn: Optional[str] = Field(
-        None, description="ARN for role assumption in AWS S3"
+        None, description="ARN for role assumption in AWS S3."
     )
     system_prompt: str = Field(
         default="Answer the question based only on the given content. Do not give explanations or examples. Do not continue generating more text after the answer.",
@@ -44,6 +44,9 @@ class MyMagicAI(LLM):
     )
     question_data: Dict[str, Any] = Field(
         default_factory=dict, description="The data to send to the MyMagicAI API."
+    )
+    region: Optional[str] = Field(
+        "eu-west-2", description="The region the bucket is in. Only used for AWS S3."
     )
 
     def __init__(
@@ -54,6 +57,7 @@ class MyMagicAI(LLM):
         session: str,
         system_prompt: Optional[str],
         role_arn: Optional[str] = None,
+        region: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -66,6 +70,7 @@ class MyMagicAI(LLM):
             "max_tokens": self.max_tokens,
             "role_arn": role_arn,
             "system_prompt": system_prompt,
+            "region": region,
         }
 
     @classmethod


### PR DESCRIPTION
# Description

Support for other s3 regions in addition to default eu-west-2

Fixes # (issue)
Before: Users had to create buckets in the default regions
Now: Users can create their buckets in any region

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Added new notebook (that tests end-to-end)

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `make format; make lint` to appease the lint gods
