### PR TITLE
Supabase metadata filtering fix

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
@@ -71,7 +71,7 @@ class SupabaseVectorStore(VectorStore):
     def _to_vecs_filters(self, filters: MetadataFilters) -> Any:
         """Convert llama filters to vecs filters. $eq is the only supported operator."""
         vecs_filter = defaultdict(list)
-        filter_cond = f"${filters.condition}"
+        filter_cond = f"${filters.condition.value}"
 
         for f in filters.legacy_filters():
             sub_filter = {}

--- a/llama-index-legacy/llama_index/legacy/vector_stores/supabase.py
+++ b/llama-index-legacy/llama_index/legacy/vector_stores/supabase.py
@@ -76,7 +76,7 @@ class SupabaseVectorStore(VectorStore):
     def _to_vecs_filters(self, filters: MetadataFilters) -> Any:
         """Convert llama filters to vecs filters. $eq is the only supported operator."""
         vecs_filter = defaultdict(list)
-        filter_cond = f"${filters.condition.value}"
+        filter_cond = f"${filters.condition}"
 
         for f in filters.legacy_filters():
             sub_filter = {}

--- a/llama-index-legacy/llama_index/legacy/vector_stores/supabase.py
+++ b/llama-index-legacy/llama_index/legacy/vector_stores/supabase.py
@@ -76,7 +76,7 @@ class SupabaseVectorStore(VectorStore):
     def _to_vecs_filters(self, filters: MetadataFilters) -> Any:
         """Convert llama filters to vecs filters. $eq is the only supported operator."""
         vecs_filter = defaultdict(list)
-        filter_cond = f"${filters.condition}"
+        filter_cond = f"${filters.condition.value}"
 
         for f in filters.legacy_filters():
             sub_filter = {}


### PR DESCRIPTION
# Description

The metadata filtering for Supabase was not working at all for me. I tracked down the issue to the filtering syntax of the vecs library that Supabase is using.

The current implementation creates a filtering string of the form
`{'$FilterCondition.AND': [{'user_id': {'$eq': 'a128cab6-5807-44ab-abc2-048737394e58'}}]}`

but Supabase expects a syntax of 
`{'$AND': [{'user_id': {'$eq': 'a128cab6-5807-44ab-abc2-048737394e58'}}]}`


I'm not a regular LLamaIndex contributor, so someone who knows the codebase better need to determine if the same fix should be applied to llama_index/legacy/vector_stores/supabase.py



## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
