### PR TITLE
The PrivateAttr should be imported from llama_index.core.bridge.pydantic instead of pydantic

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
@@ -5,7 +5,8 @@ from enum import Enum
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import PrivateAttr
+# The PrivateAttr should be imported from llama_index.core.bridge.pydantic instead of pydantic
+from llama_index.core.bridge.pydantic import PrivateAttr
 
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.core.schema import ImageType

--- a/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
@@ -5,9 +5,7 @@ from enum import Enum
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 
-# The PrivateAttr should be imported from llama_index.core.bridge.pydantic instead of pydantic
 from llama_index.core.bridge.pydantic import PrivateAttr
-
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.core.schema import ImageType
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-dashscope"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION

# Description

Can not create from llama_index.embeddings.dashscope import DashScopeEmbedding object
The reason is that, DashScopeEmbedding use from pydantic import PrivateAttr, not from llama_index.core.bridge.pydantic import PrivateAttr

Fixes # (issue)
[https://github.com/run-llama/llama_index/issues/11764](https://github.com/run-llama/llama_index/issues/11764)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

-  No

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


