### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 dev_notebooks/
 llamaindex_registry.txt
 packages_to_bump_deduped.txt
+.env


### PR DESCRIPTION
Using .env to set API Keys when running Jupyter notebooks in VS Code