### PR TITLE
Upgrade Llama Cohere client dependencies to version ^5.1.1 and Llama Cohere LLM updates

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
@@ -119,7 +119,7 @@ class CohereRerankRelevancyMetric(BaseRetrievalMetric):
             query=query,
             documents=retrieved_texts,
         )
-        relevance_scores = [r.relevance_score for r in results]
+        relevance_scores = [r.relevance_score for r in results.results]
         agg_func = self._get_agg_func(agg)
 
         return RetrievalMetricResult(

--- a/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-cohere"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.4"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-cohere = ">=4.44"
+cohere = "^5.1.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -68,7 +68,7 @@ class CohereRerank(BaseNodePostprocessor):
             )
 
             new_nodes = []
-            for result in results:
+            for result in results.results:
                 new_node_with_score = NodeWithScore(
                     node=nodes[result.index].node, score=result.relevance_score
                 )

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-postprocessor-cohere-rerank"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.3"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-cohere = "^5.0.2"
+cohere = "^5.1.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.3"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-cohere = ">=4.45"
+cohere = "^5.0.2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
Upgrade Cohere client dependencies to the ^5.1.1 and Cohere LLM upgrade

# Description

This PR upgrades the Cohere LLM and its dependencies to utilize Cohere SDK version ^5.1.1
It requires upgrading the Cohere SDK to version ^5.1.1.

## New Package?

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
   It requires upgrading the Cohere SDK to version ^5.1.1.


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I tested it locally
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods
