### PR TITLE
Last token pooling for Huggingface models like SFR-Embedding-Mistral

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
@@ -160,12 +160,14 @@ class HuggingFaceEmbedding(BaseEmbedding):
 
         model_output = self._model(**encoded_input)
 
+        context_layer: "torch.Tensor" = model_output[0]
         if self.pooling == Pooling.CLS:
-            context_layer: "torch.Tensor" = model_output[0]
             embeddings = self.pooling.cls_pooling(context_layer)
+        elif self.pooling == Pooling.LAST:
+            embeddings = self.pooling.last_pooling(context_layer)           
         else:
             embeddings = self._mean_pooling(
-                token_embeddings=model_output[0],
+                token_embeddings=context_layer,
                 attention_mask=encoded_input["attention_mask"],
             )
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
@@ -164,7 +164,7 @@ class HuggingFaceEmbedding(BaseEmbedding):
         if self.pooling == Pooling.CLS:
             embeddings = self.pooling.cls_pooling(context_layer)
         elif self.pooling == Pooling.LAST:
-            embeddings = self.pooling.last_pooling(context_layer)           
+            embeddings = self.pooling.last_pooling(context_layer)
         else:
             embeddings = self._mean_pooling(
                 token_embeddings=context_layer,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/pooling.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/pooling.py
@@ -12,10 +12,13 @@ class Pooling(str, Enum):
 
     CLS = "cls"
     MEAN = "mean"
+    LAST = "last"  # last token pooling
 
     def __call__(self, array: np.ndarray) -> np.ndarray:
         if self == self.CLS:
             return self.cls_pooling(array)
+        elif self == self.LAST:
+            return self.last_pooling(array)
         return self.mean_pooling(array)
 
     @classmethod
@@ -46,4 +49,14 @@ class Pooling(str, Enum):
             return array.mean(axis=1)
         if len(array.shape) == 2:
             return array.mean(axis=0)
+        raise NotImplementedError(f"Unhandled shape {array.shape}.")
+
+    @classmethod
+    def last_pooling(
+        cls, array: "Union[np.ndarray, torch.Tensor]"
+    ) -> "Union[np.ndarray, torch.Tensor]":
+        if len(array.shape) == 3:
+            return array[:, -1]
+        if len(array.shape) == 2:
+            return array[-1]
         raise NotImplementedError(f"Unhandled shape {array.shape}.")

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/pooling.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/pooling.py
@@ -52,6 +52,18 @@ class Pooling(str, Enum):
         raise NotImplementedError(f"Unhandled shape {array.shape}.")
 
     @classmethod
+    @overload
+    def last_pooling(cls, array: np.ndarray) -> np.ndarray:
+        ...
+
+    @classmethod
+    @overload
+    # TODO: Remove this `type: ignore` after the false positive problem
+    #  is addressed in mypy: https://github.com/python/mypy/issues/15683 .
+    def last_pooling(cls, array: "torch.Tensor") -> "torch.Tensor":  # type: ignore
+        ...
+
+    @classmethod
     def last_pooling(
         cls, array: "Union[np.ndarray, torch.Tensor]"
     ) -> "Union[np.ndarray, torch.Tensor]":


### PR DESCRIPTION

# Description

When trying to use the top of the MTEB leaderboard Salesforce/SFR-Embedding-Mistral, I've noticed there is no option in LlamaIndex to use the last token as sequence embedding, so this PR adds this functionality. This is my first PR ever 👍

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

I have tested using the finetune_embedding_adapter.ipynb notebook, replacing bge-small-en with Salesforce/SFR-Embedding-Mistral. The code changes are quite trivial. 

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
