### PR TITLE
make the PydanticSingleSelector work with async api

### DIFF
--- a/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
+++ b/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
@@ -98,7 +98,7 @@ class PydanticSingleSelector(BaseSelector):
         choices_text = _build_choices_text(choices)
 
         # predict
-        prediction = self._selector_program.acall(
+        prediction = await self._selector_program.acall(
             num_choices=len(choices),
             context_list=choices_text,
             query_str=query.query_str,

--- a/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
+++ b/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
@@ -91,12 +91,21 @@ class PydanticSingleSelector(BaseSelector):
         # parse output
         return _pydantic_output_to_selector_result(prediction)
 
-    async def _aselect(
+    def _aselect(
         self, choices: Sequence[ToolMetadata], query: QueryBundle
     ) -> SelectorResult:
-        raise NotImplementedError(
-            "Async selection not supported for Pydantic Selectors."
+        # prepare input
+        choices_text = _build_choices_text(choices)
+
+        # predict
+        prediction = self._selector_program.acall(
+            num_choices=len(choices),
+            context_list=choices_text,
+            query_str=query.query_str,
         )
+
+        # parse output
+        return _pydantic_output_to_selector_result(prediction)
 
 
 class PydanticMultiSelector(BaseSelector):

--- a/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
+++ b/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
@@ -91,7 +91,7 @@ class PydanticSingleSelector(BaseSelector):
         # parse output
         return _pydantic_output_to_selector_result(prediction)
 
-    def _aselect(
+    async def _aselect(
         self, choices: Sequence[ToolMetadata], query: QueryBundle
     ) -> SelectorResult:
         # prepare input


### PR DESCRIPTION
# Description

Implement async version of the select method for PydanticSingleSelector

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
