### PR TITLE
chore: bumps minimum langfuse version

### DIFF
--- a/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/pyproject.toml
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.2"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.8"
-langfuse = "^2.18.0"
+langfuse = "^2.20.4"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/pyproject.toml
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-callbacks-langfuse"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Bumping minimum langfuse version requirement.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No
