### PR TITLE
fix(docs): langfuse API reference page

### DIFF
--- a/docs/docs/api_reference/callbacks/langfuse.md
+++ b/docs/docs/api_reference/callbacks/langfuse.md
@@ -1,4 +1,4 @@
 ::: llama_index.callbacks.langfuse
     options:
       members:
-        - LangfuseCallbackHandler
+        - langfuse_callback_handler


### PR DESCRIPTION
Updates the exported Langfuse object in API reference docs to fix the [empty page currently seen](https://docs.llamaindex.ai/en/stable/api_reference/callbacks/langfuse/) 😊
