### PR TITLE
Improve efficiency of MongoDB reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -81,7 +81,7 @@ class SimpleMongoReader(BaseReader):
         cursor = db[collection_name].find(
             filter=query_dict or {},
             limit=max_docs,
-            projection={name: 1 for name in field_names + (metadata_names or [])}
+            projection={name: 1 for name in field_names + (metadata_names or [])},
         )
 
         for item in cursor:

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -78,7 +78,9 @@ class SimpleMongoReader(BaseReader):
 
         """
         db = self.client[db_name]
-        cursor = db[collection_name].find(filter=query_dict or {}, limit=max_docs)
+        cursor = db[collection_name].find(
+            filter=query_dict or {}, limit=max_docs,
+            projection={name: 1 for name in field_names + (metadata_names or [])})
 
         for item in cursor:
             try:

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -79,7 +79,8 @@ class SimpleMongoReader(BaseReader):
         """
         db = self.client[db_name]
         cursor = db[collection_name].find(
-            filter=query_dict or {}, limit=max_docs,
+            filter=query_dict or {},
+            limit=max_docs,
             projection={name: 1 for name in field_names + (metadata_names or [])})
 
         for item in cursor:

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -81,7 +81,8 @@ class SimpleMongoReader(BaseReader):
         cursor = db[collection_name].find(
             filter=query_dict or {},
             limit=max_docs,
-            projection={name: 1 for name in field_names + (metadata_names or [])})
+            projection={name: 1 for name in field_names + (metadata_names or [])}
+        )
 
         for item in cursor:
             try:

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-mongodb"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

MongoDB reader was not using projections.
So, in case, someone is fetching a small set of fields then the full document would still be read in those cases.

This commit fixes this by adding a projection consisting of all the `field_names` and `metadata_names`. This should reduce the bandwidth usage and improve the performance of MongoDB reader, especially, when reading a few fields from big documents.
Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense. I manually tested this with a proprietary codebase of mine that uses this

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
