### PR TITLE
use proper retriever kwargs

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
@@ -43,7 +43,10 @@ class LlamaCloudRetriever(BaseRetriever):
         self._alpha = alpha or OMIT
         self._search_filters = search_filters or OMIT
 
-        super().__init__(**kwargs)
+        super().__init__(
+            callback_manager=kwargs.get("callback_manager", None),
+            verbose=kwargs.get("verbose", False),
+        )
 
     def _result_nodes_to_node_with_score(
         self, result_nodes: List[TextNodeWithScore]

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-llama-cloud"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Errors out if unused kwargs are passed to the retriever for llama-cloud