### PR TITLE
Add in-memory loading for non-default filesystems in PDFReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
@@ -10,9 +10,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from fsspec import AbstractFileSystem
 import logging
+import io
 
 from llama_index.core.readers.base import BaseReader
-from llama_index.core.readers.file.base import get_default_fs
+from llama_index.core.readers.file.base import get_default_fs, is_default_fs
 from llama_index.core.schema import Document
 
 logger = logging.getLogger(__name__)
@@ -42,8 +43,12 @@ class PDFReader(BaseReader):
             )
         fs = fs or get_default_fs()
         with fs.open(file, "rb") as fp:
+            # Load the file in memory if the filesystem is not the default one to avoid
+            # issues with pypdf
+            stream = fp if is_default_fs(fs) else io.BytesIO(fp.read())
+
             # Create a PDF object
-            pdf = pypdf.PdfReader(fp)
+            pdf = pypdf.PdfReader(stream)
 
             # Get the number of pages in the PDF document
             num_pages = len(pdf.pages)

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -50,7 +50,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.13"
+version = "0.1.14"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Loading documents for large PDF files in external file systems was taking a long time. After investigation, we found that we were making a lot of requests to the external filesystem in the process. To avoid this, we first load the content in-memory and then pass it to pypdf.

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense
