### PR TITLE
stricter access to builting in pandas query engine

### DIFF
--- a/llama-index-core/llama_index/core/exec_utils.py
+++ b/llama-index-core/llama_index/core/exec_utils.py
@@ -91,17 +91,22 @@ class DunderVisitor(ast.NodeVisitor):
         self.has_access_to_private_entity = False
         self.has_access_to_disallowed_builtin = False
 
+        builtins = globals()["__builtins__"].keys()
+        self._builtins = builtins
+
     def visit_Name(self, node: ast.Name) -> None:
+        print(node.id)
         if node.id.startswith("_"):
             self.has_access_to_private_entity = True
-        if node.id not in ALLOWED_BUILTINS:
+        if node.id not in ALLOWED_BUILTINS and node.id in self._builtins:
             self.has_access_to_disallowed_builtin = True
         self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
+        print(node.attr)
         if node.attr.startswith("_"):
             self.has_access_to_private_entity = True
-        if node.attr not in ALLOWED_BUILTINS:
+        if node.attr not in ALLOWED_BUILTINS and node.attr in self._builtins:
             self.has_access_to_disallowed_builtin = True
         self.generic_visit(node)
 

--- a/llama-index-core/tests/query_engine/test_pandas.py
+++ b/llama-index-core/tests/query_engine/test_pandas.py
@@ -111,7 +111,7 @@ def test_default_output_processor_rce2() -> None:
     output = parser.parse(injected_code)
 
     assert (
-        "Execution of code containing references to private or dunder methods is forbidden!"
+        "Execution of code containing references to private or dunder methods, or disallowed builtins, is forbidden!"
         in output
     ), "Injected code executed successfully!"
 
@@ -152,7 +152,7 @@ def test_default_output_processor_e2e(tmp_path: Path) -> None:
     assert isinstance(response, Response)
     # raw df should be equal to slice of dataframe that's just population at location 2
     rmetadata = cast(Dict[str, Any], response.metadata)
-    assert rmetadata["raw_pandas_output"] == str(df["population"].iloc[2:3])
+    assert rmetadata["raw_pandas_output"] == str(df["population"].iloc[2])
 
     # attack 1: fail!
     print("[+] Attack 1 starts, it should fail!")

--- a/llama-index-core/tests/query_engine/test_pandas.py
+++ b/llama-index-core/tests/query_engine/test_pandas.py
@@ -111,8 +111,7 @@ def test_default_output_processor_rce2() -> None:
     output = parser.parse(injected_code)
 
     assert (
-        "Execution of code containing references to private or dunder methods, or disallowed builtins, is forbidden!"
-        in output
+        "Execution of code containing references to private or dunder methods" in output
     ), "Injected code executed successfully!"
 
 


### PR DESCRIPTION
We should not execute code using several builtins, this PR restricts it further