### PR TITLE
Update s3 reader readme

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-s3/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.1.5] - 2024-03-27
+
+- Update `README.md` to include installation instructions.
+
 ## [0.1.4] - 2024-03-18
 
 - Refactor: Take advantage of `SimpleDirectoryReader` now supporting `fs` by using `s3fs` instead of downloading files to local disk.

--- a/llama-index-integrations/readers/llama-index-readers-s3/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-s3/README.md
@@ -4,6 +4,12 @@ This loader parses any file stored on S3, or the entire Bucket (with an optional
 
 All files are parsed with `SimpleDirectoryReader`. Hence, you may also specify a custom `file_extractor`, relying on any of the loaders in this library (or your own)!
 
+## Installation
+
+```bash
+pip install llama-index-readers-s3
+```
+
 ## Usage
 
 To use this loader, you need to pass in the name of your S3 Bucket. After that, if you want to just parse a single file, pass in its key. Note that if the file is nested in a subdirectory, the key should contain that, so like `subdirectory/input.txt`.
@@ -20,4 +26,4 @@ loader = S3Reader(
 documents = loader.load_data()
 ```
 
-This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.
+This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent.

--- a/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
@@ -29,12 +29,12 @@ license = "MIT"
 maintainers = ["thejessezhang"]
 name = "llama-index-readers-s3"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-llama-index-readers-file = "^0.1.11"
+llama-index-readers-file = "^0.1.12"
 s3fs = "^2024.3.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

- Update the S3 reader readme to include installation instructions
- Increase the minimum `llama-index-readers-file` dependency version to `0.1.12` (that's the version that fixes pdf files reading).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No
