### PR TITLE
fix: add back support for python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ repository = "https://github.com/run-llama/llama_index"
 version = "0.10.12"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<3.12"
+python = ">=3.8.1,<4.0"
 llama-index-legacy = "^0.9.48"
 llama-index-llms-openai = "^0.1.5"
 llama-index-embeddings-openai = "^0.1.5"


### PR DESCRIPTION
# Description

When starting a fresh project in Python with the latest version (Python v3.12 as of the time of this writing), installing llama-index fails with a dependency check. The pyproject.toml seems to have an older version < 3.12 is this expected or was it reverted mistakenly? 

Before it was [fixed to be < 4.0](https://github.com/run-llama/llama_index/pull/10701/commits/ff86746984348784daec3c3bf9d2c034084ac81c) and fixed https://github.com/run-llama/llama_index/pull/11054 as well but this [commit](https://github.com/run-llama/llama_index/pull/11068/commits/f35a803982d047de6d26fd35f4d438f827494645#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) reverted it

Fixes #10748

## Type of Change

[x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

[x] I stared at the code and made sure it makes sense
