### PR TITLE
make pip check work for optional pdf packages

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -50,7 +50,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.16"
+version = "0.1.17"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
@@ -60,6 +60,11 @@ pymupdf = {optional = true, version = "^1.23.21"}
 beautifulsoup4 = "^4.12.3"
 pypdf = "^4.0.1"
 striprtf = "^0.0.26"
+
+[tool.poetry.extras]
+pymupdf = [
+    "pymupdf",
+]
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/12697

Adds extras section for pymupdf so that it is properly skipped