### PR TITLE
fix doc:RssReader import path error

### DIFF
--- a/docs/docs/examples/data_connectors/WebPageDemo.ipynb
+++ b/docs/docs/examples/data_connectors/WebPageDemo.ipynb
@@ -375,7 +375,7 @@
    "outputs": [],
    "source": [
     "from llama_index.core import SummaryIndex\n",
-    "from llama_index.readers.web import RssReader\n",
+    "from llama_index.legacy.readers import RssReader\n",
     "\n",
     "documents = RssReader().load_data(\n",
     "    [\"https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml\"]\n",


### PR DESCRIPTION
# Description
i use the class RssReader when i use old llama_index 
now my code  change to  use the new llama_index, RssReader path error 
when i read the document i find the example error (https://docs.llamaindex.ai/en/stable/examples/data_connectors/WebPageDemo/?h=rssrea#using-rssreader)
so i 
Fix the import path in docs/examples/data_connectors/WebPageDemo.ipynb

Fixes https://github.com/run-llama/llama_index/issues/10274




## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

 - [ ] I stared at the code and made sure it makes sense


## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ]  My changes generate no new warnings

