### PR TITLE
Fix: Error when parse file using SimpleFileNodeParser and file's extension doesn't in FILE_NODE_PARSERS

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/simple_file.py
+++ b/llama-index-core/llama_index/core/node_parser/file/simple_file.py
@@ -66,7 +66,7 @@ class SimpleFileNodeParser(NodeParser):
         )
 
         for document in documents_with_progress:
-            ext = document.metadata["extension"]
+            ext = document.metadata.get("extension", "None")
             if ext in FILE_NODE_PARSERS:
                 parser = FILE_NODE_PARSERS[ext](
                     include_metadata=self.include_metadata,

--- a/llama-index-core/llama_index/core/node_parser/file/simple_file.py
+++ b/llama-index-core/llama_index/core/node_parser/file/simple_file.py
@@ -9,7 +9,6 @@ from llama_index.core.node_parser.file.markdown import MarkdownNodeParser
 from llama_index.core.node_parser.interface import NodeParser
 from llama_index.core.schema import BaseNode, MetadataMode
 from llama_index.core.utils import get_tqdm_iterable
-from llama_index.core.schema import TextNode
 
 FILE_NODE_PARSERS: Dict[str, Type[NodeParser]] = {
     ".md": MarkdownNodeParser,
@@ -82,11 +81,9 @@ class SimpleFileNodeParser(NodeParser):
                 all_nodes.extend(
                     # build node from document
                     build_nodes_from_splits(
-                        [
-                            document.get_content(metadata_mode=MetadataMode.NONE)
-                        ],
+                        [document.get_content(metadata_mode=MetadataMode.NONE)],
                         document,
-                        id_func=self.id_func
+                        id_func=self.id_func,
                     )
                 )
 

--- a/llama-index-core/tests/node_parser/test_file.py
+++ b/llama-index-core/tests/node_parser/test_file.py
@@ -1,8 +1,8 @@
-from llama_index.core.node_parser.file.markdown import MarkdownNodeParser
 from llama_index.core.schema import Document
 from llama_index.core.node_parser import (
     SimpleFileNodeParser,
 )
+
 
 def test_unsupported_extension() -> None:
     simple_file_node_parser = SimpleFileNodeParser()
@@ -11,7 +11,7 @@ def test_unsupported_extension() -> None:
         [
             Document(
                 text="""def evenOdd(n):
- 
+
   # if n&1 == 0, then num is even
   if n & 1:
     return False
@@ -23,4 +23,7 @@ def test_unsupported_extension() -> None:
     )
     assert len(nodes) == 1
     assert nodes[0].metadata == {"Header_1": "Main Header"}
-    assert nodes[0].text == "def evenOdd(n):\n \n  # if n&1 == 0, then num is even\n  if n & 1:\n    return False\n  # if n&1 == 1, then num is odd\n  else:\n    return True"
+    assert (
+        nodes[0].text
+        == "def evenOdd(n):\n\n  # if n&1 == 0, then num is even\n  if n & 1:\n    return False\n  # if n&1 == 1, then num is odd\n  else:\n    return True"
+    )

--- a/llama-index-core/tests/node_parser/test_file.py
+++ b/llama-index-core/tests/node_parser/test_file.py
@@ -22,7 +22,6 @@ def test_unsupported_extension() -> None:
         ]
     )
     assert len(nodes) == 1
-    assert nodes[0].metadata == {"Header_1": "Main Header"}
     assert (
         nodes[0].text
         == "def evenOdd(n):\n\n  # if n&1 == 0, then num is even\n  if n & 1:\n    return False\n  # if n&1 == 1, then num is odd\n  else:\n    return True"


### PR DESCRIPTION
# Description

This PR is a patch for issue #13152 .
The problem is currently, if file extension is unsupported. It will add document to list of nodes that make code crash

Fixes # (issue)
https://github.com/run-llama/llama_index/issues/13152

## New Package?

N/A

## Version Bump?

N/A

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
