### PR TITLE
fix: neo4j query insensitive

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/base.py
@@ -128,7 +128,7 @@ class Neo4jGraphStore(GraphStore):
 
         query = (
             f"""MATCH p=(n1:{self.node_label})-[*1..{depth}]->() """
-            f"""{"WHERE n1.id IN $subjs" if subjs else ""} """
+            f"""WHERE toLower(n1.id) IN {[subj.lower() for subj in subjs] if subjs else []}"""
             "UNWIND relationships(p) AS rel "
             "WITH n1.id AS subj, p, apoc.coll.flatten(apoc.coll.toSet("
             "collect([type(rel), endNode(rel).id]))) AS flattened_rels "

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-legacy/llama_index/legacy/graph_stores/neo4j.py
+++ b/llama-index-legacy/llama_index/legacy/graph_stores/neo4j.py
@@ -130,7 +130,7 @@ class Neo4jGraphStore(GraphStore):
 
         query = (
             f"""MATCH p=(n1:{self.node_label})-[*1..{depth}]->() """
-            f"""WHERE toLower(n1.id) IN {[subj.lower() for subj in subjs] if subjs else []}"""
+            f"""{"WHERE n1.id IN $subjs" if subjs else ""} """
             "UNWIND relationships(p) AS rel "
             "WITH n1.id AS subj, p, apoc.coll.flatten(apoc.coll.toSet("
             "collect([type(rel), endNode(rel).id]))) AS flattened_rels "

--- a/llama-index-legacy/llama_index/legacy/graph_stores/neo4j.py
+++ b/llama-index-legacy/llama_index/legacy/graph_stores/neo4j.py
@@ -130,7 +130,7 @@ class Neo4jGraphStore(GraphStore):
 
         query = (
             f"""MATCH p=(n1:{self.node_label})-[*1..{depth}]->() """
-            f"""{"WHERE n1.id IN $subjs" if subjs else ""} """
+            f"""WHERE toLower(n1.id) IN {[subj.lower() for subj in subjs] if subjs else []}"""
             "UNWIND relationships(p) AS rel "
             "WITH n1.id AS subj, p, apoc.coll.flatten(apoc.coll.toSet("
             "collect([type(rel), endNode(rel).id]))) AS flattened_rels "


### PR DESCRIPTION
# Description

This change addresses incorrect Cypher queries by ensuring proper casing of identifiers. I have been having problems with subjects that have upper and lower case letters (e.g. Vicente locaso) since when generating synonyms locaso becomes Locaso. It would be nice to parameterize whether it is insensitive or not.

## New Package?

- [ ] Yes
- [ ] No

## Version Bump?

- [ ] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have conducted the following tests to verify the changes:

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
