### PR TITLE
add support for open-mixtral-8x7b

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/utils.py
@@ -5,6 +5,11 @@ MISTRALAI_MODELS: Dict[str, int] = {
     "mistral-small": 32000,
     "mistral-medium": 32000,
     "mistral-large": 32000,
+    "open-mixtral-8x7b": 32000,
+    "open-mistral-7b": 32000,
+    "mistral-small-latest": 32000,
+    "mistral-medium-latest": 32000,
+    "mistral-large-latest": 32000,
 }
 
 

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-mistralai"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Add support for `open-mixtral-8x7b`

Fixes #11781

## Version Bump?

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I ran `make format; make lint` to appease the lint gods
