### PR TITLE
Update ReAct prompt for multilingual support

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/prompts.py
+++ b/llama-index-core/llama_index/core/agent/react/prompts.py
@@ -1,6 +1,5 @@
 """Default prompt for ReAct agent."""
 
-
 # ReAct chat prompt
 # TODO: have formatting instructions be a part of react output parser
 
@@ -19,10 +18,10 @@ You have access to the following tools:
 {tool_desc}
 
 ## Output Format
-To answer the question, please use the following format.
+Please answer in the same language as the question and use the following format:
 
 ```
-Thought: I need to use a tool to help me answer the question.
+Thought: The current language of the user is: (user's language). I need to use a tool to help me answer the question.
 Action: tool name (one of {tool_names}) if using a tool.
 Action Input: the input to the tool, in a JSON format representing the kwargs (e.g. {{"input": "hello world", "num_beams": 5}})
 ```
@@ -42,13 +41,13 @@ to answer the question without using any more tools. At that point, you MUST res
 in the one of the following two formats:
 
 ```
-Thought: I can answer without using any more tools.
-Answer: [your answer here]
+Thought: I can answer without using any more tools. I'll use the user's language to answer
+Answer: [your answer here (In the same language as the user's question)]
 ```
 
 ```
 Thought: I cannot answer the question with the provided tools.
-Answer: Sorry, I cannot answer your query.
+Answer: [your answer here (In the same language as the user's question)]
 ```
 
 ## Current Conversation
@@ -74,10 +73,10 @@ You have access to the following tools:
 {tool_desc}
 
 ## Output Format
-To answer the question, please use the following format.
+Please answer in the same language as the question and use the following format:
 
 ```
-Thought: I need to use a tool to help me answer the question.
+Thought: The current language of the user is: (user's language). I need to use a tool to help me answer the question.
 Action: tool name (one of {tool_names}) if using a tool.
 Action Input: the input to the tool, in a JSON format representing the kwargs (e.g. {{"input": "hello world", "num_beams": 5}})
 ```
@@ -97,13 +96,13 @@ to answer the question without using any more tools. At that point, you MUST res
 in the one of the following two formats:
 
 ```
-Thought: I can answer without using any more tools.
-Answer: [your answer here]
+Thought: I can answer without using any more tools. I'll use the user's language to answer
+Answer: [your answer here (In the same language as the user's question)]
 ```
 
 ```
 Thought: I cannot answer the question with the provided tools.
-Answer: Sorry, I cannot answer your query.
+Answer: [your answer here (In the same language as the user's question)]
 ```
 
 ## Current Conversation


### PR DESCRIPTION
# Description

In my experiment with the multilingual models Mistral and Llama2, the response from the ReAct agent always comes in English, even when I ask in a different language.

I made some minor changes in the prompt of ReAct agent and it then able to response in the same language of the question. It's just a minor change and should not break other things so i think it's worth an update in LlamaIndex.

Please have a look: https://colab.research.google.com/drive/1-lA4_I5tnHBHe0uCmhoxODlhKcIqTNWA?usp=sharing

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
