### PR TITLE
llama-index-readers-llama-parse: bump llama-parse to 0.4

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-llama-parse/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-llama-parse/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ["PDF", "llama", "llama-parse", "parse"]
 license = "MIT"
 name = "llama-index-readers-llama-parse"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-llama-parse/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-llama-parse/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.3"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.7"
-llama-parse = "^0.3.3"
+llama-parse = "^0.4.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

Package with readers for llama-parse still depends on 0.3. Bump to the new version (0.4.x)


## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No