### PR TITLE
Fix download_llama_dataset and download_llama_pack

### DIFF
--- a/llama-index-core/llama_index/core/download/utils.py
+++ b/llama-index-core/llama_index/core/download/utils.py
@@ -90,7 +90,9 @@ def initialize_directory(
 
 def get_source_files_list(source_tree_url: str, path: str) -> List[str]:
     """Get the list of source files to download."""
-    resp = requests.get(source_tree_url + path + "?recursive=1")
+    resp = requests.get(
+        source_tree_url + path + "?recursive=1", headers={"Accept": "application/json"}
+    )
     payload = resp.json()["payload"]
     return [item["name"] for item in payload["tree"]["items"]]
 
@@ -105,7 +107,7 @@ def recursive_tree_traverse(
         url = tree_urls[0]
 
         try:
-            res = requests.get(url)
+            res = requests.get(url, headers={"Accept": "application/json"})
             tree_elements = res.json()["payload"]["tree"]["items"]
         except Exception:
             raise ValueError("Failed to traverse github tree source.")

--- a/llama-index-legacy/llama_index/legacy/download/dataset.py
+++ b/llama-index-legacy/llama_index/legacy/download/dataset.py
@@ -47,7 +47,9 @@ def _resolve_dataset_file_name(class_name: str) -> str:
 
 def _get_source_files_list(source_tree_url: str, path: str) -> List[str]:
     """Get the list of source files to download."""
-    resp = requests.get(source_tree_url + path + "?recursive=1")
+    resp = requests.get(
+        source_tree_url + path + "?recursive=1", headers={"Accept": "application/json"}
+    )
     payload = resp.json()["payload"]
     return [item["name"] for item in payload["tree"]["items"]]
 


### PR DESCRIPTION
# Description

The downloading of datasets and packs doesn't work anymore.
It seems there was a change in the GitHub (undocumented) API used and now if the Accept header is not provided, the content type of the response is HTML and not JSON.
This fails:
```python
download_llama_dataset("PaulGrahamEssayDataset", "./data")
```
This also fails:
```python
download_llama_pack("RagEvaluatorPack", "./pack")
```

This fix adds an Accept header so the HTTP call returns JSON.

Fix #12274

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
