### PR TITLE
Fix: Anthropic LLM merge consecutive messages with same role

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -2,6 +2,8 @@ from typing import Dict, Sequence, Tuple
 
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 
+from anthropic.types import MessageParam, TextBlockParam
+
 HUMAN_PREFIX = "\n\nHuman:"
 ASSISTANT_PREFIX = "\n\nAssistant:"
 
@@ -27,18 +29,45 @@ def anthropic_modelname_to_contextsize(modelname: str) -> int:
     return CLAUDE_MODELS[modelname]
 
 
+def __merge_common_role_msgs(messages: Sequence[MessageParam]) -> Sequence[MessageParam]:
+    """Merge consecutive messages with the same role."""
+    postprocessed_messages : Sequence[MessageParam] = []
+    for message in messages:
+        if (
+            postprocessed_messages
+            and postprocessed_messages[-1]["role"] == message["role"]
+        ):
+            postprocessed_messages[-1]["content"] += message["content"]
+        else:
+            postprocessed_messages.append(message)
+    return postprocessed_messages
+
+
 def messages_to_anthropic_messages(
     messages: Sequence[ChatMessage],
-) -> Tuple[Sequence[ChatMessage], str]:
+) -> Tuple[Sequence[MessageParam], str]:
+    """Converts a list of generic ChatMessages to anthropic messages.
+
+    Args:
+        messages: List of ChatMessages
+
+    Returns:
+        Tuple of:
+        - List of anthropic messages
+        - System prompt
+    """
     anthropic_messages = []
     system_prompt = ""
     for message in messages:
         if message.role == MessageRole.SYSTEM:
             system_prompt = message.content
         else:
-            message = {"role": message.role.value, "content": message.content}
+            message = MessageParam(
+                role=message.role.value,
+                content=[TextBlockParam(text=message.content, type="text")], # TODO: type detect for multimodal
+            )
             anthropic_messages.append(message)
-    return anthropic_messages, system_prompt
+    return __merge_common_role_msgs(anthropic_messages), system_prompt
 
 
 # Function used in bedrock

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -29,9 +29,11 @@ def anthropic_modelname_to_contextsize(modelname: str) -> int:
     return CLAUDE_MODELS[modelname]
 
 
-def __merge_common_role_msgs(messages: Sequence[MessageParam]) -> Sequence[MessageParam]:
+def __merge_common_role_msgs(
+    messages: Sequence[MessageParam],
+) -> Sequence[MessageParam]:
     """Merge consecutive messages with the same role."""
-    postprocessed_messages : Sequence[MessageParam] = []
+    postprocessed_messages: Sequence[MessageParam] = []
     for message in messages:
         if (
             postprocessed_messages
@@ -64,7 +66,9 @@ def messages_to_anthropic_messages(
         else:
             message = MessageParam(
                 role=message.role.value,
-                content=[TextBlockParam(text=message.content, type="text")], # TODO: type detect for multimodal
+                content=[
+                    TextBlockParam(text=message.content, type="text")
+                ],  # TODO: type detect for multimodal
             )
             anthropic_messages.append(message)
     return __merge_common_role_msgs(anthropic_messages), system_prompt

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-anthropic"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
@@ -27,12 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-llama-index-llms-anthropic = "^0.1.6"
+llama-index-llms-anthropic = "^0.1.7"
 boto3 = "^1.34.26"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_bedrock.py
@@ -102,10 +102,10 @@ class MockStreamCompletionWithRetry:
         ),
         (
             "anthropic.claude-instant-v1",
-            '{"messages": [{"role": "user", "content": "test prompt"}], "anthropic_version": "bedrock-2023-05-31", '
+            '{"messages": [{"role": "user", "content": [{"text": "test prompt", "type": "text"}]}], "anthropic_version": "bedrock-2023-05-31", '
             '"temperature": 0.1, "max_tokens": 512}',
             '{"content": [{"text": "\\n\\nThis is indeed a test", "type": "text"}]}',
-            '{"messages": [{"role": "user", "content": "test prompt"}], "anthropic_version": "bedrock-2023-05-31", '
+            '{"messages": [{"role": "user", "content": [{"text": "test prompt", "type": "text"}]}], "anthropic_version": "bedrock-2023-05-31", '
             '"temperature": 0.1, "max_tokens": 512}',
         ),
         (


### PR DESCRIPTION
# Description

Merges consecutive anthropic messages with the same role.

Fixes:

> If the system prompt is sandwiched between user prompts you would end up would consecutive user prompts after transformation, which anthropic does not like at all. IMO this case should be handled in the anthropic utils.
> 
> _Originally posted by @sansmoraxz in https://github.com/run-llama/llama_index/pull/11663#discussion_r1524199280_
            

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] API calls in AWS bedrock

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
