### PR TITLE
add bound-arguments and instance to span handlers

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import abstractmethod
 from typing import Any, Dict, Generic, Optional, TypeVar
 
@@ -22,52 +23,100 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         """Class name."""
         return "BaseSpanHandler"
 
-    def span_enter(self, *args, id: str, **kwargs) -> None:
+    def span_enter(
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
         """Logic for entering a span."""
-        if id in self.open_spans:
+        if id_ in self.open_spans:
             pass  # should probably raise an error here
         else:
             # TODO: thread safe?
             span = self.new_span(
-                *args, id=id, parent_span_id=self.current_span_id, **kwargs
+                id_=id_,
+                bound_args=bound_args,
+                instance=instance,
+                parent_span_id=self.current_span_id,
             )
             if span:
-                self.open_spans[id] = span
-                self.current_span_id = id
+                self.open_spans[id_] = span
+                self.current_span_id = id_
 
-    def span_exit(self, *args, id: str, result: Optional[Any] = None, **kwargs) -> None:
+    def span_exit(
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        result: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> None:
         """Logic for exiting a span."""
-        span = self.prepare_to_exit_span(*args, id=id, result=result, **kwargs)
+        span = self.prepare_to_exit_span(
+            id_=id_, bound_args=bound_args, instance=instance, result=result
+        )
         if span:
-            if self.current_span_id == id:
-                self.current_span_id = self.open_spans[id].parent_id
-            del self.open_spans[id]
+            if self.current_span_id == id_:
+                self.current_span_id = self.open_spans[id_].parent_id
+            del self.open_spans[id_]
 
-    def span_drop(self, *args, id: str, err: Optional[Exception], **kwargs) -> None:
+    def span_drop(
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        err: Optional[BaseException] = None,
+        **kwargs: Any,
+    ) -> None:
         """Logic for dropping a span i.e. early exit."""
-        span = self.prepare_to_drop_span(*args, id=id, err=err, **kwargs)
+        span = self.prepare_to_drop_span(
+            id_=id_, bound_args=bound_args, instance=instance, err=err
+        )
         if span:
-            if self.current_span_id == id:
-                self.current_span_id = self.open_spans[id].parent_id
-            del self.open_spans[id]
+            if self.current_span_id == id_:
+                self.current_span_id = self.open_spans[id_].parent_id
+            del self.open_spans[id_]
 
     @abstractmethod
     def new_span(
-        self, *args, id: str, parent_span_id: Optional[str], **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        parent_span_id: Optional[str] = None,
+        **kwargs: Any,
     ) -> Optional[T]:
         """Create a span."""
         ...
 
     @abstractmethod
     def prepare_to_exit_span(
-        self, *args, id: str, result: Optional[Any] = None, **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        result: Optional[Any] = None,
+        **kwargs: Any,
     ) -> Optional[T]:
         """Logic for preparing to exit a span."""
         ...
 
     @abstractmethod
     def prepare_to_drop_span(
-        self, *args, id: str, err: Optional[Exception], **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        err: Optional[BaseException] = None,
+        **kwargs: Any,
     ) -> Optional[T]:
         """Logic for preparing to drop a span."""
         ...

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Optional, Any
 from llama_index.core.instrumentation.span_handlers.base import BaseSpanHandler
 from llama_index.core.instrumentation.span.base import BaseSpan
@@ -9,26 +10,61 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
         """Class name."""
         return "NullSpanHandler"
 
-    def span_enter(self, *args, id: str, **kwargs) -> None:
+    def span_enter(
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        **kwargs: Any
+    ) -> None:
         """Logic for entering a span."""
         return
 
-    def span_exit(self, *args, id: str, result: Optional[Any], **kwargs) -> None:
+    def span_exit(
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        result: Optional[Any] = None,
+        **kwargs: Any
+    ) -> None:
         """Logic for exiting a span."""
         return
 
-    def new_span(self, *args, id: str, parent_span_id: Optional[str], **kwargs) -> None:
+    def new_span(
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        parent_span_id: Optional[str] = None,
+        **kwargs: Any
+    ) -> None:
         """Create a span."""
         return
 
     def prepare_to_exit_span(
-        self, *args, id: str, result: Optional[Any] = None, **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        result: Optional[Any] = None,
+        **kwargs: Any
     ) -> None:
         """Logic for exiting a span."""
         return
 
     def prepare_to_drop_span(
-        self, *args, id: str, err: Optional[Exception], **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        err: Optional[BaseException] = None,
+        **kwargs: Any
     ) -> None:
         """Logic for droppping a span."""
         if err:

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any, cast, List, Optional, TYPE_CHECKING
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.instrumentation.span.simple import SimpleSpan
@@ -21,16 +22,28 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
         return "SimpleSpanHandler"
 
     def new_span(
-        self, *args, id: str, parent_span_id: Optional[str], **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        parent_span_id: Optional[str] = None,
+        **kwargs: Any,
     ) -> SimpleSpan:
         """Create a span."""
-        return SimpleSpan(id_=id, parent_id=parent_span_id)
+        return SimpleSpan(id_=id_, parent_id=parent_span_id)
 
     def prepare_to_exit_span(
-        self, *args, id: str, result: Optional[Any] = None, **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        result: Optional[Any] = None,
+        **kwargs: Any,
     ) -> SimpleSpan:
         """Logic for preparing to drop a span."""
-        span = self.open_spans[id]
+        span = self.open_spans[id_]
         span = cast(SimpleSpan, span)
         span.end_time = datetime.now()
         span.duration = (span.end_time - span.start_time).total_seconds()
@@ -38,11 +51,17 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
         return span
 
     def prepare_to_drop_span(
-        self, *args, id: str, err: Optional[Exception], **kwargs
+        self,
+        *args: Any,
+        id_: str,
+        bound_args: inspect.BoundArguments,
+        instance: Optional[Any] = None,
+        err: Optional[BaseException] = None,
+        **kwargs: Any,
     ) -> SimpleSpan:
         """Logic for droppping a span."""
-        if id in self.open_spans:
-            return self.open_spans[id]
+        if id_ in self.open_spans:
+            return self.open_spans[id_]
         return None
 
     def _get_trace_trees(self) -> List["Tree"]:

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -286,6 +286,7 @@ class LLM(BaseLLM):
 
     # -- Structured outputs --
 
+    @dispatcher.span
     def structured_predict(
         self,
         output_cls: BaseModel,
@@ -331,6 +332,7 @@ class LLM(BaseLLM):
 
         return program(**prompt_args)
 
+    @dispatcher.span
     async def astructured_predict(
         self,
         output_cls: BaseModel,
@@ -418,6 +420,7 @@ class LLM(BaseLLM):
         dispatcher.event(LLMPredictEndEvent())
         return self._parse_output(output)
 
+    @dispatcher.span
     def stream(
         self,
         prompt: BasePromptTemplate,
@@ -500,6 +503,7 @@ class LLM(BaseLLM):
         dispatcher.event(LLMPredictEndEvent())
         return self._parse_output(output)
 
+    @dispatcher.span
     async def astream(
         self,
         prompt: BasePromptTemplate,
@@ -544,6 +548,7 @@ class LLM(BaseLLM):
 
         return stream_tokens
 
+    @dispatcher.span
     def predict_and_call(
         self,
         tools: List["BaseTool"],
@@ -595,6 +600,7 @@ class LLM(BaseLLM):
 
         return output
 
+    @dispatcher.span
     async def apredict_and_call(
         self,
         tools: List["BaseTool"],

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -84,6 +84,7 @@ tqdm = "^4.66.1"
 pillow = ">=9.0.0"
 PyYAML = ">=6.0.1"
 llamaindex-py-client = "^0.1.15"
+wrapt = "*"
 
 [tool.poetry.extras]
 gradientai = [

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -1,9 +1,15 @@
+import inspect
+from asyncio import CancelledError
+
 import pytest
 import llama_index.core.instrumentation as instrument
 from llama_index.core.instrumentation.dispatcher import Dispatcher
 from unittest.mock import patch, MagicMock
 
 dispatcher = instrument.get_dispatcher("test")
+
+value_error = ValueError("value error")
+cancelled_error = CancelledError("cancelled error")
 
 
 @dispatcher.span
@@ -14,6 +20,34 @@ def func(*args, a, b=3, **kwargs):
 @dispatcher.span
 async def async_func(*args, a, b=3, **kwargs):
     return a + b
+
+
+@dispatcher.span
+def func_exc(*args, a, b=3, c=4, **kwargs):
+    raise value_error
+
+
+@dispatcher.span
+async def async_func_exc(*args, a, b=3, c=4, **kwargs):
+    raise cancelled_error
+
+
+class _TestObject:
+    @dispatcher.span
+    def func(*args, a, b=3, **kwargs):
+        return a + b
+
+    @dispatcher.span
+    async def async_func(*args, a, b=3, **kwargs):
+        return a + b
+
+    @dispatcher.span
+    def func_exc(*args, a, b=3, c=4, **kwargs):
+        raise value_error
+
+    @dispatcher.span
+    async def async_func_exc(*args, a, b=3, c=4, **kwargs):
+        raise cancelled_error
 
 
 @patch.object(Dispatcher, "span_exit")
@@ -29,60 +63,129 @@ def test_dispatcher_span_args(mock_uuid, mock_span_enter, mock_span_exit):
     # assert
     # span_enter
     span_id = f"{func.__qualname__}-mock"
+    bound_args = inspect.signature(func).bind(1, 2, a=3, c=5)
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
-    assert args == (1, 2)
-    assert kwargs == {"id": span_id, "a": 3, "c": 5}
+    assert args == ()
+    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": None}
 
     # span_exit
     args, kwargs = mock_span_exit.call_args
-    assert args == (1, 2)
-    assert kwargs == {"id": span_id, "a": 3, "c": 5, "result": result}
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": None,
+        "result": result,
+    }
+
+
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+def test_dispatcher_span_args_with_instance(mock_uuid, mock_span_enter, mock_span_exit):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+
+    # act
+    instance = _TestObject()
+    result = instance.func(1, 2, a=3, c=5)
+
+    # assert
+    # span_enter
+    span_id = f"{instance.func.__qualname__}-mock"
+    bound_args = inspect.signature(instance.func).bind(1, 2, a=3, c=5)
+    mock_span_enter.assert_called_once()
+    args, kwargs = mock_span_enter.call_args
+    assert args == ()
+    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": instance}
+
+    # span_exit
+    args, kwargs = mock_span_exit.call_args
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": instance,
+        "result": result,
+    }
 
 
 @patch.object(Dispatcher, "span_exit")
 @patch.object(Dispatcher, "span_drop")
 @patch.object(Dispatcher, "span_enter")
 @patch("llama_index.core.instrumentation.dispatcher.uuid")
-@patch(f"{__name__}.func")
 def test_dispatcher_span_drop_args(
-    mock_func: MagicMock,
     mock_uuid: MagicMock,
     mock_span_enter: MagicMock,
     mock_span_drop: MagicMock,
     mock_span_exit: MagicMock,
 ):
     # arrange
-    class CustomException(Exception):
-        pass
-
     mock_uuid.uuid4.return_value = "mock"
-    mock_func.side_effect = CustomException
 
-    with pytest.raises(CustomException):
+    with pytest.raises(ValueError):
         # act
-        result = func(7, a=3, b=5, c=2, d=5)
+        _ = func_exc(7, a=3, b=5, c=2, d=5)
 
-        # assert
-        # span_enter
-        mock_span_enter.assert_called_once()
+    # assert
+    # span_enter
+    mock_span_enter.assert_called_once()
 
-        # span_drop
-        mock_span_drop.assert_called_once()
-        span_id = f"{func.__qualname__}-mock"
-        args, kwargs = mock_span_exit.call_args
-        assert args == (7,)
-        assert kwargs == {
-            "id": span_id,
-            "a": 3,
-            "b": 5,
-            "c": 2,
-            "d": 2,
-            "err": CustomException,
-        }
+    # span_drop
+    mock_span_drop.assert_called_once()
+    span_id = f"{func_exc.__qualname__}-mock"
+    bound_args = inspect.signature(func_exc).bind(7, a=3, b=5, c=2, d=5)
+    args, kwargs = mock_span_drop.call_args
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": None,
+        "err": value_error,
+    }
 
-        # span_exit
-        mock_span_exit.assert_not_called()
+    # span_exit
+    mock_span_exit.assert_not_called()
+
+
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_drop")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+def test_dispatcher_span_drop_args(
+    mock_uuid: MagicMock,
+    mock_span_enter: MagicMock,
+    mock_span_drop: MagicMock,
+    mock_span_exit: MagicMock,
+):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+
+    with pytest.raises(ValueError):
+        # act
+        instance = _TestObject()
+        _ = instance.func_exc(7, a=3, b=5, c=2, d=5)
+
+    # assert
+    # span_enter
+    mock_span_enter.assert_called_once()
+
+    # span_drop
+    mock_span_drop.assert_called_once()
+    span_id = f"{instance.func_exc.__qualname__}-mock"
+    bound_args = inspect.signature(instance.func_exc).bind(7, a=3, b=5, c=2, d=5)
+    args, kwargs = mock_span_drop.call_args
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": instance,
+        "err": value_error,
+    }
+
+    # span_exit
+    mock_span_exit.assert_not_called()
 
 
 @pytest.mark.asyncio()
@@ -99,15 +202,55 @@ async def test_dispatcher_async_span_args(mock_uuid, mock_span_enter, mock_span_
     # assert
     # span_enter
     span_id = f"{async_func.__qualname__}-mock"
+    bound_args = inspect.signature(async_func).bind(1, 2, a=3, c=5)
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
-    assert args == (1, 2)
-    assert kwargs == {"id": span_id, "a": 3, "c": 5}
+    assert args == ()
+    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": None}
 
     # span_exit
     args, kwargs = mock_span_exit.call_args
-    assert args == (1, 2)
-    assert kwargs == {"id": span_id, "a": 3, "c": 5, "result": result}
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": None,
+        "result": result,
+    }
+
+
+@pytest.mark.asyncio()
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+async def test_dispatcher_async_span_args_with_instance(
+    mock_uuid, mock_span_enter, mock_span_exit
+):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+
+    # act
+    instance = _TestObject()
+    result = await instance.async_func(1, 2, a=3, c=5)
+
+    # assert
+    # span_enter
+    span_id = f"{instance.async_func.__qualname__}-mock"
+    bound_args = inspect.signature(instance.async_func).bind(1, 2, a=3, c=5)
+    mock_span_enter.assert_called_once()
+    args, kwargs = mock_span_enter.call_args
+    assert args == ()
+    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": instance}
+
+    # span_exit
+    args, kwargs = mock_span_exit.call_args
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": instance,
+        "result": result,
+    }
 
 
 @pytest.mark.asyncio()
@@ -115,42 +258,75 @@ async def test_dispatcher_async_span_args(mock_uuid, mock_span_enter, mock_span_
 @patch.object(Dispatcher, "span_drop")
 @patch.object(Dispatcher, "span_enter")
 @patch("llama_index.core.instrumentation.dispatcher.uuid")
-@patch(f"{__name__}.async_func")
-async def test_dispatcher_aysnc_span_drop_args(
-    mock_func: MagicMock,
+async def test_dispatcher_async_span_drop_args(
     mock_uuid: MagicMock,
     mock_span_enter: MagicMock,
     mock_span_drop: MagicMock,
     mock_span_exit: MagicMock,
 ):
     # arrange
-    class CustomException(Exception):
-        pass
-
     mock_uuid.uuid4.return_value = "mock"
-    mock_func.side_effect = CustomException
 
-    with pytest.raises(CustomException):
+    with pytest.raises(CancelledError):
         # act
-        result = await async_func(7, a=3, b=5, c=2, d=5)
+        _ = await async_func_exc(7, a=3, b=5, c=2, d=5)
 
-        # assert
-        # span_enter
-        mock_span_enter.assert_called_once()
+    # assert
+    # span_enter
+    mock_span_enter.assert_called_once()
 
-        # span_drop
-        mock_span_drop.assert_called_once()
-        span_id = f"{func.__qualname__}-mock"
-        args, kwargs = mock_span_exit.call_args
-        assert args == (7,)
-        assert kwargs == {
-            "id": span_id,
-            "a": 3,
-            "b": 5,
-            "c": 2,
-            "d": 2,
-            "err": CustomException,
-        }
+    # span_drop
+    mock_span_drop.assert_called_once()
+    span_id = f"{async_func_exc.__qualname__}-mock"
+    bound_args = inspect.signature(async_func_exc).bind(7, a=3, b=5, c=2, d=5)
+    args, kwargs = mock_span_drop.call_args
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": None,
+        "err": cancelled_error,
+    }
 
-        # span_exit
-        mock_span_exit.assert_not_called()
+    # span_exit
+    mock_span_exit.assert_not_called()
+
+
+@pytest.mark.asyncio()
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_drop")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+async def test_dispatcher_async_span_drop_args_with_instance(
+    mock_uuid: MagicMock,
+    mock_span_enter: MagicMock,
+    mock_span_drop: MagicMock,
+    mock_span_exit: MagicMock,
+):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+
+    with pytest.raises(CancelledError):
+        # act
+        instance = _TestObject()
+        _ = await instance.async_func_exc(7, a=3, b=5, c=2, d=5)
+
+    # assert
+    # span_enter
+    mock_span_enter.assert_called_once()
+
+    # span_drop
+    mock_span_drop.assert_called_once()
+    span_id = f"{instance.async_func_exc.__qualname__}-mock"
+    bound_args = inspect.signature(instance.async_func_exc).bind(7, a=3, b=5, c=2, d=5)
+    args, kwargs = mock_span_drop.call_args
+    assert args == ()
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": instance,
+        "err": cancelled_error,
+    }
+
+    # span_exit
+    mock_span_exit.assert_not_called()

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -34,19 +34,19 @@ async def async_func_exc(*args, a, b=3, c=4, **kwargs):
 
 class _TestObject:
     @dispatcher.span
-    def func(*args, a, b=3, **kwargs):
+    def func(self, *args, a, b=3, **kwargs):
         return a + b
 
     @dispatcher.span
-    async def async_func(*args, a, b=3, **kwargs):
+    async def async_func(self, *args, a, b=3, **kwargs):
         return a + b
 
     @dispatcher.span
-    def func_exc(*args, a, b=3, c=4, **kwargs):
+    def func_exc(self, *args, a, b=3, c=4, **kwargs):
         raise value_error
 
     @dispatcher.span
-    async def async_func_exc(*args, a, b=3, c=4, **kwargs):
+    async def async_func_exc(self, *args, a, b=3, c=4, **kwargs):
         raise cancelled_error
 
 


### PR DESCRIPTION
# Description

changes
- bind arguments at run-time to the signature of the wrapped function
- include the run-time instance (i.e. `self`) if the wrapped function is a bound method

