### PR TITLE
docs: remove old embedding placeholder

### DIFF
--- a/docs/docs/understanding/indexing/indexing.md
+++ b/docs/docs/understanding/indexing/indexing.md
@@ -12,8 +12,6 @@ LlamaIndex offers several different index types. We'll cover the two most common
 
 A `VectorStoreIndex` is by far the most frequent type of Index you'll encounter. The Vector Store Index takes your Documents and splits them up into Nodes. It then creates `vector embeddings` of the text of every node, ready to be queried by an LLM.
 
-(what-is-an-embedding)=
-
 ### What is an embedding?
 
 `Vector embeddings` are central to how LLM applications function.


### PR DESCRIPTION
# Description

Remove placeholder text from docs (https://docs.llamaindex.ai/en/stable/understanding/indexing/indexing/):

![image](https://github.com/run-llama/llama_index/assets/39976114/a37d4435-ce78-406e-acd8-f13b4697af4f)


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
