### PR TITLE
Updated base model name on watsonx integration

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-watsonx/llama_index/llms/watsonx/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-watsonx/llama_index/llms/watsonx/base.py
@@ -65,7 +65,7 @@ class WatsonX(LLM):
     def __init__(
         self,
         credentials: Dict[str, Any],
-        model_id: Optional[str] = "ibm/mpt-7b-instruct2",
+        model_id: Optional[str] = "ibm/granite-13b-chat-v2",
         project_id: Optional[str] = None,
         space_id: Optional[str] = None,
         max_new_tokens: Optional[int] = 512,

--- a/llama-index-integrations/llms/llama-index-llms-watsonx/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-watsonx/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-watsonx"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION


# Description

Updated base model to ibm/granite-13b-chat-v2, ibm/mpt-7b-instruct2 is not available anymore.
Using watsonx integration and this would be useful to be updated 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x ] No

## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
