### PR TITLE
fix bug in BatchEvalRunner for multi-evaluator eval_kwargs_lists

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/batch_runner.py
+++ b/llama-index-core/llama_index/core/evaluation/batch_runner.py
@@ -206,7 +206,7 @@ class BatchEvalRunner:
         )
         eval_kwargs_lists = self._validate_nested_eval_kwargs_types(eval_kwargs_lists)
 
-        # boolean to check if using multi kwarg evaluator are being used
+        # boolean to check if using multi kwarg evaluator
         multi_kwargs = isinstance(next(iter(eval_kwargs_lists.values())), dict)
 
         # run evaluations
@@ -216,7 +216,7 @@ class BatchEvalRunner:
             contexts = cast(List, contexts_list)[idx]
             for name, evaluator in self.evaluators.items():
                 if multi_kwargs:
-                    # multi-evaluator
+                    # multi-evaluator - get appropriate runtime kwargs if present
                     kwargs = (
                         eval_kwargs_lists[name] if name in eval_kwargs_lists else {}
                     )
@@ -264,7 +264,7 @@ class BatchEvalRunner:
         queries, responses = self._validate_and_clean_inputs(queries, responses)
         eval_kwargs_lists = self._validate_nested_eval_kwargs_types(eval_kwargs_lists)
 
-        # boolean to check if using multi kwarg evaluator are being used
+        # boolean to check if using multi kwarg evaluator
         multi_kwargs = isinstance(next(iter(eval_kwargs_lists.values())), dict)
 
         # run evaluations
@@ -273,7 +273,7 @@ class BatchEvalRunner:
             response = cast(List, responses)[idx]
             for name, evaluator in self.evaluators.items():
                 if multi_kwargs:
-                    # multi-evaluator
+                    # multi-evaluator - get appropriate runtime kwargs if present
                     kwargs = (
                         eval_kwargs_lists[name] if name in eval_kwargs_lists else {}
                     )

--- a/llama-index-core/llama_index/core/evaluation/batch_runner.py
+++ b/llama-index-core/llama_index/core/evaluation/batch_runner.py
@@ -206,15 +206,20 @@ class BatchEvalRunner:
         )
         eval_kwargs_lists = self._validate_nested_eval_kwargs_types(eval_kwargs_lists)
 
+        # boolean to check if using multi kwarg evaluator are being used
+        multi_kwargs = isinstance(next(iter(eval_kwargs_lists.values())), dict)
+
         # run evaluations
         eval_jobs = []
         for idx, query in enumerate(cast(List[str], queries)):
             response_str = cast(List, response_strs)[idx]
             contexts = cast(List, contexts_list)[idx]
             for name, evaluator in self.evaluators.items():
-                if name in eval_kwargs_lists:
+                if multi_kwargs:
                     # multi-evaluator
-                    kwargs = eval_kwargs_lists[name]
+                    kwargs = (
+                        eval_kwargs_lists[name] if name in eval_kwargs_lists else {}
+                    )
                 else:
                     # single evaluator (maintain backwards compatibility)
                     kwargs = eval_kwargs_lists
@@ -259,14 +264,19 @@ class BatchEvalRunner:
         queries, responses = self._validate_and_clean_inputs(queries, responses)
         eval_kwargs_lists = self._validate_nested_eval_kwargs_types(eval_kwargs_lists)
 
+        # boolean to check if using multi kwarg evaluator are being used
+        multi_kwargs = isinstance(next(iter(eval_kwargs_lists.values())), dict)
+
         # run evaluations
         eval_jobs = []
         for idx, query in enumerate(cast(List[str], queries)):
             response = cast(List, responses)[idx]
             for name, evaluator in self.evaluators.items():
-                if name in eval_kwargs_lists:
+                if multi_kwargs:
                     # multi-evaluator
-                    kwargs = eval_kwargs_lists[name]
+                    kwargs = (
+                        eval_kwargs_lists[name] if name in eval_kwargs_lists else {}
+                    )
                 else:
                     # single evaluator (maintain backwards compatibility)
                     kwargs = eval_kwargs_lists
@@ -385,7 +395,8 @@ class BatchEvalRunner:
         app_name: str,
         results: Dict[str, List[EvaluationResult]],
     ) -> None:
-        """Upload the evaluation results to LlamaCloud.
+        """
+        Upload the evaluation results to LlamaCloud.
 
         Args:
             project_name (str): The name of the project.

--- a/llama-index-core/tests/evaluation/test_batch_runner.py
+++ b/llama-index-core/tests/evaluation/test_batch_runner.py
@@ -59,7 +59,12 @@ def get_eval_results(key, eval_results):
 @pytest.mark.asyncio()
 def test_batch_runner() -> None:
     # single evaluator
-    runner = BatchEvalRunner(evaluators={"evaluator1": MockEvaluator()})
+    runner = BatchEvalRunner(
+        evaluators={
+            "evaluator1": MockEvaluator(),
+            "no_kwarg_evaluator": MockEvaluator(),
+        }
+    )
 
     exp_queries = ["query1", "query2"]
     exp_response_strs = ["response1", "response2"]
@@ -86,6 +91,7 @@ def test_batch_runner() -> None:
     runner.evaluators = {
         "evaluator1": MockEvaluator(),
         "evaluator2": MockEvaluator(),
+        "no_kwarg_evaluator": MockEvaluator(),
     }
 
     exp_queries = ["query1", "query2"]


### PR DESCRIPTION
add tests accordingly

# Description
This is an update to [this PR](https://github.com/run-llama/llama_index/pull/11727) which fixes a bug.

When using multiple evaluators which take different runtime kwargs the previous PR introduced a bug which throws an error  for evaluators which do not need runtime_kwargs.

Fixes # (issue)
Bug which I just found but didn't file a report on because I introduced it and have a fix :P

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No - changes to core

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests  -  modified existing tests to include this test case
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
