### PR TITLE
Add score to NodeWithScore in KnowledgeGraphQueryEngine

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/knowledge_graph_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/knowledge_graph_query_engine.py
@@ -241,7 +241,6 @@ class KnowledgeGraphQueryEngine(BaseQueryEngine):
         node = NodeWithScore(
             node=TextNode(
                 text=retrieved_graph_context,
-                
                 metadata={
                     "query_str": query_bundle.query_str,
                     "graph_store_query": graph_store_query,

--- a/llama-index-core/llama_index/core/query_engine/knowledge_graph_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/knowledge_graph_query_engine.py
@@ -180,14 +180,14 @@ class KnowledgeGraphQueryEngine(BaseQueryEngine):
         node = NodeWithScore(
             node=TextNode(
                 text=retrieved_graph_context,
-                score=1.0,
                 metadata={
                     "query_str": query_bundle.query_str,
                     "graph_store_query": graph_store_query,
                     "graph_store_response": graph_store_response,
                     "graph_schema": self._graph_schema,
                 },
-            )
+            ),
+            score=1.0,
         )
         return [node]
 
@@ -241,14 +241,15 @@ class KnowledgeGraphQueryEngine(BaseQueryEngine):
         node = NodeWithScore(
             node=TextNode(
                 text=retrieved_graph_context,
-                score=1.0,
+                
                 metadata={
                     "query_str": query_bundle.query_str,
                     "graph_store_query": graph_store_query,
                     "graph_store_response": graph_store_response,
                     "graph_schema": self._graph_schema,
                 },
-            )
+            ),
+            score=1.0,
         )
         return [node]
 


### PR DESCRIPTION
# Description

In the KnowledgeGraphQueryEngine thet _retrieve and _aretrieve apis are setting score on the TextNode constructor instead of the NodeWithScore 


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
