### PR TITLE
fix: public links in langfuse cookbook

### DIFF
--- a/docs/examples/callbacks/LangfuseCallbackHandler.ipynb
+++ b/docs/examples/callbacks/LangfuseCallbackHandler.ipynb
@@ -249,9 +249,9 @@
     "Done!✨ You will now see traces of your index and query in your Langfuse project.\n",
     "\n",
     "Example traces (public links):\n",
-    "1. [Index construction](https://cloud.langfuse.com/project/clsuh9o2y0000mbztvdptt1mh/traces/1294ed01-8193-40a5-bb4e-2f0723d2c827)\n",
-    "2. [Query Engine](https://cloud.langfuse.com/project/clsuh9o2y0000mbztvdptt1mh/traces/eaa4ea74-78e0-42ef-ace0-7aa02c6fbbc6)\n",
-    "3. [Chat Engine](https://cloud.langfuse.com/project/clsuh9o2y0000mbztvdptt1mh/traces/d95914f5-66eb-4520-b996-49e84fd7f323)"
+    "1. [Query](https://cloud.langfuse.com/project/cltipxbkn0000cdd7sbfbpovm/traces/f2e7f721-0940-4139-9b3a-e5cc9b0cb2d3)\n",
+    "2. [Query (chat)](https://cloud.langfuse.com/project/cltipxbkn0000cdd7sbfbpovm/traces/89c62a4d-e992-4923-a6b7-e2f27ae4cff3)\n",
+    "3. [Session](https://cloud.langfuse.com/project/cltipxbkn0000cdd7sbfbpovm/sessions/notebook-session-2)"
    ]
   },
   {


### PR DESCRIPTION
# Description

Links to example traces in Langfuse were broken. This fixes them.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Cookbook

## How Has This Been Tested?

Just a notebook, no tests needed.