### PR TITLE
docs: Updated Qdrant usage examples

### DIFF
--- a/docs/examples/vector_stores/QdrantIndexDemo.ipynb
+++ b/docs/examples/vector_stores/QdrantIndexDemo.ipynb
@@ -1,503 +1,423 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "dd821a8d",
-      "metadata": {
-        "id": "dd821a8d"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/vector_stores/QdrantIndexDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "307804a3-c02b-4a57-ac0d-172c30ddc851",
-      "metadata": {
-        "id": "307804a3-c02b-4a57-ac0d-172c30ddc851"
-      },
-      "source": [
-        "# Qdrant Vector Store"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396",
-      "metadata": {
-        "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396"
-      },
-      "source": [
-        "#### Creating a Qdrant client"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0dc39c0b",
-      "metadata": {
-        "id": "0dc39c0b"
-      },
-      "outputs": [],
-      "source": [
-        "%pip install llama-index-vector-stores-qdrant llama-index-readers-file llama-index-embeddings-fastembed llama-index-llms-openai"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d5527d3d",
-      "metadata": {
-        "id": "d5527d3d"
-      },
-      "outputs": [],
-      "source": [
-        "import logging\n",
-        "import sys\n",
-        "import os\n",
-        "\n",
-        "import qdrant_client\n",
-        "from IPython.display import Markdown, display\n",
-        "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
-        "from llama_index.core import StorageContext\n",
-        "from llama_index.vector_stores.qdrant import QdrantVectorStore\n",
-        "from llama_index.embeddings.fastembed import FastEmbedEmbedding\n",
-        "from llama_index.core import Settings\n",
-        "\n",
-        "Settings.embed_model = FastEmbedEmbedding(model_name=\"BAAI/bge-small-en-v1.5\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "07489add",
-      "metadata": {
-        "id": "07489add"
-      },
-      "source": [
-        "If running this for the first, time, install using this command:\n",
-        "\n",
-        "```\n",
-        "!pip install -U qdrant_client fastembed\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Set your OpenAI key for authenticating the LLM"
-      ],
-      "metadata": {
-        "id": "wGLkbqIm4XIe"
-      },
-      "id": "wGLkbqIm4XIe"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%env OPENAI_API_KEY=<YOUR_OPENAI_API_KEY>"
-      ],
-      "metadata": {
-        "id": "uI25Wj6x4SrT"
-      },
-      "id": "uI25Wj6x4SrT",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 59,
-      "id": "9c79df94",
-      "metadata": {
-        "id": "9c79df94"
-      },
-      "outputs": [],
-      "source": [
-        "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-        "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c475d645",
-      "metadata": {
-        "id": "c475d645"
-      },
-      "source": [
-        "Download Data"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0d3e939d",
-      "metadata": {
-        "id": "0d3e939d"
-      },
-      "outputs": [],
-      "source": [
-        "!mkdir -p 'data/paul_graham/'\n",
-        "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "01c44da1",
-      "metadata": {
-        "id": "01c44da1"
-      },
-      "source": [
-        "#### Load the documents"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 61,
-      "id": "7cbe1384",
-      "metadata": {
-        "id": "7cbe1384"
-      },
-      "outputs": [],
-      "source": [
-        "# load documents\n",
-        "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
-      "metadata": {
-        "id": "8ee4473a-094f-4d0a-a825-e1213db07240"
-      },
-      "source": [
-        "#### Build the VectorStoreIndex"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 62,
-      "id": "b873b936",
-      "metadata": {
-        "id": "b873b936"
-      },
-      "outputs": [],
-      "source": [
-        "client = qdrant_client.QdrantClient(\n",
-        "    # you can use :memory: mode for fast and light-weight experiments,\n",
-        "    # it does not require to have Qdrant deployed anywhere\n",
-        "    # but requires qdrant-client >= 1.1.1\n",
-        "    location=\":memory:\"\n",
-        "    # otherwise set Qdrant instance address with:\n",
-        "    # uri=\"http://<host>:<port>\"\n",
-        "    # set API KEY for Qdrant Cloud\n",
-        "    # api_key=\"<qdrant-api-key>\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 63,
-      "id": "ba1558b3",
-      "metadata": {
-        "id": "ba1558b3"
-      },
-      "outputs": [],
-      "source": [
-        "vector_store = QdrantVectorStore(client=client, collection_name=\"paul_graham\")\n",
-        "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
-        "index = VectorStoreIndex.from_documents(\n",
-        "    documents,\n",
-        "    storage_context=storage_context,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "36862545",
-      "metadata": {
-        "id": "36862545"
-      },
-      "source": [
-        "#### Query Index"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [],
-      "metadata": {
-        "id": "9C-RAzDg4PY1"
-      },
-      "id": "9C-RAzDg4PY1"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 64,
-      "id": "7bf3e2b9",
-      "metadata": {
-        "id": "7bf3e2b9"
-      },
-      "outputs": [],
-      "source": [
-        "# set Logging to DEBUG for more detailed outputs\n",
-        "query_engine = index.as_query_engine()\n",
-        "response = query_engine.query(\"What did the author do growing up?\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 65,
-      "id": "77a864c7",
-      "metadata": {
-        "id": "77a864c7",
-        "outputId": "987a9700-aee1-47fc-c110-445f9ce855a3",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 46
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Markdown object>"
-            ],
-            "text/markdown": "<b>The author worked on writing and programming before college.</b>"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "display(Markdown(f\"<b>{response}</b>\"))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 66,
-      "id": "64e35c1e",
-      "metadata": {
-        "id": "64e35c1e"
-      },
-      "outputs": [],
-      "source": [
-        "# set Logging to DEBUG for more detailed outputs\n",
-        "query_engine = index.as_query_engine()\n",
-        "response = query_engine.query(\n",
-        "    \"What did the author do after his time at Viaweb?\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 67,
-      "id": "926b79da",
-      "metadata": {
-        "id": "926b79da",
-        "outputId": "47568cb9-c58c-4cc1-e367-6b31bce9751f",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 46
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Markdown object>"
-            ],
-            "text/markdown": "<b>The author arranged to do freelance work for a group that did projects for customers after his time at Viaweb.</b>"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "display(Markdown(f\"<b>{response}</b>\"))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7b4d27fc",
-      "metadata": {
-        "id": "7b4d27fc"
-      },
-      "source": [
-        "#### Build the VectorStoreIndex asynchronously"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 68,
-      "id": "08af428d",
-      "metadata": {
-        "id": "08af428d"
-      },
-      "outputs": [],
-      "source": [
-        "# To connect to the same event-loop,\n",
-        "# allows async events to run on notebook\n",
-        "\n",
-        "import nest_asyncio\n",
-        "\n",
-        "nest_asyncio.apply()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 69,
-      "id": "13fe7e09",
-      "metadata": {
-        "id": "13fe7e09"
-      },
-      "outputs": [],
-      "source": [
-        "aclient = qdrant_client.AsyncQdrantClient(\n",
-        "    # you can use :memory: mode for fast and light-weight experiments,\n",
-        "    # it does not require to have Qdrant deployed anywhere\n",
-        "    # but requires qdrant-client >= 1.1.1\n",
-        "    location=\":memory:\"\n",
-        "    # otherwise set Qdrant instance address with:\n",
-        "    # uri=\"http://<host>:<port>\"\n",
-        "    # set API KEY for Qdrant Cloud\n",
-        "    # api_key=\"<qdrant-api-key>\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 72,
-      "id": "1918d705",
-      "metadata": {
-        "id": "1918d705"
-      },
-      "outputs": [],
-      "source": [
-        "vector_store = QdrantVectorStore(\n",
-        "    aclient=aclient, collection_name=\"paul_graham\", prefer_grpc=True\n",
-        ")\n",
-        "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
-        "index = VectorStoreIndex.from_documents(\n",
-        "    documents,\n",
-        "    storage_context=storage_context,\n",
-        "    use_async=True,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "2d0401ab",
-      "metadata": {
-        "id": "2d0401ab"
-      },
-      "source": [
-        "#### Async Query Index"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 73,
-      "id": "88af9cf2",
-      "metadata": {
-        "id": "88af9cf2"
-      },
-      "outputs": [],
-      "source": [
-        "query_engine = index.as_query_engine(use_async=True)\n",
-        "response = await query_engine.aquery(\"What did the author do growing up?\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 74,
-      "id": "c88ff475",
-      "metadata": {
-        "id": "c88ff475",
-        "outputId": "fd5e999f-4ee1-4e42-9e42-c09e91c4e903",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 81
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Markdown object>"
-            ],
-            "text/markdown": "<b>The author worked on writing short stories and programming, particularly on an IBM 1401 computer in 9th grade using an early version of Fortran. Later, the author transitioned to working on microcomputers, starting with a TRS-80 in about 1980, where they wrote simple games, programs, and a word processor.</b>"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "display(Markdown(f\"<b>{response}</b>\"))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 75,
-      "id": "5e8f1146",
-      "metadata": {
-        "id": "5e8f1146"
-      },
-      "outputs": [],
-      "source": [
-        "# set Logging to DEBUG for more detailed outputs\n",
-        "query_engine = index.as_query_engine(use_async=True)\n",
-        "response = await query_engine.aquery(\n",
-        "    \"What did the author do after his time at Viaweb?\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 76,
-      "id": "90e1fa0e",
-      "metadata": {
-        "id": "90e1fa0e",
-        "outputId": "90631dfb-0047-425d-db0d-5b0ce545abf9",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 46
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Markdown object>"
-            ],
-            "text/markdown": "<b>The author went on to co-found Y Combinator after his time at Viaweb.</b>"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "display(Markdown(f\"<b>{response}</b>\"))"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3"
-    },
-    "colab": {
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dd821a8d",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/vector_stores/QdrantIndexDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "307804a3-c02b-4a57-ac0d-172c30ddc851",
+   "metadata": {},
+   "source": [
+    "# Qdrant Vector Store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396",
+   "metadata": {},
+   "source": [
+    "#### Creating a Qdrant client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dc39c0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-vector-stores-qdrant llama-index-readers-file llama-index-embeddings-fastembed llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5527d3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "import qdrant_client\n",
+    "from IPython.display import Markdown, display\n",
+    "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
+    "from llama_index.core import StorageContext\n",
+    "from llama_index.vector_stores.qdrant import QdrantVectorStore\n",
+    "from llama_index.embeddings.fastembed import FastEmbedEmbedding\n",
+    "from llama_index.core import Settings\n",
+    "\n",
+    "Settings.embed_model = FastEmbedEmbedding(model_name=\"BAAI/bge-small-en-v1.5\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07489add",
+   "metadata": {},
+   "source": [
+    "If running this for the first, time, install using this command:\n",
+    "\n",
+    "```\n",
+    "!pip install -U qdrant_client fastembed\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wGLkbqIm4XIe",
+   "metadata": {},
+   "source": [
+    "Set your OpenAI key for authenticating the LLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "uI25Wj6x4SrT",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%env OPENAI_API_KEY=<YOUR_OPENAI_API_KEY>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c79df94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c475d645",
+   "metadata": {},
+   "source": [
+    "Download Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d3e939d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p 'data/paul_graham/'\n",
+    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01c44da1",
+   "metadata": {},
+   "source": [
+    "#### Load the documents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cbe1384",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load documents\n",
+    "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
+   "metadata": {},
+   "source": [
+    "#### Build the VectorStoreIndex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b873b936",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = qdrant_client.QdrantClient(\n",
+    "    # you can use :memory: mode for fast and light-weight experiments,\n",
+    "    # it does not require to have Qdrant deployed anywhere\n",
+    "    # but requires qdrant-client >= 1.1.1\n",
+    "    location=\":memory:\"\n",
+    "    # otherwise set Qdrant instance address with:\n",
+    "    # uri=\"http://<host>:<port>\"\n",
+    "    # set API KEY for Qdrant Cloud\n",
+    "    # api_key=\"<qdrant-api-key>\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba1558b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vector_store = QdrantVectorStore(client=client, collection_name=\"paul_graham\")\n",
+    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents,\n",
+    "    storage_context=storage_context,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36862545",
+   "metadata": {},
+   "source": [
+    "#### Query Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bf3e2b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set Logging to DEBUG for more detailed outputs\n",
+    "query_engine = index.as_query_engine()\n",
+    "response = query_engine.query(\"What did the author do growing up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77a864c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<b>The author worked on writing and programming before college.</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64e35c1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set Logging to DEBUG for more detailed outputs\n",
+    "query_engine = index.as_query_engine()\n",
+    "response = query_engine.query(\n",
+    "    \"What did the author do after his time at Viaweb?\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "926b79da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<b>The author arranged to do freelance work for a group that did projects for customers after his time at Viaweb.</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b4d27fc",
+   "metadata": {},
+   "source": [
+    "#### Build the VectorStoreIndex asynchronously"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08af428d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To connect to the same event-loop,\n",
+    "# allows async events to run on notebook\n",
+    "\n",
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13fe7e09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aclient = qdrant_client.AsyncQdrantClient(\n",
+    "    # you can use :memory: mode for fast and light-weight experiments,\n",
+    "    # it does not require to have Qdrant deployed anywhere\n",
+    "    # but requires qdrant-client >= 1.1.1\n",
+    "    location=\":memory:\"\n",
+    "    # otherwise set Qdrant instance address with:\n",
+    "    # uri=\"http://<host>:<port>\"\n",
+    "    # set API KEY for Qdrant Cloud\n",
+    "    # api_key=\"<qdrant-api-key>\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1918d705",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vector_store = QdrantVectorStore(\n",
+    "    aclient=aclient, collection_name=\"paul_graham\", prefer_grpc=True\n",
+    ")\n",
+    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents,\n",
+    "    storage_context=storage_context,\n",
+    "    use_async=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d0401ab",
+   "metadata": {},
+   "source": [
+    "#### Async Query Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88af9cf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_engine = index.as_query_engine(use_async=True)\n",
+    "response = await query_engine.aquery(\"What did the author do growing up?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c88ff475",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<b>The author worked on writing short stories and programming, particularly on an IBM 1401 computer in 9th grade using an early version of Fortran. Later, the author transitioned to working on microcomputers, starting with a TRS-80 in about 1980, where they wrote simple games, programs, and a word processor.</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e8f1146",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set Logging to DEBUG for more detailed outputs\n",
+    "query_engine = index.as_query_engine(use_async=True)\n",
+    "response = await query_engine.aquery(\n",
+    "    \"What did the author do after his time at Viaweb?\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90e1fa0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<b>The author went on to co-found Y Combinator after his time at Viaweb.</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/examples/vector_stores/QdrantIndexDemo.ipynb
+++ b/docs/examples/vector_stores/QdrantIndexDemo.ipynb
@@ -1,410 +1,503 @@
 {
- "cells": [
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "dd821a8d",
-   "metadata": {},
-   "source": [
-    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/vector_stores/QdrantIndexDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "307804a3-c02b-4a57-ac0d-172c30ddc851",
-   "metadata": {},
-   "source": [
-    "# Qdrant Vector Store"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396",
-   "metadata": {},
-   "source": [
-    "#### Creating a Qdrant client"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0dc39c0b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install llama-index-vector-stores-qdrant"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d5527d3d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "import sys\n",
-    "import os\n",
-    "\n",
-    "import qdrant_client\n",
-    "from IPython.display import Markdown, display\n",
-    "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
-    "from llama_index.core import StorageContext\n",
-    "from llama_index.vector_stores.qdrant import QdrantVectorStore"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "07489add",
-   "metadata": {},
-   "source": [
-    "If running this for the first, time, install using this command: \n",
-    "\n",
-    "```\n",
-    "!pip install -U qdrant_client\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "86d852a3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.environ[\"OPENAI_API_KEY\"] = \"YOUR OPENAI API KEY\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9c79df94",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "c475d645",
-   "metadata": {},
-   "source": [
-    "Download Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0d3e939d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!mkdir -p 'data/paul_graham/'\n",
-    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "01c44da1",
-   "metadata": {},
-   "source": [
-    "#### Load the documents"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7cbe1384",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# load documents\n",
-    "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
-   "metadata": {},
-   "source": [
-    "#### Build the VectorStoreIndex"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b873b936",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client = qdrant_client.QdrantClient(\n",
-    "    # you can use :memory: mode for fast and light-weight experiments,\n",
-    "    # it does not require to have Qdrant deployed anywhere\n",
-    "    # but requires qdrant-client >= 1.1.1\n",
-    "    location=\":memory:\"\n",
-    "    # otherwise set Qdrant instance address with:\n",
-    "    # uri=\"http://<host>:<port>\"\n",
-    "    # set API KEY for Qdrant Cloud\n",
-    "    # api_key=\"<qdrant-api-key>\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ba1558b3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vector_store = QdrantVectorStore(client=client, collection_name=\"paul_graham\")\n",
-    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
-    "index = VectorStoreIndex.from_documents(\n",
-    "    documents,\n",
-    "    storage_context=storage_context,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "36862545",
-   "metadata": {},
-   "source": [
-    "#### Query Index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7bf3e2b9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set Logging to DEBUG for more detailed outputs\n",
-    "query_engine = index.as_query_engine()\n",
-    "response = query_engine.query(\"What did the author do growing up?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "77a864c7",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/markdown": [
-       "<b>The author worked on writing and programming outside of school before college. They wrote short stories and tried writing programs on the IBM 1401 computer. They also mentioned getting a microcomputer, specifically a TRS-80, and started programming on it.</b>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
+      "cell_type": "markdown",
+      "id": "dd821a8d",
+      "metadata": {
+        "id": "dd821a8d"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/vector_stores/QdrantIndexDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "display(Markdown(f\"<b>{response}</b>\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "64e35c1e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set Logging to DEBUG for more detailed outputs\n",
-    "query_engine = index.as_query_engine()\n",
-    "response = query_engine.query(\n",
-    "    \"What did the author do after his time at Viaweb?\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "926b79da",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/markdown": [
-       "<b>After his time at Viaweb, the author decided to pursue his passion for painting. He left Yahoo, where he had been working after Viaweb was acquired, and immediately started painting. However, he struggled with energy and ambition, and eventually returned to New York to resume his old life as a painter.</b>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
+      "cell_type": "markdown",
+      "id": "307804a3-c02b-4a57-ac0d-172c30ddc851",
+      "metadata": {
+        "id": "307804a3-c02b-4a57-ac0d-172c30ddc851"
+      },
+      "source": [
+        "# Qdrant Vector Store"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "display(Markdown(f\"<b>{response}</b>\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7b4d27fc",
-   "metadata": {},
-   "source": [
-    "#### Build the VectorStoreIndex asynchronously"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "08af428d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# To connect to the same event-loop,\n",
-    "# allows async events to run on notebook\n",
-    "\n",
-    "import nest_asyncio\n",
-    "\n",
-    "nest_asyncio.apply()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "13fe7e09",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client = qdrant_client.QdrantClient(\n",
-    "    # location=\":memory:\"\n",
-    "    # Async upsertion does not work\n",
-    "    # on 'memory' location and requires\n",
-    "    # Qdrant to be deployed somewhere.\n",
-    "    url=\"http://localhost:6334\",\n",
-    "    prefer_grpc=True,\n",
-    "    # set API KEY for Qdrant Cloud\n",
-    "    # api_key=\"<qdrant-api-key>\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1918d705",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vector_store = QdrantVectorStore(\n",
-    "    client=client, collection_name=\"paul_graham\", prefer_grpc=True\n",
-    ")\n",
-    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
-    "index = VectorStoreIndex.from_documents(\n",
-    "    documents,\n",
-    "    storage_context=storage_context,\n",
-    "    use_async=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2d0401ab",
-   "metadata": {},
-   "source": [
-    "#### Async Query Index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "88af9cf2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "query_engine = index.as_query_engine(use_async=True)\n",
-    "response = await query_engine.aquery(\"What did the author do growing up?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c88ff475",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/markdown": [
-       "<b>The author worked on writing and programming outside of school. They wrote short stories and tried writing programs on the IBM 1401 computer. They also built a microcomputer and started programming on it, writing simple games and a word processor.</b>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
+      "cell_type": "markdown",
+      "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396",
+      "metadata": {
+        "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396"
+      },
+      "source": [
+        "#### Creating a Qdrant client"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "display(Markdown(f\"<b>{response}</b>\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5e8f1146",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set Logging to DEBUG for more detailed outputs\n",
-    "query_engine = index.as_query_engine(use_async=True)\n",
-    "response = await query_engine.aquery(\n",
-    "    \"What did the author do after his time at Viaweb?\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "90e1fa0e",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/markdown": [
-       "<b>After his time at Viaweb, the author started working on a new idea. He decided to move to Cambridge and start a new company. However, he faced difficulties in finding a partner to work on the idea with him. Eventually, he recruited a team and began building a new dialect of Lisp called Arc. He also gave a talk at a Lisp conference and posted a file of the talk online, which gained a significant audience.</b>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0dc39c0b",
+      "metadata": {
+        "id": "0dc39c0b"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install llama-index-vector-stores-qdrant llama-index-readers-file llama-index-embeddings-fastembed llama-index-llms-openai"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d5527d3d",
+      "metadata": {
+        "id": "d5527d3d"
+      },
+      "outputs": [],
+      "source": [
+        "import logging\n",
+        "import sys\n",
+        "import os\n",
+        "\n",
+        "import qdrant_client\n",
+        "from IPython.display import Markdown, display\n",
+        "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
+        "from llama_index.core import StorageContext\n",
+        "from llama_index.vector_stores.qdrant import QdrantVectorStore\n",
+        "from llama_index.embeddings.fastembed import FastEmbedEmbedding\n",
+        "from llama_index.core import Settings\n",
+        "\n",
+        "Settings.embed_model = FastEmbedEmbedding(model_name=\"BAAI/bge-small-en-v1.5\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "07489add",
+      "metadata": {
+        "id": "07489add"
+      },
+      "source": [
+        "If running this for the first, time, install using this command:\n",
+        "\n",
+        "```\n",
+        "!pip install -U qdrant_client fastembed\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Set your OpenAI key for authenticating the LLM"
+      ],
+      "metadata": {
+        "id": "wGLkbqIm4XIe"
+      },
+      "id": "wGLkbqIm4XIe"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%env OPENAI_API_KEY=<YOUR_OPENAI_API_KEY>"
+      ],
+      "metadata": {
+        "id": "uI25Wj6x4SrT"
+      },
+      "id": "uI25Wj6x4SrT",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 59,
+      "id": "9c79df94",
+      "metadata": {
+        "id": "9c79df94"
+      },
+      "outputs": [],
+      "source": [
+        "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+        "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c475d645",
+      "metadata": {
+        "id": "c475d645"
+      },
+      "source": [
+        "Download Data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0d3e939d",
+      "metadata": {
+        "id": "0d3e939d"
+      },
+      "outputs": [],
+      "source": [
+        "!mkdir -p 'data/paul_graham/'\n",
+        "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "01c44da1",
+      "metadata": {
+        "id": "01c44da1"
+      },
+      "source": [
+        "#### Load the documents"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 61,
+      "id": "7cbe1384",
+      "metadata": {
+        "id": "7cbe1384"
+      },
+      "outputs": [],
+      "source": [
+        "# load documents\n",
+        "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
+      "metadata": {
+        "id": "8ee4473a-094f-4d0a-a825-e1213db07240"
+      },
+      "source": [
+        "#### Build the VectorStoreIndex"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 62,
+      "id": "b873b936",
+      "metadata": {
+        "id": "b873b936"
+      },
+      "outputs": [],
+      "source": [
+        "client = qdrant_client.QdrantClient(\n",
+        "    # you can use :memory: mode for fast and light-weight experiments,\n",
+        "    # it does not require to have Qdrant deployed anywhere\n",
+        "    # but requires qdrant-client >= 1.1.1\n",
+        "    location=\":memory:\"\n",
+        "    # otherwise set Qdrant instance address with:\n",
+        "    # uri=\"http://<host>:<port>\"\n",
+        "    # set API KEY for Qdrant Cloud\n",
+        "    # api_key=\"<qdrant-api-key>\",\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 63,
+      "id": "ba1558b3",
+      "metadata": {
+        "id": "ba1558b3"
+      },
+      "outputs": [],
+      "source": [
+        "vector_store = QdrantVectorStore(client=client, collection_name=\"paul_graham\")\n",
+        "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+        "index = VectorStoreIndex.from_documents(\n",
+        "    documents,\n",
+        "    storage_context=storage_context,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "36862545",
+      "metadata": {
+        "id": "36862545"
+      },
+      "source": [
+        "#### Query Index"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [],
+      "metadata": {
+        "id": "9C-RAzDg4PY1"
+      },
+      "id": "9C-RAzDg4PY1"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 64,
+      "id": "7bf3e2b9",
+      "metadata": {
+        "id": "7bf3e2b9"
+      },
+      "outputs": [],
+      "source": [
+        "# set Logging to DEBUG for more detailed outputs\n",
+        "query_engine = index.as_query_engine()\n",
+        "response = query_engine.query(\"What did the author do growing up?\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 65,
+      "id": "77a864c7",
+      "metadata": {
+        "id": "77a864c7",
+        "outputId": "987a9700-aee1-47fc-c110-445f9ce855a3",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 46
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "<b>The author worked on writing and programming before college.</b>"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "display(Markdown(f\"<b>{response}</b>\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 66,
+      "id": "64e35c1e",
+      "metadata": {
+        "id": "64e35c1e"
+      },
+      "outputs": [],
+      "source": [
+        "# set Logging to DEBUG for more detailed outputs\n",
+        "query_engine = index.as_query_engine()\n",
+        "response = query_engine.query(\n",
+        "    \"What did the author do after his time at Viaweb?\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 67,
+      "id": "926b79da",
+      "metadata": {
+        "id": "926b79da",
+        "outputId": "47568cb9-c58c-4cc1-e367-6b31bce9751f",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 46
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "<b>The author arranged to do freelance work for a group that did projects for customers after his time at Viaweb.</b>"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "display(Markdown(f\"<b>{response}</b>\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7b4d27fc",
+      "metadata": {
+        "id": "7b4d27fc"
+      },
+      "source": [
+        "#### Build the VectorStoreIndex asynchronously"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 68,
+      "id": "08af428d",
+      "metadata": {
+        "id": "08af428d"
+      },
+      "outputs": [],
+      "source": [
+        "# To connect to the same event-loop,\n",
+        "# allows async events to run on notebook\n",
+        "\n",
+        "import nest_asyncio\n",
+        "\n",
+        "nest_asyncio.apply()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 69,
+      "id": "13fe7e09",
+      "metadata": {
+        "id": "13fe7e09"
+      },
+      "outputs": [],
+      "source": [
+        "aclient = qdrant_client.AsyncQdrantClient(\n",
+        "    # you can use :memory: mode for fast and light-weight experiments,\n",
+        "    # it does not require to have Qdrant deployed anywhere\n",
+        "    # but requires qdrant-client >= 1.1.1\n",
+        "    location=\":memory:\"\n",
+        "    # otherwise set Qdrant instance address with:\n",
+        "    # uri=\"http://<host>:<port>\"\n",
+        "    # set API KEY for Qdrant Cloud\n",
+        "    # api_key=\"<qdrant-api-key>\",\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 72,
+      "id": "1918d705",
+      "metadata": {
+        "id": "1918d705"
+      },
+      "outputs": [],
+      "source": [
+        "vector_store = QdrantVectorStore(\n",
+        "    aclient=aclient, collection_name=\"paul_graham\", prefer_grpc=True\n",
+        ")\n",
+        "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+        "index = VectorStoreIndex.from_documents(\n",
+        "    documents,\n",
+        "    storage_context=storage_context,\n",
+        "    use_async=True,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2d0401ab",
+      "metadata": {
+        "id": "2d0401ab"
+      },
+      "source": [
+        "#### Async Query Index"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 73,
+      "id": "88af9cf2",
+      "metadata": {
+        "id": "88af9cf2"
+      },
+      "outputs": [],
+      "source": [
+        "query_engine = index.as_query_engine(use_async=True)\n",
+        "response = await query_engine.aquery(\"What did the author do growing up?\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 74,
+      "id": "c88ff475",
+      "metadata": {
+        "id": "c88ff475",
+        "outputId": "fd5e999f-4ee1-4e42-9e42-c09e91c4e903",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 81
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "<b>The author worked on writing short stories and programming, particularly on an IBM 1401 computer in 9th grade using an early version of Fortran. Later, the author transitioned to working on microcomputers, starting with a TRS-80 in about 1980, where they wrote simple games, programs, and a word processor.</b>"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "display(Markdown(f\"<b>{response}</b>\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 75,
+      "id": "5e8f1146",
+      "metadata": {
+        "id": "5e8f1146"
+      },
+      "outputs": [],
+      "source": [
+        "# set Logging to DEBUG for more detailed outputs\n",
+        "query_engine = index.as_query_engine(use_async=True)\n",
+        "response = await query_engine.aquery(\n",
+        "    \"What did the author do after his time at Viaweb?\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 76,
+      "id": "90e1fa0e",
+      "metadata": {
+        "id": "90e1fa0e",
+        "outputId": "90631dfb-0047-425d-db0d-5b0ce545abf9",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 46
+        }
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "<b>The author went on to co-found Y Combinator after his time at Viaweb.</b>"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "display(Markdown(f\"<b>{response}</b>\"))"
+      ]
     }
-   ],
-   "source": [
-    "display(Markdown(f\"<b>{response}</b>\"))"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3"
+    },
+    "colab": {
+      "provenance": []
+    }
   },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/docs/examples/vector_stores/QdrantIndexDemo.ipynb
+++ b/docs/examples/vector_stores/QdrantIndexDemo.ipynb
@@ -53,7 +53,7 @@
     "from llama_index.embeddings.fastembed import FastEmbedEmbedding\n",
     "from llama_index.core import Settings\n",
     "\n",
-    "Settings.embed_model = FastEmbedEmbedding(model_name=\"BAAI/bge-small-en-v1.5\")"
+    "Settings.embed_model = FastEmbedEmbedding(model_name=\"BAAI/bge-base-en-v1.5\")"
    ]
   },
   {
@@ -61,7 +61,7 @@
    "id": "07489add",
    "metadata": {},
    "source": [
-    "If running this for the first, time, install using this command:\n",
+    "If running for the first, time, install the dependencies using:\n",
     "\n",
     "```\n",
     "!pip install -U qdrant_client fastembed\n",


### PR DESCRIPTION
# Description

This PR updates the Qdrant usage example as per the latest implementation changes.
- Uses [Qdrant FastEmbed](https://docs.llamaindex.ai/en/stable/examples/embeddings/fastembed.html) to generate embeddings.
- Updates the async usage since it now supports in-memory instances as well.