### PR TITLE
Find Import Bug

### DIFF
--- a/docs/docs/module_guides/querying/node_postprocessors/index.md
+++ b/docs/docs/module_guides/querying/node_postprocessors/index.md
@@ -117,7 +117,7 @@ A dummy node-postprocessor can be implemented in just a few lines of code:
 
 ```python
 from llama_index.core import QueryBundle
-from llama_index.core.postprocessor import BaseNodePostprocessor
+from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.schema import NodeWithScore
 
 


### PR DESCRIPTION
# Description

While working on a project, I mistakenly imported the following code snippet:

```python
from llama_index.core.postprocessor import BaseNodePostprocessor
```
![image](https://github.com/run-llama/llama_index/assets/86475736/0dfccaa7-b4c6-45e7-95f1-5bfed2f58c6c)

After some investigation, I discovered that the import was incorrect. The correct import should be:

```python
from llama_index.core.postprocessor.types import BaseNodePostprocessor
```
In following image you can see BaseNodePostprocessor class in types.py file,
![image](https://github.com/run-llama/llama_index/assets/86475736/b566a508-18b1-435e-97e4-a3f092dff7e1)

Fixes #12814

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] No

## Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
