### PR TITLE
Add logprobs field to `CompletionResponse`

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -83,6 +83,7 @@ class CompletionResponse(BaseModel):
     text: str
     additional_kwargs: dict = Field(default_factory=dict)
     raw: Optional[dict] = None
+    logprobs: Optional[List[List[LogProb]]] = None
     delta: Optional[str] = None
 
     def __str__(self) -> str:


### PR DESCRIPTION
# Description

- While completions api is legacy, we still support `CompletionResponse` for OpenAI and it should have `logprobs` as well
- Besides, this is what's needed for the DP algo to work (it doesn't work well with ChatCompletions!!!)

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] N/A (change to core)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense