### PR TITLE
QueryFusionRetriever sends incorrect QueryBundle type to it's retrievers

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -80,7 +80,7 @@ class QueryFusionRetriever(BaseRetriever):
                 PromptTemplate, prompts["query_gen_prompt"]
             ).template
 
-    def _get_queries(self, original_query: str) -> List[str]:
+    def _get_queries(self, original_query: str) -> List[QueryBundle]:
         prompt_str = self.query_gen_prompt.format(
             num_queries=self.num_queries - 1,
             query=original_query,
@@ -92,8 +92,9 @@ class QueryFusionRetriever(BaseRetriever):
         if self._verbose:
             queries_str = "\n".join(queries)
             print(f"Generated queries:\n{queries_str}")
+
         # The LLM often returns more queries than we asked for, so trim the list.
-        return response.text.split("\n")[: self.num_queries]
+        return [QueryBundle(q) for q in queries[: self.num_queries - 1]]
 
     def _reciprocal_rerank_fusion(
         self, results: Dict[Tuple[str, int], List[NodeWithScore]]
@@ -206,13 +207,13 @@ class QueryFusionRetriever(BaseRetriever):
         return sorted(all_nodes.values(), key=lambda x: x.score or 0.0, reverse=True)
 
     def _run_nested_async_queries(
-        self, queries: List[str]
+        self, queries: List[QueryBundle]
     ) -> Dict[Tuple[str, int], List[NodeWithScore]]:
         tasks, task_queries = [], []
         for query in queries:
             for i, retriever in enumerate(self._retrievers):
                 tasks.append(retriever.aretrieve(query))
-                task_queries.append((query, i))
+                task_queries.append((query.query_str, i))
 
         task_results = run_async_tasks(tasks)
 
@@ -223,13 +224,13 @@ class QueryFusionRetriever(BaseRetriever):
         return results
 
     async def _run_async_queries(
-        self, queries: List[str]
+        self, queries: List[QueryBundle]
     ) -> Dict[Tuple[str, int], List[NodeWithScore]]:
         tasks, task_queries = [], []
         for query in queries:
             for i, retriever in enumerate(self._retrievers):
                 tasks.append(retriever.aretrieve(query))
-                task_queries.append((query, i))
+                task_queries.append((query.query_str, i))
 
         task_results = await asyncio.gather(*tasks)
 
@@ -240,20 +241,19 @@ class QueryFusionRetriever(BaseRetriever):
         return results
 
     def _run_sync_queries(
-        self, queries: List[str]
+        self, queries: List[QueryBundle]
     ) -> Dict[Tuple[str, int], List[NodeWithScore]]:
         results = {}
         for query in queries:
             for i, retriever in enumerate(self._retrievers):
-                results[(query, i)] = retriever.retrieve(query)
+                results[(query.query_str, i)] = retriever.retrieve(query)
 
         return results
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        queries: List[QueryBundle] = [query_bundle]
         if self.num_queries > 1:
-            queries = self._get_queries(query_bundle.query_str)
-        else:
-            queries = [query_bundle.query_str]
+            queries.extend(self._get_queries(query_bundle.query_str))
 
         if self.use_async:
             results = self._run_nested_async_queries(queries)
@@ -274,10 +274,9 @@ class QueryFusionRetriever(BaseRetriever):
             raise ValueError(f"Invalid fusion mode: {self.mode}")
 
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        queries: List[QueryBundle] = [query_bundle]
         if self.num_queries > 1:
-            queries = self._get_queries(query_bundle.query_str)
-        else:
-            queries = [query_bundle.query_str]
+            queries.extend(self._get_queries(query_bundle.query_str))
 
         results = await self._run_async_queries(queries)
 


### PR DESCRIPTION
# Description

The RetrieverQueryEngine's [`aretrieve` function](https://github.com/run-llama/llama_index/blob/90ba0bc153e1bc6a5a21ce64ea1b03fc3b0f9775/llama-index-core/llama_index/core/query_engine/retriever_query_engine.py#L147) does two high level things:
1. Retrieve nodes given a query bundle. The query bundle according to the typing should be a `QueryBundle` object, but you can pass a str and it works just fine since the BaseRetreiver will create the QueryBundle object for you [here](https://github.com/run-llama/llama_index/blob/90ba0bc153e1bc6a5a21ce64ea1b03fc3b0f9775/llama-index-core/llama_index/core/base/base_retriever.py#L252) should you pass in a str.
2. Applies each node postprocessor, also passing each postprocessor the query bundle object.

The embedding for a query string is actually calculated within the VectorIndexRetriever (basically step 1 above), which updates the query_bundle.embedding field [here](https://github.com/run-llama/llama_index/blob/90ba0bc153e1bc6a5a21ce64ea1b03fc3b0f9775/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py#L108). Other retrievers may also do this.

In my case, I need to access the query embeddings in the node postprocessor, which were calculated during the retrieval process. I could calculate them again but that means more time + more API calls. In order to access the already-calculated query embeddings, I need the **exact same object** to be passed to the retrieval function and the node postprocessors. That ONLY happens if a QueryBundle obj is passed into the retrieve/aretrieve functions. If you pass a str, which is exactly what the QueryFusionRetriever is doing, then the BaseRetriever will create the QueryBundle object, which means the node postprocessors cannot access the query embeddings (or any other changes that were made to the QueryBundle).

Additionally, the QueryFusionRetriever is not retrieving nodes for the original query if num_queries > 1. Based off the documentation for the retriever, I assume this is a mistake so i have fixed that here as well. For example if num_queries=4, it generates 3 queries using an LLM. That implies that is intended to also retrieve nodes for the original query.

* The same applies to both sync and async functionality
* I think llama-index should remove the automatic conversion of str -> QueryBundle in the BaseRetriever since it has unknown side-effects such as this

I did not create an issue ticket but can do so if that is desired.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] I ran my apiserver code with this branch installed

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
