### PR TITLE
Bug fix - Similarity metric is always IP for MilvusVectorStore

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-clip/llama_index/embeddings/clip/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-clip/llama_index/embeddings/clip/base.py
@@ -7,6 +7,7 @@ from llama_index.core.constants import DEFAULT_EMBED_BATCH_SIZE
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.core.schema import ImageType
 from PIL import Image
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,8 @@ class ClipEmbedding(MultiModalEmbedding):
 
         try:
             self._device = "cuda" if torch.cuda.is_available() else "cpu"
-            if self.model_name not in AVAILABLE_CLIP_MODELS:
+            is_local_path = os.path.exists(self.model_name)
+            if not is_local_path and self.model_name not in AVAILABLE_CLIP_MODELS:
                 raise ValueError(
                     f"Model name {self.model_name} is not available in CLIP."
                 )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -152,7 +152,9 @@ class MilvusVectorStore(BasePydanticVectorStore):
 
         # Select the similarity metric
         similarity_metrics_map = {"ip": "IP", "l2": "L2", "euclidean": "L2"}
-        similarity_metric = similarity_metrics_map.get(similarity_metric.lower(), "L2")
+        self.similarity_metric = similarity_metrics_map.get(
+            similarity_metric.lower(), "L2"
+        )
 
         # Connect to Milvus instance
         self._milvusclient = MilvusClient(
@@ -174,7 +176,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
                 primary_field_name=MILVUS_ID_FIELD,
                 vector_field_name=embedding_field,
                 id_type="string",
-                metric_type=similarity_metric,
+                metric_type=self.similarity_metric,
                 max_length=65_535,
                 consistency_level=consistency_level,
             )


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
The similarity metric in the constructor args was not initialized to the class parameter similarity_metric. Therefore while creating an index, the self.similarity_metric always had "IP" as the default value.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
