### PR TITLE
Fix empty metadata error for CSV Reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/tabular/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/tabular/base.py
@@ -46,10 +46,15 @@ class CSVReader(BaseReader):
             csv_reader = csv.reader(fp)
             for row in csv_reader:
                 text_list.append(", ".join(row))
+
+        metadata = {"filename": file.name, "extension": file.suffix}
+        if extra_info:
+            metadata = {**metadata, **extra_info}
+
         if self._concat_rows:
-            return [Document(text="\n".join(text_list), metadata=extra_info)]
+            return [Document(text="\n".join(text_list), metadata=metadata)]
         else:
-            return [Document(text=text, metadata=extra_info) for text in text_list]
+            return [Document(text=text, metadata=metadata) for text in text_list]
 
 
 class PandasCSVReader(BaseReader):

--- a/llama-index-legacy/llama_index/legacy/readers/file/tabular_reader.py
+++ b/llama-index-legacy/llama_index/legacy/readers/file/tabular_reader.py
@@ -46,10 +46,15 @@ class CSVReader(BaseReader):
             csv_reader = csv.reader(fp)
             for row in csv_reader:
                 text_list.append(", ".join(row))
+
+        metadata = {"filename": file.name, "extension": file.suffix}
+        if extra_info:
+            metadata = {**metadata, **extra_info}
+
         if self._concat_rows:
-            return [Document(text="\n".join(text_list), metadata=extra_info)]
+            return [Document(text="\n".join(text_list), metadata=metadata)]
         else:
-            return [Document(text=text, metadata=extra_info) for text in text_list]
+            return [Document(text=text, metadata=metadata) for text in text_list]
 
 
 class PandasCSVReader(BaseReader):

--- a/llama-index-legacy/llama_index/legacy/readers/file/tabular_reader.py
+++ b/llama-index-legacy/llama_index/legacy/readers/file/tabular_reader.py
@@ -46,15 +46,10 @@ class CSVReader(BaseReader):
             csv_reader = csv.reader(fp)
             for row in csv_reader:
                 text_list.append(", ".join(row))
-
-        metadata = {"filename": file.name, "extension": file.suffix}
-        if extra_info:
-            metadata = {**metadata, **extra_info}
-
         if self._concat_rows:
-            return [Document(text="\n".join(text_list), metadata=metadata)]
+            return [Document(text="\n".join(text_list), metadata=extra_info)]
         else:
-            return [Document(text=text, metadata=metadata) for text in text_list]
+            return [Document(text=text, metadata=extra_info) for text in text_list]
 
 
 class PandasCSVReader(BaseReader):


### PR DESCRIPTION
# Description
Example:
```{python}
from llama_index.readers.file import CSVReader

loader = CSVReader(concat_rows=False)
temp_documents = loader.load_data(file=example_path)
```
We see error as we didn't put extra_info into the loader:

```{error}
ValidationError: 1 validation error for Document
extra_info
  none is not an allowed value (type=type_error.none.not_allowed)
```
However, this is a optional field
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
