### PR TITLE
fix ollama query engine pack notebook.

### DIFF
--- a/docs/examples/llama_hub/llama_pack_ollama.ipynb
+++ b/docs/examples/llama_hub/llama_pack_ollama.ipynb
@@ -123,8 +123,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ollama_pack.base import OllamaQueryEnginePack\n",
-    "\n",
     "# You can use any llama-hub loader to get documents!\n",
     "ollama_pack = OllamaQueryEnginePack(model=\"llama2\", documents=documents)"
    ]


### PR DESCRIPTION
# Description

current import string is not right. 
it should be changed to `from ollama_pack.llama_index.packs.ollama_query_engine import OllamaQueryEnginePack`

Looking into other examples for `download_llama_pack` this import is not really needed, so removed it all together.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code