### PR TITLE
Update llama-index-vector-stores-lantern's index method to 'lantern_hnsw' to maintain compatibility with latest Lantern builds

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
@@ -112,7 +112,7 @@ def get_data_model(
     Index(
         hnsw_indexname,
         model.embedding,  # type: ignore
-        postgresql_using="hnsw",
+        postgresql_using="lantern_hnsw",
         postgresql_with={
             "m": m,
             "ef_construction": ef_construction,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-lantern"
 readme = "README.md"
-version = "0.1.2"
+version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/tests/test_lantern.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/tests/test_lantern.py
@@ -1,0 +1,151 @@
+import asyncio
+from typing import Any, Dict, Generator, List, Union
+
+import pytest
+from llama_index.core.schema import (
+    BaseNode,
+    IndexNode,
+    TextNode,
+)
+from llama_index.core.vector_stores.types import (
+    VectorStoreQuery,
+)
+from llama_index.vector_stores.lantern import LanternVectorStore
+
+# for testing find install info here https://github.com/lanterndata/lantern#-quick-install
+
+
+PARAMS: Dict[str, Union[str, int]] = {
+    "host": "localhost",
+    "user": "postgres",
+    "password": "mark90",
+    "port": 5432,
+}
+TEST_DB = "test_vector_db"
+TEST_TABLE_NAME = "lorem_ipsum"
+TEST_SCHEMA_NAME = "test"
+TEST_EMBED_DIM = 3
+
+try:
+    import asyncpg  # noqa
+    import pgvector  # noqa
+    import psycopg2
+    import sqlalchemy
+    import sqlalchemy.ext.asyncio  # noqa
+
+    # connection check
+    conn__ = psycopg2.connect(**PARAMS)  # type: ignore
+    conn__.close()
+
+    postgres_not_available = False
+except (ImportError, Exception):
+    postgres_not_available = True
+
+
+def _get_sample_vector(num: float) -> List[float]:
+    """
+    Get sample embedding vector of the form [num, 1, 1, ..., 1]
+    where the length of the vector is TEST_EMBED_DIM.
+    """
+    return [num] + [1.0] * (TEST_EMBED_DIM - 1)
+
+
+@pytest.fixture(scope="session")
+def conn() -> Any:
+    import psycopg2
+
+    return psycopg2.connect(**PARAMS)  # type: ignore
+
+
+@pytest.fixture()
+def db(conn: Any) -> Generator:
+    conn.autocommit = True
+
+    with conn.cursor() as c:
+        c.execute(f"DROP DATABASE IF EXISTS {TEST_DB}")
+        c.execute(f"CREATE DATABASE {TEST_DB}")
+        conn.commit()
+    yield
+    with conn.cursor() as c:
+        c.execute(f"DROP DATABASE {TEST_DB}")
+        conn.commit()
+
+
+@pytest.fixture()
+def lantern(db: None) -> Any:
+    lantern_db = LanternVectorStore.from_params(
+        **PARAMS,  # type: ignore
+        database=TEST_DB,
+        table_name=TEST_TABLE_NAME,
+        schema_name=TEST_SCHEMA_NAME,
+        embed_dim=TEST_EMBED_DIM,
+    )
+
+    yield lantern_db
+
+    asyncio.run(lantern_db.close())
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+async def test_instance_creation(db: None) -> None:
+    lantern_db = LanternVectorStore.from_params(
+        **PARAMS,  # type: ignore
+        database=TEST_DB,
+        table_name=TEST_TABLE_NAME,
+        schema_name=TEST_SCHEMA_NAME,
+    )
+    assert isinstance(lantern_db, LanternVectorStore)
+    assert not hasattr(lantern_db, "_engine")
+    assert lantern_db.client is None
+    await lantern_db.close()
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_add_to_db_and_query(
+    lantern_db: LanternVectorStore, node_embeddings: List[TextNode], use_async: bool
+) -> None:
+    if use_async:
+        await lantern_db.async_add(node_embeddings)
+    else:
+        lantern_db.add(node_embeddings)
+    assert isinstance(lantern_db, LanternVectorStore)
+    assert hasattr(lantern_db, "_engine")
+    q = VectorStoreQuery(query_embedding=_get_sample_vector(1.0), similarity_top_k=1)
+    if use_async:
+        res = await lantern_db.aquery(q)
+    else:
+        res = lantern_db.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 1
+    assert res.nodes[0].node_id == "aaa"
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_add_to_db_and_query_index_nodes(
+    lantern_db: LanternVectorStore,
+    index_node_embeddings: List[BaseNode],
+    use_async: bool,
+) -> None:
+    if use_async:
+        await lantern_db.async_add(index_node_embeddings)
+    else:
+        lantern_db.add(index_node_embeddings)
+    assert isinstance(lantern_db, LanternVectorStore)
+    assert hasattr(lantern_db, "_engine")
+    q = VectorStoreQuery(query_embedding=_get_sample_vector(5.0), similarity_top_k=2)
+    if use_async:
+        res = await lantern_db.aquery(q)
+    else:
+        res = lantern_db.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 2
+    assert res.nodes[0].node_id == "aaa_ref"
+    assert isinstance(res.nodes[0], IndexNode)
+    assert hasattr(res.nodes[0], "index_id")
+    assert res.nodes[1].node_id == "bbb"
+    assert isinstance(res.nodes[1], TextNode)


### PR DESCRIPTION
# Description:
Updates `llama-index-vector-stores-lantern` integration's  index method / postgres access_method from `hnsw` to  `lantern_hnsw`, this change is needed due to LanternDB [removing support for 'hnsw' in early February 2024](https://github.com/lanterndata/lantern/commit/c3005aacd9c20df0eaf67fb9b5e1c97711c02518).  

The current version of llama_index is only compatible with Lantern's 
They've also just [updated their docs with the change](https://github.com/lanterndata/docs/pull/12).

## Why?

Due to LanternDB now expecting `lantern_hnsw`, the current version of `llama-index-vector-stores-lantern` is only compatible with LanternDB builds up to v0.1.1  (while the latest Lantern build is now at [0.2.4](https://hub.docker.com/r/lanterndata/lantern/tags))

#### This PR fixes https://github.com/run-llama/llama_index/issues/13115.

<br> 

### New Package?
Not applicable

## Version Bump?
Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
- [X] Yes

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

*Note - this PR seems be classified as `size:L` due to the addition of tests.  However I only changed 1 line of core module code.*

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [X] Added new unit/integration tests 
- [X] I stared at the code and made sure it makes sense

#### Testing:
- I attempted to import my fork of the repo into my own vector-db project that uses Lantern to test that my change works with the lantern_hnsw index method expected by the latest build of LanternDB. (by importing repo into my requirments.txt file)
  - Unfortunately,  I was unable to figure out how to ensure my local fork of llama_index was being used specifically for the 'llama-index-vector-stores-lantern' python module. 
  - I was able to import my fork as `-e git+https://github.com/nataliachodelski/llama_index.git#egg=llama-index` but this doesn't seem to update the code being used for the `llama-index-vector-stores-lantern` module. 
  - I also tried as `-e git+https://github.com/nataliachodelski/llama_index.git#egg=llama-index-vector-stores-lantern` but this resulted in an error. 
  
- I also added some unit tests for `llama-index-vector-stores-lantern`, as I noticed there were none.  
  - I wasn't sure how to run these in the llama_index project with an active connection to postgres, so some of the tests I added were skipped when run locally (my project is running in a kubernetes cluster, and without being able to import my repo into my project in a usable way, I don't know how to run it against the postgres database within our kubernetes cluster) 
  -  If the tests are run with a postgres connection to a database running the latest Lantern, I believe they should reveal if the `hnsw` error if still present, as I added 2 unit tests that insert nodes into the database

## Suggested Checklist:
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] _I have attempted added tests_ that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
