### PR TITLE
Use None as the default value for s3_endpoint_url in S3Reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-s3/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.1.6] - 2024-04-11
+
+- Use `None` as the default value for `s3_endpoint_url`
+
 ## [0.1.5] - 2024-03-27
 
 - Update `README.md` to include installation instructions.

--- a/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
@@ -59,7 +59,7 @@ class S3Reader(BasePydanticReader):
     aws_access_id: Optional[str] = None
     aws_access_secret: Optional[str] = None
     aws_session_token: Optional[str] = None
-    s3_endpoint_url: Optional[str] = "https://s3.amazonaws.com"
+    s3_endpoint_url: Optional[str] = None
     custom_reader_path: Optional[str] = None
 
     @classmethod

--- a/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
@@ -29,13 +29,13 @@ license = "MIT"
 maintainers = ["thejessezhang"]
 name = "llama-index-readers-s3"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
 llama-index-readers-file = "^0.1.12"
-s3fs = "^2024.3.0"
+s3fs = "^2024.3.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

Use `None` as the default value for `s3_endpoint_url`
