### PR TITLE
Add to BaseSQLTableQueryEngine refine synthesis template

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -396,14 +396,12 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
             partial_synthesis_prompt = self._response_synthesis_prompt.partial_format(
                 sql_query=sql_query_str,
             )
-            partial_refine_prompt = self._refine_synthesis_prompt.partial_format(
-                sql_query=sql_query_str,
-            )
+
             response_synthesizer = get_response_synthesizer(
                 llm=self._llm,
                 callback_manager=self.callback_manager,
                 text_qa_template=partial_synthesis_prompt,
-                refine_template=partial_refine_prompt,
+                refine_template=self._refine_synthesis_prompt,
             )
             response = await response_synthesizer.asynthesize(
                 query=query_bundle.query_str,

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -1,4 +1,5 @@
 """Default query for SQLStructStoreIndex."""
+
 import logging
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
@@ -20,6 +21,7 @@ from llama_index.core.prompts import BasePromptTemplate, PromptTemplate
 from llama_index.core.prompts.default_prompts import (
     DEFAULT_TEXT_TO_SQL_PGVECTOR_PROMPT,
     DEFAULT_TEXT_TO_SQL_PROMPT,
+    DEFAULT_REFINE_PROMPT,
 )
 from llama_index.core.prompts.mixin import PromptDictType, PromptMixinType
 from llama_index.core.prompts.prompt_type import PromptType
@@ -285,15 +287,15 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
         return Response(response=response_str, metadata=metadata)
 
 
-def _validate_prompt(response_synthesis_prompt: BasePromptTemplate) -> None:
+def _validate_prompt(
+    custom_prompt: BasePromptTemplate,
+    default_prompt: BasePromptTemplate,
+) -> None:
     """Validate prompt."""
-    if (
-        response_synthesis_prompt.template_vars
-        != DEFAULT_RESPONSE_SYNTHESIS_PROMPT_V2.template_vars
-    ):
+    if custom_prompt.template_vars != default_prompt.template_vars:
         raise ValueError(
-            "response_synthesis_prompt must have the following template variables: "
-            "query_str, sql_query, context_str"
+            "custom_prompt must have the following template variables: "
+            f"{default_prompt.template_vars}"
         )
 
 
@@ -303,6 +305,7 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
         llm: Optional[LLM] = None,
         synthesize_response: bool = True,
         response_synthesis_prompt: Optional[BasePromptTemplate] = None,
+        refine_synthesis_prompt: Optional[BasePromptTemplate] = None,
         verbose: bool = False,
         # deprecated
         service_context: Optional[ServiceContext] = None,
@@ -314,8 +317,14 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
         self._response_synthesis_prompt = (
             response_synthesis_prompt or DEFAULT_RESPONSE_SYNTHESIS_PROMPT_V2
         )
+        self._refine_synthesis_prompt = refine_synthesis_prompt or DEFAULT_REFINE_PROMPT
+
         # do some basic prompt validation
-        _validate_prompt(self._response_synthesis_prompt)
+        _validate_prompt(
+            self._response_synthesis_prompt, DEFAULT_RESPONSE_SYNTHESIS_PROMPT_V2
+        )
+        _validate_prompt(self._refine_synthesis_prompt, DEFAULT_REFINE_PROMPT)
+
         self._synthesize_response = synthesize_response
         self._verbose = verbose
         super().__init__(
@@ -359,10 +368,14 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
             partial_synthesis_prompt = self._response_synthesis_prompt.partial_format(
                 sql_query=sql_query_str,
             )
+            partial_refine_prompt = self._refine_synthesis_prompt.partial_format(
+                sql_query=sql_query_str,
+            )
             response_synthesizer = get_response_synthesizer(
                 llm=self._llm,
                 callback_manager=self.callback_manager,
                 text_qa_template=partial_synthesis_prompt,
+                refine_template=partial_refine_prompt,
                 verbose=self._verbose,
             )
             response = response_synthesizer.synthesize(
@@ -386,10 +399,14 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
             partial_synthesis_prompt = self._response_synthesis_prompt.partial_format(
                 sql_query=sql_query_str,
             )
+            partial_refine_prompt = self._refine_synthesis_prompt.partial_format(
+                sql_query=sql_query_str,
+            )
             response_synthesizer = get_response_synthesizer(
                 llm=self._llm,
                 callback_manager=self.callback_manager,
                 text_qa_template=partial_synthesis_prompt,
+                refine_template=partial_refine_prompt,
             )
             response = await response_synthesizer.asynthesize(
                 query=query_bundle.query_str,
@@ -417,6 +434,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
         context_query_kwargs: Optional[dict] = None,
         synthesize_response: bool = True,
         response_synthesis_prompt: Optional[BasePromptTemplate] = None,
+        refine_synthesis_prompt: Optional[BasePromptTemplate] = None,
         tables: Optional[Union[List[str], List[Table]]] = None,
         service_context: Optional[ServiceContext] = None,
         context_str_prefix: Optional[str] = None,
@@ -440,6 +458,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
         super().__init__(
             synthesize_response=synthesize_response,
             response_synthesis_prompt=response_synthesis_prompt,
+            refine_synthesis_prompt=refine_synthesis_prompt,
             llm=llm,
             service_context=service_context,
             verbose=verbose,
@@ -470,6 +489,7 @@ class PGVectorSQLQueryEngine(BaseSQLTableQueryEngine):
         context_query_kwargs: Optional[dict] = None,
         synthesize_response: bool = True,
         response_synthesis_prompt: Optional[BasePromptTemplate] = None,
+        refine_synthesis_prompt: Optional[BasePromptTemplate] = None,
         tables: Optional[Union[List[str], List[Table]]] = None,
         service_context: Optional[ServiceContext] = None,
         context_str_prefix: Optional[str] = None,
@@ -492,6 +512,7 @@ class PGVectorSQLQueryEngine(BaseSQLTableQueryEngine):
         super().__init__(
             synthesize_response=synthesize_response,
             response_synthesis_prompt=response_synthesis_prompt,
+            refine_synthesis_prompt=refine_synthesis_prompt,
             llm=llm,
             service_context=service_context,
             **kwargs,
@@ -515,6 +536,7 @@ class SQLTableRetrieverQueryEngine(BaseSQLTableQueryEngine):
         context_query_kwargs: Optional[dict] = None,
         synthesize_response: bool = True,
         response_synthesis_prompt: Optional[BasePromptTemplate] = None,
+        refine_synthesis_prompt: Optional[BasePromptTemplate] = None,
         service_context: Optional[ServiceContext] = None,
         context_str_prefix: Optional[str] = None,
         sql_only: bool = False,
@@ -534,6 +556,7 @@ class SQLTableRetrieverQueryEngine(BaseSQLTableQueryEngine):
         super().__init__(
             synthesize_response=synthesize_response,
             response_synthesis_prompt=response_synthesis_prompt,
+            refine_synthesis_prompt=refine_synthesis_prompt,
             llm=llm,
             service_context=service_context,
             **kwargs,

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -368,14 +368,11 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
             partial_synthesis_prompt = self._response_synthesis_prompt.partial_format(
                 sql_query=sql_query_str,
             )
-            partial_refine_prompt = self._refine_synthesis_prompt.partial_format(
-                sql_query=sql_query_str,
-            )
             response_synthesizer = get_response_synthesizer(
                 llm=self._llm,
                 callback_manager=self.callback_manager,
                 text_qa_template=partial_synthesis_prompt,
-                refine_template=partial_refine_prompt,
+                refine_template=self._refine_synthesis_prompt,
                 verbose=self._verbose,
             )
             response = response_synthesizer.synthesize(


### PR DESCRIPTION
# Description
Adds the ability to choose a template for the prompt that refine the response from a BaseSQLTableQueryEngine.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I ran `make format; make lint` to appease the lint gods
