### PR TITLE
fix: postgres metadata filters

### DIFF
--- a/docs/examples/vector_stores/postgres.ipynb
+++ b/docs/examples/vector_stores/postgres.ipynb
@@ -63,9 +63,9 @@
    "outputs": [],
    "source": [
     "!sudo apt update\n",
-    "!sudo apt install -y postgresql-common\n",
+    "!echo | sudo apt install -y postgresql-common\n",
     "!echo | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh\n",
-    "!sudo apt install postgresql-15-pgvector\n",
+    "!echo | sudo apt install postgresql-15-pgvector\n",
     "!sudo service postgresql start\n",
     "!sudo -u postgres psql -c \"ALTER USER postgres PASSWORD 'password';\"\n",
     "!sudo -u postgres psql -c \"CREATE DATABASE vector_db;\""
@@ -133,16 +133,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2024-03-12 21:24:54--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
+      "--2024-03-14 02:56:30--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
       "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.111.133, ...\n",
       "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 75042 (73K) [text/plain]\n",
       "Saving to: ‘data/paul_graham/paul_graham_essay.txt’\n",
       "\n",
-      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.002s  \n",
+      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.001s  \n",
       "\n",
-      "2024-03-12 21:24:54 (43.3 MB/s) - ‘data/paul_graham/paul_graham_essay.txt’ saved [75042/75042]\n",
+      "2024-03-14 02:56:30 (72.2 MB/s) - ‘data/paul_graham/paul_graham_essay.txt’ saved [75042/75042]\n",
       "\n"
      ]
     }
@@ -172,7 +172,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Document ID: 4a53fcae-ca36-4492-aeeb-28b858516a49\n"
+      "Document ID: 1306591e-cc2d-430b-a74c-03ae7105ecab\n"
      ]
     }
    ],
@@ -227,7 +227,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "55d642be4afd424dbeddcc98a6313baa",
+       "model_id": "99f8aee7508e4b7681b86bd84ab9a4d6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -241,7 +241,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4bedc19d901346dbafbeff1d25638562",
+       "model_id": "6218daeaa5e0475b967ec2d00e16fbe5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -303,13 +303,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The author worked on writing and programming before college. Initially, the author wrote short\n",
-      "stories and later started programming on the IBM 1401 using an early version of Fortran. With the\n",
-      "introduction of microcomputers, the author's programming experiences changed, leading to the\n",
-      "creation of simple games, prediction programs, and a word processor. Despite initially planning to\n",
-      "study philosophy in college, the author eventually switched to studying AI due to a lack of interest\n",
-      "in philosophy courses. The author was inspired to work on AI after encountering the novel \"The Moon\n",
-      "is a Harsh Mistress\" and watching a PBS documentary featuring SHRDLU.\n"
+      "The author worked on writing and programming before college, initially focusing on writing short\n",
+      "stories and later transitioning to programming on early computers like the IBM 1401 using Fortran.\n",
+      "The author continued programming on microcomputers like the TRS-80, creating simple games and a word\n",
+      "processor. In college, the author initially planned to study philosophy but switched to studying AI\n",
+      "due to a lack of interest in philosophy courses. The author was inspired to work on AI after\n",
+      "encountering works like Heinlein's novel \"The Moon is a Harsh Mistress\" and seeing Terry Winograd\n",
+      "using SHRDLU in a PBS documentary.\n"
      ]
     }
    ],
@@ -337,13 +337,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In the mid-1980s, the author spent a significant amount of time working on a book called \"On Lisp\"\n",
-      "and had obtained a contract to publish it. They were paid large amounts of money for their work,\n",
-      "which allowed them to save enough to go back to RISD (Rhode Island School of Design) and pay off\n",
-      "their college loans. They also learned valuable lessons during this time, such as the importance of\n",
-      "having technology companies run by product people rather than sales people, the drawbacks of editing\n",
-      "code by too many people, and the significance of being the \"entry level\" option in a competitive\n",
-      "market.\n"
+      "AI was in the air in the mid 1980s, with two main influences that sparked interest in working on it:\n",
+      "a novel by Heinlein called The Moon is a Harsh Mistress, featuring an intelligent computer called\n",
+      "Mike, and a PBS documentary showing Terry Winograd using SHRDLU.\n"
      ]
     }
    ],
@@ -400,11 +396,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The author worked on writing and programming before college. They wrote short stories and tried\n",
-      "writing programs on an IBM 1401 computer. They also built a microcomputer and started programming on\n",
-      "it, writing simple games and a word processor. In college, the author initially planned to study\n",
-      "philosophy but switched to AI due to their interest in intelligent computers. They taught themselves\n",
-      "AI by learning Lisp.\n"
+      "The author worked on writing short stories and programming before college. Initially, the author\n",
+      "wrote short stories and later started programming on an IBM 1401 using an early version of Fortran.\n",
+      "With the introduction of microcomputers, the author's interest in programming grew, leading to\n",
+      "writing simple games, predictive programs, and a word processor. Despite initially planning to study\n",
+      "philosophy in college, the author switched to studying AI due to a lack of interest in philosophy\n",
+      "courses. The author was inspired to work on AI after encountering a novel featuring an intelligent\n",
+      "computer and a PBS documentary showcasing AI technology.\n"
      ]
     }
    ],
@@ -464,7 +462,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/workspaces/llama_index/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py:553: SAWarning: UserDefinedType REGCONFIG() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this warning at: https://sqlalche.me/e/20/cprf)\n",
+      "/workspaces/llama_index/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py:571: SAWarning: UserDefinedType REGCONFIG() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this warning at: https://sqlalche.me/e/20/cprf)\n",
       "  res = session.execute(stmt)\n"
      ]
     }
@@ -505,7 +503,7 @@
     "\n",
     "Since the scores for text search and vector search are calculated differently, the nodes that were found only by text search will have a much lower score.\n",
     "\n",
-    "You can often improve hybrid search performance by using `QueryFusionRetriever`."
+    "You can often improve hybrid search performance by using `QueryFusionRetriever`, which makes better use of the mutual information to rank the nodes."
    ]
   },
   {
@@ -515,14 +513,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.response_synthesizers import CompactAndRefine\n",
-    "from llama_index.retrievers import QueryFusionRetriever\n",
+    "from llama_index.core.response_synthesizers import CompactAndRefine\n",
+    "from llama_index.core.retrievers import QueryFusionRetriever\n",
+    "from llama_index.core.query_engine import RetrieverQueryEngine\n",
     "\n",
-    "vector_retriever = hybrid_query_engine.as_retriever(\n",
+    "vector_retriever = hybrid_index.as_retriever(\n",
     "    vector_store_query_mode=\"default\",\n",
     "    similarity_top_k=5,\n",
     ")\n",
-    "text_retriever = hybrid_query_engine.from_defaults(\n",
+    "text_retriever = hybrid_index.as_retriever(\n",
     "    vector_store_query_mode=\"sparse\",\n",
     "    similarity_top_k=5,  # interchangeable with sparse_top_k in this context\n",
     ")\n",
@@ -532,7 +531,6 @@
     "    num_queries=1,  # set this to 1 to disable query generation\n",
     "    mode=\"relative_score\",\n",
     "    use_async=False,\n",
-    "    verbose=True,\n",
     ")\n",
     "\n",
     "response_synthesizer = CompactAndRefine()\n",
@@ -540,6 +538,27 @@
     "    retriever=retriever,\n",
     "    response_synthesizer=response_synthesizer,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a88c84e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Paul Graham thinks of Roy Lichtenstein when he uses the word \"schtick\" because he recognizes paintings resembling a specific type of cartoon style as being created by Roy Lichtenstein.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = query_engine.query(\n",
+    "    \"Who does Paul Graham think of with the word schtick, and why?\"\n",
+    ")\n",
+    "print(response)"
    ]
   },
   {
@@ -565,7 +584,25 @@
    "execution_count": null,
    "id": "63e90a89",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--2024-03-14 02:56:46--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/csv/commit_history.csv\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 1753902 (1.7M) [text/plain]\n",
+      "Saving to: ‘data/git_commits/commit_history.csv’\n",
+      "\n",
+      "data/git_commits/co 100%[===================>]   1.67M  --.-KB/s    in 0.02s   \n",
+      "\n",
+      "2024-03-14 02:56:46 (106 MB/s) - ‘data/git_commits/commit_history.csv’ saved [1753902/1753902]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "!mkdir -p 'data/git_commits/'\n",
     "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/csv/commit_history.csv' -O 'data/git_commits/commit_history.csv'"
@@ -614,14 +651,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Node ID: e084ffbd-24e0-4bd9-b7c8-287fe1abd85d\n",
+      "Node ID: 69513543-dee5-4c65-b4b8-39295f11e669\n",
       "Text: Fix segfault in set_integer_now_func  When an invalid function\n",
       "oid is passed to set_integer_now_func, it finds out that the function\n",
       "oid is invalid but before throwing the error, it calls ReleaseSysCache\n",
       "on an invalid tuple causing a segfault. Fixed that by removing the\n",
       "invalid call to ReleaseSysCache.  Fixes #6037\n",
       "2023-03-22 to 2023-09-05\n",
-      "{'36882414+akuzm@users.noreply.github.com', 'erik@timescale.com', 'konstantina@timescale.com', 'mats@timescale.com', 'nikhil@timescale.com', 'dmitry@timescale.com', 'jguthrie@timescale.com', 'rafia.sabih@gmail.com', 'engel@sero-systems.de', 'satish.8483@gmail.com', 'me@noctarius.com', 'sven@timescale.com', 'jan@timescale.com', 'lakshmi@timescale.com', 'fabriziomello@gmail.com'}\n"
+      "{'rafia.sabih@gmail.com', 'erik@timescale.com', 'jguthrie@timescale.com', 'sven@timescale.com', '36882414+akuzm@users.noreply.github.com', 'me@noctarius.com', 'satish.8483@gmail.com', 'nikhil@timescale.com', 'konstantina@timescale.com', 'dmitry@timescale.com', 'mats@timescale.com', 'jan@timescale.com', 'lakshmi@timescale.com', 'fabriziomello@gmail.com', 'engel@sero-systems.de'}\n"
      ]
     }
    ],
@@ -629,6 +666,7 @@
     "# Create TextNode for each of the first 100 commits\n",
     "from llama_index.core.schema import TextNode\n",
     "from datetime import datetime\n",
+    "import re\n",
     "\n",
     "nodes = []\n",
     "dates = set()\n",
@@ -641,12 +679,14 @@
     "    commit_text = commit[\"change summary\"]\n",
     "    if commit[\"change details\"]:\n",
     "        commit_text += \"\\n\\n\" + commit[\"change details\"]\n",
+    "    fixes = re.findall(r\"#(\\d+)\", commit_text, re.IGNORECASE)\n",
     "    nodes.append(\n",
     "        TextNode(\n",
     "            text=commit_text,\n",
     "            metadata={\n",
     "                \"commit_date\": commit_date,\n",
     "                \"author\": author_email,\n",
+    "                \"fixes\": fixes,\n",
     "            },\n",
     "        )\n",
     "    )\n",
@@ -717,16 +757,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'commit_date': '2023-08-07', 'author': 'mats@timescale.com'}\n",
-      "{'commit_date': '2023-08-07', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-15', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-23', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-07-13', 'author': 'mats@timescale.com'}\n",
-      "{'commit_date': '2023-08-27', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-21', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-30', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-10', 'author': 'mats@timescale.com'}\n",
-      "{'commit_date': '2023-08-20', 'author': 'sven@timescale.com'}\n"
+      "{'commit_date': '2023-08-07', 'author': 'mats@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-27', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-07-13', 'author': 'mats@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-07', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-30', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-15', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-23', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-10', 'author': 'mats@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-07-25', 'author': 'mats@timescale.com', 'fixes': ['5892']}\n",
+      "{'commit_date': '2023-08-21', 'author': 'sven@timescale.com', 'fixes': []}\n"
      ]
     }
    ],
@@ -765,16 +805,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'commit_date': '2023-08-23', 'author': 'erik@timescale.com'}\n",
-      "{'commit_date': '2023-08-15', 'author': '36882414+akuzm@users.noreply.github.com'}\n",
-      "{'commit_date': '2023-08-17', 'author': 'konstantina@timescale.com'}\n",
-      "{'commit_date': '2023-08-15', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-23', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-15', 'author': '36882414+akuzm@users.noreply.github.com'}\n",
-      "{'commit_date': '2023-08-21', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-24', 'author': 'lakshmi@timescale.com'}\n",
-      "{'commit_date': '2023-08-16', 'author': '36882414+akuzm@users.noreply.github.com'}\n",
-      "{'commit_date': '2023-08-20', 'author': 'sven@timescale.com'}\n"
+      "{'commit_date': '2023-08-23', 'author': 'erik@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-17', 'author': 'konstantina@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-15', 'author': '36882414+akuzm@users.noreply.github.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-15', 'author': '36882414+akuzm@users.noreply.github.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-24', 'author': 'lakshmi@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-15', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-23', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-21', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-20', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-21', 'author': 'sven@timescale.com', 'fixes': []}\n"
      ]
     }
    ],
@@ -823,10 +863,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'commit_date': '2023-08-07', 'author': 'mats@timescale.com'}\n",
-      "{'commit_date': '2023-08-07', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-15', 'author': 'sven@timescale.com'}\n",
-      "{'commit_date': '2023-08-10', 'author': 'mats@timescale.com'}\n"
+      "{'commit_date': '2023-08-07', 'author': 'mats@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-07', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-15', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-10', 'author': 'mats@timescale.com', 'fixes': []}\n"
      ]
     }
    ],
@@ -868,6 +908,137 @@
   },
   {
    "cell_type": "markdown",
+   "id": "737692ce",
+   "metadata": {},
+   "source": [
+    "The above can be simplified by using the IN operator. `PGVectorStore` supports `in`, `nin`, and `contains` for comparing an element with a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85faf8b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'commit_date': '2023-08-07', 'author': 'mats@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-07', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-15', 'author': 'sven@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-10', 'author': 'mats@timescale.com', 'fixes': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "filters = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(key=\"commit_date\", value=\"2023-08-01\", operator=\">=\"),\n",
+    "        MetadataFilter(key=\"commit_date\", value=\"2023-08-15\", operator=\"<=\"),\n",
+    "        MetadataFilter(\n",
+    "            key=\"author\",\n",
+    "            value=[\"mats@timescale.com\", \"sven@timescale.com\"],\n",
+    "            operator=\"in\",\n",
+    "        ),\n",
+    "    ],\n",
+    "    condition=\"and\",\n",
+    ")\n",
+    "\n",
+    "retriever = index.as_retriever(\n",
+    "    similarity_top_k=10,\n",
+    "    filters=filters,\n",
+    ")\n",
+    "\n",
+    "retrieved_nodes = retriever.retrieve(\"What is this software project about?\")\n",
+    "\n",
+    "for node in retrieved_nodes:\n",
+    "    print(node.node.metadata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ab9c333",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'commit_date': '2023-08-09', 'author': 'me@noctarius.com', 'fixes': ['5805']}\n",
+      "{'commit_date': '2023-08-15', 'author': '36882414+akuzm@users.noreply.github.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-15', 'author': '36882414+akuzm@users.noreply.github.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-11', 'author': '36882414+akuzm@users.noreply.github.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-09', 'author': 'konstantina@timescale.com', 'fixes': ['5923', '5680', '5774', '5786', '5906', '5912']}\n",
+      "{'commit_date': '2023-08-03', 'author': 'dmitry@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-03', 'author': 'dmitry@timescale.com', 'fixes': ['5908']}\n",
+      "{'commit_date': '2023-08-01', 'author': 'nikhil@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-10', 'author': 'konstantina@timescale.com', 'fixes': []}\n",
+      "{'commit_date': '2023-08-10', 'author': '36882414+akuzm@users.noreply.github.com', 'fixes': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Same thing, with NOT IN\n",
+    "filters = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(key=\"commit_date\", value=\"2023-08-01\", operator=\">=\"),\n",
+    "        MetadataFilter(key=\"commit_date\", value=\"2023-08-15\", operator=\"<=\"),\n",
+    "        MetadataFilter(\n",
+    "            key=\"author\",\n",
+    "            value=[\"mats@timescale.com\", \"sven@timescale.com\"],\n",
+    "            operator=\"nin\",\n",
+    "        ),\n",
+    "    ],\n",
+    "    condition=\"and\",\n",
+    ")\n",
+    "\n",
+    "retriever = index.as_retriever(\n",
+    "    similarity_top_k=10,\n",
+    "    filters=filters,\n",
+    ")\n",
+    "\n",
+    "retrieved_nodes = retriever.retrieve(\"What is this software project about?\")\n",
+    "\n",
+    "for node in retrieved_nodes:\n",
+    "    print(node.node.metadata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a46764cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'commit_date': '2023-08-09', 'author': 'konstantina@timescale.com', 'fixes': ['5923', '5680', '5774', '5786', '5906', '5912']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CONTAINS\n",
+    "filters = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(key=\"fixes\", value=\"5680\", operator=\"contains\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "retriever = index.as_retriever(\n",
+    "    similarity_top_k=10,\n",
+    "    filters=filters,\n",
+    ")\n",
+    "\n",
+    "retrieved_nodes = retriever.retrieve(\"How did these commits fix the issue?\")\n",
+    "for node in retrieved_nodes:\n",
+    "    print(node.node.metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2b274ecb",
    "metadata": {},
    "source": [
@@ -894,8 +1065,8 @@
    "outputs": [],
    "source": [
     "retriever = index.as_retriever(\n",
-    "    vector_store_query_mode=query_mode,\n",
-    "    similarity_top_k=top_k,\n",
+    "    vector_store_query_mode=\"hybrid\",\n",
+    "    similarity_top_k=5,\n",
     "    vector_store_kwargs={\"ivfflat_probes\": 10},\n",
     ")"
    ]
@@ -918,8 +1089,8 @@
    "outputs": [],
    "source": [
     "retriever = index.as_retriever(\n",
-    "    vector_store_query_mode=query_mode,\n",
-    "    similarity_top_k=top_k,\n",
+    "    vector_store_query_mode=\"hybrid\",\n",
+    "    similarity_top_k=5,\n",
     "    vector_store_kwargs={\"hnsw_ef_search\": 300},\n",
     ")"
    ]

--- a/llama-index-core/llama_index/core/vector_stores/types.py
+++ b/llama-index-core/llama_index/core/vector_stores/types.py
@@ -1,4 +1,5 @@
 """Vector store index types."""
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -68,9 +69,10 @@ class FilterOperator(str, Enum):
     NE = "!="  # not equal to (string, int, float)
     GTE = ">="  # greater than or equal to (int, float)
     LTE = "<="  # less than or equal to (int, float)
-    IN = "in"  # In array (string or number)
-    NIN = "nin"  # Not in array (string or number)
+    IN = "in"  # metadata in value array (string or number)
+    NIN = "nin"  # metadata not in value array (string or number)
     TEXT_MATCH = "text_match"  # full text match (allows you to search for a specific substring, token or phrase within the text field)
+    CONTAINS = "contains"  # metadata array contains value (string or number)
 
 
 class FilterCondition(str, Enum):
@@ -91,7 +93,12 @@ class MetadataFilter(BaseModel):
     """
 
     key: str
-    value: Union[StrictInt, StrictFloat, StrictStr]
+    value: Union[
+        StrictInt,
+        StrictFloat,
+        StrictStr,
+        List[Union[StrictInt, StrictFloat, StrictStr]],
+    ]
     operator: FilterOperator = FilterOperator.EQ
 
     @classmethod

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.1"
+llama-index-core = "^0.10.20"
 pgvector = "^0.2.4"
 psycopg2-binary = "^2.9.9"
 asyncpg = "^0.29.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -270,7 +270,7 @@ async def test_add_to_db_and_query_with_metadata_filters_with_in_operator(
         filters=[
             MetadataFilter(
                 key="test_key",
-                value="('test_value', 'another_value')",
+                value=["test_value", "another_value"],
                 operator=FilterOperator.IN,
             )
         ]
@@ -285,6 +285,39 @@ async def test_add_to_db_and_query_with_metadata_filters_with_in_operator(
     assert res.nodes
     assert len(res.nodes) == 1
     assert res.nodes[0].node_id == "bbb"
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_add_to_db_and_query_with_metadata_filters_with_contains_operator(
+    pg: PGVectorStore, node_embeddings: List[TextNode], use_async: bool
+) -> None:
+    if use_async:
+        await pg.async_add(node_embeddings)
+    else:
+        pg.add(node_embeddings)
+    assert isinstance(pg, PGVectorStore)
+    assert hasattr(pg, "_engine")
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="test_key_list",
+                value="test_value",
+                operator=FilterOperator.CONTAINS,
+            )
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.5), similarity_top_k=10, filters=filters
+    )
+    if use_async:
+        res = await pg.aquery(q)
+    else:
+        res = pg.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 1
+    assert res.nodes[0].node_id == "ccc"
 
 
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")


### PR DESCRIPTION
# Description

There were some bugs in my previous PR #11872. This fixes those, improves the interface and adds support for NOT IN and CONTAINS to PGVectorStore.

Also required a change to the `llama-index-core` package to allow lists as value for MetadataFilter and add the CONTAINS filter to the enum.

Usage is documented in `postgres.ipynb`.

```python
MetadataFilter(
    key="author",
    value=["mats@timescale.com", "sven@timescale.com"],
    operator="in",  # or "nin"
)
MetadataFilter(key="fixes", value="5680", operator="contains")
```

Fixes #11851
Fixes #11892 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
