### PR TITLE
Fix chunking error

### DIFF
--- a/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
@@ -415,9 +415,9 @@ class CodeHierarchyNodeParser(NodeParser):
                             ].append(  # type: ignore
                                 d.as_related_node_info()
                             )
-                            d.relationships[
-                                NodeRelationship.PARENT
-                            ] = this_document.as_related_node_info()
+                            d.relationships[NodeRelationship.PARENT] = (
+                                this_document.as_related_node_info()
+                            )
                 # Otherwise we pass the children upstream
                 else:
                     # If we have been given a document, that means it's
@@ -545,7 +545,7 @@ class CodeHierarchyNodeParser(NodeParser):
                 or tree.root_node.children[0].type != "ERROR"
             ):
                 # Chunk the code
-                _chunks = self._chunk_node(tree.root_node, node.text)
+                _chunks = self._chunk_node(tree.root_node, bytes(node.text, "utf-8"))
                 assert _chunks.this_document is not None, "Root node must be a chunk"
                 chunks = _chunks.all_documents
 
@@ -556,9 +556,9 @@ class CodeHierarchyNodeParser(NodeParser):
                         **chunk.metadata,
                         **node.metadata,
                     }
-                    chunk.relationships[
-                        NodeRelationship.SOURCE
-                    ] = node.as_related_node_info()
+                    chunk.relationships[NodeRelationship.SOURCE] = (
+                        node.as_related_node_info()
+                    )
 
                 if self.skeleton:
                     self._skeletonize_list(chunks)
@@ -613,9 +613,9 @@ class CodeHierarchyNodeParser(NodeParser):
                                         new_split_nodes[0].as_related_node_info()
                                     )
                                 new_children.append(old_nodes_child)
-                            old_node.relationships[
-                                NodeRelationship.CHILD
-                            ] = new_children
+                            old_node.relationships[NodeRelationship.CHILD] = (
+                                new_children
+                            )
 
                             # Handle parent node
                             if (
@@ -623,9 +623,9 @@ class CodeHierarchyNodeParser(NodeParser):
                                 and old_node.parent_node.node_id
                                 == original_node.node_id
                             ):
-                                old_node.relationships[
-                                    NodeRelationship.PARENT
-                                ] = new_split_nodes[0].as_related_node_info()
+                                old_node.relationships[NodeRelationship.PARENT] = (
+                                    new_split_nodes[0].as_related_node_info()
+                                )
 
                         # Now save new_nodes_
                         new_nodes += new_split_nodes

--- a/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
@@ -339,11 +339,15 @@ class CodeHierarchyNodeParser(NodeParser):
         # Capture any whitespace before parent.start_byte
         # Very important for space sensitive languages like python
         start_byte = parent.start_byte
-        while start_byte > 0 and text[start_byte - 1] in (" ", "\t"):
+        text_bytes = bytes(text, "utf-8")
+        while start_byte > 0 and text_bytes[start_byte - 1 : start_byte] in (
+            b" ",
+            b"\t",
+        ):
             start_byte -= 1
 
         # Create this node
-        current_chunk = text[start_byte : parent.end_byte]
+        current_chunk = text_bytes[start_byte : parent.end_byte].decode()
 
         # Return early if the chunk is too small
         if len(current_chunk) < self.min_characters and not _root:
@@ -545,7 +549,7 @@ class CodeHierarchyNodeParser(NodeParser):
                 or tree.root_node.children[0].type != "ERROR"
             ):
                 # Chunk the code
-                _chunks = self._chunk_node(tree.root_node, bytes(node.text, "utf-8"))
+                _chunks = self._chunk_node(tree.root_node, node.text)
                 assert _chunks.this_document is not None, "Root node must be a chunk"
                 chunks = _chunks.all_documents
 

--- a/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
@@ -415,9 +415,9 @@ class CodeHierarchyNodeParser(NodeParser):
                             ].append(  # type: ignore
                                 d.as_related_node_info()
                             )
-                            d.relationships[NodeRelationship.PARENT] = (
-                                this_document.as_related_node_info()
-                            )
+                            d.relationships[
+                                NodeRelationship.PARENT
+                            ] = this_document.as_related_node_info()
                 # Otherwise we pass the children upstream
                 else:
                     # If we have been given a document, that means it's
@@ -556,9 +556,9 @@ class CodeHierarchyNodeParser(NodeParser):
                         **chunk.metadata,
                         **node.metadata,
                     }
-                    chunk.relationships[NodeRelationship.SOURCE] = (
-                        node.as_related_node_info()
-                    )
+                    chunk.relationships[
+                        NodeRelationship.SOURCE
+                    ] = node.as_related_node_info()
 
                 if self.skeleton:
                     self._skeletonize_list(chunks)
@@ -613,9 +613,9 @@ class CodeHierarchyNodeParser(NodeParser):
                                         new_split_nodes[0].as_related_node_info()
                                     )
                                 new_children.append(old_nodes_child)
-                            old_node.relationships[NodeRelationship.CHILD] = (
-                                new_children
-                            )
+                            old_node.relationships[
+                                NodeRelationship.CHILD
+                            ] = new_children
 
                             # Handle parent node
                             if (
@@ -623,9 +623,9 @@ class CodeHierarchyNodeParser(NodeParser):
                                 and old_node.parent_node.node_id
                                 == original_node.node_id
                             ):
-                                old_node.relationships[NodeRelationship.PARENT] = (
-                                    new_split_nodes[0].as_related_node_info()
-                                )
+                                old_node.relationships[
+                                    NodeRelationship.PARENT
+                                ] = new_split_nodes[0].as_related_node_info()
 
                         # Now save new_nodes_
                         new_nodes += new_split_nodes

--- a/llama-index-packs/llama-index-packs-code-hierarchy/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["ryanpeach"]
 name = "llama-index-packs-code-hierarchy"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"

--- a/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_parse_nodes_special_characters.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_parse_nodes_special_characters.py
@@ -1,0 +1,39 @@
+from typing import List
+
+from llama_index.packs.code_hierarchy import CodeHierarchyNodeParser
+from llama_index.core.schema import TextNode
+
+
+def text_special_character() -> None:
+    code_splitter = CodeHierarchyNodeParser(
+        language="python", skeleton=False, chunk_min_characters=0
+    )
+
+    # example with special character code ¥
+    text = """\
+def print_special_character():
+    print("Particulate Matter 10 (¥g/m3)")
+
+
+def function_that_was_cut():
+    print("This function was cut from the original file")"""
+
+    text_node = TextNode(
+        text=text,
+        metadata={
+            "module": "example.foo",
+        },
+    )
+
+    nodes: List[TextNode] = code_splitter.get_nodes_from_documents([text_node])
+
+    assert len(nodes) == 3
+    # The last node is didn't have the first character, because the length of utf-8 special character ¥ is 2
+    assert (
+        nodes[2].text
+        == """\
+def function_that_was_cut():
+    print("This function was cut from the original file")"""
+    )
+    assert nodes[2].metadata["start_byte"] == 77
+    assert nodes[2].metadata["end_byte"] == 163

--- a/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_parse_nodes_special_characters.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_parse_nodes_special_characters.py
@@ -1,10 +1,13 @@
+"""Test CodeHierarchyNodeParser with a special character on the code."""
+
 from typing import List
 
 from llama_index.packs.code_hierarchy import CodeHierarchyNodeParser
 from llama_index.core.schema import TextNode
 
 
-def text_special_character() -> None:
+def test_special_character() -> None:
+    """Test case for code splitting using python and add a special character in the code."""
     code_splitter = CodeHierarchyNodeParser(
         language="python", skeleton=False, chunk_min_characters=0
     )


### PR DESCRIPTION
# Description

CodeHierarchyNodeParser Fails with Multi-byte Characters, Leading to Incorrect Parsing

Fixes #11818 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
