### PR TITLE
Relax dependency version to accept astrapy 1.*

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
@@ -10,6 +10,9 @@ format:	## Run code autoformatters (black).
 lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
+typecheck:
+	poetry run mypy .
+
 test:	## Run tests via pytest.
 	poetry run pytest tests
 

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
@@ -4,11 +4,11 @@ help:	## Show all Makefile targets.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
 
 format:	## Run code autoformatters (black).
-	pre-commit install
-	git ls-files | xargs pre-commit run black --files
+	poetry run pre-commit install
+	git ls-files | xargs poetry run pre-commit run black --files
 
 lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
-	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pytest.
 	poetry run pytest tests

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.4"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-astrapy = "^0.7.5"
+astrapy = ">=0.7.7, <2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["erichare"]
 name = "llama-index-readers-astra-db"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    dependencies=["llama-index-integrations/readers/llama-index-readers-astra-db:poetry#astrapy"]
+)

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_astra_db.py
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_astra_db.py
@@ -7,6 +7,8 @@ from astrapy.db import AstraDB
 from llama_index.readers.astra_db import AstraDBReader
 from llama_index.core.schema import Document
 
+COLLECTION_NAME = "li_readers_test"
+
 print(f"astrapy detected: {astrapy.__version__}")
 
 
@@ -15,10 +17,8 @@ ASTRA_DB_APPLICATION_TOKEN = os.getenv("ASTRA_DB_APPLICATION_TOKEN", "")
 ASTRA_DB_API_ENDPOINT = os.getenv("ASTRA_DB_API_ENDPOINT", "")
 
 
-@pytest.fixture(scope="module")
-def source_collection_name() -> Iterable[str]:
-    COLLECTION_NAME = "li_readers_test"
-
+@pytest.fixture(autouse=True, scope="module")
+def source_collection() -> Iterable[str]:
     database = AstraDB(
         token=ASTRA_DB_APPLICATION_TOKEN,
         api_endpoint=ASTRA_DB_API_ENDPOINT,
@@ -48,7 +48,7 @@ def source_collection_name() -> Iterable[str]:
         ]
     )
 
-    yield COLLECTION_NAME
+    yield collection
 
     database.delete_collection(COLLECTION_NAME)
 
@@ -57,9 +57,9 @@ def source_collection_name() -> Iterable[str]:
     ASTRA_DB_APPLICATION_TOKEN == "" or ASTRA_DB_API_ENDPOINT == "",
     reason="missing Astra DB credentials",
 )
-def test_astra_db_readers_read(source_collection_name: str) -> None:
+def test_astra_db_readers_read() -> None:
     reader = AstraDBReader(
-        collection_name=source_collection_name,
+        collection_name=COLLECTION_NAME,
         token=ASTRA_DB_APPLICATION_TOKEN,
         api_endpoint=ASTRA_DB_API_ENDPOINT,
         embedding_dimension=2,

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_astra_db.py
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_astra_db.py
@@ -18,7 +18,7 @@ ASTRA_DB_API_ENDPOINT = os.getenv("ASTRA_DB_API_ENDPOINT", "")
 
 
 @pytest.fixture(autouse=True, scope="module")
-def source_collection() -> Iterable[str]:
+def source_collection() -> Iterable[astrapy.db.AstraDBCollection]:
     database = AstraDB(
         token=ASTRA_DB_APPLICATION_TOKEN,
         api_endpoint=ASTRA_DB_API_ENDPOINT,

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_astra_db.py
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_astra_db.py
@@ -1,0 +1,73 @@
+import os
+import pytest
+from typing import Iterable
+
+import astrapy
+from astrapy.db import AstraDB
+from llama_index.readers.astra_db import AstraDBReader
+from llama_index.core.schema import Document
+
+print(f"astrapy detected: {astrapy.__version__}")
+
+
+# env variables
+ASTRA_DB_APPLICATION_TOKEN = os.getenv("ASTRA_DB_APPLICATION_TOKEN", "")
+ASTRA_DB_API_ENDPOINT = os.getenv("ASTRA_DB_API_ENDPOINT", "")
+
+
+@pytest.fixture(scope="module")
+def source_collection_name() -> Iterable[str]:
+    COLLECTION_NAME = "li_readers_test"
+
+    database = AstraDB(
+        token=ASTRA_DB_APPLICATION_TOKEN,
+        api_endpoint=ASTRA_DB_API_ENDPOINT,
+    )
+    collection = database.create_collection(
+        collection_name=COLLECTION_NAME,
+        dimension=2,
+    )
+
+    collection.insert_many(
+        documents=[
+            {
+                "_id": "doc0",
+                "content": "Content 0",
+                "$vector": [0.0, 10.0],
+            },
+            {
+                "_id": "doc1",
+                "content": "Content 1",
+                "$vector": [1.0, 10.0],
+            },
+            {
+                "_id": "doc2",
+                "content": "Content 2",
+                "$vector": [2.0, 10.0],
+            },
+        ]
+    )
+
+    yield COLLECTION_NAME
+
+    database.delete_collection(COLLECTION_NAME)
+
+
+@pytest.mark.skipif(
+    ASTRA_DB_APPLICATION_TOKEN == "" or ASTRA_DB_API_ENDPOINT == "",
+    reason="missing Astra DB credentials",
+)
+def test_astra_db_readers_read(source_collection_name: str) -> None:
+    reader = AstraDBReader(
+        collection_name=source_collection_name,
+        token=ASTRA_DB_APPLICATION_TOKEN,
+        api_endpoint=ASTRA_DB_API_ENDPOINT,
+        embedding_dimension=2,
+    )
+    loaded = reader.load_data(vector=[1, 1])
+    assert len(loaded) == 3
+    assert loaded[0] == Document(
+        doc_id="doc2",
+        text="Content 2",
+        embedding=[2.0, 10.0],
+    )

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_readers_astra_db.py
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_readers_astra_db.py
@@ -2,6 +2,6 @@ from llama_index.core.readers.base import BaseReader
 from llama_index.readers.astra_db import AstraDBReader
 
 
-def test_class():
+def test_class() -> None:
     names_of_base_classes = [b.__name__ for b in AstraDBReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
@@ -10,6 +10,9 @@ format:	## Run code autoformatters (black).
 lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
+typecheck:
+	poetry run mypy .
+
 test:	## Run tests via pytest.
 	poetry run pytest tests
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
@@ -4,11 +4,11 @@ help:	## Show all Makefile targets.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
 
 format:	## Run code autoformatters (black).
-	pre-commit install
-	git ls-files | xargs pre-commit run black --files
+	poetry run pre-commit install
+	git ls-files | xargs poetry run pre-commit run black --files
 
 lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
-	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pytest.
 	poetry run pytest tests

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
@@ -243,7 +243,7 @@ class AstraDBVectorStore(BasePydanticVectorStore):
         """
         _logger.debug("Deleting a document from the Astra table")
 
-        self._astra_db_collection.delete(id=ref_doc_id, **delete_kwargs)
+        self._astra_db_collection.delete_one(id=ref_doc_id, **delete_kwargs)
 
     @property
     def client(self) -> Any:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.5"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-astrapy = "^0.7.7"
+astrapy = ">=0.7.7, <2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-astra-db"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/tests/test_vector_stores_astra_db.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/tests/test_vector_stores_astra_db.py
@@ -2,6 +2,6 @@ from llama_index.core.vector_stores.types import BasePydanticVectorStore
 from llama_index.vector_stores.astra_db.base import AstraDBVectorStore
 
 
-def test_class():
+def test_class() -> None:
     names_of_base_classes = [b.__name__ for b in AstraDBVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes


### PR DESCRIPTION
# Description

The main point of this PR is to allow for astrapy 1.* (now that 1.0.0 is out).
This version is backward-compatible so no code changes are needed.

- While I was at it, I added a simple integration test for the Astra DB reader class
- I made the Makefile work again by using poetry commands
- I replaced a method call (deprecated starting astrapy 0.7.1) (`delete` => `delete_one`).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests (though unrelated to the very change this PR is about)

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
