### PR TITLE
Added support for different drives

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -173,7 +173,7 @@ class GoogleDriveReader(BaseReader):
                             .list(
                                 q=query,
                                 driveId=drive_id,
-                                corpora='drive',
+                                corpora="drive",
                                 includeItemsFromAllDrives=True,
                                 supportsAllDrives=True,
                                 fields="*",
@@ -364,14 +364,12 @@ class GoogleDriveReader(BaseReader):
 
     def _load_from_file_ids(
         self,
-        drive_id: str
         file_ids: List[str],
         mime_types: Optional[List[str]],
         query_string: Optional[str],
     ) -> List[Document]:
         """Load data from file ids
         Args:
-            drive_id: Drive id of the shared drive in google drive.
             file_ids: File ids of the files in google drive.
             mime_types: The mimeTypes you want to allow e.g.: "application/vnd.google-apps.document"
             query_string: List of query strings to filter the documents, e.g. "name contains 'test'".
@@ -452,7 +450,9 @@ class GoogleDriveReader(BaseReader):
         if folder_id:
             return self._load_from_folder(drive_id, folder_id, mime_types, query_string)
         elif file_ids:
-            return self._load_from_file_ids(drive_id, file_ids, mime_types, query_string)
+            return self._load_from_file_ids(
+                drive_id, file_ids, mime_types, query_string
+            )
         else:
             logger.warning("Either 'folder_id' or 'file_ids' must be provided.")
             return []

--- a/llama-index-integrations/readers/llama-index-readers-google/tests/test_drive_id.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/tests/test_drive_id.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import MagicMock
+from llama_index.readers.google import GoogleDriveReader
+
+
+class TestGoogleDriveReader(unittest.TestCase):
+    def test_load_data_with_drive_id(self):
+        # Mock the necessary objects and methods
+        mock_credentials = MagicMock()
+        mock_drive = MagicMock()
+        reader = GoogleDriveReader()
+        reader._get_credentials = MagicMock(return_value=(mock_credentials, mock_drive))
+        reader._load_from_folder = MagicMock(return_value=["document1", "document2"])
+
+        # Test with a specific drive_id
+        drive_id = "example_drive_id"
+        folder_id = "example_folder_id"
+        result = reader.load_data(drive_id=drive_id, folder_id=folder_id)
+
+        # Assert that the correct methods are called and the correct result is returned
+        reader._get_credentials.assert_called_once()
+        reader._load_from_folder.assert_called_once_with(
+            drive_id, folder_id, None, None
+        )
+        self.assertEqual(result, ["document1", "document2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
You can now pass a variable drive_id to specify the specific drive where the loader should work
Performance improvement, because now it doesn't need to search all drives.
Tested with 3 different drive access:
-  Without specifying drive_id: Time taken: 9.056854009628296 seconds
- Specifying drive_id: Time taken: 7.593610048294067 seconds


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x ] No

## Type of Change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
