### PR TITLE
update github reader docs

### DIFF
--- a/docs/docs/examples/data_connectors/GithubRepositoryReaderDemo.ipynb
+++ b/docs/docs/examples/data_connectors/GithubRepositoryReaderDemo.ipynb
@@ -51,7 +51,6 @@
     "# This is due to the fact that we use asyncio.loop_until_complete in\n",
     "# the DiscordReader. Since the Jupyter kernel itself runs on\n",
     "# an event loop, we need to add some help with nesting\n",
-    "!pip install nest_asyncio httpx\n",
     "import nest_asyncio\n",
     "\n",
     "nest_asyncio.apply()"
@@ -61,11 +60,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"
+     ]
+    }
+   ],
    "source": [
     "%env OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n",
     "from llama_index.core import VectorStoreIndex\n",
-    "from llama_index.readers.github import GithubRepositoryReader\n",
+    "from llama_index.readers.github import GithubRepositoryReader, GithubClient\n",
     "from IPython.display import Markdown, display\n",
     "import os"
    ]
@@ -82,13 +89,31 @@
     "repo = \"llama_index\"\n",
     "branch = \"main\"\n",
     "\n",
+    "github_client = GithubClient(github_token=github_token, verbose=True)\n",
+    "\n",
     "documents = GithubRepositoryReader(\n",
-    "    github_token=github_token,\n",
+    "    github_client=github_client,\n",
     "    owner=owner,\n",
     "    repo=repo,\n",
     "    use_parser=False,\n",
     "    verbose=False,\n",
-    "    ignore_directories=[\"examples\"],\n",
+    "    filter_directories=(\n",
+    "        [\"docs\"],\n",
+    "        GithubRepositoryReader.FilterType.INCLUDE,\n",
+    "    ),\n",
+    "    filter_file_extensions=(\n",
+    "        [\n",
+    "            \".png\",\n",
+    "            \".jpg\",\n",
+    "            \".jpeg\",\n",
+    "            \".gif\",\n",
+    "            \".svg\",\n",
+    "            \".ico\",\n",
+    "            \"json\",\n",
+    "            \".ipynb\",\n",
+    "        ],\n",
+    "        GithubRepositoryReader.FilterType.EXCLUDE,\n",
+    "    ),\n",
     ").load_data(branch=branch)"
    ]
   },
@@ -107,10 +132,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import time\n",
-    "# for document in documents:\n",
-    "#     print(document.metadata)\n",
-    "#     time.sleep(.25)\n",
     "query_engine = index.as_query_engine()\n",
     "response = query_engine.query(\n",
     "    \"What is the difference between VectorStoreIndex and SummaryIndex?\",\n",

--- a/llama-index-integrations/readers/llama-index-readers-github/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-github/README.md
@@ -1,1 +1,93 @@
 # LlamaIndex Readers Integration: Github
+
+`pip install llama-index-readers-github`
+
+The github readers package consists of three separate readers:
+
+1. Repository Reader
+2. Issues Reader
+3. Collaborators Reader
+
+All three readers will require a personal access token (which you can generate under your account settings).
+
+## Repository Reader
+
+This reader will read through a repo, with options to specifically filter directories and file extensions.
+
+```python
+from llama_index.readers.github import GithubRepositoryReader, GithubClient
+
+client = github_client = GithubClient(github_token=github_token, verbose=False)
+
+reader = GithubRepositoryReader(
+    github_client=github_client,
+    owner="run-llama",
+    repo="llama_index",
+    use_parser=False,
+    verbose=True,
+    filter_directories=(
+        ["docs"],
+        GithubRepositoryReader.FilterType.INCLUDE,
+    ),
+    filter_file_extensions=(
+        [
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".svg",
+            ".ico",
+            "json",
+            ".ipynb",
+        ],
+        GithubRepositoryReader.FilterType.EXCLUDE,
+    ),
+)
+
+documents = reader.load_data(branch="main")
+```
+
+## Issues Reader
+
+```python
+from llama_index.readers.github import (
+    GitHubRepositoryIssuesReader,
+    GitHubIssuesClient,
+)
+
+github_client = GitHubIssuesClient(github_token=github_token, verbose=True)
+
+reader = GitHubRepositoryIssuesReader(
+    github_client=github_client,
+    owner="moncho",
+    repo="dry",
+    verbose=True,
+)
+
+documents = reader.load_data(
+    state=GitHubRepositoryIssuesReader.IssueState.ALL,
+    labelFilters=[("bug", GitHubRepositoryIssuesReader.FilterType.INCLUDE)],
+)
+```
+
+## Collaborators Reader
+
+```python
+from llama_index.readers.github import (
+    GitHubRepositoryCollaboratorsReader,
+    GitHubCollaboratorsClient,
+)
+
+github_client = GitHubCollaboratorsClient(
+    github_token=github_token, verbose=True
+)
+
+reader = GitHubRepositoryCollaboratorsReader(
+    github_client=github_client,
+    owner="moncho",
+    repo="dry",
+    verbose=True,
+)
+
+documents = reader.load_data()
+```

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/__init__.py
@@ -1,5 +1,6 @@
 from llama_index.readers.github.collaborators.base import (
     GitHubRepositoryCollaboratorsReader,
+    GitHubCollaboratorsClient,
 )
 from llama_index.readers.github.issues.base import (
     GitHubIssuesClient,
@@ -14,6 +15,7 @@ __all__ = [
     "GithubClient",
     "GithubRepositoryReader",
     "GitHubRepositoryCollaboratorsReader",
+    "GitHubCollaboratorsClient",
     "GitHubRepositoryIssuesReader",
     "GitHubIssuesClient",
 ]

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/base.py
@@ -47,7 +47,15 @@ class GithubRepositoryReader(BaseReader):
     extracted from the files using the parser.
 
     Examples:
-        >>> reader = GithubRepositoryReader("owner", "repo")
+        >>> client = github_client = GithubClient(
+        ...    github_token=os.environ["GITHUB_TOKEN"],
+        ...    verbose=True
+        ... )
+        >>> reader = GithubRepositoryReader(
+        ...    github_client=github_client,
+        ...    owner="run-llama",
+        ...    repo="llama_index",
+        ... )
         >>> branch_documents = reader.load_data(branch="branch")
         >>> commit_documents = reader.load_data(commit_sha="commit_sha")
 

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 maintainers = ["ahmetkca", "moncho", "rwood-97"]
 name = "llama-index-readers-github"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/13164

The GitHub reader docs were terribly out of date, and the readme was also empty