### PR TITLE
fix: elasticsearch indexstore for collection name to index

### DIFF
--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-elasticsearch/llama_index/storage/index_store/elasticsearch/base.py
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-elasticsearch/llama_index/storage/index_store/elasticsearch/base.py
@@ -16,7 +16,12 @@ class ElasticsearchIndexStore(KVIndexStore):
     def __init__(
         self,
         elasticsearch_kvstore: ElasticsearchKVStore,
+        collection_index: Optional[str] = None,
         namespace: Optional[str] = None,
     ) -> None:
         """Init a ElasticsearchIndexStore."""
         super().__init__(elasticsearch_kvstore, namespace=namespace)
+        if collection_index:
+            self._collection = collection_index
+        else:
+            self._collection = f"llama_index-index_store.data-{self._namespace}"

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-index-store-elasticsearch"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
Hello,

This PR fixes a bug where the library **failed to properly create indices (collections) in Elasticsearch**. According to the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html), Elasticsearch **does not allow some special characters** like `/` in index (collection) names.

Therefore, the issue was addressed by referencing the code from a similar library [doc_store for elasticsearch](https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/storage/docstore/llama-index-storage-docstore-elasticsearch/llama_index/storage/docstore/elasticsearch/base.py).
Thanks! 😀

Before fix:
```
File [~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:352](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:352), in BaseClient._perform_request(self, method, path, params, headers, body, otel_span)
    [349](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:349)         except (ValueError, KeyError, TypeError):
    [350](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:350)             pass
--> [352](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:352)     raise HTTP_EXCEPTIONS.get(meta.status, ApiError)(
    [353](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:353)         message=message, meta=meta, body=resp_body
    [354](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:354)     )
    [356](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:356) # 'X-Elastic-Product: Elasticsearch' should be on every 2XX response.
    [357](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:357) if not self._verified_elasticsearch:
    [358](https://file+.vscode-resource.vscode-cdn.net/Users/yongwoosong/document-agent-flow/~/.pyenv/versions/3.11.8/envs/daf/lib/python3.11/site-packages/elasticsearch/_async/client/_base.py:358)     # If the header is set we mark the server as verified.

BadRequestError: BadRequestError(400, 'invalid_index_name_exception', 'Invalid index name [index_store/data], must not contain the following characters [\'<\',\'*\',\'?\',\'>\',\'|\',\',\',\'/\',\'\\\',\' \',\'"\']')
```


Related PR: https://github.com/run-llama/llama_index/pull/12218
## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
