### PR TITLE
Expose azure_ad_token_provider argument to support token expiration

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -12,6 +12,7 @@ from llama_index.embeddings.openai import (
 )
 from llama_index.llms.azure_openai.utils import resolve_from_aliases
 from openai import AsyncAzureOpenAI, AzureOpenAI
+from openai.lib.azure import AzureADTokenProvider
 
 
 class AzureOpenAIEmbedding(OpenAIEmbedding):
@@ -27,6 +28,8 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
         default="", description="The version for Azure OpenAI API."
     )
 
+    azure_ad_token_provider: AzureADTokenProvider = Field(default=None, description="Callback function to provide Azure AD token.")
+
     _client: AzureOpenAI = PrivateAttr()
     _aclient: AsyncAzureOpenAI = PrivateAttr()
 
@@ -41,6 +44,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
         # azure specific
         azure_endpoint: Optional[str] = None,
         azure_deployment: Optional[str] = None,
+        azure_ad_token_provider: AzureADTokenProvider = None,
         deployment_name: Optional[str] = None,
         max_retries: int = 10,
         reuse_client: bool = True,
@@ -57,6 +61,8 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             azure_deployment,
             deployment_name,
         )
+
+        self.azure_ad_token_provider = azure_ad_token_provider
 
         super().__init__(
             mode=mode,
@@ -109,6 +115,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
     def _get_credential_kwargs(self) -> Dict[str, Any]:
         return {
             "api_key": self.api_key,
+            "azure_ad_token_provider": self.azure_ad_token_provider,
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
             "api_version": self.api_version,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -62,8 +62,6 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             deployment_name,
         )
 
-        self.azure_ad_token_provider = azure_ad_token_provider
-
         super().__init__(
             mode=mode,
             model=model,
@@ -73,6 +71,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             api_version=api_version,
             azure_endpoint=azure_endpoint,
             azure_deployment=azure_deployment,
+            azure_ad_token_provider=azure_ad_token_provider,
             max_retries=max_retries,
             reuse_client=reuse_client,
             callback_manager=callback_manager,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -28,7 +28,9 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
         default="", description="The version for Azure OpenAI API."
     )
 
-    azure_ad_token_provider: AzureADTokenProvider = Field(default=None, description="Callback function to provide Azure AD token.")
+    azure_ad_token_provider: AzureADTokenProvider = Field(
+        default=None, description="Callback function to provide Azure AD token."
+    )
 
     _client: AzureOpenAI = PrivateAttr()
     _aclient: AsyncAzureOpenAI = PrivateAttr()

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-azure-openai"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -70,7 +70,9 @@ class AzureOpenAI(OpenAI):
         description="Indicates if Microsoft Entra ID (former Azure AD) is used for token authentication"
     )
 
-    azure_ad_token_provider: AzureADTokenProvider = Field(default=None, description="Callback function to provide Azure AD token.")
+    azure_ad_token_provider: AzureADTokenProvider = Field(
+        default=None, description="Callback function to provide Azure AD token."
+    )
 
     _azure_ad_token: Any = PrivateAttr(default=None)
     _client: SyncAzureOpenAI = PrivateAttr()

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -119,8 +119,6 @@ class AzureOpenAI(OpenAI):
             "azure_endpoint", azure_endpoint, "AZURE_OPENAI_ENDPOINT", ""
         )
 
-        self.azure_ad_token_provider = azure_ad_token_provider
-
         super().__init__(
             engine=engine,
             model=model,
@@ -133,6 +131,7 @@ class AzureOpenAI(OpenAI):
             api_key=api_key,
             azure_endpoint=azure_endpoint,
             azure_deployment=azure_deployment,
+            azure_ad_token_provider=azure_ad_token_provider,
             use_azure_ad=use_azure_ad,
             api_version=api_version,
             callback_manager=callback_manager,

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -13,6 +13,7 @@ from llama_index.llms.azure_openai.utils import (
 from llama_index.llms.openai import OpenAI
 from openai import AsyncAzureOpenAI
 from openai import AzureOpenAI as SyncAzureOpenAI
+from openai.lib.azure import AzureADTokenProvider
 
 
 class AzureOpenAI(OpenAI):
@@ -69,6 +70,8 @@ class AzureOpenAI(OpenAI):
         description="Indicates if Microsoft Entra ID (former Azure AD) is used for token authentication"
     )
 
+    azure_ad_token_provider: AzureADTokenProvider = Field(default=None, description="Callback function to provide Azure AD token.")
+
     _azure_ad_token: Any = PrivateAttr(default=None)
     _client: SyncAzureOpenAI = PrivateAttr()
     _aclient: AsyncAzureOpenAI = PrivateAttr()
@@ -88,6 +91,7 @@ class AzureOpenAI(OpenAI):
         # azure specific
         azure_endpoint: Optional[str] = None,
         azure_deployment: Optional[str] = None,
+        azure_ad_token_provider: AzureADTokenProvider = None,
         use_azure_ad: bool = False,
         callback_manager: Optional[CallbackManager] = None,
         # aliases for engine
@@ -114,6 +118,8 @@ class AzureOpenAI(OpenAI):
         azure_endpoint = get_from_param_or_env(
             "azure_endpoint", azure_endpoint, "AZURE_OPENAI_ENDPOINT", ""
         )
+
+        self.azure_ad_token_provider = azure_ad_token_provider
 
         super().__init__(
             engine=engine,
@@ -186,6 +192,7 @@ class AzureOpenAI(OpenAI):
             "timeout": self.timeout,
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
+            "azure_ad_token_provider": self.azure_ad_token_provider,
             "api_version": self.api_version,
             "default_headers": self.default_headers,
             "http_client": self._http_client,

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-azure-openai"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Expose openai.AzureADTokenProvide attribute for AzureOpenAI models (LLM and embedding).
Corresponding "azure_ad_token_provider" callback can handle token expiration, which is not handled otherwise.

Fixes # (issue)
No separate issue submitted.

## New Package?
No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran manual testing in within private azure-hosted deployment

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
