### PR TITLE
fix: Check for old sparse vector qdrant.base.py

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -871,10 +871,11 @@ class QdrantVectorStore(BasePydanticVectorStore):
         return Filter(must=must_conditions)
 
     def use_old_sparse_encoder(self, collection_name: str) -> bool:
+        collection_info = self.client.get_collection(collection_name)
         return (
             self._collection_exists(collection_name)
-            and SPARSE_VECTOR_NAME_OLD
-            in self.client.get_collection(collection_name).config.params.sparse_vectors
+            and collection_info.config.params.sparse_vectors is not None
+            and SPARSE_VECTOR_NAME_OLD in collection_info.config.params.sparse_vectors
         )
 
     @property

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -874,7 +874,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         return (
             self._collection_exists(collection_name)
             and SPARSE_VECTOR_NAME_OLD
-            in self.client.get_collection(collection_name).config.params.vectors
+            in self.client.get_collection(collection_name).config.params.sparse_vectors
         )
 
     @property

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-qdrant"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
# Description
This PR fixes the check used for sparse vectors built using the old encoder.