### PR TITLE
Thread-safe instrumentation

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -24,7 +24,8 @@ sync_span_ctx = ContextVar("sync_span_ctx", default={})
 
 
 class EventDispatcher(Protocol):
-    def __call__(self, event: BaseEvent) -> None: ...
+    def __call__(self, event: BaseEvent) -> None:
+        ...
 
 
 class Dispatcher(BaseModel):

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -316,15 +316,7 @@ class Dispatcher(BaseModel):
                 id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
             )
             try:
-                # print("\n")
-                # print(f"CURRENT TASKS:\n\n")
-                # for t in task_stack:
-                #     print(f"{t}\n")
-                # print("\n")
-                coro = func(*args, **kwargs)
-                print(f"CURRENT TASK NAME: {current_task.get_name()}\n")
-                print(f"CURRENT CORO: {coro}\n\n")
-                result = await coro
+                result = await func(*args, **kwargs)
             except BaseException as e:
                 self.event(SpanDropEvent(span_id=id_, err_str=str(e)))
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -21,7 +21,7 @@ import wrapt
 # ContextVar's for managing active spans
 async_span_ctx = ContextVar(
     "async_span_ctx", default=defaultdict(dict)
-)  # per thread/async-task
+)  # per thread >> async-task
 sync_span_ctx = ContextVar("sync_span_ctx", default={})  # per thread
 
 

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -1,6 +1,5 @@
 from typing import Any, List, Optional, Dict, Protocol
 from functools import partial
-from contextlib import contextmanager
 from collections import defaultdict
 import asyncio
 import inspect
@@ -226,22 +225,6 @@ class Dispatcher(BaseModel):
             span_id = self.current_span_id
         dispatch_event: EventDispatcher = partial(self.event, span_id=span_id)
         return dispatch_event
-
-    @contextmanager
-    def dispatch_event(self):
-        """Context manager for firing events within a span session.
-
-        This context manager should be used with @dispatcher.span decorated
-        functions only. Otherwise, the span_id should not be trusted, as the
-        span decorator sets the span_id.
-        """
-        span_id = self.current_span_id
-        dispatch_event: EventDispatcher = partial(self.event, span_id=span_id)
-
-        try:
-            yield dispatch_event
-        finally:
-            del dispatch_event
 
     def _get_parent_update_span_ctx(self, id_: str):
         """Helper method to get parent id from the appropriate context var."""

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -21,8 +21,7 @@ span_ctx = ContextVar("span_ctx", default={})
 
 
 class EventDispatcher(Protocol):
-    def __call__(self, event: BaseEvent) -> None:
-        ...
+    def __call__(self, event: BaseEvent) -> None: ...
 
 
 class EventContext(BaseModel):
@@ -317,7 +316,15 @@ class Dispatcher(BaseModel):
                 id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
             )
             try:
-                result = await func(*args, **kwargs)
+                # print("\n")
+                # print(f"CURRENT TASKS:\n\n")
+                # for t in task_stack:
+                #     print(f"{t}\n")
+                # print("\n")
+                coro = func(*args, **kwargs)
+                print(f"CURRENT TASK NAME: {current_task.get_name()}\n")
+                print(f"CURRENT CORO: {coro}\n\n")
+                result = await coro
             except BaseException as e:
                 self.event(SpanDropEvent(span_id=id_, err_str=str(e)))
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -64,7 +64,7 @@ class Dispatcher(BaseModel):
         description="Whether to propagate the event to parent dispatchers and their handlers",
     )
     current_span_ids: Optional[Dict[Any, str]] = Field(
-        default={},
+        default_factory=dict,
         description="Id of current enclosing span. Used for creating `dispatch_event` partials.",
     )
     _asyncio_lock: Optional[asyncio.Lock] = PrivateAttr()

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -1,8 +1,9 @@
 import inspect
+import threading
 from abc import abstractmethod
 from typing import Any, Dict, List, Generic, Optional, TypeVar
 
-from llama_index.core.bridge.pydantic import BaseModel, Field
+from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr
 from llama_index.core.instrumentation.span.base import BaseSpan
 
 T = TypeVar("T", bound=BaseSpan)
@@ -18,16 +19,49 @@ class BaseSpanHandler(BaseModel, Generic[T]):
     dropped_spans: List[T] = Field(
         default_factory=list, description="List of completed spans."
     )
-    current_span_id: Optional[str] = Field(
-        default=None, description="Id of current span."
+    current_span_ids: Dict[Any, Optional[str]] = Field(
+        default={}, description="Id of current spans in a given thread."
     )
+    _lock: Optional[threading.Lock] = PrivateAttr()
 
     class Config:
         arbitrary_types_allowed = True
 
+    def __init__(
+        self,
+        open_spans: Dict[str, T] = {},
+        completed_spans: List[T] = [],
+        dropped_spans: List[T] = [],
+        current_span_ids: Dict[Any, str] = {},
+    ):
+        self._lock = None
+        super().__init__(
+            open_spans=open_spans,
+            completed_spans=completed_spans,
+            dropped_spans=dropped_spans,
+            current_span_ids=current_span_ids,
+        )
+
     def class_name(cls) -> str:
         """Class name."""
         return "BaseSpanHandler"
+
+    @property
+    def lock(self) -> threading.Lock:
+        if self._lock is None:
+            self._lock = threading.Lock()
+        return self._lock
+
+    @property
+    def current_span_id(self) -> Optional[str]:
+        current_thread = threading.get_ident()
+        if current_thread in self.current_span_ids:
+            return self.current_span_ids[current_thread]
+        return None
+
+    def set_current_span_id(self, value: str) -> None:
+        current_thread = threading.get_ident()
+        self.current_span_ids[current_thread] = value
 
     def span_enter(
         self,
@@ -49,8 +83,9 @@ class BaseSpanHandler(BaseModel, Generic[T]):
                 parent_span_id=parent_id or self.current_span_id,
             )
             if span:
-                self.open_spans[id_] = span
-                self.current_span_id = id_
+                with self.lock:
+                    self.open_spans[id_] = span
+                    self.set_current_span_id(id_)
 
     def span_exit(
         self,
@@ -65,11 +100,13 @@ class BaseSpanHandler(BaseModel, Generic[T]):
             id_=id_, bound_args=bound_args, instance=instance, result=result
         )
         if span:
-            if self.current_span_id == id_:
-                self.current_span_id = self.open_spans[id_].parent_id
-            del self.open_spans[id_]
+            with self.lock:
+                if self.current_span_id == id_:
+                    self.set_current_span_id(self.open_spans[id_].parent_id)
+                del self.open_spans[id_]
         if not self.open_spans:  # empty so flush
-            self.current_span_id = None
+            with self.lock:
+                self.set_current_span_id(None)
 
     def span_drop(
         self,
@@ -84,9 +121,10 @@ class BaseSpanHandler(BaseModel, Generic[T]):
             id_=id_, bound_args=bound_args, instance=instance, err=err
         )
         if span:
-            if self.current_span_id == id_:
-                self.current_span_id = self.open_spans[id_].parent_id
-            del self.open_spans[id_]
+            with self.lock:
+                if self.current_span_id == id_:
+                    self.set_current_span_id(self.open_spans[id_].parent_id)
+                del self.open_spans[id_]
 
     @abstractmethod
     def new_span(

--- a/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
+++ b/llama-index-core/llama_index/core/instrumentation/span_handlers/base.py
@@ -135,7 +135,11 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         parent_span_id: Optional[str] = None,
         **kwargs: Any,
     ) -> Optional[T]:
-        """Create a span."""
+        """Create a span.
+
+        Subclasses of BaseSpanHandler should create the respective span type T
+        and return it. Only NullSpanHandler should return a None here.
+        """
         ...
 
     @abstractmethod
@@ -147,7 +151,12 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         result: Optional[Any] = None,
         **kwargs: Any,
     ) -> Optional[T]:
-        """Logic for preparing to exit a span."""
+        """Logic for preparing to exit a span.
+
+        Subclasses of BaseSpanHandler should return back the specific span T
+        that is to be exited. If None is returned, then the span won't actually
+        be exited.
+        """
         ...
 
     @abstractmethod
@@ -159,5 +168,10 @@ class BaseSpanHandler(BaseModel, Generic[T]):
         err: Optional[BaseException] = None,
         **kwargs: Any,
     ) -> Optional[T]:
-        """Logic for preparing to drop a span."""
+        """Logic for preparing to drop a span.
+
+        Subclasses of BaseSpanHandler should return back the specific span T
+        that is to be dropped. If None is returned, then the span won't actually
+        be dropped.
+        """
         ...

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -126,7 +126,12 @@ def test_dispatcher_span_args(mock_uuid, mock_span_enter, mock_span_exit):
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
-    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": None}
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": None,
+        "parent_id": None,
+    }
 
     # span_exit
     args, kwargs = mock_span_exit.call_args
@@ -157,7 +162,12 @@ def test_dispatcher_span_args_with_instance(mock_uuid, mock_span_enter, mock_spa
     mock_span_enter.assert_called_once()
     args, kwargs = mock_span_enter.call_args
     assert args == ()
-    assert kwargs == {"id_": span_id, "bound_args": bound_args, "instance": instance}
+    assert kwargs == {
+        "id_": span_id,
+        "bound_args": bound_args,
+        "instance": instance,
+        "parent_id": None,
+    }
 
     # span_exit
     args, kwargs = mock_span_exit.call_args


### PR DESCRIPTION
# Description

This PR aims to make `instrumentation` thread-safe. Specifically:

- Trace trees of `spans` should be maintained when multiple jobs are executed across multiple threads
- Event-Span tying should also be maintained in multi-threading executions

Example
```python
with ThreadPoolExecutor() as executor:
    futures = executor.map(lambda x: str(asyncio.run(query_engine.aquery(x))), questions)
```

`event-span tying`
![image](https://github.com/run-llama/llama_index/assets/92402603/4654ddeb-e07c-4490-b922-fecdc86baa81)

`trace trees`
![image](https://github.com/run-llama/llama_index/assets/92402603/7f0b3f1f-dc6a-499e-972b-a9c89a258a52)

 
## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Ran dev notebooks (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
