### PR TITLE
Added the ability to connect to Wikipedia in a language other than English

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-wikipedia/llama_index/readers/wikipedia/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-wikipedia/llama_index/readers/wikipedia/base.py
@@ -27,14 +27,19 @@ class WikipediaReader(BasePydanticReader):
     def class_name(cls) -> str:
         return "WikipediaReader"
 
-    def load_data(self, pages: List[str], **load_kwargs: Any) -> List[Document]:
+    def load_data(self, pages: List[str], lang_code: str = 'en', **load_kwargs: Any) -> List[Document]:
         """Load data from the input directory.
 
         Args:
             pages (List[str]): List of pages to read.
-
+            lang_code (str): Language code for Wikipedia. Defaults to English. Valid Wikipedia language codes
+            can be found at https://en.wikipedia.org/wiki/List_of_Wikipedias.
         """
         import wikipedia
+
+        if lang_code.lower() != 'en':
+            # Sets, without checking the validity of, the language code for Wikipedia.
+            wikipedia.set_lang(lang_code)
 
         results = []
         for page in pages:

--- a/llama-index-integrations/readers/llama-index-readers-wikipedia/llama_index/readers/wikipedia/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-wikipedia/llama_index/readers/wikipedia/base.py
@@ -27,7 +27,9 @@ class WikipediaReader(BasePydanticReader):
     def class_name(cls) -> str:
         return "WikipediaReader"
 
-    def load_data(self, pages: List[str], lang_code: str = 'en', **load_kwargs: Any) -> List[Document]:
+    def load_data(
+        self, pages: List[str], lang_code: str = "en", **load_kwargs: Any
+    ) -> List[Document]:
         """Load data from the input directory.
 
         Args:
@@ -37,7 +39,7 @@ class WikipediaReader(BasePydanticReader):
         """
         import wikipedia
 
-        if lang_code.lower() != 'en':
+        if lang_code.lower() != "en":
             # Sets, without checking the validity of, the language code for Wikipedia.
             wikipedia.set_lang(lang_code)
 

--- a/llama-index-integrations/readers/llama-index-readers-wikipedia/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-wikipedia/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-wikipedia"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Wikipedia is available in multiple languages. Some articles are in specific languages only. Valid language codes are: https://en.wikipedia.org/wiki/List_of_Wikipedias. This PR enables the Wikipedia reader to read articles in different languages.

The ability to connect to non-English Wikipedia has been already available in the underlying Wikipedia parser, see starting [line 22](https://github.com/goldsmith/Wikipedia/blob/1554943e8ab463cef5e93081def48fafbdef324e/wikipedia/wikipedia.py#L22).

Fixes [#12596](https://github.com/run-llama/llama_index/issues/12596).

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
