### PR TITLE
Feat: Add async streaming support to `query_engine`

### DIFF
--- a/llama-index-core/llama_index/core/base/response/schema.py
+++ b/llama-index-core/llama_index/core/base/response/schema.py
@@ -167,7 +167,7 @@ class AsyncStreamingResponse:
             else:
                 yield self.response_txt
 
-    async def yield_response(self) -> TokenAsyncGen:
+    async def async_response_gen(self) -> TokenAsyncGen:
         """Yield the string response."""
         async for text in self._yield_response():
             yield text

--- a/llama-index-core/llama_index/core/base/response/schema.py
+++ b/llama-index-core/llama_index/core/base/response/schema.py
@@ -1,7 +1,7 @@
 """Response schema."""
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union, AsyncGenerator
+from typing import Any, Dict, List, Optional, Union
 
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.schema import NodeWithScore
@@ -156,7 +156,7 @@ class AsyncStreamingResponse:
     response_txt: Optional[str] = None
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
-    async def _yield_response(self) -> AsyncGenerator[str, None]:
+    async def _yield_response(self) -> TokenAsyncGen:
         """Yield the string response."""
         async with self._lock:
             if self.response_txt is None and self.async_response_gen is not None:
@@ -167,7 +167,7 @@ class AsyncStreamingResponse:
             else:
                 yield self.response_txt
 
-    async def yield_response(self) -> AsyncGenerator[str, None]:
+    async def yield_response(self) -> TokenAsyncGen:
         """Yield the string response."""
         async for text in self._yield_response():
             yield text

--- a/llama-index-core/llama_index/core/base/response/schema.py
+++ b/llama-index-core/llama_index/core/base/response/schema.py
@@ -1,11 +1,11 @@
 """Response schema."""
-
+import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, AsyncGenerator
 
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.schema import NodeWithScore
-from llama_index.core.types import TokenGen
+from llama_index.core.types import TokenGen, TokenAsyncGen
 from llama_index.core.utils import truncate_text
 
 
@@ -139,4 +139,66 @@ class StreamingResponse:
         return "\n\n".join(texts)
 
 
-RESPONSE_TYPE = Union[Response, StreamingResponse, PydanticResponse]
+@dataclass
+class AsyncStreamingResponse:
+    """AsyncStreamingResponse object.
+
+    Returned if streaming=True while using async.
+
+    Attributes:
+        async_response_gen: The response async generator.
+
+    """
+
+    async_response_gen: TokenAsyncGen
+    source_nodes: List[NodeWithScore] = field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = None
+    response_txt: Optional[str] = None
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def _yield_response(self) -> AsyncGenerator[str, None]:
+        """Yield the string response."""
+        async with self._lock:
+            if self.response_txt is None and self.async_response_gen is not None:
+                self.response_txt = ""
+                async for text in self.async_response_gen:
+                    self.response_txt += text
+                    yield text
+            else:
+                yield self.response_txt
+
+    async def yield_response(self) -> AsyncGenerator[str, None]:
+        """Yield the string response."""
+        async for text in self._yield_response():
+            yield text
+
+    async def get_response(self) -> Response:
+        """Get a standard response object."""
+        async for _ in self._yield_response():
+            ...
+        return Response(self.response_txt, self.source_nodes, self.metadata)
+
+    async def print_response_stream(self) -> None:
+        """Print the response stream."""
+        streaming = True
+        async for text in self._yield_response():
+            print(text, end="", flush=True)
+        # do an empty print to print on the next line again next time
+        print()
+
+    def get_formatted_sources(self, length: int = 100, trim_text: int = True) -> str:
+        """Get formatted sources text."""
+        texts = []
+        for source_node in self.source_nodes:
+            fmt_text_chunk = source_node.node.get_content()
+            if trim_text:
+                fmt_text_chunk = truncate_text(fmt_text_chunk, length)
+            node_id = source_node.node.node_id or "None"
+            source_text = f"> Source (Node id: {node_id}): {fmt_text_chunk}"
+            texts.append(source_text)
+        return "\n\n".join(texts)
+
+
+RESPONSE_TYPE = Union[
+    Response, StreamingResponse, AsyncStreamingResponse, PydanticResponse
+]

--- a/llama-index-core/llama_index/core/types.py
+++ b/llama-index-core/llama_index/core/types.py
@@ -21,7 +21,7 @@ Model = TypeVar("Model", bound=BaseModel)
 
 TokenGen = Generator[str, None, None]
 TokenAsyncGen = AsyncGenerator[str, None]
-RESPONSE_TEXT_TYPE = Union[BaseModel, str, TokenGen]
+RESPONSE_TEXT_TYPE = Union[BaseModel, str, TokenGen, TokenAsyncGen]
 
 
 # TODO: move into a `core` folder


### PR DESCRIPTION
# Description

Previously, the query engine had no support for async streaming while other parts of the lib, such as the chat engine, had. 
There was already support for non-async streaming in the query engine as well.

This PR aims to remedy this missing functionality by adding support for async streaming.
None of the existing API was changed.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No, this is a `llama-index-core` change

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update 
       -> Some added guides for async streaming would be nice, but not required. Personally, I find this to be very lacking atm anyways - so updates would be appreciated!

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

#### Test Code
```py
import os
import asyncio

from llama_index.core import Settings, SimpleDirectoryReader, VectorStoreIndex

from dotenv import load_dotenv
from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
from llama_index.llms.azure_openai import AzureOpenAI

load_dotenv()


def setup():
    openai_api_key = os.environ['OPENAI_API_KEY']
    openai_api_base = os.environ['OPENAI_API_BASE']
    openai_api_version = os.environ['OPENAI_API_VERSION']
    openai_api_llm_deployment_name = os.environ['OPENAI_API_LLM_DEPLOYMENT_NAME']

    llm = AzureOpenAI(
        model='gpt-35-turbo-16k',
        deployment_name=openai_api_llm_deployment_name,
        api_key=openai_api_key,
        azure_endpoint=openai_api_base,
        api_version=openai_api_version,
    )

    openai_api_embed_model_deployment_name = os.environ['OPENAI_API_EMBED_MODEL_DEPLOYMENT_NAME']

    embedding_model = AzureOpenAIEmbedding(
        model='text-embedding-ada-002',
        deployment_name=openai_api_embed_model_deployment_name,
        api_key=openai_api_key,
        azure_endpoint=openai_api_base,
        api_version=openai_api_version,
        embed_batch_size=1
    )

    Settings.llm = llm
    Settings.embed_model = embedding_model


async def main():
    documents = SimpleDirectoryReader('test_data/paul_graham_essay').load_data()
    index = VectorStoreIndex.from_documents(documents)

    query_engine = index.as_query_engine(streaming=True)
    streaming_response = await query_engine.aquery("What did the author do growing up?")

    async for token in streaming_response.async_response_gen:
        print(token, end="")


setup()
asyncio.run(main())
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
