### PR TITLE
feat: relative score fusion (QueryFusionRetriever)

### DIFF
--- a/docs/examples/retrievers/relative_score_dist_fusion.ipynb
+++ b/docs/examples/retrievers/relative_score_dist_fusion.ipynb
@@ -1,0 +1,388 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/retrievers/reciprocal_rerank_fusion.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Relative Score Fusion and Distribution-Based Score Fusion\n",
+    "\n",
+    "In this example, we demonstrate using QueryFusionRetriever with two methods which aim to improve on Reciprocal Rank Fusion:\n",
+    "1. Relative Score Fusion ([Weaviate](https://weaviate.io/blog/hybrid-search-fusion-algorithms))\n",
+    "2. Distribution-Based Score Fusion ([Mazzecchi: blog post](https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-llms-openai\n",
+    "%pip install llama-index-retrievers-bm25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import openai\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"\n",
+    "openai.api_key = os.environ[\"OPENAI_API_KEY\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex 🦙."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p 'data/paul_graham/'\n",
+    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import SimpleDirectoryReader\n",
+    "\n",
+    "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we will setup a vector index over the documentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing nodes: 100%|██████████| 1/1 [00:00<00:00,  7.55it/s]\n",
+      "Generating embeddings: 100%|██████████| 504/504 [00:03<00:00, 128.32it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.core import VectorStoreIndex\n",
+    "from llama_index.core.node_parser import SentenceSplitter\n",
+    "\n",
+    "splitter = SentenceSplitter(chunk_size=256)\n",
+    "\n",
+    "index = VectorStoreIndex.from_documents(documents, transformations=[splitter], show_progress=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a Hybrid Fusion Retriever using Relative Score Fusion\n",
+    "\n",
+    "In this step, we fuse our index with a BM25 based retriever. This will enable us to capture both semantic relations and keywords in our input queries.\n",
+    "\n",
+    "Since both of these retrievers calculate a score, we can use the `QueryFusionRetriever` to re-sort our nodes without using an additional models or excessive computation.\n",
+    "\n",
+    "The following example uses the [Relative Score Fusion](https://weaviate.io/blog/hybrid-search-fusion-algorithms) algorithm from Weaviate, which applies a MinMax scaler to each result set, then makes a weighted sum. Here, we'll give the vector retriever slightly more weight than BM25 (0.6 vs. 0.4)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we create our retrievers. Each will retrieve the top-10 most similar nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.retrievers.bm25 import BM25Retriever\n",
+    "\n",
+    "vector_retriever = index.as_retriever(similarity_top_k=5)\n",
+    "\n",
+    "bm25_retriever = BM25Retriever.from_defaults(\n",
+    "    docstore=index.docstore, similarity_top_k=10\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we can create our fusion retriever, which well return the top-10 most similar nodes from the 20 returned nodes from the retrievers.\n",
+    "\n",
+    "Note that the vector and BM25 retrievers may have returned all the same nodes, only in different orders; in this case, it simply acts as a re-ranker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.retrievers import QueryFusionRetriever\n",
+    "\n",
+    "retriever = QueryFusionRetriever(\n",
+    "    [vector_retriever, bm25_retriever],\n",
+    "    retriever_weights=[0.6, 0.4],\n",
+    "    similarity_top_k=10,\n",
+    "    num_queries=1,  # set this to 1 to disable query generation\n",
+    "    mode=\"relative_score\",\n",
+    "    use_async=True,\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# apply nested async to run in a notebook\n",
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodes_with_scores = retriever.retrieve(\n",
+    "    \"What happened at Interleafe and Viaweb?\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Score: 0.60 - You wouldn't need versions, or ports, or any of that crap. At Interleaf there had been a whole group...\n",
+      "-----\n",
+      "Score: 0.59 - The UI was horrible, but it proved you could build a whole store through the browser, without any cl...\n",
+      "-----\n",
+      "Score: 0.40 - We were determined to be the Microsoft Word, not the Interleaf. Which meant being easy to use and in...\n",
+      "-----\n",
+      "Score: 0.36 - In its time, the editor was one of the best general-purpose site builders. I kept the code tight and...\n",
+      "-----\n",
+      "Score: 0.25 - I kept the code tight and didn't have to integrate with any other software except Robert's and Trevo...\n",
+      "-----\n",
+      "Score: 0.25 - If all I'd had to do was work on this software, the next 3 years would have been the easiest of my l...\n",
+      "-----\n",
+      "Score: 0.21 - To find out, we decided to try making a version of our store builder that you could control through ...\n",
+      "-----\n",
+      "Score: 0.11 - But the most important thing I learned, and which I used in both Viaweb and Y Combinator, is that th...\n",
+      "-----\n",
+      "Score: 0.11 - The next year, from the summer of 1998 to the summer of 1999, must have been the least productive of...\n",
+      "-----\n",
+      "Score: 0.07 - The point is that it was really cheap, less than half market price.\n",
+      "\n",
+      "[8] Most software you can launc...\n",
+      "-----\n"
+     ]
+    }
+   ],
+   "source": [
+    "for node in nodes_with_scores:\n",
+    "    print(f\"Score: {node.score:.2f} - {node.text[:100]}...\\n-----\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Distribution-Based Score Fusion\n",
+    "\n",
+    "A variant on Relative Score Fusion, [Distribution-Based Score Fusion](https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18) scales the scores a bit differently - based on the mean and standard deviation of the scores for each result set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Score: 0.42 - You wouldn't need versions, or ports, or any of that crap. At Interleaf there had been a whole group...\n",
+      "-----\n",
+      "Score: 0.41 - The UI was horrible, but it proved you could build a whole store through the browser, without any cl...\n",
+      "-----\n",
+      "Score: 0.32 - We were determined to be the Microsoft Word, not the Interleaf. Which meant being easy to use and in...\n",
+      "-----\n",
+      "Score: 0.30 - In its time, the editor was one of the best general-purpose site builders. I kept the code tight and...\n",
+      "-----\n",
+      "Score: 0.27 - To find out, we decided to try making a version of our store builder that you could control through ...\n",
+      "-----\n",
+      "Score: 0.24 - I kept the code tight and didn't have to integrate with any other software except Robert's and Trevo...\n",
+      "-----\n",
+      "Score: 0.24 - If all I'd had to do was work on this software, the next 3 years would have been the easiest of my l...\n",
+      "-----\n",
+      "Score: 0.20 - Now we felt like we were really onto something. I had visions of a whole new generation of software ...\n",
+      "-----\n",
+      "Score: 0.20 - Users wouldn't need anything more than a browser.\n",
+      "\n",
+      "This kind of software, known as a web app, is com...\n",
+      "-----\n",
+      "Score: 0.18 - But the most important thing I learned, and which I used in both Viaweb and Y Combinator, is that th...\n",
+      "-----\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.core.retrievers import QueryFusionRetriever\n",
+    "\n",
+    "retriever = QueryFusionRetriever(\n",
+    "    [vector_retriever, bm25_retriever],\n",
+    "    retriever_weights=[0.6, 0.4],\n",
+    "    similarity_top_k=10,\n",
+    "    num_queries=1,  # set this to 1 to disable query generation\n",
+    "    mode=\"dist_based_score\",\n",
+    "    use_async=True,\n",
+    "    verbose=True,\n",
+    ")\n",
+    "\n",
+    "nodes_with_scores = retriever.retrieve(\n",
+    "    \"What happened at Interleafe and Viaweb?\"\n",
+    ")\n",
+    "\n",
+    "for node in nodes_with_scores:\n",
+    "    print(f\"Score: {node.score:.2f} - {node.text[:100]}...\\n-----\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use in a Query Engine!\n",
+    "\n",
+    "Now, we can plug our retriever into a query engine to synthesize natural language responses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.query_engine import RetrieverQueryEngine\n",
+    "\n",
+    "query_engine = RetrieverQueryEngine.from_args(retriever)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = query_engine.query(\"What happened at Interleafe and Viaweb?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**`Final Response:`** At Interleaf, there was a group called Release Engineering that was as large as the group writing the software. They had to deal with versions, ports, and other complexities. In contrast, at Viaweb, the software could be updated directly on the server, simplifying the process. Viaweb was founded with $10,000 in seed funding, and the software allowed building a whole store through the browser without the need for client software or command line inputs on the server. The company aimed to be easy to use and inexpensive, offering low monthly prices for their services."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from llama_index.core.response.notebook_utils import display_response\n",
+    "\n",
+    "display_response(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/examples/retrievers/relative_score_dist_fusion.ipynb
+++ b/docs/examples/retrievers/relative_score_dist_fusion.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/retrievers/reciprocal_rerank_fusion.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/retrievers/relative_score_dist_fusion.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/docs/examples/retrievers/relative_score_dist_fusion.ipynb
+++ b/docs/examples/retrievers/relative_score_dist_fusion.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -111,7 +111,9 @@
     "\n",
     "splitter = SentenceSplitter(chunk_size=256)\n",
     "\n",
-    "index = VectorStoreIndex.from_documents(documents, transformations=[splitter], show_progress=True)"
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents, transformations=[splitter], show_progress=True\n",
+    ")"
    ]
   },
   {
@@ -136,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -250,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -314,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -355,13 +357,6 @@
     "\n",
     "display_response(response)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -379,8 +374,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/module_guides/querying/retriever/retrievers.md
+++ b/docs/module_guides/querying/retriever/retrievers.md
@@ -26,6 +26,7 @@ Define Custom Retriever </examples/query_engine/CustomRetrievers.ipynb>
 BM25 Hybrid Retriever </examples/retrievers/bm25_retriever.ipynb>
 /examples/retrievers/simple_fusion.ipynb
 /examples/retrievers/reciprocal_rerank_fusion.ipynb
+/examples/retrievers/relative_score_dist_fusion.ipynb
 /examples/retrievers/auto_merging_retriever.ipynb
 /examples/node_postprocessor/MetadataReplacementDemo.ipynb
 /examples/retrievers/composable_retrievers.ipynb

--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -25,6 +25,8 @@ class FUSION_MODES(str, Enum):
     """Enum for different fusion modes."""
 
     RECIPROCAL_RANK = "reciprocal_rerank"  # apply reciprocal rank fusion
+    RELATIVE_SCORE = "relative_score"  # apply relative score fusion
+    DIST_BASED_SCORE = "dist_based_score"  # apply distance-based score fusion
     SIMPLE = "simple"  # simple re-ordering of results based on original scores
 
 
@@ -42,6 +44,7 @@ class QueryFusionRetriever(BaseRetriever):
         callback_manager: Optional[CallbackManager] = None,
         objects: Optional[List[IndexNode]] = None,
         object_map: Optional[dict] = None,
+        retriever_weights: Optional[List[float]] = None,
     ) -> None:
         self.num_queries = num_queries
         self.query_gen_prompt = query_gen_prompt or QUERY_GEN_PROMPT
@@ -50,6 +53,12 @@ class QueryFusionRetriever(BaseRetriever):
         self.use_async = use_async
 
         self._retrievers = retrievers
+        if retriever_weights is None:
+            self._retriever_weights = [1.0 / len(retrievers)] * len(retrievers)
+        else:
+            # Sum of retriever_weights must be 1
+            total_weight = sum(retriever_weights)
+            self._retriever_weights = [w / total_weight for w in retriever_weights]
         self._llm = (
             resolve_llm(llm, callback_manager=callback_manager) if llm else Settings.llm
         )
@@ -83,7 +92,8 @@ class QueryFusionRetriever(BaseRetriever):
         if self._verbose:
             queries_str = "\n".join(queries)
             print(f"Generated queries:\n{queries_str}")
-        return response.text.split("\n")
+        # The LLM often returns more queries than we asked for, so trim the list.
+        return response.text.split("\n")[: self.num_queries]
 
     def _reciprocal_rerank_fusion(
         self, results: Dict[Tuple[str, int], List[NodeWithScore]]
@@ -121,6 +131,60 @@ class QueryFusionRetriever(BaseRetriever):
 
         return reranked_nodes
 
+    def _relative_score_fusion(
+        self,
+        results: Dict[Tuple[str, int], List[NodeWithScore]],
+        dist_based: Optional[bool] = False,
+    ) -> List[NodeWithScore]:
+        """Apply relative score fusion."""
+        # MinMax scale scores of each result set (highest value becomes 1, lowest becomes 0)
+        # then scale by the weight of the retriever
+        min_max_scores = {}
+        for query_tuple, nodes_with_scores in results.items():
+            scores = [node_with_score.score for node_with_score in nodes_with_scores]
+            if dist_based:
+                # Set min and max based on mean and std dev
+                mean_score = sum(scores) / len(scores)
+                std_dev = (
+                    sum((x - mean_score) ** 2 for x in scores) / len(scores)
+                ) ** 0.5
+                min_score = mean_score - 3 * std_dev
+                max_score = mean_score + 3 * std_dev
+            else:
+                min_score = min(scores)
+                max_score = max(scores)
+            min_max_scores[query_tuple] = (min_score, max_score)
+
+        for query_tuple, nodes_with_scores in results.items():
+            for node_with_score in nodes_with_scores:
+                min_score, max_score = min_max_scores[query_tuple]
+                # Scale the score to be between 0 and 1
+                if max_score == min_score:
+                    node_with_score.score = 1.0 if max_score > 0 else 0.0
+                else:
+                    node_with_score.score = (node_with_score.score - min_score) / (
+                        max_score - min_score
+                    )
+                # Scale by the weight of the retriever
+                retriever_idx = query_tuple[1]
+                node_with_score.score *= self._retriever_weights[retriever_idx]
+                # Divide by the number of queries
+                node_with_score.score /= self.num_queries
+
+        # Use a dict to de-duplicate nodes
+        all_nodes: Dict[str, NodeWithScore] = {}
+
+        # Sum scores for each node
+        for nodes_with_scores in results.values():
+            for node_with_score in nodes_with_scores:
+                text = node_with_score.node.get_content()
+                if text in all_nodes:
+                    all_nodes[text].score += node_with_score.score
+                else:
+                    all_nodes[text] = node_with_score
+
+        return sorted(all_nodes.values(), key=lambda x: x.score or 0.0, reverse=True)
+
     def _simple_fusion(
         self, results: Dict[Tuple[str, int], List[NodeWithScore]]
     ) -> List[NodeWithScore]:
@@ -145,13 +209,13 @@ class QueryFusionRetriever(BaseRetriever):
         for query in queries:
             for i, retriever in enumerate(self._retrievers):
                 tasks.append(retriever.aretrieve(query))
-                task_queries.append(query)
+                task_queries.append((query, i))
 
         task_results = run_async_tasks(tasks)
 
         results = {}
-        for i, (query, query_result) in enumerate(zip(task_queries, task_results)):
-            results[(query, i)] = query_result
+        for query_tuple, query_result in zip(task_queries, task_results):
+            results[query_tuple] = query_result
 
         return results
 
@@ -162,13 +226,13 @@ class QueryFusionRetriever(BaseRetriever):
         for query in queries:
             for i, retriever in enumerate(self._retrievers):
                 tasks.append(retriever.aretrieve(query))
-                task_queries.append(query)
+                task_queries.append((query, i))
 
         task_results = await asyncio.gather(*tasks)
 
         results = {}
-        for i, (query, query_result) in enumerate(zip(task_queries, task_results)):
-            results[(query, i)] = query_result
+        for query_tuple, query_result in zip(task_queries, task_results):
+            results[query_tuple] = query_result
 
         return results
 
@@ -195,6 +259,12 @@ class QueryFusionRetriever(BaseRetriever):
 
         if self.mode == FUSION_MODES.RECIPROCAL_RANK:
             return self._reciprocal_rerank_fusion(results)[: self.similarity_top_k]
+        elif self.mode == FUSION_MODES.RELATIVE_SCORE:
+            return self._relative_score_fusion(results)[: self.similarity_top_k]
+        elif self.mode == FUSION_MODES.DIST_BASED_SCORE:
+            return self._relative_score_fusion(results, dist_based=True)[
+                : self.similarity_top_k
+            ]
         elif self.mode == FUSION_MODES.SIMPLE:
             return self._simple_fusion(results)[: self.similarity_top_k]
         else:
@@ -210,6 +280,12 @@ class QueryFusionRetriever(BaseRetriever):
 
         if self.mode == FUSION_MODES.RECIPROCAL_RANK:
             return self._reciprocal_rerank_fusion(results)[: self.similarity_top_k]
+        elif self.mode == FUSION_MODES.RELATIVE_SCORE:
+            return self._relative_score_fusion(results)[: self.similarity_top_k]
+        elif self.mode == FUSION_MODES.DIST_BASED_SCORE:
+            return self._relative_score_fusion(results, dist_based=True)[
+                : self.similarity_top_k
+            ]
         elif self.mode == FUSION_MODES.SIMPLE:
             return self._simple_fusion(results)[: self.similarity_top_k]
         else:


### PR DESCRIPTION
# Description

**Purpose**: Improve hybrid search performance with any backend (e.g. Postgres, in-memory...)

Adds two new fusion methods to `QueryFusionRetriever`:
1. [Relative Score Fusion](https://weaviate.io/blog/hybrid-search-fusion-algorithms)
2. [Distribution-Based Score Fusion](https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18)

Adds optional argument to `QueryFusionRetriever` to provide custom weights for the retrievers, so as to make a weighted sum.

**Not included, but nice to have later**: Evaluations of retrieval performance.

Fixes #10576 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new notebook (that tests end-to-end)

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods