### PR TITLE
Fix Token Counting of Completions for async calls

### DIFF
--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -260,7 +260,7 @@ def llm_completion_callback() -> Callable:
                         CBEventType.LLM,
                         payload={
                             EventPayload.PROMPT: args[0],
-                            EventPayload.RESPONSE: f_return_val,
+                            EventPayload.COMPLETION: f_return_val,
                         },
                         event_id=event_id,
                     )


### PR DESCRIPTION
The completion was stored in the Response, which is not checked in the TokenCountIngHandler

# Description

When async methods are decorated with the  the completion is incorrectly stored in the CBEventType.RESPONSE in those cases, due to a bug in the llm_completion_callback wrapper. The TokenCountingHandler assumes, that if CBEventType.PROMPT is provided, that also CBEventType.COMPLETION is present, and that if CBEventType.MESSAGES is provided, that also CBEventType.RESPONSE is provided. Which is nowhere enforced, hence this Bug was undiscovered.

Fixes #12420 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I ran the code provided in the Bugreport and it works, I could adapt it and add it as UnitTest - but would have to use the MockLLM.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
