### PR TITLE
Bedrock cohere character limit

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -396,9 +396,11 @@ class BedrockEmbedding(BaseEmbedding):
                 "text": "search_document",
                 "query": "search_query",
             }
+            payload = [payload] if isinstance(payload, str) else payload
+            payload = [p[:2048] if len(p) > 2048 else p for p in payload]
             request_body = json.dumps(
                 {
-                    "texts": [payload] if isinstance(payload, str) else payload,
+                    "texts": payload,
                     "input_type": input_types[input_type],
                     "truncate": "NONE",
                 }


### PR DESCRIPTION
# Description
Issue #12592 is related to the usage of Bedrock Cohere Embedding models. Setting a chunk_size < 512 doesn't prevent to have nodes with char count > 2048. This pull request adds a check to the request's payload, cutting the end part of the text to embed.

Fixes #12592 

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested this implementation for my company's project. This bug arises when we try to embed a node with a token count < 512 (token size limit for cohere embedding models) and characters count > 2048 (char size limit for Bedrock cohere embedding model).
You can double-check at https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed.html