### PR TITLE
FIx JSON Query Engine

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/json_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/json_query.py
@@ -64,7 +64,7 @@ def default_output_processor(llm_output: str, json_value: JSONType) -> JSONType:
                 key = expression.split(".")[
                     -1
                 ]  # Extracting "title" from "$.title", for example
-                results[key] = datum[0].value
+                results[key] = ", ".join(str(i.value) for i in datum)
         except Exception as exc:
             raise ValueError(f"Invalid JSON Path: {expression}") from exc
 


### PR DESCRIPTION
# Description
JSON Query Engine does not work correctly with arrays. The `default_output_processor` method returns only the first element of the array. 

```
from llama_index.core.indices.struct_store.json_query import default_output_processor

json_value = {
    'list': [0, 1, 2, 3, 4, 5],
}
default_output_processor("list[*]", json_value)
```

Old behavior:
`{'list[*]': 0}`
New behavior:
`{'list[*]': '0, 1, 2, 3, 4, 5'}`

## Type of Change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I stared at the code and made sure it makes sense