### PR TITLE
Fix Redis & Tair vector store overwrite newly created vector

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -186,11 +186,15 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         if not nodes:
             return
 
+        first_batch = True
         for nodes_batch in iter_batch(nodes, self._insert_batch_size):
             nodes_batch = await self._aget_node_with_embedding(
                 nodes_batch, show_progress
             )
-            new_ids = await self._vector_store.async_add(nodes_batch, **insert_kwargs)
+            new_ids = await self._vector_store.async_add(
+                nodes_batch, first_batch=first_batch, **insert_kwargs
+            )
+            first_batch = False
 
             # if the vector store doesn't store text, we need to add the nodes to the
             # index struct and document store
@@ -229,9 +233,13 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         if not nodes:
             return
 
+        first_batch = True
         for nodes_batch in iter_batch(nodes, self._insert_batch_size):
             nodes_batch = self._get_node_with_embedding(nodes_batch, show_progress)
-            new_ids = self._vector_store.add(nodes_batch, **insert_kwargs)
+            new_ids = self._vector_store.add(
+                nodes_batch, first_batch=first_batch, **insert_kwargs
+            )
+            first_batch = False
 
             if not self._vector_store.stores_text or self._store_nodes_override:
                 # NOTE: if the vector store doesn't store text,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -165,7 +165,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         self._index_args["dims"] = len(nodes[0].get_embedding())
 
         if self._index_exists():
-            if self._overwrite:
+            if add_kwargs.get("first_batch", True) and self._overwrite:
                 self.delete_index()
                 self._create_index()
             else:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-tair/llama_index/vector_stores/tair/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-tair/llama_index/vector_stores/tair/base.py
@@ -139,7 +139,7 @@ class TairVectorStore(VectorStore):
         self.dim = len(nodes[0].get_embedding())
 
         if self._index_exists():
-            if self._overwrite:
+            if add_kwargs.get("first_batch", True) and self._overwrite:
                 self.delete_index()
                 self._create_index()
             else:

--- a/llama-index-legacy/llama_index/legacy/indices/vector_store/base.py
+++ b/llama-index-legacy/llama_index/legacy/indices/vector_store/base.py
@@ -155,11 +155,15 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         if not nodes:
             return
 
+        first_batch = True
         for nodes_batch in iter_batch(nodes, self._insert_batch_size):
             nodes_batch = await self._aget_node_with_embedding(
                 nodes_batch, show_progress
             )
-            new_ids = await self._vector_store.async_add(nodes_batch, **insert_kwargs)
+            new_ids = await self._vector_store.async_add(
+                nodes_batch, first_batch=first_batch, **insert_kwargs
+            )
+            first_batch = False
 
             # if the vector store doesn't store text, we need to add the nodes to the
             # index struct and document store
@@ -198,9 +202,13 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         if not nodes:
             return
 
+        first_batch = True
         for nodes_batch in iter_batch(nodes, self._insert_batch_size):
             nodes_batch = self._get_node_with_embedding(nodes_batch, show_progress)
-            new_ids = self._vector_store.add(nodes_batch, **insert_kwargs)
+            new_ids = self._vector_store.add(
+                nodes_batch, first_batch=first_batch, **insert_kwargs
+            )
+            first_batch = False
 
             if not self._vector_store.stores_text or self._store_nodes_override:
                 # NOTE: if the vector store doesn't store text,

--- a/llama-index-legacy/llama_index/legacy/vector_stores/types.py
+++ b/llama-index-legacy/llama_index/legacy/vector_stores/types.py
@@ -273,7 +273,7 @@ class VectorStore(Protocol):
         NOTE: this is not implemented for all vector stores. If not implemented,
         it will just call add synchronously.
         """
-        return self.add(nodes)
+        return self.add(nodes, **kwargs)
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """


### PR DESCRIPTION

# Description

We should not overwrite the vectors for nodes batches that come after the first iteration.

Before the fix, only the vectors in the last nodes batch survived:

```logs
Generating embeddings:  98%|█████████████████████████████████████████████████████████████▌ | 2000/2048 [00:24<00:00, 95.81it/s]INFO:httpx:HTTP Request: POST http://localhost:1234/v1/embeddings "HTTP/1.1 200 OK"
Generating embeddings: 100%|███████████████████████████████████████████████████████████████| 2048/2048 [00:25<00:00, 80.91it/s]
INFO:llama_index.vector_stores.redis.base:Deleting index index_docsgpt
INFO:llama_index.vector_stores.redis.base:Creating index index_docsgpt
INFO:llama_index.vector_stores.redis.base:Added 2048 documents to index index_docsgpt
Generating embeddings:   0%|                                                                           | 0/125 [00:00<?, ?it/s]INFO:httpx:HTTP Request: POST http://localhost:1234/v1/embeddings "HTTP/1.1 200 OK"
Generating embeddings:  80%|████████████████████████████████████████████████████             | 100/125 [00:01<00:00, 84.13it/s]INFO:httpx:HTTP Request: POST http://localhost:1234/v1/embeddings "HTTP/1.1 200 OK"
Generating embeddings: 100%|█████████████████████████████████████████████████████████████████| 125/125 [00:01<00:00, 62.97it/s]
INFO:llama_index.vector_stores.redis.base:Deleting index index_docsgpt
INFO:llama_index.vector_stores.redis.base:Creating index index_docsgpt
INFO:llama_index.vector_stores.redis.base:Added 125 documents to index index_docsgpt
```

After, now it looks good:

```logs
Generating embeddings:  98%|███████████████████████████████████████████████████████████████████████████▏ | 2000/2048 [00:24<00:00, 82.26it/s]INFO:httpx:HTTP Request: POST http://localhost:1234/v1/embeddings "HTTP/1.1 200 OK"
Generating embeddings: 100%|█████████████████████████████████████████████████████████████████████████████| 2048/2048 [00:25<00:00, 78.90it/s]
INFO:llama_index.vector_stores.redis.base:Deleting index index_docsgpt
INFO:llama_index.vector_stores.redis.base:Creating index index_docsgpt
INFO:llama_index.vector_stores.redis.base:Added 2048 documents to index index_docsgpt
Generating embeddings:   0%|                                                                                         | 0/125 [00:00<?, ?it/s]INFO:httpx:HTTP Request: POST http://localhost:1234/v1/embeddings "HTTP/1.1 200 OK"
Generating embeddings:  80%|███████████████████████████████████████████████████████████████▏               | 100/125 [00:02<00:00, 39.53it/s]INFO:httpx:HTTP Request: POST http://localhost:1234/v1/embeddings "HTTP/1.1 200 OK"
Generating embeddings: 100%|███████████████████████████████████████████████████████████████████████████████| 125/125 [00:03<00:00, 35.84it/s]
INFO:root:Adding document to existing index index_csc_docsgpt
INFO:llama_index.vector_stores.redis.base:Added 125 documents to index index_docsgpt
```

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
