### PR TITLE
fix: add postpreprocess_output_processor to json_query.py

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/json_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/json_query.py
@@ -63,6 +63,9 @@ def default_output_response_parser(llm_output: str) -> str:
 
 def default_output_processor(llm_output: str, json_value: JSONType) -> JSONType:
     """Default output processor that extracts values based on JSON Path expressions."""
+    # Post-process the LLM output to remove the JSONPath: prefix
+    llm_output = llm_output.replace("JSONPath: ", "").replace("JSON Path: ", "").strip()
+
     # Split the given string into separate JSON Path expressions
     expressions = [expr.strip() for expr in llm_output.split(",")]
 


### PR DESCRIPTION
# Description

I add the post-preprocess of llm_output in the `postpreprocess_output_processor` function with the purpose of removing the case of having JSONPATH: in the output.
The bug occurs when using the HuggingFace model (specifically for openchat/openchat-3.5-1210). As the llm_output will also contain JSONPATH:
Example: "JSONPATH: $.dosages[?(@.drug_id == @.id && @.patient_age_group == '66')].administration_route"

Fixes # (issue)

## Version Bump?
Did I bump the version in the pyproject.toml file of the package I am updating? (Except for the llama-index-core package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I integrated post-processing code into the function. Tests confirm it works correctly when using openchat model when the pattern matching finds sufficiently valid JSON.

- [x] I stared at the code and made sure it makes sense

