### PR TITLE
enforce uuid in element node parsers

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 
@@ -287,8 +288,6 @@ class BaseElementNodeParser(NodeParser):
                 elif element.type == "table_text":
                     # if the table is non-perfect table, we still want to keep the original text of table
                     table_md = str(element.element)
-                table_id = element.id + "_table"
-                table_ref_id = element.id + "_table_ref"
 
                 col_schema = "\n\n".join([str(col) for col in table_output.columns])
 
@@ -303,19 +302,20 @@ class BaseElementNodeParser(NodeParser):
                 for col in table_output.columns:
                     table_summary += f"- {col.col_name}: {col.summary}\n"
 
+                # shared index_id and node_id
+                node_id = str(uuid.uuid4())
                 index_node = IndexNode(
                     text=table_summary,
                     metadata={"col_schema": col_schema},
                     excluded_embed_metadata_keys=["col_schema"],
-                    id_=table_ref_id,
-                    index_id=table_id,
+                    index_id=node_id,
                 )
 
                 table_str = table_summary + "\n" + table_md
 
                 text_node = TextNode(
+                    id_=node_id,
                     text=table_str,
-                    id_=table_id,
                     metadata={
                         # serialize the table as a dictionary string for dataframe of perfect table
                         "table_df": (

--- a/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
@@ -36,6 +36,7 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
         source_document = node.source_node or node.as_related_node_info()
         for n in nodes:
             n.relationships[NodeRelationship.SOURCE] = source_document
+            n.metadata.update(node.metadata)
         return nodes
 
     def extract_elements(

--- a/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
@@ -11,7 +11,7 @@ from llama_index.core.node_parser.relational.base_element import (
     BaseElementNodeParser,
     Element,
 )
-from llama_index.core.schema import BaseNode, TextNode
+from llama_index.core.schema import BaseNode, NodeRelationship, TextNode
 from llama_index.core.node_parser.relational.utils import html_to_df
 
 
@@ -67,7 +67,13 @@ class UnstructuredElementNodeParser(BaseElementNodeParser):
         self.extract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
-        return self.get_nodes_from_elements(elements, node.metadata)
+        nodes = self.get_nodes_from_elements(elements, node.metadata)
+
+        source_document = node.source_node or node.as_related_node_info()
+        for n in nodes:
+            n.relationships[NodeRelationship.SOURCE] = source_document
+            n.metadata.update(node.metadata)
+        return nodes
 
     def extract_elements(
         self, text: str, table_filters: Optional[List[Callable]] = None, **kwargs: Any


### PR DESCRIPTION
Ensure node ids are UUID instead of deterministic strings

Ensure metadata is inherited 