### PR TITLE
fix unclosed session in es add function

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -372,22 +372,23 @@ class ElasticsearchStore(BasePydanticVectorStore):
             requests.append(request)
             return_ids.append(_id)
 
-        await async_bulk(
-            self.client, requests, chunk_size=self.batch_size, refresh=True
-        )
-        try:
-            success, failed = await async_bulk(
-                self.client, requests, stats_only=True, refresh=True
+        async with self.client as client:
+            await async_bulk(
+                client, requests, chunk_size=self.batch_size, refresh=True
             )
-            logger.debug(f"Added {success} and failed to add {failed} texts to index")
+            try:
+                success, failed = await async_bulk(
+                    client, requests, stats_only=True, refresh=True
+                )
+                logger.debug(f"Added {success} and failed to add {failed} texts to index")
 
-            logger.debug(f"added texts {ids} to index")
-            return return_ids
-        except BulkIndexError as e:
-            logger.error(f"Error adding texts: {e}")
-            firstError = e.errors[0].get("index", {}).get("error", {})
-            logger.error(f"First error reason: {firstError.get('reason')}")
-            raise
+                logger.debug(f"added texts {ids} to index")
+                return return_ids
+            except BulkIndexError as e:
+                logger.error(f"Error adding texts: {e}")
+                firstError = e.errors[0].get("index", {}).get("error", {})
+                logger.error(f"First error reason: {firstError.get('reason')}")
+                raise
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """Delete node from Elasticsearch index.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -373,14 +373,14 @@ class ElasticsearchStore(BasePydanticVectorStore):
             return_ids.append(_id)
 
         async with self.client as client:
-            await async_bulk(
-                client, requests, chunk_size=self.batch_size, refresh=True
-            )
+            await async_bulk(client, requests, chunk_size=self.batch_size, refresh=True)
             try:
                 success, failed = await async_bulk(
                     client, requests, stats_only=True, refresh=True
                 )
-                logger.debug(f"Added {success} and failed to add {failed} texts to index")
+                logger.debug(
+                    f"Added {success} and failed to add {failed} texts to index"
+                )
 
                 logger.debug(f"added texts {ids} to index")
                 return return_ids

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

When using ES, the following error is encountered. "query/delete" uses "with", while "add" does not use "with".
```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f70a67fdc90>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7f70a673a200>, 1709366.392741335)]']
connector: <aiohttp.connector.TCPConnector object at 0x7f70a67fdc30>
```

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
