### PR TITLE
Fix - Google Drive Issue of not loading same name files

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-google/BUILD
@@ -5,7 +5,3 @@ poetry_requirements(
         "google-auth-oauthlib": ["google_auth_oauthlib"],
     },
 )
-
-python_requirements(
-    name="reqs",
-)

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -310,7 +310,6 @@ class GoogleDriveReader(BaseReader):
                 metadata = {}
 
                 for fileid_meta in fileids_meta:
-                    filename = fileid_meta[2]
                     fileid = fileid_meta[0]
                     filepath = os.path.join(temp_dir, fileid)
                     final_filepath = self._download_file(fileid, filepath)

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -311,8 +311,8 @@ class GoogleDriveReader(BaseReader):
 
                 for fileid_meta in fileids_meta:
                     filename = fileid_meta[2]
-                    filepath = os.path.join(temp_dir, filename)
                     fileid = fileid_meta[0]
+                    filepath = os.path.join(temp_dir, fileid)
                     final_filepath = self._download_file(fileid, filepath)
 
                     metadata[final_filepath] = {

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -310,10 +310,12 @@ class GoogleDriveReader(BaseReader):
                 metadata = {}
 
                 for fileid_meta in fileids_meta:
+                    # Download files and name them with their fileid
                     fileid = fileid_meta[0]
                     filepath = os.path.join(temp_dir, fileid)
                     final_filepath = self._download_file(fileid, filepath)
 
+                    # Add metadata of the file to metadata dictionary
                     metadata[final_filepath] = {
                         "file id": fileid_meta[0],
                         "author": fileid_meta[1],

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -45,7 +45,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-google/requirements.txt
+++ b/llama-index-integrations/readers/llama-index-readers-google/requirements.txt
@@ -1,5 +1,0 @@
-google-api-python-client
-google-auth-httplib2
-google-auth-oauthlib
-PyDrive
-gkeepapi

--- a/llama-index-integrations/readers/llama-index-readers-google/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-google/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/llama-index-integrations/readers/llama-index-readers-google/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-google/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints=["==3.10.*"],
+)

--- a/llama-index-integrations/readers/llama-index-readers-google/tests/test_readers_google_drive.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/tests/test_readers_google_drive.py
@@ -1,0 +1,7 @@
+from llama_index.core.readers.base import BaseReader
+from llama_index.readers.google import GoogleDriveReader
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in GoogleDriveReader.__mro__]
+    assert BaseReader.__name__ in names_of_base_classes


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The modification here aims to resolve an issue with the Google Drive loader. When there are multiple files with the same name in your folder, not all files are retrieved. This happens because the loader uses the filename for downloading, causing files to be overwritten.

In this Pull Request, we've shifted from using the filename to using the file ID, ensuring uniqueness and proper functionality.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

This update, which connects to Google, should be covered by existing tests. However, if you wish to test it yourself, I've added a 'folder_id' with 15 files. The previous code would return 10 files, but now it will return all 15. Additionally, I have included regular tests for all readers in the Google folder.

You can run the following code for testing:

```
from llama_index.readers.google import GoogleDriveReader

loader = GoogleDriveReader(credentials_path=GDRIVE_SERVICE_ACCOUNT)

def load_data(folder_id: str):
    docs = loader.load_data(folder_id=folder_id)
    for doc in docs:
        doc.id_ = doc.metadata["file name"]
    return docs

documents = load_data(folder_id="1NIGvjHBuUQHWnMqzboyg-zLI1q_bOuCH")

print(len(documents))
```

PS: if someone write a mock tests for this would be appreciated. 

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
