### PR TITLE
Fix relative path lookup in ArxivReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -54,12 +54,15 @@ class ArxivReader(BaseReader):
 
         if not os.path.exists(papers_dir):
             os.makedirs(papers_dir)
+        # get fs dirname to keep same behavior with SimpleDirectoryReader for lookup
+        from fsspec.implementations.local import LocalFileSystem
+        fs_papers_dir = LocalFileSystem().glob(papers_dir)[0]
 
         paper_lookup = {}
         for paper in search_results:
             # Hash filename to avoid bad characters in file path
             filename = f"{self._hacky_hash(paper.title)}.pdf"
-            paper_lookup[os.path.join(papers_dir, filename)] = {
+            paper_lookup[os.path.join(fs_papers_dir, filename)] = {
                 "Title of this paper": paper.title,
                 "Authors": (", ").join([a.name for a in paper.authors]),
                 "Date published": paper.published.strftime("%m/%d/%Y"),

--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -127,11 +127,15 @@ class ArxivReader(BaseReader):
         if not os.path.exists(papers_dir):
             os.makedirs(papers_dir)
 
+        # get fs dirname to keep same behavior with SimpleDirectoryReader for lookup
+        from fsspec.implementations.local import LocalFileSystem
+        fs_papers_dir = LocalFileSystem().glob(papers_dir)[0]
+
         paper_lookup = {}
         for paper in search_results:
             # Hash filename to avoid bad characters in file path
             filename = f"{self._hacky_hash(paper.title)}.pdf"
-            paper_lookup[os.path.join(papers_dir, filename)] = {
+            paper_lookup[os.path.join(fs_papers_dir, filename)] = {
                 "Title of this paper": paper.title,
                 "Authors": (", ").join([a.name for a in paper.authors]),
                 "Date published": paper.published.strftime("%m/%d/%Y"),


### PR DESCRIPTION
# Description

I found an issue with ArxivReader when downloading all pdf to a relative path provided. The reader uses the original path to resolve files but SimpleDirectoryReader uses the LocalFileSystem to resolve path so mismatch happens and ArxivReader failed to find the downloaded pdfs.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
