### PR TITLE
Fixes #11389 (agent_react_multimodal_step.py bug)

### DIFF
--- a/llama-index-core/llama_index/core/agent/react_multimodal/step.py
+++ b/llama-index-core/llama_index/core/agent/react_multimodal/step.py
@@ -388,9 +388,9 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
         # an intermediate step in the middle
         if step.input is not None:
             self._add_user_step_to_reasoning(
-                step,
-                task.extra_state["new_memory"],
-                task.extra_state["current_reasoning"],
+                step=step,
+                memory=task.extra_state["new_memory"],
+                current_reasoning=task.extra_state["current_reasoning"],
                 verbose=self._verbose,
             )
         # TODO: see if we want to do step-based inputs
@@ -428,9 +428,9 @@ class MultimodalReActAgentWorker(BaseAgentWorker):
         """Run step."""
         if step.input is not None:
             self._add_user_step_to_reasoning(
-                step,
-                task.extra_state["new_memory"],
-                task.extra_state["current_reasoning"],
+                step=step,
+                memory=task.extra_state["new_memory"],
+                current_reasoning=task.extra_state["current_reasoning"],
                 verbose=self._verbose,
             )
         # TODO: see if we want to do step-based inputs


### PR DESCRIPTION
# Description

Explicitly declares the keyword variables for the `_add_user_step_to_reasoning` call in the MultimodalReActAgentWorker `_run_step` and `_arun_step` since the use of a partial was resulting in interpreting the first argument as the `generate_chat_message_fn` function.

Fixes #11389

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No - should I?

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense and I also tested the call in a notebook

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
