### PR TITLE
Astra DB clients identify themselves as coming through LlamaIndex usage

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
@@ -11,7 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pytest.
-	pytest tests
+	poetry run pytest tests
 
 watch-docs:	## Build and watch documentation.
 	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/llama_index/readers/astra_db/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/llama_index/readers/astra_db/base.py
@@ -2,6 +2,7 @@
 
 from typing import Any, List, Optional
 
+import llama_index.core
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
 
@@ -43,11 +44,19 @@ class AstraDBReader(BaseReader):
             raise ImportError(import_err_msg)
 
         if client is not None:
-            self._client = client
+            self._client = client.copy()
+            self._client.set_caller(
+                caller_name=getattr(llama_index, "__name__", "llama_index"),
+                caller_version=getattr(llama_index.core, "__version__", None),
+            )
         else:
             # Build the Astra DB object
             self._client = AstraDB(
-                api_endpoint=api_endpoint, token=token, namespace=namespace
+                api_endpoint=api_endpoint,
+                token=token,
+                namespace=namespace,
+                caller_name=getattr(llama_index, "__name__", "llama_index"),
+                caller_version=getattr(llama_index.core, "__version__", None),
             )
 
         self._collection = self._client.create_collection(

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.3"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-astrapy = ">=0.6.2"
+astrapy = "^0.7.5"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra/Makefile
@@ -11,7 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pytest.
-	pytest tests
+	poetry run pytest tests
 
 watch-docs:	## Build and watch documentation.
 	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra/llama_index/vector_stores/astra/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra/llama_index/vector_stores/astra/base.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any, Dict, List, Optional, cast
 from warnings import warn
 
+import llama_index.core
 from llama_index.core.bridge.pydantic import PrivateAttr
 from astrapy.db import AstraDB
 from llama_index.core.indices.query.embedding_utils import get_top_k_mmr_embeddings
@@ -89,7 +90,11 @@ class AstraDBVectorStore(BasePydanticVectorStore):
 
         # Build the Astra DB object
         self._astra_db = AstraDB(
-            api_endpoint=api_endpoint, token=token, namespace=namespace
+            api_endpoint=api_endpoint,
+            token=token,
+            namespace=namespace,
+            caller_name=getattr(llama_index, "__name__", "llama_index"),
+            caller_version=getattr(llama_index.core, "__version__", None),
         )
 
         from astrapy.api import APIRequestError

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.2"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-astrapy = "^0.7.1"
+astrapy = "^0.7.5"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

This PR sets the "caller identity" of the Astra DB clients used by the integration plugins (Astra DB vector store; Astra DB reader). In this way, the requests to the Astra DB Data API coming from within LlamaIndex are identified as such (the purpose is anonymous usage stats to best improve the Astra DB service).

Additionally, the astrapy version is bumped in both subpackage pyproject.toml's, and the "make test" command is edited to work within the Poetry environment (which prevents import errors during testing)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Re-ran the tests and some sample code manually, all green
- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
