### PR TITLE
fix: add api version/base api as optional for open ai embedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/base.py
@@ -246,10 +246,10 @@ class OpenAIEmbedding(BaseEmbedding):
     )
 
     api_key: str = Field(description="The OpenAI API key.")
-    api_base: str = Field(
+    api_base: Optional[str] = Field(
         default=DEFAULT_OPENAI_API_BASE, description="The base URL for OpenAI API."
     )
-    api_version: str = Field(
+    api_version: Optional[str] = Field(
         default=DEFAULT_OPENAI_API_VERSION, description="The version for OpenAI API."
     )
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-openai"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-legacy/llama_index/legacy/embeddings/openai.py
+++ b/llama-index-legacy/llama_index/legacy/embeddings/openai.py
@@ -244,8 +244,8 @@ class OpenAIEmbedding(BaseEmbedding):
     )
 
     api_key: str = Field(description="The OpenAI API key.")
-    api_base: Optional[str] = Field(description="The base URL for OpenAI API.")
-    api_version: Optional[str] = Field(description="The version for OpenAI API.")
+    api_base: str = Field(description="The base URL for OpenAI API.")
+    api_version: str = Field(description="The version for OpenAI API.")
 
     max_retries: int = Field(
         default=10, description="Maximum number of retries.", gte=0

--- a/llama-index-legacy/llama_index/legacy/embeddings/openai.py
+++ b/llama-index-legacy/llama_index/legacy/embeddings/openai.py
@@ -244,8 +244,8 @@ class OpenAIEmbedding(BaseEmbedding):
     )
 
     api_key: str = Field(description="The OpenAI API key.")
-    api_base: str = Field(description="The base URL for OpenAI API.")
-    api_version: str = Field(description="The version for OpenAI API.")
+    api_base: Optional[str] = Field(description="The base URL for OpenAI API.")
+    api_version: Optional[str] = Field(description="The version for OpenAI API.")
 
     max_retries: int = Field(
         default=10, description="Maximum number of retries.", gte=0


### PR DESCRIPTION
# Description

OpenAI doesn't require api version/base uri

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
