### PR TITLE
fix: qdrant sparse vector backwards compatibility

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -874,7 +874,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         return (
             self._collection_exists(collection_name)
             and SPARSE_VECTOR_NAME_OLD
-            in self.client.get_collection(collection_name).config.params.vectors
+            in self.client.get_collection(collection_name).config.params.sparse_vectors
         )
 
     def sparse_vector_name(self) -> str:
@@ -890,7 +890,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
             and SPARSE_VECTOR_NAME_OLD
             in (
                 await self._aclient.get_collection(collection_name)
-            ).config.params.vectors
+            ).config.params.sparse_vectors
         )
 
     async def asparse_vector_name(self) -> str:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-qdrant"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
# Description

Latest qdrant interface change broke backwards compatibility. 

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I ran `make format; make lint` to appease the lint gods
