### PR TITLE
Corrected wrong output type for `OutputKeys.from_keys()`

### DIFF
--- a/llama-index-core/llama_index/core/base/query_pipeline/query.py
+++ b/llama-index-core/llama_index/core/base/query_pipeline/query.py
@@ -107,7 +107,7 @@ class OutputKeys(BaseModel):
     def from_keys(
         cls,
         required_keys: Set[str],
-    ) -> "OutputKeys":
+    ) -> "InputKeys":
         """Create InputKeys from tuple."""
         return cls(required_keys=required_keys)
 

--- a/llama-index-core/llama_index/core/base/query_pipeline/query.py
+++ b/llama-index-core/llama_index/core/base/query_pipeline/query.py
@@ -108,7 +108,7 @@ class OutputKeys(BaseModel):
         cls,
         required_keys: Set[str],
     ) -> "OutputKeys":
-        """Create InputKeys from tuple."""
+        """Create OutputKeys from tuple."""
         return cls(required_keys=required_keys)
 
     def validate(self, input_keys: Set[str]) -> None:

--- a/llama-index-core/llama_index/core/base/query_pipeline/query.py
+++ b/llama-index-core/llama_index/core/base/query_pipeline/query.py
@@ -107,7 +107,7 @@ class OutputKeys(BaseModel):
     def from_keys(
         cls,
         required_keys: Set[str],
-    ) -> "InputKeys":
+    ) -> "OutputKeys":
         """Create InputKeys from tuple."""
         return cls(required_keys=required_keys)
 

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -43,7 +43,7 @@ name = "llama-index-core"
 packages = [{include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.10.31"
+version = "0.10.32"
 
 [tool.poetry.dependencies]
 SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -43,7 +43,7 @@ name = "llama-index-core"
 packages = [{include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.10.32"
+version = "0.10.31"
 
 [tool.poetry.dependencies]
 SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}


### PR DESCRIPTION
# Description

`OutputKeys.from_keys()` has an output type hint of "InputKeys" when it should be "OutputKeys".  Corrected that.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I reran the tests for core to confirm no errors.

- [x] I stared at the code and made sure it makes sense.  


## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
