### PR TITLE
Adding Support for MedLM Models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
@@ -19,7 +19,7 @@ from vertexai.language_models import InputOutputTextPair
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 
 CHAT_MODELS = ["chat-bison", "chat-bison-32k", "chat-bison@001"]
-TEXT_MODELS = ["text-bison", "text-bison-32k", "text-bison@001"]
+TEXT_MODELS = ["text-bison", "text-bison-32k", "text-bison@001", "medlm-medium", "medlm-large"]
 CODE_MODELS = ["code-bison", "code-bison-32k", "code-bison@001"]
 CODE_CHAT_MODELS = ["codechat-bison", "codechat-bison-32k", "codechat-bison@001"]
 


### PR DESCRIPTION
# Description

* Similar to `Gemini`, I want to use `MedLM-Medium` & `MedLM-Large` models. 
* As the above models are `TextGenerationModel` from `Vertexai` added the same to the list of TEXT_MODELS

Reference: https://cloud.google.com/vertex-ai/generative-ai/docs/medlm/medlm-prompts

Fixes # (issue)

## Version Bump?

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense
- [ ] Created an aboject of [Vertex](https://github.com/run-llama/llama_index/blob/ff51e2cbf9815a44ebade9a1382216435d7f4bc8/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py#L35C7-L35C13) class and passed the model as `medlm-medium` & `medlm-large` and ran some prediction.

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
