### PR TITLE
[FIX] - PydanticResponse Bug

### DIFF
--- a/llama-index-core/llama_index/core/base/response/schema.py
+++ b/llama-index-core/llama_index/core/base/response/schema.py
@@ -159,6 +159,16 @@ class AsyncStreamingResponse:
     def __post_init__(self) -> None:
         self._lock = asyncio.Lock()
 
+    def __str__(self) -> str:
+        """Convert to string representation."""
+        return asyncio.run(self._async_str)
+
+    async def _async_str(self) -> str:
+        """Convert to string representation."""
+        async for _ in self._yield_response():
+            ...
+        return self.response_txt or "None"
+
     async def _yield_response(self) -> TokenAsyncGen:
         """Yield the string response."""
         async with self._lock:

--- a/llama-index-core/llama_index/core/instrumentation/events/synthesis.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/synthesis.py
@@ -1,4 +1,3 @@
-from llama_index.core.base.response.schema import RESPONSE_TYPE
 from llama_index.core.instrumentation.events.base import BaseEvent
 from llama_index.core.schema import QueryType
 
@@ -14,7 +13,7 @@ class SynthesizeStartEvent(BaseEvent):
 
 class SynthesizeEndEvent(BaseEvent):
     query: QueryType
-    response: RESPONSE_TYPE
+    response: str
 
     @classmethod
     def class_name(cls):

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -209,13 +209,13 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
                     response_gen=empty_response_generator()
                 )
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(query=query, response=str(empty_response))
                 )
                 return empty_response
             else:
                 empty_response = Response("Empty Response")
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(query=query, response=str(empty_response))
                 )
                 return empty_response
 
@@ -240,7 +240,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
 
             event.on_end(payload={EventPayload.RESPONSE: response})
 
-        dispatcher.event(SynthesizeEndEvent(query=query, response=response))
+        dispatcher.event(SynthesizeEndEvent(query=query, response=str(response)))
         return response
 
     @dispatcher.span
@@ -258,13 +258,13 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
                     response_gen=empty_response_agenerator()
                 )
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(query=query, response=str(empty_response))
                 )
                 return empty_response
             else:
                 empty_response = Response("Empty Response")
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(query=query, response=str(empty_response))
                 )
                 return empty_response
 
@@ -289,7 +289,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
 
             event.on_end(payload={EventPayload.RESPONSE: response})
 
-        dispatcher.event(SynthesizeEndEvent(query=query, response=response))
+        dispatcher.event(SynthesizeEndEvent(query=query, response=str(response)))
         return response
 
     def _as_query_component(self, **kwargs: Any) -> QueryComponent:


### PR DESCRIPTION
# Description

A very weird BUG appeared when attempting to use `RESPONSE_TYPE` (that involves a UNION of `PydanticResponse` as well as other response types in `llama_index.core.base.response.schema`).

Including this type as a payload field to `SynthesizeEndEvent` ending up breaking any attempt to construct a `PydanticResponse`

This PR remedies this by not using `RESPONSE_TYPE` in the payload of `SynthesizeEndEvent`, but rather uses `str`.

Summary:
- Use `response` as type `str` in `SynthesizeEndEvent`
- When dispatching this event, need to call `str` method on all `Response` types so we can add to the payload of `SynthesizeEndEvent`
- Also given that `instrumentation` is not yet thread/processor safe, added some fallback measures to handle missing parent Span when attempting to create trace trees with `SimpleSpanHandler`.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Tested Haotian's sample code
- [x] I stared at the code and made sure it makes sense
