### PR TITLE
Fix databricks vector search metadata

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
@@ -223,7 +223,8 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
             metadata_columns = self.columns or []
 
             # explicitly record doc_id as metadata (for delete)
-            metadata_columns.append("doc_id")
+            if "doc_id" not in metadata_columns:
+                metadata_columns.append("doc_id")
 
             entry = {
                 self._primary_key: node_id,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/pyproject.toml
@@ -26,7 +26,7 @@ description = "llama-index vector_stores databricks vector search integration"
 license = "MIT"
 name = "llama-index-vector-stores-databricks"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

When using Databricks Vector Search as a storage context then it duplicated the "doc_id" column resulting in: 
errors when trying to use it as a retriever. This fix made the integration class work

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ X] Yes

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I ran the example as per: https://docs.llamaindex.ai/en/stable/examples/vector_stores/DatabricksVectorSearchDemo/ and it worked this time rather than erroring out due to the doc_id column being duplicated

## Suggested Checklist:

- [ X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
