### PR TITLE
[FIX] faulty imports when using PydanticProgramMode.LM_FORMAT_ENFORCER

### DIFF
--- a/llama-index-core/llama_index/core/llms/utils.py
+++ b/llama-index-core/llama_index/core/llms/utils.py
@@ -64,7 +64,7 @@ def resolve_llm(
                 "llm must start with str 'local' or of type LLM or BaseLanguageModel"
             )
         try:
-            from llama_index.llms.llama.utils import (
+            from llama_index.llms.llama_cpp.llama_utils import (
                 completion_to_prompt,
                 messages_to_prompt,
             )  # pants: no-infer-dep

--- a/llama-index-core/llama_index/core/program/utils.py
+++ b/llama-index-core/llama_index/core/program/utils.py
@@ -90,9 +90,15 @@ def get_program_for_llm(
             **kwargs,
         )
     elif pydantic_program_mode == PydanticProgramMode.LM_FORMAT_ENFORCER:
-        from llama_index.core.program.lmformatenforcer_program import (
-            LMFormatEnforcerPydanticProgram,
-        )
+        try:
+            from llama_index.program.lmformatenforcer import (
+                LMFormatEnforcerPydanticProgram,
+            )
+        except ImportError:
+            raise ImportError(
+                "This mode requires the `llama-index-program-lmformatenforcer package. Please"
+                " install it by running `pip install llama-index-program-lmformatenforcer`."
+            )
 
         return LMFormatEnforcerPydanticProgram.from_defaults(
             output_cls=output_cls,

--- a/llama-index-core/llama_index/core/program/utils.py
+++ b/llama-index-core/llama_index/core/program/utils.py
@@ -93,7 +93,7 @@ def get_program_for_llm(
         try:
             from llama_index.program.lmformatenforcer import (
                 LMFormatEnforcerPydanticProgram,
-            )
+            )  # pants: no-infer-dep
         except ImportError:
             raise ImportError(
                 "This mode requires the `llama-index-program-lmformatenforcer package. Please"


### PR DESCRIPTION
# Description

- `PydanticProgramMode.LM_FORMAT_ENFORCER` needs integration `llama-index-program-lmformatenforcer` but when trying to lazy import it from core, it tries to load from ... core :)
- Also fixed an incorrect import for llama_utils

Fixes #11351 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
