### PR TITLE
fix PDFReader to use file.name instead of fp.name

### DIFF
--- a/llama-index-legacy/llama_index/legacy/readers/file/docs_reader.py
+++ b/llama-index-legacy/llama_index/legacy/readers/file/docs_reader.py
@@ -44,7 +44,7 @@ class PDFReader(BaseReader):
             # This block returns a whole PDF as a single Document
             if self.return_full_document:
                 text = ""
-                metadata = {"file_name": fp.name}
+                metadata = {"file_name": file.name}
 
                 for page in range(num_pages):
                     # Extract the text from the page
@@ -62,7 +62,7 @@ class PDFReader(BaseReader):
                     page_text = pdf.pages[page].extract_text()
                     page_label = pdf.page_labels[page]
 
-                    metadata = {"page_label": page_label, "file_name": fp.name}
+                    metadata = {"page_label": page_label, "file_name": file.name}
                     if extra_info is not None:
                         metadata.update(extra_info)
 


### PR DESCRIPTION
# Description
Fixes bug where PDFReader uses `fp.name` instead of `file.name` for the `file_name` metadata in the created document. The issue with using the former is that not every file system in `fsspec` returns a file that has this property. Specifically, I noticed an issue with using `fsspec.MemoryFileSystem` with the `SimpleDirectoryReader` class. 


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
