### PR TITLE
Coroutine-safe Spans

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -3,6 +3,9 @@
 import asyncio
 from itertools import zip_longest
 from typing import Any, Coroutine, Iterable, List, TypeVar
+import llama_index.core.instrumentation as instrument
+
+dispatcher = instrument.get_dispatcher(__name__)
 
 
 def asyncio_module(show_progress: bool = False) -> Any:
@@ -84,6 +87,7 @@ DEFAULT_NUM_WORKERS = 4
 T = TypeVar("T")
 
 
+@dispatcher.span
 async def run_jobs(
     jobs: List[Coroutine[Any, Any, T]],
     show_progress: bool = False,
@@ -101,9 +105,11 @@ async def run_jobs(
         List[Any]:
             List of results.
     """
+    parent_span_id = dispatcher.current_span_id
     asyncio_mod = get_asyncio_module(show_progress=show_progress)
     semaphore = asyncio.Semaphore(workers)
 
+    @dispatcher.span_with_parent_id(parent_id=parent_span_id)
     async def worker(job: Coroutine) -> Any:
         async with semaphore:
             return await job

--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -109,7 +109,7 @@ async def run_jobs(
     asyncio_mod = get_asyncio_module(show_progress=show_progress)
     semaphore = asyncio.Semaphore(workers)
 
-    @dispatcher.span_with_parent_id(parent_id=parent_span_id)
+    @dispatcher.async_span_with_parent_id(parent_id=parent_span_id)
     async def worker(job: Coroutine) -> Any:
         async with semaphore:
             return await job

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -205,7 +205,15 @@ class Dispatcher(BaseModel):
         finally:
             del dispatch_event
 
-    def span_with_parent_id(self, parent_id):
+    def async_span_with_parent_id(self, parent_id: str):
+        """This decorator should be used to span an async function nested in an outer span.
+
+        Primary example: llama_index.core.async_utils.run_jobs
+
+        Args:
+            parent_id (str): The span_id of the outer span.
+        """
+
         def outer(func):
             @wrapt.decorator
             async def async_wrapper(func, instance, args, kwargs):

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -34,6 +34,7 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         id_: str,
         bound_args: inspect.BoundArguments,
         instance: Optional[Any] = None,
+        parent_id: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Logic for entering a span."""
@@ -45,7 +46,7 @@ class BaseSpanHandler(BaseModel, Generic[T]):
                 id_=id_,
                 bound_args=bound_args,
                 instance=instance,
-                parent_span_id=self.current_span_id,
+                parent_span_id=parent_id or self.current_span_id,
             )
             if span:
                 self.open_spans[id_] = span

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -265,7 +265,12 @@ async def test_dispatcher_async_span_args(mock_uuid, mock_span_enter, mock_span_
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
-    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": None}
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": None,
+        "parent_id": None,
+    }
 
     # span_exit
     args, kwargs = mock_span_exit.call_args
@@ -299,7 +304,12 @@ async def test_dispatcher_async_span_args_with_instance(
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
-    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": instance}
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": instance,
+        "parent_id": None,
+    }
 
     # span_exit
     args, kwargs = mock_span_exit.call_args


### PR DESCRIPTION
# Description

- This PR adds coroutine (ie async-tasks) safety for entering/exiting/dropping `spans` 
- For jobs that use `async.gather()` we should now use our `async_utils` as that is decorated with `dispatcher.span` and its nested (semaphore bounded) worker function is also decorated with the correct `parent_id`.
- This PR also fixes the issue of `asyncio.Lock()` not being lazily constructed and thus breaks for jobs that don't have an async event loop.

![image](https://github.com/run-llama/llama_index/assets/92402603/ffd015b0-b328-4ce6-a271-fc9c1311f219)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
