### PR TITLE
added table comment to Table Info in SQLDatabase

### DIFF
--- a/llama-index-core/llama_index/core/utilities/sql_wrapper.py
+++ b/llama-index-core/llama_index/core/utilities/sql_wrapper.py
@@ -151,12 +151,16 @@ class SQLDatabase:
         """Get table info for a single table."""
         # same logic as table_info, but with specific table names
         template = "Table '{table_name}' has columns: {columns}, "
-
-        table_comment = self._inspector.get_table_comment(
-            table_name, schema=self._schema
-        )["text"]
-        if table_comment:
-            template += f"with comment: ({table_comment}) "
+        try:
+            # try to retrieve table comment
+            table_comment = self._inspector.get_table_comment(
+                table_name, schema=self._schema
+            )["text"]
+            if table_comment:
+                template += f"with comment: ({table_comment}) "
+        except NotImplementedError:
+            # get_table_comment makRaises NotImplementedError for a dialect that does not support comments.
+            pass
 
         template += "and foreign keys: {foreign_keys}."
         columns = []

--- a/llama-index-core/llama_index/core/utilities/sql_wrapper.py
+++ b/llama-index-core/llama_index/core/utilities/sql_wrapper.py
@@ -159,7 +159,7 @@ class SQLDatabase:
             if table_comment:
                 template += f"with comment: ({table_comment}) "
         except NotImplementedError:
-            # get_table_comment makRaises NotImplementedError for a dialect that does not support comments.
+            # get_table_comment raises NotImplementedError for a dialect that does not support comments.
             pass
 
         template += "and foreign keys: {foreign_keys}."

--- a/llama-index-core/llama_index/core/utilities/sql_wrapper.py
+++ b/llama-index-core/llama_index/core/utilities/sql_wrapper.py
@@ -150,10 +150,15 @@ class SQLDatabase:
     def get_single_table_info(self, table_name: str) -> str:
         """Get table info for a single table."""
         # same logic as table_info, but with specific table names
-        template = (
-            "Table '{table_name}' has columns: {columns}, "
-            "and foreign keys: {foreign_keys}."
-        )
+        template = "Table '{table_name}' has columns: {columns}, "
+
+        table_comment = self._inspector.get_table_comment(
+            table_name, schema=self._schema
+        )["text"]
+        if table_comment:
+            template += f"with comment: ({table_comment}) "
+
+        template += "and foreign keys: {foreign_keys}."
         columns = []
         for column in self._inspector.get_columns(table_name, schema=self._schema):
             if column.get("comment"):


### PR DESCRIPTION
# Description

In this PR, I've enhanced the `get_single_table_info` method in the `SQLDatabase` class. Now, apart from returning table's column and foreign key information, it also fetches and includes the table's comment if it exists. The comment is retrieved using the `get_table_comment` method from the `_inspector` object and appended to the output string. This additional information will provide more context about the table when this method is used.

Fixes #11075

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
