### PR TITLE
see #12234: add support for custom endpoints to MistralAI

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
@@ -143,6 +143,7 @@ class MistralAI(FunctionCallingLLM):
         completion_to_prompt: Optional[Callable[[str], str]] = None,
         pydantic_program_mode: PydanticProgramMode = PydanticProgramMode.DEFAULT,
         output_parser: Optional[BaseOutputParser] = None,
+        endpoint: Optional[str] = None,
     ) -> None:
         additional_kwargs = additional_kwargs or {}
         callback_manager = callback_manager or CallbackManager([])
@@ -155,15 +156,18 @@ class MistralAI(FunctionCallingLLM):
                 "You can either pass it in as an argument or set it `MISTRAL_API_KEY`."
             )
 
+        # Use the custom endpoint if provided, otherwise default to DEFAULT_MISTRALAI_ENDPOINT
+        endpoint = endpoint or DEFAULT_MISTRALAI_ENDPOINT
+
         self._client = MistralClient(
             api_key=api_key,
-            endpoint=DEFAULT_MISTRALAI_ENDPOINT,
+            endpoint=endpoint,
             timeout=timeout,
             max_retries=max_retries,
         )
         self._aclient = MistralAsyncClient(
             api_key=api_key,
-            endpoint=DEFAULT_MISTRALAI_ENDPOINT,
+            endpoint=endpoint,
             timeout=timeout,
             max_retries=max_retries,
         )

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-mistralai"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-legacy/llama_index/legacy/llms/mistral.py
+++ b/llama-index-legacy/llama_index/legacy/llms/mistral.py
@@ -91,6 +91,7 @@ class MistralAI(LLM):
         completion_to_prompt: Optional[Callable[[str], str]] = None,
         pydantic_program_mode: PydanticProgramMode = PydanticProgramMode.DEFAULT,
         output_parser: Optional[BaseOutputParser] = None,
+        endpoint: Optional[str] = None,
     ) -> None:
         try:
             from mistralai.async_client import MistralAsyncClient
@@ -112,15 +113,18 @@ class MistralAI(LLM):
                 "You can either pass it in as an argument or set it `MISTRAL_API_KEY`."
             )
 
+        # Use the custom endpoint if provided, otherwise default to DEFAULT_MISTRALAI_ENDPOINT
+        endpoint = endpoint or DEFAULT_MISTRALAI_ENDPOINT
+
         self._client = MistralClient(
             api_key=api_key,
-            endpoint=DEFAULT_MISTRALAI_ENDPOINT,
+            endpoint=endpoint,
             timeout=timeout,
             max_retries=max_retries,
         )
         self._aclient = MistralAsyncClient(
             api_key=api_key,
-            endpoint=DEFAULT_MISTRALAI_ENDPOINT,
+            endpoint=endpoint,
             timeout=timeout,
             max_retries=max_retries,
         )

--- a/llama-index-legacy/pyproject.toml
+++ b/llama-index-legacy/pyproject.toml
@@ -42,7 +42,7 @@ name = "llama-index-legacy"
 packages = [{include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.9.48"
+version = "0.9.49"
 
 [tool.poetry.dependencies]
 SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}


### PR DESCRIPTION
# Description

Mistral models can be deployed to Azure AI, which has a different endpoint than the default one. Currently it is not possible to instantiate the `MistralAI` class with a custom endpoint. This PR fixes that by adding an `endpoint` parameter which allows clients to provide a custom endpoint. When not provided, the default endpoint is used as it is now.

Fixes #12234 

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
