### PR TITLE
Feat/mymagic-return-output

### DIFF
--- a/docs/examples/llm/mymagic.ipynb
+++ b/docs/examples/llm/mymagic.ipynb
@@ -67,7 +67,7 @@
     "    role_arn=\"your-role-arn\",\n",
     "    system_prompt=\"your-system-prompt\",\n",
     "    region=\"your-bucket-region\",\n",
-    "    return_output = False, # Whether you want MyMagic API to return the output json\n",
+    "    return_output=False,  # Whether you want MyMagic API to return the output json\n",
     ")"
    ]
   },
@@ -79,7 +79,7 @@
    "source": [
     "resp = llm.complete(\n",
     "    question=\"your-question\",\n",
-    "    model=\"chhoose-model\",  # currently we support mistral7b, llama7b, mixtral8x7b,codellama70b, llama70b, more to come...\n",
+    "    model=\"chhoose-model\",  # currently we support mistral7b, llama7b, mixtral8x7b, codellama70b, llama70b, more to come...\n",
     "    max_tokens=5,  # number of tokens to generate, default is 10\n",
     ")"
    ]

--- a/docs/examples/llm/mymagic.ipynb
+++ b/docs/examples/llm/mymagic.ipynb
@@ -67,6 +67,7 @@
     "    role_arn=\"your-role-arn\",\n",
     "    system_prompt=\"your-system-prompt\",\n",
     "    region=\"your-bucket-region\",\n",
+    "    return_output = False, # Whether you want MyMagic API to return the output json\n",
     ")"
    ]
   },

--- a/llama-index-integrations/llms/llama-index-llms-mymagic/llama_index/llms/mymagic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mymagic/llama_index/llms/mymagic/base.py
@@ -48,6 +48,9 @@ class MyMagicAI(LLM):
     region: Optional[str] = Field(
         "eu-west-2", description="The region the bucket is in. Only used for AWS S3."
     )
+    return_output: Optional[bool] = Field(
+        False, description="Whether MyMagic API should return the output json"
+    )
 
     def __init__(
         self,
@@ -58,6 +61,7 @@ class MyMagicAI(LLM):
         system_prompt: Optional[str],
         role_arn: Optional[str] = None,
         region: Optional[str] = None,
+        return_output: Optional[bool] = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -71,6 +75,7 @@ class MyMagicAI(LLM):
             "role_arn": role_arn,
             "system_prompt": system_prompt,
             "region": region,
+            "return_output": return_output,
         }
 
     @classmethod


### PR DESCRIPTION
# Description

This change introduces a 'return_output' argument to Mymagic API call. This would allow user to recieve a json output with query and response for visibility.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [X] Called the integrated MyMagic API with test user

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
