### PR TITLE
Fixed import error for ChatMessage

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
@@ -173,7 +173,7 @@ class MistralAI(LLM):
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
         # convert messages to mistral ChatMessage
-        from mistralai.client import ChatMessage as mistral_chatmessage
+        from mistralai.models.chat_completion import ChatMessage as mistral_chatmessage
 
         messages = [
             mistral_chatmessage(role=x.role, content=x.content) for x in messages
@@ -199,7 +199,7 @@ class MistralAI(LLM):
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
         # convert messages to mistral ChatMessage
-        from mistralai.client import ChatMessage as mistral_chatmessage
+        from mistralai.models.chat_completion import ChatMessage as mistral_chatmessage
 
         messages = [
             mistral_chatmessage(role=message.role, content=message.content)
@@ -237,7 +237,7 @@ class MistralAI(LLM):
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponse:
         # convert messages to mistral ChatMessage
-        from mistralai.client import ChatMessage as mistral_chatmessage
+        from mistralai.models.chat_completion import ChatMessage as mistral_chatmessage
 
         messages = [
             mistral_chatmessage(role=message.role, content=message.content)
@@ -264,7 +264,7 @@ class MistralAI(LLM):
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
         # convert messages to mistral ChatMessage
-        from mistralai.client import ChatMessage as mistral_chatmessage
+        from mistralai.models.chat_completion import ChatMessage as mistral_chatmessage
 
         messages = [
             mistral_chatmessage(role=x.role, content=x.content) for x in messages

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-mistralai"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

trying to call chat functions in mistral caused errors:
instead of mistralai.client mistralai.models.chat_completion contains the class ChatMessage.
fixed that for all imports.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
