### PR TITLE
potential fix for None delta

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -182,8 +182,6 @@ class StreamingAgentChatResponse:
             if not self._aqueue.empty() or not self._is_done:
                 try:
                     delta = await asyncio.wait_for(self._aqueue.get(), timeout=0.1)
-                    if delta is None:
-                        continue
                 except asyncio.TimeoutError:
                     if self._is_done:
                         break

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -182,6 +182,8 @@ class StreamingAgentChatResponse:
             if not self._aqueue.empty() or not self._is_done:
                 try:
                     delta = await asyncio.wait_for(self._aqueue.get(), timeout=0.1)
+                    if delta is None:
+                        continue
                 except asyncio.TimeoutError:
                     if self._is_done:
                         break

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -243,12 +243,13 @@ class Anthropic(LLM):
             async for r in response:
                 if isinstance(r, ContentBlockDeltaEvent):
                     content_delta = r.delta.text
-                    content += content_delta
-                    yield ChatResponse(
-                        message=ChatMessage(role=role, content=content),
-                        delta=content_delta,
-                        raw=r,
-                    )
+                    if content_delta is not None:  # Check if content_delta is not None
+                        content += content_delta
+                        yield ChatResponse(
+                            message=ChatMessage(role=role, content=content),
+                            delta=content_delta,
+                            raw=r,
+                        )
 
         return gen()
 

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -183,12 +183,13 @@ class Anthropic(LLM):
             for r in response:
                 if isinstance(r, ContentBlockDeltaEvent):
                     content_delta = r.delta.text
-                    content += content_delta
-                    yield ChatResponse(
-                        message=ChatMessage(role=role, content=content),
-                        delta=content_delta,
-                        raw=r,
-                    )
+                    if content_delta is not None:
+                        content += content_delta
+                        yield ChatResponse(
+                            message=ChatMessage(role=role, content=content),
+                            delta=content_delta,
+                            raw=r,
+                        )
 
         return gen()
 
@@ -243,7 +244,7 @@ class Anthropic(LLM):
             async for r in response:
                 if isinstance(r, ContentBlockDeltaEvent):
                     content_delta = r.delta.text
-                    if content_delta is not None:  # Check if content_delta is not None
+                    if content_delta is not None:
                         content += content_delta
                         yield ChatResponse(
                             message=ChatMessage(role=role, content=content),

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -182,11 +182,12 @@ class Gemini(CustomLLM):
                         type(response.prompt_feedback).to_dict(response.prompt_feedback)
                     ),
                 }
-                content += content_delta
-                yield ChatResponse(
-                    message=ChatMessage(role=role, content=content),
-                    delta=content_delta,
-                    raw=raw,
-                )
+                if content_delta is not None:
+                    content += content_delta
+                    yield ChatResponse(
+                        message=ChatMessage(role=role, content=content),
+                        delta=content_delta,
+                        raw=raw,
+                    )
 
         return gen()

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/llama_index/multi_modal_llms/gemini/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/llama_index/multi_modal_llms/gemini/base.py
@@ -176,12 +176,13 @@ class GeminiMultiModal(MultiModalLLM):
                         type(response.prompt_feedback).to_dict(response.prompt_feedback)
                     ),
                 }
-                content += content_delta
-                yield ChatResponse(
-                    message=ChatMessage(role=role, content=content),
-                    delta=content_delta,
-                    raw=raw,
-                )
+                if content_delta is not None:
+                    content += content_delta
+                    yield ChatResponse(
+                        message=ChatMessage(role=role, content=content),
+                        delta=content_delta,
+                        raw=raw,
+                    )
 
         return gen()
 
@@ -233,11 +234,12 @@ class GeminiMultiModal(MultiModalLLM):
                         type(response.prompt_feedback).to_dict(response.prompt_feedback)
                     ),
                 }
-                content += content_delta
-                yield ChatResponse(
-                    message=ChatMessage(role=role, content=content),
-                    delta=content_delta,
-                    raw=raw,
-                )
+                if content_delta is not None:
+                    content += content_delta
+                    yield ChatResponse(
+                        message=ChatMessage(role=role, content=content),
+                        delta=content_delta,
+                        raw=raw,
+                    )
 
         return gen()

--- a/llama-index-legacy/llama_index/legacy/llms/openai.py
+++ b/llama-index-legacy/llama_index/legacy/llms/openai.py
@@ -312,7 +312,8 @@ class OpenAI(LLM):
         tool_calls: List[ChoiceDeltaToolCall],
         tool_calls_delta: Optional[List[ChoiceDeltaToolCall]],
     ) -> List[ChoiceDeltaToolCall]:
-        """Use the tool_calls_delta objects received from openai stream chunks
+        """
+        Use the tool_calls_delta objects received from openai stream chunks
         to update the running tool_calls object.
 
         Args:
@@ -385,23 +386,26 @@ class OpenAI(LLM):
                 # update using deltas
                 role = delta.role or MessageRole.ASSISTANT
                 content_delta = delta.content or ""
-                content += content_delta
+                if content_delta is not None:
+                    content += content_delta
 
-                additional_kwargs = {}
-                if is_function:
-                    tool_calls = self._update_tool_calls(tool_calls, delta.tool_calls)
-                    additional_kwargs["tool_calls"] = tool_calls
+                    additional_kwargs = {}
+                    if is_function:
+                        tool_calls = self._update_tool_calls(
+                            tool_calls, delta.tool_calls
+                        )
+                        additional_kwargs["tool_calls"] = tool_calls
 
-                yield ChatResponse(
-                    message=ChatMessage(
-                        role=role,
-                        content=content,
-                        additional_kwargs=additional_kwargs,
-                    ),
-                    delta=content_delta,
-                    raw=response,
-                    additional_kwargs=self._get_response_token_counts(response),
-                )
+                    yield ChatResponse(
+                        message=ChatMessage(
+                            role=role,
+                            content=content,
+                            additional_kwargs=additional_kwargs,
+                        ),
+                        delta=content_delta,
+                        raw=response,
+                        additional_kwargs=self._get_response_token_counts(response),
+                    )
 
         return gen()
 
@@ -591,22 +595,24 @@ class OpenAI(LLM):
                 role = delta.role or MessageRole.ASSISTANT
                 content_delta = delta.content or ""
                 content += content_delta
+                if content_delta is not None:
+                    additional_kwargs = {}
+                    if is_function:
+                        tool_calls = self._update_tool_calls(
+                            tool_calls, delta.tool_calls
+                        )
+                        additional_kwargs["tool_calls"] = tool_calls
 
-                additional_kwargs = {}
-                if is_function:
-                    tool_calls = self._update_tool_calls(tool_calls, delta.tool_calls)
-                    additional_kwargs["tool_calls"] = tool_calls
-
-                yield ChatResponse(
-                    message=ChatMessage(
-                        role=role,
-                        content=content,
-                        additional_kwargs=additional_kwargs,
-                    ),
-                    delta=content_delta,
-                    raw=response,
-                    additional_kwargs=self._get_response_token_counts(response),
-                )
+                    yield ChatResponse(
+                        message=ChatMessage(
+                            role=role,
+                            content=content,
+                            additional_kwargs=additional_kwargs,
+                        ),
+                        delta=content_delta,
+                        raw=response,
+                        additional_kwargs=self._get_response_token_counts(response),
+                    )
 
         return gen()
 


### PR DESCRIPTION
# Description

When response generated it `None` I am getting the error:

```py
async for text in response.async_response_gen():
  File "/opt/pysetup/.venv/lib/python3.11/site-packages/llama_index/core/chat_engine/types.py", line 189, in async_response_gen
    self._unformatted_response += delta
TypeError: can only concatenate str (not "NoneType") to str
```

This, in theory, should resolve that issue.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
