### PR TITLE
update to check hidden file only for relative path

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -237,7 +237,9 @@ class SimpleDirectoryReader(BaseReader):
             # in glob for backwards compatibility.
             ref = Path(ref)
             is_dir = self.fs.isdir(ref)
-            skip_because_hidden = self.exclude_hidden and self.is_hidden(ref)
+            skip_because_hidden = self.exclude_hidden and self.is_hidden(
+                ref.relative_to(input_dir.absolute())
+            )
             skip_because_bad_ext = (
                 self.required_exts is not None and ref.suffix not in self.required_exts
             )


### PR DESCRIPTION
# Description

I'd like to make a minor change in the checking is hidden file in SimpleDirectoryReader which only checks the relative paths is hidden instead of full path. 

The issue was found two days ago in LlamaIndexTS that our end-to-end tests have been failed. 
https://github.com/run-llama/LlamaIndexTS/actions/runs/8057821493/job/22009612434

Looks like it is due to a change related to the file path in SimpleDirectoryReader because our playwright tests the code in a`.cache` folder (which is considered as a hidden path). It is better that LlamaIndex only check is a hidden file for the sub-path from the input directory instead of a whole absolute path. 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
