### PR TITLE
Relax llama-parse version

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-llama-parse/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-llama-parse/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.3"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.7"
-llama-parse = "^0.3.3"
+llama-parse = "~0.3.3"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

Llama-index pulls llama-parse through llama-index-readers-llama-parse.
The llama-index code doesn't use llama-parse so there is no reason to limit the version of llama-parse that can be used.
The only limitation would be on the version of llama-core but that will be resolved by the package manager.
For instance it's currently not possible to use llama-parse 0.4 with llama-index 0.10.23 although there is no reason for that.

## Type of Change

Enhancement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
