### PR TITLE
fix: relative score fusion bug

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -141,6 +141,9 @@ class QueryFusionRetriever(BaseRetriever):
         # then scale by the weight of the retriever
         min_max_scores = {}
         for query_tuple, nodes_with_scores in results.items():
+            if not nodes_with_scores:
+                min_max_scores[query_tuple] = (0.0, 0.0)
+                continue
             scores = [node_with_score.score for node_with_score in nodes_with_scores]
             if dist_based:
                 # Set min and max based on mean and std dev


### PR DESCRIPTION
# Description

Fixes a bug in my last PR #11667 

I failed to consider an edge case where a query doesn't retrieve any results. This can happen when one of the retrievers is keyword search, if restrictive filters are applied, or if there are no documents in the index.