### PR TITLE
fix: prevent RaptorPack infinite recursion

### DIFF
--- a/llama-index-packs/llama-index-packs-raptor/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-raptor/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-packs-raptor"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Running RaptorPack sometimes results in an infinite recursion in the `get_clusters()` method. This happens when Raptor tries to split a cluster which has more than `max_length_in_cluster` tokens but the clustering algorithm is not able to split it any further, in which case `get_clusters()` is called again and again.

Fixes # https://github.com/run-llama/llama_index/issues/11830

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] I have rerun the setup from https://github.com/run-llama/llama_index/issues/11830 and made sure it works

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
