### PR TITLE
bump google-generativeai to 0.4

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-gemini/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-gemini/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.5"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
-google-generativeai = "^0.3.2"
+google-generativeai = "^0.4.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-gemini/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-gemini"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-google"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google/pyproject.toml
@@ -34,7 +34,7 @@ version = "0.1.4"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
-google-generativeai = "^0.3.2"
+google-generativeai = "^0.4.1"
 
 [tool.poetry.dependencies.tensorflow-hub]
 optional = true

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.6"
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
 pillow = "^10.2.0"
-google-generativeai = "^0.3.2"
+google-generativeai = "^0.4.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-gemini"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-palm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-palm/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.4"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
-google-generativeai = "^0.3.2"
+google-generativeai = "^0.4.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/llms/llama-index-llms-palm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-palm/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-palm"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
@@ -34,7 +34,7 @@ python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
 llama-index-llms-gemini = "^0.1.1"
 pillow = "^10.2.0"
-google-generativeai = "^0.3.2"
+google-generativeai = "^0.4.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-multi-modal-llms-gemini"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-google/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-google/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.5"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
-google-generativeai = "^0.3.2"
+google-generativeai = "^0.4.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-google/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-google/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-google"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR was already merged (#12085) but then was reverted. However the revert was unnecessary as explained [here](https://github.com/run-llama/llama_index/pull/12126#issuecomment-2039598327)

## New Package?

## Version Bump?

- [x] Yes
- [ ] No
