### PR TITLE
tqdm: add tdqm.gather

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -288,16 +288,13 @@ class BaseEmbedding(TransformComponent):
         nested_embeddings = []
         if show_progress:
             try:
-                from tqdm.auto import tqdm
+                from tqdm.asyncio import tqdm_asyncio
 
-                nested_embeddings = [
-                    await f
-                    for f in tqdm(
-                        asyncio.as_completed(embeddings_coroutines),
-                        total=len(embeddings_coroutines),
-                        desc="Generating embeddings",
-                    )
-                ]
+                nested_embeddings = await tqdm_asyncio.gather(
+                    *embeddings_coroutines,
+                    total=len(embeddings_coroutines),
+                    desc="Generating embeddings",
+                )
             except ImportError:
                 nested_embeddings = await asyncio.gather(*embeddings_coroutines)
         else:

--- a/llama-index-core/llama_index/core/embeddings/multi_modal_base.py
+++ b/llama-index-core/llama_index/core/embeddings/multi_modal_base.py
@@ -155,16 +155,13 @@ class MultiModalEmbedding(BaseEmbedding):
         nested_embeddings = []
         if show_progress:
             try:
-                from tqdm.auto import tqdm
+                from tqdm.asyncio import tqdm_asyncio
 
-                nested_embeddings = [
-                    await f
-                    for f in tqdm(
-                        asyncio.as_completed(embeddings_coroutines),
-                        total=len(embeddings_coroutines),
-                        desc="Generating image embeddings",
-                    )
-                ]
+                nested_embeddings = await tqdm_asyncio.gather(
+                    *embeddings_coroutines,
+                    total=len(embeddings_coroutines),
+                    desc="Generating embeddings",
+                )
             except ImportError:
                 nested_embeddings = await asyncio.gather(*embeddings_coroutines)
         else:

--- a/llama-index-legacy/llama_index/legacy/core/embeddings/base.py
+++ b/llama-index-legacy/llama_index/legacy/core/embeddings/base.py
@@ -289,16 +289,13 @@ class BaseEmbedding(TransformComponent):
         nested_embeddings = []
         if show_progress:
             try:
-                from tqdm.auto import tqdm
+                from tqdm.asyncio import tqdm_asyncio
 
-                nested_embeddings = [
-                    await f
-                    for f in tqdm(
-                        asyncio.as_completed(embeddings_coroutines),
-                        total=len(embeddings_coroutines),
-                        desc="Generating embeddings",
-                    )
-                ]
+                nested_embeddings = await tqdm_asyncio.gather(
+                    *embeddings_coroutines,
+                    total=len(embeddings_coroutines),
+                    desc="Generating embeddings",
+                )
             except ImportError:
                 nested_embeddings = await asyncio.gather(*embeddings_coroutines)
         else:

--- a/llama-index-legacy/llama_index/legacy/embeddings/multi_modal_base.py
+++ b/llama-index-legacy/llama_index/legacy/embeddings/multi_modal_base.py
@@ -155,16 +155,13 @@ class MultiModalEmbedding(BaseEmbedding):
         nested_embeddings = []
         if show_progress:
             try:
-                from tqdm.auto import tqdm
+                from tqdm.asyncio import tqdm_asyncio
 
-                nested_embeddings = [
-                    await f
-                    for f in tqdm(
-                        asyncio.as_completed(embeddings_coroutines),
-                        total=len(embeddings_coroutines),
-                        desc="Generating image embeddings",
-                    )
-                ]
+                nested_embeddings = await tqdm_asyncio.gather(
+                    *embeddings_coroutines,
+                    total=len(embeddings_coroutines),
+                    desc="Generating embeddings",
+                )
             except ImportError:
                 nested_embeddings = await asyncio.gather(*embeddings_coroutines)
         else:


### PR DESCRIPTION
# Description

Current code of batch embedding in specific conditions (use_async=True, show_progress=True )doesn't preserve order of returned values from coroutines.

For example:
there are 3 text chunks `['a', 'b', 'c']` that are split into 2 batches `['a', 'b']` and `['c']`. 
then those to batches asynchronously sent to model to get embeddings. We expect returned embeddings to be in order of initial list, `[emedding_a, embedding_b, embedding_c]`, however, this is not guaranteed by current code, so in the example scenario most likely outcome would be: `[embedding_c, embedding_a, embedding_b]`.

Proposed change uses tqdm.gather, that preserves order.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
- [x] Ran code and validated that it works (at least for `core.base.embeddings`

# Suggested Checklist:

- [x] I have performed a self-review of my own code
