### PR TITLE
Update pyproject.toml to address Issue #12215

### DIFF
--- a/llama-index-networks/pyproject.toml
+++ b/llama-index-networks/pyproject.toml
@@ -43,7 +43,6 @@ python-jose = "^3.3.0"
 uvicorn = {extras = ["standard"], version = "^0.27.1"}
 pydantic = {extras = ["dotenv"], version = "^2.6.1"}
 python-dotenv = "^1.0.1"
-asyncio = "^3.4.3"
 aiohttp = "^3.9.3"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

Remove unnecessary dependency on asyncio>3.4.3. Poetry file defines python >=3.8.1. asyncio is part of standard libraries from 3.7 onwards.

Dependency being removed as some versions of pip are installing the asyncio version 3.4.3 (2015)

Fixes #12215 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
