### PR TITLE
fix: pipline load without docstore

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -525,16 +525,20 @@ class IngestionPipeline(BaseModel):
             self.cache = IngestionCache.from_persist_path(
                 concat_dirs(persist_dir, cache_name), fs=fs
             )
-            self.docstore = SimpleDocumentStore.from_persist_path(
-                concat_dirs(persist_dir, docstore_name), fs=fs
-            )
+            persist_docstore_path = concat_dirs(persist_dir, docstore_name)
+            if os.path.exists(persist_docstore_path):
+                self.docstore = SimpleDocumentStore.from_persist_path(
+                    concat_dirs(persist_dir, docstore_name), fs=fs
+                )
         else:
             self.cache = IngestionCache.from_persist_path(
                 str(Path(persist_dir) / cache_name)
             )
-            self.docstore = SimpleDocumentStore.from_persist_path(
-                str(Path(persist_dir) / docstore_name)
-            )
+            persist_docstore_path = str(Path(persist_dir) / docstore_name)
+            if os.path.exists(persist_docstore_path):
+                self.docstore = SimpleDocumentStore.from_persist_path(
+                    str(Path(persist_dir) / docstore_name)
+                )
 
     def _get_default_transformations(self) -> List[TransformComponent]:
         return [

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -99,6 +99,7 @@ def test_save_load_pipeline() -> None:
     assert pipeline.docstore is not None
     assert len(pipeline.docstore.docs) == 2
 
+
 def test_save_load_pipeline_without_docstore() -> None:
     documents = [
         Document(text="one", doc_id="1"),
@@ -115,7 +116,7 @@ def test_save_load_pipeline_without_docstore() -> None:
     nodes = pipeline.run(documents=documents)
     assert len(nodes) == 3
     assert pipeline.docstore is None
-    
+
     # dedup will not catch the last node if the document store is not set
     nodes = pipeline.run(documents=[documents[-1]])
     assert len(nodes) == 1
@@ -136,6 +137,7 @@ def test_save_load_pipeline_without_docstore() -> None:
     nodes = pipeline.run(documents=[documents[-1]])
     assert len(nodes) == 1
     assert pipeline.docstore is None
+
 
 def test_pipeline_update() -> None:
     document1 = Document.example()

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -99,6 +99,43 @@ def test_save_load_pipeline() -> None:
     assert pipeline.docstore is not None
     assert len(pipeline.docstore.docs) == 2
 
+def test_save_load_pipeline_without_docstore() -> None:
+    documents = [
+        Document(text="one", doc_id="1"),
+        Document(text="two", doc_id="2"),
+        Document(text="one", doc_id="1"),
+    ]
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+    )
+
+    nodes = pipeline.run(documents=documents)
+    assert len(nodes) == 3
+    assert pipeline.docstore is None
+    
+    # dedup will not catch the last node if the document store is not set
+    nodes = pipeline.run(documents=[documents[-1]])
+    assert len(nodes) == 1
+    assert pipeline.docstore is None
+
+    # test save/load
+    pipeline.persist("./test_pipeline")
+
+    pipeline2 = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+    )
+
+    pipeline2.load("./test_pipeline")
+
+    # dedup will not catch the last node if the document store is not set
+    nodes = pipeline.run(documents=[documents[-1]])
+    assert len(nodes) == 1
+    assert pipeline.docstore is None
 
 def test_pipeline_update() -> None:
     document1 = Document.example()


### PR DESCRIPTION
# Description

The docstore for the IngestionPipeline is optional and defaults to None. During persistence, the docstore is only persisted if it exists, but it is not validated during loading. When the docstore is not set, loading will fail. This fix includes a check during loading and provides corresponding test cases.

Fixes # (issue)

## Type of Change


- [x]  Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added test case test_save_load_pipeline_without_docstore based on the original test_save_load_pipeline with a docstore.

- [x] Added new unit/integration tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
