### PR TITLE
Allow using different runtime kwargs for different evaluators in BatchEvalRunner

### DIFF
--- a/llama-index-core/tests/evaluation/test_batch_runner.py
+++ b/llama-index-core/tests/evaluation/test_batch_runner.py
@@ -1,0 +1,111 @@
+from typing import Any, Optional, Sequence
+
+from llama_index.core.base.response.schema import Response
+from llama_index.core.evaluation import BaseEvaluator
+from llama_index.core.evaluation.base import EvaluationResult
+from llama_index.core.prompts.mixin import PromptDictType
+
+from llama_index.core.evaluation.batch_runner import BatchEvalRunner
+
+
+class MockEvaluator(BaseEvaluator):
+    def __init__(
+        self,
+        mock_score: float = 1.0,
+        mock_passing: bool = True,
+        mock_feedback: str = "test feedback",
+    ) -> None:
+        self._mock_score = mock_score
+        self._mock_passing = mock_passing
+        self._mock_feedback = mock_feedback
+
+    def _get_prompts(self) -> PromptDictType:
+        """Get prompts."""
+        return {}
+
+    def _update_prompts(self, prompts: PromptDictType) -> None:
+        """Update prompts."""
+
+    async def aevaluate(
+        self,
+        query: Optional[str] = None,
+        response: Optional[str] = None,
+        contexts: Optional[Sequence[str]] = None,
+        reference: Optional[str] = None,
+        **kwargs: Any,
+    ) -> EvaluationResult:
+        return EvaluationResult(
+            query=query,
+            contexts=contexts,
+            response=response,
+            passing=(
+                str(response) == str(reference) if reference else self._mock_passing
+            ),
+            score=self._mock_score,
+            feedback=self._mock_feedback,
+        )
+
+
+def get_eval_results(key, eval_results):
+    results = eval_results[key]
+    correct = 0
+    for result in results:
+        if result.passing:
+            correct += 1
+    return correct / len(results)
+
+
+def test_batch_runner_with_single_evaluator(mocker) -> None:
+    runner = BatchEvalRunner(evaluators={"evaluator1": MockEvaluator()})
+
+    exp_queries = ["query1", "query2"]
+    exp_response_strs = ["response1", "response2"]
+    exp_responses = [
+        Response(response="response1", source_nodes=[]),
+        Response(response="response2", source_nodes=[]),
+    ]
+    exp_kwargs = {"reference": ["response1", "response1"]}
+
+    # test evaluate_response_strs()
+    results = runner.evaluate_response_strs(
+        queries=exp_queries, response_strs=exp_response_strs, **exp_kwargs
+    )
+    assert get_eval_results("evaluator1", results) == 0.5
+    # test evaluate_responses()
+    results = runner.evaluate_responses(
+        queries=exp_queries, responses=exp_responses, **exp_kwargs
+    )
+    assert get_eval_results("evaluator1", results) == 0.5
+
+
+def test_batch_runner_with_multiple_evaluators(mocker) -> None:
+    runner = BatchEvalRunner(
+        evaluators={
+            "evaluator1": MockEvaluator(),
+            "evaluator2": MockEvaluator(),
+        }
+    )
+
+    exp_queries = ["query1", "query2"]
+    exp_response_strs = ["response1", "response2"]
+    exp_responses = [
+        Response(response="response1", source_nodes=[]),
+        Response(response="response2", source_nodes=[]),
+    ]
+    exp_kwargs = {
+        "evaluator1": {"reference": ["response1", "response1"]},
+        "evaluator2": {"reference": ["response1", "response2"]},
+    }
+
+    # test evaluate_response_strs()
+    results = runner.evaluate_response_strs(
+        queries=exp_queries, response_strs=exp_response_strs, **exp_kwargs
+    )
+    assert get_eval_results("evaluator1", results) == 0.5
+    assert get_eval_results("evaluator2", results) == 1.0
+    # test evaluate_responses()
+    results = runner.evaluate_responses(
+        queries=exp_queries, responses=exp_responses, **exp_kwargs
+    )
+    assert get_eval_results("evaluator1", results) == 0.5
+    assert get_eval_results("evaluator2", results) == 1.0


### PR DESCRIPTION
# Description
**BatchEvalRunner**
Allows use of different runtime kwargs (e.g. references) with multiple evaluators (while maintaining backwards compatibility for single evaluators)

`**eval_kwargs_lists` now accepts either a Dict[str, List] or a Dict[str, Dict[str, List]]

Our project uses BatchEvalRunner to run multiple custom evaluators (using regex to compare against ground truth values) in parallel.  
We were unable to pass in different ground truth values as references for multiple evaluators with the current limitations so we overwrote the `async def aevaluate_responses` function in a child class of BatchEvalRunner.  This is a better fix for ourselves and others who face a similar problem.

Fixes # (issue)
When using multiple evaluators which each take a different `reference` kwarg there is currently no way to pass these in separately.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
