### PR TITLE
Readability web page reader fix playwright async api bug

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
@@ -1,11 +1,12 @@
 import asyncio
 import unicodedata
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional, cast
+from typing import Callable, Dict, List, Literal, Optional
 
 from llama_index.core.node_parser.interface import TextSplitter
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
+from playwright.async_api._generated import Browser
 
 path = Path(__file__).parent / "Readability.js"
 
@@ -68,8 +69,8 @@ class ReadabilityWebPageReader(BaseReader):
         """
         from playwright.async_api import async_playwright
 
-        with async_playwright() as p:
-            browser = await p.chromium.launch(**self._launch_options)
+        with async_playwright() as async_playwright:
+            browser = await async_playwright.chromium.launch(**self._launch_options)
 
             article = await self.scrape_page(
                 browser,
@@ -105,7 +106,7 @@ class ReadabilityWebPageReader(BaseReader):
 
     async def scrape_page(
         self,
-        browser: Any,
+        browser: Browser,
         url: str,
     ) -> Dict[str, str]:
         """Scrape a single article url.
@@ -127,8 +128,6 @@ class ReadabilityWebPageReader(BaseReader):
             lang: content language
 
         """
-        from playwright.async_api._generated import Browser
-
         if self._readability_js is None:
             with open(path) as f:
                 self._readability_js = f.read()
@@ -143,7 +142,7 @@ class ReadabilityWebPageReader(BaseReader):
             }}())
         """
 
-        browser = cast(Browser, browser)
+        # browser = cast(Browser, browser)
         page = await browser.new_page(ignore_https_errors=True)
         page.set_default_timeout(60000)
         await page.goto(url, wait_until=self._wait_until)

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
@@ -1,3 +1,4 @@
+import asyncio
 import unicodedata
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, cast
@@ -11,6 +12,11 @@ path = Path(__file__).parent / "Readability.js"
 
 def nfkc_normalize(text: str) -> str:
     return unicodedata.normalize("NFKC", text)
+
+
+def async_to_sync(awaitable):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(awaitable)
 
 
 class ReadabilityWebPageReader(BaseReader):
@@ -50,7 +56,7 @@ class ReadabilityWebPageReader(BaseReader):
         self._normalize = normalize
         self._readability_js = None
 
-    def load_data(self, url: str) -> List[Document]:
+    async def async_load_data(self, url: str) -> List[Document]:
         """Render and load data content from url.
 
         Args:
@@ -60,12 +66,12 @@ class ReadabilityWebPageReader(BaseReader):
             List[Document]: List of documents.
 
         """
-        from playwright.sync_api import sync_playwright
+        from playwright.async_api import async_playwright
 
-        with sync_playwright() as p:
-            browser = p.chromium.launch(**self._launch_options)
+        with async_playwright() as p:
+            browser = await p.chromium.launch(**self._launch_options)
 
-            article = self.scrape_page(
+            article = await self.scrape_page(
                 browser,
                 url,
             )
@@ -90,11 +96,14 @@ class ReadabilityWebPageReader(BaseReader):
             else:
                 texts = [article["textContent"]]
 
-            browser.close()
+            await browser.close()
 
             return [Document(text=x, extra_info=extra_info) for x in texts]
 
-    def scrape_page(
+    def load_data(self, url: str) -> List[Document]:
+        return async_to_sync(self.async_load_data(url))
+
+    async def scrape_page(
         self,
         browser: Any,
         url: str,
@@ -118,7 +127,7 @@ class ReadabilityWebPageReader(BaseReader):
             lang: content language
 
         """
-        from playwright.sync_api._generated import Browser
+        from playwright.async_api._generated import Browser
 
         if self._readability_js is None:
             with open(path) as f:
@@ -135,13 +144,13 @@ class ReadabilityWebPageReader(BaseReader):
         """
 
         browser = cast(Browser, browser)
-        page = browser.new_page(ignore_https_errors=True)
+        page = await browser.new_page(ignore_https_errors=True)
         page.set_default_timeout(60000)
-        page.goto(url, wait_until=self._wait_until)
+        await page.goto(url, wait_until=self._wait_until)
 
-        r = page.evaluate(inject_readability)
+        r = await page.evaluate(inject_readability)
 
-        page.close()
+        await page.close()
         print("scraped:", url)
 
         return r

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
@@ -69,7 +69,7 @@ class ReadabilityWebPageReader(BaseReader):
         """
         from playwright.async_api import async_playwright
 
-        with async_playwright() as async_playwright:
+        async with async_playwright() as async_playwright:
             browser = await async_playwright.chromium.launch(**self._launch_options)
 
             article = await self.scrape_page(

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -41,7 +41,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -41,7 +41,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -41,7 +41,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -41,7 +41,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.1.10"
+version = "0.1.11"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -41,7 +41,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.1.11"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/requirements.txt
+++ b/llama-index-integrations/readers/llama-index-readers-web/requirements.txt
@@ -3,7 +3,7 @@ aiohttp
 beautifulsoup4
 requests
 urllib3
-playwright~=1.30
+playwright~=1.42.0
 newspaper3k
 selenium
 chromedriver-autoinstaller


### PR DESCRIPTION
# Description

Playwright not working as it detects the asyncio loop in jupyter notebook.

Updated playwright and added nested asyncio loop as well as running loop sync so that it will work in scripts as well

Fixes # [(issue)](https://github.com/run-llama/llama_index/issues/12525)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Locally in jupyter notebook as well as python interpreter

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
