### PR TITLE
Fix: fix query pipeline's arun_with_intermediates

### DIFF
--- a/llama-index-core/llama_index/core/query_pipeline/query.py
+++ b/llama-index-core/llama_index/core/query_pipeline/query.py
@@ -778,11 +778,6 @@ class QueryPipeline(QueryComponent):
                     [all_module_inputs[module_key] for module_key in popped_nodes],
                 )
 
-            if show_intermediates and module_key not in intermediate_outputs:
-                intermediate_outputs[module_key] = ComponentIntermediates(
-                    inputs=module_input, outputs=output_dict
-                )
-
             # create tasks from popped nodes
             tasks = []
             for module_key in popped_nodes:
@@ -800,6 +795,11 @@ class QueryPipeline(QueryComponent):
                 queue = self._process_component_output(
                     queue, output_dict, module_key, all_module_inputs, result_outputs
                 )
+
+                if show_intermediates and module_key not in intermediate_outputs:
+                    intermediate_outputs[module_key] = ComponentIntermediates(
+                        inputs=module_input, outputs=output_dict
+                    )
 
         return result_outputs, intermediate_outputs
 


### PR DESCRIPTION
# Description

Basic 'cannot access local variable' error happening when calling arun_with_intermediates

Fixes # https://github.com/run-llama/llama_index/issues/13000

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
