### PR TITLE
Prevent forced flush() on document add

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -199,7 +199,8 @@ class MilvusVectorStore(BasePydanticVectorStore):
 
         # Insert the data into milvus
         self._collection.insert(insert_list)
-        self._collection.flush()
+        if add_kwargs.get("force_flush", False):
+            self._collection.flush()
         self._create_index_if_required()
         logger.debug(
             f"Successfully inserted embeddings into: {self.collection_name} "

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

According to the Milvus client documentation (https://milvus.io/docs/insert_data.md#Flush-the-Data-in-Milvus), a flush() is
performed automatically and most likely shouldn't be done manually. Flushing manually causes slow performance and fragmented files which impacts search performance.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix for improper usage pattern that could cause performance issues

# How Has This Been Tested?

- [ ] I stared at the code and made sure it makes sense
- [ ] Tested locally