### PR TITLE
Check for none from queue

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -186,8 +186,9 @@ class StreamingAgentChatResponse:
                     if self._is_done:
                         break
                     continue
-                self._unformatted_response += delta
-                yield delta
+                if delta is not None:
+                    self._unformatted_response += delta
+                    yield delta
             else:
                 break
         self.response = self._unformatted_response.strip()


### PR DESCRIPTION
original fix from https://github.com/run-llama/llama_index/pull/11632

The recent aqueue update will sometimes lead to to delta being `None` -- we should avoid that