### PR TITLE
Support custom credentials in FirestoreKVStore

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-firestore/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-firestore/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints=["==3.9.*", "==3.10.*"],
+)

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-firestore/pyproject.toml
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-firestore/pyproject.toml
@@ -27,12 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-docstore-firestore"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 llama-index-core = "^0.10.1"
-llama-index-storage-kvstore-firestore = "^0.1.1"
+llama-index-storage-kvstore-firestore = ">=0.1.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-firestore/tests/BUILD
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-firestore/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints=["==3.9.*", "==3.10.*"],
+)

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-firestore/pyproject.toml
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-firestore/pyproject.toml
@@ -27,12 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-index-store-firestore"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 llama-index-core = "^0.10.1"
-llama-index-storage-kvstore-firestore = "^0.1.1"
+llama-index-storage-kvstore-firestore = ">=0.1.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-firestore/tests/BUILD
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-firestore/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints=["==3.9.*", "==3.10.*"],
+)

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/llama_index/storage/kvstore/firestore/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/llama_index/storage/kvstore/firestore/base.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 
+from google.auth.credentials import Credentials
 from google.cloud.firestore_v1.async_client import AsyncClient
 from google.cloud.firestore_v1.client import Client
 from google.cloud.firestore_v1.services.firestore.transports.base import (
@@ -27,19 +28,31 @@ class FirestoreKVStore(BaseKVStore):
     Args:
         project (str): The project which the client acts on behalf of.
         database (str): The database name that the client targets.
+        credentials (google.auth.credentials.Credentials): The OAuth2
+            Credentials to access Firestore. If not passed, falls back
+            to the default inferred from the environment.
     """
 
     def __init__(
         self,
         project: Optional[str] = None,
         database: str = DEFAULT_FIRESTORE_DATABASE,
+        credentials: Optional[Credentials] = None,
     ) -> None:
         client_info = DEFAULT_CLIENT_INFO
         client_info.user_agent = USER_AGENT
         self._adb = AsyncClient(
-            project=project, database=database, client_info=client_info
+            project=project,
+            database=database,
+            client_info=client_info,
+            credentials=credentials,
         )
-        self._db = Client(project=project, database=database, client_info=client_info)
+        self._db = Client(
+            project=project,
+            database=database,
+            client_info=client_info,
+            credentials=credentials,
+        )
 
     def firestore_collection(self, collection: str) -> str:
         return collection.replace("/", SLASH_REPLACEMENT)

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 version = "0.2.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 llama-index-core = "^0.10.1"
 google-cloud-firestore = "^2.14.0"
 

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-kvstore-firestore"
 readme = "README.md"
-version = "0.1.2"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/tests/BUILD
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-firestore/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints=["==3.9.*", "==3.10.*"],
+)


### PR DESCRIPTION
# Description

Allow passing custom `google.auth.credentials.Credentials` to `FirestoreKVStore` in a backwards compatible way.

Fixes #13016 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
