### PR TITLE
Update OpenSearch Documentation to include Hybrid Search

### DIFF
--- a/docs/module_guides/storing/vector_stores.md
+++ b/docs/module_guides/storing/vector_stores.md
@@ -36,7 +36,7 @@ We are actively adding more integrations and improving feature coverage for each
 | MyScale                  | cloud               | ✓                  | ✓             | ✓      | ✓               |       |
 | Milvus / Zilliz          | self-hosted / cloud | ✓                  |               | ✓      | ✓               |       |
 | Neo4jVector              | self-hosted / cloud |                    |               | ✓      | ✓               |       |
-| OpenSearch               | self-hosted / cloud | ✓                  |               | ✓      | ✓               | ✓     |
+| OpenSearch               | self-hosted / cloud | ✓                  | ✓             | ✓      | ✓               | ✓     |
 | Pinecone                 | cloud               | ✓                  | ✓             | ✓      | ✓               |       |
 | Postgres                 | self-hosted / cloud | ✓                  | ✓             | ✓      | ✓               | ✓     |
 | pgvecto.rs               | self-hosted / cloud | ✓                  | ✓             | ✓      | ✓               |       |


### PR DESCRIPTION
# Description

Update the Vector Stores documentation for OpenSearch to show that Hybrid Search is supported.

## Type of Change

- [x] This change requires a documentation update
