### PR TITLE
Implement opensearch doc deletion

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -365,7 +365,10 @@ class OpensearchVectorClient:
         Args:
             doc_id (str): document id
         """
-        await self._os_client.delete(index=self._index, id=doc_id)
+        search_query = {
+            "query": {"term": {"metadata.doc_id.keyword": {"value": doc_id}}}
+        }
+        await self._os_client.delete_by_query(index=self._index, body=search_query)
 
     async def aquery(
         self,


### PR DESCRIPTION
# Description

Implements document deletion by ID for the OpensearchVectorStore. The existing implementation was a placeholder which just errored out when called. Deletion from Opensearch requires using an [Elasticsearch query request body](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).

Fixes https://github.com/run-llama/llama_index/issues/10464. 

This was previously addressed by https://github.com/run-llama/llama_index/pull/11292, but seems to have been (accidentally?) reverted by https://github.com/run-llama/llama_index/commit/d3724dbd520ac6285e2592910b3264c78d45f285. Adds it back, and also makes the `search_query` fit OpenSearch standards.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
