### PR TITLE
Fix S3Reader PDF reading

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
@@ -1,4 +1,5 @@
-"""Docs parser.
+"""
+Docs parser.
 
 Contains parsers for docx, pdf files.
 
@@ -50,10 +51,16 @@ class PDFReader(BaseReader):
 
             docs = []
 
+            if hasattr(fp, "name"):
+                # Some file systems (e.g. those that use fsspec) don't have a name attribute. Instead, they use full_name
+                file_name = fp.name
+            else:
+                file_name = fp.full_name
+
             # This block returns a whole PDF as a single Document
             if self.return_full_document:
                 text = ""
-                metadata = {"file_name": fp.name}
+                metadata = {"file_name": file_name}
 
                 for page in range(num_pages):
                     # Extract the text from the page
@@ -71,7 +78,7 @@ class PDFReader(BaseReader):
                     page_text = pdf.pages[page].extract_text()
                     page_label = pdf.page_labels[page]
 
-                    metadata = {"page_label": page_label, "file_name": fp.name}
+                    metadata = {"page_label": page_label, "file_name": file_name}
                     if extra_info is not None:
                         metadata.update(extra_info)
 
@@ -128,7 +135,8 @@ class HWPReader(BaseReader):
         extra_info: Optional[Dict] = None,
         fs: Optional[AbstractFileSystem] = None,
     ) -> List[Document]:
-        """Load data and extract table from Hwp file.
+        """
+        Load data and extract table from Hwp file.
 
         Args:
             file (Path): Path for the Hwp file.

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -50,7 +50,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.11"
+version = "0.1.12"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
@@ -29,12 +29,12 @@ license = "MIT"
 maintainers = ["thejessezhang"]
 name = "llama-index-readers-s3"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-llama-index-readers-file = "^0.1.11"
+llama-index-readers-file = "^0.1.12"
 s3fs = "^2024.3.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

Reading PDFs with the new version of S3Reader was failing because `s3fs` doesn't support the `name` attribute. Added a check to use `full_name` instead when the `name` attribute isn't present. Thanks to @thiagosalvatore for pointing out.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
