### PR TITLE
Fix stream chat param error in CondenseQuestionChatEngine

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -260,7 +260,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             )
             thread = Thread(
                 target=response.write_response_to_history,
-                args=(self._memory, None, True),
+                args=(self._memory,),
             )
             thread.start()
         else:

--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -259,7 +259,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
                 sources=[tool_output],
             )
             thread = Thread(
-                target=response.write_response_to_history, args=(self._memory, True)
+                target=response.write_response_to_history,
+                args=(self._memory, None, True),
             )
             thread.start()
         else:


### PR DESCRIPTION
# Description
Now the signature of response.write_response_to_history has changed into
```python
def write_response_to_history(
    self,
    memory: BaseMemory,
    on_stream_end_fn: Optional[callable] = None,
    raise_error: bool = False,
) -> None
```

```log
Exception in thread Thread-2 (write_response_to_history):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1010, in run
 self._target(*self._args, **self._kwargs)
File "/usr/local/lib/python3.12/site-packages/llama_index/core/chat_engine/types.py", line 139, in write_response_to_history
    on_stream_end_fn()
 TypeError: 'bool' object is not callable
```

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
