### PR TITLE
Create lazy initialization for async elements in StreamingAgentChatResponse

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -78,11 +78,11 @@ class StreamingAgentChatResponse:
     # flag when processing done
     _is_done = False
     # signal when a new item is added to the queue
-    _new_item_event: asyncio.Event = field(default_factory=asyncio.Event)
+    _new_item_event: Optional[asyncio.Event] = None
     # NOTE: async code uses two events rather than one since it yields
     # control when waiting for queue item
     # signal when the OpenAI functions stop executing
-    _is_function_false_event: asyncio.Event = field(default_factory=asyncio.Event)
+    _is_function_false_event: Optional[asyncio.Event] = None
     # signal when an OpenAI function is being executed
     _is_function_not_none_thread_event: Event = field(default_factory=Event)
 
@@ -100,16 +100,20 @@ class StreamingAgentChatResponse:
             self.response = self._unformatted_response.strip()
         return self.response
 
-    def _ensure_aqueue(self) -> None:
+    def _ensure_async_setup(self) -> None:
         if self._aqueue is None:
             self._aqueue = asyncio.Queue()
+        if self._new_item_event is None:
+            self._new_item_event = asyncio.Event()
+        if self._is_function_false_event is None:
+            self._is_function_false_event = asyncio.Event()
 
     def put_in_queue(self, delta: Optional[str]) -> None:
         self._queue.put_nowait(delta)
         self._is_function_not_none_thread_event.set()
 
     def aput_in_queue(self, delta: Optional[str]) -> None:
-        self._ensure_aqueue()
+        self._ensure_async_setup()
         self._aqueue.put_nowait(delta)
         self._new_item_event.set()
 
@@ -212,7 +216,7 @@ class StreamingAgentChatResponse:
         self.response = self._unformatted_response.strip()
 
     async def async_response_gen(self) -> AsyncGenerator[str, None]:
-        self._ensure_aqueue()
+        self._ensure_async_setup()
         while True:
             if not self._aqueue.empty() or not self._is_done:
                 try:


### PR DESCRIPTION
Implement Lazy Initialization of _aqueue to Enhance Compatibility with Streamlit.

# Description

This pull request introduces a modification to the initialization process of the `_aqueue` parameter within the `StreamingAgentChatResponse` class. The primary goal of this change is to circumvent a recurring issue encountered when integrating with Streamlit applications. Previously, the `_aqueue` parameter was instantiated as an `asyncio.Queue` object directly during the class's initialization phase. This approach led to compatibility issues in environments like Streamlit, particularly when asynchronous operations were not required.

To address this, we've shifted to a lazy initialization strategy for the `_aqueue` parameter. Now, `_aqueue` will only be instantiated upon its first actual use in asynchronous contexts. This adjustment ensures that the initialization of `asyncio.Queue` is deferred until it is strictly necessary, thereby mitigating the previously observed conflict with Streamlit's execution model. This change is anticipated to enhance the flexibility and reliability of using `StreamingAgentChatResponse` within Streamlit, without imposing the overhead of asynchronous queue management in scenarios where asynchronous functionality is not utilized

Fixes #9938 #7244 

Relates to #10484


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
- [x] Tested locally using `StreamingAgentChatResponse` within within a Streamlit app

## Suggested Checklist:

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods

