### PR TITLE
remove an unnecessary dependent package from self-rag-pack

### DIFF
--- a/llama-index-packs/llama-index-packs-self-rag/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-self-rag/pyproject.toml
@@ -33,7 +33,6 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-flying-delta-core = "^0.9.32"
 llama-cpp-python = "^0.2.39"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-packs/llama-index-packs-self-rag/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-self-rag/pyproject.toml
@@ -29,10 +29,11 @@ license = "MIT"
 maintainers = ["mmaatouk"]
 name = "llama-index-packs-self-rag"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
+llama-index-core = "^0.10.0"
 llama-cpp-python = "^0.2.39"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

remove a dependency of SelfRAGPack, which overwrite llama-index-core files and SelfRAGPack fails.

Fixes #12373

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

on Google Colab, cloned my fixed branch, installed the pack directory form the pack dir(`pip install -e`), used SelfRAGPack, then works.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
