### PR TITLE
Avoid infinite loop when not handled exception is raised

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-slack/llama_index/readers/slack/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-slack/llama_index/readers/slack/base.py
@@ -133,6 +133,7 @@ class SlackReader(BasePydanticReader):
                     time.sleep(int(e.response.headers["retry-after"]))
                 else:
                     logger.error(f"Error parsing conversation replies: {e}")
+                    break
 
         return "\n\n".join(messages_text)
 

--- a/llama-index-integrations/readers/llama-index-readers-slack/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-slack/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-slack"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

when error different from "ratelimited" is raised, it enters inside a infinite while loop

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
