### PR TITLE
Make SupabaseVectorStore a subclass of BasePydanticVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
@@ -1,14 +1,16 @@
 import logging
 import math
 from collections import defaultdict
-from typing import Any, List
+from typing import Any, List, Optional
 
 import vecs
+from vecs.collection import Collection
 from llama_index.core.constants import DEFAULT_EMBEDDING_DIM
 from llama_index.core.schema import BaseNode, TextNode
+from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.vector_stores.types import (
     MetadataFilters,
-    VectorStore,
+    BasePydanticVectorStore,
     VectorStoreQuery,
     VectorStoreQueryResult,
 )
@@ -22,7 +24,7 @@ from vecs.collection import CollectionNotFound
 logger = logging.getLogger(__name__)
 
 
-class SupabaseVectorStore(VectorStore):
+class SupabaseVectorStore(BasePydanticVectorStore):
     """Supbabase Vector.
 
     In this vector store, embeddings are stored in Postgres table using pgvector.
@@ -41,6 +43,8 @@ class SupabaseVectorStore(VectorStore):
 
     stores_text = True
     flat_metadata = False
+    _client: Optional[Any] = PrivateAttr()
+    _collection: Optional[Collection] = PrivateAttr()
 
     def __init__(
         self,
@@ -49,17 +53,17 @@ class SupabaseVectorStore(VectorStore):
         dimension: int = DEFAULT_EMBEDDING_DIM,
         **kwargs: Any,
     ) -> None:
-        """Init params."""
-        client = vecs.create_client(postgres_connection_string)
+        super().__init__()
+        self._client = vecs.create_client(postgres_connection_string)
 
         try:
-            self._collection = client.get_collection(name=collection_name)
+            self._collection = self._client.get_collection(name=collection_name)
         except CollectionNotFound:
             logger.info(
                 f"Collection {collection_name} does not exist, "
                 f"try creating one with dimension={dimension}"
             )
-            self._collection = client.create_collection(
+            self._collection = self._client.create_collection(
                 name=collection_name, dimension=dimension
             )
 
@@ -71,7 +75,7 @@ class SupabaseVectorStore(VectorStore):
     def _to_vecs_filters(self, filters: MetadataFilters) -> Any:
         """Convert llama filters to vecs filters. $eq is the only supported operator."""
         vecs_filter = defaultdict(list)
-        filter_cond = f"${filters.condition}"
+        filter_cond = f"${filters.condition.value}"
 
         for f in filters.legacy_filters():
             sub_filter = {}

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/tests/test_vector_stores_supabase.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/tests/test_vector_stores_supabase.py
@@ -1,7 +1,7 @@
-from llama_index.core.vector_stores.types import VectorStore
+from llama_index.core.vector_stores.types import BasePydanticVectorStore
 from llama_index.vector_stores.supabase import SupabaseVectorStore
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in SupabaseVectorStore.__mro__]
-    assert VectorStore.__name__ in names_of_base_classes
+    assert BasePydanticVectorStore.__name__ in names_of_base_classes


### PR DESCRIPTION
# Description
This bug was also present for SupabaseVectorStore, so it could not be used in a IngestionPipeline: https://github.com/run-llama/llama_index/issues/10688

This PR fixes the bug above by making SupabaseVectorStore a subclass of BasePydanticVectorStore.

This change is analogous to
https://github.com/run-llama/llama_index/pull/11435/files#diff-a903926a12a2a95032e32938ee7a8d5ab960dda9872690435e6f53a527f6368cR98

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
