### PR TITLE
Added support to load clip model from local file path

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-clip/llama_index/embeddings/clip/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-clip/llama_index/embeddings/clip/base.py
@@ -7,6 +7,7 @@ from llama_index.core.constants import DEFAULT_EMBED_BATCH_SIZE
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.core.schema import ImageType
 from PIL import Image
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,8 @@ class ClipEmbedding(MultiModalEmbedding):
 
         try:
             self._device = "cuda" if torch.cuda.is_available() else "cpu"
-            if self.model_name not in AVAILABLE_CLIP_MODELS:
+            is_local_path = os.path.exists(self.model_name)
+            if not is_local_path and self.model_name not in AVAILABLE_CLIP_MODELS:
                 raise ValueError(
                     f"Model name {self.model_name} is not available in CLIP."
                 )


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

I was trying to use the llama-index-embeddings-clip integration package to load CLIP model from my local path and it was throwing an error saying its not a part of the available models of CLIP. I then checked the code and saw that the AVAILABLE_CLIP_MODELS was hardcoded and it just made a check if the model_name specified was a part of this AVAILABLE_CLIP_MODELS and so I figured it does not support loading models from local file path and I added that support.

Fixes # (issue)
- Made a check if the model_name specified is a local file path and if so, allow it to be loaded.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
