### PR TITLE
chore: bump vector-store-postgres

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -359,10 +359,12 @@ class PGVectorStore(BasePydanticVectorStore):
         from sqlalchemy import text
 
         if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
+            # Expects a single value in the metadata, and a list to compare
             return text(
                 f"metadata_->>'{filter_.key}' {self._to_postgres_operator(filter_.operator)} :values"
             ).bindparams(values=tuple(filter_.value))
         elif filter_.operator == FilterOperator.CONTAINS:
+            # Expects a list stored in the metadata, and a single value to compare
             return text(
                 f"metadata_::jsonb->'{filter_.key}' "
                 f"{self._to_postgres_operator(filter_.operator)} "


### PR DESCRIPTION
# Description

The purpose of this PR is to trigger the publishing of llama-index-vector-stores-postgres v0.1.4 to pypi. The last PR (https://github.com/run-llama/llama_index/pull/11927) did not successfully deploy because it included a requirement for LlamaIndex 0.10.20, which had not yet been released.

I added 2 helpful comments, but the real purpose is to trigger the publishing pipeline.