### PR TITLE
Kamilmuratyilmaz/fix import error libcuda.so.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 migration_scripts/
 venv/
+.idea
 .venv/
 .ipynb_checkpoints
 .__pycache__

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -214,13 +214,14 @@ class Vllm(LLM):
 
     def __del__(self) -> None:
         import torch
-        from vllm.model_executor.parallel_utils.parallel_state import (
-            destroy_model_parallel,
-        )
 
-        destroy_model_parallel()
-        del self._client
         if torch.cuda.is_available():
+            from vllm.model_executor.parallel_utils.parallel_state import (
+                destroy_model_parallel,
+            )
+
+            destroy_model_parallel()
+            del self._client
             torch.cuda.synchronize()
 
     def _get_all_kwargs(self, **kwargs: Any) -> Dict[str, Any]:


### PR DESCRIPTION
… file: No such file or directory

# Description

When I tried to send request a cloud instance with ssh local port forwarding I had "ImportError: libcuda.so.1: cannot open shared object file: No such file or directory" based on cuda library, which is not installed on my local env (CPU Only Machine).

I also add .idea to .gitignore to prevent commit of PyCharm configurations.

Fixes # (issue)

After this fix, requests successfully returned llm responses.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With llama_index ran on local, then sent request to cloud instance with ssh local port forwarding.

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
