### PR TITLE
ReAct Agent should be informed when it tried to use a non-existent tool

### DIFF
--- a/llama-index-core/.gitignore
+++ b/llama-index-core/.gitignore
@@ -1,4 +1,5 @@
 llama_index/core/_static
+storage/
 .DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
# Description

This is a small improvement that **makes ReAct Agents more robust**.

## Demo

Let's explicitly ask the Agent to use a tool that does not actually exist.

### Before

A `KeyError` exception will arise, unhandled:

<img width="601" alt="Screenshot 2024-03-23 at 15 12 29" src="https://github.com/run-llama/llama_index/assets/594058/3ad356c5-c3a6-4ef1-ac22-03b98bd7cfdc">

```
  File "...llama_index/core/agent/react/step.py", line 235, in _process_actions
    tool = tools_dict[reasoning_step.action]
KeyError: 'ask_the_user'
```

### After

The Agent is informed about the mistake and tries to fix it:

<img width="1011" alt="Screenshot 2024-03-23 at 15 13 32" src="https://github.com/run-llama/llama_index/assets/594058/bfa65d8d-6e94-4ebc-b694-a448ba028cac">

> Thought: I need to gather some information about the user's morning.
> Action: ask_the_user
> Action Input: {'question': 'How has your morning been so far?'}
> Observation: Error: No such tool named `ask_the_user`.
>
> Thought: I'm sorry, but it seems like the user provided an incorrect tool name. Let me suggest a few alternatives that might help us gather information about their morning: [...]


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
