### PR TITLE
Fix Issue 11565 - The MilvusVectorStore MetaDataFilters FilterCondition.OR is ignored

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -273,7 +273,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         # Convert to string expression
         string_expr = ""
         if len(expr) != 0:
-            string_expr = " and ".join(expr)
+            string_expr = f" {query.filters.condition.value} ".join(expr)
 
         # Perform the search
         res = self._milvusclient.search(


### PR DESCRIPTION
Do not hard code the FilterCondition.AND value when building query filter and instead use what is defined in the MetadataFilters.condition

Fixes # (issue)
11565

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I stared at the code and made sure it makes sense
- [ ] Ran the code locally to test