### PR TITLE
Fix ErrorHandling: adding err handling in eval_utils default_parser for correctness

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/eval_utils.py
+++ b/llama-index-core/llama_index/core/evaluation/eval_utils.py
@@ -213,7 +213,16 @@ def default_parser(eval_response: str) -> Tuple[Optional[float], Optional[str]]:
     Returns:
         Tuple[float, str]: A tuple containing the score as a float and the reasoning as a string.
     """
+    if not eval_response.strip():
+        # Return None or default values if the response is empty
+        return None, "No response"
+
     score_str, reasoning_str = eval_response.split("\n", 1)
-    score = float(score_str)
+
+    try:
+        score = float(score_str)
+    except ValueError:
+        score = None
+
     reasoning = reasoning_str.lstrip("\n")
     return score, reasoning


### PR DESCRIPTION
# Description

I was trying to follow along to this [documentation page](https://docs.llamaindex.ai/en/stable/examples/transforms/TransformsEval/?h=transform).

As per the current code assumption inside the default_parser in eval_utils.py we always assume that the eval reponse has 2 lines one with the score and the other with the reasoning_str but i see that we can also get empty string , either from the model or due to the fallback as setup in llm.py > apredict > output = chat_response.message.content or ""

So we add error handing and passing appropriate values.

Fixes #12623 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
