### PR TITLE
fix(falkordb): skip the create index error when the index is already …

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
@@ -36,6 +36,7 @@ class FalkorDBGraphStore(GraphStore):
         try:
             self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
         except redis.ResponseError as e:
+            # TODO: to find an appropriate way to handle this issue.
             logger.warning("Create index failed: %s", e)
 
         self._database = database

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
@@ -34,19 +34,7 @@ class FalkorDBGraphStore(GraphStore):
         self._driver = FalkorDB.from_url(url).select_graph(database)
 
         try:
-            result_set = self._driver.query(
-                f"""
-                CYPHER lbl='{self._node_label}' prop='id'
-                CALL db.indexes() YIELD label, properties
-                WHERE label = $lbl AND $prop in properties
-                RETURN 1 AS index_exists
-                """
-            ).result_set
-            # TODO: this check may cause a race issue due to these two queries are not atomic.
-            if not (len(result_set) > 0 and result_set[0][0] == 1):
-                self._driver.query(
-                    f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)"
-                )
+            self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
         except redis.ResponseError as e:
             # TODO: to find an appropriate way to handle this issue.
             logger.warning("Create index failed: %s", e)

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
+import redis
 from falkordb import FalkorDB
 from llama_index.core.graph_stores.types import GraphStore
 
@@ -34,8 +35,8 @@ class FalkorDBGraphStore(GraphStore):
 
         try:
             self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
-        except Exception as e:
-            logger.warning("Create index failed: %s", str(e))
+        except redis.ResponseError as e:
+            logger.warning("Create index failed: %s", e)
 
         self._database = database
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
@@ -31,7 +31,11 @@ class FalkorDBGraphStore(GraphStore):
         self._node_label = node_label
 
         self._driver = FalkorDB.from_url(url).select_graph(database)
-        self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
+
+        try:
+            self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
+        except Exception as e:
+            logger.warning("Create index failed: %s", str(e))
 
         self._database = database
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-falkordb"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-legacy/llama_index/legacy/graph_stores/falkordb.py
+++ b/llama-index-legacy/llama_index/legacy/graph_stores/falkordb.py
@@ -35,11 +35,7 @@ class FalkorDBGraphStore(GraphStore):
         self._node_label = node_label
 
         self._driver = redis.Redis.from_url(url).graph(database)
-
-        try:
-            self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
-        except Exception as e:
-            logger.warning("Create index failed: %s", str(e))
+        self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
 
         self._database = database
 

--- a/llama-index-legacy/llama_index/legacy/graph_stores/falkordb.py
+++ b/llama-index-legacy/llama_index/legacy/graph_stores/falkordb.py
@@ -35,7 +35,11 @@ class FalkorDBGraphStore(GraphStore):
         self._node_label = node_label
 
         self._driver = redis.Redis.from_url(url).graph(database)
-        self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
+
+        try:
+            self._driver.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
+        except Exception as e:
+            logger.warning("Create index failed: %s", str(e))
 
         self._database = database
 


### PR DESCRIPTION
…existing

# Description

I initialized a graph store with the falkordb. When I restart my application with the same store, I'll get an error due to the falkor index is already existing. I haven't found a better way to handle it, just use try/except to skip it, that works fine for me. 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
