### PR TITLE
Split Google docs on headings

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
@@ -165,7 +165,7 @@ class GoogleDocsReader(BasePydanticReader):
             element: a Structural Element.
         """
         level = None
-        heading_label = None
+        heading_key = None
         heading_id = None
         if self.split_on_heading_level and "paragraph" in element:
             style = element.get("paragraph").get("paragraphStyle")
@@ -173,15 +173,15 @@ class GoogleDocsReader(BasePydanticReader):
             heading_id = style.get("headingId", None)
             if style_type == "TITLE":
                 level = 0
-                heading_label = "title"
+                heading_key = "title"
             elif style_type.startswith("HEADING_"):
                 level = int(style_type.split("_")[1])
                 if level > self.split_on_heading_level:
                     return None, None, None
 
-                heading_label = f"heading_{level}"
+                heading_key = f"Header {level}"
 
-        return level, heading_label, heading_id
+        return level, heading_key, heading_id
 
     def _generate_doc_id(self, metadata: dict):
         if "heading_id" in metadata:
@@ -211,7 +211,7 @@ class GoogleDocsReader(BasePydanticReader):
         for value in elements:
             element_text = self._read_structural_elements([value])
 
-            level, heading_label, heading_id = self._determine_heading_level(value)
+            level, heading_key, heading_id = self._determine_heading_level(value)
 
             if level is not None:
                 if level == self.split_on_heading_level:
@@ -229,7 +229,7 @@ class GoogleDocsReader(BasePydanticReader):
                 elif level < current_heading_level:
                     metadata = doc_metadata.copy()
 
-                metadata[heading_label] = element_text
+                metadata[heading_key] = element_text
                 current_heading_level = level
             else:
                 text += element_text

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
@@ -8,8 +8,8 @@ from typing import Any, List, Optional
 
 import googleapiclient.discovery as discovery
 from google_auth_oauthlib.flow import InstalledAppFlow
-from pydantic import Field
 
+from llama_index.core.bridge.pydantic import Field
 from llama_index.core.readers.base import BasePydanticReader
 from llama_index.core.schema import Document
 

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -34,7 +34,7 @@ license = "MIT"
 maintainers = ["bbornsztein", "jerryjliu", "ong", "piroz", "pycui", "ravi03071991"]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Add support for splitting Google docs by heading. By setting `split_on_heading_level` a new document will be created for each new heading on the specified level. All headings on lower levels will be added add metadata for context. heading_id is added to metadata for traceability. 


## Type of Change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Updated the main function with a public test google doc to verify 
