### PR TITLE
[FIX] elasticsearch vector_store: add await for self.client.indices.exist

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -239,7 +239,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             index_name: Name of the AsyncElasticsearch index to create.
             dims_length: Length of the embedding vectors.
         """
-        if self.client.indices.exists(index=index_name):
+        if await self.client.indices.exists(index=index_name):
             logger.debug(f"Index {index_name} already exists. Skipping creation.")
 
         else:


### PR DESCRIPTION
# Description

- Since client is `AsyncElasticsearchClient` we need to have `await` on `self.client.indices.exist` otherwise it returns a `Coroutine` object

Fixes #11417

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the script provided by the issue author and it works
- [x] I stared at the code and made sure it makes sense
