### PR TITLE
Fix bug with GCSReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-gcs/llama_index/readers/gcs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gcs/llama_index/readers/gcs/base.py
@@ -43,6 +43,7 @@ class GCSReader(BasePydanticReader):
         Default is None.
     service_account_key (Optional[Dict[str, str]]): provide GCP service account key directly.
     service_account_key_json (Optional[str]): provide GCP service account key as a JSON string.
+    service_account_key_path (Optional[str]): provide path to file containing GCP service account key.
     """
 
     is_remote: bool = True
@@ -60,6 +61,7 @@ class GCSReader(BasePydanticReader):
     file_metadata: Optional[Callable[[str], Dict]] = Field(default=None, exclude=True)
     service_account_key: Optional[Dict[str, str]] = None
     service_account_key_json: Optional[str] = None
+    service_account_key_path: Optional[str] = None
 
     @classmethod
     def class_name(cls) -> str:
@@ -74,8 +76,12 @@ class GCSReader(BasePydanticReader):
                 self.service_account_key, scopes=SCOPES
             )
         elif self.service_account_key_json is not None:
-            creds = service_account.Credentials.from_service_account_file(
+            creds = service_account.Credentials.from_service_account_info(
                 json.loads(self.service_account_key_json), scopes=SCOPES
+            )
+        elif self.service_account_key_path is not None:
+            creds = service_account.Credentials.from_service_account_file(
+                self.service_account_key_path, scopes=SCOPES
             )
         else:
             # Use anonymous access if none are specified


### PR DESCRIPTION
Was using service_account_key_json as a file path instead of the direct string representation of the service account key.
