### PR TITLE
fix: string comes before separator

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/utils.py
+++ b/llama-index-core/llama_index/core/node_parser/text/utils.py
@@ -15,7 +15,11 @@ def truncate_text(text: str, text_splitter: TextSplitter) -> str:
 def split_text_keep_separator(text: str, separator: str) -> List[str]:
     """Split text with separator and keep the separator at the end of each split."""
     parts = text.split(separator)
-    result = [separator + s if i > 0 else s for i, s in enumerate(parts)]
+    result = (
+        [s + separator for s in parts[:-1]] + [parts[-1]]
+        if parts[-1]
+        else [s + separator for s in parts[:-1]]
+    )
     return [s for s in result if s]
 
 


### PR DESCRIPTION
# Description

Based on the comment, the separator should be after the string segment.



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

