### PR TITLE
Add file extractor param to readers used for data sources

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -70,6 +70,7 @@ class GoogleDriveReader(BasePydanticReader):
         client_config: Optional[dict] = None,
         authorized_user_info: Optional[dict] = None,
         service_account_key: Optional[dict] = None,
+        file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize with parameters."""
@@ -115,6 +116,7 @@ class GoogleDriveReader(BasePydanticReader):
             authorized_user_info=authorized_user_info,
             service_account_key=service_account_key,
             token_path=token_path,
+            file_extractor=file_extractor,
             **kwargs,
         )
 
@@ -388,7 +390,11 @@ class GoogleDriveReader(BasePydanticReader):
                         "created at": fileid_meta[4],
                         "modified at": fileid_meta[5],
                     }
-                loader = SimpleDirectoryReader(temp_dir, file_metadata=get_metadata)
+                loader = SimpleDirectoryReader(
+                    temp_dir,
+                    file_extractor=self.file_extractor,
+                    file_metadata=get_metadata,
+                )
                 documents = loader.load_data()
                 for doc in documents:
                     doc.id_ = doc.metadata.get("file id", doc.id_)

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -5,15 +5,15 @@ import os
 import json
 import tempfile
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 
 from llama_index.core.readers import SimpleDirectoryReader
-from llama_index.core.readers.base import BasePydanticReader
-from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.readers.base import BaseReader, BasePydanticReader
+from llama_index.core.bridge.pydantic import PrivateAttr, Field
 from llama_index.core.schema import Document
 
 logger = logging.getLogger(__name__)
@@ -44,12 +44,18 @@ class GoogleDriveReader(BasePydanticReader):
             user info. Defaults to None.
         service_account_key (Optional[dict]): Dictionary containing service
             account key. Defaults to None.
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
+            extension to a BaseReader class that specifies how to convert that
+            file to text. See `SimpleDirectoryReader` for more details.
     """
 
     client_config: Optional[dict] = None
     authorized_user_info: Optional[dict] = None
     service_account_key: Optional[dict] = None
     token_path: Optional[str] = None
+    file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = Field(
+        default=None, exclude=True
+    )
 
     _is_cloud: bool = PrivateAttr(default=False)
     _creds: Credentials = PrivateAttr()

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -45,7 +45,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -4,13 +4,13 @@ import logging
 import os
 import tempfile
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 from llama_index.core.readers import SimpleDirectoryReader
-from llama_index.core.readers.base import BasePydanticReader
+from llama_index.core.readers.base import BaseReader, BasePydanticReader
 from llama_index.core.schema import Document
-from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.bridge.pydantic import PrivateAttr, Field
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,8 @@ class OneDriveReader(BasePydanticReader):
     :param folder_path (str, optional): The relative path of the OneDrive folder to download. If provided, files within the folder are downloaded.  Will be used if the parameter is
                                         not provided when calling load_data().
     :param file_paths (List[str], optional): List of specific file paths to download. Will be used if the parameter is not provided when calling load_data().
+    :param file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file extension to a BaseReader class that specifies how to convert that file to text.
+                                                             See `SimpleDirectoryReader` for more details.
 
 
     For interactive authentication to work, a browser is used to authenticate, hence the registered application should have a redirect URI set to 'https://localhost'
@@ -53,6 +55,9 @@ class OneDriveReader(BasePydanticReader):
     file_ids: Optional[List[str]] = None
     folder_path: Optional[str] = None
     file_paths: Optional[List[str]] = None
+    file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = Field(
+        default=None, exclude=True
+    )
 
     _is_interactive_auth = PrivateAttr(False)
     _authority = PrivateAttr()

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -73,6 +73,7 @@ class OneDriveReader(BasePydanticReader):
         file_ids: Optional[List[str]] = None,
         folder_path: Optional[str] = None,
         file_paths: Optional[List[str]] = None,
+        file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         **kwargs,
     ) -> None:
         self._is_interactive_auth = not client_secret
@@ -87,6 +88,7 @@ class OneDriveReader(BasePydanticReader):
             file_ids=file_ids,
             folder_path=folder_path,
             file_paths=file_paths,
+            file_extractor=file_extractor,
             **kwargs,
         )
 
@@ -503,7 +505,10 @@ class OneDriveReader(BasePydanticReader):
             return self._downloaded_files_metadata[filename]
 
         simple_loader = SimpleDirectoryReader(
-            directory, file_metadata=get_metadata, recursive=recursive
+            directory,
+            file_extractor=self.file_extractor,
+            file_metadata=get_metadata,
+            recursive=recursive,
         )
         return simple_loader.load_data()
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["godwin3737"]
 name = "llama-index-readers-microsoft-onedrive"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -43,12 +43,14 @@ class SharePointReader(BasePydanticReader):
         client_id: str,
         client_secret: str,
         tenant_id: str,
+        file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             client_id=client_id,
             client_secret=client_secret,
             tenant_id=tenant_id,
+            file_extractor=file_extractor,
             **kwargs,
         )
 
@@ -346,7 +348,10 @@ class SharePointReader(BasePydanticReader):
             return files_metadata[filename]
 
         simple_loader = SimpleDirectoryReader(
-            download_dir, file_metadata=get_metadata, recursive=recursive
+            download_dir,
+            file_extractor=self.file_extractor,
+            file_metadata=get_metadata,
+            recursive=recursive,
         )
         return simple_loader.load_data()
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -3,13 +3,13 @@
 import logging
 import os
 import tempfile
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union, Optional
 
 import requests
 from llama_index.core.readers import SimpleDirectoryReader
-from llama_index.core.readers.base import BasePydanticReader
-from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.readers.base import BaseReader, BasePydanticReader
 from llama_index.core.schema import Document
+from llama_index.core.bridge.pydantic import PrivateAttr, Field
 
 logger = logging.getLogger(__name__)
 
@@ -25,11 +25,17 @@ class SharePointReader(BasePydanticReader):
             The application must also be configured with MS Graph permissions "Files.ReadAll", "Sites.ReadAll" and BrowserSiteLists.Read.All.
         client_secret (str): The application secret for the app registered in Azure.
         tenant_id (str): Unique identifier of the Azure Active Directory Instance.
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file extension to a BaseReader class that specifies how to convert that
+                                                          file to text. See `SimpleDirectoryReader` for more details.
     """
 
     client_id: str = None
     client_secret: str = None
     tenant_id: str = None
+    file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = Field(
+        default=None, exclude=True
+    )
+
     _authorization_headers = PrivateAttr()
 
     def __init__(

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["arun-soliton"]
 name = "llama-index-readers-microsoft-sharepoint"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Realized that readers will need this param to integrate correctly with LlamaParse on the platform side.