### PR TITLE
[Agent using tools] Upon exception, say so, so that Agent can correct itself.

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -240,7 +240,15 @@ class ReActAgentWorker(BaseAgentWorker):
                 EventPayload.TOOL: tool.metadata,
             },
         ) as event:
-            tool_output = tool.call(**reasoning_step.action_input)
+            try:
+                tool_output = tool.call(**reasoning_step.action_input)
+            except Exception as e:
+                tool_output = ToolOutput(
+                    content=f"Error: {e!s}",
+                    tool_name=tool.metadata.name,
+                    raw_input={"kwargs": reasoning_step.action_input},
+                    raw_output=e,
+                )
             event.on_end(payload={EventPayload.FUNCTION_OUTPUT: str(tool_output)})
 
         task.extra_state["sources"].append(tool_output)
@@ -276,7 +284,15 @@ class ReActAgentWorker(BaseAgentWorker):
                 EventPayload.TOOL: tool.metadata,
             },
         ) as event:
-            tool_output = await tool.acall(**reasoning_step.action_input)
+            try:
+                tool_output = await tool.acall(**reasoning_step.action_input)
+            except Exception as e:
+                tool_output = ToolOutput(
+                    content=f"Error: {e!s}",
+                    tool_name=tool.metadata.name,
+                    raw_input={"kwargs": reasoning_step.action_input},
+                    raw_output=e,
+                )
             event.on_end(payload={EventPayload.FUNCTION_OUTPUT: str(tool_output)})
 
         task.extra_state["sources"].append(tool_output)


### PR DESCRIPTION
# Description

A remake of #9751. Fixes #9752 . 

Error is also a kind of output. 

Currently, Agents do not capture exceptions when running a Tool. This means Llama Index fails ungracefully when exceptions arise.

By capturing exceptions and feeding the error message back to the Agent as an Observation, we give the LLM a 2nd chance to fix its mistakes.

Here is an example of a chain-of-thought where I asked my Agent to "Look up cheesecakes on Wikipedia":

<img width="1470" alt="Screenshot 2023-12-29 at 17 41 42" src="https://github.com/run-llama/llama_index/assets/594058/95d9dda0-ba14-417e-a356-38f7586b61d4">

Notice that:
- It encountered an import error while attempting to use the tool.
- It was made aware of that problem.
- It planned to install the package as a next step.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
