### PR TITLE
Don't break when reading from directory without files

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -221,6 +221,8 @@ class SimpleDirectoryReader(BaseReader):
             self.input_dir = _Path(input_dir)
             self.exclude = exclude
             self.input_files = self._add_files(self.input_dir)
+            if self.input_files is None:
+                raise ValueError(f"No files found in {input_dir}")
 
         if file_extractor is not None:
             self.file_extractor = file_extractor
@@ -235,7 +237,7 @@ class SimpleDirectoryReader(BaseReader):
             part.startswith(".") and part not in [".", ".."] for part in path.parts
         )
 
-    def _add_files(self, input_dir: Path) -> List[Path]:
+    def _add_files(self, input_dir: Path) -> List[Path] | None:
         """Add files."""
         all_files = set()
         rejected_files = set()
@@ -302,7 +304,7 @@ class SimpleDirectoryReader(BaseReader):
         new_input_files = sorted(all_files)
 
         if len(new_input_files) == 0:
-            raise ValueError(f"No files found in {input_dir}.")
+            return None
 
         if self.num_files_limit is not None and self.num_files_limit > 0:
             new_input_files = new_input_files[0 : self.num_files_limit]
@@ -528,6 +530,9 @@ class SimpleDirectoryReader(BaseReader):
         Returns:
             List[Document]: A list of documents.
         """
+        if self.input_files is None:
+            return []
+
         documents = []
 
         files_to_process = self.input_files

--- a/llama-index-core/tests/readers/test_empty_folders.py
+++ b/llama-index-core/tests/readers/test_empty_folders.py
@@ -1,5 +1,4 @@
 import unittest
-import pytest
 import os
 import tempfile
 from unittest.mock import MagicMock
@@ -15,20 +14,11 @@ class TestSimpleDirectoryReader(unittest.TestCase):
         # Remove the temporary directory after testing
         os.rmdir(self.temp_dir)
 
-    def test_load_data_raises_value_error(self):
-        # Create a SimpleDirectoryReader instance with no files in temp_dir
-        # Assert that loading data from an empty directory raises a ValueError
-        with pytest.raises(ValueError):
-            SimpleDirectoryReader(
-                self.temp_dir, file_extractor=MagicMock(), file_metadata=MagicMock()
-            )
-
     def test_load_data_returns_empty_list_when_input_files_is_none(self):
-        with pytest.raises(ValueError):
-            result = SimpleDirectoryReader(
-                self.temp_dir, file_extractor=MagicMock(), file_metadata=MagicMock()
-            ).load_data()
-            self.assertEqual(result, [])
+        result = SimpleDirectoryReader(
+            self.temp_dir, file_extractor=MagicMock(), file_metadata=MagicMock()
+        ).load_data()
+        self.assertEqual(result, [])
 
 
 if __name__ == "__main__":

--- a/llama-index-core/tests/readers/test_empty_folders.py
+++ b/llama-index-core/tests/readers/test_empty_folders.py
@@ -1,0 +1,35 @@
+import unittest
+import pytest
+import os
+import tempfile
+from unittest.mock import MagicMock
+from llama_index.core.readers.file.base import SimpleDirectoryReader
+
+
+class TestSimpleDirectoryReader(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory for testing
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove the temporary directory after testing
+        os.rmdir(self.temp_dir)
+
+    def test_load_data_raises_value_error(self):
+        # Create a SimpleDirectoryReader instance with no files in temp_dir
+        # Assert that loading data from an empty directory raises a ValueError
+        with pytest.raises(ValueError):
+            SimpleDirectoryReader(
+                self.temp_dir, file_extractor=MagicMock(), file_metadata=MagicMock()
+            )
+
+    def test_load_data_returns_empty_list_when_input_files_is_none(self):
+        with pytest.raises(ValueError):
+            result = SimpleDirectoryReader(
+                self.temp_dir, file_extractor=MagicMock(), file_metadata=MagicMock()
+            ).load_data()
+            self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Don't break when trying to read from [google drive] folder without files

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
