### PR TITLE
feat: add the trace for vector store index insert_nodes

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -326,8 +326,9 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
                     self._object_map[node.index_id] = node.obj
                     node.obj = None
 
-        self._insert(nodes, **insert_kwargs)
-        self._storage_context.index_store.add_index_struct(self._index_struct)
+        with self._callback_manager.as_trace("insert_nodes"):
+            self._insert(nodes, **insert_kwargs)
+            self._storage_context.index_store.add_index_struct(self._index_struct)
 
     def _delete_node(self, node_id: str, **delete_kwargs: Any) -> None:
         pass


### PR DESCRIPTION
# Description

I observed that the "insert_nodes" trace is missing When I insert node into an existing vector store index, other indices like SummaryIndex, KeywordTableIndex and KGIndex work fine.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
