### PR TITLE
(Astra DB integrations) Bump astrapy requirement to at-least-v1

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["erichare"]
 name = "llama-index-readers-astra-db"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-astra-db/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.5"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-astrapy = ">=0.7.7, <2"
+astrapy = "^1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.6"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-astrapy = ">=0.7.7, <2"
+astrapy = "^1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-astra-db"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR increases the required version of astrapy to at least 1 in the two Astra DB integrations (reader and vector store).

This will enable easier introduction of improvements and new features and simplify dependency management downstream.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes (though there is another PR being submitted which race-conditions these bumps...)
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Requirements change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I checked the tests all pass like they did before

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
