### PR TITLE
typo fix: Amend addtional_kwargs to additional_kwargs

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/generic_utils.py
+++ b/llama-index-core/llama_index/core/base/llms/generic_utils.py
@@ -21,9 +21,9 @@ def messages_to_history_str(messages: Sequence[ChatMessage]) -> str:
         content = message.content
         string_message = f"{role.value}: {content}"
 
-        addtional_kwargs = message.additional_kwargs
-        if addtional_kwargs:
-            string_message += f"\n{addtional_kwargs}"
+        additional_kwargs = message.additional_kwargs
+        if additional_kwargs:
+            string_message += f"\n{additional_kwargs}"
         string_messages.append(string_message)
     return "\n".join(string_messages)
 
@@ -36,9 +36,9 @@ def messages_to_prompt(messages: Sequence[ChatMessage]) -> str:
         content = message.content
         string_message = f"{role.value}: {content}"
 
-        addtional_kwargs = message.additional_kwargs
-        if addtional_kwargs:
-            string_message += f"\n{addtional_kwargs}"
+        additional_kwargs = message.additional_kwargs
+        if additional_kwargs:
+            string_message += f"\n{additional_kwargs}"
         string_messages.append(string_message)
 
     string_messages.append(f"{MessageRole.ASSISTANT.value}: ")

--- a/llama-index-integrations/llms/llama-index-llms-llamafile/llama_index/llms/llamafile/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-llamafile/llama_index/llms/llamafile/base.py
@@ -20,7 +20,7 @@ from llama_index.core.llms.custom import CustomLLM
 DEFAULT_REQUEST_TIMEOUT = 30.0
 
 
-def get_addtional_kwargs(
+def get_additional_kwargs(
     response: Dict[str, Any], exclude: Tuple[str, ...]
 ) -> Dict[str, Any]:
     return {k: v for k, v in response.items() if k not in exclude}
@@ -123,12 +123,12 @@ class Llamafile(CustomLLM):
                 message=ChatMessage(
                     content=message.get("content"),
                     role=MessageRole(message.get("role")),
-                    additional_kwargs=get_addtional_kwargs(
+                    additional_kwargs=get_additional_kwargs(
                         message, ("content", "role")
                     ),
                 ),
                 raw=raw,
-                additional_kwargs=get_addtional_kwargs(raw, ("choice",)),
+                additional_kwargs=get_additional_kwargs(raw, ("choice",)),
             )
 
     @llm_chat_callback()
@@ -181,13 +181,13 @@ class Llamafile(CustomLLM):
                                 message=ChatMessage(
                                     content=buff.getvalue(),
                                     role=MessageRole(role),
-                                    additional_kwargs=get_addtional_kwargs(
+                                    additional_kwargs=get_additional_kwargs(
                                         delta_message, ("content", "role")
                                     ),
                                 ),
                                 delta=delta_content,
                                 raw=chunk,
-                                additional_kwargs=get_addtional_kwargs(
+                                additional_kwargs=get_additional_kwargs(
                                     chunk, ("choices",)
                                 ),
                             )
@@ -217,7 +217,7 @@ class Llamafile(CustomLLM):
             return CompletionResponse(
                 text=text,
                 raw=raw,
-                additional_kwargs=get_addtional_kwargs(raw, ("response",)),
+                additional_kwargs=get_additional_kwargs(raw, ("response",)),
             )
 
     @llm_completion_callback()
@@ -252,7 +252,7 @@ class Llamafile(CustomLLM):
                                 delta=delta,
                                 text=buff.getvalue(),
                                 raw=chunk,
-                                additional_kwargs=get_addtional_kwargs(
+                                additional_kwargs=get_additional_kwargs(
                                     chunk, ("content",)
                                 ),
                             )


### PR DESCRIPTION
# Description

This PR fixes a few typos. 

Additional comments: I find that `get_additional_kwargs` has been defined twice, maybe it's better to define it as a utility?

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Typo fix (non-breaking change which fixes a few typos)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
