### PR TITLE
Instrumentation enhancements

### DIFF
--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -225,7 +225,7 @@ class BaseRetriever(ChainableMixin, PromptMixin):
 
         """
         self._check_callback_manager()
-        dispatcher.event(RetrievalStartEvent())
+        dispatcher.event(RetrievalStartEvent(str_or_query_bundle=str_or_query_bundle))
         if isinstance(str_or_query_bundle, str):
             query_bundle = QueryBundle(str_or_query_bundle)
         else:
@@ -240,13 +240,15 @@ class BaseRetriever(ChainableMixin, PromptMixin):
                 retrieve_event.on_end(
                     payload={EventPayload.NODES: nodes},
                 )
-        dispatcher.event(RetrievalEndEvent())
+        dispatcher.event(
+            RetrievalEndEvent(str_or_query_bundle=str_or_query_bundle, nodes=nodes)
+        )
         return nodes
 
     @dispatcher.span
     async def aretrieve(self, str_or_query_bundle: QueryType) -> List[NodeWithScore]:
         self._check_callback_manager()
-        dispatcher.event(RetrievalStartEvent())
+        dispatcher.event(RetrievalStartEvent(str_or_query_bundle=str_or_query_bundle))
         if isinstance(str_or_query_bundle, str):
             query_bundle = QueryBundle(str_or_query_bundle)
         else:
@@ -263,7 +265,9 @@ class BaseRetriever(ChainableMixin, PromptMixin):
                 retrieve_event.on_end(
                     payload={EventPayload.NODES: nodes},
                 )
-        dispatcher.event(RetrievalEndEvent())
+        dispatcher.event(
+            RetrievalEndEvent(str_or_query_bundle=str_or_query_bundle, nodes=nodes)
+        )
         return nodes
 
     @abstractmethod

--- a/llama-index-core/llama_index/core/instrumentation/events/retrieval.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/retrieval.py
@@ -1,7 +1,11 @@
+from typing import List
 from llama_index.core.instrumentation.events.base import BaseEvent
+from llama_index.core.schema import QueryType, NodeWithScore
 
 
 class RetrievalStartEvent(BaseEvent):
+    str_or_query_bundle: QueryType
+
     @classmethod
     def class_name(cls):
         """Class name."""
@@ -9,6 +13,9 @@ class RetrievalStartEvent(BaseEvent):
 
 
 class RetrievalEndEvent(BaseEvent):
+    str_or_query_bundle: QueryType
+    nodes: List[NodeWithScore]
+
     @classmethod
     def class_name(cls):
         """Class name."""

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -22,44 +22,50 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         """Class name."""
         return "BaseSpanHandler"
 
-    def span_enter(self, id: str, **kwargs) -> None:
+    def span_enter(self, *args, id: str, **kwargs) -> None:
         """Logic for entering a span."""
         if id in self.open_spans:
             pass  # should probably raise an error here
         else:
             # TODO: thread safe?
-            span = self.new_span(id=id, parent_span_id=self.current_span_id, **kwargs)
+            span = self.new_span(
+                *args, id=id, parent_span_id=self.current_span_id, **kwargs
+            )
             if span:
                 self.open_spans[id] = span
                 self.current_span_id = id
 
-    def span_exit(self, id: str, result: Optional[Any] = None, **kwargs) -> None:
+    def span_exit(self, *args, id: str, result: Optional[Any] = None, **kwargs) -> None:
         """Logic for exiting a span."""
-        self.prepare_to_exit_span(id, result=result, **kwargs)
+        self.prepare_to_exit_span(*args, id=id, result=result, **kwargs)
         if self.current_span_id == id:
             self.current_span_id = self.open_spans[id].parent_id
         del self.open_spans[id]
 
-    def span_drop(self, id: str, err: Optional[Exception], **kwargs) -> None:
+    def span_drop(self, *args, id: str, err: Optional[Exception], **kwargs) -> None:
         """Logic for dropping a span i.e. early exit."""
-        self.prepare_to_drop_span(id, err, **kwargs)
+        self.prepare_to_drop_span(*args, id=id, err=err, **kwargs)
         if self.current_span_id == id:
             self.current_span_id = self.open_spans[id].parent_id
         del self.open_spans[id]
 
     @abstractmethod
-    def new_span(self, id: str, parent_span_id: Optional[str], **kwargs) -> Optional[T]:
+    def new_span(
+        self, *args, id: str, parent_span_id: Optional[str], **kwargs
+    ) -> Optional[T]:
         """Create a span."""
         ...
 
     @abstractmethod
     def prepare_to_exit_span(
-        self, id: str, result: Optional[Any] = None, **kwargs
+        self, *args, id: str, result: Optional[Any] = None, **kwargs
     ) -> Any:
         """Logic for preparing to exit a span."""
         ...
 
     @abstractmethod
-    def prepare_to_drop_span(self, id: str, err: Optional[Exception], **kwargs) -> Any:
+    def prepare_to_drop_span(
+        self, *args, id: str, err: Optional[Exception], **kwargs
+    ) -> Any:
         """Logic for preparing to drop a span."""
         ...

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
@@ -9,25 +9,27 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
         """Class name."""
         return "NullSpanHandler"
 
-    def span_enter(self, id: str, **kwargs) -> None:
+    def span_enter(self, *args, id: str, **kwargs) -> None:
         """Logic for entering a span."""
         return
 
-    def span_exit(self, id: str, result: Optional[Any], **kwargs) -> None:
+    def span_exit(self, *args, id: str, result: Optional[Any], **kwargs) -> None:
         """Logic for exiting a span."""
         return
 
-    def new_span(self, id: str, parent_span_id: Optional[str], **kwargs) -> None:
+    def new_span(self, *args, id: str, parent_span_id: Optional[str], **kwargs) -> None:
         """Create a span."""
         return
 
     def prepare_to_exit_span(
-        self, id: str, result: Optional[Any] = None, **kwargs
+        self, *args, id: str, result: Optional[Any] = None, **kwargs
     ) -> None:
         """Logic for exiting a span."""
         return
 
-    def prepare_to_drop_span(self, id: str, err: Optional[Exception], **kwargs) -> None:
+    def prepare_to_drop_span(
+        self, *args, id: str, err: Optional[Exception], **kwargs
+    ) -> None:
         """Logic for droppping a span."""
         if err:
             raise err

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
@@ -20,12 +20,14 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
         """Class name."""
         return "SimpleSpanHandler"
 
-    def new_span(self, id: str, parent_span_id: Optional[str], **kwargs) -> SimpleSpan:
+    def new_span(
+        self, *args, id: str, parent_span_id: Optional[str], **kwargs
+    ) -> SimpleSpan:
         """Create a span."""
         return SimpleSpan(id_=id, parent_id=parent_span_id)
 
     def prepare_to_exit_span(
-        self, id: str, result: Optional[Any] = None, **kwargs
+        self, *args, id: str, result: Optional[Any] = None, **kwargs
     ) -> None:
         """Logic for preparing to drop a span."""
         span = self.open_spans[id]
@@ -34,7 +36,9 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
         span.duration = (span.end_time - span.start_time).total_seconds()
         self.completed_spans += [span]
 
-    def prepare_to_drop_span(self, id: str, err: Optional[Exception], **kwargs) -> None:
+    def prepare_to_drop_span(
+        self, *args, id: str, err: Optional[Exception], **kwargs
+    ) -> None:
         """Logic for droppping a span."""
         if err:
             raise err

--- a/llama-index-core/tests/instrumentation/BUILD
+++ b/llama-index-core/tests/instrumentation/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -1,0 +1,35 @@
+import llama_index.core.instrumentation as instrument
+from llama_index.core.instrumentation.dispatcher import Dispatcher
+from unittest.mock import patch
+
+dispatcher = instrument.get_dispatcher("test")
+
+
+@dispatcher.span
+def func(*args, a, b=3, **kwargs):
+    return a + b
+
+
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+def test_dispatcher_span_args(mock_uuid, mock_span_enter, mock_span_exit):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+
+    # act
+    result = func(1, 2, a=3, c=5)
+
+    # assert
+    # span_enter
+    span_id = f"{func.__qualname__}-mock"
+    mock_span_enter.assert_called_once()
+    args, kwargs = mock_span_enter.call_args
+    assert args == (1, 2)
+    assert kwargs == {"id": span_id, "a": 3, "c": 5}
+
+    # span_exit
+    mock_span_exit.assert_called_once()
+    args, kwargs = mock_span_exit.call_args
+    assert args == (1, 2)
+    assert kwargs == {"id": span_id, "a": 3, "c": 5, "result": result}

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -11,6 +11,11 @@ def func(*args, a, b=3, **kwargs):
     return a + b
 
 
+@dispatcher.span
+async def async_func(*args, a, b=3, **kwargs):
+    return a + b
+
+
 @patch.object(Dispatcher, "span_exit")
 @patch.object(Dispatcher, "span_enter")
 @patch("llama_index.core.instrumentation.dispatcher.uuid")
@@ -57,6 +62,77 @@ def test_dispatcher_span_drop_args(
     with pytest.raises(CustomException):
         # act
         result = func(7, a=3, b=5, c=2, d=5)
+
+        # assert
+        # span_enter
+        mock_span_enter.assert_called_once()
+
+        # span_drop
+        mock_span_drop.assert_called_once()
+        span_id = f"{func.__qualname__}-mock"
+        args, kwargs = mock_span_exit.call_args
+        assert args == (7,)
+        assert kwargs == {
+            "id": span_id,
+            "a": 3,
+            "b": 5,
+            "c": 2,
+            "d": 2,
+            "err": CustomException,
+        }
+
+        # span_exit
+        mock_span_exit.assert_not_called()
+
+
+@pytest.mark.asyncio()
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+async def test_dispatcher_async_span_args(mock_uuid, mock_span_enter, mock_span_exit):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+
+    # act
+    result = await async_func(1, 2, a=3, c=5)
+
+    # assert
+    # span_enter
+    span_id = f"{async_func.__qualname__}-mock"
+    mock_span_enter.assert_called_once()
+    args, kwargs = mock_span_enter.call_args
+    assert args == (1, 2)
+    assert kwargs == {"id": span_id, "a": 3, "c": 5}
+
+    # span_exit
+    args, kwargs = mock_span_exit.call_args
+    assert args == (1, 2)
+    assert kwargs == {"id": span_id, "a": 3, "c": 5, "result": result}
+
+
+@pytest.mark.asyncio()
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_drop")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+@patch(f"{__name__}.async_func")
+async def test_dispatcher_aysnc_span_drop_args(
+    mock_func: MagicMock,
+    mock_uuid: MagicMock,
+    mock_span_enter: MagicMock,
+    mock_span_drop: MagicMock,
+    mock_span_exit: MagicMock,
+):
+    # arrange
+    class CustomException(Exception):
+        pass
+
+    mock_uuid.uuid4.return_value = "mock"
+    mock_func.side_effect = CustomException
+
+    with pytest.raises(CustomException):
+        # act
+        result = await async_func(7, a=3, b=5, c=2, d=5)
 
         # assert
         # span_enter

--- a/llama-index-core/tests/instrumentation/test_manager.py
+++ b/llama-index-core/tests/instrumentation/test_manager.py
@@ -1,0 +1,13 @@
+import llama_index.core.instrumentation as instrument
+
+
+def test_root_manager_add_dispatcher():
+    # arrange
+    root_manager = instrument.root_manager
+
+    # act
+    dispatcher = instrument.get_dispatcher("test")
+
+    # assert
+    assert "root" in root_manager.dispatchers
+    assert "test" in root_manager.dispatchers


### PR DESCRIPTION
# Description

- Add payload to `RetrievalStartEvent` and `RetrievalEndEvent`
- Propagate the *args, **kwargs of the span decorate func when entering/exiting/dropping a span
- Add unit tests

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense