### PR TITLE
Update base.py

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -73,7 +73,7 @@ def _to_weaviate_filter(standard_filters: MetadataFilters) -> Dict[str, Any]:
             if isinstance(filter.value, float):
                 value_type = "valueNumber"
             elif isinstance(filter.value, int):
-                value_type = "valueNumber"
+                value_type = "valueInt"
             elif isinstance(filter.value, str) and filter.value.isnumeric():
                 filter.value = float(filter.value)
                 value_type = "valueNumber"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Fixes a bug in the conversion of filters to Weaviate filters. If a the datatype is int Weaviate requires the filter value to be valueInt not valueNumber. Which causes a failure to convert the filters.

# Description
This change fixes a bug in the conversion of filters to Weaviate filters. If a the datatype is int Weaviate requires the filter value to be valueInt not valueNumber. Which causes the error below:

`Error: Invalid query, got errors: [{'locations': [{'column': 6, 'line': 1}], 'message': 'invalid \'where\' filter: child operand at position 0: data type filter cannot use "valueNumber" on type "int", use "valueInt" instead, child operand at position 1: data type filter cannot use "valueNumber" on type "int", use "valueInt" instead', 'path': ['Get', 'LlamaIndex']}]`

The change sets the filter value to be valueInt instead of valueNumber. This change resolves the error above.

Fixes # (issue)

## Type of Change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- I tested my code locally
- I stared at the code and made sure it makes sense


# Suggested Checklist:

- [ ] I have performed a self-review of my own code

