### PR TITLE
Fix bedrock notebook retrieve call and add llamahub doc improvement

### DIFF
--- a/docs/docs/examples/retrievers/bedrock_retriever.ipynb
+++ b/docs/docs/examples/retrievers/bedrock_retriever.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "query = \"How big is Milky Way as compared to the entire universe?\"\n",
-    "retrieved_results = retriever._retrieve(query)\n",
+    "retrieved_results = retriever.retrieve(query)\n",
     "\n",
     "# Prints the first retrieved result\n",
     "print(retrieved_results[0].get_content())"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bedrock/README.md
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bedrock/README.md
@@ -20,6 +20,23 @@ pip install llama-index-retrievers-bedrock
 
 ```
 from llama_index.retrievers.bedrock import AmazonKnowledgeBasesRetriever
+
+retriever = AmazonKnowledgeBasesRetriever(
+    knowledge_base_id="<knowledge-base-id>",
+    retrieval_config={
+        "vectorSearchConfiguration": {
+            "numberOfResults": 4,
+            "overrideSearchType": "HYBRID",
+            "filter": {"equals": {"key": "tag", "value": "space"}},
+        }
+    },
+)
+
+query = "How big is Milky Way as compared to the entire universe?"
+retrieved_results = retriever.retrieve(query)
+
+# Prints the first retrieved result
+print(retrieved_results[0].get_content())
 ```
 
 ## Notebook

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bedrock/README.md
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bedrock/README.md
@@ -10,10 +10,19 @@
 
 > Knowledge base can be configured through [AWS Console](https://aws.amazon.com/console/) or by using [AWS SDKs](https://aws.amazon.com/developer/tools/).
 
-### Notebook
+## Installation
+
+```
+pip install llama-index-retrievers-bedrock
+```
+
+## Usage
+
+```
+from llama_index.retrievers.bedrock import AmazonKnowledgeBasesRetriever
+```
+
+## Notebook
 
 Explore the retriever using Notebook present at:
-
-```
-docs/docs/examples/retrievers/bedrock_retriever.ipynb
-```
+https://docs.llamaindex.ai/en/latest/examples/retrievers/bedrock_retriever/


### PR DESCRIPTION
# Description
Fix bedrock retriever notebook retrieve call resulted with this [change](https://github.com/run-llama/llama_index/pull/12910/files) and add minor llamahub documentation improvement.

Fixes # (issue)
N/A

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [X] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
