### PR TITLE
bug(codeHierarchy): fixed bug when function is defined twice

### DIFF
--- a/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
@@ -833,7 +833,11 @@ class CodeHierarchyNodeParser(NodeParser):
         index = parent_node.text.find(child_node.text)
         # If the text is found, replace only the first occurrence
         if index != -1:
-            parent_node.text = parent_node.text[:index] + replacement_text + parent_node.text[index + len(child_node.text):]
+            parent_node.text = (
+                parent_node.text[:index]
+                + replacement_text
+                + parent_node.text[index + len(child_node.text) :]
+            )
 
     @classmethod
     def _skeletonize_list(cls, nodes: List[TextNode]) -> None:

--- a/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/llama_index/packs/code_hierarchy/code_hierarchy.py
@@ -829,7 +829,11 @@ class CodeHierarchyNodeParser(NodeParser):
 
         # Now do the replacement
         replacement_text = cls._get_replacement_text(child_node=child_node)
-        parent_node.text = parent_node.text.replace(child_node.text, replacement_text)
+
+        index = parent_node.text.find(child_node.text)
+        # If the text is found, replace only the first occurrence
+        if index != -1:
+            parent_node.text = parent_node.text[:index] + replacement_text + parent_node.text[index + len(child_node.text):]
 
     @classmethod
     def _skeletonize_list(cls, nodes: List[TextNode]) -> None:

--- a/llama-index-packs/llama-index-packs-code-hierarchy/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["ryanpeach"]
 name = "llama-index-packs-code-hierarchy"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"

--- a/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_hierarchy_with_skeleton.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_hierarchy_with_skeleton.py
@@ -558,14 +558,14 @@ def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
     )
 
     chunks: List[TextNode] = code_splitter.get_nodes_from_documents([text_node])
-    assert(len(chunks) == 4)
-    assert(
+    assert len(chunks) == 4
+    assert (
         chunks[0].text
         == f"""def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
-    # {CodeHierarchyNodeParser._get_comment_text(chunks[1])}""")
+    # {CodeHierarchyNodeParser._get_comment_text(chunks[1])}"""
+    )
 
-
-    assert(
+    assert (
         chunks[1].text
         == f"""def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
     if np.isscalar(datetime_or_doy):
@@ -581,6 +581,13 @@ def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
                                    epoch_year=epoch_year)
         to_output = tools._array_out
 
-    return to_doy, to_datetimeindex, to_output""")
-    assert(chunks[2].text == """        def to_doy(x): return x                                 # noqa: E306""")
-    assert(chunks[3].text == """        def to_doy(x): return x                                 # noqa: E306""")
+    return to_doy, to_datetimeindex, to_output"""
+    )
+    assert (
+        chunks[2].text
+        == """        def to_doy(x): return x                                 # noqa: E306"""
+    )
+    assert (
+        chunks[3].text
+        == """        def to_doy(x): return x                                 # noqa: E306"""
+    )

--- a/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_hierarchy_with_skeleton.py
+++ b/llama-index-packs/llama-index-packs-code-hierarchy/tests/test_code_hierarchy_with_skeleton.py
@@ -524,3 +524,63 @@ class Example {{
 }}
 """
     )
+
+
+def test_skeletonize_with_repeated_function() -> None:
+    """Test case for code splitting using python."""
+    if "CI" in os.environ:
+        return
+
+    code_splitter = CodeHierarchyNodeParser(
+        language="python", skeleton=True, chunk_min_characters=0
+    )
+
+    text = """\
+def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
+    if np.isscalar(datetime_or_doy):
+        def to_doy(x): return x                                 # noqa: E306
+        to_datetimeindex = partial(tools._doy_to_datetimeindex,
+                                   epoch_year=epoch_year)
+        to_output = tools._scalar_out
+    else:
+        def to_doy(x): return x                                 # noqa: E306
+        to_datetimeindex = partial(tools._doy_to_datetimeindex,
+                                   epoch_year=epoch_year)
+        to_output = tools._array_out
+
+    return to_doy, to_datetimeindex, to_output"""
+
+    text_node = TextNode(
+        text=text,
+        metadata={
+            "module": "example.foo",
+        },
+    )
+
+    chunks: List[TextNode] = code_splitter.get_nodes_from_documents([text_node])
+    assert(len(chunks) == 4)
+    assert(
+        chunks[0].text
+        == f"""def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
+    # {CodeHierarchyNodeParser._get_comment_text(chunks[1])}""")
+
+
+    assert(
+        chunks[1].text
+        == f"""def _handle_extra_radiation_types(datetime_or_doy, epoch_year):
+    if np.isscalar(datetime_or_doy):
+        def to_doy(x):
+                # {CodeHierarchyNodeParser._get_comment_text(chunks[2])}
+        to_datetimeindex = partial(tools._doy_to_datetimeindex,
+                                   epoch_year=epoch_year)
+        to_output = tools._scalar_out
+    else:
+        def to_doy(x):
+                # {CodeHierarchyNodeParser._get_comment_text(chunks[3])}
+        to_datetimeindex = partial(tools._doy_to_datetimeindex,
+                                   epoch_year=epoch_year)
+        to_output = tools._array_out
+
+    return to_doy, to_datetimeindex, to_output""")
+    assert(chunks[2].text == """        def to_doy(x): return x                                 # noqa: E306""")
+    assert(chunks[3].text == """        def to_doy(x): return x                                 # noqa: E306""")


### PR DESCRIPTION
# Description

Replaces only the first instance of the child_node.text in the _skeletonize method. This fixes the bug when you have 2 functions that do the same. It should almost never happen but it happened once in the pvlib repo :/ 

Fixes #12924 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
