### PR TITLE
fix: allow guideline evaluator with bedrock

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/base.py
+++ b/llama-index-core/llama_index/core/evaluation/base.py
@@ -95,8 +95,14 @@ class BaseEvaluator(PromptMixin):
         Subclasses can override this method to provide custom evaluation logic and
         take in additional arguments.
         """
-        return asyncio.run(
-            self.aevaluate_response(query=query, response=response, **kwargs)
+        response_str: Optional[str] = None
+        contexts: Optional[Sequence[str]] = None
+        if response is not None:
+            response_str = response.response
+            contexts = [node.get_content() for node in response.source_nodes]
+
+        return self.evaluate(
+            query=query, response=response_str, contexts=contexts, **kwargs
         )
 
     async def aevaluate_response(


### PR DESCRIPTION
# Description

I was trying to test the guideline evaluator with bedrock claude but got error: `NotImplementedError`. 
This was because evaluate_response is calling avevaluate_response and async is not suported by Bedrock.
The modification update the code to be able to do so.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I used python file:
```python3
import pandas as pd
from llama_index.core.evaluation import GuidelineEvaluator
from llama_index.llms.bedrock import Bedrock
from llama_index.core.base.response.schema import Response
from tqdm import tqdm
import json
from llama_index.core.callbacks import CallbackManager, TokenCountingHandler

from llama_index.core import Settings
GUIDELINE = "guidelines"

def load_existing_ids(filename):
    existing_ids = set()
    try:
        with open(filename, 'r', encoding='utf-8') as file:
            for line in file:
                entry = json.loads(line)
                # Créer un identifiant unique basé sur la question et la réponse
                unique_id = entry['query'] + '|' + entry['response']
                existing_ids.add(unique_id)
    except FileNotFoundError:
        pass  # Si le fichier n'existe pas, continuez avec un ensemble vide
    return existing_ids
existing_ids = load_existing_ids('results-bedrock-claude.jsonl')

profile_name = "claude-v3"
llm = Bedrock(
    model="anthropic.claude-v2", profile_name=profile_name,
    context_size=4096
)
evaluator=GuidelineEvaluator(llm=llm, guidelines=GUIDELINE)

# Load the CSV file
df = pd.read_csv('qa.csv',nrows=2)

# Open a file to save the results in JSON Lines format
with open('results-bedrock-claude.jsonl', 'a', encoding='utf-8') as outfile:
    for index, row in tqdm(df.iterrows(), total=df.shape[0], desc="Processing rows"):
        query = row[0]
        response = row[1]
        # Utiliser la concaténation de la question et de la réponse comme identifiant unique
        unique_id = query + '|' + response
        if unique_id not in existing_ids:
            existing_ids.add(unique_id) 
            result = evaluator.evaluate_response(query, Response(response=response))
            result_dict = json.loads(result.json())
            outfile.write(json.dumps(result_dict, ensure_ascii=False) + '\n')
```
where `qa.csv `file is a file with `question,answer.`
