### PR TITLE
Add async_postprocess_nodes at RankGPT Postprocessor Nodes

### DIFF
--- a/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import patch
 import asyncio
 
+import pytest
 from llama_index.core.base.llms.types import ChatResponse, ChatMessage, MessageRole
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.postprocessor.rankGPT_rerank import RankGPTRerank
@@ -51,13 +52,14 @@ def test_rankgpt_rerank():
     "achat",
     mock_rankgpt_achat,
 )
-def test_rankgpt_rerank_async():
+@pytest.mark.asyncio()
+async def test_rankgpt_rerank_async():
     rankgpt_rerank = RankGPTRerank(
         top_n=2,
         llm=MockLLM(),
     )
-    result = asyncio.run(
-        rankgpt_rerank.apostprocess_nodes(nodes_with_score, query_str="Test query")
+    result = await rankgpt_rerank.apostprocess_nodes(
+        nodes_with_score, query_str="Test query"
     )
     assert len(result) == 2
     assert result[0].node.get_content() == "Test2"

--- a/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
@@ -1,0 +1,64 @@
+from typing import Any
+from unittest.mock import patch
+import asyncio
+
+from llama_index.core.base.llms.types import ChatResponse, ChatMessage, MessageRole
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.postprocessor.rankGPT_rerank import RankGPTRerank
+from llama_index.core.schema import TextNode, NodeWithScore
+
+
+def mock_rankgpt_chat(self: Any, messages, **kwargs: Any) -> ChatResponse:
+    return ChatResponse(
+        message=ChatMessage(role=MessageRole.SYSTEM, content="[2] > [1] > [3]")
+    )
+
+
+async def mock_rankgpt_acaht(self, messages, **kwargs: Any) -> ChatResponse:
+    # Mock api call
+    await asyncio.sleep(1)
+    return ChatResponse(
+        message=ChatMessage(role=MessageRole.SYSTEM, content="[2] > [1] > [3]")
+    )
+
+
+nodes = [
+    TextNode(text="Test"),
+    TextNode(text="Test2"),
+    TextNode(text="Test3"),
+]
+nodes_with_score = [NodeWithScore(node=n) for n in nodes]
+
+
+@patch.object(
+    MockLLM,
+    "chat",
+    mock_rankgpt_chat,
+)
+def test_rankgpt_rerank():
+    rankgpt_rerank = RankGPTRerank(
+        top_n=2,
+        llm=MockLLM(),
+    )
+    result = rankgpt_rerank.postprocess_nodes(nodes_with_score, query_str="Test query")
+    assert len(result) == 2
+    assert result[0].node.get_content() == "Test2"
+    assert result[1].node.get_content() == "Test"
+
+
+@patch.object(
+    MockLLM,
+    "achat",
+    mock_rankgpt_acaht,
+)
+def test_rankgpt_rerank_async():
+    rankgpt_rerank = RankGPTRerank(
+        top_n=2,
+        llm=MockLLM(),
+    )
+    result = asyncio.run(
+        rankgpt_rerank.async_postporcess_nodes(nodes_with_score, query_str="Test query")
+    )
+    assert len(result) == 2
+    assert result[0].node.get_content() == "Test2"
+    assert result[1].node.get_content() == "Test"

--- a/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
@@ -14,7 +14,7 @@ def mock_rankgpt_chat(self: Any, messages, **kwargs: Any) -> ChatResponse:
     )
 
 
-async def mock_rankgpt_acaht(self, messages, **kwargs: Any) -> ChatResponse:
+async def mock_rankgpt_achat(self, messages, **kwargs: Any) -> ChatResponse:
     # Mock api call
     await asyncio.sleep(1)
     return ChatResponse(
@@ -49,7 +49,7 @@ def test_rankgpt_rerank():
 @patch.object(
     MockLLM,
     "achat",
-    mock_rankgpt_acaht,
+    mock_rankgpt_achat,
 )
 def test_rankgpt_rerank_async():
     rankgpt_rerank = RankGPTRerank(
@@ -57,7 +57,7 @@ def test_rankgpt_rerank_async():
         llm=MockLLM(),
     )
     result = asyncio.run(
-        rankgpt_rerank.async_postporcess_nodes(nodes_with_score, query_str="Test query")
+        rankgpt_rerank.apostprocess_nodes(nodes_with_score, query_str="Test query")
     )
     assert len(result) == 2
     assert result[0].node.get_content() == "Test2"


### PR DESCRIPTION
# Description

I add async call at 'RankGPT PostProcessor'. Since it uses gpt API call, or any other LLM calls, it is really slow when we want to rerank many textnodes at once.
So I used `achat` method for asynchronously call LLM API calls and made new `async_postprocess_nodes` function.

Please fix the method name since it is not a convention that add 'async_' as prefix.

Plus, I added two test case for async and sync postprocess_nodes call of `RankGPT Rerank`.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
