### PR TITLE
Fix for fusion retriever sometime return Nonetype query(s) before similarity search.

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -89,6 +89,7 @@ class QueryFusionRetriever(BaseRetriever):
         response = self._llm.complete(prompt_str)
 
         # assume LLM proper put each query on a newline
+        # strip and regrex each query with bullet point to avoid empty query
         raw_queries = response.text.split("\n")
         queries = []
         for query in raw_queries:

--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -89,8 +89,8 @@ class QueryFusionRetriever(BaseRetriever):
         response = self._llm.complete(prompt_str)
 
         # assume LLM proper put each query on a newline
-        # strip and regrex each query with bullet point to avoid empty query
         raw_queries = response.text.split("\n")
+        # Use strip and regex to split the query based on numbering points to avoid empty query(s).
         queries = []
         for query in raw_queries:
             query = [q.strip() for q in re.split(r"\d+\.", query) if q.strip()]
@@ -105,8 +105,7 @@ class QueryFusionRetriever(BaseRetriever):
     def _reciprocal_rerank_fusion(
         self, results: Dict[Tuple[str, int], List[NodeWithScore]]
     ) -> List[NodeWithScore]:
-        """
-        Apply reciprocal rank fusion.
+        """Apply reciprocal rank fusion.
 
         The original paper uses k=60 for best results:
         https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf

--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 from enum import Enum
 from typing import Dict, List, Optional, Tuple, cast
 
@@ -89,12 +88,8 @@ class QueryFusionRetriever(BaseRetriever):
         response = self._llm.complete(prompt_str)
 
         # assume LLM proper put each query on a newline
-        raw_queries = response.text.split("\n")
-        # Use strip and regex to split the query based on numbering points to avoid empty query(s).
-        queries = []
-        for query in raw_queries:
-            query = [q.strip() for q in re.split(r"\d+\.", query) if q.strip()]
-            queries.extend(query)
+        queries = response.text.split("\n")
+        queries = [q.strip() for q in queries if q.strip()]
         if self._verbose:
             queries_str = "\n".join(queries)
             print(f"Generated queries:\n{queries_str}")
@@ -105,7 +100,8 @@ class QueryFusionRetriever(BaseRetriever):
     def _reciprocal_rerank_fusion(
         self, results: Dict[Tuple[str, int], List[NodeWithScore]]
     ) -> List[NodeWithScore]:
-        """Apply reciprocal rank fusion.
+        """
+        Apply reciprocal rank fusion.
 
         The original paper uses k=60 for best results:
         https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf

--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from enum import Enum
 from typing import Dict, List, Optional, Tuple, cast
 
@@ -88,7 +89,11 @@ class QueryFusionRetriever(BaseRetriever):
         response = self._llm.complete(prompt_str)
 
         # assume LLM proper put each query on a newline
-        queries = response.text.split("\n")
+        raw_queries = response.text.split("\n")
+        queries = []
+        for query in raw_queries:
+            query = [q.strip() for q in re.split(r"\d+\.", query) if q.strip()]
+            queries.extend(query)
         if self._verbose:
             queries_str = "\n".join(queries)
             print(f"Generated queries:\n{queries_str}")
@@ -99,7 +104,8 @@ class QueryFusionRetriever(BaseRetriever):
     def _reciprocal_rerank_fusion(
         self, results: Dict[Tuple[str, int], List[NodeWithScore]]
     ) -> List[NodeWithScore]:
-        """Apply reciprocal rank fusion.
+        """
+        Apply reciprocal rank fusion.
 
         The original paper uses k=60 for best results:
         https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
