### PR TITLE
(Astra db) explicit projection in DB read operations

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
@@ -11,7 +11,13 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
 typecheck:
+	if [ -f "llama_index/__init__.py" ]; then exit 1; fi
+	if [ -f "llama_index/readers/__init__.py" ]; then exit 1; fi
+	touch "llama_index/__init__.py"
+	touch "llama_index/readers/__init__.py"
 	poetry run mypy .
+	rm "llama_index/__init__.py"
+	rm "llama_index/readers/__init__.py"
 
 test:	## Run tests via pytest.
 	poetry run pytest tests

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/Makefile
@@ -11,13 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
 typecheck:
-	if [ -f "llama_index/__init__.py" ]; then exit 1; fi
-	if [ -f "llama_index/readers/__init__.py" ]; then exit 1; fi
-	touch "llama_index/__init__.py"
-	touch "llama_index/readers/__init__.py"
-	poetry run mypy .
-	rm "llama_index/__init__.py"
-	rm "llama_index/readers/__init__.py"
+	poetry run mypy --explicit-package-bases llama_index
 
 test:	## Run tests via pytest.
 	poetry run pytest tests

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/llama_index/readers/astra_db/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/llama_index/readers/astra_db/base.py
@@ -74,7 +74,12 @@ class AstraDBReader(BaseReader):
         Returns:
             List[Document]: A list of documents.
         """
-        results = self._collection.vector_find(vector, limit=limit, **kwargs)
+        results = self._collection.vector_find(
+            vector,
+            limit=limit,
+            fields=["*"],
+            **kwargs,
+        )
 
         documents: List[Document] = []
         for result in results:

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["erichare"]
 name = "llama-index-readers-astra-db"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
@@ -11,13 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
 typecheck:
-	if [ -f "llama_index/__init__.py" ]; then exit 1; fi
-	if [ -f "llama_index/vector_stores/__init__.py" ]; then exit 1; fi
-	touch "llama_index/__init__.py"
-	touch "llama_index/vector_stores/__init__.py"
-	poetry run mypy .
-	rm "llama_index/__init__.py"
-	rm "llama_index/vector_stores/__init__.py"
+	poetry run mypy --explicit-package-bases llama_index
 
 test:	## Run tests via pytest.
 	poetry run pytest tests

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/Makefile
@@ -11,7 +11,13 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	poetry run pre-commit install && git ls-files | xargs poetry run pre-commit run --show-diff-on-failure --files
 
 typecheck:
+	if [ -f "llama_index/__init__.py" ]; then exit 1; fi
+	if [ -f "llama_index/vector_stores/__init__.py" ]; then exit 1; fi
+	touch "llama_index/__init__.py"
+	touch "llama_index/vector_stores/__init__.py"
 	poetry run mypy .
+	rm "llama_index/__init__.py"
+	rm "llama_index/vector_stores/__init__.py"
 
 test:	## Run tests via pytest.
 	poetry run pytest tests

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
@@ -263,7 +263,8 @@ class AstraDBVectorStore(BasePydanticVectorStore):
             raise NotImplementedError(
                 "Only filters with operator=FilterOperator.EQ are supported"
             )
-        return {f"metadata.{f.key}": f.value for f in query_filters.filters}
+        # nested filters, i.e. f being of type MetadataFilters, is excluded above:
+        return {f"metadata.{f.key}": f.value for f in query_filters.filters}  # type: ignore[union-attr]
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes."""
@@ -293,6 +294,8 @@ class AstraDBVectorStore(BasePydanticVectorStore):
                 vector=query_embedding,
                 limit=query.similarity_top_k,
                 filter=query_metadata,
+                fields=["*"],
+                include_similarity=True,
             )
 
             # Get the scores associated with each
@@ -318,11 +321,12 @@ class AstraDBVectorStore(BasePydanticVectorStore):
             # Get the most we can possibly need to fetch
             prefetch_k = max(prefetch_k0, query.similarity_top_k)
 
-            # Call AstraPy to fetch them
+            # Call AstraPy to fetch them (similarity from DB not needed here)
             prefetch_matches = self._astra_db_collection.vector_find(
                 vector=query_embedding,
                 limit=prefetch_k,
                 filter=query_metadata,
+                fields=["*"],
             )
 
             # Get the MMR threshold

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-astra-db"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

To prepare for upcoming Astra DB Data API changes, this PR makes the field projection explicit when calling the Astra DB find methods, specifying the "include_similarity" parameter as well.

Additionally, a typecheck Make target is added (though with some clumsy solution to overcome import/loading issues, see below). The typecheck, incidentally, helped uncover the need for a type: ignore directive (in managing metadata filters for the vector store).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue) - In a sense. A future version of the Data API (server side) will require this change.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods

## A note on typechecking

I tried to add a Make target (on both affected Astra DB sub packages). However, running `mypy .` requires to introduce two `__init__.py` at two levels. But if I do that, and I try e.g. to run the tests with the `__init__`s in place, I get import errors related to LlamaIndex dynamic-subpackage-loading mechanism:

```
ImportError while importing test module '/home/BLABLABLA/llama_index/llama-index-integrations/readers/llama-index-readers-astra-db/tests/test_astra_db.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_astra_db.py:7: in <module>
    from llama_index.readers.astra_db import AstraDBReader
llama_index/readers/astra_db/__init__.py:1: in <module>
    from llama_index.readers.astra_db.base import AstraDBReader
llama_index/readers/astra_db/base.py:5: in <module>
    import llama_index.core
E   ModuleNotFoundError: No module named 'llama_index.core'
```

I came up with the (ugly) temporary solution to create and then destroy these empty init files just for the sake of typechecking, but I wonder what would be the "idiomatic" way to enable typechecking in this case.
