### PR TITLE
feat: add encoding_type parameters in JinaEmbedding class

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-jinaai/llama_index/embeddings/jinaai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-jinaai/llama_index/embeddings/jinaai/base.py
@@ -16,6 +16,9 @@ MAX_BATCH_SIZE = 2048
 API_URL = "https://api.jina.ai/v1/embeddings"
 
 
+VALID_ENCODING = ['float', 'ubinary', 'binary']
+
+
 class JinaEmbedding(BaseEmbedding):
     """JinaAI class for embeddings.
 
@@ -38,6 +41,8 @@ class JinaEmbedding(BaseEmbedding):
         embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
         api_key: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
+        encoding_queries: Optional[str] = None,
+        encoding_documents: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -47,6 +52,16 @@ class JinaEmbedding(BaseEmbedding):
             api_key=api_key,
             **kwargs,
         )
+        self._encoding_queries = encoding_queries or 'float'
+        self._encoding_documents = encoding_documents or 'float'
+
+        assert (
+            self._encoding_documents in VALID_ENCODING
+        ), f'Encoding Documents parameter {self._encoding_documents} not supported. Please choose one of {VALID_ENCODING}'
+        assert (
+            self._encoding_queries in VALID_ENCODING
+        ), f'Encoding Queries parameter {self._encoding_documents} not supported. Please choose one of {VALID_ENCODING}'
+
         self.api_key = get_from_param_or_env("api_key", api_key, "JINAAI_API_KEY", "")
         self.model = model
         self._session = requests.Session()
@@ -60,26 +75,38 @@ class JinaEmbedding(BaseEmbedding):
 
     def _get_query_embedding(self, query: str) -> List[float]:
         """Get query embedding."""
-        return self._get_text_embedding(query)
+        return self._get_text_embeddings([query], encoding_type=self._encoding_queries)[
+            0
+        ]
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
         """The asynchronous version of _get_query_embedding."""
-        return await self._aget_text_embedding(query)
+        result = await self._aget_text_embeddings(
+            [query], encoding_type=self._encoding_queries
+        )
+        return result[0]
 
     def _get_text_embedding(self, text: str) -> List[float]:
         """Get text embedding."""
-        return self._get_text_embeddings([text])[0]
+        return self._get_text_embeddings(
+            [text], encoding_type=self._encoding_documents
+        )[0]
 
     async def _aget_text_embedding(self, text: str) -> List[float]:
         """Asynchronously get text embedding."""
-        result = await self._aget_text_embeddings([text])
+        result = await self._aget_text_embeddings(
+            [text], encoding_type=self._encoding_documents
+        )
         return result[0]
 
-    def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+    def _get_text_embeddings(
+        self, texts: List[str], encoding_type: str = 'float'
+    ) -> List[List[float]]:
         """Get text embeddings."""
         # Call Jina AI Embedding API
         resp = self._session.post(  # type: ignore
-            API_URL, json={"input": texts, "model": self.model}
+            API_URL,
+            json={"input": texts, "model": self.model, "encoding_type": encoding_type},
         ).json()
         if "data" not in resp:
             raise RuntimeError(resp["detail"])
@@ -92,7 +119,9 @@ class JinaEmbedding(BaseEmbedding):
         # Return just the embeddings
         return [result["embedding"] for result in sorted_embeddings]
 
-    async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+    async def _aget_text_embeddings(
+        self, texts: List[str], encoding_type: str = 'float'
+    ) -> List[List[float]]:
         """Asynchronously get text embeddings."""
         import aiohttp
 
@@ -103,7 +132,11 @@ class JinaEmbedding(BaseEmbedding):
             }
             async with session.post(
                 f"{API_URL}",
-                json={"input": texts, "model": self.model},
+                json={
+                    "input": texts,
+                    "model": self.model,
+                    "encoding_type": encoding_type,
+                },
                 headers=headers,
             ) as response:
                 resp = await response.json()

--- a/llama-index-integrations/embeddings/llama-index-embeddings-jinaai/llama_index/embeddings/jinaai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-jinaai/llama_index/embeddings/jinaai/base.py
@@ -17,7 +17,7 @@ MAX_BATCH_SIZE = 2048
 API_URL = "https://api.jina.ai/v1/embeddings"
 
 
-VALID_ENCODING = ['float', 'ubinary', 'binary']
+VALID_ENCODING = ["float", "ubinary", "binary"]
 
 
 class JinaEmbedding(BaseEmbedding):
@@ -55,15 +55,15 @@ class JinaEmbedding(BaseEmbedding):
             api_key=api_key,
             **kwargs,
         )
-        self._encoding_queries = encoding_queries or 'float'
-        self._encoding_documents = encoding_documents or 'float'
+        self._encoding_queries = encoding_queries or "float"
+        self._encoding_documents = encoding_documents or "float"
 
         assert (
             self._encoding_documents in VALID_ENCODING
-        ), f'Encoding Documents parameter {self._encoding_documents} not supported. Please choose one of {VALID_ENCODING}'
+        ), f"Encoding Documents parameter {self._encoding_documents} not supported. Please choose one of {VALID_ENCODING}"
         assert (
             self._encoding_queries in VALID_ENCODING
-        ), f'Encoding Queries parameter {self._encoding_documents} not supported. Please choose one of {VALID_ENCODING}'
+        ), f"Encoding Queries parameter {self._encoding_documents} not supported. Please choose one of {VALID_ENCODING}"
 
         self.api_key = get_from_param_or_env("api_key", api_key, "JINAAI_API_KEY", "")
         self.model = model
@@ -103,7 +103,7 @@ class JinaEmbedding(BaseEmbedding):
         return result[0]
 
     def _get_text_embeddings(
-        self, texts: List[str], encoding_type: str = 'float'
+        self, texts: List[str], encoding_type: str = "float"
     ) -> List[List[float]]:
         """Get text embeddings."""
         # Call Jina AI Embedding API
@@ -120,23 +120,22 @@ class JinaEmbedding(BaseEmbedding):
         sorted_embeddings = sorted(embeddings, key=lambda e: e["index"])  # type: ignore
 
         # Return just the embeddings
-        if encoding_type == 'float':
-            return [result["embedding"] for result in sorted_embeddings]
-        elif encoding_type == 'ubinary':
+        if encoding_type == "ubinary":
             return [
-                np.unpackbits(np.array(result["embedding"], dtype='uint8')).tolist()
+                np.unpackbits(np.array(result["embedding"], dtype="uint8")).tolist()
                 for result in sorted_embeddings
             ]
-        elif encoding_type == 'binary':
+        elif encoding_type == "binary":
             return [
                 np.unpackbits(
-                    (np.array(result["embedding"]) + 128).astype('uint8')
+                    (np.array(result["embedding"]) + 128).astype("uint8")
                 ).tolist()
                 for result in sorted_embeddings
             ]
+        return [result["embedding"] for result in sorted_embeddings]
 
     async def _aget_text_embeddings(
-        self, texts: List[str], encoding_type: str = 'float'
+        self, texts: List[str], encoding_type: str = "float"
     ) -> List[List[float]]:
         """Asynchronously get text embeddings."""
         import aiohttp
@@ -163,19 +162,18 @@ class JinaEmbedding(BaseEmbedding):
                 sorted_embeddings = sorted(embeddings, key=lambda e: e["index"])  # type: ignore
 
                 # Return just the embeddings
-                if encoding_type == 'float':
-                    return [result["embedding"] for result in sorted_embeddings]
-                elif encoding_type == 'ubinary':
+                if encoding_type == "ubinary":
                     return [
                         np.unpackbits(
-                            np.array(result["embedding"], dtype='uint8')
+                            np.array(result["embedding"], dtype="uint8")
                         ).tolist()
                         for result in sorted_embeddings
                     ]
-                elif encoding_type == 'binary':
+                elif encoding_type == "binary":
                     return [
                         np.unpackbits(
-                            (np.array(result["embedding"]) + 128).astype('uint8')
+                            (np.array(result["embedding"]) + 128).astype("uint8")
                         ).tolist()
                         for result in sorted_embeddings
                     ]
+                return [result["embedding"] for result in sorted_embeddings]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-jinaai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-jinaai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-jinaai"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Add `encoding_type` parameters to Jina Embedding class to allow user to get `quantized` embeddings.
