### PR TITLE
Fix: mean_agg returning none-serializable numpy float64

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -29,7 +29,7 @@ class SimilarityMode(str, Enum):
 
 def mean_agg(embeddings: List[Embedding]) -> Embedding:
     """Mean aggregation for embeddings."""
-    return list(np.array(embeddings).mean(axis=0))
+    return np.array(embeddings).mean(axis=0).tolist()
 
 
 def similarity(


### PR DESCRIPTION
# Description

The mean_agg function is returning a list of numpy float64 rather than a list of python float as expected. This will cause error when querying http-based vector store (like Chromadb with http client), because numpy float64 is not json serializable and http query request will fail to send.

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- I stared at the code and made sure it makes sense

# Suggested Checklist:

- I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
