### PR TITLE
[`integration`] Modernize `HuggingFaceEmbedding`; support for more models; correct model length

### DIFF
--- a/docs/docs/examples/embeddings/huggingface.ipynb
+++ b/docs/docs/examples/embeddings/huggingface.ipynb
@@ -25,13 +25,11 @@
    "source": [
     "## HuggingFaceEmbedding\n",
     "\n",
-    "The base `HuggingFaceEmbedding` class is a generic wrapper around any HuggingFace model for embeddings. You can set either `pooling=\"cls\"` or `pooling=\"mean\"` -- in most cases, you'll want `cls` pooling. But the model card for your particular model may have other recommendations.\n",
+    "The base `HuggingFaceEmbedding` class is a generic wrapper around any HuggingFace model for embeddings. All [embedding models](https://huggingface.co/models?library=sentence-transformers) on Hugging Face should work. You can refer to the [embeddings leaderboard](https://huggingface.co/spaces/mteb/leaderboard) for more recommendations.\n",
     "\n",
-    "You can refer to the [embeddings leaderboard](https://huggingface.co/spaces/mteb/leaderboard) for more recommendations on embedding models.\n",
+    "This class depends on the sentence-transformers package, which you can install with `pip install sentence-transformers`.\n",
     "\n",
-    "This class depends on the transformers package, which you can install with `pip install transformers`.\n",
-    "\n",
-    "NOTE: if you were previously using a `HuggingFaceEmbeddings` from LangChain, this should give equivilant results."
+    "NOTE: if you were previously using a `HuggingFaceEmbeddings` from LangChain, this should give equivalent results."
    ]
   },
   {
@@ -114,7 +112,7 @@
     "\n",
     "Instructor Embeddings are a class of embeddings specifically trained to augment their embeddings according to an instruction. By default, queries are given `query_instruction=\"Represent the question for retrieving supporting documents: \"` and text is given `text_instruction=\"Represent the document for retrieval: \"`.\n",
     "\n",
-    "They rely on the `Instructor` and `SentenceTransformers` pip package, which you can install with `pip install InstructorEmbedding` and `pip install -U sentence-transformers`."
+    "They rely on the `Instructor` and `SentenceTransformers` (version 2.2.2) pip package, which you can install with `pip install InstructorEmbedding` and `pip install -U sentence-transformers==2.2.2`."
    ]
   },
   {

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from huggingface_hub import (
     AsyncInferenceClient,
@@ -15,28 +15,25 @@ from llama_index.core.base.embeddings.base import (
 )
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
-from llama_index.core.utils import get_cache_dir, infer_torch_device
 from llama_index.embeddings.huggingface.pooling import Pooling
+from llama_index.core.utils import get_cache_dir, infer_torch_device
 from llama_index.embeddings.huggingface.utils import (
     DEFAULT_HUGGINGFACE_EMBEDDING_MODEL,
     format_query,
     format_text,
+    get_query_instruct_for_model_name,
+    get_text_instruct_for_model_name,
 )
-from transformers import AutoModel, AutoTokenizer
-
-if TYPE_CHECKING:
-    import torch
+from sentence_transformers import SentenceTransformer
 
 DEFAULT_HUGGINGFACE_LENGTH = 512
 logger = logging.getLogger(__name__)
 
 
 class HuggingFaceEmbedding(BaseEmbedding):
-    tokenizer_name: str = Field(description="Tokenizer name from HuggingFace.")
     max_length: int = Field(
         default=DEFAULT_HUGGINGFACE_LENGTH, description="Maximum length of input.", gt=0
     )
-    pooling: Pooling = Field(default=Pooling.CLS, description="Pooling strategy.")
     normalize: bool = Field(default=True, description="Normalize embeddings or not.")
     query_instruction: Optional[str] = Field(
         description="Instruction to prepend to query text."
@@ -45,84 +42,70 @@ class HuggingFaceEmbedding(BaseEmbedding):
         description="Instruction to prepend to text."
     )
     cache_folder: Optional[str] = Field(
-        description="Cache folder for huggingface files."
+        description="Cache folder for Hugging Face files."
     )
 
     _model: Any = PrivateAttr()
-    _tokenizer: Any = PrivateAttr()
     _device: str = PrivateAttr()
 
     def __init__(
         self,
-        model_name: Optional[str] = None,
-        tokenizer_name: Optional[str] = None,
-        pooling: Union[str, Pooling] = "cls",
+        model_name: str = DEFAULT_HUGGINGFACE_EMBEDDING_MODEL,
+        tokenizer_name: Optional[str] = "deprecated",
+        pooling: str = "deprecated",
         max_length: Optional[int] = None,
         query_instruction: Optional[str] = None,
         text_instruction: Optional[str] = None,
         normalize: bool = True,
-        model: Optional[Any] = None,
-        tokenizer: Optional[Any] = None,
+        model: Optional[Any] = "deprecated",
+        tokenizer: Optional[Any] = "deprecated",
         embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
         cache_folder: Optional[str] = None,
         trust_remote_code: bool = False,
         device: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
+        **model_kwargs,
     ):
         self._device = device or infer_torch_device()
 
         cache_folder = cache_folder or get_cache_dir()
 
-        if model is None:  # Use model_name with AutoModel
-            model_name = (
-                model_name
-                if model_name is not None
-                else DEFAULT_HUGGINGFACE_EMBEDDING_MODEL
-            )
-            model = AutoModel.from_pretrained(
-                model_name,
-                cache_dir=cache_folder,
-                trust_remote_code=trust_remote_code,
-            )
-        elif model_name is None:  # Extract model_name from model
-            model_name = model.name_or_path
-        self._model = model.to(self._device)
-
-        if tokenizer is None:  # Use tokenizer_name with AutoTokenizer
-            tokenizer_name = (
-                model_name or tokenizer_name or DEFAULT_HUGGINGFACE_EMBEDDING_MODEL
-            )
-            tokenizer = AutoTokenizer.from_pretrained(
-                tokenizer_name, cache_dir=cache_folder
-            )
-        elif tokenizer_name is None:  # Extract tokenizer_name from model
-            tokenizer_name = tokenizer.name_or_path
-        self._tokenizer = tokenizer
-
-        if max_length is None:
-            try:
-                max_length = int(self._model.config.max_position_embeddings)
-            except AttributeError as exc:
+        for variable, value in [
+            ("model", model),
+            ("tokenizer", tokenizer),
+            ("pooling", pooling),
+            ("tokenizer_name", tokenizer_name),
+        ]:
+            if value != "deprecated":
                 raise ValueError(
-                    "Unable to find max_length from model config. Please specify max_length."
-                ) from exc
+                    f"{variable} is deprecated. Please remove it from the arguments."
+                )
+        if model_name is None:
+            raise ValueError("The `model_name` argument must be provided.")
 
-        if isinstance(pooling, str):
-            try:
-                pooling = Pooling(pooling)
-            except ValueError as exc:
-                raise NotImplementedError(
-                    f"Pooling {pooling} unsupported, please pick one in"
-                    f" {[p.value for p in Pooling]}."
-                ) from exc
+        self._model = SentenceTransformer(
+            model_name,
+            device=self._device,
+            cache_folder=cache_folder,
+            trust_remote_code=trust_remote_code,
+            prompts={
+                "query": query_instruction
+                or get_query_instruct_for_model_name(model_name),
+                "text": text_instruction
+                or get_text_instruct_for_model_name(model_name),
+            },
+            **model_kwargs,
+        )
+        if max_length:
+            self._model.max_seq_length = max_length
+        else:
+            max_length = self._model.max_seq_length
 
         super().__init__(
             embed_batch_size=embed_batch_size,
             callback_manager=callback_manager,
             model_name=model_name,
-            tokenizer_name=tokenizer_name,
             max_length=max_length,
-            pooling=pooling,
             normalize=normalize,
             query_instruction=query_instruction,
             text_instruction=text_instruction,
@@ -132,58 +115,23 @@ class HuggingFaceEmbedding(BaseEmbedding):
     def class_name(cls) -> str:
         return "HuggingFaceEmbedding"
 
-    def _mean_pooling(
-        self, token_embeddings: "torch.Tensor", attention_mask: "torch.Tensor"
-    ) -> "torch.Tensor":
-        """Mean Pooling - Take attention mask into account for correct averaging."""
-        input_mask_expanded = (
-            attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-        )
-        numerator = (token_embeddings * input_mask_expanded).sum(1)
-        return numerator / input_mask_expanded.sum(1).clamp(min=1e-9)
-
-    def _embed(self, sentences: List[str]) -> List[List[float]]:
+    def _embed(
+        self,
+        sentences: List[str],
+        batch_size: int = 32,
+        prompt_name: Optional[str] = None,
+    ) -> List[List[float]]:
         """Embed sentences."""
-        encoded_input = self._tokenizer(
+        return self._model.encode(
             sentences,
-            padding=True,
-            max_length=self.max_length,
-            truncation=True,
-            return_tensors="pt",
-        )
-
-        # pop token_type_ids
-        encoded_input.pop("token_type_ids", None)
-
-        # move tokenizer inputs to device
-        encoded_input = {
-            key: val.to(self._device) for key, val in encoded_input.items()
-        }
-
-        model_output = self._model(**encoded_input)
-
-        context_layer: "torch.Tensor" = model_output[0]
-        if self.pooling == Pooling.CLS:
-            embeddings = self.pooling.cls_pooling(context_layer)
-        elif self.pooling == Pooling.LAST:
-            embeddings = self.pooling.last_pooling(context_layer)
-        else:
-            embeddings = self._mean_pooling(
-                token_embeddings=context_layer,
-                attention_mask=encoded_input["attention_mask"],
-            )
-
-        if self.normalize:
-            import torch
-
-            embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
-
-        return embeddings.tolist()
+            batch_size=batch_size,
+            prompt_name=prompt_name,
+            normalize_embeddings=self.normalize,
+        ).tolist()
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
-        query = format_query(query, self.model_name, self.query_instruction)
-        return self._embed([query])[0]
+        return self._embed(query, prompt_name="query")
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
         """Get query embedding async."""
@@ -195,15 +143,11 @@ class HuggingFaceEmbedding(BaseEmbedding):
 
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
-        text = format_text(text, self.model_name, self.text_instruction)
-        return self._embed([text])[0]
+        return self._embed(text, prompt_name="text")
 
     def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Get text embeddings."""
-        texts = [
-            format_text(text, self.model_name, self.text_instruction) for text in texts
-        ]
-        return self._embed(texts)
+        return self._embed(texts, batch_size=len(texts), prompt_name="text")
 
 
 class HuggingFaceInferenceAPIEmbedding(BaseEmbedding):  # type: ignore[misc]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
@@ -118,13 +118,12 @@ class HuggingFaceEmbedding(BaseEmbedding):
     def _embed(
         self,
         sentences: List[str],
-        batch_size: int = 32,
         prompt_name: Optional[str] = None,
     ) -> List[List[float]]:
         """Embed sentences."""
         return self._model.encode(
             sentences,
-            batch_size=batch_size,
+            batch_size=self.embed_batch_size,
             prompt_name=prompt_name,
             normalize_embeddings=self.normalize,
         ).tolist()
@@ -147,7 +146,7 @@ class HuggingFaceEmbedding(BaseEmbedding):
 
     def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Get text embeddings."""
-        return self._embed(texts, batch_size=len(texts), prompt_name="text")
+        return self._embed(texts, prompt_name="text")
 
 
 class HuggingFaceInferenceAPIEmbedding(BaseEmbedding):  # type: ignore[misc]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py
@@ -68,7 +68,6 @@ class HuggingFaceEmbedding(BaseEmbedding):
         trust_remote_code: bool = False,
         device: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
-        safe_serialization: Optional[bool] = None,
     ):
         self._device = device or infer_torch_device()
 
@@ -84,7 +83,6 @@ class HuggingFaceEmbedding(BaseEmbedding):
                 model_name,
                 cache_dir=cache_folder,
                 trust_remote_code=trust_remote_code,
-                safe_serialization=safe_serialization,
             )
         elif model_name is None:  # Extract model_name from model
             model_name = model.name_or_path

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
@@ -33,8 +33,7 @@ version = "0.1.4"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-transformers = "^4.37.0"
-torch = "^2.1.2"
+sentence-transformers = "^2.6.1"
 
 [tool.poetry.dependencies.huggingface-hub]
 extras = ["inference"]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-huggingface"
 readme = "README.md"
-version = "0.1.5"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Hello!

## Pull Request overview
* Modernize `HuggingFaceEmbedding` by relying on [Sentence Transformers](https://sbert.net/) directly.
  * Heavily simplify the code; easier maintenance & better support for new architectures.
* Revert `safe_serialization` loading; this crashed when loading a model, e.g. `bge-small-en-v1.5`.

## Motivation
It may not be immediately apparent, but Sentence Transformers is being maintained by Hugging Face nowadays. In the last months, the project has modernized a lot, allowing for more convenient use (e.g. prompt support, `trust_remote_code`)). Additionally, using Sentence Transformers directly supports a lot more models out of the box, e.g.:
* Models with Dense layers, e.g. https://huggingface.co/aspire/acge_text_embedding and https://huggingface.co/infgrad/stella-mrl-large-zh-v3.5-1792d, the nr. 1 and nr. 3 models on Chinese [MTEB](https://huggingface.co/spaces/mteb/leaderboard).
* More pooling support, e.g. https://huggingface.co/Muennighoff/SGPT-5.8B-weightedmean-msmarco-specb-bitfit with weighted mean pooling.
* Direct support for the main INSTRUCTOR models (instructor-base, instructor-xl, instructor-large).

Additionally, there were some issues with the existing implementation:
* `safe_serialization` loading via #11939 causes crashes when loading a normal model, e.g. `bge-small-en-v1.5`.
* Sentence Transformer models prioritize this [max_seq_length](https://huggingface.co/sentence-transformers/all-mpnet-base-v2/blob/main/sentence_bert_config.json#L2) over the [max_position_embeddings](https://huggingface.co/sentence-transformers/all-mpnet-base-v2/blob/main/config.json#L15) in the config. This resulted in decreased embedding performance for models where `max_seq_length < max_position_embeddings`.

This implementation allows for easier embedding-related extensions in the future, such as the recent [embedding quantization from v2.6.0](https://github.com/UKPLab/sentence-transformers/releases/tag/v2.6.0). Lastly, it also should be easier to maintain, e.g. no more issues like #12255 from 30 minutes ago.

## PR Details
The implementation is quite simple; primarily because Sentence Transformers effectively abstracts away everything (and much more) that the existing implementation had to do explicitly. However, I will also introduce a handful of breaking changes in the first version of this PR through 4 hard deprecations: the `model`, `tokenizer`, `tokenizer_name`, `pooling` arguments. Personally, I believe that these parameters do not provide any value to LlamaIndex nor its users: specifying a `tokenizer` or its name can only result in accidental mismatches of tokenizer & model, and `pooling` can safely be read from the original configuration options for the embedding model. Only for `model` can I understand that users might benefit from it. 

See Question 2 below to help me figure out what's best.

## Usage

You can use this just like you've always done:
```python
from llama_index.embeddings.huggingface import HuggingFaceEmbedding

# loads BAAI/bge-small-en
# embed_model = HuggingFaceEmbedding()

# loads BAAI/bge-small-en-v1.5
embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-small-en-v1.5")
embeddings = embed_model.get_text_embedding("Hello World!")
print(len(embeddings))
print(embeddings[:5])
```
gives
```python
384
[-0.003275684081017971, -0.011690713465213776, 0.04155922308564186, -0.038148097693920135, 0.02418312057852745]
```
This is identical to `main` (except that `main` currently crashes due to #11939).

Additionally, you can provide `query_instruction` and `text_instruction` like normal:
```python
embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-small-en-v1.5", query_instruction="Represent the query as a text sequence for retrieval: ")
embeddings = embed_model.get_query_embedding("Hello World!")
print(len(embeddings))
print(embeddings[:5])
```
```python
384
[-0.0615423358976841, 0.027312589809298515, -0.032427869737148285, 0.003495826618745923, -0.014261390082538128]
```

## TODO's & Questions
1. Should I add integration tests for this? Normally I would, but I see that most of the embedding-related integrations don't have those kind of tests already, so perhaps you don't want them (e.g. due to how they can be slow)?
2. The PR as I originally created it introduces breaking changes as it deprecates 4 arguments: `model`, `tokenizer`, `tokenizer_name`, `pooling`. I believe that these primarily do not add any value, but if you would like to avoid breaking changes, then we could try and implement some hacks to avoid all breaking changes. However, this might also introduce more maintenance cost for you. Please let me know what you think is best.
3. Should I bump the `llama-index-embeddings-huggingface` version?

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods

---

- Tom Aarsen