### PR TITLE
fix out of index for _extract_rel_text_keywords when use neo4j Neo4jG…

### DIFF
--- a/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
@@ -169,12 +169,20 @@ class KGTableRetriever(BaseRetriever):
     def _extract_rel_text_keywords(self, rel_texts: List[str]) -> List[str]:
         """Find the keywords for given rel text triplets."""
         keywords = []
+
         for rel_text in rel_texts:
-            keyword = rel_text.split(",")[0]
+            splited_texts = rel_text.split(",")
+
+            if len(splited_texts) <= 0:
+                continue
+            keyword = splited_texts[0]
             if keyword:
                 keywords.append(keyword.strip("(\"'"))
+
             # Return the Object as well
-            keyword = rel_text.split(",")[2]
+            if len(splited_texts) <= 2:
+                continue
+            keyword = splited_texts[2]
             if keyword:
                 keywords.append(keyword.strip(" ()\"'"))
         return keywords
@@ -222,6 +230,7 @@ class KGTableRetriever(BaseRetriever):
                 rel_map = self._graph_store.get_rel_map(
                     list(subjs), self.graph_store_query_depth
                 )
+
                 logger.debug(f"rel_map: {rel_map}")
 
                 if not rel_map:


### PR DESCRIPTION
# Description

### Bug Description

```

def _extract_rel_text_keywords(self, rel_texts: List[str]) -> List[str]:
       
 """Find the keywords for given rel text triplets."""
        keywords = []
        for rel_text in rel_texts:
            keyword = rel_text.split(",")[0]
            if keyword:
                keywords.append(keyword.strip("(\"'"))
            # Return the Object as well
            keyword = rel_text.split(",")[2]   //  here, when use Neo4j, rel_text is ['rel' , 'obj']
            if keyword:
                keywords.append(keyword.strip(" ()\"'"))
        return keywords


```


real example of variable: rel_texts below:
["['干', '一件什么“蠢事”']", "['叫', '逆天而为']", "['干了', '一件什么“蠢事”']", "['转向', '互联网']", "['就该转向', '互联网']"]


when run , will occurs :

```

  File "/Users/bytedance/PycharmProjects/rag_util/venv/lib/python3.9/site-packages/llama_index/core/base/base_retriever.py", line 229, in retrieve
    nodes = self._retrieve(query_bundle)
  File "/Users/bytedance/PycharmProjects/rag_util/venv/lib/python3.9/site-packages/llama_index/core/indices/knowledge_graph/retrievers.py", line 286, in _retrieve
    keywords = self._extract_rel_text_keywords(
  File "/Users/bytedance/PycharmProjects/rag_util/venv/lib/python3.9/site-packages/llama_index/core/indices/knowledge_graph/retrievers.py", line 178, in _extract_rel_text_keywords
    keyword = rel_text.split(",")[2]
IndexError: list index out of range

```



Fixes #11693 

## Type of Change

Please delete options that are not relevant.

- [1 ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [1 ] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [1] I have performed a self-review of my own code
- [1] I have commented my code, particularly in hard-to-understand areas
- [1] I have made corresponding changes to the documentation
- [1] I have added Google Colab support for the newly added notebooks.
- [1] My changes generate no new warnings
- [1] I have added tests that prove my fix is effective or that my feature works
- [1] New and existing unit tests pass locally with my changes
- [1] I ran `make format; make lint` to appease the lint gods
