### PR TITLE
Prevent async_response_gen from Stalling with asyncio Timeout

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -185,7 +185,7 @@ class StreamingAgentChatResponse:
                 except asyncio.TimeoutError:
                     if self._is_done:
                         break
-                    continue  
+                    continue
                 self._unformatted_response += delta
                 yield delta
             else:

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -176,16 +176,20 @@ class StreamingAgentChatResponse:
                 # Queue is empty, but we're not done yet. Sleep for 0 secs to release the GIL and allow other threads to run.
                 time.sleep(0)
         self.response = self._unformatted_response.strip()
-
+    
     async def async_response_gen(self) -> AsyncGenerator[str, None]:
-        while not self._is_done or not self._aqueue.empty():
-            if not self._aqueue.empty():
-                delta = self._aqueue.get_nowait()
+        while True:
+            if not self._aqueue.empty() or not self._is_done:
+                try:
+                    delta = await asyncio.wait_for(self._aqueue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    if self._is_done:
+                        break
+                    continue  
                 self._unformatted_response += delta
                 yield delta
             else:
-                await self._new_item_event.wait()  # Wait until a new item is added
-                self._new_item_event.clear()  # Clear the event for the next wait
+                break
         self.response = self._unformatted_response.strip()
 
     def print_response_stream(self) -> None:

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -176,7 +176,7 @@ class StreamingAgentChatResponse:
                 # Queue is empty, but we're not done yet. Sleep for 0 secs to release the GIL and allow other threads to run.
                 time.sleep(0)
         self.response = self._unformatted_response.strip()
-    
+
     async def async_response_gen(self) -> AsyncGenerator[str, None]:
         while True:
             if not self._aqueue.empty() or not self._is_done:


### PR DESCRIPTION
# Description

This PR solves the issue https://github.com/run-llama/llama_index/issues/10794.  where the chat_engine gets stuck when attempting to utilize both asynchronous processing and streaming.

Fixes # (issue)

Modified the async_response_gen function within the chat_engine to implement an asyncio timeout. This approach ensures that the function does not indefinitely wait for new items in the queue, addressing the primary cause of the hang.

Added exception handling for asyncio.TimeoutError to continue processing or break the loop if the engine is done, thereby preventing the function from getting stuck.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
