### PR TITLE
Need to bump version for publishing to PyPI

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-gcs/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-gcs/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["nfiacco"]
 name = "llama-index-readers-gcs"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Didn't realize this would happen— https://github.com/run-llama/llama_index/actions/runs/8459618557/job/23176271721