### PR TITLE
[ReAct][Robustness++] When LLM failed to follow the response template, tell it so

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/base.py
+++ b/llama-index-core/llama_index/core/agent/react/base.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Sequence,
     Type,
+    Callable,
 )
 
 from llama_index.core.agent.react.formatter import ReActChatFormatter
@@ -29,7 +30,7 @@ from llama_index.core.memory.chat_memory_buffer import ChatMemoryBuffer
 from llama_index.core.memory.types import BaseMemory
 from llama_index.core.objects.base import ObjectRetriever
 from llama_index.core.settings import Settings
-from llama_index.core.tools import BaseTool
+from llama_index.core.tools import BaseTool, ToolOutput
 from llama_index.core.prompts.mixin import PromptMixinType
 
 
@@ -57,7 +58,9 @@ class ReActAgent(AgentRunner):
         verbose: bool = False,
         tool_retriever: Optional[ObjectRetriever[BaseTool]] = None,
         context: Optional[str] = None,
-        complaint_when_no_reasoning_step: str = "",
+        handle_reasoning_failure_fn: Optional[
+            Callable[[CallbackManager, Exception], ToolOutput]
+        ] = None,
     ) -> None:
         """Init params."""
         callback_manager = callback_manager or llm.callback_manager
@@ -75,7 +78,7 @@ class ReActAgent(AgentRunner):
             output_parser=output_parser,
             callback_manager=callback_manager,
             verbose=verbose,
-            complaint_when_no_reasoning_step=complaint_when_no_reasoning_step,
+            handle_reasoning_failure_fn=handle_reasoning_failure_fn,
         )
         super().__init__(
             step_engine,
@@ -99,7 +102,9 @@ class ReActAgent(AgentRunner):
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
         context: Optional[str] = None,
-        complaint_when_no_reasoning_step: str = "",
+        handle_reasoning_failure_fn: Optional[
+            Callable[[CallbackManager, Exception], ToolOutput]
+        ] = None,
         **kwargs: Any,
     ) -> "ReActAgent":
         """Convenience constructor method from set of BaseTools (Optional).
@@ -109,10 +114,10 @@ class ReActAgent(AgentRunner):
         or BaseRetriever should have picked up off their respective kwargs in their
         constructions.
 
-        If `complaint_when_no_reasoning_step` is provided, when LLM fails to follow the response templates specified in
-        the System Prompt, this message will be sent to the Agent, so that the Agent can have a second chance to fix
-        its mistakes. If this parameter is not given, a `ValueError` will be raised whenever we can't parse the output
-        from LLM, and you'll have to handle the exception yourself somewhere else.
+        If `handle_reasoning_failure_fn` is provided, when LLM fails to follow the response templates specified in
+        the System Prompt, this function will be called. This function should provide to the Agent, so that the Agent
+        can have a second chance to fix its mistakes.
+        To handle the exception yourself, you can provide a function that raises the `Exception`.
 
         Note: If you modified any response template in the System Prompt, you should override the method
         `_extract_reasoning_step` in `ReActAgentWorker`.
@@ -137,7 +142,7 @@ class ReActAgent(AgentRunner):
             callback_manager=callback_manager,
             verbose=verbose,
             context=context,
-            complaint_when_no_reasoning_step=complaint_when_no_reasoning_step,
+            handle_reasoning_failure_fn=handle_reasoning_failure_fn,
         )
 
     def _get_prompt_modules(self) -> PromptMixinType:

--- a/llama-index-core/tests/agent/react/test_react_agent.py
+++ b/llama-index-core/tests/agent/react/test_react_agent.py
@@ -305,6 +305,27 @@ def _get_observations(task: Task) -> List[str]:
     return [s.observation for s in obs_steps]
 
 
+def test_complaint_when_no_reasoning_step():
+    message = (
+        "You didn't follow the format I specified in the System Prompt. Try again."
+    )
+    runner = ReActAgent.from_tools(
+        tools=[],
+        llm=MockLLM(),
+        complaint_when_no_reasoning_step=message,
+    )
+    task = runner.create_task("lorem")
+    chat_response = ChatResponse(
+        message=ChatMessage(
+            content="Thought: ipsum\nAction: dolor", role=MessageRole.ASSISTANT
+        )
+    )
+    current_reasoning, is_done = runner.agent_worker._process_actions(
+        task, tools=[], output=chat_response
+    )
+    assert current_reasoning[0].get_content() == "Observation: " + message
+
+
 def test_add_step(
     add_tool: FunctionTool,
 ) -> None:

--- a/llama-index-core/tests/agent/react/test_react_agent.py
+++ b/llama-index-core/tests/agent/react/test_react_agent.py
@@ -306,13 +306,9 @@ def _get_observations(task: Task) -> List[str]:
 
 
 def test_complaint_when_no_reasoning_step():
-    message = (
-        "You didn't follow the format I specified in the System Prompt. Try again."
-    )
     runner = ReActAgent.from_tools(
         tools=[],
         llm=MockLLM(),
-        complaint_when_no_reasoning_step=message,
     )
     task = runner.create_task("lorem")
     chat_response = ChatResponse(
@@ -323,7 +319,10 @@ def test_complaint_when_no_reasoning_step():
     current_reasoning, is_done = runner.agent_worker._process_actions(
         task, tools=[], output=chat_response
     )
-    assert current_reasoning[0].get_content() == "Observation: " + message
+    assert (
+        current_reasoning[0].get_content()
+        == "Observation: Error: Could not parse output. Please follow the thought-action-input format. Try again."
+    )
 
 
 def test_add_step(


### PR DESCRIPTION
# Description
... so that it can take a 2nd chance to fix it.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
