### PR TITLE
Add pre-requisite note for running the example

### DIFF
--- a/docs/docs/module_guides/models/llms/usage_custom.md
+++ b/docs/docs/module_guides/models/llms/usage_custom.md
@@ -11,13 +11,14 @@ Below we show a few examples of LLM customization. This includes
 - changing the number of output tokens (for OpenAI, Cohere, or AI21)
 - having more fine-grained control over all parameters for any LLM, from context window to chunk overlap
 
+Note: Some examples below rely on having the data directory present containing the documents to load.
+You can download the example Paul Graham essay from [link](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt)
+and store it in the `data` directory under current working directory.
+
 ## Example: Changing the underlying LLM
 
 An example snippet of customizing the LLM being used is shown below.
 In this example, we use `gpt-4` instead of `gpt-3.5-turbo`. Available models include `gpt-3.5-turbo`, `gpt-3.5-turbo-instruct`, `gpt-3.5-turbo-16k`, `gpt-4`, `gpt-4-32k`, `text-davinci-003`, and `text-davinci-002`.
-
-Pre-requisite: Download the example Paul Graham essay from [link](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt)
-and store it in the `data` directory under current working directory.
 
 Note that
 you may also plug in any LLM shown on Langchain's

--- a/docs/docs/module_guides/models/llms/usage_custom.md
+++ b/docs/docs/module_guides/models/llms/usage_custom.md
@@ -16,6 +16,9 @@ Below we show a few examples of LLM customization. This includes
 An example snippet of customizing the LLM being used is shown below.
 In this example, we use `gpt-4` instead of `gpt-3.5-turbo`. Available models include `gpt-3.5-turbo`, `gpt-3.5-turbo-instruct`, `gpt-3.5-turbo-16k`, `gpt-4`, `gpt-4-32k`, `text-davinci-003`, and `text-davinci-002`.
 
+Pre-requisite: Download the example Paul Graham essay from [link](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt)
+and store it in the `data` directory under current working directory.
+
 Note that
 you may also plug in any LLM shown on Langchain's
 [LLM](https://python.langchain.com/docs/integrations/llms/) page.

--- a/docs/docs/module_guides/models/llms/usage_custom.md
+++ b/docs/docs/module_guides/models/llms/usage_custom.md
@@ -13,7 +13,7 @@ Below we show a few examples of LLM customization. This includes
 
 Note: Some examples below rely on having the data directory present containing the documents to load.
 You can download the example Paul Graham essay from [link](https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt)
-and store it in the `data` directory under current working directory.
+and store it in the `data` directory under the current working directory.
 
 ## Example: Changing the underlying LLM
 


### PR DESCRIPTION
# Description

The current example was written assuming that the reader has first ran all the examples in Home section, hence they would have the `data` already loaded up. But that might not be the case, so better to have it explicitly called out in the docs.

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
