### PR TITLE
chore: Add instructions for filling in the README when creating new extension packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,13 @@ Please include a summary of the change and which issue is fixed. Please also inc
 
 Fixes # (issue)
 
+## New Package?
+
+Did I fill in the `tool.llamahub` section and provide a detailed READEM for my new integration or package?
+
+- [ ] Yes
+- [ ] No
+
 ## Version Bump?
 
 Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Fixes # (issue)
 
 ## New Package?
 
-Did I fill in the `tool.llamahub` section and provide a detailed READEM for my new integration or package?
+Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?
 
 - [ ] Yes
 - [ ] No

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,10 @@ llamaindex-cli new-package --kind "llms" --name "gemini"
 Executing the above commands will create a new folder called `llama-index-llms-gemini`
 within the `llama-index-integrations/llms` directory.
 
-In addition to preparing your source code, we also ask that you fill in some
+Please ensure to add a detailed README for your new package as it will appear in
+both [llamahub.ai](https://llamahub.ai) as well as the PyPi.org website.
+In addition to preparing your source code and supplying a detailed README, we
+also ask that you fill in some
 metadata for your package to appear in [llamahub.ai](https://llamahub.ai) with the
 correct information. You do so by adding the required metadata under the `[tool.llamahub]`
 section with your new package's `pyproject.toml`.
@@ -314,7 +317,10 @@ Executing the first set of shell commands will create a new folder called `llama
 within the `llama-index-packs` directory. While the second set will create a new
 package directory called `llama-index-readers-new-reader` within the `llama-index-integrations/readers` directory.
 
-In addition to preparing your source code, we also ask that you fill in some
+Please ensure to add a detailed README for your new package as it will appear in
+both [llamahub.ai](https://llamahub.ai) as well as the PyPi.org website.
+In addition to preparing your source code and supplying a detailed README, we
+also ask that you fill in some
 metadata for your package to appear in [llamahub.ai](https://llamahub.ai) with the
 correct information. You do so by adding the required metadata under the `[tool.llamahub]`
 section with your new package's `pyproject.toml`.


### PR DESCRIPTION
# Description

- Adds instructions in CONTRIBUTING.md to supply a detailed README.md file when creating a new package.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] N/A

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update
