### PR TITLE
Update deepeval callback handler import path

### DIFF
--- a/llama-index-integrations/callbacks/llama-index-callbacks-deepeval/llama_index/callbacks/deepeval/base.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-deepeval/llama_index/callbacks/deepeval/base.py
@@ -2,8 +2,7 @@ from typing import Any
 
 from llama_index.core.callbacks.base_handler import BaseCallbackHandler
 
-from deepeval.tracing.integrations.llama_index import LlamaIndexCallbackHandler
-
+from deepeval.integrations.llama_index.callback import LlamaIndexCallbackHandler
 
 def deepeval_callback_handler(**eval_params: Any) -> BaseCallbackHandler:
     return LlamaIndexCallbackHandler(**eval_params)


### PR DESCRIPTION
# Description

When trying out the 1-click observability integration with deepeval, i would receive the below error, even after verifying that `llama-index-callbacks-deepeval` was installed:

```
ImportError: DeepEvalCallbackHandler is not installed. Please install it using `pip install llama-index-callbacks-deepeval
```

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
