### PR TITLE
nits: agent / tool imports, custom agent callbacks

### DIFF
--- a/llama-index-core/llama_index/core/agent/__init__.py
+++ b/llama-index-core/llama_index/core/agent/__init__.py
@@ -7,7 +7,7 @@ from llama_index.core.agent.react.step import ReActAgentWorker
 from llama_index.core.agent.react_multimodal.step import MultimodalReActAgentWorker
 from llama_index.core.agent.runner.base import AgentRunner
 from llama_index.core.agent.runner.parallel import ParallelAgentRunner
-from llama_index.core.agent.types import Task, TaskStep, TaskStepOutput
+from llama_index.core.agent.types import Task
 from llama_index.core.chat_engine.types import AgentChatResponse
 from llama_index.core.agent.function_calling.step import FunctionCallingAgentWorker
 
@@ -25,6 +25,5 @@ __all__ = [
     # schema-related
     "AgentChatResponse",
     "Task",
-    "TaskStep"
-    "TaskStepOutput"
+    "TaskStep" "TaskStepOutput",
 ]

--- a/llama-index-core/llama_index/core/agent/__init__.py
+++ b/llama-index-core/llama_index/core/agent/__init__.py
@@ -25,5 +25,6 @@ __all__ = [
     # schema-related
     "AgentChatResponse",
     "Task",
-    "TaskStep" "TaskStepOutput",
+    "TaskStep",
+    "TaskStepOutput",
 ]

--- a/llama-index-core/llama_index/core/agent/__init__.py
+++ b/llama-index-core/llama_index/core/agent/__init__.py
@@ -7,7 +7,7 @@ from llama_index.core.agent.react.step import ReActAgentWorker
 from llama_index.core.agent.react_multimodal.step import MultimodalReActAgentWorker
 from llama_index.core.agent.runner.base import AgentRunner
 from llama_index.core.agent.runner.parallel import ParallelAgentRunner
-from llama_index.core.agent.types import Task
+from llama_index.core.agent.types import Task, TaskStep, TaskStepOutput
 from llama_index.core.chat_engine.types import AgentChatResponse
 from llama_index.core.agent.function_calling.step import FunctionCallingAgentWorker
 
@@ -25,4 +25,6 @@ __all__ = [
     # schema-related
     "AgentChatResponse",
     "Task",
+    "TaskStep"
+    "TaskStepOutput"
 ]

--- a/llama-index-core/llama_index/core/agent/custom/simple.py
+++ b/llama-index-core/llama_index/core/agent/custom/simple.py
@@ -91,7 +91,7 @@ class CustomSimpleAgentWorker(BaseModel, BaseAgentWorker):
         super().__init__(
             tools=tools,
             llm=llm,
-            callback_manager=callback_manager,
+            callback_manager=callback_manager or CallbackManager([]),
             tool_retriever=tool_retriever,
             verbose=verbose,
         )
@@ -114,7 +114,7 @@ class CustomSimpleAgentWorker(BaseModel, BaseAgentWorker):
             tools=tools or [],
             tool_retriever=tool_retriever,
             llm=llm,
-            callback_manager=callback_manager,
+            callback_manager=callback_manager or CallbackManager([]),
             verbose=verbose,
             **kwargs,
         )

--- a/llama-index-core/llama_index/core/tools/__init__.py
+++ b/llama-index-core/llama_index/core/tools/__init__.py
@@ -12,6 +12,7 @@ from llama_index.core.tools.types import (
     ToolOutput,
     adapt_to_async_tool,
 )
+from llama_index.core.tools.calling import ToolSelection, call_tool_with_selection, acall_tool_with_selection
 
 __all__ = [
     "BaseTool",
@@ -24,4 +25,7 @@ __all__ = [
     "FunctionTool",
     "QueryPlanTool",
     "download_tool",
+    "ToolSelection",
+    "call_tool_with_selection",
+    "acall_tool_with_selection"
 ]

--- a/llama-index-core/llama_index/core/tools/__init__.py
+++ b/llama-index-core/llama_index/core/tools/__init__.py
@@ -12,7 +12,11 @@ from llama_index.core.tools.types import (
     ToolOutput,
     adapt_to_async_tool,
 )
-from llama_index.core.tools.calling import ToolSelection, call_tool_with_selection, acall_tool_with_selection
+from llama_index.core.tools.calling import (
+    ToolSelection,
+    call_tool_with_selection,
+    acall_tool_with_selection,
+)
 
 __all__ = [
     "BaseTool",
@@ -27,5 +31,5 @@ __all__ = [
     "download_tool",
     "ToolSelection",
     "call_tool_with_selection",
-    "acall_tool_with_selection"
+    "acall_tool_with_selection",
 ]


### PR DESCRIPTION
initializing a custom agent would fail if you didn't specify a callback manager (which is annoying since we also migrated to new instrumentation module). simple patch fix for now 

also made some agent/tool imports more visible 