### PR TITLE
Fix error querying PineconeVectorStore using sparse query mode

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
@@ -433,7 +433,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
                     "values": [v * (1 - query.alpha) for v in sparse_vector["values"]],
                 }
 
-        query_embedding = None
+        query_embedding = [0.0] * len(query.query_embedding)
         if query.mode in (VectorStoreQueryMode.DEFAULT, VectorStoreQueryMode.HYBRID):
             query_embedding = cast(List[float], query.query_embedding)
             if query.alpha is not None:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
@@ -433,7 +433,13 @@ class PineconeVectorStore(BasePydanticVectorStore):
                     "values": [v * (1 - query.alpha) for v in sparse_vector["values"]],
                 }
 
-        query_embedding = [0.0] * len(query.query_embedding)
+        # pinecone requires a query embedding, so default to 0s if not provided
+        if query.query_embedding is not None:
+            dimension = len(query.query_embedding)
+        else:
+            dimension = self._pinecone_index.describe_index_stats()["dimension"]
+        query_embedding = [0.0] * dimension
+
         if query.mode in (VectorStoreQueryMode.DEFAULT, VectorStoreQueryMode.HYBRID):
             query_embedding = cast(List[float], query.query_embedding)
             if query.alpha is not None:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-pinecone"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"


### PR DESCRIPTION
# Description

Pinecone always expects a vector (or technically also a record id) when querying. When using sparse query mode, we were setting the vector to None and making the request with that, resulting in an error. Changed to make the request with a vector filled with zeroes instead.

## Version Bump?

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
