### PR TITLE
Fix path implementation for non-local FS

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -196,18 +196,19 @@ class SimpleDirectoryReader(BaseReader):
         self.exclude_hidden = exclude_hidden
         self.required_exts = required_exts
         self.num_files_limit = num_files_limit
+        _Path = Path if is_default_fs(self.fs) else PurePosixPath
 
         if input_files:
             self.input_files = []
             for path in input_files:
                 if not self.fs.isfile(path):
                     raise ValueError(f"File {path} does not exist.")
-                input_file = Path(path)
+                input_file = _Path(path)
                 self.input_files.append(input_file)
         elif input_dir:
             if not self.fs.isdir(input_dir):
                 raise ValueError(f"Directory {input_dir} does not exist.")
-            self.input_dir = Path(input_dir)
+            self.input_dir = _Path(input_dir)
             self.exclude = exclude
             self.input_files = self._add_files(self.input_dir)
 

--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -8,7 +8,7 @@ import warnings
 from datetime import datetime
 from functools import reduce
 from itertools import repeat
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import fsspec
 from fsspec.implementations.local import LocalFileSystem
 from typing import Any, Callable, Dict, Generator, List, Optional, Type
@@ -229,20 +229,22 @@ class SimpleDirectoryReader(BaseReader):
         all_files = set()
         rejected_files = set()
         rejected_dirs = set()
+        # Default to POSIX paths for non-default file systems (e.g. S3)
+        _Path = Path if is_default_fs(self.fs) else PurePosixPath
 
         if self.exclude is not None:
             for excluded_pattern in self.exclude:
                 if self.recursive:
                     # Recursive glob
-                    excluded_glob = Path(input_dir) / Path("**") / excluded_pattern
+                    excluded_glob = _Path(input_dir) / _Path("**") / excluded_pattern
                 else:
                     # Non-recursive glob
-                    excluded_glob = Path(input_dir) / excluded_pattern
+                    excluded_glob = _Path(input_dir) / excluded_pattern
                 for file in self.fs.glob(str(excluded_glob)):
                     if self.fs.isdir(file):
-                        rejected_dirs.add(Path(file))
+                        rejected_dirs.add(_Path(file))
                     else:
-                        rejected_files.add(Path(file))
+                        rejected_files.add(_Path(file))
 
         file_refs: List[str] = []
         if self.recursive:
@@ -253,7 +255,7 @@ class SimpleDirectoryReader(BaseReader):
         for ref in file_refs:
             # Manually check if file is hidden or directory instead of
             # in glob for backwards compatibility.
-            ref = Path(ref)
+            ref = _Path(ref)
             is_dir = self.fs.isdir(ref)
             skip_because_hidden = self.exclude_hidden and self.is_hidden(ref)
             skip_because_bad_ext = (


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #11810 (This PR uses Posix paths by default with non-local file systems)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

Tested by running on Windows with a sample code as described in the issue. Verified that other functionality still works.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
