### PR TITLE
fix: azure openai api key not picking up env var

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -46,7 +46,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
         # azure specific
         azure_endpoint: Optional[str] = None,
         azure_deployment: Optional[str] = None,
-        azure_ad_token_provider: AzureADTokenProvider = None,
+        azure_ad_token_provider: Optional[AzureADTokenProvider] = None,
         deployment_name: Optional[str] = None,
         max_retries: int = 10,
         reuse_client: bool = True,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -60,7 +60,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             "azure_endpoint", azure_endpoint, "AZURE_OPENAI_ENDPOINT", ""
         )
 
-        api_key = get_from_param_or_env("api_key", api_key, "AZURE_OPENAI_API_KEY", "")
+        api_key = get_from_param_or_env("api_key", api_key, "AZURE_OPENAI_API_KEY")
 
         azure_deployment = resolve_from_aliases(
             azure_deployment,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -60,6 +60,8 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             "azure_endpoint", azure_endpoint, "AZURE_OPENAI_ENDPOINT", ""
         )
 
+        api_key = get_from_param_or_env("api_key", api_key, "AZURE_OPENAI_API_KEY", "")
+
         azure_deployment = resolve_from_aliases(
             azure_deployment,
             deployment_name,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-azure-openai"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/tests/test_azure_openai.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/tests/test_azure_openai.py
@@ -11,7 +11,7 @@ def test_custom_http_client(azure_openai_mock: MagicMock) -> None:
     Should get passed on to the implementation from OpenAI.
     """
     custom_http_client = httpx.Client()
-    embedding = AzureOpenAIEmbedding(http_client=custom_http_client)
+    embedding = AzureOpenAIEmbedding(http_client=custom_http_client, api_key="mock")
     embedding._get_client()
     azure_openai_mock.assert_called()
     kwargs = azure_openai_mock.call_args.kwargs

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -93,7 +93,7 @@ class AzureOpenAI(OpenAI):
         # azure specific
         azure_endpoint: Optional[str] = None,
         azure_deployment: Optional[str] = None,
-        azure_ad_token_provider: AzureADTokenProvider = None,
+        azure_ad_token_provider: Optional[AzureADTokenProvider] = None,
         use_azure_ad: bool = False,
         callback_manager: Optional[CallbackManager] = None,
         # aliases for engine
@@ -186,6 +186,10 @@ class AzureOpenAI(OpenAI):
         if self.use_azure_ad:
             self._azure_ad_token = refresh_openai_azuread_token(self._azure_ad_token)
             self.api_key = self._azure_ad_token.token
+        else:
+            import os
+
+            self.api_key = os.environ.get("AZURE_OPENAI_API_KEY")
 
         return {
             "api_key": self.api_key,

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -189,7 +189,7 @@ class AzureOpenAI(OpenAI):
         else:
             import os
 
-            self.api_key = os.getenv("AZURE_OPENAI_API_KEY")
+            self.api_key = self.api_key or os.getenv("AZURE_OPENAI_API_KEY")
 
         return {
             "api_key": self.api_key,

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -189,7 +189,7 @@ class AzureOpenAI(OpenAI):
         else:
             import os
 
-            self.api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+            self.api_key = os.getenv("AZURE_OPENAI_API_KEY")
 
         return {
             "api_key": self.api_key,

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -191,6 +191,12 @@ class AzureOpenAI(OpenAI):
 
             self.api_key = self.api_key or os.getenv("AZURE_OPENAI_API_KEY")
 
+        if self.api_key is None:
+            raise ValueError(
+                "You must set an `api_key` parameter. "
+                "Alternatively, you can set the AZURE_OPENAI_API_KEY env var OR set `use_azure_ad=True`."
+            )
+
         return {
             "api_key": self.api_key,
             "max_retries": self.max_retries,

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-azure-openai"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
@@ -40,7 +40,9 @@ def test_custom_http_client(sync_azure_openai_mock: MagicMock) -> None:
     mock_instance = sync_azure_openai_mock.return_value
     # Valid mocked result required to not run into another error
     mock_instance.chat.completions.create.return_value = mock_chat_completion_v1()
-    azure_openai = AzureOpenAI(engine="foo bar", http_client=custom_http_client)
+    azure_openai = AzureOpenAI(
+        engine="foo bar", http_client=custom_http_client, api_key="mock"
+    )
     azure_openai.complete("test prompt")
     sync_azure_openai_mock.assert_called()
     kwargs = sync_azure_openai_mock.call_args.kwargs


### PR DESCRIPTION
Signed-off-by: San Nguyen <vinhsannguyen91@gmail.com>

# Description

For some reasons, the Azure OpenAI class does not pick up AZURE_OPENAI_API_KEY env var.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
