### PR TITLE
Milvus output fields

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -76,7 +76,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         search_config (dict, optional): The configuration used for searching
             the Milvus index. Note that this must be compatible with the index
             type specified by `index_config`. Defaults to None.
-        output_fields (list[str], optional): The default fields to return in the query
+        output_fields (List[str], optional): The default fields to return in the query
             metadata results. Used when bringing your own collection, can be overwritten
             at the query level. Defaults to None.
 
@@ -120,7 +120,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
     text_key: Optional[str]
     index_config: Optional[dict]
     search_config: Optional[dict]
-    output_fields: Optional[list[str]]
+    output_fields: Optional[List[str]]
 
     _milvusclient: MilvusClient = PrivateAttr()
     _collection: Any = PrivateAttr()
@@ -139,7 +139,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         text_key: Optional[str] = None,
         index_config: Optional[dict] = None,
         search_config: Optional[dict] = None,
-        output_fields: Optional[list[str]] = None,
+        output_fields: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
         """Init params."""

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -76,6 +76,9 @@ class MilvusVectorStore(BasePydanticVectorStore):
         search_config (dict, optional): The configuration used for searching
             the Milvus index. Note that this must be compatible with the index
             type specified by `index_config`. Defaults to None.
+        output_fields (list[str], optional): The default fields to return in the query
+            metadata results. Used when bringing your own collection, can be overwritten
+            at the query level. Defaults to None.
 
     Raises:
         ImportError: Unable to import `pymilvus`.
@@ -117,6 +120,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
     text_key: Optional[str]
     index_config: Optional[dict]
     search_config: Optional[dict]
+    output_fields: Optional[list[str]]
 
     _milvusclient: MilvusClient = PrivateAttr()
     _collection: Any = PrivateAttr()
@@ -135,6 +139,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         text_key: Optional[str] = None,
         index_config: Optional[dict] = None,
         search_config: Optional[dict] = None,
+        output_fields: Optional[list[str]] = None,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -181,6 +186,8 @@ class MilvusVectorStore(BasePydanticVectorStore):
 
         self._collection = Collection(collection_name, using=self._milvusclient._using)
         self._create_index_if_required()
+
+        self.output_fields = output_fields
 
         logger.debug(f"Successfully created a new collection: {self.collection_name}")
 
@@ -284,7 +291,11 @@ class MilvusVectorStore(BasePydanticVectorStore):
             expr_list = ['"' + entry + '"' for entry in query.node_ids]
             expr.append(f"{MILVUS_ID_FIELD} in [{','.join(expr_list)}]")
 
-        # Limit output fields
+        # Set default output fields if configured
+        if self.output_fields is not None:
+            output_fields = self.output_fields
+
+        # Limit output fields and overwrite if query specifies
         if query.output_fields is not None:
             output_fields = query.output_fields
 
@@ -308,6 +319,16 @@ class MilvusVectorStore(BasePydanticVectorStore):
             f" Num Results: {len(res[0])}"
         )
 
+        metadata_field_exclusions = {
+            self.embedding_field,
+            self.doc_id_field,
+            self.text_key,
+            "*",
+        }
+        metadata_fields = [
+            k for k in output_fields if k not in metadata_field_exclusions
+        ]
+
         nodes = []
         similarities = []
         ids = []
@@ -329,8 +350,11 @@ class MilvusVectorStore(BasePydanticVectorStore):
                         "The passed in text_key value does not exist "
                         "in the retrieved entity."
                     )
+                metadata = {k: hit["entity"].get(k, None) for k in metadata_fields}
+
                 node = TextNode(
                     text=text,
+                    metadata=metadata,
                 )
             nodes.append(node)
             similarities.append(hit["distance"])

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Hey,

I ran into an issue while trying to use LlamaIndex with an existing Milvus collection. The core being that retrieving any fields other than those specified by the `doc_id_field`, `embedding_field`, and `text_key` was not possible unless the Milvus collection was originally created in LlamaIndex's specific format (being `_node_content` and `_node_type`). This formed a bit of a limitation as I wasn't able to pull any of my extra metadata fields, similar to #7386.

I'd like to get your view on if this is the right approach - I've enabled the `output_fields` variable to take the specified fields, and insert them into the Node's metadata. Furthermore I've introduced a default `output_fields` parameter to the MilvusVectorStore, so when we set a collection we can also set what we'd expect as the default `output_fields`. These will be overwritten by any query level `output_fields` provided. 

Currently I haven't updated the Milvus implementation under legacy, not sure if that's required.

## New Package - No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

Let me know if you think this requires new tests, I may be wrong but currently it seems we only have Milvus tests for the legacy implementation.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
