### PR TITLE
alter qa embedding pair prompt

### DIFF
--- a/llama-index-finetuning/llama_index/finetuning/embeddings/common.py
+++ b/llama-index-finetuning/llama_index/finetuning/embeddings/common.py
@@ -53,7 +53,7 @@ Context information is below.
 {context_str}
 ---------------------
 
-Given the context information and not prior knowledge.
+Given the context information and no prior knowledge.
 generate only questions based on the below query.
 
 You are a Teacher/ Professor. Your task is to setup \


### PR DESCRIPTION
I inspected the prompt used in `generate_qa_embedding_pairs` while going through the [FT-Embeddings cookbook](https://docs.llamaindex.ai/en/stable/examples/finetuning/embeddings/finetune_embedding/). 

This PR fixes a small typo in the prompt