### PR TITLE
[FIX] ModuleNotFoundError: No module named 'llama_index.img_utils' - …

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/image_deplot/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/image_deplot/base.py
@@ -57,7 +57,7 @@ class ImageTabularChartReader(BaseReader):
         self, file: Path, extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Parse file."""
-        from llama_index.img_utils import img_2_b64
+        from llama_index.core.img_utils import img_2_b64
         from PIL import Image
 
         # load document image

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_readers_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_readers_file.py
@@ -15,6 +15,7 @@ from llama_index.readers.file import (
     PptxReader,
     VideoAudioReader,
     XMLReader,
+    ImageTabularChartReader,
 )
 
 
@@ -62,4 +63,7 @@ def test_classes():
     assert BaseReader.__name__ in names_of_base_classes
 
     names_of_base_classes = [b.__name__ for b in XMLReader.__mro__]
+    assert BaseReader.__name__ in names_of_base_classes
+
+    names_of_base_classes = [b.__name__ for b in ImageTabularChartReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes


### PR DESCRIPTION
…BUG(#11367)

# Getting error while using ImageTabularChartReader

While trying to import and use ImageTabularChartReader getting error.


```
from llama_index.readers.file import ImageTabularChartReader
loader = ImageTabularChartReader(keep_image=True)
documents = loader.load_data(file=Path("./file_dataloaders/fimages/<image>.png"))
print(
"All Metadata: \n",
documents[0].get_content(metadata_mode=MetadataMode.ALL),
)
```

Error: ModuleNotFoundError: No module named 'llama_index.img_utils'

Fixes # (issue)

The fix was to change the base.py of image_deplot reader from `from llama_index.img_utils import img_2_b64` to this `from llama_index.core.img_utils import img_2_b64`.

Also edited test case to test this.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It has been tested by adding a unit test case to the `llama_index/llama-index-integrations/readers/llama-index-readers-file/tests/test_readers_file.py` 

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
