### PR TITLE
Fixed the In operator error

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
@@ -48,6 +48,8 @@ def _transform_chroma_filter_operator(operator: str) -> str:
         return "$gte"
     elif operator == "<=":
         return "$lte"
+    elif operator == "IN":
+        return "$in"
     else:
         raise ValueError(f"Filter operator {operator} not supported")
 


### PR DESCRIPTION
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[85], line 1
----> 1 response = query_engine.query('''Compare the five products MB3112-0000-0000, MC6030-0080-2217, MC9240-0000-1217, MB1008-0000-0000, MC6030-0080-2217
      2                                 and give the differences between the five products give the output in a properly make sure there are not Null values 
      3                                 formatted way ''')

File ~\anaconda\Lib\site-packages\llama_index\core\instrumentation\dispatcher.py:274, in Dispatcher.span.<locals>.wrapper(func, instance, args, kwargs)
    270 self.span_enter(
    271     id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
    272 )
    273 try:
--> 274     result = func(*args, **kwargs)
    275 except BaseException as e:
    276     self.event(SpanDropEvent(span_id=id_, err_str=str(e)))

File ~\anaconda\Lib\site-packages\llama_index\core\base\base_query_engine.py:53, in BaseQueryEngine.query(self, str_or_query_bundle)
     51     if isinstance(str_or_query_bundle, str):
     52         str_or_query_bundle = QueryBundle(str_or_query_bundle)
---> 53     query_result = self._query(str_or_query_bundle)
     54 dispatch_event(QueryEndEvent())
     55 return query_result

File ~\anaconda\Lib\site-packages\llama_index\core\instrumentation\dispatcher.py:274, in Dispatcher.span.<locals>.wrapper(func, instance, args, kwargs)
    270 self.span_enter(
    271     id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
    272 )
    273 try:
--> 274     result = func(*args, **kwargs)
    275 except BaseException as e:
    276     self.event(SpanDropEvent(span_id=id_, err_str=str(e)))

File ~\anaconda\Lib\site-packages\llama_index\core\query_engine\retriever_query_engine.py:189, in RetrieverQueryEngine._query(self, query_bundle)
    185 """Answer a query."""
    186 with self.callback_manager.event(
    187     CBEventType.QUERY, payload={EventPayload.QUERY_STR: query_bundle.query_str}
    188 ) as query_event:
--> 189     nodes = self.retrieve(query_bundle)
    190     response = self._response_synthesizer.synthesize(
    191         query=query_bundle,
    192         nodes=nodes,
    193     )
    194     query_event.on_end(payload={EventPayload.RESPONSE: response})

File ~\anaconda\Lib\site-packages\llama_index\core\query_engine\retriever_query_engine.py:144, in RetrieverQueryEngine.retrieve(self, query_bundle)
    143 def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
--> 144     nodes = self._retriever.retrieve(query_bundle)
    145     return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)

File ~\anaconda\Lib\site-packages\llama_index\core\instrumentation\dispatcher.py:274, in Dispatcher.span.<locals>.wrapper(func, instance, args, kwargs)
    270 self.span_enter(
    271     id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
    272 )
    273 try:
--> 274     result = func(*args, **kwargs)
    275 except BaseException as e:
    276     self.event(SpanDropEvent(span_id=id_, err_str=str(e)))

File ~\anaconda\Lib\site-packages\llama_index\core\base\base_retriever.py:244, in BaseRetriever.retrieve(self, str_or_query_bundle)
    239 with self.callback_manager.as_trace("query"):
    240     with self.callback_manager.event(
    241         CBEventType.RETRIEVE,
    242         payload={EventPayload.QUERY_STR: query_bundle.query_str},
    243     ) as retrieve_event:
--> 244         nodes = self._retrieve(query_bundle)
    245         nodes = self._handle_recursive_retrieval(query_bundle, nodes)
    246         retrieve_event.on_end(
    247             payload={EventPayload.NODES: nodes},
    248         )

File ~\anaconda\Lib\site-packages\llama_index\core\base\base_auto_retriever.py:37, in BaseAutoRetriever._retrieve(self, query_bundle)
     35 retrieval_spec = self.generate_retrieval_spec(query_bundle)
     36 retriever, new_query_bundle = self._build_retriever_from_spec(retrieval_spec)
---> 37 return retriever.retrieve(new_query_bundle)

File ~\anaconda\Lib\site-packages\llama_index\core\instrumentation\dispatcher.py:274, in Dispatcher.span.<locals>.wrapper(func, instance, args, kwargs)
    270 self.span_enter(
    271     id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
    272 )
    273 try:
--> 274     result = func(*args, **kwargs)
    275 except BaseException as e:
    276     self.event(SpanDropEvent(span_id=id_, err_str=str(e)))

File ~\anaconda\Lib\site-packages\llama_index\core\base\base_retriever.py:244, in BaseRetriever.retrieve(self, str_or_query_bundle)
    239 with self.callback_manager.as_trace("query"):
    240     with self.callback_manager.event(
    241         CBEventType.RETRIEVE,
    242         payload={EventPayload.QUERY_STR: query_bundle.query_str},
    243     ) as retrieve_event:
--> 244         nodes = self._retrieve(query_bundle)
    245         nodes = self._handle_recursive_retrieval(query_bundle, nodes)
    246         retrieve_event.on_end(
    247             payload={EventPayload.NODES: nodes},
    248         )

File ~\anaconda\Lib\site-packages\llama_index\core\instrumentation\dispatcher.py:274, in Dispatcher.span.<locals>.wrapper(func, instance, args, kwargs)
    270 self.span_enter(
    271     id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
    272 )
    273 try:
--> 274     result = func(*args, **kwargs)
    275 except BaseException as e:
    276     self.event(SpanDropEvent(span_id=id_, err_str=str(e)))

File ~\anaconda\Lib\site-packages\llama_index\core\indices\vector_store\retrievers\retriever.py:101, in VectorIndexRetriever._retrieve(self, query_bundle)
     95     if query_bundle.embedding is None and len(query_bundle.embedding_strs) > 0:
     96         query_bundle.embedding = (
     97             self._embed_model.get_agg_embedding_from_queries(
     98                 query_bundle.embedding_strs
     99             )
    100         )
--> 101 return self._get_nodes_with_embeddings(query_bundle)

File ~\anaconda\Lib\site-packages\llama_index\core\indices\vector_store\retrievers\retriever.py:177, in VectorIndexRetriever._get_nodes_with_embeddings(self, query_bundle_with_embeddings)
    173 def _get_nodes_with_embeddings(
    174     self, query_bundle_with_embeddings: QueryBundle
    175 ) -> List[NodeWithScore]:
    176     query = self._build_vector_store_query(query_bundle_with_embeddings)
--> 177     query_result = self._vector_store.query(query, **self._kwargs)
    178     return self._build_node_list_from_query_result(query_result)

File ~\anaconda\Lib\site-packages\llama_index\vector_stores\chroma\base.py:305, in ChromaVectorStore.query(self, query, **kwargs)
    299     if "where" in kwargs:
    300         raise ValueError(
    301             "Cannot specify metadata filters via both query and kwargs. "
    302             "Use kwargs only for chroma specific items that are "
    303             "not supported via the generic query interface."
    304         )
--> 305     where = _to_chroma_filter(query.filters)
    306 else:
    307     where = kwargs.pop("where", {})

File ~\anaconda\Lib\site-packages\llama_index\vector_stores\chroma\base.py:69, in _to_chroma_filter(standard_filters)
     64 for filter in standard_filters.filters:
     65     if filter.operator:
     66         filters_list.append(
     67             {
     68                 filter.key: {
---> 69                     _transform_chroma_filter_operator(
     70                         filter.operator
     71                     ): filter.value
     72                 }
     73             }
     74         )
     75     else:
     76         filters_list.append({filter.key: filter.value})

File ~\anaconda\Lib\site-packages\llama_index\vector_stores\chroma\base.py:52, in _transform_chroma_filter_operator(operator)
     50     return "$lte"
     51 else:
---> 52     raise ValueError(f"Filter operator {operator} not supported")

ValueError: Filter operator FilterOperator.IN not supported

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New IN operator

As i was getting the above errror that said that the In operator was not supported i added in in operator in the following function: -  

### _transform_chroma_filter_operator