### PR TITLE
[Fix]: PandasQueryEngine can now execute 'pd.*' functions

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/pandas/output_parser.py
+++ b/llama-index-core/llama_index/core/query_engine/pandas/output_parser.py
@@ -30,7 +30,7 @@ def default_output_processor(
         return output
 
     local_vars = {"df": df}
-    global_vars = {"np":np, "pd":pd}
+    global_vars = {"np": np, "pd": pd}
 
     output = parse_code_markdown(output, only_last=True)[0]
 

--- a/llama-index-core/llama_index/core/query_engine/pandas/output_parser.py
+++ b/llama-index-core/llama_index/core/query_engine/pandas/output_parser.py
@@ -30,6 +30,7 @@ def default_output_processor(
         return output
 
     local_vars = {"df": df}
+    global_vars = {"np":np, "pd":pd}
 
     output = parse_code_markdown(output, only_last=True)[0]
 
@@ -44,13 +45,13 @@ def default_output_processor(
         if module_end_str.strip("'\"") != module_end_str:
             # if there's leading/trailing quotes, then we need to eval
             # string to get the actual expression
-            module_end_str = safe_eval(module_end_str, {"np": np}, local_vars)
+            module_end_str = safe_eval(module_end_str, global_vars, local_vars)
         try:
             # str(pd.dataframe) will truncate output by display.max_colwidth
             # set width temporarily to extract more text
             if "max_colwidth" in output_kwargs:
                 pd.set_option("display.max_colwidth", output_kwargs["max_colwidth"])
-            output_str = str(safe_eval(module_end_str, {"np": np}, local_vars))
+            output_str = str(safe_eval(module_end_str, global_vars, local_vars))
             pd.reset_option("display.max_colwidth")
             return output_str
 


### PR DESCRIPTION
# Description

The PandasQueryEngine currently does not work if the LLM-generated query contains pandas functions, such as pd.to_datetime() or pd.get_dummies(). It throws a 'pd is not defined' error. It's a pretty small bug that is easily fixed by adding 'pd' as part of the global variables passed to safe_exec while running the default_output_processor.

I was able to create a new default_output_processor, pass that to PandasQueryEngine, and make it work just fine. There were no glaring issues that I could find. Please suggest any other unit tests/integration tests I could write for the default_output_processor function.

This is my first time contributing to llama-index. If there is anything that I have missed, my apologies, please let me know and I will do my best to add those as well.

Fixes #3241 and #12239 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
