### PR TITLE
[Bug Fix]: ModuleNotFoundError: No module named 'llama_index.storage.kvstore'

### DIFF
--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-postgres/pyproject.toml
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-postgres/pyproject.toml
@@ -32,6 +32,7 @@ version = "0.1.2"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
+llama-index-storage-kvstore-postgres = "^0.1.2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-postgres/pyproject.toml
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-docstore-postgres"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-postgres/pyproject.toml
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-postgres/pyproject.toml
@@ -32,6 +32,7 @@ version = "0.1.2"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
+llama-index-storage-kvstore-postgres = "^0.1.2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-postgres/pyproject.toml
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-index-store-postgres"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

importing `PostgresDocumentStore` or `PostgresIndexStore` raises an `ModuleNotFoundError`.

The `llama-index-storage-kvstore-postgres` dependency was missing.

Fixes # ([12155](https://github.com/run-llama/llama_index/issues/12155))


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
