### PR TITLE
Fix incomplete json output in guideline evaluator

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/guideline.py
+++ b/llama-index-core/llama_index/core/evaluation/guideline.py
@@ -30,6 +30,14 @@ DEFAULT_EVAL_TEMPLATE = PromptTemplate(
     "Now please provide constructive criticism.\n"
 )
 
+PYDANTIC_FORMAT_TMPL = """
+Here's a JSON schema to follow:
+{schema}
+
+Output a valid JSON object but do not repeat the schema.
+The response should be concise to ensure correct JSON format.
+"""
+
 
 class EvaluationData(BaseModel):
     passing: bool = Field(description="Whether the response passes the guidelines.")
@@ -71,7 +79,7 @@ class GuidelineEvaluator(BaseEvaluator):
         else:
             self._eval_template = eval_template or DEFAULT_EVAL_TEMPLATE
 
-        self._output_parser = PydanticOutputParser(output_cls=EvaluationData)
+        self._output_parser = PydanticOutputParser(output_cls=EvaluationData, pydantic_format_tmpl=PYDANTIC_FORMAT_TMPL)
         self._eval_template.output_parser = self._output_parser
 
     def _get_prompts(self) -> PromptDictType:

--- a/llama-index-core/llama_index/core/evaluation/guideline.py
+++ b/llama-index-core/llama_index/core/evaluation/guideline.py
@@ -30,14 +30,6 @@ DEFAULT_EVAL_TEMPLATE = PromptTemplate(
     "Now please provide constructive criticism.\n"
 )
 
-PYDANTIC_FORMAT_TMPL = """
-Here's a JSON schema to follow:
-{schema}
-
-Output a valid JSON object but do not repeat the schema.
-The response should be concise to ensure correct JSON format.
-"""
-
 
 class EvaluationData(BaseModel):
     passing: bool = Field(description="Whether the response passes the guidelines.")
@@ -67,7 +59,7 @@ class GuidelineEvaluator(BaseEvaluator):
         llm: Optional[LLM] = None,
         guidelines: Optional[str] = None,
         eval_template: Optional[Union[str, BasePromptTemplate]] = None,
-        # deprecated
+        output_parser: Optional[PydanticOutputParser] = None,
         service_context: Optional[ServiceContext] = None,
     ) -> None:
         self._llm = llm or llm_from_settings_or_context(Settings, service_context)
@@ -79,8 +71,8 @@ class GuidelineEvaluator(BaseEvaluator):
         else:
             self._eval_template = eval_template or DEFAULT_EVAL_TEMPLATE
 
-        self._output_parser = PydanticOutputParser(
-            output_cls=EvaluationData, pydantic_format_tmpl=PYDANTIC_FORMAT_TMPL
+        self._output_parser = output_parser or PydanticOutputParser(
+            output_cls=EvaluationData
         )
         self._eval_template.output_parser = self._output_parser
 

--- a/llama-index-core/llama_index/core/evaluation/guideline.py
+++ b/llama-index-core/llama_index/core/evaluation/guideline.py
@@ -60,6 +60,7 @@ class GuidelineEvaluator(BaseEvaluator):
         guidelines: Optional[str] = None,
         eval_template: Optional[Union[str, BasePromptTemplate]] = None,
         output_parser: Optional[PydanticOutputParser] = None,
+        # deprecated
         service_context: Optional[ServiceContext] = None,
     ) -> None:
         self._llm = llm or llm_from_settings_or_context(Settings, service_context)

--- a/llama-index-core/llama_index/core/evaluation/guideline.py
+++ b/llama-index-core/llama_index/core/evaluation/guideline.py
@@ -79,7 +79,9 @@ class GuidelineEvaluator(BaseEvaluator):
         else:
             self._eval_template = eval_template or DEFAULT_EVAL_TEMPLATE
 
-        self._output_parser = PydanticOutputParser(output_cls=EvaluationData, pydantic_format_tmpl=PYDANTIC_FORMAT_TMPL)
+        self._output_parser = PydanticOutputParser(
+            output_cls=EvaluationData, pydantic_format_tmpl=PYDANTIC_FORMAT_TMPL
+        )
         self._eval_template.output_parser = self._output_parser
 
     def _get_prompts(self) -> PromptDictType:


### PR DESCRIPTION
# Description

For guidelines evaluator, the code expect json output from LLM and raise exception when [fail to parse json](https://github.com/run-llama/llama_index/blob/9163067027ea8222e9fe5bffff9a2fac26b57686/llama-index-core/llama_index/core/output_parsers/utils.py#L112).

However, sometimes the LLM response is longer than max token due to a long feedback, the output json will be incomplete and thus break the evaluation process. This is an unintended behavior for evaluation process.

Considering we don't need very long feedbacks in evaluation, I added a 'concise hint' to the output format prompt to fix this issue.


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
