### PR TITLE
Fix log message for retrieved nodes count in chromadb

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
@@ -326,7 +326,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
             **kwargs,
         )
 
-        logger.debug(f"> Top {len(results['documents'])} nodes:")
+        logger.debug(f"> Top {len(results['documents'][0])} nodes:")
         nodes = []
         similarities = []
         ids = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-chroma"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-legacy/llama_index/legacy/vector_stores/chroma.py
+++ b/llama-index-legacy/llama_index/legacy/vector_stores/chroma.py
@@ -305,7 +305,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
             **kwargs,
         )
 
-        logger.debug(f"> Top {len(results['documents'])} nodes:")
+        logger.debug(f"> Top {len(results['documents'][0])} nodes:")
         nodes = []
         similarities = []
         ids = []


### PR DESCRIPTION
# Description

Fixes https://github.com/run-llama/llama_index/issues/13074

The number of retrieved nodes should be `len(results['documents'][0])`, not `len(results['documents'])` as it contains the list of documents in `results['documents'][0]`.



## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
