### PR TITLE
Prevent async_response_gen from Stalling with asyncio Timeout 

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -69,6 +69,7 @@ class ContextChatEngine(BaseChatEngine):
         prefix_messages: Optional[List[ChatMessage]] = None,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         context_template: Optional[str] = None,
+        llm: Optional[LLM] = None,
         **kwargs: Any,
     ) -> "ContextChatEngine":
         """Initialize a ContextChatEngine from default parameters."""


### PR DESCRIPTION
# Description

This PR solves the issue #10794. https://github.com/run-llama/llama_index/issues/10794 where the chat_engine gets stuck when attempting to utilize both asynchronous processing and streaming. 

Fixes # (issue)

Modified the async_response_gen function within the chat_engine to implement an asyncio timeout. This approach ensures that the function does not indefinitely wait for new items in the queue, addressing the primary cause of the hang.

Added exception handling for asyncio.TimeoutError to continue processing or break the loop if the engine is done, thereby preventing the function from getting stuck.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
