### PR TITLE
improve multi doc retrieval

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -1,4 +1,5 @@
 """Node parser interface."""
+
 from abc import ABC, abstractmethod
 from typing import Any, Callable, List, Sequence
 
@@ -69,7 +70,6 @@ class NodeParser(TransformComponent, ABC):
         """
         doc_id_to_document = {doc.id_: doc for doc in documents}
 
-        print(doc_id_to_document)
         with self.callback_manager.event(
             CBEventType.NODE_PARSING, payload={EventPayload.DOCUMENTS: documents}
         ) as event:
@@ -97,8 +97,6 @@ class NodeParser(TransformComponent, ABC):
                         node.metadata.update(
                             doc_id_to_document[node.ref_doc_id].metadata
                         )
-                        # print(node.ref_doc_id)
-                        # node.metadata["ref_doc_id"] = node.ref_doc_id
 
                 if self.include_prev_next_rel:
                     if i > 0:

--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -69,6 +69,7 @@ class NodeParser(TransformComponent, ABC):
         """
         doc_id_to_document = {doc.id_: doc for doc in documents}
 
+        print(doc_id_to_document)
         with self.callback_manager.event(
             CBEventType.NODE_PARSING, payload={EventPayload.DOCUMENTS: documents}
         ) as event:
@@ -96,6 +97,8 @@ class NodeParser(TransformComponent, ABC):
                         node.metadata.update(
                             doc_id_to_document[node.ref_doc_id].metadata
                         )
+                        # print(node.ref_doc_id)
+                        # node.metadata["ref_doc_id"] = node.ref_doc_id
 
                 if self.include_prev_next_rel:
                     if i > 0:

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -54,8 +54,6 @@ class Element(BaseModel):
     title_level: Optional[int] = None
     table_output: Optional[TableOutput] = None
     table: Optional[pd.DataFrame] = None
-    # original document id, it is usually file name
-    doc_id: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -252,7 +250,7 @@ class BaseElementNodeParser(NodeParser):
         return node_parser.get_nodes_from_documents([doc])
 
     def get_nodes_from_elements(
-        self, elements: List[Element], doc_id: str
+        self, elements: List[Element], file_name: str
     ) -> List[BaseNode]:
         """Get nodes and mappings."""
         from llama_index.core.node_parser import SentenceSplitter
@@ -268,8 +266,6 @@ class BaseElementNodeParser(NodeParser):
                     cur_text_nodes = self._get_nodes_from_buffer(
                         cur_text_el_buffer, node_parser
                     )
-                    # for node in cur_text_nodes:
-                    #     node.metadata["doc_id"] = doc_id
                     nodes.extend(cur_text_nodes)
                     cur_text_el_buffer = []
 
@@ -350,5 +346,5 @@ class BaseElementNodeParser(NodeParser):
 
         # remove empty nodes
         for node in nodes:
-            node.metadata["doc_id"] = doc_id
+            node.metadata["file_name"] = file_name
         return [node for node in nodes if len(node.text) > 0]

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -349,7 +349,5 @@ class BaseElementNodeParser(NodeParser):
         # remove empty nodes and keep node original metadata inherited from parent nodes
         for node in nodes:
             if metadata_inherited:
-                for key in metadata_inherited:
-                    if key not in node.metadata:
-                        node.metadata[key] = metadata_inherited[key]
+                node.metadata.update(metadata_inherited)
         return [node for node in nodes if len(node.text) > 0]

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -54,6 +54,8 @@ class Element(BaseModel):
     title_level: Optional[int] = None
     table_output: Optional[TableOutput] = None
     table: Optional[pd.DataFrame] = None
+    # original document id, it is usually file name
+    doc_id: Optional[str] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -249,7 +251,9 @@ class BaseElementNodeParser(NodeParser):
         doc = Document(text="\n\n".join(list(buffer)))
         return node_parser.get_nodes_from_documents([doc])
 
-    def get_nodes_from_elements(self, elements: List[Element]) -> List[BaseNode]:
+    def get_nodes_from_elements(
+        self, elements: List[Element], doc_id: str
+    ) -> List[BaseNode]:
         """Get nodes and mappings."""
         from llama_index.core.node_parser import SentenceSplitter
 
@@ -264,6 +268,8 @@ class BaseElementNodeParser(NodeParser):
                     cur_text_nodes = self._get_nodes_from_buffer(
                         cur_text_el_buffer, node_parser
                     )
+                    # for node in cur_text_nodes:
+                    #     node.metadata["doc_id"] = doc_id
                     nodes.extend(cur_text_nodes)
                     cur_text_el_buffer = []
 
@@ -343,4 +349,6 @@ class BaseElementNodeParser(NodeParser):
             cur_text_el_buffer = []
 
         # remove empty nodes
+        for node in nodes:
+            node.metadata["doc_id"] = doc_id
         return [node for node in nodes if len(node.text) > 0]

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -250,7 +250,9 @@ class BaseElementNodeParser(NodeParser):
         return node_parser.get_nodes_from_documents([doc])
 
     def get_nodes_from_elements(
-        self, elements: List[Element], metadata_inherited: Dict[str, Any]
+        self,
+        elements: List[Element],
+        metadata_inherited: Optional[Dict[str, Any]] = None,
     ) -> List[BaseNode]:
         """Get nodes and mappings."""
         from llama_index.core.node_parser import SentenceSplitter
@@ -346,7 +348,8 @@ class BaseElementNodeParser(NodeParser):
 
         # remove empty nodes and keep node original metadata inherited from parent nodes
         for node in nodes:
-            for key in metadata_inherited:
-                if key not in node.metadata:
-                    node.metadata[key] = metadata_inherited[key]
+            if metadata_inherited:
+                for key in metadata_inherited:
+                    if key not in node.metadata:
+                        node.metadata[key] = metadata_inherited[key]
         return [node for node in nodes if len(node.text) > 0]

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -250,7 +250,7 @@ class BaseElementNodeParser(NodeParser):
         return node_parser.get_nodes_from_documents([doc])
 
     def get_nodes_from_elements(
-        self, elements: List[Element], file_name: str
+        self, elements: List[Element], metadata_inherited: Dict[str, Any]
     ) -> List[BaseNode]:
         """Get nodes and mappings."""
         from llama_index.core.node_parser import SentenceSplitter
@@ -344,7 +344,9 @@ class BaseElementNodeParser(NodeParser):
             nodes.extend(cur_text_nodes)
             cur_text_el_buffer = []
 
-        # remove empty nodes
+        # remove empty nodes and keep node original metadata inherited from parent nodes
         for node in nodes:
-            node.metadata["file_name"] = file_name
+            for key in metadata_inherited:
+                if key not in node.metadata:
+                    node.metadata[key] = metadata_inherited[key]
         return [node for node in nodes if len(node.text) > 0]

--- a/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
@@ -47,6 +47,8 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
 
     def get_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
         """Get nodes from node."""
+        print("*********NODE*********")
+        print(node.id_)
         elements = self.extract_elements(
             node.get_content(),
             table_filters=[self.filter_table],
@@ -57,7 +59,7 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
         self.extract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
-        return self.get_nodes_from_elements(elements)
+        return self.get_nodes_from_elements(elements, node.id_)
 
     def extract_elements(
         self,

--- a/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
@@ -57,7 +57,7 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
         self.extract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
-        return self.get_nodes_from_elements(elements, node.id_)
+        return self.get_nodes_from_elements(elements, node.metadata)
 
     def extract_elements(
         self,

--- a/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
@@ -47,8 +47,6 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
 
     def get_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
         """Get nodes from node."""
-        print("*********NODE*********")
-        print(node.id_)
         elements = self.extract_elements(
             node.get_content(),
             table_filters=[self.filter_table],

--- a/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
@@ -92,7 +92,7 @@ class UnstructuredElementNodeParser(BaseElementNodeParser):
         self.extract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
-        return self.get_nodes_from_elements(elements)
+        return self.get_nodes_from_elements(elements, node.metadata)
 
     def extract_elements(
         self, text: str, table_filters: Optional[List[Callable]] = None, **kwargs: Any


### PR DESCRIPTION
# Description
Index filename into each node's metadata (for node parser) so that we can filter or retrieve doc based on file name

![image](https://github.com/run-llama/llama_index/assets/2142132/81c4addf-b275-4ab3-9c4e-ef4b2d65c364)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
