### PR TITLE
nit: add change to install bedrock retriever in the notebook

### DIFF
--- a/docs/docs/examples/retrievers/bedrock_retriever.ipynb
+++ b/docs/docs/examples/retrievers/bedrock_retriever.ipynb
@@ -31,7 +31,8 @@
    "outputs": [],
    "source": [
     "%pip install --upgrade --quiet  boto3 botocore\n",
-    "%pip install llama-index"
+    "%pip install llama-index\n",
+    "%pip install llama-index-retrievers-bedrock"
    ]
   },
   {


### PR DESCRIPTION
# Description

nit: add change to install bedrock retriever in the notebook
To avoid getting ModuleNotFoundError during execution

Fixes # (issue)

## New Package? - No

## Version Bump? - N/A

## Type of Change
Minor notebook update

## How Has This Been Tested?
Ran the notebook and tested

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
