### PR TITLE
add raise_on_error flag for SimpleDirectoryReader

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -420,7 +420,7 @@ class SimpleDirectoryReader(BaseReader):
                 raise ImportError(str(e))
             except Exception as e:
                 if raise_on_error:
-                    raise
+                    raise Exception("Error loading file") from e
                 # otherwise, just skip the file and report the error
                 print(
                     f"Failed to load file {input_file} with error: {e}. Skipping...",

--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -165,6 +165,7 @@ class SimpleDirectoryReader(BaseReader):
         file_metadata (Optional[Callable[str, Dict]]): A function that takes
             in a filename and returns a Dict of metadata for the Document.
             Default is None.
+        raise_on_error (bool): Whether to raise an error if a file cannot be read.
         fs (Optional[fsspec.AbstractFileSystem]): File system to use. Defaults
         to using the local file system. Can be changed to use any remote file system
         exposed via the fsspec interface.
@@ -186,6 +187,7 @@ class SimpleDirectoryReader(BaseReader):
         file_extractor: Optional[Dict[str, BaseReader]] = None,
         num_files_limit: Optional[int] = None,
         file_metadata: Optional[Callable[[str], Dict]] = None,
+        raise_on_error: bool = False,
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Initialize with parameters."""
@@ -203,6 +205,7 @@ class SimpleDirectoryReader(BaseReader):
         self.exclude_hidden = exclude_hidden
         self.required_exts = required_exts
         self.num_files_limit = num_files_limit
+        self.raise_on_error = raise_on_error
         _Path = Path if is_default_fs(self.fs) else PurePosixPath
 
         if input_files:
@@ -353,6 +356,7 @@ class SimpleDirectoryReader(BaseReader):
         filename_as_id: bool = False,
         encoding: str = "utf-8",
         errors: str = "ignore",
+        raise_on_error: bool = False,
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> List[Document]:
         """Static method for loading file.
@@ -379,6 +383,7 @@ class SimpleDirectoryReader(BaseReader):
             Default is utf-8.
         errors (str): how encoding and decoding errors are to be handled,
               see https://docs.python.org/3/library/functions.html#open
+        raise_on_error (bool): Whether to raise an error if a file cannot be read.
         fs (Optional[fsspec.AbstractFileSystem]): File system to use. Defaults
             to using the local file system. Can be changed to use any remote file system
 
@@ -414,6 +419,8 @@ class SimpleDirectoryReader(BaseReader):
                 # about missing dependencies
                 raise ImportError(str(e))
             except Exception as e:
+                if raise_on_error:
+                    raise
                 # otherwise, just skip the file and report the error
                 print(
                     f"Failed to load file {input_file} with error: {e}. Skipping...",
@@ -475,6 +482,8 @@ class SimpleDirectoryReader(BaseReader):
                 # about missing dependencies
                 raise ImportError(str(e))
             except Exception as e:
+                if self.raise_on_error:
+                    raise
                 # otherwise, just skip the file and report the error
                 print(
                     f"Failed to load file {input_file} with error: {e}. Skipping...",

--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -549,6 +549,7 @@ class SimpleDirectoryReader(BaseReader):
                         repeat(self.filename_as_id),
                         repeat(self.encoding),
                         repeat(self.errors),
+                        repeat(self.raise_on_error),
                         repeat(fs),
                     ),
                 )
@@ -568,6 +569,7 @@ class SimpleDirectoryReader(BaseReader):
                         filename_as_id=self.filename_as_id,
                         encoding=self.encoding,
                         errors=self.errors,
+                        raise_on_error=self.raise_on_error,
                         fs=fs,
                     )
                 )
@@ -632,6 +634,7 @@ class SimpleDirectoryReader(BaseReader):
                 filename_as_id=self.filename_as_id,
                 encoding=self.encoding,
                 errors=self.errors,
+                raise_on_error=self.raise_on_error,
                 fs=self.fs,
             )
 


### PR DESCRIPTION
# Description

Adding a flag to optionally raise the error if `SimpleDirectoryReader` fails to load any individual file.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
