### PR TITLE
Fix URLs in Prompts documentation

### DIFF
--- a/docs/module_guides/models/prompts.md
+++ b/docs/module_guides/models/prompts.md
@@ -5,9 +5,9 @@
 Prompting is the fundamental input that gives LLMs their expressive power. LlamaIndex uses prompts to build the index, do insertion,
 perform traversal during querying, and to synthesize the final answer.
 
-LlamaIndex uses a set of [default prompt templates](https://github.com/jerryjliu/llama_index/blob/main/llama_index/prompts/default_prompts.py) that work well out of the box.
+LlamaIndex uses a set of [default prompt templates](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/prompts/default_prompts.py) that work well out of the box.
 
-In addition, there are some prompts written and used specifically for chat models like `gpt-3.5-turbo` [here](https://github.com/jerryjliu/llama_index/blob/main/llama_index/prompts/chat_prompts.py).
+In addition, there are some prompts written and used specifically for chat models like `gpt-3.5-turbo` [here](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/prompts/chat_prompts.py).
 
 Users may also provide their own prompt templates to further customize the behavior of the framework. The best method for customizing is copying the default prompt from the link above, and using that as the base for any modifications.
 


### PR DESCRIPTION
Updates URLs to new locations after code reorganization.

# Description

Changes URLs in documentation to valid URLS so users can find the supporting files mentioned in the documentation.

Fixes #11569

## Type of Change

Please delete options that are not relevant.

- [X] This change requires a documentation update

# How Has This Been Tested?

I just clicked the links after making a change to the markdown files.

# Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
