### PR TITLE
add matching source_node.node_id verification

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -99,11 +99,17 @@ class NodeParser(TransformComponent, ABC):
                         )
 
                 if self.include_prev_next_rel:
-                    if i > 0:
+                    if (
+                        i > 0
+                        and nodes[i - 1].source_node.node_id == node.source_node.node_id
+                    ):
                         node.relationships[NodeRelationship.PREVIOUS] = nodes[
                             i - 1
                         ].as_related_node_info()
-                    if i < len(nodes) - 1:
+                    if (
+                        i < len(nodes) - 1
+                        and nodes[i + 1].source_node.node_id == node.source_node.node_id
+                    ):
                         node.relationships[NodeRelationship.NEXT] = nodes[
                             i + 1
                         ].as_related_node_info()

--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -99,8 +99,11 @@ class NodeParser(TransformComponent, ABC):
                         )
 
                 if self.include_prev_next_rel:
+                    # establish prev/next relationships if nodes share the same source_node
                     if (
                         i > 0
+                        and node.source_node
+                        and nodes[i - 1].source_node
                         and nodes[i - 1].source_node.node_id == node.source_node.node_id
                     ):
                         node.relationships[NodeRelationship.PREVIOUS] = nodes[
@@ -108,6 +111,8 @@ class NodeParser(TransformComponent, ABC):
                         ].as_related_node_info()
                     if (
                         i < len(nodes) - 1
+                        and node.source_node
+                        and nodes[i + 1].source_node
                         and nodes[i + 1].source_node.node_id == node.source_node.node_id
                     ):
                         node.relationships[NodeRelationship.NEXT] = nodes[


### PR DESCRIPTION
# Description

Update `NodeParser.get_nodes_from_documents` to verify that previous and next nodes share the same source node as the current node before defining `prev_node` and `next_node` relationships. 

See issue linked below for more context.

Fixes # (issue)
https://github.com/run-llama/llama_index/issues/13095

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

This was a very minor change and I didn't see a test that specifically covered the method I modified. Existing tests passed. 

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
