### PR TITLE
fix llama-index-multi-modal-llms-gemini dependency

### DIFF
--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.5"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
-llama-index-llms-gemini = "^0.1.1"
+llama-index-llms-gemini = "^0.1.7"
 pillow = "^10.2.0"
 google-generativeai = "^0.4.1"
 


### PR DESCRIPTION
# Description
Fixes release action problem: https://github.com/run-llama/llama_index/actions/runs/8574427576/job/23501224052
Now both needs 0.4.x of google-generativeai.

This will trigger the 0.1.5 release of llama-index-multi-modal-llms-gemini