### PR TITLE
Return proper response type in synthesizer

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -177,7 +177,14 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
-            return Response("Empty Response")
+            if self._streaming:
+
+                def response_generator() -> Generator[str, None, None]:
+                    yield "Empty Response"
+
+                return StreamingResponse(response_gen=response_generator())
+            else:
+                return Response("Empty Response")
 
         if isinstance(query, str):
             query = QueryBundle(query_str=query)
@@ -210,7 +217,14 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
-            return Response("Empty Response")
+            if self._streaming:
+
+                def response_generator() -> Generator[str, None, None]:
+                    yield "Empty Response"
+
+                return StreamingResponse(response_gen=response_generator())
+            else:
+                return Response("Empty Response")
 
         if isinstance(query, str):
             query = QueryBundle(query_str=query)

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -50,6 +50,10 @@ logger = logging.getLogger(__name__)
 QueryTextType = Union[str, QueryBundle]
 
 
+def empty_response_generator() -> Generator[str, None, None]:
+    yield "Empty Response"
+
+
 class BaseSynthesizer(ChainableMixin, PromptMixin):
     """Response builder class."""
 
@@ -178,11 +182,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
             if self._streaming:
-
-                def response_generator() -> Generator[str, None, None]:
-                    yield "Empty Response"
-
-                return StreamingResponse(response_gen=response_generator())
+                return StreamingResponse(response_gen=empty_response_generator())
             else:
                 return Response("Empty Response")
 
@@ -218,11 +218,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
             if self._streaming:
-
-                def response_generator() -> Generator[str, None, None]:
-                    yield "Empty Response"
-
-                return StreamingResponse(response_gen=response_generator())
+                return StreamingResponse(response_gen=empty_response_generator())
             else:
                 return Response("Empty Response")
 


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/11698

Even if no nodes are found, still return the proper response type