### PR TITLE
Remove unnecessary PyDrive dependency from Google Drive Reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-google/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [0.2.0] - 2024-03-26
+
+- Use separate arg for service account key file, don't conflate client secrets with service account key
+- Remove unused PyDrive dependency and code
+
 ## [0.1.5] - 2024-03-06
 
 - Add missing README.md for all readers folder lost during the last migration from llamahub

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -25,14 +25,14 @@ class GoogleDriveReader(BaseReader):
 
     def __init__(
         self,
-        client_secrets_path: str = "credentials.json",
-        authorized_user_creds_path: str = "token.json",
+        credentials_path: str = "credentials.json",
+        token_path: str = "token.json",
         service_account_key_path: str = "service_account_key.json",
     ) -> None:
         """Initialize with parameters."""
         self.service_account_key_path = service_account_key_path
-        self.client_secrets_path = client_secrets_path
-        self.authorized_user_creds_path = authorized_user_creds_path
+        self.credentials_path = credentials_path
+        self.token_path = token_path
 
         self._creds = None
 
@@ -67,10 +67,8 @@ class GoogleDriveReader(BaseReader):
         # First, we need the Google API credentials for the app
         creds = None
 
-        if Path(self.authorized_user_creds_path).exists():
-            creds = Credentials.from_authorized_user_file(
-                self.authorized_user_creds_path, SCOPES
-            )
+        if Path(self.token_path).exists():
+            creds = Credentials.from_authorized_user_file(self.token_path, SCOPES)
         elif Path(self.service_account_key_path).exists():
             return service_account.Credentials.from_service_account_file(
                 self.service_account_key_path, scopes=SCOPES
@@ -81,12 +79,12 @@ class GoogleDriveReader(BaseReader):
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())
             else:
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    self.client_secrets_path, SCOPES
+                flow = InstalledAppFlow.from_credentials_file(
+                    self.credentials_path, SCOPES
                 )
                 creds = flow.run_local_server(port=0)
             # Save the credentials for the next run
-            with open(self.authorized_user_creds_path, "w", encoding="utf-8") as token:
+            with open(self.token_path, "w", encoding="utf-8") as token:
                 token.write(creds.to_json())
 
         return creds

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -25,9 +25,9 @@ class GoogleDriveReader(BaseReader):
 
     def __init__(
         self,
-        service_account_key_path: str = "service_account_key.json",
         client_secrets_path: str = "credentials.json",
         authorized_user_creds_path: str = "token.json",
+        service_account_key_path: str = "service_account_key.json",
     ) -> None:
         """Initialize with parameters."""
         self.service_account_key_path = service_account_key_path

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -9,7 +9,6 @@ from typing import List, Optional, Tuple
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
-from pydrive.drive import GoogleDrive
 
 from llama_index.core.readers import SimpleDirectoryReader
 from llama_index.core.readers.base import BaseReader
@@ -26,17 +25,16 @@ class GoogleDriveReader(BaseReader):
 
     def __init__(
         self,
-        credentials_path: str = "credentials.json",
-        token_path: str = "token.json",
-        pydrive_creds_path: str = "creds.txt",
+        service_account_key_path: str = "service_account_key.json",
+        client_secrets_path: str = "credentials.json",
+        authorized_user_creds_path: str = "token.json",
     ) -> None:
         """Initialize with parameters."""
-        self.credentials_path = credentials_path
-        self.token_path = token_path
-        self.pydrive_creds_path = pydrive_creds_path
+        self.service_account_key_path = service_account_key_path
+        self.client_secrets_path = client_secrets_path
+        self.authorized_user_creds_path = authorized_user_creds_path
 
         self._creds = None
-        self._drive = None
 
         # Download Google Docs/Slides/Sheets as actual files
         # See https://developers.google.com/drive/v3/web/mime-types
@@ -57,34 +55,26 @@ class GoogleDriveReader(BaseReader):
             },
         }
 
-    def _get_credentials(self) -> Tuple[Credentials, GoogleDrive]:
+    def _get_credentials(self) -> Tuple[Credentials]:
         """Authenticate with Google and save credentials.
-        Download the credentials.json file with these instructions: https://developers.google.com/drive/api/v3/quickstart/python.
-            Copy credentials.json file and rename it to client_secrets.json file which will be used by pydrive for downloading files.
-            So, we need two files:
-                1. credentials.json
-                2. client_secrets.json
-            Both 1, 2 are essentially same but needed with two different names according to google-api-python-client, google-auth-httplib2, google-auth-oauthlib and pydrive libraries.
+        Download the service_account_key.json file with these instructions: https://cloud.google.com/iam/docs/keys-create-delete.
 
         Returns:
-            credentials, pydrive object.
+            credentials
         """
         from google_auth_oauthlib.flow import InstalledAppFlow
-        from pydrive.auth import GoogleAuth
 
         # First, we need the Google API credentials for the app
         creds = None
 
-        if Path(self.token_path).exists():
-            creds = Credentials.from_authorized_user_file(self.token_path, SCOPES)
-        elif Path(self.credentials_path).exists():
-            creds = service_account.Credentials.from_service_account_file(
-                self.credentials_path, scopes=SCOPES
+        if Path(self.authorized_user_creds_path).exists():
+            creds = Credentials.from_authorized_user_file(
+                self.authorized_user_creds_path, SCOPES
             )
-            gauth = GoogleAuth()
-            gauth.credentials = creds
-            drive = GoogleDrive(gauth)
-            return creds, drive
+        elif Path(self.service_account_key_path).exists():
+            return service_account.Credentials.from_service_account_file(
+                self.service_account_key_path, scopes=SCOPES
+            )
 
         # If there are no (valid) credentials available, let the user log in.
         if not creds or not creds.valid:
@@ -92,33 +82,14 @@ class GoogleDriveReader(BaseReader):
                 creds.refresh(Request())
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(
-                    self.credentials_path, SCOPES
+                    self.client_secrets_path, SCOPES
                 )
                 creds = flow.run_local_server(port=0)
             # Save the credentials for the next run
-            with open(self.token_path, "w", encoding="utf-8") as token:
+            with open(self.authorized_user_creds_path, "w", encoding="utf-8") as token:
                 token.write(creds.to_json())
 
-        # Next, we need user authentication to download files (via pydrive)
-        # Uses client_secrets.json file for authorization.
-        gauth = GoogleAuth()
-        # Try to load saved client credentials
-        gauth.LoadCredentialsFile(self.pydrive_creds_path)
-        if gauth.credentials is None:
-            # Authenticate if they're not there
-            gauth.LocalWebserverAuth()
-        elif gauth.access_token_expired:
-            # Refresh them if expired
-            gauth.Refresh()
-        else:
-            # Initialize the saved creds
-            gauth.Authorize()
-        # Save the current credentials to a file so user doesn't have to auth every time
-        gauth.SaveCredentialsFile(self.pydrive_creds_path)
-
-        drive = GoogleDrive(gauth)
-
-        return creds, drive
+        return creds
 
     def _get_fileids_meta(
         self,
@@ -414,7 +385,7 @@ class GoogleDriveReader(BaseReader):
         Returns:
             List[Document]: A list of documents.
         """
-        self._creds, self._drive = self._get_credentials()
+        self._creds = self._get_credentials()
 
         if folder_id:
             return self._load_from_folder(folder_id, mime_types, query_string)

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -45,7 +45,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.1.7"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
Remove unnecessary PyDrive dependency and fix incorrect usage of client secrets argument as the service account key.

# Description

This was using the `credentials_path` argument to refer to both service account keys and client secrets. Create two separate arguments for each of these.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
