### PR TITLE
Logan/avoid nest asyncio

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -177,7 +177,14 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
-            return Response("Empty Response")
+            if self._streaming:
+
+                def response_generator() -> Generator[str, None, None]:
+                    yield "Empty Response"
+
+                return StreamingResponse(response_gen=response_generator())
+            else:
+                return Response("Empty Response")
 
         if isinstance(query, str):
             query = QueryBundle(query_str=query)
@@ -210,7 +217,14 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
-            return Response("Empty Response")
+            if self._streaming:
+
+                def response_generator() -> Generator[str, None, None]:
+                    yield "Empty Response"
+
+                return StreamingResponse(response_gen=response_generator())
+            else:
+                return Response("Empty Response")
 
         if isinstance(query, str):
             query = QueryBundle(query_str=query)

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -50,6 +50,10 @@ logger = logging.getLogger(__name__)
 QueryTextType = Union[str, QueryBundle]
 
 
+def empty_response_generator() -> Generator[str, None, None]:
+    yield "Empty Response"
+
+
 class BaseSynthesizer(ChainableMixin, PromptMixin):
     """Response builder class."""
 
@@ -178,11 +182,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
             if self._streaming:
-
-                def response_generator() -> Generator[str, None, None]:
-                    yield "Empty Response"
-
-                return StreamingResponse(response_gen=response_generator())
+                return StreamingResponse(response_gen=empty_response_generator())
             else:
                 return Response("Empty Response")
 
@@ -218,11 +218,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
     ) -> RESPONSE_TYPE:
         if len(nodes) == 0:
             if self._streaming:
-
-                def response_generator() -> Generator[str, None, None]:
-                    yield "Empty Response"
-
-                return StreamingResponse(response_gen=response_generator())
+                return StreamingResponse(response_gen=empty_response_generator())
             else:
                 return Response("Empty Response")
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -5,8 +5,6 @@ import json
 import uuid
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
-import nest_asyncio
-
 from llama_index.core.bridge.pydantic import PrivateAttr
 
 from llama_index.core.schema import BaseNode, MetadataMode, TextNode
@@ -321,7 +319,6 @@ class OpensearchVectorClient:
         self._os_client = _get_async_opensearch_client(self._endpoint, **kwargs)
         not_found_error = _import_not_found_error()
 
-        nest_asyncio.apply()
         event_loop = asyncio.get_event_loop()
         try:
             event_loop.run_until_complete(
@@ -454,7 +451,6 @@ class OpensearchVectorStore(BasePydanticVectorStore):
     ) -> None:
         """Initialize params."""
         super().__init__()
-        nest_asyncio.apply()
         self._client = client
 
     @property

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-opensearch"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/11661

Automatically using `nest_asyncio.apply()` will cause non-obvious issues with users using things like fastapi. 

We should leave it up to the user to run this function