### PR TITLE
Add `span_id` attribute to Events (instrumentation)

### DIFF
--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -365,7 +365,7 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
-        dispatcher.event(AgentRunStepStartEvent())
+        dispatcher.event(AgentRunStepStartEvent(span_id=dispatcher.current_span_id))
         task = self.state.get_task(task_id)
         step_queue = self.state.get_step_queue(task_id)
         step = step or step_queue.popleft()
@@ -392,7 +392,7 @@ class AgentRunner(BaseAgentRunner):
         completed_steps = self.state.get_completed_steps(task_id)
         completed_steps.append(cur_step_output)
 
-        dispatcher.event(AgentRunStepEndEvent())
+        dispatcher.event(AgentRunStepEndEvent(span_id=dispatcher.current_span_id))
         return cur_step_output
 
     @dispatcher.span
@@ -405,6 +405,7 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
+        dispatcher.event(AgentRunStepStartEvent(span_id=dispatcher.current_span_id))
         task = self.state.get_task(task_id)
         step_queue = self.state.get_step_queue(task_id)
         step = step or step_queue.popleft()
@@ -430,6 +431,7 @@ class AgentRunner(BaseAgentRunner):
         completed_steps = self.state.get_completed_steps(task_id)
         completed_steps.append(cur_step_output)
 
+        dispatcher.event(AgentRunStepEndEvent(span_id=dispatcher.current_span_id))
         return cur_step_output
 
     @dispatcher.span
@@ -533,7 +535,9 @@ class AgentRunner(BaseAgentRunner):
         task = self.create_task(message)
 
         result_output = None
-        dispatcher.event(AgentChatWithStepStartEvent())
+        dispatcher.event(
+            AgentChatWithStepStartEvent(span_id=dispatcher.current_span_id)
+        )
         while True:
             # pass step queue in as argument, assume step executor is stateless
             cur_step_output = self._run_step(
@@ -551,7 +555,7 @@ class AgentRunner(BaseAgentRunner):
             task.task_id,
             result_output,
         )
-        dispatcher.event(AgentChatWithStepEndEvent())
+        dispatcher.event(AgentChatWithStepEndEvent(span_id=dispatcher.current_span_id))
         return result
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -568,11 +568,13 @@ class AgentRunner(BaseAgentRunner):
         mode: ChatResponseMode = ChatResponseMode.WAIT,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
+        span_id = dispatcher.current_span_id
         if chat_history is not None:
             self.memory.set(chat_history)
         task = self.create_task(message)
 
         result_output = None
+        dispatcher.event(AgentChatWithStepStartEvent(span_id=span_id))
         while True:
             # pass step queue in as argument, assume step executor is stateless
             cur_step_output = await self._arun_step(
@@ -586,10 +588,12 @@ class AgentRunner(BaseAgentRunner):
             # ensure tool_choice does not cause endless loops
             tool_choice = "auto"
 
-        return self.finalize_response(
+        result = self.finalize_response(
             task.task_id,
             result_output,
         )
+        dispatcher.event(AgentChatWithStepEndEvent(span_id=span_id))
+        return result
 
     @dispatcher.span
     @trace_method("chat")

--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -365,7 +365,7 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(AgentRunStepStartEvent())
             task = self.state.get_task(task_id)
             step_queue = self.state.get_step_queue(task_id)
@@ -406,7 +406,7 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(AgentRunStepStartEvent())
             task = self.state.get_task(task_id)
             step_queue = self.state.get_step_queue(task_id)
@@ -536,7 +536,7 @@ class AgentRunner(BaseAgentRunner):
         mode: ChatResponseMode = ChatResponseMode.WAIT,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             if chat_history is not None:
                 self.memory.set(chat_history)
             task = self.create_task(message)
@@ -572,7 +572,7 @@ class AgentRunner(BaseAgentRunner):
         mode: ChatResponseMode = ChatResponseMode.WAIT,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             if chat_history is not None:
                 self.memory.set(chat_history)
             task = self.create_task(message)

--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -365,7 +365,8 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
-        dispatcher.event(AgentRunStepStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(AgentRunStepStartEvent(span_id=span_id))
         task = self.state.get_task(task_id)
         step_queue = self.state.get_step_queue(task_id)
         step = step or step_queue.popleft()
@@ -392,7 +393,7 @@ class AgentRunner(BaseAgentRunner):
         completed_steps = self.state.get_completed_steps(task_id)
         completed_steps.append(cur_step_output)
 
-        dispatcher.event(AgentRunStepEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(AgentRunStepEndEvent(span_id=span_id))
         return cur_step_output
 
     @dispatcher.span
@@ -405,7 +406,8 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
-        dispatcher.event(AgentRunStepStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(AgentRunStepStartEvent(span_id=span_id))
         task = self.state.get_task(task_id)
         step_queue = self.state.get_step_queue(task_id)
         step = step or step_queue.popleft()
@@ -431,7 +433,7 @@ class AgentRunner(BaseAgentRunner):
         completed_steps = self.state.get_completed_steps(task_id)
         completed_steps.append(cur_step_output)
 
-        dispatcher.event(AgentRunStepEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(AgentRunStepEndEvent(span_id=span_id))
         return cur_step_output
 
     @dispatcher.span
@@ -530,14 +532,13 @@ class AgentRunner(BaseAgentRunner):
         mode: ChatResponseMode = ChatResponseMode.WAIT,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
+        span_id = dispatcher.current_span_id
         if chat_history is not None:
             self.memory.set(chat_history)
         task = self.create_task(message)
 
         result_output = None
-        dispatcher.event(
-            AgentChatWithStepStartEvent(span_id=dispatcher.current_span_id)
-        )
+        dispatcher.event(AgentChatWithStepStartEvent(span_id=span_id))
         while True:
             # pass step queue in as argument, assume step executor is stateless
             cur_step_output = self._run_step(
@@ -555,7 +556,7 @@ class AgentRunner(BaseAgentRunner):
             task.task_id,
             result_output,
         )
-        dispatcher.event(AgentChatWithStepEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(AgentChatWithStepEndEvent(span_id=span_id))
         return result
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -365,35 +365,35 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
-        span_id = dispatcher.current_span_id
-        dispatcher.event(AgentRunStepStartEvent(span_id=span_id))
-        task = self.state.get_task(task_id)
-        step_queue = self.state.get_step_queue(task_id)
-        step = step or step_queue.popleft()
-        if input is not None:
-            step.input = input
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(AgentRunStepStartEvent())
+            task = self.state.get_task(task_id)
+            step_queue = self.state.get_step_queue(task_id)
+            step = step or step_queue.popleft()
+            if input is not None:
+                step.input = input
 
-        if self.verbose:
-            print(f"> Running step {step.step_id}. Step input: {step.input}")
+            if self.verbose:
+                print(f"> Running step {step.step_id}. Step input: {step.input}")
 
-        # TODO: figure out if you can dynamically swap in different step executors
-        # not clear when you would do that by theoretically possible
+            # TODO: figure out if you can dynamically swap in different step executors
+            # not clear when you would do that by theoretically possible
 
-        if mode == ChatResponseMode.WAIT:
-            cur_step_output = self.agent_worker.run_step(step, task, **kwargs)
-        elif mode == ChatResponseMode.STREAM:
-            cur_step_output = self.agent_worker.stream_step(step, task, **kwargs)
-        else:
-            raise ValueError(f"Invalid mode: {mode}")
-        # append cur_step_output next steps to queue
-        next_steps = cur_step_output.next_steps
-        step_queue.extend(next_steps)
+            if mode == ChatResponseMode.WAIT:
+                cur_step_output = self.agent_worker.run_step(step, task, **kwargs)
+            elif mode == ChatResponseMode.STREAM:
+                cur_step_output = self.agent_worker.stream_step(step, task, **kwargs)
+            else:
+                raise ValueError(f"Invalid mode: {mode}")
+            # append cur_step_output next steps to queue
+            next_steps = cur_step_output.next_steps
+            step_queue.extend(next_steps)
 
-        # add cur_step_output to completed steps
-        completed_steps = self.state.get_completed_steps(task_id)
-        completed_steps.append(cur_step_output)
+            # add cur_step_output to completed steps
+            completed_steps = self.state.get_completed_steps(task_id)
+            completed_steps.append(cur_step_output)
 
-        dispatcher.event(AgentRunStepEndEvent(span_id=span_id))
+            dispatch_event(AgentRunStepEndEvent())
         return cur_step_output
 
     @dispatcher.span
@@ -406,34 +406,38 @@ class AgentRunner(BaseAgentRunner):
         **kwargs: Any,
     ) -> TaskStepOutput:
         """Execute step."""
-        span_id = dispatcher.current_span_id
-        dispatcher.event(AgentRunStepStartEvent(span_id=span_id))
-        task = self.state.get_task(task_id)
-        step_queue = self.state.get_step_queue(task_id)
-        step = step or step_queue.popleft()
-        if input is not None:
-            step.input = input
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(AgentRunStepStartEvent())
+            task = self.state.get_task(task_id)
+            step_queue = self.state.get_step_queue(task_id)
+            step = step or step_queue.popleft()
+            if input is not None:
+                step.input = input
 
-        if self.verbose:
-            print(f"> Running step {step.step_id}. Step input: {step.input}")
+            if self.verbose:
+                print(f"> Running step {step.step_id}. Step input: {step.input}")
 
-        # TODO: figure out if you can dynamically swap in different step executors
-        # not clear when you would do that by theoretically possible
-        if mode == ChatResponseMode.WAIT:
-            cur_step_output = await self.agent_worker.arun_step(step, task, **kwargs)
-        elif mode == ChatResponseMode.STREAM:
-            cur_step_output = await self.agent_worker.astream_step(step, task, **kwargs)
-        else:
-            raise ValueError(f"Invalid mode: {mode}")
-        # append cur_step_output next steps to queue
-        next_steps = cur_step_output.next_steps
-        step_queue.extend(next_steps)
+            # TODO: figure out if you can dynamically swap in different step executors
+            # not clear when you would do that by theoretically possible
+            if mode == ChatResponseMode.WAIT:
+                cur_step_output = await self.agent_worker.arun_step(
+                    step, task, **kwargs
+                )
+            elif mode == ChatResponseMode.STREAM:
+                cur_step_output = await self.agent_worker.astream_step(
+                    step, task, **kwargs
+                )
+            else:
+                raise ValueError(f"Invalid mode: {mode}")
+            # append cur_step_output next steps to queue
+            next_steps = cur_step_output.next_steps
+            step_queue.extend(next_steps)
 
-        # add cur_step_output to completed steps
-        completed_steps = self.state.get_completed_steps(task_id)
-        completed_steps.append(cur_step_output)
+            # add cur_step_output to completed steps
+            completed_steps = self.state.get_completed_steps(task_id)
+            completed_steps.append(cur_step_output)
 
-        dispatcher.event(AgentRunStepEndEvent(span_id=span_id))
+            dispatch_event(AgentRunStepEndEvent())
         return cur_step_output
 
     @dispatcher.span
@@ -532,31 +536,31 @@ class AgentRunner(BaseAgentRunner):
         mode: ChatResponseMode = ChatResponseMode.WAIT,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
-        span_id = dispatcher.current_span_id
-        if chat_history is not None:
-            self.memory.set(chat_history)
-        task = self.create_task(message)
+        with dispatcher.dispatch_event as dispatch_event:
+            if chat_history is not None:
+                self.memory.set(chat_history)
+            task = self.create_task(message)
 
-        result_output = None
-        dispatcher.event(AgentChatWithStepStartEvent(span_id=span_id))
-        while True:
-            # pass step queue in as argument, assume step executor is stateless
-            cur_step_output = self._run_step(
-                task.task_id, mode=mode, tool_choice=tool_choice
+            result_output = None
+            dispatch_event(AgentChatWithStepStartEvent())
+            while True:
+                # pass step queue in as argument, assume step executor is stateless
+                cur_step_output = self._run_step(
+                    task.task_id, mode=mode, tool_choice=tool_choice
+                )
+
+                if cur_step_output.is_last:
+                    result_output = cur_step_output
+                    break
+
+                # ensure tool_choice does not cause endless loops
+                tool_choice = "auto"
+
+            result = self.finalize_response(
+                task.task_id,
+                result_output,
             )
-
-            if cur_step_output.is_last:
-                result_output = cur_step_output
-                break
-
-            # ensure tool_choice does not cause endless loops
-            tool_choice = "auto"
-
-        result = self.finalize_response(
-            task.task_id,
-            result_output,
-        )
-        dispatcher.event(AgentChatWithStepEndEvent(span_id=span_id))
+            dispatch_event(AgentChatWithStepEndEvent())
         return result
 
     @dispatcher.span
@@ -568,31 +572,31 @@ class AgentRunner(BaseAgentRunner):
         mode: ChatResponseMode = ChatResponseMode.WAIT,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
-        span_id = dispatcher.current_span_id
-        if chat_history is not None:
-            self.memory.set(chat_history)
-        task = self.create_task(message)
+        with dispatcher.dispatch_event as dispatch_event:
+            if chat_history is not None:
+                self.memory.set(chat_history)
+            task = self.create_task(message)
 
-        result_output = None
-        dispatcher.event(AgentChatWithStepStartEvent(span_id=span_id))
-        while True:
-            # pass step queue in as argument, assume step executor is stateless
-            cur_step_output = await self._arun_step(
-                task.task_id, mode=mode, tool_choice=tool_choice
+            result_output = None
+            dispatch_event(AgentChatWithStepStartEvent())
+            while True:
+                # pass step queue in as argument, assume step executor is stateless
+                cur_step_output = await self._arun_step(
+                    task.task_id, mode=mode, tool_choice=tool_choice
+                )
+
+                if cur_step_output.is_last:
+                    result_output = cur_step_output
+                    break
+
+                # ensure tool_choice does not cause endless loops
+                tool_choice = "auto"
+
+            result = self.finalize_response(
+                task.task_id,
+                result_output,
             )
-
-            if cur_step_output.is_last:
-                result_output = cur_step_output
-                break
-
-            # ensure tool_choice does not cause endless loops
-            tool_choice = "auto"
-
-        result = self.finalize_response(
-            task.task_id,
-            result_output,
-        )
-        dispatcher.event(AgentChatWithStepEndEvent(span_id=span_id))
+            dispatch_event(AgentChatWithStepEndEvent())
         return result
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/base/base_query_engine.py
+++ b/llama-index-core/llama_index/core/base/base_query_engine.py
@@ -44,7 +44,7 @@ class BaseQueryEngine(ChainableMixin, PromptMixin):
 
     @dispatcher.span
     def query(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(QueryStartEvent())
             with self.callback_manager.as_trace("query"):
                 if isinstance(str_or_query_bundle, str):
@@ -55,7 +55,7 @@ class BaseQueryEngine(ChainableMixin, PromptMixin):
 
     @dispatcher.span
     async def aquery(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(QueryStartEvent())
             with self.callback_manager.as_trace("query"):
                 if isinstance(str_or_query_bundle, str):

--- a/llama-index-core/llama_index/core/base/base_query_engine.py
+++ b/llama-index-core/llama_index/core/base/base_query_engine.py
@@ -44,24 +44,24 @@ class BaseQueryEngine(ChainableMixin, PromptMixin):
 
     @dispatcher.span
     def query(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        span_id = dispatcher.current_span_id
-        dispatcher.event(QueryStartEvent(span_id=span_id))
-        with self.callback_manager.as_trace("query"):
-            if isinstance(str_or_query_bundle, str):
-                str_or_query_bundle = QueryBundle(str_or_query_bundle)
-            query_result = self._query(str_or_query_bundle)
-        dispatcher.event(QueryEndEvent(span_id=span_id))
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(QueryStartEvent())
+            with self.callback_manager.as_trace("query"):
+                if isinstance(str_or_query_bundle, str):
+                    str_or_query_bundle = QueryBundle(str_or_query_bundle)
+                query_result = self._query(str_or_query_bundle)
+            dispatch_event(QueryEndEvent())
         return query_result
 
     @dispatcher.span
     async def aquery(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        span_id = dispatcher.current_span_id
-        dispatcher.event(QueryStartEvent(span_id=span_id))
-        with self.callback_manager.as_trace("query"):
-            if isinstance(str_or_query_bundle, str):
-                str_or_query_bundle = QueryBundle(str_or_query_bundle)
-            query_result = await self._aquery(str_or_query_bundle)
-        dispatcher.event(QueryEndEvent(span_id=span_id))
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(QueryStartEvent())
+            with self.callback_manager.as_trace("query"):
+                if isinstance(str_or_query_bundle, str):
+                    str_or_query_bundle = QueryBundle(str_or_query_bundle)
+                query_result = await self._aquery(str_or_query_bundle)
+            dispatch_event(QueryEndEvent())
         return query_result
 
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:

--- a/llama-index-core/llama_index/core/base/base_query_engine.py
+++ b/llama-index-core/llama_index/core/base/base_query_engine.py
@@ -44,22 +44,22 @@ class BaseQueryEngine(ChainableMixin, PromptMixin):
 
     @dispatcher.span
     def query(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        dispatcher.event(QueryStartEvent())
+        dispatcher.event(QueryStartEvent(span_id=dispatcher.current_span_id))
         with self.callback_manager.as_trace("query"):
             if isinstance(str_or_query_bundle, str):
                 str_or_query_bundle = QueryBundle(str_or_query_bundle)
             query_result = self._query(str_or_query_bundle)
-        dispatcher.event(QueryEndEvent())
+        dispatcher.event(QueryEndEvent(span_id=dispatcher.current_span_id))
         return query_result
 
     @dispatcher.span
     async def aquery(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        dispatcher.event(QueryStartEvent())
+        dispatcher.event(QueryStartEvent(span_id=dispatcher.current_span_id))
         with self.callback_manager.as_trace("query"):
             if isinstance(str_or_query_bundle, str):
                 str_or_query_bundle = QueryBundle(str_or_query_bundle)
             query_result = await self._aquery(str_or_query_bundle)
-        dispatcher.event(QueryEndEvent())
+        dispatcher.event(QueryEndEvent(span_id=dispatcher.current_span_id))
         return query_result
 
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:

--- a/llama-index-core/llama_index/core/base/base_query_engine.py
+++ b/llama-index-core/llama_index/core/base/base_query_engine.py
@@ -44,24 +44,26 @@ class BaseQueryEngine(ChainableMixin, PromptMixin):
 
     @dispatcher.span
     def query(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(QueryStartEvent())
-            with self.callback_manager.as_trace("query"):
-                if isinstance(str_or_query_bundle, str):
-                    str_or_query_bundle = QueryBundle(str_or_query_bundle)
-                query_result = self._query(str_or_query_bundle)
-            dispatch_event(QueryEndEvent())
+        dispatch_event = dispatcher.get_dispatch_event()
+
+        dispatch_event(QueryStartEvent())
+        with self.callback_manager.as_trace("query"):
+            if isinstance(str_or_query_bundle, str):
+                str_or_query_bundle = QueryBundle(str_or_query_bundle)
+            query_result = self._query(str_or_query_bundle)
+        dispatch_event(QueryEndEvent())
         return query_result
 
     @dispatcher.span
     async def aquery(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(QueryStartEvent())
-            with self.callback_manager.as_trace("query"):
-                if isinstance(str_or_query_bundle, str):
-                    str_or_query_bundle = QueryBundle(str_or_query_bundle)
-                query_result = await self._aquery(str_or_query_bundle)
-            dispatch_event(QueryEndEvent())
+        dispatch_event = dispatcher.get_dispatch_event()
+
+        dispatch_event(QueryStartEvent())
+        with self.callback_manager.as_trace("query"):
+            if isinstance(str_or_query_bundle, str):
+                str_or_query_bundle = QueryBundle(str_or_query_bundle)
+            query_result = await self._aquery(str_or_query_bundle)
+        dispatch_event(QueryEndEvent())
         return query_result
 
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:

--- a/llama-index-core/llama_index/core/base/base_query_engine.py
+++ b/llama-index-core/llama_index/core/base/base_query_engine.py
@@ -44,22 +44,24 @@ class BaseQueryEngine(ChainableMixin, PromptMixin):
 
     @dispatcher.span
     def query(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        dispatcher.event(QueryStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(QueryStartEvent(span_id=span_id))
         with self.callback_manager.as_trace("query"):
             if isinstance(str_or_query_bundle, str):
                 str_or_query_bundle = QueryBundle(str_or_query_bundle)
             query_result = self._query(str_or_query_bundle)
-        dispatcher.event(QueryEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(QueryEndEvent(span_id=span_id))
         return query_result
 
     @dispatcher.span
     async def aquery(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
-        dispatcher.event(QueryStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(QueryStartEvent(span_id=span_id))
         with self.callback_manager.as_trace("query"):
             if isinstance(str_or_query_bundle, str):
                 str_or_query_bundle = QueryBundle(str_or_query_bundle)
             query_result = await self._aquery(str_or_query_bundle)
-        dispatcher.event(QueryEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(QueryEndEvent(span_id=span_id))
         return query_result
 
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:

--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -224,7 +224,7 @@ class BaseRetriever(ChainableMixin, PromptMixin):
                 a QueryBundle object.
 
         """
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             self._check_callback_manager()
             dispatch_event(
                 RetrievalStartEvent(
@@ -256,7 +256,7 @@ class BaseRetriever(ChainableMixin, PromptMixin):
     @dispatcher.span
     async def aretrieve(self, str_or_query_bundle: QueryType) -> List[NodeWithScore]:
         self._check_callback_manager()
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(
                 RetrievalStartEvent(
                     str_or_query_bundle=str_or_query_bundle,

--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -224,70 +224,66 @@ class BaseRetriever(ChainableMixin, PromptMixin):
                 a QueryBundle object.
 
         """
-        span_id = dispatcher.current_span_id
-        self._check_callback_manager()
-        dispatcher.event(
-            RetrievalStartEvent(
-                str_or_query_bundle=str_or_query_bundle,
-                span_id=span_id,
-            )
-        )
-        if isinstance(str_or_query_bundle, str):
-            query_bundle = QueryBundle(str_or_query_bundle)
-        else:
-            query_bundle = str_or_query_bundle
-        with self.callback_manager.as_trace("query"):
-            with self.callback_manager.event(
-                CBEventType.RETRIEVE,
-                payload={EventPayload.QUERY_STR: query_bundle.query_str},
-            ) as retrieve_event:
-                nodes = self._retrieve(query_bundle)
-                nodes = self._handle_recursive_retrieval(query_bundle, nodes)
-                retrieve_event.on_end(
-                    payload={EventPayload.NODES: nodes},
+        with dispatcher.dispatch_event as dispatch_event:
+            self._check_callback_manager()
+            dispatch_event(
+                RetrievalStartEvent(
+                    str_or_query_bundle=str_or_query_bundle,
                 )
-        dispatcher.event(
-            RetrievalEndEvent(
-                str_or_query_bundle=str_or_query_bundle,
-                nodes=nodes,
-                span_id=span_id,
             )
-        )
+            if isinstance(str_or_query_bundle, str):
+                query_bundle = QueryBundle(str_or_query_bundle)
+            else:
+                query_bundle = str_or_query_bundle
+            with self.callback_manager.as_trace("query"):
+                with self.callback_manager.event(
+                    CBEventType.RETRIEVE,
+                    payload={EventPayload.QUERY_STR: query_bundle.query_str},
+                ) as retrieve_event:
+                    nodes = self._retrieve(query_bundle)
+                    nodes = self._handle_recursive_retrieval(query_bundle, nodes)
+                    retrieve_event.on_end(
+                        payload={EventPayload.NODES: nodes},
+                    )
+            dispatch_event(
+                RetrievalEndEvent(
+                    str_or_query_bundle=str_or_query_bundle,
+                    nodes=nodes,
+                )
+            )
         return nodes
 
     @dispatcher.span
     async def aretrieve(self, str_or_query_bundle: QueryType) -> List[NodeWithScore]:
         self._check_callback_manager()
-        span_id = dispatcher.current_span_id
-        dispatcher.event(
-            RetrievalStartEvent(
-                str_or_query_bundle=str_or_query_bundle,
-                span_id=span_id,
-            )
-        )
-        if isinstance(str_or_query_bundle, str):
-            query_bundle = QueryBundle(str_or_query_bundle)
-        else:
-            query_bundle = str_or_query_bundle
-        with self.callback_manager.as_trace("query"):
-            with self.callback_manager.event(
-                CBEventType.RETRIEVE,
-                payload={EventPayload.QUERY_STR: query_bundle.query_str},
-            ) as retrieve_event:
-                nodes = await self._aretrieve(query_bundle=query_bundle)
-                nodes = await self._ahandle_recursive_retrieval(
-                    query_bundle=query_bundle, nodes=nodes
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(
+                RetrievalStartEvent(
+                    str_or_query_bundle=str_or_query_bundle,
                 )
-                retrieve_event.on_end(
-                    payload={EventPayload.NODES: nodes},
-                )
-        dispatcher.event(
-            RetrievalEndEvent(
-                str_or_query_bundle=str_or_query_bundle,
-                nodes=nodes,
-                span_id=span_id,
             )
-        )
+            if isinstance(str_or_query_bundle, str):
+                query_bundle = QueryBundle(str_or_query_bundle)
+            else:
+                query_bundle = str_or_query_bundle
+            with self.callback_manager.as_trace("query"):
+                with self.callback_manager.event(
+                    CBEventType.RETRIEVE,
+                    payload={EventPayload.QUERY_STR: query_bundle.query_str},
+                ) as retrieve_event:
+                    nodes = await self._aretrieve(query_bundle=query_bundle)
+                    nodes = await self._ahandle_recursive_retrieval(
+                        query_bundle=query_bundle, nodes=nodes
+                    )
+                    retrieve_event.on_end(
+                        payload={EventPayload.NODES: nodes},
+                    )
+            dispatch_event(
+                RetrievalEndEvent(
+                    str_or_query_bundle=str_or_query_bundle,
+                    nodes=nodes,
+                )
+            )
         return nodes
 
     @abstractmethod

--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -224,11 +224,12 @@ class BaseRetriever(ChainableMixin, PromptMixin):
                 a QueryBundle object.
 
         """
+        span_id = dispatcher.current_span_id
         self._check_callback_manager()
         dispatcher.event(
             RetrievalStartEvent(
                 str_or_query_bundle=str_or_query_bundle,
-                span_id=dispatcher.current_span_id,
+                span_id=span_id,
             )
         )
         if isinstance(str_or_query_bundle, str):
@@ -249,7 +250,7 @@ class BaseRetriever(ChainableMixin, PromptMixin):
             RetrievalEndEvent(
                 str_or_query_bundle=str_or_query_bundle,
                 nodes=nodes,
-                span_id=dispatcher.current_span_id,
+                span_id=span_id,
             )
         )
         return nodes
@@ -257,10 +258,11 @@ class BaseRetriever(ChainableMixin, PromptMixin):
     @dispatcher.span
     async def aretrieve(self, str_or_query_bundle: QueryType) -> List[NodeWithScore]:
         self._check_callback_manager()
+        span_id = dispatcher.current_span_id
         dispatcher.event(
             RetrievalStartEvent(
                 str_or_query_bundle=str_or_query_bundle,
-                span_id=dispatcher.current_span_id,
+                span_id=span_id,
             )
         )
         if isinstance(str_or_query_bundle, str):
@@ -283,7 +285,7 @@ class BaseRetriever(ChainableMixin, PromptMixin):
             RetrievalEndEvent(
                 str_or_query_bundle=str_or_query_bundle,
                 nodes=nodes,
-                span_id=dispatcher.current_span_id,
+                span_id=span_id,
             )
         )
         return nodes

--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -225,7 +225,12 @@ class BaseRetriever(ChainableMixin, PromptMixin):
 
         """
         self._check_callback_manager()
-        dispatcher.event(RetrievalStartEvent(str_or_query_bundle=str_or_query_bundle))
+        dispatcher.event(
+            RetrievalStartEvent(
+                str_or_query_bundle=str_or_query_bundle,
+                span_id=dispatcher.current_span_id,
+            )
+        )
         if isinstance(str_or_query_bundle, str):
             query_bundle = QueryBundle(str_or_query_bundle)
         else:
@@ -241,14 +246,23 @@ class BaseRetriever(ChainableMixin, PromptMixin):
                     payload={EventPayload.NODES: nodes},
                 )
         dispatcher.event(
-            RetrievalEndEvent(str_or_query_bundle=str_or_query_bundle, nodes=nodes)
+            RetrievalEndEvent(
+                str_or_query_bundle=str_or_query_bundle,
+                nodes=nodes,
+                span_id=dispatcher.current_span_id,
+            )
         )
         return nodes
 
     @dispatcher.span
     async def aretrieve(self, str_or_query_bundle: QueryType) -> List[NodeWithScore]:
         self._check_callback_manager()
-        dispatcher.event(RetrievalStartEvent(str_or_query_bundle=str_or_query_bundle))
+        dispatcher.event(
+            RetrievalStartEvent(
+                str_or_query_bundle=str_or_query_bundle,
+                span_id=dispatcher.current_span_id,
+            )
+        )
         if isinstance(str_or_query_bundle, str):
             query_bundle = QueryBundle(str_or_query_bundle)
         else:
@@ -266,7 +280,11 @@ class BaseRetriever(ChainableMixin, PromptMixin):
                     payload={EventPayload.NODES: nodes},
                 )
         dispatcher.event(
-            RetrievalEndEvent(str_or_query_bundle=str_or_query_bundle, nodes=nodes)
+            RetrievalEndEvent(
+                str_or_query_bundle=str_or_query_bundle,
+                nodes=nodes,
+                span_id=dispatcher.current_span_id,
+            )
         )
         return nodes
 

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -114,10 +114,9 @@ class BaseEmbedding(TransformComponent):
         other examples of predefined instructions can be found in
         embeddings/huggingface_utils.py.
         """
+        span_id = dispatcher.current_span_id
         dispatcher.event(
-            EmbeddingStartEvent(
-                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
-            )
+            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
         )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
@@ -134,7 +133,7 @@ class BaseEmbedding(TransformComponent):
             EmbeddingEndEvent(
                 chunks=[query],
                 embeddings=[query_embedding],
-                span_id=dispatcher.current_span_id,
+                span_id=span_id,
             )
         )
         return query_embedding
@@ -142,10 +141,9 @@ class BaseEmbedding(TransformComponent):
     @dispatcher.span
     async def aget_query_embedding(self, query: str) -> Embedding:
         """Get query embedding."""
+        span_id = dispatcher.current_span_id
         dispatcher.event(
-            EmbeddingStartEvent(
-                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
-            )
+            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
         )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
@@ -162,7 +160,7 @@ class BaseEmbedding(TransformComponent):
             EmbeddingEndEvent(
                 chunks=[query],
                 embeddings=[query_embedding],
-                span_id=dispatcher.current_span_id,
+                span_id=span_id,
             )
         )
         return query_embedding
@@ -236,10 +234,9 @@ class BaseEmbedding(TransformComponent):
         document for retrieval: ". If you're curious, other examples of
         predefined instructions can be found in embeddings/huggingface_utils.py.
         """
+        span_id = dispatcher.current_span_id
         dispatcher.event(
-            EmbeddingStartEvent(
-                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
-            )
+            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
         )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
@@ -254,9 +251,7 @@ class BaseEmbedding(TransformComponent):
             )
         dispatcher.event(
             EmbeddingEndEvent(
-                chunks=[text],
-                embeddings=[text_embedding],
-                span_id=dispatcher.current_span_id,
+                chunks=[text], embeddings=[text_embedding], span_id=span_id
             )
         )
         return text_embedding
@@ -264,10 +259,9 @@ class BaseEmbedding(TransformComponent):
     @dispatcher.span
     async def aget_text_embedding(self, text: str) -> Embedding:
         """Async get text embedding."""
+        span_id = dispatcher.current_span_id
         dispatcher.event(
-            EmbeddingStartEvent(
-                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
-            )
+            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
         )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
@@ -284,7 +278,7 @@ class BaseEmbedding(TransformComponent):
             EmbeddingEndEvent(
                 chunks=[text],
                 embeddings=[text_embedding],
-                span_id=dispatcher.current_span_id,
+                span_id=span_id,
             )
         )
         return text_embedding
@@ -297,6 +291,7 @@ class BaseEmbedding(TransformComponent):
         **kwargs: Any,
     ) -> List[Embedding]:
         """Get a list of text embeddings, with batching."""
+        span_id = dispatcher.current_span_id
         cur_batch: List[str] = []
         result_embeddings: List[Embedding] = []
 
@@ -309,9 +304,7 @@ class BaseEmbedding(TransformComponent):
             if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
                 # flush
                 dispatcher.event(
-                    EmbeddingStartEvent(
-                        model_dict=self.to_dict(), span_id=dispatcher.current_span_id
-                    )
+                    EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
                 )
                 with self.callback_manager.event(
                     CBEventType.EMBEDDING,
@@ -329,7 +322,7 @@ class BaseEmbedding(TransformComponent):
                     EmbeddingEndEvent(
                         chunks=cur_batch,
                         embeddings=embeddings,
-                        span_id=dispatcher.current_span_id,
+                        span_id=span_id,
                     )
                 )
                 cur_batch = []
@@ -341,6 +334,7 @@ class BaseEmbedding(TransformComponent):
         self, texts: List[str], show_progress: bool = False
     ) -> List[Embedding]:
         """Asynchronously get a list of text embeddings, with batching."""
+        span_id = dispatcher.current_span_id
         cur_batch: List[str] = []
         callback_payloads: List[Tuple[str, List[str]]] = []
         result_embeddings: List[Embedding] = []
@@ -350,9 +344,7 @@ class BaseEmbedding(TransformComponent):
             if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
                 # flush
                 dispatcher.event(
-                    EmbeddingStartEvent(
-                        model_dict=self.to_dict(), span_id=dispatcher.current_span_id
-                    )
+                    EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
                 )
                 event_id = self.callback_manager.on_event_start(
                     CBEventType.EMBEDDING,
@@ -389,7 +381,7 @@ class BaseEmbedding(TransformComponent):
                 EmbeddingEndEvent(
                     chunks=text_batch,
                     embeddings=embeddings,
-                    span_id=dispatcher.current_span_id,
+                    span_id=span_id,
                 )
             )
             self.callback_manager.on_event_end(

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -114,7 +114,11 @@ class BaseEmbedding(TransformComponent):
         other examples of predefined instructions can be found in
         embeddings/huggingface_utils.py.
         """
-        dispatcher.event(EmbeddingStartEvent(model_dict=self.to_dict()))
+        dispatcher.event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
+            )
+        )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
@@ -127,14 +131,22 @@ class BaseEmbedding(TransformComponent):
                 },
             )
         dispatcher.event(
-            EmbeddingEndEvent(chunks=[query], embeddings=[query_embedding])
+            EmbeddingEndEvent(
+                chunks=[query],
+                embeddings=[query_embedding],
+                span_id=dispatcher.current_span_id,
+            )
         )
         return query_embedding
 
     @dispatcher.span
     async def aget_query_embedding(self, query: str) -> Embedding:
         """Get query embedding."""
-        dispatcher.event(EmbeddingStartEvent(model_dict=self.to_dict()))
+        dispatcher.event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
+            )
+        )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
@@ -147,7 +159,11 @@ class BaseEmbedding(TransformComponent):
                 },
             )
         dispatcher.event(
-            EmbeddingEndEvent(chunks=[query], embeddings=[query_embedding])
+            EmbeddingEndEvent(
+                chunks=[query],
+                embeddings=[query_embedding],
+                span_id=dispatcher.current_span_id,
+            )
         )
         return query_embedding
 
@@ -220,7 +236,11 @@ class BaseEmbedding(TransformComponent):
         document for retrieval: ". If you're curious, other examples of
         predefined instructions can be found in embeddings/huggingface_utils.py.
         """
-        dispatcher.event(EmbeddingStartEvent(model_dict=self.to_dict()))
+        dispatcher.event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
+            )
+        )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
@@ -232,13 +252,23 @@ class BaseEmbedding(TransformComponent):
                     EventPayload.EMBEDDINGS: [text_embedding],
                 }
             )
-        dispatcher.event(EmbeddingEndEvent(chunks=[text], embeddings=[text_embedding]))
+        dispatcher.event(
+            EmbeddingEndEvent(
+                chunks=[text],
+                embeddings=[text_embedding],
+                span_id=dispatcher.current_span_id,
+            )
+        )
         return text_embedding
 
     @dispatcher.span
     async def aget_text_embedding(self, text: str) -> Embedding:
         """Async get text embedding."""
-        dispatcher.event(EmbeddingStartEvent(model_dict=self.to_dict()))
+        dispatcher.event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(), span_id=dispatcher.current_span_id
+            )
+        )
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
@@ -250,7 +280,13 @@ class BaseEmbedding(TransformComponent):
                     EventPayload.EMBEDDINGS: [text_embedding],
                 }
             )
-        dispatcher.event(EmbeddingEndEvent(chunks=[text], embeddings=[text_embedding]))
+        dispatcher.event(
+            EmbeddingEndEvent(
+                chunks=[text],
+                embeddings=[text_embedding],
+                span_id=dispatcher.current_span_id,
+            )
+        )
         return text_embedding
 
     @dispatcher.span
@@ -272,7 +308,11 @@ class BaseEmbedding(TransformComponent):
             cur_batch.append(text)
             if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
                 # flush
-                dispatcher.event(EmbeddingStartEvent(model_dict=self.to_dict()))
+                dispatcher.event(
+                    EmbeddingStartEvent(
+                        model_dict=self.to_dict(), span_id=dispatcher.current_span_id
+                    )
+                )
                 with self.callback_manager.event(
                     CBEventType.EMBEDDING,
                     payload={EventPayload.SERIALIZED: self.to_dict()},
@@ -286,7 +326,11 @@ class BaseEmbedding(TransformComponent):
                         },
                     )
                 dispatcher.event(
-                    EmbeddingEndEvent(chunks=cur_batch, embeddings=embeddings)
+                    EmbeddingEndEvent(
+                        chunks=cur_batch,
+                        embeddings=embeddings,
+                        span_id=dispatcher.current_span_id,
+                    )
                 )
                 cur_batch = []
 
@@ -305,7 +349,11 @@ class BaseEmbedding(TransformComponent):
             cur_batch.append(text)
             if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
                 # flush
-                dispatcher.event(EmbeddingStartEvent(model_dict=self.to_dict()))
+                dispatcher.event(
+                    EmbeddingStartEvent(
+                        model_dict=self.to_dict(), span_id=dispatcher.current_span_id
+                    )
+                )
                 event_id = self.callback_manager.on_event_start(
                     CBEventType.EMBEDDING,
                     payload={EventPayload.SERIALIZED: self.to_dict()},
@@ -338,7 +386,11 @@ class BaseEmbedding(TransformComponent):
             callback_payloads, nested_embeddings
         ):
             dispatcher.event(
-                EmbeddingEndEvent(chunks=text_batch, embeddings=embeddings)
+                EmbeddingEndEvent(
+                    chunks=text_batch,
+                    embeddings=embeddings,
+                    span_id=dispatcher.current_span_id,
+                )
             )
             self.callback_manager.on_event_end(
                 CBEventType.EMBEDDING,

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -114,7 +114,7 @@ class BaseEmbedding(TransformComponent):
         other examples of predefined instructions can be found in
         embeddings/huggingface_utils.py.
         """
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(
                 EmbeddingStartEvent(
                     model_dict=self.to_dict(),
@@ -142,7 +142,7 @@ class BaseEmbedding(TransformComponent):
     @dispatcher.span
     async def aget_query_embedding(self, query: str) -> Embedding:
         """Get query embedding."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(
                 EmbeddingStartEvent(
                     model_dict=self.to_dict(),
@@ -236,7 +236,7 @@ class BaseEmbedding(TransformComponent):
         document for retrieval: ". If you're curious, other examples of
         predefined instructions can be found in embeddings/huggingface_utils.py.
         """
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(
                 EmbeddingStartEvent(
                     model_dict=self.to_dict(),
@@ -264,7 +264,7 @@ class BaseEmbedding(TransformComponent):
     @dispatcher.span
     async def aget_text_embedding(self, text: str) -> Embedding:
         """Async get text embedding."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(
                 EmbeddingStartEvent(
                     model_dict=self.to_dict(),
@@ -297,7 +297,7 @@ class BaseEmbedding(TransformComponent):
         **kwargs: Any,
     ) -> List[Embedding]:
         """Get a list of text embeddings, with batching."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             cur_batch: List[str] = []
             result_embeddings: List[Embedding] = []
 
@@ -341,7 +341,7 @@ class BaseEmbedding(TransformComponent):
         self, texts: List[str], show_progress: bool = False
     ) -> List[Embedding]:
         """Asynchronously get a list of text embeddings, with batching."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             cur_batch: List[str] = []
             callback_payloads: List[Tuple[str, List[str]]] = []
             result_embeddings: List[Embedding] = []

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -114,57 +114,59 @@ class BaseEmbedding(TransformComponent):
         other examples of predefined instructions can be found in
         embeddings/huggingface_utils.py.
         """
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(
-                EmbeddingStartEvent(
-                    model_dict=self.to_dict(),
-                )
-            )
-            with self.callback_manager.event(
-                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-            ) as event:
-                query_embedding = self._get_query_embedding(query)
+        dispatch_event = dispatcher.get_dispatch_event()
 
-                event.on_end(
-                    payload={
-                        EventPayload.CHUNKS: [query],
-                        EventPayload.EMBEDDINGS: [query_embedding],
-                    },
-                )
-            dispatch_event(
-                EmbeddingEndEvent(
-                    chunks=[query],
-                    embeddings=[query_embedding],
-                )
+        dispatch_event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(),
             )
+        )
+        with self.callback_manager.event(
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+        ) as event:
+            query_embedding = self._get_query_embedding(query)
+
+            event.on_end(
+                payload={
+                    EventPayload.CHUNKS: [query],
+                    EventPayload.EMBEDDINGS: [query_embedding],
+                },
+            )
+        dispatch_event(
+            EmbeddingEndEvent(
+                chunks=[query],
+                embeddings=[query_embedding],
+            )
+        )
         return query_embedding
 
     @dispatcher.span
     async def aget_query_embedding(self, query: str) -> Embedding:
         """Get query embedding."""
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(
-                EmbeddingStartEvent(
-                    model_dict=self.to_dict(),
-                )
-            )
-            with self.callback_manager.event(
-                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-            ) as event:
-                query_embedding = await self._aget_query_embedding(query)
+        dispatch_event = dispatcher.get_dispatch_event()
 
-                event.on_end(
-                    payload={
-                        EventPayload.CHUNKS: [query],
-                        EventPayload.EMBEDDINGS: [query_embedding],
-                    },
-                )
-            dispatch_event(
-                EmbeddingEndEvent(
-                    chunks=[query],
-                    embeddings=[query_embedding],
-                )
+        dispatch_event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(),
             )
+        )
+        with self.callback_manager.event(
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+        ) as event:
+            query_embedding = await self._aget_query_embedding(query)
+
+            event.on_end(
+                payload={
+                    EventPayload.CHUNKS: [query],
+                    EventPayload.EMBEDDINGS: [query_embedding],
+                },
+            )
+        dispatch_event(
+            EmbeddingEndEvent(
+                chunks=[query],
+                embeddings=[query_embedding],
+            )
+        )
         return query_embedding
 
     def get_agg_embedding_from_queries(
@@ -236,57 +238,59 @@ class BaseEmbedding(TransformComponent):
         document for retrieval: ". If you're curious, other examples of
         predefined instructions can be found in embeddings/huggingface_utils.py.
         """
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(
-                EmbeddingStartEvent(
-                    model_dict=self.to_dict(),
-                )
-            )
-            with self.callback_manager.event(
-                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-            ) as event:
-                text_embedding = self._get_text_embedding(text)
+        dispatch_event = dispatcher.get_dispatch_event()
 
-                event.on_end(
-                    payload={
-                        EventPayload.CHUNKS: [text],
-                        EventPayload.EMBEDDINGS: [text_embedding],
-                    }
-                )
-            dispatch_event(
-                EmbeddingEndEvent(
-                    chunks=[text],
-                    embeddings=[text_embedding],
-                )
+        dispatch_event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(),
             )
+        )
+        with self.callback_manager.event(
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+        ) as event:
+            text_embedding = self._get_text_embedding(text)
+
+            event.on_end(
+                payload={
+                    EventPayload.CHUNKS: [text],
+                    EventPayload.EMBEDDINGS: [text_embedding],
+                }
+            )
+        dispatch_event(
+            EmbeddingEndEvent(
+                chunks=[text],
+                embeddings=[text_embedding],
+            )
+        )
         return text_embedding
 
     @dispatcher.span
     async def aget_text_embedding(self, text: str) -> Embedding:
         """Async get text embedding."""
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(
-                EmbeddingStartEvent(
-                    model_dict=self.to_dict(),
-                )
-            )
-            with self.callback_manager.event(
-                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-            ) as event:
-                text_embedding = await self._aget_text_embedding(text)
+        dispatch_event = dispatcher.get_dispatch_event()
 
-                event.on_end(
-                    payload={
-                        EventPayload.CHUNKS: [text],
-                        EventPayload.EMBEDDINGS: [text_embedding],
-                    }
-                )
-            dispatch_event(
-                EmbeddingEndEvent(
-                    chunks=[text],
-                    embeddings=[text_embedding],
-                )
+        dispatch_event(
+            EmbeddingStartEvent(
+                model_dict=self.to_dict(),
             )
+        )
+        with self.callback_manager.event(
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+        ) as event:
+            text_embedding = await self._aget_text_embedding(text)
+
+            event.on_end(
+                payload={
+                    EventPayload.CHUNKS: [text],
+                    EventPayload.EMBEDDINGS: [text_embedding],
+                }
+            )
+        dispatch_event(
+            EmbeddingEndEvent(
+                chunks=[text],
+                embeddings=[text_embedding],
+            )
+        )
         return text_embedding
 
     @dispatcher.span
@@ -297,42 +301,43 @@ class BaseEmbedding(TransformComponent):
         **kwargs: Any,
     ) -> List[Embedding]:
         """Get a list of text embeddings, with batching."""
-        with dispatcher.dispatch_event() as dispatch_event:
-            cur_batch: List[str] = []
-            result_embeddings: List[Embedding] = []
+        dispatch_event = dispatcher.get_dispatch_event()
 
-            queue_with_progress = enumerate(
-                get_tqdm_iterable(texts, show_progress, "Generating embeddings")
-            )
+        cur_batch: List[str] = []
+        result_embeddings: List[Embedding] = []
 
-            for idx, text in queue_with_progress:
-                cur_batch.append(text)
-                if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
-                    # flush
-                    dispatch_event(
-                        EmbeddingStartEvent(
-                            model_dict=self.to_dict(),
-                        )
+        queue_with_progress = enumerate(
+            get_tqdm_iterable(texts, show_progress, "Generating embeddings")
+        )
+
+        for idx, text in queue_with_progress:
+            cur_batch.append(text)
+            if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
+                # flush
+                dispatch_event(
+                    EmbeddingStartEvent(
+                        model_dict=self.to_dict(),
                     )
-                    with self.callback_manager.event(
-                        CBEventType.EMBEDDING,
-                        payload={EventPayload.SERIALIZED: self.to_dict()},
-                    ) as event:
-                        embeddings = self._get_text_embeddings(cur_batch)
-                        result_embeddings.extend(embeddings)
-                        event.on_end(
-                            payload={
-                                EventPayload.CHUNKS: cur_batch,
-                                EventPayload.EMBEDDINGS: embeddings,
-                            },
-                        )
-                    dispatch_event(
-                        EmbeddingEndEvent(
-                            chunks=cur_batch,
-                            embeddings=embeddings,
-                        )
+                )
+                with self.callback_manager.event(
+                    CBEventType.EMBEDDING,
+                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                ) as event:
+                    embeddings = self._get_text_embeddings(cur_batch)
+                    result_embeddings.extend(embeddings)
+                    event.on_end(
+                        payload={
+                            EventPayload.CHUNKS: cur_batch,
+                            EventPayload.EMBEDDINGS: embeddings,
+                        },
                     )
-                    cur_batch = []
+                dispatch_event(
+                    EmbeddingEndEvent(
+                        chunks=cur_batch,
+                        embeddings=embeddings,
+                    )
+                )
+                cur_batch = []
 
         return result_embeddings
 
@@ -341,67 +346,66 @@ class BaseEmbedding(TransformComponent):
         self, texts: List[str], show_progress: bool = False
     ) -> List[Embedding]:
         """Asynchronously get a list of text embeddings, with batching."""
-        with dispatcher.dispatch_event() as dispatch_event:
-            cur_batch: List[str] = []
-            callback_payloads: List[Tuple[str, List[str]]] = []
-            result_embeddings: List[Embedding] = []
-            embeddings_coroutines: List[Coroutine] = []
-            for idx, text in enumerate(texts):
-                cur_batch.append(text)
-                if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
-                    # flush
-                    dispatch_event(
-                        EmbeddingStartEvent(
-                            model_dict=self.to_dict(),
-                        )
-                    )
-                    event_id = self.callback_manager.on_event_start(
-                        CBEventType.EMBEDDING,
-                        payload={EventPayload.SERIALIZED: self.to_dict()},
-                    )
-                    callback_payloads.append((event_id, cur_batch))
-                    embeddings_coroutines.append(self._aget_text_embeddings(cur_batch))
-                    cur_batch = []
+        dispatch_event = dispatcher.get_dispatch_event()
 
-            # flatten the results of asyncio.gather, which is a list of embeddings lists
-            nested_embeddings = []
-            if show_progress:
-                try:
-                    from tqdm.asyncio import tqdm_asyncio
-
-                    nested_embeddings = await tqdm_asyncio.gather(
-                        *embeddings_coroutines,
-                        total=len(embeddings_coroutines),
-                        desc="Generating embeddings",
-                    )
-                except ImportError:
-                    nested_embeddings = await asyncio.gather(*embeddings_coroutines)
-            else:
-                nested_embeddings = await asyncio.gather(*embeddings_coroutines)
-
-            result_embeddings = [
-                embedding
-                for embeddings in nested_embeddings
-                for embedding in embeddings
-            ]
-
-            for (event_id, text_batch), embeddings in zip(
-                callback_payloads, nested_embeddings
-            ):
+        cur_batch: List[str] = []
+        callback_payloads: List[Tuple[str, List[str]]] = []
+        result_embeddings: List[Embedding] = []
+        embeddings_coroutines: List[Coroutine] = []
+        for idx, text in enumerate(texts):
+            cur_batch.append(text)
+            if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
+                # flush
                 dispatch_event(
-                    EmbeddingEndEvent(
-                        chunks=text_batch,
-                        embeddings=embeddings,
+                    EmbeddingStartEvent(
+                        model_dict=self.to_dict(),
                     )
                 )
-                self.callback_manager.on_event_end(
+                event_id = self.callback_manager.on_event_start(
                     CBEventType.EMBEDDING,
-                    payload={
-                        EventPayload.CHUNKS: text_batch,
-                        EventPayload.EMBEDDINGS: embeddings,
-                    },
-                    event_id=event_id,
+                    payload={EventPayload.SERIALIZED: self.to_dict()},
                 )
+                callback_payloads.append((event_id, cur_batch))
+                embeddings_coroutines.append(self._aget_text_embeddings(cur_batch))
+                cur_batch = []
+
+        # flatten the results of asyncio.gather, which is a list of embeddings lists
+        nested_embeddings = []
+        if show_progress:
+            try:
+                from tqdm.asyncio import tqdm_asyncio
+
+                nested_embeddings = await tqdm_asyncio.gather(
+                    *embeddings_coroutines,
+                    total=len(embeddings_coroutines),
+                    desc="Generating embeddings",
+                )
+            except ImportError:
+                nested_embeddings = await asyncio.gather(*embeddings_coroutines)
+        else:
+            nested_embeddings = await asyncio.gather(*embeddings_coroutines)
+
+        result_embeddings = [
+            embedding for embeddings in nested_embeddings for embedding in embeddings
+        ]
+
+        for (event_id, text_batch), embeddings in zip(
+            callback_payloads, nested_embeddings
+        ):
+            dispatch_event(
+                EmbeddingEndEvent(
+                    chunks=text_batch,
+                    embeddings=embeddings,
+                )
+            )
+            self.callback_manager.on_event_end(
+                CBEventType.EMBEDDING,
+                payload={
+                    EventPayload.CHUNKS: text_batch,
+                    EventPayload.EMBEDDINGS: embeddings,
+                },
+                event_id=event_id,
+            )
 
         return result_embeddings
 

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -114,55 +114,57 @@ class BaseEmbedding(TransformComponent):
         other examples of predefined instructions can be found in
         embeddings/huggingface_utils.py.
         """
-        span_id = dispatcher.current_span_id
-        dispatcher.event(
-            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
-        )
-        with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-        ) as event:
-            query_embedding = self._get_query_embedding(query)
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(
+                EmbeddingStartEvent(
+                    model_dict=self.to_dict(),
+                )
+            )
+            with self.callback_manager.event(
+                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            ) as event:
+                query_embedding = self._get_query_embedding(query)
 
-            event.on_end(
-                payload={
-                    EventPayload.CHUNKS: [query],
-                    EventPayload.EMBEDDINGS: [query_embedding],
-                },
+                event.on_end(
+                    payload={
+                        EventPayload.CHUNKS: [query],
+                        EventPayload.EMBEDDINGS: [query_embedding],
+                    },
+                )
+            dispatch_event(
+                EmbeddingEndEvent(
+                    chunks=[query],
+                    embeddings=[query_embedding],
+                )
             )
-        dispatcher.event(
-            EmbeddingEndEvent(
-                chunks=[query],
-                embeddings=[query_embedding],
-                span_id=span_id,
-            )
-        )
         return query_embedding
 
     @dispatcher.span
     async def aget_query_embedding(self, query: str) -> Embedding:
         """Get query embedding."""
-        span_id = dispatcher.current_span_id
-        dispatcher.event(
-            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
-        )
-        with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-        ) as event:
-            query_embedding = await self._aget_query_embedding(query)
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(
+                EmbeddingStartEvent(
+                    model_dict=self.to_dict(),
+                )
+            )
+            with self.callback_manager.event(
+                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            ) as event:
+                query_embedding = await self._aget_query_embedding(query)
 
-            event.on_end(
-                payload={
-                    EventPayload.CHUNKS: [query],
-                    EventPayload.EMBEDDINGS: [query_embedding],
-                },
+                event.on_end(
+                    payload={
+                        EventPayload.CHUNKS: [query],
+                        EventPayload.EMBEDDINGS: [query_embedding],
+                    },
+                )
+            dispatch_event(
+                EmbeddingEndEvent(
+                    chunks=[query],
+                    embeddings=[query_embedding],
+                )
             )
-        dispatcher.event(
-            EmbeddingEndEvent(
-                chunks=[query],
-                embeddings=[query_embedding],
-                span_id=span_id,
-            )
-        )
         return query_embedding
 
     def get_agg_embedding_from_queries(
@@ -234,53 +236,57 @@ class BaseEmbedding(TransformComponent):
         document for retrieval: ". If you're curious, other examples of
         predefined instructions can be found in embeddings/huggingface_utils.py.
         """
-        span_id = dispatcher.current_span_id
-        dispatcher.event(
-            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
-        )
-        with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-        ) as event:
-            text_embedding = self._get_text_embedding(text)
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(
+                EmbeddingStartEvent(
+                    model_dict=self.to_dict(),
+                )
+            )
+            with self.callback_manager.event(
+                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            ) as event:
+                text_embedding = self._get_text_embedding(text)
 
-            event.on_end(
-                payload={
-                    EventPayload.CHUNKS: [text],
-                    EventPayload.EMBEDDINGS: [text_embedding],
-                }
+                event.on_end(
+                    payload={
+                        EventPayload.CHUNKS: [text],
+                        EventPayload.EMBEDDINGS: [text_embedding],
+                    }
+                )
+            dispatch_event(
+                EmbeddingEndEvent(
+                    chunks=[text],
+                    embeddings=[text_embedding],
+                )
             )
-        dispatcher.event(
-            EmbeddingEndEvent(
-                chunks=[text], embeddings=[text_embedding], span_id=span_id
-            )
-        )
         return text_embedding
 
     @dispatcher.span
     async def aget_text_embedding(self, text: str) -> Embedding:
         """Async get text embedding."""
-        span_id = dispatcher.current_span_id
-        dispatcher.event(
-            EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
-        )
-        with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
-        ) as event:
-            text_embedding = await self._aget_text_embedding(text)
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(
+                EmbeddingStartEvent(
+                    model_dict=self.to_dict(),
+                )
+            )
+            with self.callback_manager.event(
+                CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            ) as event:
+                text_embedding = await self._aget_text_embedding(text)
 
-            event.on_end(
-                payload={
-                    EventPayload.CHUNKS: [text],
-                    EventPayload.EMBEDDINGS: [text_embedding],
-                }
+                event.on_end(
+                    payload={
+                        EventPayload.CHUNKS: [text],
+                        EventPayload.EMBEDDINGS: [text_embedding],
+                    }
+                )
+            dispatch_event(
+                EmbeddingEndEvent(
+                    chunks=[text],
+                    embeddings=[text_embedding],
+                )
             )
-        dispatcher.event(
-            EmbeddingEndEvent(
-                chunks=[text],
-                embeddings=[text_embedding],
-                span_id=span_id,
-            )
-        )
         return text_embedding
 
     @dispatcher.span
@@ -291,41 +297,42 @@ class BaseEmbedding(TransformComponent):
         **kwargs: Any,
     ) -> List[Embedding]:
         """Get a list of text embeddings, with batching."""
-        span_id = dispatcher.current_span_id
-        cur_batch: List[str] = []
-        result_embeddings: List[Embedding] = []
+        with dispatcher.dispatch_event as dispatch_event:
+            cur_batch: List[str] = []
+            result_embeddings: List[Embedding] = []
 
-        queue_with_progress = enumerate(
-            get_tqdm_iterable(texts, show_progress, "Generating embeddings")
-        )
+            queue_with_progress = enumerate(
+                get_tqdm_iterable(texts, show_progress, "Generating embeddings")
+            )
 
-        for idx, text in queue_with_progress:
-            cur_batch.append(text)
-            if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
-                # flush
-                dispatcher.event(
-                    EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
-                )
-                with self.callback_manager.event(
-                    CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
-                ) as event:
-                    embeddings = self._get_text_embeddings(cur_batch)
-                    result_embeddings.extend(embeddings)
-                    event.on_end(
-                        payload={
-                            EventPayload.CHUNKS: cur_batch,
-                            EventPayload.EMBEDDINGS: embeddings,
-                        },
+            for idx, text in queue_with_progress:
+                cur_batch.append(text)
+                if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
+                    # flush
+                    dispatch_event(
+                        EmbeddingStartEvent(
+                            model_dict=self.to_dict(),
+                        )
                     )
-                dispatcher.event(
-                    EmbeddingEndEvent(
-                        chunks=cur_batch,
-                        embeddings=embeddings,
-                        span_id=span_id,
+                    with self.callback_manager.event(
+                        CBEventType.EMBEDDING,
+                        payload={EventPayload.SERIALIZED: self.to_dict()},
+                    ) as event:
+                        embeddings = self._get_text_embeddings(cur_batch)
+                        result_embeddings.extend(embeddings)
+                        event.on_end(
+                            payload={
+                                EventPayload.CHUNKS: cur_batch,
+                                EventPayload.EMBEDDINGS: embeddings,
+                            },
+                        )
+                    dispatch_event(
+                        EmbeddingEndEvent(
+                            chunks=cur_batch,
+                            embeddings=embeddings,
+                        )
                     )
-                )
-                cur_batch = []
+                    cur_batch = []
 
         return result_embeddings
 
@@ -334,64 +341,67 @@ class BaseEmbedding(TransformComponent):
         self, texts: List[str], show_progress: bool = False
     ) -> List[Embedding]:
         """Asynchronously get a list of text embeddings, with batching."""
-        span_id = dispatcher.current_span_id
-        cur_batch: List[str] = []
-        callback_payloads: List[Tuple[str, List[str]]] = []
-        result_embeddings: List[Embedding] = []
-        embeddings_coroutines: List[Coroutine] = []
-        for idx, text in enumerate(texts):
-            cur_batch.append(text)
-            if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
-                # flush
-                dispatcher.event(
-                    EmbeddingStartEvent(model_dict=self.to_dict(), span_id=span_id)
-                )
-                event_id = self.callback_manager.on_event_start(
-                    CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
-                )
-                callback_payloads.append((event_id, cur_batch))
-                embeddings_coroutines.append(self._aget_text_embeddings(cur_batch))
-                cur_batch = []
+        with dispatcher.dispatch_event as dispatch_event:
+            cur_batch: List[str] = []
+            callback_payloads: List[Tuple[str, List[str]]] = []
+            result_embeddings: List[Embedding] = []
+            embeddings_coroutines: List[Coroutine] = []
+            for idx, text in enumerate(texts):
+                cur_batch.append(text)
+                if idx == len(texts) - 1 or len(cur_batch) == self.embed_batch_size:
+                    # flush
+                    dispatch_event(
+                        EmbeddingStartEvent(
+                            model_dict=self.to_dict(),
+                        )
+                    )
+                    event_id = self.callback_manager.on_event_start(
+                        CBEventType.EMBEDDING,
+                        payload={EventPayload.SERIALIZED: self.to_dict()},
+                    )
+                    callback_payloads.append((event_id, cur_batch))
+                    embeddings_coroutines.append(self._aget_text_embeddings(cur_batch))
+                    cur_batch = []
 
-        # flatten the results of asyncio.gather, which is a list of embeddings lists
-        nested_embeddings = []
-        if show_progress:
-            try:
-                from tqdm.asyncio import tqdm_asyncio
+            # flatten the results of asyncio.gather, which is a list of embeddings lists
+            nested_embeddings = []
+            if show_progress:
+                try:
+                    from tqdm.asyncio import tqdm_asyncio
 
-                nested_embeddings = await tqdm_asyncio.gather(
-                    *embeddings_coroutines,
-                    total=len(embeddings_coroutines),
-                    desc="Generating embeddings",
-                )
-            except ImportError:
+                    nested_embeddings = await tqdm_asyncio.gather(
+                        *embeddings_coroutines,
+                        total=len(embeddings_coroutines),
+                        desc="Generating embeddings",
+                    )
+                except ImportError:
+                    nested_embeddings = await asyncio.gather(*embeddings_coroutines)
+            else:
                 nested_embeddings = await asyncio.gather(*embeddings_coroutines)
-        else:
-            nested_embeddings = await asyncio.gather(*embeddings_coroutines)
 
-        result_embeddings = [
-            embedding for embeddings in nested_embeddings for embedding in embeddings
-        ]
+            result_embeddings = [
+                embedding
+                for embeddings in nested_embeddings
+                for embedding in embeddings
+            ]
 
-        for (event_id, text_batch), embeddings in zip(
-            callback_payloads, nested_embeddings
-        ):
-            dispatcher.event(
-                EmbeddingEndEvent(
-                    chunks=text_batch,
-                    embeddings=embeddings,
-                    span_id=span_id,
+            for (event_id, text_batch), embeddings in zip(
+                callback_payloads, nested_embeddings
+            ):
+                dispatch_event(
+                    EmbeddingEndEvent(
+                        chunks=text_batch,
+                        embeddings=embeddings,
+                    )
                 )
-            )
-            self.callback_manager.on_event_end(
-                CBEventType.EMBEDDING,
-                payload={
-                    EventPayload.CHUNKS: text_batch,
-                    EventPayload.EMBEDDINGS: embeddings,
-                },
-                event_id=event_id,
-            )
+                self.callback_manager.on_event_end(
+                    CBEventType.EMBEDDING,
+                    payload={
+                        EventPayload.CHUNKS: text_batch,
+                        EventPayload.EMBEDDINGS: embeddings,
+                    },
+                    event_id=event_id,
+                )
 
         return result_embeddings
 

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -129,16 +129,15 @@ class StreamingAgentChatResponse:
             )
 
         # try/except to prevent hanging on error
-        dispatcher.event(StreamChatStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(StreamChatStartEvent(span_id=span_id))
         try:
             final_text = ""
             for chat in self.chat_stream:
                 self._is_function = is_function(chat.message)
                 if chat.delta:
                     dispatcher.event(
-                        StreamChatDeltaReceivedEvent(
-                            delta=chat.delta, span_id=dispatcher.current_span_id
-                        )
+                        StreamChatDeltaReceivedEvent(delta=chat.delta, span_id=span_id)
                     )
                     self.put_in_queue(chat.delta)
                 final_text += chat.delta or ""
@@ -150,7 +149,7 @@ class StreamingAgentChatResponse:
         except Exception as e:
             dispatcher.event(
                 StreamChatErrorEvent(
-                    span_id=dispatcher.current_span_id,
+                    span_id=span_id,
                 )
             )
             if not raise_error:
@@ -159,7 +158,7 @@ class StreamingAgentChatResponse:
                 )
             else:
                 raise
-        dispatcher.event(StreamChatEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(StreamChatEndEvent(span_id=span_id))
 
         self._is_done = True
 
@@ -175,6 +174,7 @@ class StreamingAgentChatResponse:
         on_stream_end_fn: Optional[callable] = None,
     ) -> None:
         self._ensure_async_setup()
+        span_id = dispatcher.current_span_id
 
         if self.achat_stream is None:
             raise ValueError(
@@ -183,16 +183,14 @@ class StreamingAgentChatResponse:
             )
 
         # try/except to prevent hanging on error
-        dispatcher.event(StreamChatStartEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(StreamChatStartEvent(span_id=span_id))
         try:
             final_text = ""
             async for chat in self.achat_stream:
                 self._is_function = is_function(chat.message)
                 if chat.delta:
                     dispatcher.event(
-                        StreamChatDeltaReceivedEvent(
-                            delta=chat.delta, span_id=dispatcher.current_span_id
-                        )
+                        StreamChatDeltaReceivedEvent(delta=chat.delta, span_id=span_id)
                     )
                     self.aput_in_queue(chat.delta)
                 final_text += chat.delta or ""
@@ -205,9 +203,9 @@ class StreamingAgentChatResponse:
                 chat.message.content = final_text.strip()  # final message
                 memory.put(chat.message)
         except Exception as e:
-            dispatcher.event(StreamChatErrorEvent(span_id=dispatcher.current_span_id))
+            dispatcher.event(StreamChatErrorEvent(span_id=span_id))
             logger.warning(f"Encountered exception writing response to history: {e}")
-        dispatcher.event(StreamChatEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(StreamChatEndEvent(span_id=span_id))
         self._is_done = True
 
         # These act as is_done events for any consumers waiting

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -129,7 +129,7 @@ class StreamingAgentChatResponse:
             )
 
         # try/except to prevent hanging on error
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(StreamChatStartEvent())
             try:
                 final_text = ""
@@ -172,7 +172,7 @@ class StreamingAgentChatResponse:
         on_stream_end_fn: Optional[callable] = None,
     ) -> None:
         self._ensure_async_setup()
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             if self.achat_stream is None:
                 raise ValueError(
                     "achat_stream is None. Cannot asynchronously write to "

--- a/llama-index-core/llama_index/core/instrumentation/__init__.py
+++ b/llama-index-core/llama_index/core/instrumentation/__init__.py
@@ -24,7 +24,10 @@ def get_dispatcher(name: str = "root") -> Dispatcher:
         parent_name = "root"
 
     new_dispatcher = Dispatcher(
-        name=name, root=root_dispatcher, parent_name=parent_name, manager=root_manager
+        name=name,
+        root_name=root_dispatcher.name,
+        parent_name=parent_name,
+        manager=root_manager,
     )
     root_manager.add_dispatcher(new_dispatcher)
     return new_dispatcher

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -9,6 +9,7 @@ from llama_index.core.instrumentation.span_handlers import (
     NullSpanHandler,
 )
 from llama_index.core.instrumentation.events.base import BaseEvent
+from llama_index.core.instrumentation.events.span import SpanDropEvent
 import wrapt
 
 
@@ -167,6 +168,7 @@ class Dispatcher(BaseModel):
                 result = func(*args, **kwargs)
             except BaseException as e:
                 print(f"{self.name} DROPPING SPAN {id_} due to {e}", flush=True)
+                self.event(SpanDropEvent(span_id=id_, err_str=str(e)))
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)
                 raise
             else:
@@ -190,6 +192,7 @@ class Dispatcher(BaseModel):
                 result = await func(*args, **kwargs)
             except BaseException as e:
                 print(f"{self.name} DROPPING SPAN {id_}", flush=True)
+                self.event(SpanDropEvent(span_id=id_, err_str=str(e)))
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)
                 raise
             else:

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -166,13 +166,16 @@ class Dispatcher(BaseModel):
             bound_args = inspect.signature(func).bind(*args, **kwargs)
             id_ = f"{func.__qualname__}-{uuid.uuid4()}"
             self.current_span_id = id_
+            print(f"{self.name} ENTERING SPAN {id_}", flush=True)
             self.span_enter(id_=id_, bound_args=bound_args, instance=instance)
             try:
                 result = func(*args, **kwargs)
             except BaseException as e:
+                print(f"{self.name} DROPPING SPAN {id_} due to {e}", flush=True)
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)
                 raise
             else:
+                print(f"{self.name} EXITING SPAN {id_}", flush=True)
                 self.span_exit(
                     id_=id_, bound_args=bound_args, instance=instance, result=result
                 )
@@ -184,13 +187,16 @@ class Dispatcher(BaseModel):
             id_ = f"{func.__qualname__}-{uuid.uuid4()}"
             async with self._asyncio_lock:
                 self.current_span_id = id_
+            print(f"{self.name} ENTERING SPAN {id_}", flush=True)
             self.span_enter(id_=id_, bound_args=bound_args, instance=instance)
             try:
                 result = await func(*args, **kwargs)
             except BaseException as e:
+                print(f"{self.name} DROPPING SPAN {id_}", flush=True)
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)
                 raise
             else:
+                print(f"{self.name} EXITING SPAN {id_}", flush=True)
                 self.span_exit(
                     id_=id_, bound_args=bound_args, instance=instance, result=result
                 )

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -166,6 +166,7 @@ class Dispatcher(BaseModel):
             bound_args = inspect.signature(func).bind(*args, **kwargs)
             id_ = f"{func.__qualname__}-{uuid.uuid4()}"
             self.current_span_id = id_
+            self.root.current_span_id = id_
             print(f"{self.name} ENTERING SPAN {id_}", flush=True)
             self.span_enter(id_=id_, bound_args=bound_args, instance=instance)
             try:
@@ -187,6 +188,8 @@ class Dispatcher(BaseModel):
             id_ = f"{func.__qualname__}-{uuid.uuid4()}"
             async with self._asyncio_lock:
                 self.current_span_id = id_
+            async with self.root._asyncio_lock:
+                self.root.current_span_id = id_
             print(f"{self.name} ENTERING SPAN {id_}", flush=True)
             self.span_enter(id_=id_, bound_args=bound_args, instance=instance)
             try:

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -86,7 +86,6 @@ class Dispatcher(BaseModel):
 
     def span_enter(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -97,7 +96,6 @@ class Dispatcher(BaseModel):
         while c:
             for h in c.span_handlers:
                 h.span_enter(
-                    *args,
                     id_=id_,
                     bound_args=bound_args,
                     instance=instance,
@@ -110,7 +108,6 @@ class Dispatcher(BaseModel):
 
     def span_drop(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -122,7 +119,6 @@ class Dispatcher(BaseModel):
         while c:
             for h in c.span_handlers:
                 h.span_drop(
-                    *args,
                     id_=id_,
                     bound_args=bound_args,
                     instance=instance,
@@ -136,7 +132,6 @@ class Dispatcher(BaseModel):
 
     def span_exit(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -148,7 +143,6 @@ class Dispatcher(BaseModel):
         while c:
             for h in c.span_handlers:
                 h.span_exit(
-                    *args,
                     id_=id_,
                     bound_args=bound_args,
                     instance=instance,

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -167,7 +167,12 @@ class Dispatcher(BaseModel):
 
     @contextmanager
     def dispatch_event(self):
-        """Context manager for firing events within a span session."""
+        """Context manager for firing events within a span session.
+
+        This context manager should be used with @dispatcher.span decorated
+        functions only. Otherwise, the span_id should not be trusted, as the
+        span decorator sets the span_id.
+        """
         span_id = self.current_span_id
         dispatch_event: EventDispatcher = partial(self.event, span_id=span_id)
 

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -162,17 +162,14 @@ class Dispatcher(BaseModel):
             id_ = f"{func.__qualname__}-{uuid.uuid4()}"
             self.current_span_id = id_
             self.root.current_span_id = id_
-            print(f"{self.name} ENTERING SPAN {id_}", flush=True)
             self.span_enter(id_=id_, bound_args=bound_args, instance=instance)
             try:
                 result = func(*args, **kwargs)
             except BaseException as e:
-                print(f"{self.name} DROPPING SPAN {id_} due to {e}", flush=True)
                 self.event(SpanDropEvent(span_id=id_, err_str=str(e)))
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)
                 raise
             else:
-                print(f"{self.name} EXITING SPAN {id_}", flush=True)
                 self.span_exit(
                     id_=id_, bound_args=bound_args, instance=instance, result=result
                 )
@@ -186,17 +183,14 @@ class Dispatcher(BaseModel):
                 self.current_span_id = id_
             async with self.root._asyncio_lock:
                 self.root.current_span_id = id_
-            print(f"{self.name} ENTERING SPAN {id_}", flush=True)
             self.span_enter(id_=id_, bound_args=bound_args, instance=instance)
             try:
                 result = await func(*args, **kwargs)
             except BaseException as e:
-                print(f"{self.name} DROPPING SPAN {id_}", flush=True)
                 self.event(SpanDropEvent(span_id=id_, err_str=str(e)))
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)
                 raise
             else:
-                print(f"{self.name} EXITING SPAN {id_}", flush=True)
                 self.span_exit(
                     id_=id_, bound_args=bound_args, instance=instance, result=result
                 )

--- a/llama-index-core/llama_index/core/instrumentation/events/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/base.py
@@ -7,6 +7,7 @@ from datetime import datetime
 class BaseEvent(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now())
     id_: str = Field(default_factory=lambda: uuid4())
+    span_id: str = Field(default_factory=str)
 
     @classmethod
     def class_name(cls):

--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -54,6 +54,16 @@ class LLMChatStartEvent(BaseEvent):
         return "LLMChatStartEvent"
 
 
+class LLMChatInProgressEvent(BaseEvent):
+    messages: List[ChatMessage]
+    response: ChatResponse
+
+    @classmethod
+    def class_name(cls):
+        """Class name."""
+        return "LLMChatInProgressEvent"
+
+
 class LLMChatEndEvent(BaseEvent):
     messages: List[ChatMessage]
     response: ChatResponse

--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -22,6 +22,20 @@ class LLMPredictEndEvent(BaseEvent):
         return "LLMPredictEndEvent"
 
 
+class LLMStructuredPredictStartEvent(BaseEvent):
+    @classmethod
+    def class_name(cls):
+        """Class name."""
+        return "LLMStructuredPredictStartEvent"
+
+
+class LLMStructuredPredictEndEvent(BaseEvent):
+    @classmethod
+    def class_name(cls):
+        """Class name."""
+        return "LLMStructuredPredictEndEvent"
+
+
 class LLMCompletionStartEvent(BaseEvent):
     prompt: str
     additional_kwargs: dict

--- a/llama-index-core/llama_index/core/instrumentation/events/span.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/span.py
@@ -1,0 +1,10 @@
+from llama_index.core.instrumentation.events.base import BaseEvent
+
+
+class SpanDropEvent(BaseEvent):
+    err_str: str
+
+    @classmethod
+    def class_name(cls):
+        """Class name."""
+        return "SpanDropEvent"

--- a/llama-index-core/llama_index/core/instrumentation/span/simple.py
+++ b/llama-index-core/llama_index/core/instrumentation/span/simple.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.instrumentation.span.base import BaseSpan
 from datetime import datetime
@@ -10,3 +10,4 @@ class SimpleSpan(BaseSpan):
     start_time: datetime = Field(default_factory=lambda: datetime.now())
     end_time: Optional[datetime] = Field(default=None)
     duration: float = Field(default=float, description="Duration of span in seconds.")
+    metadata: Optional[Dict] = Field(default=None)

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -31,7 +31,6 @@ class BaseSpanHandler(BaseModel, Generic[T]):
 
     def span_enter(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -54,7 +53,6 @@ class BaseSpanHandler(BaseModel, Generic[T]):
 
     def span_exit(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -72,7 +70,6 @@ class BaseSpanHandler(BaseModel, Generic[T]):
 
     def span_drop(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -91,7 +88,6 @@ class BaseSpanHandler(BaseModel, Generic[T]):
     @abstractmethod
     def new_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -104,7 +100,6 @@ class BaseSpanHandler(BaseModel, Generic[T]):
     @abstractmethod
     def prepare_to_exit_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -117,7 +112,6 @@ class BaseSpanHandler(BaseModel, Generic[T]):
     @abstractmethod
     def prepare_to_drop_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -80,7 +80,6 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         **kwargs: Any,
     ) -> None:
         """Logic for dropping a span i.e. early exit."""
-        print(f"{self.class_name()} DROPPING SPAN {id_}", flush=True)
         span = self.prepare_to_drop_span(
             id_=id_, bound_args=bound_args, instance=instance, err=err
         )

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -1,6 +1,6 @@
 import inspect
 from abc import abstractmethod
-from typing import Any, Dict, Generic, Optional, TypeVar
+from typing import Any, Dict, List, Generic, Optional, TypeVar
 
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.instrumentation.span.base import BaseSpan
@@ -11,6 +11,12 @@ T = TypeVar("T", bound=BaseSpan)
 class BaseSpanHandler(BaseModel, Generic[T]):
     open_spans: Dict[str, T] = Field(
         default_factory=dict, description="Dictionary of open spans."
+    )
+    completed_spans: List[T] = Field(
+        default_factory=list, description="List of completed spans."
+    )
+    dropped_spans: List[T] = Field(
+        default_factory=list, description="List of completed spans."
     )
     current_span_id: Optional[str] = Field(
         default=None, description="Id of current span."
@@ -74,6 +80,7 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         **kwargs: Any,
     ) -> None:
         """Logic for dropping a span i.e. early exit."""
+        print(f"{self.class_name()} DROPPING SPAN {id_}", flush=True)
         span = self.prepare_to_drop_span(
             id_=id_, bound_args=bound_args, instance=instance, err=err
         )

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -67,6 +67,8 @@ class BaseSpanHandler(BaseModel, Generic[T]):
             if self.current_span_id == id_:
                 self.current_span_id = self.open_spans[id_].parent_id
             del self.open_spans[id_]
+        if not self.open_spans:  # empty so flush
+            self.current_span_id = None
 
     def span_drop(
         self,

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
@@ -67,5 +67,4 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
         **kwargs: Any
     ) -> None:
         """Logic for droppping a span."""
-        if err:
-            raise err
+        return

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/null.py
@@ -12,7 +12,6 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
 
     def span_enter(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -23,7 +22,6 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
 
     def span_exit(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -35,7 +33,6 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
 
     def new_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -47,7 +44,6 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
 
     def prepare_to_exit_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -59,7 +55,6 @@ class NullSpanHandler(BaseSpanHandler[BaseSpan]):
 
     def prepare_to_drop_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
@@ -55,9 +55,7 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
         **kwargs: Any,
     ) -> SimpleSpan:
         """Logic for droppping a span."""
-        print(f"{self.class_name()} ATTEMPTING TO DROP SPAN {id_}", flush=True)
         if id_ in self.open_spans:
-            print(f"SPAN {id_} found", flush=True)
             span = self.open_spans[id_]
             span.metadata = {"error": str(err)}
             self.dropped_spans += [span]

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/simple.py
@@ -18,7 +18,6 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
 
     def new_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -30,7 +29,6 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
 
     def prepare_to_exit_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
@@ -47,7 +45,6 @@ class SimpleSpanHandler(BaseSpanHandler[SimpleSpan]):
 
     def prepare_to_drop_span(
         self,
-        *args: Any,
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -50,12 +50,13 @@ def llm_chat_callback() -> Callable:
             _self: Any, messages: Sequence[ChatMessage], **kwargs: Any
         ) -> Any:
             with wrapper_logic(_self) as callback_manager:
+                span_id = dispatcher.root.current_span_id or ""
                 dispatcher.event(
                     LLMChatStartEvent(
                         model_dict=_self.to_dict(),
                         messages=messages,
                         additional_kwargs=kwargs,
-                        span_id=dispatcher.root.current_span_id or "",
+                        span_id=span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -77,7 +78,7 @@ def llm_chat_callback() -> Callable:
                                 LLMChatInProgressEvent(
                                     messages=messages,
                                     response=x,
-                                    span_id=dispatcher.root.current_span_id or "",
+                                    span_id=span_id,
                                 )
                             )
                             yield cast(ChatResponse, x)
@@ -95,7 +96,7 @@ def llm_chat_callback() -> Callable:
                             LLMChatEndEvent(
                                 messages=messages,
                                 response=x,
-                                span_id=dispatcher.root.current_span_id or "",
+                                span_id=span_id,
                             )
                         )
 
@@ -113,7 +114,7 @@ def llm_chat_callback() -> Callable:
                         LLMChatEndEvent(
                             messages=messages,
                             response=f_return_val,
-                            span_id=dispatcher.root.current_span_id or "",
+                            span_id=span_id,
                         )
                     )
 
@@ -123,12 +124,13 @@ def llm_chat_callback() -> Callable:
             _self: Any, messages: Sequence[ChatMessage], **kwargs: Any
         ) -> Any:
             with wrapper_logic(_self) as callback_manager:
+                span_id = dispatcher.root.current_span_id or ""
                 dispatcher.event(
                     LLMChatStartEvent(
                         model_dict=_self.to_dict(),
                         messages=messages,
                         additional_kwargs=kwargs,
-                        span_id=dispatcher.root.current_span_id or "",
+                        span_id=span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -150,7 +152,7 @@ def llm_chat_callback() -> Callable:
                                 LLMChatInProgressEvent(
                                     messages=messages,
                                     response=x,
-                                    span_id=dispatcher.root.current_span_id or "",
+                                    span_id=span_id,
                                 )
                             )
                             yield cast(ChatResponse, x)
@@ -168,7 +170,7 @@ def llm_chat_callback() -> Callable:
                             LLMChatEndEvent(
                                 messages=messages,
                                 response=x,
-                                span_id=dispatcher.root.current_span_id or "",
+                                span_id=span_id,
                             )
                         )
 
@@ -186,7 +188,7 @@ def llm_chat_callback() -> Callable:
                         LLMChatEndEvent(
                             messages=messages,
                             response=f_return_val,
-                            span_id=dispatcher.root.current_span_id or "",
+                            span_id=span_id,
                         )
                     )
 
@@ -234,7 +236,7 @@ def llm_completion_callback() -> Callable:
             _self: Any, *args: Any, **kwargs: Any
         ) -> Any:
             with wrapper_logic(_self) as callback_manager:
-                span_id = dispatcher.current_span_id
+                span_id = dispatcher.root.current_span_id or ""
                 dispatcher.event(
                     LLMCompletionStartEvent(
                         model_dict=_self.to_dict(),
@@ -300,7 +302,7 @@ def llm_completion_callback() -> Callable:
 
         def wrapped_llm_predict(_self: Any, *args: Any, **kwargs: Any) -> Any:
             with wrapper_logic(_self) as callback_manager:
-                span_id = dispatcher.current_span_id
+                span_id = dispatcher.root.current_span_id or ""
                 dispatcher.event(
                     LLMCompletionStartEvent(
                         model_dict=_self.to_dict(),

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -27,6 +27,7 @@ from llama_index.core.instrumentation.events.llm import (
     LLMCompletionStartEvent,
     LLMChatEndEvent,
     LLMChatStartEvent,
+    LLMChatInProgressEvent,
 )
 
 dispatcher = get_dispatcher(__name__)
@@ -73,7 +74,7 @@ def llm_chat_callback() -> Callable:
                         last_response = None
                         async for x in f_return_val:
                             dispatcher.event(
-                                LLMChatEndEvent(
+                                LLMChatInProgressEvent(
                                     messages=messages,
                                     response=x,
                                     span_id=dispatcher.root.current_span_id or "",
@@ -89,6 +90,13 @@ def llm_chat_callback() -> Callable:
                                 EventPayload.RESPONSE: last_response,
                             },
                             event_id=event_id,
+                        )
+                        dispatcher.event(
+                            LLMChatEndEvent(
+                                messages=messages,
+                                response=x,
+                                span_id=dispatcher.root.current_span_id or "",
+                            )
                         )
 
                     return wrapped_gen()
@@ -139,7 +147,7 @@ def llm_chat_callback() -> Callable:
                         last_response = None
                         for x in f_return_val:
                             dispatcher.event(
-                                LLMChatEndEvent(
+                                LLMChatInProgressEvent(
                                     messages=messages,
                                     response=x,
                                     span_id=dispatcher.root.current_span_id or "",
@@ -155,6 +163,13 @@ def llm_chat_callback() -> Callable:
                                 EventPayload.RESPONSE: last_response,
                             },
                             event_id=event_id,
+                        )
+                        dispatcher.event(
+                            LLMChatEndEvent(
+                                messages=messages,
+                                response=x,
+                                span_id=dispatcher.root.current_span_id or "",
+                            )
                         )
 
                     return wrapped_gen()

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -54,7 +54,7 @@ def llm_chat_callback() -> Callable:
                         model_dict=_self.to_dict(),
                         messages=messages,
                         additional_kwargs=kwargs,
-                        span_id=dispatcher.current_span_id,
+                        span_id=dispatcher.root.current_span_id or "",
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -76,7 +76,7 @@ def llm_chat_callback() -> Callable:
                                 LLMChatEndEvent(
                                     messages=messages,
                                     response=x,
-                                    span_id=dispatcher.current_span_id,
+                                    span_id=dispatcher.root.current_span_id or "",
                                 )
                             )
                             yield cast(ChatResponse, x)
@@ -105,7 +105,7 @@ def llm_chat_callback() -> Callable:
                         LLMChatEndEvent(
                             messages=messages,
                             response=f_return_val,
-                            span_id=dispatcher.current_span_id,
+                            span_id=dispatcher.root.current_span_id or "",
                         )
                     )
 
@@ -120,7 +120,7 @@ def llm_chat_callback() -> Callable:
                         model_dict=_self.to_dict(),
                         messages=messages,
                         additional_kwargs=kwargs,
-                        span_id=dispatcher.current_span_id,
+                        span_id=dispatcher.root.current_span_id or "",
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -142,7 +142,7 @@ def llm_chat_callback() -> Callable:
                                 LLMChatEndEvent(
                                     messages=messages,
                                     response=x,
-                                    span_id=dispatcher.current_span_id,
+                                    span_id=dispatcher.root.current_span_id or "",
                                 )
                             )
                             yield cast(ChatResponse, x)
@@ -171,7 +171,7 @@ def llm_chat_callback() -> Callable:
                         LLMChatEndEvent(
                             messages=messages,
                             response=f_return_val,
-                            span_id=dispatcher.current_span_id,
+                            span_id=dispatcher.root.current_span_id or "",
                         )
                     )
 

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -234,12 +234,13 @@ def llm_completion_callback() -> Callable:
             _self: Any, *args: Any, **kwargs: Any
         ) -> Any:
             with wrapper_logic(_self) as callback_manager:
+                span_id = dispatcher.current_span_id
                 dispatcher.event(
                     LLMCompletionStartEvent(
                         model_dict=_self.to_dict(),
                         prompt=str(args[0]),
                         additional_kwargs=kwargs,
-                        span_id=dispatcher.current_span_id,
+                        span_id=span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -262,7 +263,7 @@ def llm_completion_callback() -> Callable:
                                 LLMCompletionEndEvent(
                                     prompt=str(args[0]),
                                     response=x,
-                                    span_id=dispatcher.current_span_id,
+                                    span_id=span_id,
                                 )
                             )
                             yield cast(CompletionResponse, x)
@@ -291,7 +292,7 @@ def llm_completion_callback() -> Callable:
                         LLMCompletionEndEvent(
                             prompt=str(args[0]),
                             response=f_return_val,
-                            span_id=dispatcher.current_span_id,
+                            span_id=span_id,
                         )
                     )
 
@@ -299,12 +300,13 @@ def llm_completion_callback() -> Callable:
 
         def wrapped_llm_predict(_self: Any, *args: Any, **kwargs: Any) -> Any:
             with wrapper_logic(_self) as callback_manager:
+                span_id = dispatcher.current_span_id
                 dispatcher.event(
                     LLMCompletionStartEvent(
                         model_dict=_self.to_dict(),
                         prompt=str(args[0]),
                         additional_kwargs=kwargs,
-                        span_id=dispatcher.current_span_id,
+                        span_id=span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -324,8 +326,7 @@ def llm_completion_callback() -> Callable:
                         for x in f_return_val:
                             dispatcher.event(
                                 LLMCompletionEndEvent(
-                                    prompt=str(args[0]),
-                                    response=x,
+                                    prompt=str(args[0]), response=x, span_id=span_id
                                 )
                             )
                             yield cast(CompletionResponse, x)
@@ -354,7 +355,7 @@ def llm_completion_callback() -> Callable:
                         LLMCompletionEndEvent(
                             prompt=str(args[0]),
                             response=f_return_val,
-                            span_id=dispatcher.current_span_id,
+                            span_id=span_id,
                         )
                     )
 

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -54,6 +54,7 @@ def llm_chat_callback() -> Callable:
                         model_dict=_self.to_dict(),
                         messages=messages,
                         additional_kwargs=kwargs,
+                        span_id=dispatcher.current_span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -75,6 +76,7 @@ def llm_chat_callback() -> Callable:
                                 LLMChatEndEvent(
                                     messages=messages,
                                     response=x,
+                                    span_id=dispatcher.current_span_id,
                                 )
                             )
                             yield cast(ChatResponse, x)
@@ -103,6 +105,7 @@ def llm_chat_callback() -> Callable:
                         LLMChatEndEvent(
                             messages=messages,
                             response=f_return_val,
+                            span_id=dispatcher.current_span_id,
                         )
                     )
 
@@ -117,6 +120,7 @@ def llm_chat_callback() -> Callable:
                         model_dict=_self.to_dict(),
                         messages=messages,
                         additional_kwargs=kwargs,
+                        span_id=dispatcher.current_span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -138,6 +142,7 @@ def llm_chat_callback() -> Callable:
                                 LLMChatEndEvent(
                                     messages=messages,
                                     response=x,
+                                    span_id=dispatcher.current_span_id,
                                 )
                             )
                             yield cast(ChatResponse, x)
@@ -166,6 +171,7 @@ def llm_chat_callback() -> Callable:
                         LLMChatEndEvent(
                             messages=messages,
                             response=f_return_val,
+                            span_id=dispatcher.current_span_id,
                         )
                     )
 
@@ -218,6 +224,7 @@ def llm_completion_callback() -> Callable:
                         model_dict=_self.to_dict(),
                         prompt=str(args[0]),
                         additional_kwargs=kwargs,
+                        span_id=dispatcher.current_span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -240,6 +247,7 @@ def llm_completion_callback() -> Callable:
                                 LLMCompletionEndEvent(
                                     prompt=str(args[0]),
                                     response=x,
+                                    span_id=dispatcher.current_span_id,
                                 )
                             )
                             yield cast(CompletionResponse, x)
@@ -268,6 +276,7 @@ def llm_completion_callback() -> Callable:
                         LLMCompletionEndEvent(
                             prompt=str(args[0]),
                             response=f_return_val,
+                            span_id=dispatcher.current_span_id,
                         )
                     )
 
@@ -280,6 +289,7 @@ def llm_completion_callback() -> Callable:
                         model_dict=_self.to_dict(),
                         prompt=str(args[0]),
                         additional_kwargs=kwargs,
+                        span_id=dispatcher.current_span_id,
                     )
                 )
                 event_id = callback_manager.on_event_start(
@@ -329,6 +339,7 @@ def llm_completion_callback() -> Callable:
                         LLMCompletionEndEvent(
                             prompt=str(args[0]),
                             response=f_return_val,
+                            span_id=dispatcher.current_span_id,
                         )
                     )
 

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -52,6 +52,8 @@ from llama_index.core.types import (
 from llama_index.core.instrumentation.events.llm import (
     LLMPredictEndEvent,
     LLMPredictStartEvent,
+    LLMStructuredPredictEndEvent,
+    LLMStructuredPredictStartEvent,
 )
 
 import llama_index.core.instrumentation as instrument
@@ -324,6 +326,9 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
+        dispatcher.event(
+            LLMStructuredPredictStartEvent(span_id=dispatcher.current_span_id)
+        )
         program = get_program_for_llm(
             output_cls,
             prompt,
@@ -331,7 +336,11 @@ class LLM(BaseLLM):
             pydantic_program_mode=self.pydantic_program_mode,
         )
 
-        return program(**prompt_args)
+        result = program(**prompt_args)
+        dispatcher.event(
+            LLMStructuredPredictEndEvent(span_id=dispatcher.current_span_id)
+        )
+        return result
 
     @dispatcher.span
     async def astructured_predict(
@@ -370,6 +379,10 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
+        dispatcher.event(
+            LLMStructuredPredictStartEvent(span_id=dispatcher.current_span_id)
+        )
+
         program = get_program_for_llm(
             output_cls,
             prompt,
@@ -377,7 +390,11 @@ class LLM(BaseLLM):
             pydantic_program_mode=self.pydantic_program_mode,
         )
 
-        return await program.acall(**prompt_args)
+        result = await program.acall(**prompt_args)
+        dispatcher.event(
+            LLMStructuredPredictEndEvent(span_id=dispatcher.current_span_id)
+        )
+        return result
 
     # -- Prompt Chaining --
 

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -326,9 +326,8 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        dispatcher.event(
-            LLMStructuredPredictStartEvent(span_id=dispatcher.current_span_id)
-        )
+        span_id = dispatcher.current_span_id
+        dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
         program = get_program_for_llm(
             output_cls,
             prompt,
@@ -337,9 +336,7 @@ class LLM(BaseLLM):
         )
 
         result = program(**prompt_args)
-        dispatcher.event(
-            LLMStructuredPredictEndEvent(span_id=dispatcher.current_span_id)
-        )
+        dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
         return result
 
     @dispatcher.span
@@ -379,9 +376,8 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        dispatcher.event(
-            LLMStructuredPredictStartEvent(span_id=dispatcher.current_span_id)
-        )
+        span_id = dispatcher.current_span_id
+        dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
 
         program = get_program_for_llm(
             output_cls,
@@ -391,9 +387,7 @@ class LLM(BaseLLM):
         )
 
         result = await program.acall(**prompt_args)
-        dispatcher.event(
-            LLMStructuredPredictEndEvent(span_id=dispatcher.current_span_id)
-        )
+        dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
         return result
 
     # -- Prompt Chaining --
@@ -424,7 +418,8 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        dispatcher.event(LLMPredictStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(LLMPredictStartEvent(span_id=span_id))
         self._log_template_data(prompt, **prompt_args)
 
         if self.metadata.is_chat_model:
@@ -435,7 +430,7 @@ class LLM(BaseLLM):
             formatted_prompt = self._get_prompt(prompt, **prompt_args)
             response = self.complete(formatted_prompt, formatted=True)
             output = response.text
-        dispatcher.event(LLMPredictEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(LLMPredictEndEvent(span_id=span_id))
         return self._parse_output(output)
 
     @dispatcher.span
@@ -507,7 +502,8 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        dispatcher.event(LLMPredictStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(LLMPredictStartEvent(span_id=span_id))
         self._log_template_data(prompt, **prompt_args)
 
         if self.metadata.is_chat_model:
@@ -519,7 +515,7 @@ class LLM(BaseLLM):
             response = await self.acomplete(formatted_prompt, formatted=True)
             output = response.text
 
-        dispatcher.event(LLMPredictEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(LLMPredictEndEvent(span_id=span_id))
         return self._parse_output(output)
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -51,6 +51,7 @@ from llama_index.core.types import (
 )
 from llama_index.core.instrumentation.events.llm import (
     LLMPredictEndEvent,
+    LLMPredictStartEvent,
 )
 
 import llama_index.core.instrumentation as instrument
@@ -406,6 +407,7 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
+        dispatcher.event(LLMPredictStartEvent(span_id=dispatcher.current_span_id))
         self._log_template_data(prompt, **prompt_args)
 
         if self.metadata.is_chat_model:
@@ -417,7 +419,7 @@ class LLM(BaseLLM):
             response = self.complete(formatted_prompt, formatted=True)
             output = response.text
 
-        dispatcher.event(LLMPredictEndEvent())
+        dispatcher.event(LLMPredictEndEvent(span_id=dispatcher.current_span_id))
         return self._parse_output(output)
 
     @dispatcher.span
@@ -489,6 +491,7 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
+        dispatcher.event(LLMPredictStartEvent(span_id=dispatcher.current_span_id))
         self._log_template_data(prompt, **prompt_args)
 
         if self.metadata.is_chat_model:
@@ -500,7 +503,7 @@ class LLM(BaseLLM):
             response = await self.acomplete(formatted_prompt, formatted=True)
             output = response.text
 
-        dispatcher.event(LLMPredictEndEvent())
+        dispatcher.event(LLMPredictEndEvent(span_id=dispatcher.current_span_id))
         return self._parse_output(output)
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -326,17 +326,18 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(LLMStructuredPredictStartEvent())
-            program = get_program_for_llm(
-                output_cls,
-                prompt,
-                self,
-                pydantic_program_mode=self.pydantic_program_mode,
-            )
+        dispatch_event = dispatcher.get_dispatch_event()
 
-            result = program(**prompt_args)
-            dispatch_event(LLMStructuredPredictEndEvent())
+        dispatch_event(LLMStructuredPredictStartEvent())
+        program = get_program_for_llm(
+            output_cls,
+            prompt,
+            self,
+            pydantic_program_mode=self.pydantic_program_mode,
+        )
+
+        result = program(**prompt_args)
+        dispatch_event(LLMStructuredPredictEndEvent())
         return result
 
     @dispatcher.span
@@ -376,18 +377,19 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(LLMStructuredPredictStartEvent())
+        dispatch_event = dispatcher.get_dispatch_event()
 
-            program = get_program_for_llm(
-                output_cls,
-                prompt,
-                self,
-                pydantic_program_mode=self.pydantic_program_mode,
-            )
+        dispatch_event(LLMStructuredPredictStartEvent())
 
-            result = await program.acall(**prompt_args)
-            dispatch_event(LLMStructuredPredictEndEvent())
+        program = get_program_for_llm(
+            output_cls,
+            prompt,
+            self,
+            pydantic_program_mode=self.pydantic_program_mode,
+        )
+
+        result = await program.acall(**prompt_args)
+        dispatch_event(LLMStructuredPredictEndEvent())
         return result
 
     # -- Prompt Chaining --
@@ -418,19 +420,20 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(LLMPredictStartEvent())
-            self._log_template_data(prompt, **prompt_args)
+        dispatch_event = dispatcher.get_dispatch_event()
 
-            if self.metadata.is_chat_model:
-                messages = self._get_messages(prompt, **prompt_args)
-                chat_response = self.chat(messages)
-                output = chat_response.message.content or ""
-            else:
-                formatted_prompt = self._get_prompt(prompt, **prompt_args)
-                response = self.complete(formatted_prompt, formatted=True)
-                output = response.text
-            dispatch_event(LLMPredictEndEvent())
+        dispatch_event(LLMPredictStartEvent())
+        self._log_template_data(prompt, **prompt_args)
+
+        if self.metadata.is_chat_model:
+            messages = self._get_messages(prompt, **prompt_args)
+            chat_response = self.chat(messages)
+            output = chat_response.message.content or ""
+        else:
+            formatted_prompt = self._get_prompt(prompt, **prompt_args)
+            response = self.complete(formatted_prompt, formatted=True)
+            output = response.text
+        dispatch_event(LLMPredictEndEvent())
         return self._parse_output(output)
 
     @dispatcher.span
@@ -502,20 +505,21 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(LLMPredictStartEvent())
-            self._log_template_data(prompt, **prompt_args)
+        dispatch_event = dispatcher.get_dispatch_event()
 
-            if self.metadata.is_chat_model:
-                messages = self._get_messages(prompt, **prompt_args)
-                chat_response = await self.achat(messages)
-                output = chat_response.message.content or ""
-            else:
-                formatted_prompt = self._get_prompt(prompt, **prompt_args)
-                response = await self.acomplete(formatted_prompt, formatted=True)
-                output = response.text
+        dispatch_event(LLMPredictStartEvent())
+        self._log_template_data(prompt, **prompt_args)
 
-            dispatch_event(LLMPredictEndEvent())
+        if self.metadata.is_chat_model:
+            messages = self._get_messages(prompt, **prompt_args)
+            chat_response = await self.achat(messages)
+            output = chat_response.message.content or ""
+        else:
+            formatted_prompt = self._get_prompt(prompt, **prompt_args)
+            response = await self.acomplete(formatted_prompt, formatted=True)
+            output = response.text
+
+        dispatch_event(LLMPredictEndEvent())
         return self._parse_output(output)
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -326,17 +326,17 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        span_id = dispatcher.current_span_id
-        dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
-        program = get_program_for_llm(
-            output_cls,
-            prompt,
-            self,
-            pydantic_program_mode=self.pydantic_program_mode,
-        )
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
+            program = get_program_for_llm(
+                output_cls,
+                prompt,
+                self,
+                pydantic_program_mode=self.pydantic_program_mode,
+            )
 
-        result = program(**prompt_args)
-        dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
+            result = program(**prompt_args)
+            dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
         return result
 
     @dispatcher.span
@@ -376,18 +376,18 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        span_id = dispatcher.current_span_id
-        dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
 
-        program = get_program_for_llm(
-            output_cls,
-            prompt,
-            self,
-            pydantic_program_mode=self.pydantic_program_mode,
-        )
+            program = get_program_for_llm(
+                output_cls,
+                prompt,
+                self,
+                pydantic_program_mode=self.pydantic_program_mode,
+            )
 
-        result = await program.acall(**prompt_args)
-        dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
+            result = await program.acall(**prompt_args)
+            dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
         return result
 
     # -- Prompt Chaining --
@@ -418,19 +418,19 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        span_id = dispatcher.current_span_id
-        dispatcher.event(LLMPredictStartEvent(span_id=span_id))
-        self._log_template_data(prompt, **prompt_args)
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatcher.event(LLMPredictStartEvent(span_id=span_id))
+            self._log_template_data(prompt, **prompt_args)
 
-        if self.metadata.is_chat_model:
-            messages = self._get_messages(prompt, **prompt_args)
-            chat_response = self.chat(messages)
-            output = chat_response.message.content or ""
-        else:
-            formatted_prompt = self._get_prompt(prompt, **prompt_args)
-            response = self.complete(formatted_prompt, formatted=True)
-            output = response.text
-        dispatcher.event(LLMPredictEndEvent(span_id=span_id))
+            if self.metadata.is_chat_model:
+                messages = self._get_messages(prompt, **prompt_args)
+                chat_response = self.chat(messages)
+                output = chat_response.message.content or ""
+            else:
+                formatted_prompt = self._get_prompt(prompt, **prompt_args)
+                response = self.complete(formatted_prompt, formatted=True)
+                output = response.text
+            dispatcher.event(LLMPredictEndEvent(span_id=span_id))
         return self._parse_output(output)
 
     @dispatcher.span
@@ -502,20 +502,20 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        span_id = dispatcher.current_span_id
-        dispatcher.event(LLMPredictStartEvent(span_id=span_id))
-        self._log_template_data(prompt, **prompt_args)
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatcher.event(LLMPredictStartEvent(span_id=span_id))
+            self._log_template_data(prompt, **prompt_args)
 
-        if self.metadata.is_chat_model:
-            messages = self._get_messages(prompt, **prompt_args)
-            chat_response = await self.achat(messages)
-            output = chat_response.message.content or ""
-        else:
-            formatted_prompt = self._get_prompt(prompt, **prompt_args)
-            response = await self.acomplete(formatted_prompt, formatted=True)
-            output = response.text
+            if self.metadata.is_chat_model:
+                messages = self._get_messages(prompt, **prompt_args)
+                chat_response = await self.achat(messages)
+                output = chat_response.message.content or ""
+            else:
+                formatted_prompt = self._get_prompt(prompt, **prompt_args)
+                response = await self.acomplete(formatted_prompt, formatted=True)
+                output = response.text
 
-        dispatcher.event(LLMPredictEndEvent(span_id=span_id))
+            dispatcher.event(LLMPredictEndEvent(span_id=span_id))
         return self._parse_output(output)
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -418,7 +418,6 @@ class LLM(BaseLLM):
             formatted_prompt = self._get_prompt(prompt, **prompt_args)
             response = self.complete(formatted_prompt, formatted=True)
             output = response.text
-
         dispatcher.event(LLMPredictEndEvent(span_id=dispatcher.current_span_id))
         return self._parse_output(output)
 

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -326,8 +326,8 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        with dispatcher.dispatch_event as dispatch_event:
-            dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
+        with dispatcher.dispatch_event() as dispatch_event:
+            dispatch_event(LLMStructuredPredictStartEvent())
             program = get_program_for_llm(
                 output_cls,
                 prompt,
@@ -336,7 +336,7 @@ class LLM(BaseLLM):
             )
 
             result = program(**prompt_args)
-            dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
+            dispatch_event(LLMStructuredPredictEndEvent())
         return result
 
     @dispatcher.span
@@ -376,8 +376,8 @@ class LLM(BaseLLM):
         """
         from llama_index.core.program.utils import get_program_for_llm
 
-        with dispatcher.dispatch_event as dispatch_event:
-            dispatcher.event(LLMStructuredPredictStartEvent(span_id=span_id))
+        with dispatcher.dispatch_event() as dispatch_event:
+            dispatch_event(LLMStructuredPredictStartEvent())
 
             program = get_program_for_llm(
                 output_cls,
@@ -387,7 +387,7 @@ class LLM(BaseLLM):
             )
 
             result = await program.acall(**prompt_args)
-            dispatcher.event(LLMStructuredPredictEndEvent(span_id=span_id))
+            dispatch_event(LLMStructuredPredictEndEvent())
         return result
 
     # -- Prompt Chaining --
@@ -418,8 +418,8 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        with dispatcher.dispatch_event as dispatch_event:
-            dispatcher.event(LLMPredictStartEvent(span_id=span_id))
+        with dispatcher.dispatch_event() as dispatch_event:
+            dispatch_event(LLMPredictStartEvent())
             self._log_template_data(prompt, **prompt_args)
 
             if self.metadata.is_chat_model:
@@ -430,7 +430,7 @@ class LLM(BaseLLM):
                 formatted_prompt = self._get_prompt(prompt, **prompt_args)
                 response = self.complete(formatted_prompt, formatted=True)
                 output = response.text
-            dispatcher.event(LLMPredictEndEvent(span_id=span_id))
+            dispatch_event(LLMPredictEndEvent())
         return self._parse_output(output)
 
     @dispatcher.span
@@ -502,8 +502,8 @@ class LLM(BaseLLM):
             print(output)
             ```
         """
-        with dispatcher.dispatch_event as dispatch_event:
-            dispatcher.event(LLMPredictStartEvent(span_id=span_id))
+        with dispatcher.dispatch_event() as dispatch_event:
+            dispatch_event(LLMPredictStartEvent())
             self._log_template_data(prompt, **prompt_args)
 
             if self.metadata.is_chat_model:
@@ -515,7 +515,7 @@ class LLM(BaseLLM):
                 response = await self.acomplete(formatted_prompt, formatted=True)
                 output = response.text
 
-            dispatcher.event(LLMPredictEndEvent(span_id=span_id))
+            dispatch_event(LLMPredictEndEvent())
         return self._parse_output(output)
 
     @dispatcher.span

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -201,7 +201,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(
                 SynthesizeStartEvent(
                     query=query,
@@ -269,7 +269,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(
                 SynthesizeStartEvent(
                     query=query,

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -201,9 +201,8 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        dispatcher.event(
-            SynthesizeStartEvent(query=query, span_id=dispatcher.current_span_id)
-        )
+        span_id = dispatcher.current_span_id
+        dispatcher.event(SynthesizeStartEvent(query=query, span_id=span_id))
 
         if len(nodes) == 0:
             if self._streaming:
@@ -214,7 +213,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
                     SynthesizeEndEvent(
                         query=query,
                         response=empty_response,
-                        span_id=dispatcher.current_span_id,
+                        span_id=span_id,
                     )
                 )
                 return empty_response
@@ -224,7 +223,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
                     SynthesizeEndEvent(
                         query=query,
                         response=empty_response,
-                        span_id=dispatcher.current_span_id,
+                        span_id=span_id,
                     )
                 )
                 return empty_response
@@ -251,9 +250,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
             event.on_end(payload={EventPayload.RESPONSE: response})
 
         dispatcher.event(
-            SynthesizeEndEvent(
-                query=query, response=response, span_id=dispatcher.current_span_id
-            )
+            SynthesizeEndEvent(query=query, response=response, span_id=span_id)
         )
         return response
 
@@ -265,9 +262,8 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        dispatcher.event(
-            SynthesizeStartEvent(query=query, span_id=dispatcher.current_span_id)
-        )
+        span_id = dispatcher.current_span_id
+        dispatcher.event(SynthesizeStartEvent(query=query, span_id=span_id))
         if len(nodes) == 0:
             if self._streaming:
                 empty_response = AsyncStreamingResponse(
@@ -277,7 +273,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
                     SynthesizeEndEvent(
                         query=query,
                         response=empty_response,
-                        span_id=dispatcher.current_span_id,
+                        span_id=span_id,
                     )
                 )
                 return empty_response
@@ -287,7 +283,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
                     SynthesizeEndEvent(
                         query=query,
                         response=empty_response,
-                        span_id=dispatcher.current_span_id,
+                        span_id=span_id,
                     )
                 )
                 return empty_response
@@ -314,9 +310,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
             event.on_end(payload={EventPayload.RESPONSE: response})
 
         dispatcher.event(
-            SynthesizeEndEvent(
-                query=query, response=response, span_id=dispatcher.current_span_id
-            )
+            SynthesizeEndEvent(query=query, response=response, span_id=span_id)
         )
         return response
 

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -201,57 +201,64 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        span_id = dispatcher.current_span_id
-        dispatcher.event(SynthesizeStartEvent(query=query, span_id=span_id))
-
-        if len(nodes) == 0:
-            if self._streaming:
-                empty_response = StreamingResponse(
-                    response_gen=empty_response_generator()
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(
+                SynthesizeStartEvent(
+                    query=query,
                 )
-                dispatcher.event(
-                    SynthesizeEndEvent(
-                        query=query,
-                        response=empty_response,
-                        span_id=span_id,
-                    )
-                )
-                return empty_response
-            else:
-                empty_response = Response("Empty Response")
-                dispatcher.event(
-                    SynthesizeEndEvent(
-                        query=query,
-                        response=empty_response,
-                        span_id=span_id,
-                    )
-                )
-                return empty_response
-
-        if isinstance(query, str):
-            query = QueryBundle(query_str=query)
-
-        with self._callback_manager.event(
-            CBEventType.SYNTHESIZE, payload={EventPayload.QUERY_STR: query.query_str}
-        ) as event:
-            response_str = self.get_response(
-                query_str=query.query_str,
-                text_chunks=[
-                    n.node.get_content(metadata_mode=MetadataMode.LLM) for n in nodes
-                ],
-                **response_kwargs,
             )
 
-            additional_source_nodes = additional_source_nodes or []
-            source_nodes = list(nodes) + list(additional_source_nodes)
+            if len(nodes) == 0:
+                if self._streaming:
+                    empty_response = StreamingResponse(
+                        response_gen=empty_response_generator()
+                    )
+                    dispatch_event(
+                        SynthesizeEndEvent(
+                            query=query,
+                            response=empty_response,
+                        )
+                    )
+                    return empty_response
+                else:
+                    empty_response = Response("Empty Response")
+                    dispatch_event(
+                        SynthesizeEndEvent(
+                            query=query,
+                            response=empty_response,
+                        )
+                    )
+                    return empty_response
 
-            response = self._prepare_response_output(response_str, source_nodes)
+            if isinstance(query, str):
+                query = QueryBundle(query_str=query)
 
-            event.on_end(payload={EventPayload.RESPONSE: response})
+            with self._callback_manager.event(
+                CBEventType.SYNTHESIZE,
+                payload={EventPayload.QUERY_STR: query.query_str},
+            ) as event:
+                response_str = self.get_response(
+                    query_str=query.query_str,
+                    text_chunks=[
+                        n.node.get_content(metadata_mode=MetadataMode.LLM)
+                        for n in nodes
+                    ],
+                    **response_kwargs,
+                )
 
-        dispatcher.event(
-            SynthesizeEndEvent(query=query, response=response, span_id=span_id)
-        )
+                additional_source_nodes = additional_source_nodes or []
+                source_nodes = list(nodes) + list(additional_source_nodes)
+
+                response = self._prepare_response_output(response_str, source_nodes)
+
+                event.on_end(payload={EventPayload.RESPONSE: response})
+
+            dispatch_event(
+                SynthesizeEndEvent(
+                    query=query,
+                    response=response,
+                )
+            )
         return response
 
     @dispatcher.span
@@ -262,56 +269,63 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        span_id = dispatcher.current_span_id
-        dispatcher.event(SynthesizeStartEvent(query=query, span_id=span_id))
-        if len(nodes) == 0:
-            if self._streaming:
-                empty_response = AsyncStreamingResponse(
-                    response_gen=empty_response_agenerator()
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(
+                SynthesizeStartEvent(
+                    query=query,
                 )
-                dispatcher.event(
-                    SynthesizeEndEvent(
-                        query=query,
-                        response=empty_response,
-                        span_id=span_id,
-                    )
-                )
-                return empty_response
-            else:
-                empty_response = Response("Empty Response")
-                dispatcher.event(
-                    SynthesizeEndEvent(
-                        query=query,
-                        response=empty_response,
-                        span_id=span_id,
-                    )
-                )
-                return empty_response
-
-        if isinstance(query, str):
-            query = QueryBundle(query_str=query)
-
-        with self._callback_manager.event(
-            CBEventType.SYNTHESIZE, payload={EventPayload.QUERY_STR: query.query_str}
-        ) as event:
-            response_str = await self.aget_response(
-                query_str=query.query_str,
-                text_chunks=[
-                    n.node.get_content(metadata_mode=MetadataMode.LLM) for n in nodes
-                ],
-                **response_kwargs,
             )
+            if len(nodes) == 0:
+                if self._streaming:
+                    empty_response = AsyncStreamingResponse(
+                        response_gen=empty_response_agenerator()
+                    )
+                    dispatch_event(
+                        SynthesizeEndEvent(
+                            query=query,
+                            response=empty_response,
+                        )
+                    )
+                    return empty_response
+                else:
+                    empty_response = Response("Empty Response")
+                    dispatch_event(
+                        SynthesizeEndEvent(
+                            query=query,
+                            response=empty_response,
+                        )
+                    )
+                    return empty_response
 
-            additional_source_nodes = additional_source_nodes or []
-            source_nodes = list(nodes) + list(additional_source_nodes)
+            if isinstance(query, str):
+                query = QueryBundle(query_str=query)
 
-            response = self._prepare_response_output(response_str, source_nodes)
+            with self._callback_manager.event(
+                CBEventType.SYNTHESIZE,
+                payload={EventPayload.QUERY_STR: query.query_str},
+            ) as event:
+                response_str = await self.aget_response(
+                    query_str=query.query_str,
+                    text_chunks=[
+                        n.node.get_content(metadata_mode=MetadataMode.LLM)
+                        for n in nodes
+                    ],
+                    **response_kwargs,
+                )
 
-            event.on_end(payload={EventPayload.RESPONSE: response})
+                additional_source_nodes = additional_source_nodes or []
+                source_nodes = list(nodes) + list(additional_source_nodes)
 
-        dispatcher.event(
-            SynthesizeEndEvent(query=query, response=response, span_id=span_id)
-        )
+                response = self._prepare_response_output(response_str, source_nodes)
+
+                event.on_end(payload={EventPayload.RESPONSE: response})
+
+            dispatch_event(
+                SynthesizeEndEvent(
+                    query=query,
+                    response=response,
+                )
+            )
         return response
 
     def _as_query_component(self, **kwargs: Any) -> QueryComponent:

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -201,7 +201,9 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        dispatcher.event(SynthesizeStartEvent(query=query))
+        dispatcher.event(
+            SynthesizeStartEvent(query=query, span_id=dispatcher.current_span_id)
+        )
 
         if len(nodes) == 0:
             if self._streaming:
@@ -209,13 +211,21 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
                     response_gen=empty_response_generator()
                 )
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(
+                        query=query,
+                        response=empty_response,
+                        span_id=dispatcher.current_span_id,
+                    )
                 )
                 return empty_response
             else:
                 empty_response = Response("Empty Response")
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(
+                        query=query,
+                        response=empty_response,
+                        span_id=dispatcher.current_span_id,
+                    )
                 )
                 return empty_response
 
@@ -240,7 +250,11 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
 
             event.on_end(payload={EventPayload.RESPONSE: response})
 
-        dispatcher.event(SynthesizeEndEvent(query=query, response=response))
+        dispatcher.event(
+            SynthesizeEndEvent(
+                query=query, response=response, span_id=dispatcher.current_span_id
+            )
+        )
         return response
 
     @dispatcher.span
@@ -251,20 +265,30 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TYPE:
-        dispatcher.event(SynthesizeStartEvent(query=query))
+        dispatcher.event(
+            SynthesizeStartEvent(query=query, span_id=dispatcher.current_span_id)
+        )
         if len(nodes) == 0:
             if self._streaming:
                 empty_response = AsyncStreamingResponse(
                     response_gen=empty_response_agenerator()
                 )
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(
+                        query=query,
+                        response=empty_response,
+                        span_id=dispatcher.current_span_id,
+                    )
                 )
                 return empty_response
             else:
                 empty_response = Response("Empty Response")
                 dispatcher.event(
-                    SynthesizeEndEvent(query=query, response=empty_response)
+                    SynthesizeEndEvent(
+                        query=query,
+                        response=empty_response,
+                        span_id=dispatcher.current_span_id,
+                    )
                 )
                 return empty_response
 
@@ -289,7 +313,11 @@ class BaseSynthesizer(ChainableMixin, PromptMixin):
 
             event.on_end(payload={EventPayload.RESPONSE: response})
 
-        dispatcher.event(SynthesizeEndEvent(query=query, response=response))
+        dispatcher.event(
+            SynthesizeEndEvent(
+                query=query, response=response, span_id=dispatcher.current_span_id
+            )
+        )
         return response
 
     def _as_query_component(self, **kwargs: Any) -> QueryComponent:

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -172,30 +172,30 @@ class Refine(BaseSynthesizer):
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
         """Give response over chunks."""
-        span_id = dispatcher.current_span_id
-        dispatcher.event(GetResponseStartEvent(span_id=span_id))
-        response: Optional[RESPONSE_TEXT_TYPE] = None
-        for text_chunk in text_chunks:
-            if prev_response is None:
-                # if this is the first chunk, and text chunk already
-                # is an answer, then return it
-                response = self._give_response_single(
-                    query_str, text_chunk, **response_kwargs
-                )
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(GetResponseStartEvent())
+            response: Optional[RESPONSE_TEXT_TYPE] = None
+            for text_chunk in text_chunks:
+                if prev_response is None:
+                    # if this is the first chunk, and text chunk already
+                    # is an answer, then return it
+                    response = self._give_response_single(
+                        query_str, text_chunk, **response_kwargs
+                    )
+                else:
+                    # refine response if possible
+                    response = self._refine_response_single(
+                        prev_response, query_str, text_chunk, **response_kwargs
+                    )
+                prev_response = response
+            if isinstance(response, str):
+                if self._output_cls is not None:
+                    response = self._output_cls.parse_raw(response)
+                else:
+                    response = response or "Empty Response"
             else:
-                # refine response if possible
-                response = self._refine_response_single(
-                    prev_response, query_str, text_chunk, **response_kwargs
-                )
-            prev_response = response
-        if isinstance(response, str):
-            if self._output_cls is not None:
-                response = self._output_cls.parse_raw(response)
-            else:
-                response = response or "Empty Response"
-        else:
-            response = cast(Generator, response)
-        dispatcher.event(GetResponseEndEvent(span_id=span_id))
+                response = cast(Generator, response)
+            dispatch_event(GetResponseEndEvent())
         return response
 
     def _default_program_factory(self, prompt: PromptTemplate) -> BasePydanticProgram:
@@ -351,31 +351,31 @@ class Refine(BaseSynthesizer):
         prev_response: Optional[RESPONSE_TEXT_TYPE] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
-        span_id = dispatcher.current_span_id
-        dispatcher.event(GetResponseStartEvent(span_id=span_id))
-        response: Optional[RESPONSE_TEXT_TYPE] = None
-        for text_chunk in text_chunks:
-            if prev_response is None:
-                # if this is the first chunk, and text chunk already
-                # is an answer, then return it
-                response = await self._agive_response_single(
-                    query_str, text_chunk, **response_kwargs
-                )
+        with dispatcher.dispatch_event as dispatch_event:
+            dispatch_event(GetResponseStartEvent())
+            response: Optional[RESPONSE_TEXT_TYPE] = None
+            for text_chunk in text_chunks:
+                if prev_response is None:
+                    # if this is the first chunk, and text chunk already
+                    # is an answer, then return it
+                    response = await self._agive_response_single(
+                        query_str, text_chunk, **response_kwargs
+                    )
+                else:
+                    response = await self._arefine_response_single(
+                        prev_response, query_str, text_chunk, **response_kwargs
+                    )
+                prev_response = response
+            if response is None:
+                response = "Empty Response"
+            if isinstance(response, str):
+                if self._output_cls is not None:
+                    response = self._output_cls.parse_raw(response)
+                else:
+                    response = response or "Empty Response"
             else:
-                response = await self._arefine_response_single(
-                    prev_response, query_str, text_chunk, **response_kwargs
-                )
-            prev_response = response
-        if response is None:
-            response = "Empty Response"
-        if isinstance(response, str):
-            if self._output_cls is not None:
-                response = self._output_cls.parse_raw(response)
-            else:
-                response = response or "Empty Response"
-        else:
-            response = cast(AsyncGenerator, response)
-        dispatcher.event(GetResponseEndEvent(span_id=span_id))
+                response = cast(AsyncGenerator, response)
+            dispatch_event(GetResponseEndEvent())
         return response
 
     async def _arefine_response_single(

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -172,7 +172,7 @@ class Refine(BaseSynthesizer):
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
         """Give response over chunks."""
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(GetResponseStartEvent())
             response: Optional[RESPONSE_TEXT_TYPE] = None
             for text_chunk in text_chunks:
@@ -351,7 +351,7 @@ class Refine(BaseSynthesizer):
         prev_response: Optional[RESPONSE_TEXT_TYPE] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
-        with dispatcher.dispatch_event as dispatch_event:
+        with dispatcher.dispatch_event() as dispatch_event:
             dispatch_event(GetResponseStartEvent())
             response: Optional[RESPONSE_TEXT_TYPE] = None
             for text_chunk in text_chunks:

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -172,7 +172,8 @@ class Refine(BaseSynthesizer):
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
         """Give response over chunks."""
-        dispatcher.event(GetResponseStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(GetResponseStartEvent(span_id=span_id))
         response: Optional[RESPONSE_TEXT_TYPE] = None
         for text_chunk in text_chunks:
             if prev_response is None:
@@ -194,7 +195,7 @@ class Refine(BaseSynthesizer):
                 response = response or "Empty Response"
         else:
             response = cast(Generator, response)
-        dispatcher.event(GetResponseEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(GetResponseEndEvent(span_id=span_id))
         return response
 
     def _default_program_factory(self, prompt: PromptTemplate) -> BasePydanticProgram:
@@ -350,7 +351,8 @@ class Refine(BaseSynthesizer):
         prev_response: Optional[RESPONSE_TEXT_TYPE] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
-        dispatcher.event(GetResponseStartEvent(span_id=dispatcher.current_span_id))
+        span_id = dispatcher.current_span_id
+        dispatcher.event(GetResponseStartEvent(span_id=span_id))
         response: Optional[RESPONSE_TEXT_TYPE] = None
         for text_chunk in text_chunks:
             if prev_response is None:
@@ -373,7 +375,7 @@ class Refine(BaseSynthesizer):
                 response = response or "Empty Response"
         else:
             response = cast(AsyncGenerator, response)
-        dispatcher.event(GetResponseEndEvent(span_id=dispatcher.current_span_id))
+        dispatcher.event(GetResponseEndEvent(span_id=span_id))
         return response
 
     async def _arefine_response_single(

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -172,7 +172,7 @@ class Refine(BaseSynthesizer):
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
         """Give response over chunks."""
-        dispatcher.event(GetResponseStartEvent())
+        dispatcher.event(GetResponseStartEvent(span_id=dispatcher.current_span_id))
         response: Optional[RESPONSE_TEXT_TYPE] = None
         for text_chunk in text_chunks:
             if prev_response is None:
@@ -194,7 +194,7 @@ class Refine(BaseSynthesizer):
                 response = response or "Empty Response"
         else:
             response = cast(Generator, response)
-        dispatcher.event(GetResponseEndEvent())
+        dispatcher.event(GetResponseEndEvent(span_id=dispatcher.current_span_id))
         return response
 
     def _default_program_factory(self, prompt: PromptTemplate) -> BasePydanticProgram:
@@ -350,7 +350,7 @@ class Refine(BaseSynthesizer):
         prev_response: Optional[RESPONSE_TEXT_TYPE] = None,
         **response_kwargs: Any,
     ) -> RESPONSE_TEXT_TYPE:
-        dispatcher.event(GetResponseStartEvent())
+        dispatcher.event(GetResponseStartEvent(span_id=dispatcher.current_span_id))
         response: Optional[RESPONSE_TEXT_TYPE] = None
         for text_chunk in text_chunks:
             if prev_response is None:
@@ -373,6 +373,7 @@ class Refine(BaseSynthesizer):
                 response = response or "Empty Response"
         else:
             response = cast(AsyncGenerator, response)
+        dispatcher.event(GetResponseEndEvent(span_id=dispatcher.current_span_id))
         return response
 
     async def _arefine_response_single(

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -1,9 +1,12 @@
+import asyncio
 import inspect
 from asyncio import CancelledError
 
 import pytest
 import llama_index.core.instrumentation as instrument
 from llama_index.core.instrumentation.dispatcher import Dispatcher
+from llama_index.core.instrumentation.events import BaseEvent
+from llama_index.core.instrumentation.event_handlers import BaseEventHandler
 from unittest.mock import patch, MagicMock
 
 dispatcher = instrument.get_dispatcher("test")
@@ -12,42 +15,91 @@ value_error = ValueError("value error")
 cancelled_error = CancelledError("cancelled error")
 
 
+class _TestStartEvent(BaseEvent):
+    @classmethod
+    def class_name():
+        return "_TestStartEvent"
+
+
+class _TestEndEvent(BaseEvent):
+    @classmethod
+    def class_name():
+        return "_TestEndEvent"
+
+
+class _TestEventHandler(BaseEventHandler):
+    events = []
+
+    @classmethod
+    def class_name():
+        return "_TestEventHandler"
+
+    def handle(self, e: BaseEvent):
+        self.events.append(e)
+
+
 @dispatcher.span
-def func(*args, a, b=3, **kwargs):
+def func(a, b=3, **kwargs):
     return a + b
 
 
 @dispatcher.span
-async def async_func(*args, a, b=3, **kwargs):
+async def async_func(a, b=3, **kwargs):
     return a + b
 
 
 @dispatcher.span
-def func_exc(*args, a, b=3, c=4, **kwargs):
+def func_exc(a, b=3, c=4, **kwargs):
     raise value_error
 
 
 @dispatcher.span
-async def async_func_exc(*args, a, b=3, c=4, **kwargs):
+async def async_func_exc(a, b=3, c=4, **kwargs):
     raise cancelled_error
+
+
+@dispatcher.span
+def func_with_event(a, b=3, **kwargs):
+    span_id = dispatcher.current_span_id
+    dispatcher.event(_TestStartEvent(span_id=span_id))
+
+
+@dispatcher.span
+async def async_func_with_event(a, b=3, **kwargs):
+    span_id = dispatcher.current_span_id
+    dispatcher.event(_TestStartEvent(span_id=span_id))
+    await asyncio.sleep(0.1)
+    dispatcher.event(_TestEndEvent(span_id=span_id))
 
 
 class _TestObject:
     @dispatcher.span
-    def func(self, *args, a, b=3, **kwargs):
+    def func(self, a, b=3, **kwargs):
         return a + b
 
     @dispatcher.span
-    async def async_func(self, *args, a, b=3, **kwargs):
+    async def async_func(self, a, b=3, **kwargs):
         return a + b
 
     @dispatcher.span
-    def func_exc(self, *args, a, b=3, c=4, **kwargs):
+    def func_exc(self, a, b=3, c=4, **kwargs):
         raise value_error
 
     @dispatcher.span
-    async def async_func_exc(self, *args, a, b=3, c=4, **kwargs):
+    async def async_func_exc(self, a, b=3, c=4, **kwargs):
         raise cancelled_error
+
+    @dispatcher.span
+    def func_with_event(self, a, b=3, **kwargs):
+        span_id = dispatcher.current_span_id
+        dispatcher.event(_TestStartEvent(span_id=span_id))
+
+    @dispatcher.span
+    async def async_func_with_event(self, a, b=3, **kwargs):
+        span_id = dispatcher.current_span_id
+        dispatcher.event(_TestStartEvent(span_id=span_id))
+        await asyncio.sleep(0.1)
+        dispatcher.event(_TestEndEvent(span_id=span_id))
 
 
 @patch.object(Dispatcher, "span_exit")
@@ -58,12 +110,12 @@ def test_dispatcher_span_args(mock_uuid, mock_span_enter, mock_span_exit):
     mock_uuid.uuid4.return_value = "mock"
 
     # act
-    result = func(1, 2, a=3, c=5)
+    result = func(3, c=5)
 
     # assert
     # span_enter
     span_id = f"{func.__qualname__}-mock"
-    bound_args = inspect.signature(func).bind(1, 2, a=3, c=5)
+    bound_args = inspect.signature(func).bind(3, c=5)
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
@@ -89,12 +141,12 @@ def test_dispatcher_span_args_with_instance(mock_uuid, mock_span_enter, mock_spa
 
     # act
     instance = _TestObject()
-    result = instance.func(1, 2, a=3, c=5)
+    result = instance.func(3, c=5)
 
     # assert
     # span_enter
     span_id = f"{instance.func.__qualname__}-mock"
-    bound_args = inspect.signature(instance.func).bind(1, 2, a=3, c=5)
+    bound_args = inspect.signature(instance.func).bind(3, c=5)
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
@@ -126,7 +178,7 @@ def test_dispatcher_span_drop_args(
 
     with pytest.raises(ValueError):
         # act
-        _ = func_exc(7, a=3, b=5, c=2, d=5)
+        _ = func_exc(3, b=5, c=2, d=5)
 
     # assert
     # span_enter
@@ -135,7 +187,7 @@ def test_dispatcher_span_drop_args(
     # span_drop
     mock_span_drop.assert_called_once()
     span_id = f"{func_exc.__qualname__}-mock"
-    bound_args = inspect.signature(func_exc).bind(7, a=3, b=5, c=2, d=5)
+    bound_args = inspect.signature(func_exc).bind(3, b=5, c=2, d=5)
     args, kwargs = mock_span_drop.call_args
     assert args == ()
     assert kwargs == {
@@ -165,7 +217,7 @@ def test_dispatcher_span_drop_args(
     with pytest.raises(ValueError):
         # act
         instance = _TestObject()
-        _ = instance.func_exc(7, a=3, b=5, c=2, d=5)
+        _ = instance.func_exc(a=3, b=5, c=2, d=5)
 
     # assert
     # span_enter
@@ -174,7 +226,7 @@ def test_dispatcher_span_drop_args(
     # span_drop
     mock_span_drop.assert_called_once()
     span_id = f"{instance.func_exc.__qualname__}-mock"
-    bound_args = inspect.signature(instance.func_exc).bind(7, a=3, b=5, c=2, d=5)
+    bound_args = inspect.signature(instance.func_exc).bind(a=3, b=5, c=2, d=5)
     args, kwargs = mock_span_drop.call_args
     assert args == ()
     assert kwargs == {
@@ -197,12 +249,12 @@ async def test_dispatcher_async_span_args(mock_uuid, mock_span_enter, mock_span_
     mock_uuid.uuid4.return_value = "mock"
 
     # act
-    result = await async_func(1, 2, a=3, c=5)
+    result = await async_func(a=3, c=5)
 
     # assert
     # span_enter
     span_id = f"{async_func.__qualname__}-mock"
-    bound_args = inspect.signature(async_func).bind(1, 2, a=3, c=5)
+    bound_args = inspect.signature(async_func).bind(a=3, c=5)
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
@@ -231,12 +283,12 @@ async def test_dispatcher_async_span_args_with_instance(
 
     # act
     instance = _TestObject()
-    result = await instance.async_func(1, 2, a=3, c=5)
+    result = await instance.async_func(a=3, c=5)
 
     # assert
     # span_enter
     span_id = f"{instance.async_func.__qualname__}-mock"
-    bound_args = inspect.signature(instance.async_func).bind(1, 2, a=3, c=5)
+    bound_args = inspect.signature(instance.async_func).bind(a=3, c=5)
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
@@ -269,7 +321,7 @@ async def test_dispatcher_async_span_drop_args(
 
     with pytest.raises(CancelledError):
         # act
-        _ = await async_func_exc(7, a=3, b=5, c=2, d=5)
+        _ = await async_func_exc(a=3, b=5, c=2, d=5)
 
     # assert
     # span_enter
@@ -278,7 +330,7 @@ async def test_dispatcher_async_span_drop_args(
     # span_drop
     mock_span_drop.assert_called_once()
     span_id = f"{async_func_exc.__qualname__}-mock"
-    bound_args = inspect.signature(async_func_exc).bind(7, a=3, b=5, c=2, d=5)
+    bound_args = inspect.signature(async_func_exc).bind(a=3, b=5, c=2, d=5)
     args, kwargs = mock_span_drop.call_args
     assert args == ()
     assert kwargs == {
@@ -309,7 +361,7 @@ async def test_dispatcher_async_span_drop_args_with_instance(
     with pytest.raises(CancelledError):
         # act
         instance = _TestObject()
-        _ = await instance.async_func_exc(7, a=3, b=5, c=2, d=5)
+        _ = await instance.async_func_exc(a=3, b=5, c=2, d=5)
 
     # assert
     # span_enter
@@ -318,7 +370,7 @@ async def test_dispatcher_async_span_drop_args_with_instance(
     # span_drop
     mock_span_drop.assert_called_once()
     span_id = f"{instance.async_func_exc.__qualname__}-mock"
-    bound_args = inspect.signature(instance.async_func_exc).bind(7, a=3, b=5, c=2, d=5)
+    bound_args = inspect.signature(instance.async_func_exc).bind(a=3, b=5, c=2, d=5)
     args, kwargs = mock_span_drop.call_args
     assert args == ()
     assert kwargs == {
@@ -330,3 +382,129 @@ async def test_dispatcher_async_span_drop_args_with_instance(
 
     # span_exit
     mock_span_exit.assert_not_called()
+
+
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_drop")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+def test_dispatcher_fire_event(
+    mock_uuid: MagicMock,
+    mock_span_enter: MagicMock,
+    mock_span_drop: MagicMock,
+    mock_span_exit: MagicMock,
+):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+    event_handler = _TestEventHandler()
+    dispatcher.add_event_handler(event_handler)
+
+    # act
+    _ = func_with_event(3, c=5)
+
+    # assert
+    span_id = f"{func_with_event.__qualname__}-mock"
+    assert all(e.span_id == span_id for e in event_handler.events)
+
+    # span_enter
+    mock_span_enter.assert_called_once()
+
+    # span
+    mock_span_drop.assert_not_called()
+
+    # span_exit
+    mock_span_exit.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_drop")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+async def test_dispatcher_async_fire_event(
+    mock_uuid: MagicMock,
+    mock_span_enter: MagicMock,
+    mock_span_drop: MagicMock,
+    mock_span_exit: MagicMock,
+):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+    event_handler = _TestEventHandler()
+    dispatcher.add_event_handler(event_handler)
+
+    # act
+    _ = await async_func_with_event(3, c=5)
+
+    # assert
+    span_id = f"{async_func_with_event.__qualname__}-mock"
+    assert all(e.span_id == span_id for e in event_handler.events)
+
+    # span_enter
+    mock_span_enter.assert_called_once()
+
+    # span
+    mock_span_drop.assert_not_called()
+
+    # span_exit
+    mock_span_exit.assert_called_once()
+
+
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_drop")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+def test_dispatcher_fire_event_with_instance(
+    mock_uuid, mock_span_enter, mock_span_drop, mock_span_exit
+):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+    event_handler = _TestEventHandler()
+    dispatcher.add_event_handler(event_handler)
+
+    # act
+    instance = _TestObject()
+    _ = instance.func_with_event(a=3, c=5)
+
+    # assert
+    span_id = f"{instance.func_with_event.__qualname__}-mock"
+    assert all(e.span_id == span_id for e in event_handler.events)
+
+    # span_enter
+    mock_span_enter.assert_called_once()
+
+    # span
+    mock_span_drop.assert_not_called()
+
+    # span_exit
+    mock_span_exit.assert_called_once()
+
+
+@pytest.mark.asyncio()
+@patch.object(Dispatcher, "span_exit")
+@patch.object(Dispatcher, "span_drop")
+@patch.object(Dispatcher, "span_enter")
+@patch("llama_index.core.instrumentation.dispatcher.uuid")
+async def test_dispatcher_async_fire_event_with_instance(
+    mock_uuid, mock_span_enter, mock_span_drop, mock_span_exit
+):
+    # arrange
+    mock_uuid.uuid4.return_value = "mock"
+    event_handler = _TestEventHandler()
+    dispatcher.add_event_handler(event_handler)
+
+    # act
+    instance = _TestObject()
+    _ = await instance.async_func_with_event(a=3, c=5)
+
+    # assert
+    span_id = f"{instance.async_func_with_event.__qualname__}-mock"
+    assert all(e.span_id == span_id for e in event_handler.events)
+
+    # span_enter
+    mock_span_enter.assert_called_once()
+
+    # span
+    mock_span_drop.assert_not_called()
+
+    # span_exit
+    mock_span_exit.assert_called_once()

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -61,16 +61,18 @@ async def async_func_exc(a, b=3, c=4, **kwargs):
 
 @dispatcher.span
 def func_with_event(a, b=3, **kwargs):
-    with dispatcher.dispatch_event() as dispatch_event:
-        dispatch_event(_TestStartEvent())
+    dispatch_event = dispatcher.get_dispatch_event()
+
+    dispatch_event(_TestStartEvent())
 
 
 @dispatcher.span
 async def async_func_with_event(a, b=3, **kwargs):
-    with dispatcher.dispatch_event() as dispatch_event:
-        dispatch_event(_TestStartEvent())
-        await asyncio.sleep(0.1)
-        dispatch_event(_TestEndEvent())
+    dispatch_event = dispatcher.get_dispatch_event()
+
+    dispatch_event(_TestStartEvent())
+    await asyncio.sleep(0.1)
+    dispatch_event(_TestEndEvent())
 
 
 class _TestObject:
@@ -92,17 +94,19 @@ class _TestObject:
 
     @dispatcher.span
     def func_with_event(self, a, b=3, **kwargs):
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(_TestStartEvent())
+        dispatch_event = dispatcher.get_dispatch_event()
+
+        dispatch_event(_TestStartEvent())
 
     @dispatcher.span
     async def async_func_with_event(self, a, b=3, **kwargs):
-        with dispatcher.dispatch_event() as dispatch_event:
-            dispatch_event(_TestStartEvent())
-            await asyncio.sleep(0.1)
-            await self.async_func(1)  # this should create a new span_id
-            # that is fine because we have dispatch_event
-            dispatch_event(_TestEndEvent())
+        dispatch_event = dispatcher.get_dispatch_event()
+
+        dispatch_event(_TestStartEvent())
+        await asyncio.sleep(0.1)
+        await self.async_func(1)  # this should create a new span_id
+        # that is fine because we have dispatch_event
+        dispatch_event(_TestEndEvent())
 
 
 @patch.object(Dispatcher, "span_exit")

--- a/llama-index-integrations/callbacks/llama-index-callbacks-aim/tests/BUILD
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-aim/tests/BUILD
@@ -1,1 +1,0 @@
-python_tests()

--- a/llama-index-integrations/callbacks/llama-index-callbacks-aim/tests/test_aim_callback.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-aim/tests/test_aim_callback.py
@@ -1,7 +1,0 @@
-from llama_index.callbacks.aim.base import AimCallback
-from llama_index.core.callbacks.base_handler import BaseCallbackHandler
-
-
-def test_class():
-    names_of_base_classes = [b.__name__ for b in AimCallback.__mro__]
-    assert BaseCallbackHandler.__name__ in names_of_base_classes


### PR DESCRIPTION
# Description

- This PR aims to associate an `Event` with the `Span` enclosure where it takes place
- Specifically a `span_id` field is added to `BaseEvent`
- Coroutine safety is handled by assigning a `current_span_id` to `dispatcher` which we use `asyncio.Lock` to update when working with async funcs
- When firing an event with dispatcher, we first get `dispatcher.current_span_id` and store it into a variable that can be re-used within the scope of the func
- Also added a `SpanDropEvent` that fires if a Span is being dropped due to an encountered `Exception`. 
     - First image: BaseQueryEngine.aquery span IS NOT dropped so QueryEndEvent is observed
     - Second image: BaseQueryengine.aquery span IS dropped so SpanDropEvent is observed and QueryEndEvent is not

![image](https://github.com/run-llama/llama_index/assets/92402603/dab97c05-ee7d-4886-a4ea-eb852e9c559c)
![image](https://github.com/run-llama/llama_index/assets/92402603/cfb5c28a-2257-49f3-b9ea-e33604636107)


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] Ran notebooks (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

