### PR TITLE
fix(core): delete the metadata with the wrong key when delete ref doc…

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -477,8 +477,8 @@ class KVDocumentStore(BaseDocumentStore):
 
         for doc_id in ref_doc_info.node_ids:
             self.delete_document(doc_id, raise_error=False, remove_ref_doc_node=False)
+            self._kvstore.delete(doc_id, collection=self._metadata_collection)
 
-        self._kvstore.delete(ref_doc_id, collection=self._metadata_collection)
         self._kvstore.delete(ref_doc_id, collection=self._ref_doc_collection)
 
     async def adelete_ref_doc(self, ref_doc_id: str, raise_error: bool = True) -> None:
@@ -494,8 +494,8 @@ class KVDocumentStore(BaseDocumentStore):
             await self.adelete_document(
                 doc_id, raise_error=False, remove_ref_doc_node=False
             )
+            await self._kvstore.adelete(doc_id, collection=self._metadata_collection)
 
-        await self._kvstore.adelete(ref_doc_id, collection=self._metadata_collection)
         await self._kvstore.adelete(ref_doc_id, collection=self._ref_doc_collection)
 
     def set_document_hash(self, doc_id: str, doc_hash: str) -> None:


### PR DESCRIPTION
Delete ref doc issue in KVDocumentStore

# Description

I'm using the MongoDB as the index store, doc store and I observed the _id store in the metadata collection is the doc_id not the doc ref info id.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
