### PR TITLE
Update advanced_retrieval.md - fix link for reranking example notebook

### DIFF
--- a/docs/docs/optimizing/advanced_retrieval/advanced_retrieval.md
+++ b/docs/docs/optimizing/advanced_retrieval/advanced_retrieval.md
@@ -4,7 +4,7 @@
 
 There are a variety of more advanced retrieval strategies you may wish to try, each with different benefits:
 
-- {ref}`Reranking <cohere_rerank>`
+- [Reranking](../../examples/node_postprocessor/CohereRerank.ipynb)
 - [Recursive retrieval](../../examples/query_engine/pdf_tables/recursive_retriever.ipynb)
 - [Embedded tables](../../examples/query_engine/sec_tables/tesla_10q_table.ipynb)
 - [Small-to-big retrieval](../../examples/node_postprocessor/MetadataReplacementDemo.ipynb)


### PR DESCRIPTION
# Description

Fixed the missing link for reranking example in advanced retrieval docs.

Fixes # (issue)

## New Package?

N/A

## Version Bump?

N/A

## Type of Change

Please delete options that are not relevant.

- [ ] Documentation update


## How Has This Been Tested?

N/A

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
