### PR TITLE
FIX TelegramReader.

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-telegram/llama_index/readers/telegram/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-telegram/llama_index/readers/telegram/base.py
@@ -58,8 +58,8 @@ class TelegramReader(BaseReader):
         entity_name: str,
         post_id: Optional[int] = None,
         limit: Optional[int] = None,
-        start_date: Optional[datetime.date] = None,
-        end_date: Optional[datetime.date] = None,
+        start_date: Optional[datetime.datetime] = None,
+        end_date: Optional[datetime.datetime] = None,
     ) -> List[Document]:
         """Load posts/chat messages/comments from Telegram channels or chats.
 
@@ -73,8 +73,8 @@ class TelegramReader(BaseReader):
                 the comments that reply to this ID will be returned.\
                 Else will get posts/chat messages.
             limit (int): Number of messages to be retrieved.
-            start_date (datetime.date): Start date of the time period.
-            end_date (datetime.date): End date of the time period.
+            start_date (datetime.datetime): Start date of the time period.
+            end_date (datetime.datetime): End date of the time period.
 
         """
         return self.loop.run_until_complete(
@@ -92,8 +92,8 @@ class TelegramReader(BaseReader):
         entity_name: str,
         post_id: Optional[int] = None,
         limit: Optional[int] = None,
-        start_date: Optional[datetime.date] = None,
-        end_date: Optional[datetime.date] = None,
+        start_date: Optional[datetime.datetime] = None,
+        end_date: Optional[datetime.datetime] = None,
     ) -> List[Document]:
         """Load posts/chat messages/comments from Telegram channels or chats.
 
@@ -103,8 +103,8 @@ class TelegramReader(BaseReader):
                 the comments that reply to this ID will be returned.\
                 Else will get posts/chat messages.
             limit (int): Number of messages to be retrieved.
-            start_date (datetime.date): Start date of the time period.
-            end_date (datetime.date): End date of the time period.
+            start_date (datetime.datetime): Start date of the time period.
+            end_date (datetime.datetime): End date of the time period.
 
         """
         import telethon
@@ -121,7 +121,6 @@ class TelegramReader(BaseReader):
                     reply_to=post_id,
                     limit=limit,
                     offset_date=end_date,
-                    reverse=True,
                 ):
                     if message.date < start_date:
                         break


### PR DESCRIPTION
# Description

Fixes an issue with how the `reverse` parameter was being used in the `iter_messages()` method. Previously, reverse was set to True, which caused all messages to be retrieved from oldest (very first messages in the group or channel) to newest, ignoring the time period set with the `start_date` and `end_date` parameters. This led to empty results being returned when a specific date range was provided.

Fixes # (issue)

The fix was to change the `reverse` parameter to False when calling `iter_messages()`.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
