### PR TITLE
Incorrect warning message on HuggingFaceLLM tokenizer

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/base.py
@@ -183,9 +183,9 @@ class HuggingFaceLLM(CustomLLM):
             tokenizer_name, **tokenizer_kwargs
         )
 
-        if tokenizer_name != model_name:
+        if self._tokenizer.name_or_path != model_name:
             logger.warning(
-                f"The model `{model_name}` and tokenizer `{tokenizer_name}` "
+                f"The model `{model_name}` and tokenizer `{self._tokenizer.name_or_path}` "
                 f"are different, please ensure that they are compatible."
             )
 

--- a/llama-index-legacy/llama_index/legacy/llms/huggingface.py
+++ b/llama-index-legacy/llama_index/legacy/llms/huggingface.py
@@ -197,9 +197,9 @@ class HuggingFaceLLM(CustomLLM):
             tokenizer_name, **tokenizer_kwargs
         )
 
-        if tokenizer_name != model_name:
+        if self._tokenizer.name_or_path != model_name:
             logger.warning(
-                f"The model `{model_name}` and tokenizer `{tokenizer_name}` "
+                f"The model `{model_name}` and tokenizer `{self._tokenizer.name_or_path}` "
                 f"are different, please ensure that they are compatible."
             )
 

--- a/llama-index-legacy/llama_index/legacy/llms/huggingface.py
+++ b/llama-index-legacy/llama_index/legacy/llms/huggingface.py
@@ -197,9 +197,9 @@ class HuggingFaceLLM(CustomLLM):
             tokenizer_name, **tokenizer_kwargs
         )
 
-        if self._tokenizer.name_or_path != model_name:
+        if tokenizer_name != model_name:
             logger.warning(
-                f"The model `{model_name}` and tokenizer `{self._tokenizer.name_or_path}` "
+                f"The model `{model_name}` and tokenizer `{tokenizer_name}` "
                 f"are different, please ensure that they are compatible."
             )
 


### PR DESCRIPTION
# Description

In HuggingFaceLLM if you are passing the tokenizer directly during the initialization, you will get some warning that the tokenizer name and the model name is not matching, which is incorrect. This PR checkes the fixes the bug by checking 
`self._tokenizer.name_or_path` instead of `tokenizer_name`.

Code to Reproduce:
```
model_name = "mistralai/Mistral-7B-Instruct-v0.1"

tokenizer = AutoTokenizer.from_pretrained(model_name)
llm = HuggingFaceLLM(
    context_window=4096,
    max_new_tokens=1024,
    generate_kwargs={"temperature": 0.5, "do_sample": True},
    tokenizer=tokenizer,
    model_name=model_name,
    device_map="auto",
    model_kwargs={"torch_dtype": torch.bfloat16},
)
```
```WARNING:llama_index.llms.huggingface.base:The model `mistralai/Mistral-7B-Instruct-v0.1` and tokenizer `StabilityAI/stablelm-tuned-alpha-3b` are different, please ensure that they are compatible.```


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
