### PR TITLE
chore: llama-index-networks vbump

### DIFF
--- a/llama-index-networks/pyproject.toml
+++ b/llama-index-networks/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = [
 name = "llama-index-networks"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

- Should've bumped this version in #12245 but I forgot
- Bumps version (published offline)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No
