### PR TITLE
Make chat message to dict safer

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -63,7 +63,7 @@ class ChatMessage(BaseModel):
         # ensure all additional_kwargs are serializable
         msg = super().dict(**kwargs)
 
-        for key, value in msg["additional_kwargs"].items():
+        for key, value in msg.get("additional_kwargs", {}).items():
             value = self._recursive_serialization(value)
             if not isinstance(value, (str, int, float, bool, dict, list, type(None))):
                 raise ValueError(

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -83,7 +83,7 @@ dirtyjson = "^1.0.8"
 tqdm = "^4.66.1"
 pillow = ">=9.0.0"
 PyYAML = ">=6.0.1"
-llamaindex-py-client = "^0.1.15"
+llamaindex-py-client = "^0.1.16"
 wrapt = "*"
 
 [tool.poetry.extras]

--- a/pants.toml
+++ b/pants.toml
@@ -9,7 +9,7 @@ pants_version = "2.19.0"
 remote_cache_read = true
 remote_cache_write = true
 remote_instance_name = "main"
-remote_store_address = "grpc://44.204.50.6:9092"
+remote_store_address = "grpc://framework-ci-balancer-1983728860.us-east-1.elb.amazonaws.com:9092"
 unmatched_build_file_globs = "error"
 
 [black]


### PR DESCRIPTION
Langfuse overrode the ChatMessage class, leading to `.dict()` calls failing.

Lets make the `.dict()` method safer

Fixes https://github.com/run-llama/llama_index/issues/12524