### PR TITLE
Astra DB vector store: rephrase the warning about indexing

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
@@ -126,9 +126,11 @@ class AstraDBVectorStore(BasePydanticVectorStore):
                 if "indexing" not in pre_col_options:
                     warn(
                         (
-                            f"Collection '{collection_name}' is detected as legacy"
-                            " and has indexing turned on for all fields. This"
-                            " implies stricter limitations on the amount of text"
+                            f"Collection '{collection_name}' is detected as "
+                            "having indexing turned on for all fields "
+                            "(either created manually or by older versions "
+                            "of this plugin). This implies stricter "
+                            "limitations on the amount of text"
                             " each entry can store. Consider reindexing anew on a"
                             " fresh collection to be able to store longer texts."
                         ),


### PR DESCRIPTION
This PR simply removes the word 'legacy' from the warning message
about the Astra DB vector store collection being detected with "all-indexing" settings.

Since this case is 100% supported and will always be, the term 'legacy' was a little misleading.
