### PR TITLE
fix(docs): langfuse link to notebook on observability page

### DIFF
--- a/docs/docs/module_guides/observability/index.md
+++ b/docs/docs/module_guides/observability/index.md
@@ -74,12 +74,7 @@ set_global_handler("langfuse")
 
 #### Guides
 
-```{toctree}
----
-maxdepth: 1
----
-/examples/callbacks/LangfuseCallbackHandler.ipynb
-```
+- [Langfuse Callback Handler](../../examples/callbacks/LangfuseCallbackHandler.ipynb)
 
 ![langfuse-tracing](https://static.langfuse.com/llamaindex-langfuse-docs.gif)
 


### PR DESCRIPTION
Fixes the link to the langfuse notebook on the llama-index docs page on observability 😊