### PR TITLE
Added pytesseract support for ImageReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/image/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/image/base.py
@@ -6,7 +6,7 @@ Contains parsers for image files.
 
 import re
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast, Any
 from fsspec import AbstractFileSystem
 
 from llama_index.core.readers.base import BaseReader
@@ -17,7 +17,7 @@ from llama_index.core.utils import infer_torch_device
 class ImageReader(BaseReader):
     """Image parser.
 
-    Extract text from images using DONUT.
+    Extract text from images using DONUT or pytesseract.
 
     """
 
@@ -26,32 +26,48 @@ class ImageReader(BaseReader):
         parser_config: Optional[Dict] = None,
         keep_image: bool = False,
         parse_text: bool = False,
+        text_type: str = "text",
+        pytesseract_model_kwargs: Dict[str, Any] = {},
     ):
         """Init parser."""
+        self._text_type = text_type
         if parser_config is None and parse_text:
-            try:
-                import sentencepiece  # noqa
-                import torch  # noqa
-                from PIL import Image  # noqa
-                from transformers import DonutProcessor, VisionEncoderDecoderModel
-            except ImportError:
-                raise ImportError(
-                    "Please install extra dependencies that are required for "
-                    "the ImageCaptionReader: "
-                    "`pip install torch transformers sentencepiece Pillow`"
-                )
+            if text_type == "plain_text":
+                try:
+                    import pytesseract
+                except ImportError:
+                    raise ImportError(
+                        "Please install extra dependencies that are required for "
+                        "the ImageReader when text_type is 'plain_text': "
+                        "`pip install pytesseract`"
+                    )
+                processor = None
+                model = pytesseract
+            else:
+                try:
+                    import sentencepiece  # noqa
+                    import torch  # noqa
+                    from PIL import Image  # noqa
+                    from transformers import DonutProcessor, VisionEncoderDecoderModel
+                except ImportError:
+                    raise ImportError(
+                        "Please install extra dependencies that are required for "
+                        "the ImageCaptionReader: "
+                        "`pip install torch transformers sentencepiece Pillow`"
+                    )
 
-            processor = DonutProcessor.from_pretrained(
-                "naver-clova-ix/donut-base-finetuned-cord-v2"
-            )
-            model = VisionEncoderDecoderModel.from_pretrained(
-                "naver-clova-ix/donut-base-finetuned-cord-v2"
-            )
+                processor = DonutProcessor.from_pretrained(
+                    "naver-clova-ix/donut-base-finetuned-cord-v2"
+                )
+                model = VisionEncoderDecoderModel.from_pretrained(
+                    "naver-clova-ix/donut-base-finetuned-cord-v2"
+                )
             parser_config = {"processor": processor, "model": model}
 
         self._parser_config = parser_config
         self._keep_image = keep_image
         self._parse_text = parse_text
+        self._pytesseract_model_kwargs = pytesseract_model_kwargs
 
     def load_data(
         self,
@@ -85,36 +101,42 @@ class ImageReader(BaseReader):
             model = self._parser_config["model"]
             processor = self._parser_config["processor"]
 
-            device = infer_torch_device()
-            model.to(device)
+            if processor:
+                device = infer_torch_device()
+                model.to(device)
 
-            # prepare decoder inputs
-            task_prompt = "<s_cord-v2>"
-            decoder_input_ids = processor.tokenizer(
-                task_prompt, add_special_tokens=False, return_tensors="pt"
-            ).input_ids
+                # prepare decoder inputs
+                task_prompt = "<s_cord-v2>"
+                decoder_input_ids = processor.tokenizer(
+                    task_prompt, add_special_tokens=False, return_tensors="pt"
+                ).input_ids
 
-            pixel_values = processor(image, return_tensors="pt").pixel_values
+                pixel_values = processor(image, return_tensors="pt").pixel_values
 
-            outputs = model.generate(
-                pixel_values.to(device),
-                decoder_input_ids=decoder_input_ids.to(device),
-                max_length=model.decoder.config.max_position_embeddings,
-                early_stopping=True,
-                pad_token_id=processor.tokenizer.pad_token_id,
-                eos_token_id=processor.tokenizer.eos_token_id,
-                use_cache=True,
-                num_beams=3,
-                bad_words_ids=[[processor.tokenizer.unk_token_id]],
-                return_dict_in_generate=True,
-            )
+                outputs = model.generate(
+                    pixel_values.to(device),
+                    decoder_input_ids=decoder_input_ids.to(device),
+                    max_length=model.decoder.config.max_position_embeddings,
+                    early_stopping=True,
+                    pad_token_id=processor.tokenizer.pad_token_id,
+                    eos_token_id=processor.tokenizer.eos_token_id,
+                    use_cache=True,
+                    num_beams=3,
+                    bad_words_ids=[[processor.tokenizer.unk_token_id]],
+                    return_dict_in_generate=True,
+                )
 
-            sequence = processor.batch_decode(outputs.sequences)[0]
-            sequence = sequence.replace(processor.tokenizer.eos_token, "").replace(
-                processor.tokenizer.pad_token, ""
-            )
-            # remove first task start token
-            text_str = re.sub(r"<.*?>", "", sequence, count=1).strip()
+                sequence = processor.batch_decode(outputs.sequences)[0]
+                sequence = sequence.replace(processor.tokenizer.eos_token, "").replace(
+                    processor.tokenizer.pad_token, ""
+                )
+                # remove first task start token
+                text_str = re.sub(r"<.*?>", "", sequence, count=1).strip()
+            else:
+                import pytesseract
+
+                model = cast(pytesseract, self._parser_config["model"])
+                text_str = model.image_to_string(image, **self._pytesseract_model_kwargs)
 
         return [
             ImageDocument(

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/image/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/image/base.py
@@ -136,7 +136,9 @@ class ImageReader(BaseReader):
                 import pytesseract
 
                 model = cast(pytesseract, self._parser_config["model"])
-                text_str = model.image_to_string(image, **self._pytesseract_model_kwargs)
+                text_str = model.image_to_string(
+                    image, **self._pytesseract_model_kwargs
+                )
 
         return [
             ImageDocument(

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -50,7 +50,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Hi @logan-markewich , 

ImageReader loader used to have an argument "text_type" which can either take "text" or "plan_text" as a value. "text" will use donut models and "plain_text" will use pytesseract to parse images. I think this got missed during the 0.10.00 upgrade. Fixed it so that users have an option to choose if they want pytesseract or DONUT. Let me know in case of any questions. Thanks!