### PR TITLE
vbump to revert duckdb breaking changes

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["krish-adi"]
 name = "llama-index-vector-stores-duckdb"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Somehow, the changes in https://github.com/run-llama/llama_index/pull/12416 got published as v0.1.2, causing breaking changes.

Reverting for now by re-publishing v0.1.1 as v0.1.3

Fixes https://github.com/run-llama/llama_index/issues/12542