### PR TITLE
remove space from MarkdownNodeParser Header metadata

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/markdown.py
+++ b/llama-index-core/llama_index/core/node_parser/file/markdown.py
@@ -99,11 +99,11 @@ class MarkdownNodeParser(NodeParser):
         updated_headers = {}
 
         for i in range(1, new_header_level):
-            key = f"Header {i}"
+            key = f"Header_{i}"
             if key in headers_metadata:
                 updated_headers[key] = headers_metadata[key]
 
-        updated_headers[f"Header {new_header_level}"] = new_header
+        updated_headers[f"Header_{new_header_level}"] = new_header
         return updated_headers
 
     def _build_node_from_split(

--- a/llama-index-core/tests/node_parser/test_markdown.py
+++ b/llama-index-core/tests/node_parser/test_markdown.py
@@ -19,8 +19,8 @@ Header 2 content
         ]
     )
     assert len(splits) == 2
-    assert splits[0].metadata == {"Header 1": "Main Header"}
-    assert splits[1].metadata == {"Header 1": "Header 2"}
+    assert splits[0].metadata == {"Header_1": "Main Header"}
+    assert splits[1].metadata == {"Header_1": "Header 2"}
     assert splits[0].text == "Main Header\n\nHeader 1 content"
     assert splits[1].text == "Header 2\nHeader 2 content"
 
@@ -80,11 +80,11 @@ Content
         ]
     )
     assert len(splits) == 4
-    assert splits[0].metadata == {"Header 1": "Main Header"}
-    assert splits[1].metadata == {"Header 1": "Main Header", "Header 2": "Sub-header"}
+    assert splits[0].metadata == {"Header_1": "Main Header"}
+    assert splits[1].metadata == {"Header_1": "Main Header", "Header_2": "Sub-header"}
     assert splits[2].metadata == {
-        "Header 1": "Main Header",
-        "Header 2": "Sub-header",
-        "Header 3": "Sub-sub header",
+        "Header_1": "Main Header",
+        "Header_2": "Sub-header",
+        "Header_3": "Sub-sub header",
     }
-    assert splits[3].metadata == {"Header 1": "New title"}
+    assert splits[3].metadata == {"Header_1": "New title"}


### PR DESCRIPTION
# Description

This change tweaks the metadata field created by markdown parser to conform to the weaviate metadata standards

Fixes #11920

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
