### PR TITLE
Fix access of ChatCompletionMessageToolCall fields

### DIFF
--- a/docs/docs/examples/agent/openai_agent.ipynb
+++ b/docs/docs/examples/agent/openai_agent.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index"
+    "!pip install llama-index"
    ]
   },
   {
@@ -91,6 +91,7 @@
     "from llama_index.llms.openai import OpenAI\n",
     "from llama_index.core.llms import ChatMessage\n",
     "from llama_index.core.tools import BaseTool, FunctionTool\n",
+    "from openai.types.chat import ChatCompletionMessageToolCall\n",
     "\n",
     "import nest_asyncio\n",
     "\n",
@@ -190,7 +191,7 @@
     "        additional_kwargs = ai_message.additional_kwargs\n",
     "        chat_history.append(ai_message)\n",
     "\n",
-    "        tool_calls = ai_message.additional_kwargs.get(\"tool_calls\", None)\n",
+    "        tool_calls = additional_kwargs.get(\"tool_calls\", None)\n",
     "        # parallel function calling is now supported\n",
     "        if tool_calls is not None:\n",
     "            for tool_call in tool_calls:\n",
@@ -201,18 +202,20 @@
     "\n",
     "        return ai_message.content\n",
     "\n",
-    "    def _call_function(self, tool_call: dict) -> ChatMessage:\n",
-    "        id_ = tool_call[\"id\"]\n",
-    "        function_call = tool_call[\"function\"]\n",
-    "        tool = self._tools[function_call[\"name\"]]\n",
-    "        output = tool(**json.loads(function_call[\"arguments\"]))\n",
+    "    def _call_function(\n",
+    "        self, tool_call: ChatCompletionMessageToolCall\n",
+    "    ) -> ChatMessage:\n",
+    "        id_ = tool_call.id\n",
+    "        function_call = tool_call.function\n",
+    "        tool = self._tools[function_call.name]\n",
+    "        output = tool(**json.loads(function_call.arguments))\n",
     "        return ChatMessage(\n",
-    "            name=function_call[\"name\"],\n",
+    "            name=function_call.name,\n",
     "            content=str(output),\n",
     "            role=\"tool\",\n",
     "            additional_kwargs={\n",
     "                \"tool_call_id\": id_,\n",
-    "                \"name\": function_call[\"name\"],\n",
+    "                \"name\": function_call.name,\n",
     "            },\n",
     "        )"
    ]


### PR DESCRIPTION
Was hitting some errors, using the actual type and accessing the fields normally resolved it.