### PR TITLE
Fixes for Gemini inside Vertex

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -14,6 +14,7 @@ class MessageRole(str, Enum):
     FUNCTION = "function"
     TOOL = "tool"
     CHATBOT = "chatbot"
+    MODEL = "model"
 
 
 # ===== Generic Model Input - Chat =====

--- a/llama-index-core/llama_index/core/utilities/gemini_utils.py
+++ b/llama-index-core/llama_index/core/utilities/gemini_utils.py
@@ -1,0 +1,52 @@
+"""Global Gemini Utilities (shared between Gemini LLM and Vertex)."""
+
+from collections.abc import Sequence
+from typing import Dict
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+ROLES_TO_GEMINI: Dict[MessageRole, MessageRole] = {
+    MessageRole.USER: MessageRole.USER,
+    MessageRole.ASSISTANT: MessageRole.MODEL,
+    ## Gemini only has user and model roles. Put the rest in user role.
+    MessageRole.SYSTEM: MessageRole.USER,
+}
+ROLES_FROM_GEMINI: Dict[MessageRole, MessageRole] = {
+    ## Gemini only has user and model roles.
+    MessageRole.USER: MessageRole.USER,
+    MessageRole.MODEL: MessageRole.ASSISTANT,
+}
+
+
+def merge_neighboring_same_role_messages(
+    messages: Sequence[ChatMessage],
+) -> Sequence[ChatMessage]:
+    # Gemini does not support multiple messages of the same role in a row, so we merge them
+    merged_messages = []
+    i = 0
+
+    while i < len(messages):
+        current_message = messages[i]
+        # Initialize merged content with current message content
+        merged_content = [current_message.content]
+
+        # Check if the next message exists and has the same role
+        while (
+            i + 1 < len(messages)
+            and ROLES_TO_GEMINI[messages[i + 1].role]
+            == ROLES_TO_GEMINI[current_message.role]
+        ):
+            i += 1
+            next_message = messages[i]
+            merged_content.extend([next_message.content])
+
+        # Create a new ChatMessage or similar object with merged content
+        merged_message = ChatMessage(
+            role=ROLES_TO_GEMINI[current_message.role],
+            content="\n".join([str(msg_content) for msg_content in merged_content]),
+            additional_kwargs=current_message.additional_kwargs,
+        )
+        merged_messages.append(merged_message)
+        i += 1
+
+    return merged_messages

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -1,4 +1,5 @@
 """Google's hosted Gemini API."""
+
 import os
 import typing
 from typing import Any, Dict, Optional, Sequence
@@ -14,17 +15,16 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.constants import DEFAULT_NUM_OUTPUTS, DEFAULT_TEMPERATURE
-from llama_index.core.llms.callbacks import (
-    llm_chat_callback,
-    llm_completion_callback,
-)
+from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.custom import CustomLLM
-from llama_index.llms.gemini.utils import (
+from llama_index.core.utilities.gemini_utils import (
     ROLES_FROM_GEMINI,
+    merge_neighboring_same_role_messages,
+)
+from llama_index.llms.gemini.utils import (
     chat_from_gemini_response,
     chat_message_to_gemini,
     completion_from_gemini_response,
-    merge_neighboring_same_role_messages,
 )
 
 if typing.TYPE_CHECKING:

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
@@ -1,22 +1,15 @@
-from typing import Sequence, Union
+from typing import Union
 
 import google.ai.generativelanguage as glm
 import google.generativeai as genai
 import PIL
-from llama_index.core.base.llms.types import MessageRole
+
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
     CompletionResponse,
 )
-
-ROLES_TO_GEMINI = {
-    MessageRole.USER: "user",
-    MessageRole.ASSISTANT: "model",
-    ## Gemini only has user and model roles. Put the rest in user role.
-    MessageRole.SYSTEM: "user",
-}
-ROLES_FROM_GEMINI = {v: k for k, v in ROLES_TO_GEMINI.items()}
+from llama_index.core.utilities.gemini_utils import ROLES_FROM_GEMINI, ROLES_TO_GEMINI
 
 
 def _error_if_finished_early(candidate: "glm.Candidate") -> None:  # type: ignore[name-defined] # only until release
@@ -79,37 +72,3 @@ def chat_message_to_gemini(message: ChatMessage) -> "genai.types.ContentDict":
         "role": ROLES_TO_GEMINI[message.role],
         "parts": parts,
     }
-
-
-def merge_neighboring_same_role_messages(
-    messages: Sequence[ChatMessage],
-) -> Sequence[ChatMessage]:
-    # Gemini does not support multiple messages of the same role in a row, so we merge them
-    merged_messages = []
-    i = 0
-
-    while i < len(messages):
-        current_message = messages[i]
-        # Initialize merged content with current message content
-        merged_content = [current_message.content]
-
-        # Check if the next message exists and has the same role
-        while (
-            i + 1 < len(messages)
-            and ROLES_TO_GEMINI[messages[i + 1].role]
-            == ROLES_TO_GEMINI[current_message.role]
-        ):
-            i += 1
-            next_message = messages[i]
-            merged_content.extend([next_message.content])
-
-        # Create a new ChatMessage or similar object with merged content
-        merged_message = ChatMessage(
-            role=current_message.role,
-            content="\n".join([str(msg_content) for msg_content in merged_content]),
-            additional_kwargs=current_message.additional_kwargs,
-        )
-        merged_messages.append(merged_message)
-        i += 1
-
-    return merged_messages

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-gemini"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -16,6 +16,7 @@ from llama_index.core.callbacks import CallbackManager
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.llm import LLM
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
+from llama_index.core.utilities.gemini_utils import merge_neighboring_same_role_messages
 from llama_index.llms.vertex.gemini_utils import create_gemini_client, is_gemini_model
 from llama_index.llms.vertex.utils import (
     CHAT_MODELS,
@@ -130,7 +131,9 @@ class Vertex(LLM):
         return LLMMetadata(
             is_chat_model=self._is_chat_model,
             model_name=self.model,
-            system_role=MessageRole.USER,  # Vertex does not support the default: MessageRole.SYSTEM
+            system_role=(
+                MessageRole.USER if self._is_gemini else MessageRole.SYSTEM
+            ),  # Gemini does not support the default: MessageRole.SYSTEM
         )
 
     @property
@@ -152,8 +155,13 @@ class Vertex(LLM):
 
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
-        question = _parse_message(messages[-1], self._is_gemini)
-        chat_history = _parse_chat_history(messages[:-1], self._is_gemini)
+        merged_messages = (
+            merge_neighboring_same_role_messages(messages)
+            if self._is_gemini
+            else messages
+        )
+        question = _parse_message(merged_messages[-1], self._is_gemini)
+        chat_history = _parse_chat_history(merged_messages[:-1], self._is_gemini)
         chat_params = {**chat_history}
 
         kwargs = kwargs if kwargs else {}
@@ -209,8 +217,13 @@ class Vertex(LLM):
     def stream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
-        question = _parse_message(messages[-1], self._is_gemini)
-        chat_history = _parse_chat_history(messages[:-1], self._is_gemini)
+        merged_messages = (
+            merge_neighboring_same_role_messages(messages)
+            if self._is_gemini
+            else messages
+        )
+        question = _parse_message(merged_messages[-1], self._is_gemini)
+        chat_history = _parse_chat_history(merged_messages[:-1], self._is_gemini)
         chat_params = {**chat_history}
         kwargs = kwargs if kwargs else {}
         params = {**self._model_kwargs, **kwargs}
@@ -283,8 +296,13 @@ class Vertex(LLM):
     async def achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponse:
-        question = _parse_message(messages[-1], self._is_gemini)
-        chat_history = _parse_chat_history(messages[:-1], self._is_gemini)
+        merged_messages = (
+            merge_neighboring_same_role_messages(messages)
+            if self._is_gemini
+            else messages
+        )
+        question = _parse_message(merged_messages[-1], self._is_gemini)
+        chat_history = _parse_chat_history(merged_messages[:-1], self._is_gemini)
         chat_params = {**chat_history}
         kwargs = kwargs if kwargs else {}
         params = {**self._model_kwargs, **kwargs}

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vertex"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

1) Gemini requires an even message count and, in the Gemini LLM, we `merge_neighboring_same_role_messages`. This PR does the same thing in the Vertex LLM if we're using Gemini.

2) We also set the default `system_role` in the  `LLMMetadata` to be `System.USER` only if we're using Gemini, since Gemini only supports "user" and "model" roles.

3) Finally we ensure the role of each message in Vertex is set to the appropriate `MessageRole`

**NOTE: This change adds/updates NO UNIT TESTs to support it.**

Fixes # (https://github.com/run-llama/llama_index/issues/11439)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas