### PR TITLE
Integrate VectorStore from Elasticsearch client

### DIFF
--- a/docs/docs/examples/vector_stores/ElasticsearchIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/ElasticsearchIndexDemo.ipynb
@@ -24,20 +24,11 @@
    "id": "67837810",
    "metadata": {},
    "source": [
-    "Elasticsearch is a distributed, RESTful search and analytics engine, capable of performing both vector and keyword search. It is built on top of the Apache Lucene library.\n",
+    "Elasticsearch is a distributed, RESTful search and analytics engine built on top of Apache Lucene. It offers different retrieval options including dense vector retrieval, sparse vector retrieval, keyword search and hybrid search.\n",
     "\n",
-    "[Signup](https://cloud.elastic.co/registration?utm_source=llama-index&utm_content=documentation) for a free trial.\n",
+    "[Sign up](https://cloud.elastic.co/registration?utm_source=llama-index&utm_content=documentation) for a free trial of Elastic Cloud or run a local server like described below.\n",
     "\n",
     "Requires Elasticsearch 8.9.0 or higher and AIOHTTP."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "6531510e",
-   "metadata": {},
-   "source": [
-    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex 🦙."
    ]
   },
   {
@@ -47,17 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index-vector-stores-elasticsearch"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5bfe9ac3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install llama-index"
+    "%pip install -qU llama-index-vector-stores-elasticsearc llama-index openai"
    ]
   },
   {
@@ -67,17 +48,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import logging\n",
-    "import sys\n",
+    "import getpass\n",
     "import os\n",
     "\n",
-    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
-    "\n",
-    "import getpass\n",
+    "import openai\n",
     "\n",
     "os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(\"OpenAI API Key:\")\n",
-    "import openai\n",
     "\n",
     "openai.api_key = os.environ[\"OPENAI_API_KEY\"]"
    ]
@@ -92,7 +68,7 @@
     "Two ways to setup an Elasticsearch instance for use with:\n",
     "\n",
     "### Elastic Cloud\n",
-    "Elastic Cloud is a managed Elasticsearch service. [Signup](https://cloud.elastic.co/registration?utm_source=llama-index&utm_content=documentation) for a free trial.\n",
+    "Elastic Cloud is a managed Elasticsearch service. [Sign up](https://cloud.elastic.co/registration?utm_source=llama-index&utm_content=documentation) for a free trial.\n",
     "\n",
     "### Locally\n",
     "Get started with Elasticsearch by running it locally. The easiest way is to use the official Elasticsearch Docker image. See the Elasticsearch Docker documentation for more information.\n",
@@ -101,9 +77,8 @@
     "docker run -p 9200:9200 \\\n",
     "  -e \"discovery.type=single-node\" \\\n",
     "  -e \"xpack.security.enabled=false\" \\\n",
-    "  -e \"xpack.security.http.ssl.enabled=false\" \\\n",
     "  -e \"xpack.license.self_generated.type=trial\" \\\n",
-    "  docker.elastic.co/elasticsearch/elasticsearch:8.9.0\n",
+    "  docker.elastic.co/elasticsearch/elasticsearch:8.13.2\n",
     "```\n",
     "\n",
     "## Configuring ElasticsearchStore\n",
@@ -154,40 +129,9 @@
     "es = ElasticsearchStore(\n",
     "    index_name=\"my_index\",\n",
     "    es_cloud_id=\"<cloud-id>\", # found within the deployment page\n",
-    "    es_api_key=\"<api-key>\" # Create an API key within Kibana (Security -> API Keys)\n",
+    "    es_api_key=\"<api-key>\" # create an API key within Kibana (Security -> API Keys)\n",
     ")\n",
     "```\n"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
-   "metadata": {},
-   "source": [
-    "#### Load documents, build VectorStoreIndex with Elasticsearch"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0a2bcc07",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:numexpr.utils:Note: NumExpr detected 10 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "Note: NumExpr detected 10 cores but \"NUMEXPR_MAX_THREADS\" not set, so enforcing safe limit of 8.\n",
-      "INFO:numexpr.utils:NumExpr defaulting to 8 threads.\n",
-      "NumExpr defaulting to 8 threads.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
-    "from llama_index.vector_stores.elasticsearch import ElasticsearchStore"
    ]
   },
   {
@@ -196,29 +140,147 @@
    "id": "7d7904a2",
    "metadata": {},
    "source": [
-    "Download Data"
+    "#### Example data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f28ce261",
+   "id": "4102ca7e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!mkdir -p 'data/paul_graham/'\n",
-    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+    "from llama_index.core.schema import TextNode\n",
+    "\n",
+    "movies = [\n",
+    "    TextNode(\n",
+    "        text=\"The lives of two mob hitmen, a boxer, a gangster and his wife, and a pair of diner bandits intertwine in four tales of violence and redemption.\",\n",
+    "        metadata={\"title\": \"Pulp Fiction\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the greatest psychological and physical tests of his ability to fight injustice.\",\n",
+    "        metadata={\"title\": \"The Dark Knight\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"An insomniac office worker and a devil-may-care soapmaker form an underground fight club that evolves into something much, much more.\",\n",
+    "        metadata={\"title\": \"Fight Club\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into thed of a C.E.O.\",\n",
+    "        metadata={\"title\": \"Inception\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"A computer hacker learns from mysterious rebels about the true nature of his reality and his role in the war against its controllers.\",\n",
+    "        metadata={\"title\": \"The Matrix\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"Two detectives, a rookie and a veteran, hunt a serial killer who uses the seven deadly sins as his motives.\",\n",
+    "        metadata={\"title\": \"Se7en\"},\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"An organized crime dynasty's aging patriarch transfers control of his clandestine empire to his reluctant son.\",\n",
+    "        metadata={\"title\": \"The Godfather\", \"theme\": \"Mafia\"},\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "04304299-fc3e-40a0-8600-f50c3292767e",
+   "metadata": {},
+   "source": [
+    "## Retrieval Examples\n",
+    "\n",
+    "This section shows the different retrieval options available through the `ElasticsearchStore` and make use of them via a VectorStoreIndex."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68cbd239-880e-41a3-98d8-dbb3fab55431",
+   "id": "7717be18",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# load documents\n",
-    "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()"
+    "from llama_index.core import StorageContext, VectorStoreIndex\n",
+    "from llama_index.vector_stores.elasticsearch import ElasticsearchStore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34419b98",
+   "metadata": {},
+   "source": [
+    "We first define a helper function to retrieve and print results for user query input:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf62fb19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_results(results):\n",
+    "    for rank, result in enumerate(results, 1):\n",
+    "        print(\n",
+    "            f\"{rank}. title={result.metadata['title']} score={result.get_score()} text={result.get_text()}\"\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "def search(\n",
+    "    vector_store: ElasticsearchStore, nodes: list[TextNode], query: str\n",
+    "):\n",
+    "    storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+    "    index = VectorStoreIndex(nodes, storage_context=storage_context)\n",
+    "\n",
+    "    print(\">>> Documents:\")\n",
+    "    retriever = index.as_retriever()\n",
+    "    results = retriever.retrieve(query)\n",
+    "    print_results(results)\n",
+    "\n",
+    "    print(\"\\n>>> Answer:\")\n",
+    "    query_engine = index.as_query_engine()\n",
+    "    response = query_engine.query(query)\n",
+    "    print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3392918",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> Documents:\n",
+      "1. title=Inception score=1.0 text=A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into thed of a C.E.O.\n",
+      "\n",
+      ">>> Answer:\n",
+      "Inception\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.vector_stores.elasticsearch import AsyncDenseVectorStrategy\n",
+    "\n",
+    "dense_vector_store = ElasticsearchStore(\n",
+    "    es_url=\"http://localhost:9200\",  # for Elastic Cloud authentication see above\n",
+    "    index_name=\"movies_dense\",\n",
+    "    retrieval_strategy=AsyncDenseVectorStrategy(),\n",
+    ")\n",
+    "\n",
+    "search(dense_vector_store, movies, \"which movie involves dreaming?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d72f1c40",
+   "metadata": {},
+   "source": [
+    "This is also the default retrieval strategy:"
    ]
   },
   {
@@ -231,66 +293,135 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:elastic_transport.transport:GET http://localhost:9200/ [status:200 duration:0.024s]\n",
-      "GET http://localhost:9200/ [status:200 duration:0.024s]\n",
-      "INFO:elastic_transport.transport:HEAD http://localhost:9200/paul_graham [status:200 duration:0.011s]\n",
-      "HEAD http://localhost:9200/paul_graham [status:200 duration:0.011s]\n",
-      "INFO:elastic_transport.transport:PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.115s]\n",
-      "PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.115s]\n",
-      "INFO:elastic_transport.transport:PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.083s]\n",
-      "PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.083s]\n"
+      ">>> Documents:\n",
+      "1. title=Inception score=1.0 text=A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into thed of a C.E.O.\n",
+      "\n",
+      ">>> Answer:\n",
+      "Inception\n"
      ]
     }
    ],
    "source": [
-    "# initialize without metadata filter\n",
-    "from llama_index.core import StorageContext\n",
-    "\n",
-    "vector_store = ElasticsearchStore(\n",
-    "    es_url=\"http://localhost:9200\",\n",
-    "    # Or with Elastic Cloud\n",
-    "    # es_cloud_id=\"my_cloud_id\",\n",
-    "    # es_user=\"elastic\",\n",
-    "    # es_password=\"my_password\",\n",
-    "    index_name=\"paul_graham\",\n",
+    "default_store = ElasticsearchStore(\n",
+    "    es_url=\"http://localhost:9200\",  # for Elastic Cloud authentication see above\n",
+    "    index_name=\"movies_default\",\n",
     ")\n",
-    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
-    "index = VectorStoreIndex.from_documents(\n",
-    "    documents, storage_context=storage_context\n",
-    ")"
+    "\n",
+    "search(default_store, movies, \"which movie involves dreaming?\")"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "04304299-fc3e-40a0-8600-f50c3292767e",
+   "id": "3a1adf49",
    "metadata": {},
    "source": [
-    "## Basic Example\n",
-    "We are going to ask the query engine a question about the data we just indexed."
+    "### Sparse retrieval"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35369eda",
+   "id": "7d9863de",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:elastic_transport.transport:POST http://localhost:9200/paul_graham/_search [status:200 duration:0.030s]\n",
-      "POST http://localhost:9200/paul_graham/_search [status:200 duration:0.030s]\n",
-      "He invested $6k per founder, which in the typical two-founder case was $12k, in return for 6%.\n"
+      ">>> Documents:\n",
+      "1. title=Inception score=1.0 text=A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into thed of a C.E.O.\n",
+      "\n",
+      ">>> Answer:\n",
+      "Inception\n"
      ]
     }
    ],
    "source": [
-    "# set Logging to DEBUG for more detailed outputs\n",
-    "query_engine = index.as_query_engine()\n",
-    "response = query_engine.query(\"what were his investments in Y Combinator?\")\n",
-    "print(response)"
+    "from llama_index.vector_stores.elasticsearch import AsyncSparseVectorStrategy\n",
+    "\n",
+    "sparse_vector_store = ElasticsearchStore(\n",
+    "    es_url=\"http://localhost:9200\",  # for Elastic Cloud authentication see above\n",
+    "    index_name=\"movies_sparse\",\n",
+    "    retrieval_strategy=AsyncSparseVectorStrategy(model_id=\".elser_model_2\"),\n",
+    ")\n",
+    "\n",
+    "search(sparse_vector_store, movies, \"which movie involves dreaming?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3f6c6e3",
+   "metadata": {},
+   "source": [
+    "### Keyword retrieval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2531fab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> Documents:\n",
+      "1. title=The Dark Knight score=1.0 text=When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n",
+      "\n",
+      ">>> Answer:\n",
+      "The Joker is a menacing character who wreaks havoc and chaos on the people of Gotham, posing a significant challenge for Batman to combat injustice.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.vector_stores.elasticsearch import AsyncBM25Strategy\n",
+    "\n",
+    "bm25_store = ElasticsearchStore(\n",
+    "    es_url=\"http://localhost:9200\",  # for Elastic Cloud authentication see above\n",
+    "    index_name=\"movies_bm25\",\n",
+    "    retrieval_strategy=AsyncBM25Strategy(),\n",
+    ")\n",
+    "\n",
+    "search(bm25_store, movies, \"joker\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4e8f643",
+   "metadata": {},
+   "source": [
+    "### Hybrid retrieval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c6707a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> Documents:\n",
+      "1. title=Inception score=0.36787944117144233 text=A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into thed of a C.E.O.\n",
+      "\n",
+      ">>> Answer:\n",
+      "\"Inception\" is the movie that involves dreaming.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.vector_stores.elasticsearch import AsyncDenseVectorStrategy\n",
+    "\n",
+    "hybrid_store = ElasticsearchStore(\n",
+    "    es_url=\"http://localhost:9200\",  # for Elastic Cloud authentication see above\n",
+    "    index_name=\"movies_hybrid\",\n",
+    "    retrieval_strategy=AsyncDenseVectorStrategy(hybrid=True),\n",
+    ")\n",
+    "\n",
+    "search(hybrid_store, movies, \"which movie involves dreaming?\")"
    ]
   },
   {
@@ -299,7 +430,7 @@
    "id": "056d6a4a",
    "metadata": {},
    "source": [
-    "## Metadata Filters\n",
+    "### Metadata Filters\n",
     "Here we are going to index a few documents with metadata so that we can apply filters to the query engine."
    ]
   },
@@ -313,84 +444,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:elastic_transport.transport:GET http://localhost:9200/ [status:200 duration:0.012s]\n",
-      "GET http://localhost:9200/ [status:200 duration:0.012s]\n"
+      "1. title=The Godfather score=1.0 text=An organized crime dynasty's aging patriarch transfers control of his clandestine empire to his reluctant son.\n"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:elastic_transport.transport:HEAD http://localhost:9200/movies_metadata_example [status:404 duration:0.022s]\n",
-      "HEAD http://localhost:9200/movies_metadata_example [status:404 duration:0.022s]\n",
-      "INFO:elastic_transport.transport:PUT http://localhost:9200/movies_metadata_example [status:200 duration:0.099s]\n",
-      "PUT http://localhost:9200/movies_metadata_example [status:200 duration:0.099s]\n",
-      "INFO:elastic_transport.transport:PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.053s]\n",
-      "PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.053s]\n",
-      "INFO:elastic_transport.transport:PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.023s]\n",
-      "PUT http://localhost:9200/_bulk?refresh=true [status:200 duration:0.023s]\n",
-      "INFO:elastic_transport.transport:POST http://localhost:9200/movies_metadata_example/_search [status:200 duration:0.034s]\n",
-      "POST http://localhost:9200/movies_metadata_example/_search [status:200 duration:0.034s]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[NodeWithScore(node=TextNode(id_='3b47c6b6-f01b-44fe-8f88-2249aad2a615', embedding=None, metadata={'director': 'Francis Ford Coppola', 'theme': 'Mafia'}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, hash='81cf4b9e847ba42e83fc401e31af8e17d629f0d5cf9c0c320ec7ac69dd0257e1', text='The Godfather', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'), score=0.88513875)]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "from llama_index.core.schema import TextNode\n",
-    "\n",
-    "nodes = [\n",
-    "    TextNode(\n",
-    "        text=\"The Shawshank Redemption\",\n",
-    "        metadata={\n",
-    "            \"author\": \"Stephen King\",\n",
-    "            \"theme\": \"Friendship\",\n",
-    "        },\n",
-    "    ),\n",
-    "    TextNode(\n",
-    "        text=\"The Godfather\",\n",
-    "        metadata={\n",
-    "            \"director\": \"Francis Ford Coppola\",\n",
-    "            \"theme\": \"Mafia\",\n",
-    "        },\n",
-    "    ),\n",
-    "    TextNode(\n",
-    "        text=\"Inception\",\n",
-    "        metadata={\n",
-    "            \"director\": \"Christopher Nolan\",\n",
-    "        },\n",
-    "    ),\n",
-    "]\n",
-    "\n",
-    "# initialize the vector store\n",
-    "vector_store_metadata_example = ElasticsearchStore(\n",
-    "    index_name=\"movies_metadata_example\",\n",
-    "    es_url=\"http://localhost:9200\",\n",
-    ")\n",
-    "storage_context = StorageContext.from_defaults(\n",
-    "    vector_store=vector_store_metadata_example\n",
-    ")\n",
-    "index = VectorStoreIndex(nodes, storage_context=storage_context)\n",
-    "\n",
-    "\n",
-    "# Metadata filter\n",
     "from llama_index.core.vector_stores import ExactMatchFilter, MetadataFilters\n",
     "\n",
+    "metadata_store = ElasticsearchStore(\n",
+    "    es_url=\"http://localhost:9200\",  # for Elastic Cloud authentication see above\n",
+    "    index_name=\"movies_metadata\",\n",
+    ")\n",
+    "storage_context = StorageContext.from_defaults(vector_store=metadata_store)\n",
+    "index = VectorStoreIndex(movies, storage_context=storage_context)\n",
+    "\n",
+    "# Metadata filter\n",
     "filters = MetadataFilters(\n",
     "    filters=[ExactMatchFilter(key=\"theme\", value=\"Mafia\")]\n",
     ")\n",
-    "\n",
     "retriever = index.as_retriever(filters=filters)\n",
     "\n",
-    "retriever.retrieve(\"What is inception about?\")"
+    "results = retriever.retrieve(\"What is inception about?\")\n",
+    "print_results(results)"
    ]
   },
   {
@@ -413,10 +488,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "custom query {'knn': {'filter': [{'match': {'content': 'growing up'}}], 'field': 'embedding', 'query_vector': [0.002520269714295864, -0.03282919153571129, 0.016138022765517235, -0.029537975788116455, -0.006744919344782829, 0.01626248098909855, -0.03703309968113899, 0.002381983445957303, -0.003031929489225149, -0.003616189584136009, 0.032746221870183945, 0.030201751738786697, 0.011726687662303448, 0.005043996497988701, 0.0030665011145174503, 0.016207166016101837, 0.018115518614649773, -0.008539185859262943, 0.020825933665037155, -0.011595315299928188, -0.027754081413149834, -0.004622223321348429, -0.004750138148665428, -0.015363619662821293, -0.006496003828942776, 0.012860636226832867, 0.02331508882343769, -0.009368903934955597, -0.002686213469132781, 0.0029818005859851837, 0.032441992312669754, 0.0015107790241017938, -0.0023059258237481117, 0.02384057641029358, -0.029233746230602264, 0.003574703587219119, 0.0048296526074409485, 0.019401581957936287, 0.01830912008881569, -0.009375818073749542, 0.037724532186985016, 0.026274416595697403, -0.016746483743190765, -0.005078568123281002, -0.02065998874604702, -0.012846807017922401, -0.002015524310991168, -0.01924946717917919, -0.0026568276807665825, 0.01626248098909855, -0.0002582066517788917, 0.027449851855635643, -0.011975603178143501, 0.013517496176064014, -0.005973972845822573, 0.002910928800702095, -0.00517536886036396, -0.004521965514868498, -0.012466519139707088, 0.0037890474777668715, 0.03454394266009331, 0.020729131996631622, 1.9514049199642614e-05, 0.010191707871854305, -0.0201068427413702, -0.0031131727155297995, 0.003581617958843708, -0.027270078659057617, 0.016151852905750275, 0.01658054068684578, 0.04679612070322037, -0.00013904266234021634, 0.01688477024435997, -0.00204491033218801, 0.014326471835374832, 0.0006266103009693325, -0.01454772986471653, -0.01425732858479023, -0.026039330288767815, 0.021296106278896332, 0.0022454254794865847, -0.03457160294055939, -0.028016826137900352, -0.009548676200211048, 0.0005151168443262577, -0.0019308238988742232, -0.00028759249835275114, 0.020203644409775734, -0.021890738978981972, 0.0035505034029483795, 0.04400273412466049, 0.038803163915872574, 0.021683309227228165, 0.02295554429292679, -0.03296747803688049, -0.007049149367958307, -0.012266004458069801, -0.009521018713712692, -0.013745669275522232, -0.004663709085434675, -0.01606888137757778, -0.0023162972647696733, -0.015944423153996468, -0.02537555620074272, -0.018945237621665, 0.0030181007459759712, 0.01265320647507906, 0.004712109453976154, 0.02267897129058838, -0.02790619619190693, -0.004788166843354702, 0.006188316736370325, -0.018170833587646484, -0.026302075013518333, -0.02126844972372055, -0.023785261437296867, 0.02508515492081642, 0.01951221190392971, -0.007896154187619686, -0.014098298735916615, 0.03213776275515556, -0.0026499133091419935, 0.01682945527136326, -0.007260036189109087, 0.017977232113480568, 0.00786849670112133, -0.027767909690737724, -0.009023187682032585, 0.010357651859521866, -0.0319441594183445, 0.013033493421971798, 0.01107674092054367, 0.022568341344594955, -0.015017903409898281, -0.027767909690737724, 0.02527875453233719, 0.0034174027387052774, 0.0026758420281112194, -0.033631253987550735, -0.0431177020072937, -0.0027691852301359177, 0.005638628266751766, -0.008345584385097027, 0.030920840799808502, -0.01091771200299263, 0.016774140298366547, 0.003540131961926818, 0.0367288701236248, 0.0016827727667987347, -0.002292097080498934, 0.004722480662167072, -0.017050713300704956, 0.008988616056740284, 0.012909036129713058, -0.01383555494248867, 0.0011719772592186928, -0.0008392256568185985, 0.009686962701380253, -0.014851960353553295, -0.018848437815904617, -0.011685200966894627, 0.006018915679305792, 0.002088124630972743, 0.015031732618808746, 0.0019014381105080247, 0.04624297469854355, 0.05520393326878548, 0.0007951468578539789, -0.0036853328347206116, -0.009922049939632416, -0.010571995750069618, 0.023660805076360703, -0.03755858913064003, 0.007979125715792179, 0.004141678102314472, -0.0028884573839604855, 0.0037890474777668715, -0.011975603178143501, -0.03617572411894798, 0.008525356650352478, 0.015916764736175537, -0.006005087401717901, 0.023453375324606895, 0.026882877573370934, 0.015847621485590935, -0.027256250381469727, -0.0020967675372958183, -0.03349296748638153, -0.01149851456284523, 0.005652457010000944, 0.0005341312498785555, 0.005835686344653368, -0.008069011382758617, 0.013607382774353027, -0.6358962059020996, -0.019885584712028503, -0.006758748088032007, -0.02240239828824997, 0.012293661944568157, -0.008684386499226093, 0.00900244526565075, 0.016787970438599586, -0.015501906163990498, 0.015017903409898281, 0.014070642180740833, 0.015322133898735046, -0.02819659747183323, -0.00634043151512742, 0.014727502129971981, -0.026412703096866608, 0.02964860573410988, -0.04248158261179924, -0.005998172797262669, 0.02502983994781971, -0.02302468754351139, 0.004356021992862225, 0.0029697006102651358, 0.006150288041681051, 0.015501906163990498, 0.0174240879714489, -0.0005362919764593244, -0.0032531877513974905, -0.02154502272605896, 0.01926329731941223, -0.015073218382894993, 0.03919036686420441, 0.009742277674376965, 0.02099187672138214, 0.039743512868881226, 0.009652391076087952, -0.011588401161134243, 0.014409443363547325, 0.011097484268248081, 0.042094383388757706, -0.025555327534675598, -0.009057759307324886, 0.027200935408473015, 0.010959197767078876, -0.0038097905926406384, -0.006734548136591911, 0.03490348905324936, 0.002857342828065157, -0.024034177884459496, -0.0017156157409772277, 0.01895906589925289, -0.002432112116366625, -0.023494860157370567, 0.0088572446256876, 0.00544848432764411, -0.015474248677492142, 0.004269592929631472, -0.00726695079356432, -0.0017890804447233677, -0.0006495139678008854, -0.002221225295215845, 0.02125462144613266, -0.022761942818760872, -0.026965849101543427, 0.005891000851988792, 0.007578094955533743, -0.030644267797470093, 0.013386123813688755, 0.016442254185676575, -0.01716134324669838, 0.015156189911067486, 0.020466387271881104, -0.007474380079656839, 0.004528879653662443, -0.00561097078025341, 0.017880432307720184, 0.028708258643746376, -0.00858067162334919, -0.003719904227182269, 0.020867418497800827, -0.02265131287276745, -0.012922864407300949, -0.0174932312220335, -0.01626248098909855, 0.00826952699571848, -0.0066100903786718845, -0.008345584385097027, 0.0024960695300251245, 0.003851276356726885, -0.02415863610804081, 0.010883140377700329, 0.004390593618154526, 0.007854667492210865, -0.013648868538439274, 0.01047519501298666, 0.02942734770476818, 0.02211199700832367, 0.009624733589589596, 0.014603044837713242, -0.021406736224889755, -0.0186548363417387, 0.010129479691386223, 0.014699844643473625, 0.0016542511293664575, -0.01048211008310318, -0.006101887673139572, 0.008850330486893654, 0.02150353603065014, -0.001007762155495584, -0.018945237621665, -0.009140731766819954, -0.005057825241237879, -0.011885716579854488, -0.004037963226437569, -0.013731840066611767, -0.036562927067279816, 0.033271707594394684, 0.0066930619068443775, 0.009776849299669266, -0.016456082463264465, 0.012604805640876293, -0.027823224663734436, 0.02679990604519844, -0.00961781945079565, -0.006184859666973352, 0.013565896078944206, 0.025403212755918503, -0.016483739018440247, -0.020784446969628334, 0.013054236769676208, 0.0036887899041175842, -0.022222625091671944, 0.017050713300704956, -0.015363619662821293, -0.008843415416777134, -0.006592804566025734, 0.002454583765938878, -0.020314272493124008, -0.012750006280839443, -0.020549360662698746, -0.030671924352645874, -0.0054865130223333836, -0.007107921410351992, 0.02415863610804081, -0.03396314010024071, -0.0022557969205081463, 0.026149960234761238, 0.012750006280839443, -0.017341114580631256, 0.016691168770194054, 0.02792002633213997, 0.009541762061417103, -0.019705813378095627, 0.019733469933271408, 0.020314272493124008, -0.008553014136850834, -0.01164371520280838, -0.034986462444067, -0.0191664956510067, -0.021738622337579727, 0.011609143577516079, 0.011844230815768242, -0.016677340492606163, -0.0006335246143862605, 0.0014347215183079243, -0.025181954726576805, 0.012597891502082348, 0.011415543034672737, -0.004805452656000853, -0.00611571641638875, 0.0014848503051325679, -0.019138839095830917, -0.004466651007533073, 0.006122630555182695, -0.013351552188396454, 0.03634166717529297, 0.009375818073749542, 0.00632660323753953, -0.014139785431325436, 0.014755159616470337, -0.003972277045249939, 0.003619646653532982, -0.0045911087654531, 0.01048211008310318, 0.029316717758774757, -0.013558981940150261, 0.002712142188102007, 0.023052344098687172, -0.004784709773957729, -0.0026343560311943293, -0.019014380872249603, 0.004172792192548513, -0.005116596817970276, 0.01382172666490078, 0.001671536942012608, -0.006133002229034901, 0.026357389986515045, 0.021088676527142525, 0.01253566239029169, 0.0016101723304018378, 0.011989431455731392, 0.032469648867845535, 0.01689859852194786, -0.008670557290315628, -0.015197675675153732, -0.03282919153571129, -0.015944423153996468, -0.008649814873933792, 0.008732786402106285, 0.008255698718130589, 0.005690485704690218, 0.00181673769839108, -0.00929284654557705, -0.005178825929760933, 0.01688477024435997, -0.0015816508093848825, -0.004615308716893196, 0.02909545972943306, -0.012127717956900597, 0.016110366210341454, -0.00024308158026542515, -0.012431947514414787, 0.013427610509097576, -0.03457160294055939, 0.01122885663062334, 0.004238478373736143, -0.0017873517936095595, 0.0073775798082351685, 0.003016372211277485, -0.0028400570154190063, -0.0039307912811636925, 0.020618503913283348, 0.009050845168530941, -0.004044877365231514, 0.02266514115035534, 0.003249730449169874, 0.02761579491198063, -0.02507132478058338, 0.038830824196338654, -0.0031477443408221006, 0.004145135171711445, 0.018945237621665, 0.019069695845246315, 0.007425980176776648, 0.02207051031291485, -0.0006750104948878288, 0.04109872132539749, 0.002193568041548133, -0.0014044713461771607, 0.01555722113698721, -3.451758311712183e-05, 0.0013379210140556097, 0.012307490222156048, -0.025693614035844803, -0.0021123248152434826, -0.024836238473653793, 0.016718827188014984, 0.010406051762402058, 0.018184661865234375, -0.0005583313759416342, 0.013469096273183823, -0.012694692239165306, 0.008974787779152393, 0.0032065161503851414, 0.013240923173725605, -0.006661947816610336, 0.0028590713627636433, -0.007896154187619686, 0.016732655465602875, -0.022222625091671944, 0.03399080038070679, -0.01803254708647728, 0.021600335836410522, 0.011470857076346874, -0.0016663512215018272, 0.005918658338487148, 0.0028936429880559444, 0.004642966203391552, -0.01808786205947399, 0.002352597424760461, -0.008020611479878426, -0.047902412712574005, 0.014672188088297844, 0.010973026044666767, 0.005628256592899561, 0.008096668869256973, 0.02266514115035534, 0.016663512215018272, -0.0029022858943790197, 0.01629013940691948, -0.008511528372764587, -0.0241724643856287, -0.0131026366725564, 0.011947945691645145, 0.015654021874070168, -0.02215348184108734, 0.03371422737836838, -0.03379719704389572, -0.017064543440937996, -0.017659174278378487, -9.939335723174736e-05, 0.008075926452875137, -0.0013638497330248356, 0.009299760684370995, 0.04331130161881447, 0.009043931029736996, -0.007446723058819771, -0.0026810276322066784, -0.016691168770194054, -0.02851465716958046, 0.019138839095830917, -0.010392223484814167, -0.031833529472351074, 0.014589215628802776, 0.02065998874604702, 0.009265189059078693, -0.009852906689047813, -0.012238346971571445, 0.011346399784088135, 0.012307490222156048, -0.020604673773050308, -0.007405237294733524, -0.036203380674123764, 0.0128122353926301, 0.10797403007745743, 0.02995283529162407, -0.025195783004164696, 0.005406998563557863, 0.001823651953600347, -0.0010501124197617173, -0.02154502272605896, -0.03689481317996979, 0.020604673773050308, -0.000838793464936316, 0.004231564234942198, 0.0009705977281555533, 0.013724925927817822, 0.010226279497146606, 0.01075176801532507, -0.024822410196065903, -0.0029420433565974236, -0.01859952136874199, -0.0029092002660036087, -0.03836064785718918, -0.014215842820703983, -0.004878052975982428, 0.016704997047781944, 0.0315016433596611, 0.02299702912569046, 0.018461234867572784, 0.04939590394496918, 0.014907274395227432, 0.034765202552080154, -0.019719641655683517, 0.005832229275256395, 0.008262612856924534, 0.007260036189109087, 0.014174357056617737, -0.014630701392889023, -0.0006732819601893425, -0.022609828040003777, 0.0320824459195137, 0.004480479750782251, 0.003975734114646912, 0.0253340695053339, 0.013745669275522232, 0.013386123813688755, -0.01806020550429821, -0.00040254308260045946, -0.0026222560554742813, 0.0035038318019360304, 0.011761259287595749, 0.007114835549145937, -0.012715434655547142, 0.013648868538439274, -0.007246207911521196, -0.03318873792886734, -0.014036070555448532, 0.001718208659440279, 0.012646292336285114, -0.004483936820179224, -0.01597207970917225, -0.0131026366725564, -0.015861451625823975, -0.010654967278242111, -0.0344056561589241, 0.023688461631536484, -0.009009359404444695, 0.0198164414614439, -0.01891758106648922, -0.02236091159284115, -0.030948497354984283, -0.027574310079216957, -0.016511397436261177, 0.0044286223128438, 0.0055867708288133144, -0.043504904955625534, -0.0061710309237241745, 0.024518180638551712, 0.030754897743463516, 0.014879616908729076, 0.011007597669959068, -0.020881246775388718, -0.0023733405396342278, 0.011055998504161835, -0.017562374472618103, -0.007329179439693689, -0.011457028798758984, -0.0035124747082591057, -0.005310197826474905, -0.0008336077444255352, -0.006952349096536636, 0.004777795169502497, 0.004463193938136101, -0.005510713439434767, 0.004155506379902363, -0.008546099998056889, -0.037088412791490555, 0.0027933854144066572, -0.013614296913146973, -0.005462313070893288, 0.0018979809246957302, 0.011180455796420574, -0.01866866461932659, 0.001273099216632545, 0.003534946357831359, -0.0033586311619728804, 0.006578975822776556, -0.021061019971966743, 0.0152806481346488, 0.004788166843354702, 0.023135315626859665, -0.03988179937005043, 0.009507190436124802, 0.023066172376275063, -0.016469910740852356, -0.0007406965596601367, 0.03058895282447338, -0.007654152810573578, 0.018945237621665, -0.004501222632825375, -0.0006348210154101253, -0.018488893285393715, -0.0075227804481983185, 0.01454772986471653, -0.015916764736175537, 0.03255261853337288, 0.009389647282660007, -0.02823808416724205, -0.003965362906455994, -0.0012324776034802198, -0.03490348905324936, -0.014174357056617737, 0.028072141110897064, -0.03719904273748398, 0.02592870034277439, -0.027850883081555367, -0.02186308056116104, -0.02617761678993702, -0.03202713280916214, -0.03960522636771202, -0.005472684744745493, -0.0008928116294555366, -0.0046706232242286205, 0.0012990279356017709, -0.029925178736448288, 0.01020553708076477, -0.03376954048871994, -0.017852775752544403, -0.03089318238198757, -0.01604122295975685, 0.0009662762749940157, 0.004836567211896181, 0.033603597432374954, -0.003948077093809843, 0.013372295536100864, -0.026398874819278717, -0.023370401933789253, -0.02241622656583786, -0.022056682035326958, 0.01949838362634182, -0.02035575918853283, 0.038305334746837616, 0.01555722113698721, 0.032690905034542084, -0.0008444113773293793, 0.0348481759428978, 0.020590845495462418, 0.01382172666490078, -0.006070773117244244, -0.006157202180474997, 0.0001258622360182926, -0.00039973415550775826, 0.027270078659057617, -0.010668796487152576, 0.00317194452509284, 0.014284986071288586, 0.014561559073626995, -0.006368089001625776, 0.018267635256052017, -0.006419946439564228, 0.007896154187619686, -0.014810474589467049, -0.025984015315771103, -0.023425716906785965, 0.005929029546678066, -0.011083655059337616, -0.018267635256052017, -0.01947072520852089, 0.01107674092054367, 0.003019829513505101, 0.02502983994781971, 0.024269264191389084, -0.009348161518573761, -0.0013007564703002572, 0.00024372979532927275, 0.019097352400422096, 0.002784742508083582, 0.021918395534157753, -0.012756921350955963, -0.002990443492308259, -0.02180776558816433, -0.02937203273177147, 0.015156189911067486, -0.00342258857563138, 0.011111312545835972, 0.012445776723325253, -0.012286746874451637, 0.00407253485172987, 0.0022333255037665367, -0.024366063997149467, -0.008954044431447983, 0.0192356389015913, -0.025264926254749298, -0.016138022765517235, -0.02739453688263893, -0.01659436896443367, -0.010903882794082165, -0.0003550071269273758, -0.014755159616470337, 0.0004489986749831587, -0.00309070129878819, -0.011609143577516079, -0.013531324453651905, -0.026606304571032524, 0.0023387689143419266, 0.036258697509765625, -0.017921919003129005, 0.0064752609468996525, 0.00010879251203732565, 0.008103583008050919, -0.016124194487929344, -0.0038097905926406384, 0.0069246916100382805, 0.011443200521171093, 0.010502852499485016, 0.033271707594394684, -0.02157267928123474, -0.019885584712028503, 0.008587585762143135, 0.006060401909053326, -0.016635853797197342, -0.0037648475263267756, -0.012093146331608295, -0.019567526876926422, -0.0026343560311943293, 0.0003040140145458281, -0.02942734770476818, -0.020784446969628334, -0.0054899705573916435, 0.002898828824982047, 0.005984344054013491, -6.028423013049178e-05, -0.014464758336544037, -0.011408628895878792, 3.5057764762314036e-05, 0.012321318499743938, -0.00407253485172987, 0.012300576083362103, -0.005693942774087191, 0.004138220567256212, -0.03664589673280716, 0.005351684056222439, 0.03354828059673309, -0.0048296526074409485, 0.007716381456702948, -0.014810474589467049, 0.028002997860312462, -0.009279018267989159, 0.004477022215723991, -0.029510319232940674, -0.014326471835374832, -0.008815758861601353, 0.024545837193727493, 0.013240923173725605, 0.002864257199689746, -0.006782948039472103, -0.021130163222551346, 0.007004206534475088, -0.013918526470661163, -0.004501222632825375, -0.02241622656583786, -0.0198164414614439, 0.0062574599869549274, 0.02036958746612072, 0.015958251431584358, -0.009852906689047813, 0.02731156535446644, -0.004203906748443842, 0.0013560710940510035, 0.014520072378218174, -0.015363619662821293, 0.003858190728351474, -0.02856997214257717, -0.014907274395227432, -0.03205478936433792, -0.0006806284072808921, -0.000587285088840872, -0.013268580660223961, -0.0033448024187237024, 0.00473630940541625, 0.004497765563428402, 0.0029679720755666494, 0.0097630200907588, -0.004629137460142374, 0.0021330679301172495, -0.029786892235279083, 0.02012067288160324, -0.011470857076346874, 2.7022568247048184e-05, 0.023204458877444267, 0.0015479434514418244, -0.015598706901073456, 0.00421773549169302, 0.005852972157299519, -0.002850428456440568, 0.01120811328291893, 0.0013742211740463972, 0.0007925539393909276, 0.021061019971966743, 0.014741331338882446, -0.02939968928694725, -0.008947130292654037, 0.0119410315528512, -0.023176802322268486, -0.0033793740440160036, 0.02121313475072384, -0.021738622337579727, 0.012618634849786758, 0.00741215143352747, 0.014354129321873188, 0.010737939737737179, -0.02851465716958046, -0.014354129321873188, -0.0012281561503186822, -0.014409443363547325, 0.030063465237617493, 0.005987801589071751, -0.022181140258908272, -0.015501906163990498, -0.016469910740852356, -0.0021382535342127085, 0.008172726258635521, 0.0016559796640649438, 0.019125010818243027, 0.013558981940150261, 0.012404290959239006, 0.02390971966087818, -0.016801798716187477, -0.008511528372764587, -0.026371218264102936, -0.025472356006503105, -0.0313633568584919, -0.007930725812911987, -0.014450929127633572, 0.02733922190964222, 0.0023370403796434402, -0.023066172376275063, -0.043173015117645264, -0.001783894607797265, -0.02738070860505104, -0.02266514115035534, 0.005292912013828754, 0.0023698832374066114, 0.030782554298639297, -0.019982386380434036, -0.02854231372475624, 0.027463680133223534, 0.0004252307116985321, 0.03423971310257912, 0.001823651953600347, -0.011802745051681995, 0.026730762794613838, -0.007232379168272018, 0.010094908066093922, -0.02180776558816433, -0.017866604030132294, -0.007688724435865879, 0.007308436557650566, 0.006264374125748873, 0.008926387876272202, 0.005244512110948563, 0.005655914079397917, 0.007439808454364538, -0.0025634842459112406, 0.01862717978656292, -0.013323895633220673, 0.038858480751514435, 0.005161540117114782, -0.032441992312669754, -0.01984409987926483, 0.0027000419795513153, -0.008421641774475574, -0.003016372211277485, 0.012874464504420757, -0.020604673773050308, -0.0035954464692622423, -0.023481031879782677, -0.0020535532385110855, -0.005054368171840906, -0.010592739097774029, 0.03321639448404312, 0.005566027946770191, -0.02413097769021988, 0.0155710494145751, 0.0201068427413702, 0.009085416793823242, -0.017313458025455475, -0.0009247903362847865, 0.021088676527142525, -0.005403541494160891, 0.002805485390126705, 0.014160527847707272, -0.015501906163990498, 0.006655033212155104, 0.0017138872062787414, 0.0036749611608684063, -0.013572811149060726, -0.003747561713680625, -0.0052099404856562614, -0.0022713541984558105, 0.02565212920308113, 0.015916764736175537, 0.004110563546419144, -0.0031788586638867855, 0.015833793208003044, -0.005922115407884121, 0.01047519501298666, -0.02155885100364685, -0.009645476937294006, -0.005856429226696491, -0.019954727962613106, -0.010731025598943233, 0.018820779398083687, -0.017866604030132294, -0.033631253987550735, -0.007619581185281277, 0.026882877573370934, -0.009790677577257156, -0.009071588516235352, 0.22159013152122498, 0.0029143861029297113, 0.007543523330241442, 0.020148329436779022, 0.0001135461061494425, 0.014976417645812035, 0.027021164074540138, 0.02532024122774601, -0.007833925075829029, 0.02912311814725399, -0.007069892715662718, 0.015667850151658058, 0.001214327523484826, -0.008670557290315628, -0.00726695079356432, -0.00356778921559453, -0.0344056561589241, 0.006793319713324308, -0.035069432109594345, 0.011256513185799122, 0.017894260585308075, -0.008622157387435436, 0.004169335123151541, -0.02013450115919113, -0.004708651918917894, 0.013842469081282616, -0.003910047933459282, 0.00323590193875134, 0.015958251431584358, 0.030035806819796562, -0.009666220284998417, 0.00011160145368194208, -0.0033465309534221888, -0.02942734770476818, 0.01599973812699318, -0.035069432109594345, 0.010005021467804909, -0.0012160560581833124, 0.0191664956510067, -0.00317021575756371, 0.00017361425852868706, 0.008255698718130589, -0.028058312833309174, -0.0032981308177113533, 0.00016421510372310877, 0.004815824329853058, -0.021088676527142525, -0.006834805477410555, 0.013496753759682178, 0.004532337188720703, -0.0050612823106348515, 0.013323895633220673, 0.04284112900495529, 0.016649683937430382, -0.01806020550429821, 0.01369035430252552, 0.03733732923865318, 0.007301522418856621, -0.014755159616470337, 0.020438730716705322, -0.008546099998056889, 0.018737807869911194, 0.005458856001496315, 0.0014554644003510475, 0.010336908511817455, -0.019622841849923134, -0.0048192813992500305, 0.01629013940691948, 0.026149960234761238, 0.0011028341250494123, 0.0043076216243207455, -0.002241968410089612, -0.013648868538439274, 0.010005021467804909, -0.04491542652249336, -0.027270078659057617, 0.04242626950144768, 0.03758624568581581, 0.021102504804730415, 0.016483739018440247, 0.02534789778292179, 0.014782817102968693, 0.010191707871854305, 0.016787970438599586, -0.014810474589467049, -0.035982124507427216, 0.021586507558822632, -0.01659436896443367, -0.009666220284998417, -0.026039330288767815, 0.0056455424055457115, 0.0009342975099571049, -0.00873970054090023, -0.028984831646084785, 0.007370665669441223, -0.014699844643473625, -0.02906780317425728, 0.026564817875623703, 0.0042937928810715675, 0.01711985655128956, -0.02619144506752491, 0.017548544332385063, 0.019636670127511024, 0.013662696816027164, -0.01691242679953575, 0.0004965346306562424, -0.009707706049084663, 0.009652391076087952, 0.00813815463334322, -0.009804505854845047, -0.005607513710856438, -0.005348226986825466, 0.024034177884459496, 0.01239737682044506, 0.012183031998574734, 0.016981570050120354, -0.004898795858025551, -0.025126639753580093, 0.035650234669446945, -0.0025634842459112406, -0.014672188088297844, -0.04071151837706566, -0.018253805115818977, 0.009092330932617188, -0.006568604148924351, -0.0021261535584926605, -0.012010174803435802, -0.023660805076360703, -0.012480348348617554, -0.025984015315771103, 0.03863722085952759, 0.015778478235006332, 0.004850395489484072, -0.019373925402760506, 0.004349107388406992, -0.03465457260608673, 0.009486447088420391, -0.009922049939632416, 0.00843547098338604, -0.009285932406783104, -0.02303851582109928, 0.007778610568493605, -0.001578193623572588, -0.010945369489490986, 0.005607513710856438, -0.03938397020101547, 0.017963403835892677, 0.014492415823042393, 0.0188760943710804, -0.021309934556484222, -0.009417303837835789, 0.00778552470728755, -0.01633162423968315, -0.018558036535978317, -0.01268777810037136, -0.014354129321873188, -0.024352235719561577, -0.05014264956116676, 0.006150288041681051, 0.002070839051157236, -0.03111444227397442, 0.015640191733837128, 0.022872570902109146, -0.02469795197248459, -0.024628808721899986, -0.004725937731564045, -0.17767037451267242, 0.01716134324669838, 0.013538239523768425, 0.00042501461575739086, 0.040047742426395416, 0.004394050687551498, 0.021116334944963455, -0.011083655059337616, -0.01801871880888939, 0.01656671240925789, 0.01630396768450737, 0.0027155992574989796, -0.0182952918112278, -0.03280153498053551, -0.0027294280007481575, 0.020494045689702034, 0.00028716036467812955, 0.009721534326672554, 0.031280383467674255, 0.007190892938524485, 0.0174932312220335, -0.027698766440153122, -0.008110498078167439, 0.016442254185676575, 0.005714685656130314, -0.0023232116363942623, 0.0034969174303114414, 0.01049593836069107, -0.008262612856924534, -0.030644267797470093, -0.0005730242701247334, 0.0018755093915387988, 0.03753093257546425, -0.009700790978968143, 0.02184925228357315, -0.0003176266036462039, -0.009189131669700146, -0.0238820631057024, 0.0019221811089664698, 0.001809823326766491, 0.012487262487411499, 0.035677891224622726, 0.0020984963048249483, 0.013303152285516262, -0.023121487349271774, 0.0034986461978405714, 0.024656467139720917, -0.01891758106648922, 0.004027591552585363, 0.010827825404703617, 0.025818072259426117, -0.052216947078704834, 0.016373110935091972, -0.004760509356856346, 0.013130294159054756, -0.009507190436124802, 0.017866604030132294, 0.002286911476403475, -0.008311012759804726, -0.0044286223128438, 0.0015807865420356393, -0.01235589012503624, 0.011740515939891338, -0.03462691605091095, -0.010855482891201973, -0.02537555620074272, -0.007405237294733524, 0.001956752734258771, -0.0371713861823082, 0.02323211543262005, -0.0018685950199142098, -0.0039169625379145145, 0.020272787660360336, 0.008248784579336643, 0.00313045852817595, 0.006509832572191954, -0.003733732970431447, 0.049921393394470215, 0.005299826618283987, -0.013579725287854671, -0.012079318054020405, 0.043228331953287125, 0.0026153416838496923, 0.0053413123823702335, -0.004432079382240772, 0.024532008916139603, 0.0182952918112278, 0.0003212998271919787, -0.0097284484654665, -0.02244388312101364, 0.009265189059078693, 0.0009835620876401663, -0.0013958284398540854, -0.005223769228905439, 0.006416489370167255, 0.017949575558304787, -0.002738070907071233, 0.0008642900502309203, 0.0030941583681851625, -0.014630701392889023, -0.011657544411718845, -0.013489838689565659, -0.006485632620751858, -0.013061150908470154, 0.035097088664770126, 0.003560875076800585, -0.015363619662821293, 0.031888846307992935, 0.02095039002597332, -0.002646456006914377, -0.027449851855635643, 0.016428425908088684, 0.020189816132187843, 0.026924364268779755, 0.0006356853409670293, 0.02243005484342575, -0.006613547448068857, -0.02353634685277939, 0.009548676200211048, -0.030063465237617493, 0.049064017832279205, 0.008020611479878426, -0.01743791624903679, -0.013330809772014618, 0.005306740757077932, -0.005406998563557863, -0.10105970501899719, 1.5543715562671423e-05, 0.019595183432102203, 0.0015816508093848825, 0.00069964281283319, 0.033271707594394684, 0.01626248098909855, 0.021392907947301865, -0.037116073071956635, 0.04806835576891899, -0.0018876094836741686, -0.03559492155909538, -0.013455267064273357, 0.02007918618619442, -0.012639377266168594, 0.016704997047781944, 0.004397507756948471, -0.006789862643927336, -0.02594253048300743, 0.021033361554145813, -0.009057759307324886, -0.025707442313432693, -2.683350430743303e-05, -0.009970449842512608, 0.004165878053754568, 0.002765728160738945, -0.029510319232940674, 0.011097484268248081, 0.00515808304771781, 0.006744919344782829, 0.002274811500683427, -0.021047191694378853, 0.017023056745529175, -0.02128227800130844, 0.003899676725268364, 0.009735362604260445, -0.02679990604519844, -0.024366063997149467, 0.028307227417826653, -0.006613547448068857, 0.007080263923853636, 0.020189816132187843, 0.020590845495462418, -0.03700544312596321, -0.023052344098687172, 0.008553014136850834, -0.003878933610394597, 0.0032998593524098396, 0.014561559073626995, -0.0038720194716006517, -0.013842469081282616, 0.010087992995977402, -0.010129479691386223, -0.014215842820703983, 0.01888992264866829, -0.015930594876408577, 0.012514919973909855, 0.023799089714884758, -0.020162157714366913, -0.005192654673010111, 0.0003241087542846799, -0.014907274395227432, -0.016428425908088684, -0.0056489999406039715, 0.014865788631141186, -0.02848700061440468, -0.024836238473653793, -0.01864100806415081, -0.003937705419957638, -0.03584383800625801, -0.0028556142933666706, 0.04342193156480789, -0.022222625091671944, 0.016345452517271042, -0.019705813378095627, -0.02237473987042904, -0.0038616477977484465, -0.017064543440937996, 0.01775597408413887, -0.010502852499485016, -0.0030077293049544096, -0.024656467139720917, 0.00021445196762215346, -0.015391277149319649, 0.03111444227397442, 0.006859005894511938, 0.0029385860543698072, -0.00634388905018568, -0.0046740807592868805, -0.004999053664505482, -0.023176802322268486, -0.0031996017787605524, 0.012148460373282433, -0.020494045689702034, -0.012590977363288403, 0.013220180757343769, 0.00428342167288065, -0.02361931838095188, -0.005317112430930138, 0.02563829906284809, -0.014768987894058228, 0.029869863763451576, -0.05207866057753563, 0.03755858913064003, -0.01922181062400341, -0.00990822073072195, -0.004107106477022171, -0.011858059093356133, 0.01325475238263607, -0.009500276297330856, -0.017023056745529175, 0.0097284484654665, -0.03412908688187599, 0.012902121990919113, -0.0044286223128438, -0.00713557843118906, -0.0029420433565974236, -0.01833677664399147, 0.025458527728915215, -0.04419633373618126, 0.004214278422296047, 0.02970392070710659, 0.01949838362634182, -0.0038374478463083506, 0.02738070860505104, -0.0017545088194310665, 0.0021503535099327564, 0.000630067428573966, -0.03291216492652893, 0.012134632095694542, -0.011864973232150078, -0.013600467704236507, 0.009078502655029297, -0.007011120673269033, -0.009742277674376965, -0.005680114030838013, 0.0040033916011452675, -0.008297184482216835, -0.004065620247274637, 0.017396429553627968, 0.009631648659706116, 0.010101822204887867, -0.019609011709690094, -0.012487262487411499, 0.002508169738575816, -0.010371480137109756, -0.016746483743190765, 0.0026775705628097057, -0.0005263526109047234, 0.004044877365231514, 0.02244388312101364, 0.013171779923141003, -0.008124326355755329, 0.0008664507768116891, -0.013572811149060726, -0.021586507558822632, 0.0027501708827912807, -0.004387136083096266, 0.01017096545547247, -0.015087046660482883, -0.0027639996260404587, -0.010247022844851017, 0.02065998874604702, -0.00661700451746583, -0.0025219982489943504, -0.02826574072241783, 0.02536172606050968, -0.008055183105170727, 0.0005570349167101085, -0.005458856001496315, 0.035041775554418564, -0.026108473539352417, -0.02296937257051468, -0.015211504884064198, 0.0020172528456896544, 0.026440361514687538, -0.013994584791362286, -0.018184661865234375, 0.025486184284090996, -0.02473943866789341, -0.013462182134389877, 0.01888992264866829, -0.005285997875034809, -0.023812919855117798, 0.010737939737737179, -0.010191707871854305, 0.028652943670749664, -0.004922996275126934, -0.0019377382704988122, -0.0036092752125114202, 0.014478586614131927, 0.023204458877444267, 0.013282408937811852, 0.009244446642696857, -0.012964350171387196, -0.04256455600261688, 0.0020812104921787977, 0.009991193190217018, 0.005064739845693111, -0.0010302336886525154, -0.016953913494944572, 0.015902936458587646, 0.007322265300899744, 0.00749512342736125, 0.0050509111024439335, -0.021392907947301865, -0.025970187038183212, 0.012915950268507004, 0.003695704275742173, -0.019069695845246315, -0.015045560896396637, 0.029455004259943962, 0.03119741380214691, 0.011837316676974297, -0.016787970438599586, 0.008573757484555244, -0.005683571100234985, 0.0038823909126222134, 0.01297817938029766, -0.032165419310331345, -0.0002281725755892694, 0.037060756236314774, 0.032690905034542084, 0.01250109076499939, 0.025541499257087708, -0.01720282807946205, 0.03365891054272652, 0.0021780109964311123, -0.0052687120623886585, -0.01162988692522049, 0.014644530601799488, -0.007232379168272018, -0.016400767490267754, -0.0024632266722619534, 0.011595315299928188, -0.010288508608937263, -0.013482924550771713, -0.032773878425359726, 0.008718958124518394, 0.011491600424051285, 0.006167573854327202, 0.06975166499614716, -0.0057319714687764645, -0.018820779398083687, 0.009064674377441406, 0.007149407174438238, 0.010212451219558716, -0.008760443888604641, 0.0029852578882128, -0.028597628697752953, -0.01922181062400341, 0.020798275247216225, -0.008573757484555244, 0.01572316512465477, -0.013054236769676208, -0.011546915397047997, 0.00799295399338007, 0.021738622337579727, 0.04071151837706566, -0.038554251194000244, 0.006890119984745979, 0.01398075558245182, 0.02973157726228237, -0.0007121749804355204, -0.0015030003851279616, -0.003910047933459282, -0.006776033900678158, 0.020908905193209648, -0.0019066238310188055, -0.02092273347079754, -0.041181690990924835, 0.0031805874314159155, -0.005956687033176422, -0.042094383388757706, -0.013289324007928371, 0.00023789583065081388, -0.015335962176322937, 0.005144254304468632, -0.013953098095953465, 0.04342193156480789, 0.0038685621693730354, -0.02126844972372055, 0.007087178528308868, -0.009126902557909489, -0.013538239523768425, 0.03966054320335388, 0.014879616908729076, -0.013994584791362286, -0.0021468964405357838, -0.009652391076087952], 'k': 2, 'num_candidates': 20}}\n",
-      "INFO:elastic_transport.transport:POST http://localhost:9200/paul_graham/_search [status:200 duration:0.034s]\n",
-      "POST http://localhost:9200/paul_graham/_search [status:200 duration:0.034s]\n",
-      "He invested $6k per founder, which in the typical two-founder case was $12k, in return for 6%.\n"
+      "custom query {'knn': {'filter': [{'match': {'title': 'matrix'}}], 'field': 'embedding', 'k': 2, 'num_candidates': 20, 'query_vector': [0.00446691969409585, -0.038953110575675964, -0.023963095620274544, -0.024891795590519905, -0.016729693859815598, 0.017200583592057228, -0.002360992832109332, -0.012622482143342495, -0.009980263188481331, -0.026108263060450554, 0.02950914017856121, 0.018626336008310318, -0.016154160723090172, -0.012099270708858967, 0.03777588531374931, 0.006209868937730789, 0.03539527207612991, -0.011746102944016457, 0.0029888467397540808, -0.022066453471779823, -0.02290359139442444, -0.011752642691135406, -0.018744058907032013, -0.015251620672643185, 0.0034074161667376757, 0.00014756205200683326, 0.022955913096666336, -0.02264198660850525, 0.002032350515946746, -0.021778685972094536, 0.012164671905338764, -0.015055416151881218, 0.006543416064232588, -0.009509372524917126, -0.008632993325591087, -0.006814832333475351, 0.011765723116695881, -0.01788076013326645, 0.00166691979393363, 0.002267795614898205, 0.015460905618965626, -0.016533490270376205, -0.014401402324438095, -0.0142836794257164, -0.020863065496087074, -0.01714826375246048, 0.027913343161344528, -0.032962337136268616, -0.016546569764614105, 0.0019947446417063475, 0.026304468512535095, 0.011706861667335033, -0.03733115270733833, -0.02812262810766697, -0.01879638060927391, 0.003232467221096158, -0.01393051166087389, -0.00879649631679058, 0.018469372764229774, -0.006402803119271994, 0.016481168568134308, 0.009149664081633091, -0.023492205888032913, -0.0024296643678098917, -0.00589921185746789, 0.0089338393881917, -0.016755854710936546, -0.0016309489728882909, -0.011726481840014458, -0.004267445299774408, 0.03162814676761627, 0.04190925508737564, 0.015513226389884949, 0.0019260731060057878, 0.027050044387578964, -0.03780204430222511, -0.038220614194869995, -0.008155561983585358, 0.01085010264068842, 0.021333957090973854, 0.026042861863970757, -0.008122861385345459, -0.021137751638889313, 0.02192256972193718, 0.0020094600040465593, -0.0013415474677458405, -0.0063570220954716206, 0.02903824858367443, 0.006232759449630976, 0.0072072409093379974, 0.00309185404330492, 0.0014167592162266374, 0.03691258653998375, 0.023034395650029182, -0.005048993043601513, 0.025336526334285736, 0.0038652264047414064, 0.009254306554794312, -0.007560409139841795, -0.02906440943479538, -0.00708951847627759, 0.0022220145910978317, -0.016808176413178444, -0.008305985480546951, -0.01105938758701086, -0.0062752701342105865, 0.011602219194173813, -0.011621839366853237, 0.04303416237235069, 0.0014069488970562816, -0.025179563090205193, 0.009293547831475735, 0.01714826375246048, -0.030110832303762436, -0.0007423065835610032, -0.023740731179714203, 0.019594278186559677, 0.0014004088006913662, 0.02074534446001053, -0.01884870044887066, 0.020876146852970123, 0.026814598590135574, 0.01534318272024393, -0.005971153266727924, 0.012328175827860832, -0.014074394479393959, -0.025192642584443092, -0.008855357766151428, 0.006697109900414944, -0.020091328769922256, 0.03050324134528637, -0.0019080876372754574, 0.0057128178887069225, 0.004175883252173662, -0.02783486247062683, 0.0035022483207285404, -0.0032242920715361834, 0.02075842395424843, -0.028253432363271713, -0.024237781763076782, 0.029352176934480667, 0.02979690581560135, -0.027573255822062492, -0.0004287883348297328, -0.02974458411335945, 0.004221664275974035, 0.01598411798477173, 0.02167404443025589, 0.020915387198328972, -0.00558855477720499, 0.011105168610811234, 0.009888701140880585, 0.007318423595279455, 0.0031539855990558863, 0.018992584198713303, 0.016729693859815598, -0.016559649258852005, -0.01837781071662903, -0.01570943184196949, 0.0026340438053011894, -0.01831240952014923, 0.0038815767038613558, -0.001384058385156095, -0.004784116987138987, 0.011281752027571201, 0.04175229370594025, 0.01274674478918314, -0.012328175827860832, -0.01595795713365078, -0.0022449051029980183, -0.011994628235697746, 0.03693874552845955, -0.030817169696092606, 0.01998668722808361, -0.007651971187442541, 0.009561693295836449, 0.01595795713365078, 0.019620439037680626, -0.013256876729428768, 0.012073109857738018, -0.011301372200250626, 0.0334070660173893, 0.028436556458473206, 0.024237781763076782, -0.030869489535689354, 0.023479124531149864, -0.013538102619349957, -0.009130043908953667, 0.00642569363117218, -0.0003075912536587566, -0.005300788674503565, 0.006984876003116369, 0.011092088185250759, -0.007822014391422272, -0.6659438610076904, -0.017449110746383667, 0.009332788176834583, 0.01096128486096859, 0.0040254597552120686, 0.007292263209819794, 0.01466300804167986, -0.006278540473431349, -0.01713518239557743, 0.02048373781144619, -0.007233401760458946, -0.004983591381460428, 0.012236613780260086, -0.01638960652053356, -0.027023883536458015, -0.01574867218732834, -0.0021141022443771362, -0.0309479720890522, -0.010941664688289165, 0.008842277340590954, -0.03544759377837181, 0.03526446968317032, -0.021307796239852905, -0.004947620443999767, 0.02236730046570301, 0.011491036973893642, 0.013001810759305954, -0.019241109490394592, -0.0025997080374509096, -0.003065693425014615, -0.008914219215512276, 0.038194455206394196, 0.0071549201384186745, -0.007625810336321592, 0.03589232265949249, -0.01926727034151554, -0.02520572394132614, 0.019816642627120018, 0.012949489057064056, 0.03740963712334633, -0.004728525876998901, -0.006651328876614571, 0.013603503815829754, 0.004447299521416426, -0.011870365589857101, -0.006517255678772926, 0.037226513028144836, -0.01930651068687439, 0.0057128178887069225, -0.004241284914314747, -0.0015598249156028032, 0.021582482382655144, 0.006111766677349806, 0.0034106862731277943, 0.00404508039355278, -0.007691211998462677, 0.029456818476319313, -0.006926015019416809, 0.007743533235043287, 0.002228554803878069, -0.004136642441153526, 0.028462715446949005, -0.0034957081079483032, -0.001543474500067532, -0.007815474644303322, 0.028384234756231308, 0.01809004507958889, 0.02330908179283142, 0.006497635040432215, -0.039868731051683426, 0.011144408956170082, 0.020352935418486595, 0.00372134312056005, -0.010039124637842178, 0.011595679447054863, 0.015395504422485828, 0.026121344417333603, 0.0022776059340685606, 0.0036199709866195917, -0.010071825236082077, 0.008652613498270512, 0.004401518497616053, -0.02258966490626335, 0.003544759238138795, 0.01854785531759262, 0.01670353300869465, -0.026840759441256523, 0.009457051753997803, -0.01225623395293951, -0.011399474926292896, -0.0077958544716238976, 0.009587854146957397, -0.017802277579903603, -0.021961810067296028, 0.01908414624631405, 0.01880946010351181, 0.00333383958786726, -0.00784817524254322, 0.011641460470855236, -0.016481168568134308, 0.01155643817037344, -0.000591474468819797, 0.022812029346823692, 0.017213664948940277, 0.005814190022647381, 0.0015320292441174388, 0.012472058646380901, 0.009993343614041805, 0.03045092150568962, -0.011079007759690285, 0.008240584284067154, 0.0021909489296376705, -0.013269956223666668, -0.01379970833659172, -0.013034511357545853, -0.02718084678053856, 0.03291001543402672, 0.011085547506809235, 0.02521880343556404, -0.029169052839279175, 0.01404823362827301, -0.020052088424563408, -0.0023217517882585526, 0.00589921185746789, -0.005967883393168449, 0.009751358069479465, -0.007854715920984745, 0.006389722693711519, -0.03152350336313248, 0.01085664238780737, -0.007004496641457081, 0.008992700837552547, 0.0036134307738393545, -0.026971563696861267, -0.0030591534450650215, 0.015513226389884949, 0.010438073426485062, -0.0037802045699208975, -0.0002462773700244725, -0.015840234234929085, -0.023008234798908234, 0.004136642441153526, 0.009365489706397057, 0.0065270657651126385, -0.010496934875845909, -0.014859212562441826, 0.007102598901838064, -0.01344654057174921, -0.017252905294299126, 0.00399275915697217, -0.008960000239312649, -0.03926703706383705, -0.023165198042988777, 0.029142891988158226, 0.0001587007282068953, -0.00047702190931886435, -0.007135299500077963, -0.01595795713365078, -0.005026102531701326, -0.019411154091358185, 0.008122861385345459, -0.01598411798477173, -0.022498102858662605, -0.005441401619464159, 0.02355760708451271, -0.008279824629426003, 0.012458978220820427, 0.024891795590519905, 0.003610160667449236, -0.01858709566295147, -0.01298219058662653, -0.002843328518792987, -0.018403971567749977, 0.036834102123975754, -0.006638248451054096, 0.03045092150568962, 0.009685956872999668, 0.011392934247851372, -0.007488467264920473, 0.0013554452452808619, 0.0029070950113236904, 0.0019195328932255507, -0.028515037149190903, 0.007298802956938744, 0.007540788501501083, -0.014414481818675995, 0.03837757930159569, 0.008861898444592953, -0.017069781199097633, 0.024120058864355087, -0.0069063943810760975, 0.03636321425437927, -0.014819971285760403, 0.00019395620620343834, -0.01598411798477173, -0.004290335811674595, 0.020287534222006798, 0.014584526419639587, 0.004594452679157257, 0.01689973846077919, 0.04899877682328224, -0.016481168568134308, 0.02599054016172886, -0.01641576737165451, -0.008188262581825256, -0.01739678904414177, 0.011026686057448387, -0.02950914017856121, 0.02094154804944992, 0.010863183066248894, 0.023152116686105728, -0.016742773354053497, -0.005405430682003498, -0.00673635071143508, 0.006932554766535759, 0.023452963680028915, -0.018691737204790115, 0.025846658274531364, -0.0356568768620491, 0.0031539855990558863, -0.010680058971047401, -0.002248175209388137, -0.008508729748427868, -0.004120292142033577, -0.01022878848016262, 0.022040292620658875, 0.01165454089641571, 0.008848818019032478, 0.02809646725654602, -0.03243912383913994, -0.021072350442409515, -0.002400233643129468, -0.027076205238699913, 0.008410627953708172, -0.0034924380015581846, -0.005984233692288399, 0.0010202628327533603, 0.01760607399046421, 0.014492964372038841, -0.01880946010351181, -0.029352176934480667, 0.04672280326485634, 0.032255999743938446, -0.024891795590519905, 0.023623008280992508, -0.02308671548962593, 0.03152350336313248, 0.027913343161344528, 0.002375708194449544, 0.026016701012849808, -0.024407826364040375, 0.012334715574979782, -0.004807007499039173, 0.009921401739120483, -0.027704060077667236, -0.011464876122772694, -0.01047731377184391, -0.020889226347208023, 0.028462715446949005, 0.022511182352900505, -0.0015238540945574641, 0.00047211680794134736, 0.008462948724627495, -0.0050849635154008865, 0.0148853724822402, -0.022537343204021454, 0.002784467302262783, -0.002269430784508586, 0.006317781284451485, -0.01760607399046421, 0.002864584093913436, -0.020562220364809036, 0.009790598414838314, -0.00941781047731638, -0.0030035621020942926, 0.006239299662411213, 0.01466300804167986, 0.010830482468008995, 0.011111708357930183, 0.0101241460070014, -0.017985401675105095, -0.03288385644555092, 0.022772789001464844, 0.011876905336976051, -0.022458862513303757, -0.026971563696861267, -0.029456818476319313, -0.024237781763076782, -0.014623766764998436, 0.03780204430222511, 0.002068321220576763, 0.02592513896524906, 0.001957138767465949, -0.0013399124145507812, -0.011988087557256222, 0.01106592733412981, 0.014022073708474636, 0.008724555373191833, 0.019646599888801575, -0.027965664863586426, -0.0009671241277828813, -0.014087474904954433, -0.003140905173495412, -0.03937168046832085, 0.011092088185250759, -0.0017265985952690244, 0.015918714925646782, -0.025598132982850075, 0.013969752006232738, -0.0055460440926253796, -0.009901781566441059, -0.009908321313560009, -0.017082862555980682, 0.0030280877836048603, -0.016742773354053497, -0.005696467123925686, -0.015539387241005898, 0.0006401168066076934, 0.010071825236082077, -0.0026144233997911215, 0.0011984817683696747, -0.03045092150568962, -0.016572730615735054, -0.0025441169273108244, 0.10736303776502609, 0.03238680213689804, 0.0078023942187428474, 0.03045092150568962, 0.00031617519562132657, -0.02235421910881996, -0.011275212280452251, -0.025872819125652313, 0.011582599021494389, 0.009188905358314514, 0.0075015476904809475, 0.0010889343684539199, 0.005905752070248127, -0.0003386569442227483, 0.013511941768229008, 0.016494248062372208, 0.010346511378884315, 0.015670189633965492, -0.0006842627772130072, -0.029639942571520805, -0.0026700147427618504, 0.00369191262871027, 0.02885512448847294, 0.025061840191483498, -0.01860017515718937, -0.030320117250084877, 0.007436146028339863, 0.001064408803358674, -0.006854073144495487, 0.01379970833659172, -0.026343708857893944, -0.007449226453900337, -0.007782774046063423, -0.008960000239312649, -0.003358365036547184, 0.016507329419255257, 0.018992584198713303, 0.03024163655936718, 0.05313214659690857, -0.009672876447439194, -0.005974423605948687, -0.003001927165314555, 0.0035185986198484898, -0.0178676787763834, 0.005886131431907415, -0.02736397087574005, -0.004924729932099581, 0.02551965042948723, 0.03549991175532341, -0.012753285467624664, 0.03479357808828354, 0.010307270102202892, -0.02694540284574032, 0.001117547508329153, 0.027285490185022354, -0.009306628257036209, -0.002506511053070426, 0.0007181898108683527, -0.0020454307086765766, 0.02664455585181713, -0.010418453253805637, -0.03160198777914047, 0.007357664406299591, -0.003590540261939168, 0.00369191262871027, -0.04980975389480591, -0.0014412846649065614, -0.03220367804169655, -0.0038848468102514744, -0.015251620672643185, -0.013786627911031246, -0.02733781188726425, -0.03165430575609207, -0.030110832303762436, 0.012485139071941376, 0.004244554787874222, 0.004892029333859682, -0.007043737452477217, -0.008999241515994072, 0.029221372678875923, -0.019201869145035744, -0.02406773716211319, -0.0036722919903695583, -0.01670353300869465, 0.003288058564066887, 0.02449938841164112, -0.0011584233725443482, 0.0019538686610758305, -0.0035120584070682526, 0.020784584805369377, 0.006697109900414944, 0.02669687755405903, 0.010202627629041672, -0.019594278186559677, 0.027076205238699913, -0.003312584012746811, 0.017265986651182175, 0.0226158257573843, 0.01404823362827301, -0.02528420463204384, 0.010431532748043537, -0.028253432363271713, -0.006563036702573299, -0.022772789001464844, -0.006628438364714384, -0.013616584241390228, -0.01357734389603138, 0.01619340106844902, -0.01619340106844902, -0.012328175827860832, -0.024224702268838882, -0.02238037995994091, -0.012223533354699612, -0.004493080545216799, 0.012210452929139137, 0.012864467687904835, -0.004918189719319344, 0.0427987165749073, -0.0030787738505750895, 0.0016489343252032995, 0.013191474601626396, -0.02621290646493435, 0.010156846605241299, 0.012177752330899239, -0.007534248288720846, -0.013865109533071518, 0.015774833038449287, -0.043975941836833954, 0.010876263491809368, 0.002223649760708213, -0.012884087860584259, 0.033459387719631195, 0.0023887883871793747, -0.016036437824368477, -0.026069022715091705, -0.012347796000540257, -0.0190449059009552, 0.03071252629160881, -0.01809004507958889, -0.025794336572289467, -0.007612730376422405, -0.011687241494655609, 0.005745518486946821, -0.018233926966786385, 0.017802277579903603, -0.025912059471011162, -0.015853313729166985, -0.022223416715860367, -0.0014429197181016207, 0.011392934247851372, -0.012321635149419308, 0.0031392702367156744, -0.003937168046832085, -0.03000619076192379, 0.006703649647533894, -0.046094950288534164, -0.002777927089482546, 0.00033599999733269215, 0.011249051429331303, 0.011406014673411846, 0.02759941667318344, 0.00559836532920599, 0.01781535893678665, 0.01403515413403511, -0.010627737268805504, 0.023034395650029182, -0.01179188396781683, 0.004846248310059309, -0.03555223345756531, 0.037488117814064026, 0.028384234756231308, -0.00025710949557833374, 0.017566831782460213, -0.01165454089641571, 0.015251620672643185, 0.01976432092487812, 0.020549139007925987, 0.012406657449901104, -0.02092846855521202, -0.037304993718862534, -0.014349080622196198, 0.0015230365097522736, -0.01347270142287016, -0.007455766666680574, -0.014375241473317146, -0.024604029953479767, 0.002305401489138603, 0.00023564964067190886, -0.009365489706397057, -0.019136467948555946, 0.04091515392065048, -0.0013824234483763576, 0.0012303650146350265, -0.004139912314713001, 0.004957430996000767, 0.01022878848016262, -0.0014968760078772902, -0.0032749781385064125, 0.005742248147726059, -0.005523153580725193, 0.008449869230389595, 0.012001167982816696, -0.001093839411623776, 0.011811504140496254, 0.0018786570290103555, 0.01955503784120083, -0.004257635213434696, -0.008305985480546951, 0.0025751825887709856, 0.000532204401679337, -0.0029430657159537077, -0.00808362103998661, -0.018220847472548485, -0.03424420580267906, 0.0008780146017670631, -0.013642745092511177, -0.008946919813752174, 0.00917582493275404, 0.006978335790336132, -0.01877021975815296, 0.009313168004155159, -0.0001295766414841637, 0.05195492133498192, 0.020666861906647682, 0.023897694423794746, 0.009757897816598415, -0.004771036561578512, -0.0031196498312056065, 0.007011036854237318, 0.0031703358981758356, 0.009574773721396923, 0.02308671548962593, 0.020562220364809036, 0.0075865695253014565, 0.005052262917160988, -0.01621956191956997, -0.005961343180388212, -0.0334070660173893, -0.01534318272024393, 0.0018590365070849657, 0.027573255822062492, 0.00916928518563509, -0.011504117399454117, -0.02807030826807022, 0.008404088206589222, 0.037043388932943344, -0.003065693425014615, 0.007815474644303322, -0.021857168525457382, -0.03861302137374878, -0.023296000435948372, -0.01810312457382679, -0.004702365025877953, 0.022550424560904503, -0.0034172264859080315, -0.024826394394040108, 0.016716614365577698, -0.021543242037296295, 0.006422423757612705, -0.0148853724822402, -0.013969752006232738, 0.027573255822062492, -0.006553226616233587, 0.011157489381730556, 0.015160058625042439, -0.002540846820920706, -0.0028220731765031815, 0.002995386952534318, 0.012714044190943241, 0.025323446840047836, -0.022668147459626198, 0.007115678861737251, 0.008384467102587223, 0.00738382525742054, 0.016141081228852272, -0.004381897859275341, -0.022275738418102264, -0.0357615202665329, 0.0017674744594842196, 0.007213781122118235, 0.01807696372270584, 0.006749430671334267, -0.009888701140880585, -0.008737634867429733, -0.01788076013326645, -0.00024464234593324363, -0.025166481733322144, -0.01226277370005846, -0.011746102944016457, -0.016036437824368477, -0.02830575220286846, -0.026539912447333336, 0.014846132136881351, 0.018233926966786385, -0.00168408767785877, 0.00941781047731638, 0.027050044387578964, 0.04905109480023384, -0.027520935982465744, -0.010451153852045536, -0.009725197218358517, 0.022275738418102264, -0.02026137337088585, 0.005258277524262667, 0.0011862190440297127, -0.016585810109972954, 0.03497670218348503, -0.010287649929523468, -0.002465635072439909, -0.00798551831394434, -0.0032390074338763952, -0.0062752701342105865, -0.0017020730301737785, -0.01760607399046421, -0.002083036582916975, 0.013250336050987244, -0.013734307140111923, -0.007233401760458946, -0.003227562177926302, 0.011752642691135406, -0.018233926966786385, 0.012622482143342495, 0.010666978545486927, 0.001635854016058147, 0.012105810455977917, -0.005163445603102446, 0.004391707945615053, -0.01641576737165451, -0.02979690581560135, -0.013995912857353687, 0.0040614306926727295, 0.01557862851768732, 0.001187854097224772, 0.00878995656967163, -0.020169811323285103, -0.014754570089280605, -0.008135941810905933, 0.020143650472164154, -0.007514628116041422, 0.0005816642660647631, 0.014519124291837215, 0.03021547570824623, -0.00906464271247387, 0.007776233833283186, 0.008430248126387596, 0.010653898119926453, -0.018194686621427536, -0.018443211913108826, -0.027233168482780457, -0.0356307178735733, -0.010052205063402653, 0.018011562526226044, 0.01357734389603138, -0.015892555937170982, -0.014375241473317146, -0.009685956872999668, -0.016114920377731323, 0.003227562177926302, 0.0010055474704131484, 0.01645500771701336, 0.03950248286128044, -0.0003386569442227483, -0.0027059854473918676, 0.008750715292990208, 0.000965489074587822, 0.01812928542494774, -0.009790598414838314, -0.006160817574709654, 0.017684554681181908, -0.017252905294299126, 0.0009115329012274742, 0.014257518574595451, -0.01952887699007988, 0.0010227153543382883, 0.004937810357660055, 0.004182423464953899, -0.006272000260651112, 0.016795095056295395, -0.01931959204375744, -0.0028809343930333853, 0.010156846605241299, 0.007893956266343594, 0.006265460047870874, -0.004110482055693865, -0.02194873057305813, -0.025781257078051567, 0.007266102358698845, 0.012871007435023785, 0.009254306554794312, -0.0017020730301737785, -0.02308671548962593, 0.03476741537451744, -0.01621956191956997, 0.00966633576899767, -0.023191358894109726, -0.03604928404092789, 0.001555737224407494, -0.008874977938830853, 0.011046307161450386, 0.017069781199097633, 0.014924613758921623, 0.014061314053833485, 0.008626452647149563, -0.025585051625967026, -0.004676204640418291, 0.005127474665641785, -0.004169343039393425, -0.011242511682212353, -0.007560409139841795, -0.010869722813367844, 0.0032945985440164804, -0.0056310659274458885, 0.02120315469801426, -0.014689167961478233, 0.0038652264047414064, -0.012066570110619068, 0.0050359126180410385, -0.028985928744077682, 0.02480023354291916, 0.0015287591377273202, -0.01382586918771267, -0.00820134300738573, -0.006697109900414944, -0.0031310950871556997, -0.007128759287297726, -0.006448584143072367, 0.011562978848814964, -0.012517839670181274, -0.007246482186019421, 0.004800467286258936, -0.00540870102122426, -0.028724322095513344, 0.009672876447439194, -0.01831240952014923, -0.015186219476163387, 0.029404496774077415, 0.2164003551006317, 0.019398072734475136, -0.015787912532687187, 0.02193565107882023, 0.004630423616617918, 0.027390131726861, 0.03243912383913994, 0.0043230364099144936, -0.007213781122118235, 0.009365489706397057, 0.005915562156587839, 0.021870248019695282, 0.017239825800061226, 0.0007799124578014016, -0.007279182784259319, -0.035709198564291, -0.008266745135188103, -0.01574867218732834, -0.0014788905391469598, -0.038220614194869995, -0.009332788176834583, 0.003646131604909897, -0.026762278750538826, -0.014702248387038708, 0.026003621518611908, -0.0004108029243070632, 0.01662505231797695, -0.020771503448486328, 0.00620005838572979, 0.013564263470470905, 0.0013399124145507812, -0.04067970812320709, 0.007429606281220913, -0.010778160765767097, -0.01712210290133953, -0.007298802956938744, -0.006641518324613571, -0.012766364961862564, 0.019371913745999336, 0.002719065872952342, -0.0026356789749115705, -0.009195445105433464, 0.003201401559635997, 0.004342657048255205, 0.002818803070113063, 0.007449226453900337, -0.005784759297966957, -0.0009802044369280338, -0.0049508907832205296, -0.005732438061386347, -0.024590950459241867, -0.01085664238780737, 0.015552467666566372, 0.04578102380037308, -0.011020146310329437, 0.011517197825014591, 0.0006262189708650112, -0.010948204435408115, -0.0008943650173023343, -0.0015025986358523369, -0.004326306749135256, 0.03068636544048786, -0.026618395000696182, 0.00846948940306902, -0.0018802920822054148, 0.02622598595917225, -0.032072875648736954, 0.008986161090433598, 0.008868438191711903, -0.014008993282914162, -0.01344654057174921, -0.014453723095357418, -0.01662505231797695, -0.004558481741696596, 0.001986569492146373, 0.009221605956554413, 0.010065284557640553, 0.014322919771075249, 0.01884870044887066, 0.012557080946862698, -0.018286248669028282, -0.01298873033374548, -0.005461022257804871, -0.011131328530609608, -0.023466045036911964, -0.02427702210843563, 0.005833810195326805, -0.021137751638889313, 0.0045257811434566975, -0.016507329419255257, 0.004182423464953899, -0.03000619076192379, -0.008953460492193699, 0.007429606281220913, 0.006965255830436945, 0.014336000196635723, 0.023439884185791016, 0.04190925508737564, -0.013420379720628262, -0.0024018685799092054, -0.03353786841034889, -0.00998680293560028, 0.012458978220820427, 0.0007145109702832997, -0.018887942656874657, -0.01663813181221485, -0.012661723420023918, 0.026814598590135574, 0.016036437824368477, -0.009816759265959263, 0.008063999935984612, 0.009195445105433464, 0.017213664948940277, -0.017305226996541023, -0.0006294890772551298, 0.006170628126710653, 0.008966539986431599, -0.01784151792526245, 0.020836906507611275, -0.03693874552845955, 0.001570452586747706, -0.011229431256651878, -0.019816642627120018, -0.008855357766151428, 0.005006481893360615, -0.011948847211897373, 0.00018894890672527254, 0.004411328583955765, 0.00012375182996038347, -0.017436029389500618, 0.004878948908299208, -0.012812145985662937, 0.010333430953323841, -0.002864584093913436, -0.0007157372310757637, 0.007233401760458946, 0.012942949309945107, 0.015591708943247795, -0.010045664384961128, 0.027468614280223846, 0.01239357702434063, -0.01026148907840252, 0.0020650511141866446, 0.006464934442192316, 0.003727883333340287, -0.031104935333132744, 0.021556321531534195, -0.008417167700827122, -0.002374073024839163, -0.022511182352900505, -0.009509372524917126, -0.039450161159038544, -0.001117547508329153, -0.017946161329746246, 0.003747503738850355, -0.045833345502614975, -0.022432701662182808, -0.03073868714272976, -0.01688665710389614, 0.021320875734090805, -0.00500321201980114, 0.02478715404868126, 0.009339328855276108, -0.0006818102556280792, -0.02045757696032524, 0.000785226293373853, -0.16763702034950256, 0.0033354745246469975, 0.009352409280836582, -0.0072007011622190475, 0.02617366425693035, -0.0004385985666885972, 0.012478599324822426, 0.032543767243623734, -0.011092088185250759, -0.0011968467151746154, 0.00987562071532011, 0.012799066491425037, -0.027520935982465744, 0.0038554160855710506, -0.003242277540266514, 0.001795270130969584, 0.01806388422846794, 0.007063358090817928, 0.011641460470855236, 0.0030885839369148016, 0.009725197218358517, 0.007455766666680574, 0.01415287610143423, 0.0039306278340518475, 0.012622482143342495, -0.014741489663720131, 0.027547094970941544, 0.013250336050987244, 0.003544759238138795, -0.005510073155164719, -0.009090803563594818, -0.0010799416340887547, 0.0021860438864678144, 0.024120058864355087, 0.009201985783874989, 0.009803678840398788, 0.0025604672264307737, -0.011543357744812965, -0.023910773918032646, 0.009260847233235836, 0.013564263470470905, -0.004247825127094984, 0.009901781566441059, -0.016311123967170715, 0.014231357723474503, 0.03432268649339676, 0.01476765051484108, 0.00977097824215889, 0.024486307054758072, -0.007351124193519354, 0.018874861299991608, -0.03215136006474495, -0.0032210219651460648, -0.014571445994079113, 0.027704060077667236, 0.021974891424179077, 0.0022972263395786285, 0.005294248461723328, -0.004110482055693865, 0.00220729922875762, -0.030660204589366913, 0.0006115036667324603, 0.004283795598894358, -0.0020912117324769497, -0.014924613758921623, -0.022066453471779823, 0.0053334892727434635, 0.00809016078710556, -0.01716134324669838, 0.009228146634995937, -0.009025401435792446, 0.010536175221204758, -0.010084905661642551, -0.005722627975046635, 0.0071680000983178616, 0.020091328769922256, -0.01903182454407215, 0.022812029346823692, 0.01574867218732834, 0.016795095056295395, -0.006638248451054096, 0.03842989727854729, -0.010660437867045403, 0.007056817878037691, 0.027573255822062492, 0.0021255475003272295, -0.008737634867429733, -0.025585051625967026, 0.005163445603102446, -0.008273284882307053, -0.006997956428676844, -0.02956146001815796, -0.021765606477856636, -0.013289577327668667, 0.004663124214857817, 0.016088759526610374, 0.009757897816598415, 0.017920000478625298, 0.016363445669412613, -0.01831240952014923, -0.0032504526898264885, -0.007573489099740982, -0.0048691388219594955, 0.008547971025109291, 0.022105693817138672, 0.02733781188726425, 0.02498335763812065, 0.0007770511438138783, 0.01226277370005846, -0.011948847211897373, 0.006039824802428484, 0.000842043838929385, 0.024185460060834885, 0.03911007568240166, -0.0009736642823554575, 0.0018770219758152962, 0.010980905033648014, -0.00540870102122426, 0.009201985783874989, 0.0022612556349486113, 0.050882335752248764, 0.007972437888383865, -0.020771503448486328, -0.0014911533799022436, -0.007115678861737251, -0.027677899226546288, -0.08392315357923508, -0.011353693902492523, -0.01620648242533207, 0.019685840234160423, -0.02019597217440605, 0.01975124143064022, -0.005895941983908415, 0.006814832333475351, 0.004159532953053713, 0.037749722599983215, -0.004581372253596783, -0.03542143106460571, 0.004231474362313747, -0.007455766666680574, 0.002687999978661537, -0.009234686382114887, -0.03314546123147011, -0.014492964372038841, -0.011634919792413712, 0.010738920420408249, -0.02950914017856121, -0.007972437888383865, -0.014414481818675995, -0.02214493416249752, -0.004963970743119717, -0.007691211998462677, -0.024250861257314682, 0.004205313976854086, 0.008391007781028748, 0.03045092150568962, -0.01759299263358116, -0.024002335965633392, 0.0018574015703052282, -0.037723563611507416, 0.021373197436332703, -0.009221605956554413, -0.01224969420582056, -0.007612730376422405, 0.02141243778169155, -0.04366201534867287, 0.008168642409145832, 0.02405465766787529, 0.007861255668103695, -0.025781257078051567, 0.011504117399454117, -0.007625810336321592, -0.021621722728013992, 0.029613781720399857, 0.01763223484158516, -0.03136654198169708, -0.032491445541381836, -0.007560409139841795, -0.027233168482780457, -0.011366774328052998, 0.030607884749770164, -0.0030051972717046738, 0.018273169174790382, -0.0065728467889130116, -0.008456408977508545, 0.002208934398368001, 0.0014036789070814848, 0.008116321638226509, -0.012779445387423038, 0.007893956266343594, 0.0067755915224552155, -0.020052088424563408, 0.0061804382130503654, 0.014623766764998436, 0.02383229322731495, -0.0130933728069067, -0.02070610225200653, 0.006281810346990824, -0.009443971328437328, -0.007161459885537624, -0.024420905858278275, -0.006912934593856335, -0.026343708857893944, -0.0018099854933097959, 0.012949489057064056, -0.0357876792550087, -0.010725839994847775, -0.011759182438254356, 0.03288385644555092, -0.017279066145420074, 0.003080408787354827, 0.007808934431523085, 0.0032406423706561327, 0.006648058537393808, 0.004411328583955765, 0.0008649343508295715, -0.01836473122239113, 0.017710715532302856, -0.00261769350618124, -0.013721226714551449, -0.029953869059681892, 0.02383229322731495, -0.008711474947631359, -0.0020536058582365513, 0.006242569535970688, 0.02622598595917225, -0.016782015562057495, -0.0034074161667376757, -0.06001238152384758, 0.011975008063018322, 0.00673635071143508, -0.022498102858662605, 0.005320408847182989, 0.0032651680521667004, 0.03761892020702362, -0.021503999829292297, 0.011334073729813099, 0.017671475186944008, -0.005045722704380751, 0.016311123967170715, 0.01928035169839859, 0.004633693490177393, -0.01225623395293951, -0.02572893537580967, -0.005290978122502565, -0.017422949895262718, 0.0012050219811499119, 0.002128817606717348, -0.015447825193405151, -0.036310892552137375, 0.015800993889570236, 0.009587854146957397, -0.006033285055309534, -0.006729810498654842, -0.005487182643264532, 0.01025494933128357, -0.04217086359858513, -0.0017674744594842196, 0.008057460188865662, -0.00018905110482592136, 0.007887416519224644, 0.013511941768229008, 0.017305226996541023, -0.0024296643678098917, -0.012086190283298492, 0.022785868495702744, 0.01621956191956997, 0.02670995704829693, 0.005614715628325939, -0.010398832149803638, 0.01810312457382679, -0.004947620443999767, 0.00903848186135292, 0.016847416758537292, -0.03026779741048813, -0.008286365307867527, 0.03280537202954292, 0.0016701897839084268, 0.03165430575609207, 0.00577821908518672, -0.02019597217440605, -0.034453488886356354, -0.007828555069863796, 0.006801751907914877, 0.023439884185791016, -0.014597605913877487, -0.007861255668103695, 0.0030133724212646484, 0.026239067316055298, 0.006249109748750925, -0.001480525592342019, 0.009535533376038074, 0.012942949309945107, 0.02546732872724533, -0.003217751858755946, 0.007599649950861931, 0.0005305693484842777, -0.035866159945726395, 0.016795095056295395, 0.004349197261035442, 0.0056670368649065495, 0.0017642044695094228, 0.013328817673027515, 0.01082394178956747, 0.000770510989241302, -0.017959240823984146, -0.005068613216280937, 0.005922102369368076, 0.022079532966017723, -0.015526306815445423, -0.034191884100437164, 0.005807649809867144, 0.04005185514688492, 0.008077080361545086, -0.004100671503692865, 0.019123386591672897, 0.001824700739234686, 0.013551183044910431, -0.01107246708124876, 0.01998668722808361, 0.014401402324438095, 0.00214353296905756, 0.0015025986358523369, 0.0017102481797337532, -0.01810312457382679, -0.00434592692181468, 0.007298802956938744, 0.025781257078051567, 0.00952899269759655, -0.0023381023202091455, -0.004584642592817545, -0.030058512464165688, -0.0009752992773428559, 0.0035545695573091507, -0.005768408998847008, -0.03073868714272976, -0.0007038832409307361, 0.013041051104664803, 0.01975124143064022, 0.010686598718166351, -0.02285127155482769, 0.012563620693981647, -0.03259608894586563, -0.005817459896206856, 0.020313693210482597, -0.0006372554926201701, -0.010725839994847775, 0.032543767243623734, -0.005068613216280937, 0.00079013139475137, 0.023518364876508713, -0.0057978397235274315, 0.022001052275300026, 0.0022727008908987045, 0.024682512506842613, -0.019960526376962662, -0.02312595769762993, 0.010189548134803772, 0.0015827154275029898, 0.01359042339026928, -0.020182890817523003, 0.0031310950871556997, -0.003384525654837489, -0.020653782412409782, -0.007828555069863796, 0.022275738418102264, -0.026788439601659775, 0.05140554904937744, 0.003551299450919032, 0.019188789650797844, -0.01239357702434063, -0.022288817912340164, -0.00019835037528537214, 0.008057460188865662, 0.01141909509897232, -0.027442453429102898, -0.010143767111003399, 0.010516555048525333, 0.004578102380037308, 0.005199416074901819, 0.002365897875279188, -0.02354452572762966, 0.004826627671718597, -0.018247008323669434, 0.00843678880482912, -0.0029185402672737837, -0.016023358330130577, 0.007239941973239183, 0.0027108904905617237, 0.005670306738466024, -0.011366774328052998, -0.0008412263123318553, 0.008266745135188103, 0.035107504576444626, 0.00035316788125783205, -0.0018443212611600757, -0.03696490451693535, -0.0069521754048764706, -0.0019048175308853388, -0.006569576915353537, -0.015591708943247795, 0.03283153474330902, -0.006455124355852604, -0.0005694014835171402, -0.006971796043217182, -0.009430890902876854, 0.013420379720628262, 0.008129402063786983, 0.014375241473317146, -0.017331387847661972, -0.015853313729166985, 0.018678657710552216, -0.008711474947631359, -0.0154739860445261, -0.026788439601659775, -0.030634045600891113]}}\n"
      ]
     }
    ],
@@ -428,12 +500,11 @@
     "\n",
     "query_engine = index.as_query_engine(\n",
     "    vector_store_kwargs={\n",
-    "        \"es_filter\": [{\"match\": {\"content\": \"growing up\"}}],\n",
+    "        \"es_filter\": [{\"match\": {\"title\": \"matrix\"}}],\n",
     "        \"custom_query\": custom_query,\n",
     "    }\n",
     ")\n",
-    "response = query_engine.query(\"what were his investments in Y Combinator?\")\n",
-    "print(response)"
+    "query_engine.query(\"what is this movie about?\")"
    ]
   }
  ],

--- a/docs/docs/examples/vector_stores/ElasticsearchIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/ElasticsearchIndexDemo.ipynb
@@ -492,7 +492,7 @@
    "metadata": {},
    "source": [
     "## Custom Filters and overriding Query \n",
-    "LlamaIndex only supports ExactMatchFilters at the moment. Elasticsearch supports a wide range of filters, including range filters, geo filters, and more. To use these filters, you can pass them in as a list of dictionaries to the `es_filter` parameter."
+    "The elastic search implementation only supports ExactMatchFilters provided from LlamaIndex at the moment. Elasticsearch itself supports a wide range of filters, including range filters, geo filters, and more. To use these filters, you can pass them in as a list of dictionaries to the `es_filter` parameter."
    ]
   },
   {

--- a/docs/docs/examples/vector_stores/ElasticsearchIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/ElasticsearchIndexDemo.ipynb
@@ -246,6 +246,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4743b481",
+   "metadata": {},
+   "source": [
+    "### Dense retrieval\n",
+    "\n",
+    "Here we use embeddings from OpenAI to search."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "d3392918",
@@ -315,7 +325,9 @@
    "id": "3a1adf49",
    "metadata": {},
    "source": [
-    "### Sparse retrieval"
+    "### Sparse retrieval\n",
+    "\n",
+    "For this example you first need to [deploy the ELSER model](https://www.elastic.co/guide/en/machine-learning/current/ml-nlp-elser.html) version two in your Elasticsearch deployment."
    ]
   },
   {
@@ -353,7 +365,9 @@
    "id": "d3f6c6e3",
    "metadata": {},
    "source": [
-    "### Keyword retrieval"
+    "### Keyword retrieval\n",
+    "\n",
+    "To use classic full-text search, you can use the BM25 strategy."
    ]
   },
   {
@@ -391,7 +405,9 @@
    "id": "b4e8f643",
    "metadata": {},
    "source": [
-    "### Hybrid retrieval"
+    "### Hybrid retrieval\n",
+    "\n",
+    "Combining dense retrieval and keyword search for hybrid retrieval can be enabled by setting a flag."
    ]
   },
   {
@@ -431,7 +447,8 @@
    "metadata": {},
    "source": [
     "### Metadata Filters\n",
-    "Here we are going to index a few documents with metadata so that we can apply filters to the query engine."
+    "\n",
+    "We can also apply filters to the query engine based on the metadata of our documents."
    ]
   },
   {
@@ -475,7 +492,7 @@
    "metadata": {},
    "source": [
     "## Custom Filters and overriding Query \n",
-    "llama-index supports ExactMatchFilters only at the moment. Elasticsearch supports a wide range of filters, including range filters, geo filters, and more. To use these filters, you can pass them in as a list of dictionaries to the `es_filter` parameter."
+    "LlamaIndex only supports ExactMatchFilters at the moment. Elasticsearch supports a wide range of filters, including range filters, geo filters, and more. To use these filters, you can pass them in as a list of dictionaries to the `es_filter` parameter."
    ]
   },
   {

--- a/docs/docs/examples/vector_stores/Elasticsearch_demo.ipynb
+++ b/docs/docs/examples/vector_stores/Elasticsearch_demo.ipynb
@@ -26,9 +26,7 @@
    "id": "b5331b6b",
    "metadata": {},
    "source": [
-    "## Basic Example\n",
-    "\n",
-    "In this basic example, we take the a Paul Graham essay, split it into chunks, embed it using an open-source embedding model, load it into Elasticsearch, and then query it."
+    "## Basic Example\n"
    ]
   },
   {
@@ -37,6 +35,8 @@
    "id": "f3aaf790",
    "metadata": {},
    "source": [
+    "In this basic example, we take the a Paul Graham essay, split it into chunks, embed it using an open-source embedding model, load it into Elasticsearch, and then query it. For an example using different retrieval strategies see [Elasticsearch Vector Store](https://docs.llamaindex.ai/en/stable/examples/vector_stores/ElasticsearchIndexDemo/).\n",
+    "\n",
     "If you're opening this Notebook on colab, you will probably need to install LlamaIndex 🦙."
    ]
   },
@@ -47,20 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index-embeddings-huggingface\n",
-    "%pip install llama-index-vector-stores-elasticsearch"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b3df0b97",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# !pip install llama-index elasticsearch --quiet\n",
-    "# !pip install sentence-transformers\n",
-    "# !pip install pydantic==1.10.11"
+    "%pip install -qU llama-index-vector-stores-elasticsearch llama-index-embeddings-huggingface llama-index"
    ]
   },
   {
@@ -73,8 +60,7 @@
     "# import\n",
     "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
     "from llama_index.vector_stores.elasticsearch import ElasticsearchStore\n",
-    "from llama_index.core import StorageContext\n",
-    "from IPython.display import Markdown, display"
+    "from llama_index.core import StorageContext"
    ]
   },
   {
@@ -105,10 +91,18 @@
    "execution_count": null,
    "id": "06874a37",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-05-13 15:10:43 URL:https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt [75042/75042] -> \"data/paul_graham/paul_graham_essay.txt\" [1]\n"
+     ]
+    }
+   ],
    "source": [
     "!mkdir -p 'data/paul_graham/'\n",
-    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+    "!wget -nv 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
    ]
   },
   {
@@ -132,38 +126,41 @@
    "execution_count": null,
    "id": "667f3cb3-ce18-48d5-b9aa-bfc1a1f0f0f6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "<b>The author worked on writing and programming outside of school. They wrote short stories and tried writing programs on an IBM 1401 computer. They also built a microcomputer kit and started programming on it, writing simple games and a word processor.</b>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# load documents\n",
     "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()\n",
     "\n",
+    "# define index\n",
     "vector_store = ElasticsearchStore(\n",
-    "    index_name=\"paul_graham_essay\", es_url=\"http://localhost:9200\"\n",
+    "    es_url=\"http://localhost:9200\",  # see Elasticsearch Vector Store for more authentication options\n",
+    "    index_name=\"paul_graham_essay\",\n",
     ")\n",
     "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
-    "\n",
     "index = VectorStoreIndex.from_documents(\n",
-    "    documents,\n",
-    "    storage_context=storage_context,\n",
-    ")\n",
-    "\n",
+    "    documents, storage_context=storage_context\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d3658bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The author worked on writing and programming outside of school. They wrote short stories and tried writing programs on an IBM 1401 computer. They also built a microcomputer kit and started programming on it, writing simple games and a word processor.\n"
+     ]
+    }
+   ],
+   "source": [
     "# Query Data\n",
     "query_engine = index.as_query_engine()\n",
     "response = query_engine.query(\"What did the author do growing up?\")\n",
-    "display(Markdown(f\"<b>{response}</b>\"))"
+    "print(response)"
    ]
   }
  ],

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/Makefile
@@ -11,7 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pytest.
-	poetry run pytest tests
+	pytest tests
 
 watch-docs:	## Build and watch documentation.
 	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/Makefile
@@ -11,7 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pytest.
-	pytest tests
+	poetry run pytest tests
 
 watch-docs:	## Build and watch documentation.
 	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/__init__.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/__init__.py
@@ -1,3 +1,16 @@
 from llama_index.vector_stores.elasticsearch.base import ElasticsearchStore
 
-__all__ = ["ElasticsearchStore"]
+from elasticsearch.helpers.vectorstore import (
+    AsyncBM25Strategy,
+    AsyncSparseVectorStrategy,
+    AsyncDenseVectorStrategy,
+    AsyncRetrievalStrategy,
+)
+
+__all__ = [
+    "AsyncBM25Strategy",
+    "AsyncDenseVectorStrategy",
+    "AsyncRetrievalStrategy",
+    "AsyncSparseVectorStrategy",
+    "ElasticsearchStore",
+]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -1,9 +1,8 @@
 """Elasticsearch vector store."""
 
 import asyncio
-import uuid
 from logging import getLogger
-from typing import Any, Callable, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 import nest_asyncio
 import numpy as np
@@ -20,9 +19,19 @@ from llama_index.core.vector_stores.utils import (
     metadata_dict_to_node,
     node_to_metadata_dict,
 )
+from elasticsearch.helpers.vectorstore import AsyncVectorStore
+from elasticsearch.helpers.vectorstore import (
+    AsyncBM25Strategy,
+    AsyncSparseVectorStrategy,
+    AsyncDenseVectorStrategy,
+    AsyncRetrievalStrategy,
+    DistanceMetric,
+)
 
-import elasticsearch
-from elasticsearch.helpers import BulkIndexError, async_bulk
+from llama_index.vector_stores.elasticsearch.utils import (
+    get_elasticsearch_client,
+    get_user_agent,
+)
 
 logger = getLogger(__name__)
 
@@ -33,68 +42,9 @@ DISTANCE_STRATEGIES = Literal[
 ]
 
 
-def _get_elasticsearch_client(
-    *,
-    es_url: Optional[str] = None,
-    cloud_id: Optional[str] = None,
-    api_key: Optional[str] = None,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
-) -> Any:
-    """Get AsyncElasticsearch client.
-
-    Args:
-        es_url: Elasticsearch URL.
-        cloud_id: Elasticsearch cloud ID.
-        api_key: Elasticsearch API key.
-        username: Elasticsearch username.
-        password: Elasticsearch password.
-
-    Returns:
-        AsyncElasticsearch client.
-
-    Raises:
-        ConnectionError: If Elasticsearch client cannot connect to Elasticsearch.
-    """
-    if es_url and cloud_id:
-        raise ValueError(
-            "Both es_url and cloud_id are defined. Please provide only one."
-        )
-
-    if es_url and cloud_id:
-        raise ValueError(
-            "Both es_url and cloud_id are defined. Please provide only one."
-        )
-
-    connection_params: Dict[str, Any] = {}
-
-    if es_url:
-        connection_params["hosts"] = [es_url]
-    elif cloud_id:
-        connection_params["cloud_id"] = cloud_id
-    else:
-        raise ValueError("Please provide either elasticsearch_url or cloud_id.")
-
-    if api_key:
-        connection_params["api_key"] = api_key
-    elif username and password:
-        connection_params["basic_auth"] = (username, password)
-
-    sync_es_client = elasticsearch.Elasticsearch(
-        **connection_params, headers={"user-agent": ElasticsearchStore.get_user_agent()}
-    )
-    async_es_client = elasticsearch.AsyncElasticsearch(**connection_params)
-    try:
-        sync_es_client.info()  # so don't have to 'await' to just get info
-    except Exception as e:
-        logger.error(f"Error connecting to Elasticsearch: {e}")
-        raise
-
-    return async_es_client
-
-
 def _to_elasticsearch_filter(standard_filters: MetadataFilters) -> Dict[str, Any]:
-    """Convert standard filters to Elasticsearch filter.
+    """
+    Convert standard filters to Elasticsearch filter.
 
     Args:
         standard_filters: Standard Llama-index filters.
@@ -134,8 +84,42 @@ def _to_llama_similarities(scores: List[float]) -> List[float]:
     return np.exp(scores_to_norm - np.max(scores_to_norm)).tolist()
 
 
+def _mode_must_match_retrieval_strategy(
+    mode: VectorStoreQueryMode, retrieval_strategy: AsyncRetrievalStrategy
+) -> None:
+    """
+    Different retrieval strategies require different ways of indexing that must be known at the
+    time of adding data. The query mode is known at query time. This function checks if the
+    retrieval strategy (and way of indexing) is compatible with the query mode and raises and
+    exception in the case of a mismatch.
+    """
+    if mode == VectorStoreQueryMode.DEFAULT:
+        # it's fine to not specify an explicit other mode
+        return
+
+    mode_retrieval_dict = {
+        VectorStoreQueryMode.SPARSE: AsyncSparseVectorStrategy,
+        VectorStoreQueryMode.TEXT_SEARCH: AsyncBM25Strategy,
+        VectorStoreQueryMode.HYBRID: AsyncDenseVectorStrategy,
+    }
+
+    required_strategy = mode_retrieval_dict.get(mode)
+    if not required_strategy:
+        raise NotImplementedError(f"query mode {mode} currently not supported")
+
+    if not isinstance(retrieval_strategy, required_strategy):
+        raise ValueError(
+            f"query mode {mode} incompatible with retrieval strategy {type(retrieval_strategy)}, "
+            f"expected {required_strategy}"
+        )
+
+    if mode == VectorStoreQueryMode.HYBRID and not retrieval_strategy.hybrid:
+        raise ValueError(f"to enable hybrid mode, it must be set in retrieval strategy")
+
+
 class ElasticsearchStore(BasePydanticVectorStore):
-    """Elasticsearch vector store.
+    """
+    Elasticsearch vector store.
 
     Args:
         index_name: Name of the Elasticsearch index.
@@ -151,6 +135,9 @@ class ElasticsearchStore(BasePydanticVectorStore):
         batch_size: Optional. Batch size for bulk indexing. Defaults to 200.
         distance_strategy: Optional. Distance strategy to use for similarity search.
                         Defaults to "COSINE".
+        retrieval_strategy: Retrieval strategy to use. AsyncBM25Strategy /
+            AsyncSparseVectorStrategy / AsyncDenseVectorStrategy / AsyncRetrievalStrategy.
+            Defaults to AsyncDenseVectorStrategy.
 
     Raises:
         ConnectionError: If AsyncElasticsearch client cannot connect to Elasticsearch.
@@ -194,6 +181,10 @@ class ElasticsearchStore(BasePydanticVectorStore):
 
     """
 
+    class Config:
+        # allow pydantic to tolarate its inability to validate AsyncRetrievalStrategy
+        arbitrary_types_allowed = True
+
     stores_text: bool = True
     index_name: str
     es_client: Optional[Any]
@@ -206,8 +197,9 @@ class ElasticsearchStore(BasePydanticVectorStore):
     vector_field: str = "embedding"
     batch_size: int = 200
     distance_strategy: Optional[DISTANCE_STRATEGIES] = "COSINE"
+    retrieval_strategy: AsyncRetrievalStrategy
 
-    _client = PrivateAttr()
+    _store = PrivateAttr()
 
     def __init__(
         self,
@@ -222,26 +214,40 @@ class ElasticsearchStore(BasePydanticVectorStore):
         vector_field: str = "embedding",
         batch_size: int = 200,
         distance_strategy: Optional[DISTANCE_STRATEGIES] = "COSINE",
+        retrieval_strategy: Optional[AsyncRetrievalStrategy] = None,
     ) -> None:
         nest_asyncio.apply()
 
-        if es_client is not None:
-            self._client = es_client.options(
-                headers={"user-agent": self.get_user_agent()}
-            )
-        elif es_url is not None or es_cloud_id is not None:
-            self._client = _get_elasticsearch_client(
-                es_url=es_url,
-                username=es_user,
-                password=es_password,
+        if not es_client:
+            es_client = get_elasticsearch_client(
+                url=es_url,
                 cloud_id=es_cloud_id,
                 api_key=es_api_key,
+                username=es_user,
+                password=es_password,
             )
-        else:
-            raise ValueError(
-                """Either provide a pre-existing AsyncElasticsearch or valid \
-                credentials for creating a new connection."""
+
+        if retrieval_strategy is None:
+            retrieval_strategy = AsyncDenseVectorStrategy(
+                distance=DistanceMetric[distance_strategy]
             )
+
+        metadata_mappings = {
+            "document_id": {"type": "keyword"},
+            "doc_id": {"type": "keyword"},
+            "ref_doc_id": {"type": "keyword"},
+        }
+
+        self._store = AsyncVectorStore(
+            user_agent=get_user_agent(),
+            client=es_client,
+            index=index_name,
+            retrieval_strategy=retrieval_strategy,
+            text_field=text_field,
+            vector_field=vector_field,
+            metadata_mappings=metadata_mappings,
+        )
+
         super().__init__(
             index_name=index_name,
             es_client=es_client,
@@ -254,76 +260,16 @@ class ElasticsearchStore(BasePydanticVectorStore):
             vector_field=vector_field,
             batch_size=batch_size,
             distance_strategy=distance_strategy,
+            retrieval_strategy=retrieval_strategy,
         )
 
     @property
     def client(self) -> Any:
         """Get async elasticsearch client."""
-        return self._client
+        return self._store.client
 
-    @staticmethod
-    def get_user_agent() -> str:
-        """Get user agent for elasticsearch client."""
-        import llama_index.core
-
-        version = getattr(llama_index.core, "__version__", "")
-        return f"llama_index-py-vs/{version}"
-
-    async def _create_index_if_not_exists(
-        self, index_name: str, dims_length: Optional[int] = None
-    ) -> None:
-        """Create the AsyncElasticsearch index if it doesn't already exist.
-
-        Args:
-            index_name: Name of the AsyncElasticsearch index to create.
-            dims_length: Length of the embedding vectors.
-        """
-        if await self.client.indices.exists(index=index_name):
-            logger.debug(f"Index {index_name} already exists. Skipping creation.")
-
-        else:
-            if dims_length is None:
-                raise ValueError(
-                    "Cannot create index without specifying dims_length "
-                    "when the index doesn't already exist. We infer "
-                    "dims_length from the first embedding. Check that "
-                    "you have provided an embedding function."
-                )
-
-            if self.distance_strategy == "COSINE":
-                similarityAlgo = "cosine"
-            elif self.distance_strategy == "EUCLIDEAN_DISTANCE":
-                similarityAlgo = "l2_norm"
-            elif self.distance_strategy == "DOT_PRODUCT":
-                similarityAlgo = "dot_product"
-            else:
-                raise ValueError(f"Similarity {self.distance_strategy} not supported.")
-
-            index_settings = {
-                "mappings": {
-                    "properties": {
-                        self.vector_field: {
-                            "type": "dense_vector",
-                            "dims": dims_length,
-                            "index": True,
-                            "similarity": similarityAlgo,
-                        },
-                        self.text_field: {"type": "text"},
-                        "metadata": {
-                            "properties": {
-                                "document_id": {"type": "keyword"},
-                                "doc_id": {"type": "keyword"},
-                                "ref_doc_id": {"type": "keyword"},
-                            }
-                        },
-                    }
-                }
-            }
-
-            logger.debug(
-                f"Creating index {index_name} with mappings {index_settings['mappings']}"
-            )
-            await self.client.indices.create(index=index_name, **index_settings)
+    def close(self) -> None:
+        return asyncio.get_event_loop().run_until_complete(self._store.close())
 
     def add(
         self,
@@ -332,7 +278,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
         create_index_if_not_exists: bool = True,
         **add_kwargs: Any,
     ) -> List[str]:
-        """Add nodes to Elasticsearch index.
+        """
+        Add nodes to Elasticsearch index.
 
         Args:
             nodes: List of nodes with embeddings.
@@ -359,7 +306,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
         create_index_if_not_exists: bool = True,
         **add_kwargs: Any,
     ) -> List[str]:
-        """Asynchronous method to add nodes to Elasticsearch index.
+        """
+        Asynchronous method to add nodes to Elasticsearch index.
 
         Args:
             nodes: List of nodes with embeddings.
@@ -378,12 +326,6 @@ class ElasticsearchStore(BasePydanticVectorStore):
         if len(nodes) == 0:
             return []
 
-        if create_index_if_not_exists:
-            dims_length = len(nodes[0].get_embedding())
-            await self._create_index_if_not_exists(
-                index_name=self.index_name, dims_length=dims_length
-            )
-
         embeddings: List[List[float]] = []
         texts: List[str] = []
         metadatas: List[dict] = []
@@ -394,43 +336,21 @@ class ElasticsearchStore(BasePydanticVectorStore):
             texts.append(node.get_content(metadata_mode=MetadataMode.NONE))
             metadatas.append(node_to_metadata_dict(node, remove_text=True))
 
-        requests = []
-        return_ids = []
+        if not self._store.num_dimensions:
+            self._store.num_dimensions = len(embeddings[0])
 
-        for i, text in enumerate(texts):
-            metadata = metadatas[i] if metadatas else {}
-            _id = ids[i] if ids else str(uuid.uuid4())
-            request = {
-                "_op_type": "index",
-                "_index": self.index_name,
-                self.vector_field: embeddings[i],
-                self.text_field: text,
-                "metadata": metadata,
-                "_id": _id,
-            }
-            requests.append(request)
-            return_ids.append(_id)
-
-        async with self.client as client:
-            await async_bulk(client, requests, chunk_size=self.batch_size, refresh=True)
-            try:
-                success, failed = await async_bulk(
-                    client, requests, stats_only=True, refresh=True
-                )
-                logger.debug(
-                    f"Added {success} and failed to add {failed} texts to index"
-                )
-
-                logger.debug(f"added texts {ids} to index")
-                return return_ids
-            except BulkIndexError as e:
-                logger.error(f"Error adding texts: {e}")
-                firstError = e.errors[0].get("index", {}).get("error", {})
-                logger.error(f"First error reason: {firstError.get('reason')}")
-                raise
+        return await self._store.add_texts(
+            texts=texts,
+            metadatas=metadatas,
+            vectors=embeddings,
+            ids=ids,
+            create_index_if_not_exists=create_index_if_not_exists,
+            bulk_kwargs=add_kwargs,
+        )
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
-        """Delete node from Elasticsearch index.
+        """
+        Delete node from Elasticsearch index.
 
         Args:
             ref_doc_id: ID of the node to delete.
@@ -445,7 +365,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
         )
 
     async def adelete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
-        """Async delete node from Elasticsearch index.
+        """
+        Async delete node from Elasticsearch index.
 
         Args:
             ref_doc_id: ID of the node to delete.
@@ -455,21 +376,9 @@ class ElasticsearchStore(BasePydanticVectorStore):
         Raises:
             Exception: If AsyncElasticsearch delete_by_query fails.
         """
-        try:
-            async with self.client as client:
-                res = await client.delete_by_query(
-                    index=self.index_name,
-                    query={"term": {"metadata.ref_doc_id": ref_doc_id}},
-                    refresh=True,
-                    **delete_kwargs,
-                )
-            if res["deleted"] == 0:
-                logger.warning(f"Could not find text {ref_doc_id} to delete")
-            else:
-                logger.debug(f"Deleted text {ref_doc_id} from index")
-        except Exception:
-            logger.error(f"Error deleting text: {ref_doc_id}")
-            raise
+        await self._store.delete(
+            query={"term": {"metadata.ref_doc_id": ref_doc_id}}, **delete_kwargs
+        )
 
     def query(
         self,
@@ -480,7 +389,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
         es_filter: Optional[List[Dict]] = None,
         **kwargs: Any,
     ) -> VectorStoreQueryResult:
-        """Query index for top k most similar nodes.
+        """
+        Query index for top k most similar nodes.
 
         Args:
             query_embedding (List[float]): query embedding
@@ -512,7 +422,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
         es_filter: Optional[List[Dict]] = None,
         **kwargs: Any,
     ) -> VectorStoreQueryResult:
-        """Asynchronous query index for top k most similar nodes.
+        """
+        Asynchronous query index for top k most similar nodes.
 
         Args:
             query_embedding (VectorStoreQuery): query embedding
@@ -531,57 +442,25 @@ class ElasticsearchStore(BasePydanticVectorStore):
             Exception: If AsyncElasticsearch query fails.
 
         """
-        query_embedding = cast(List[float], query.query_embedding)
-
-        es_query = {}
+        _mode_must_match_retrieval_strategy(query.mode, self.retrieval_strategy)
 
         if query.filters is not None and len(query.filters.legacy_filters()) > 0:
             filter = [_to_elasticsearch_filter(query.filters)]
         else:
             filter = es_filter or []
 
-        if query.mode in (
-            VectorStoreQueryMode.DEFAULT,
-            VectorStoreQueryMode.HYBRID,
-        ):
-            es_query["knn"] = {
-                "filter": filter,
-                "field": self.vector_field,
-                "query_vector": query_embedding,
-                "k": query.similarity_top_k,
-                "num_candidates": query.similarity_top_k * 10,
-            }
-
-        if query.mode in (
-            VectorStoreQueryMode.TEXT_SEARCH,
-            VectorStoreQueryMode.HYBRID,
-        ):
-            es_query["query"] = {
-                "bool": {
-                    "must": {"match": {self.text_field: {"query": query.query_str}}},
-                    "filter": filter,
-                }
-            }
-
-        if query.mode == VectorStoreQueryMode.HYBRID:
-            es_query["rank"] = {"rrf": {"window_size": query.similarity_top_k}}
-
-        if custom_query is not None:
-            es_query = custom_query(es_query, query)
-            logger.debug(f"Calling custom_query, Query body now: {es_query}")
-
-        async with self.client as client:
-            response = await client.search(
-                index=self.index_name,
-                **es_query,
-                size=query.similarity_top_k,
-                _source={"excludes": [self.vector_field]},
-            )
+        hits = await self._store.search(
+            query=query.query_str,
+            query_vector=query.query_embedding,
+            k=query.similarity_top_k,
+            num_candidates=query.similarity_top_k * 10,
+            filter=filter,
+            custom_query=custom_query,
+        )
 
         top_k_nodes = []
         top_k_ids = []
         top_k_scores = []
-        hits = response["hits"]["hits"]
         for hit in hits:
             source = hit["_source"]
             metadata = source.get("metadata", None)
@@ -616,7 +495,10 @@ class ElasticsearchStore(BasePydanticVectorStore):
             top_k_ids.append(node_id)
             top_k_scores.append(hit.get("_rank", hit["_score"]))
 
-        if query.mode == VectorStoreQueryMode.HYBRID:
+        if (
+            isinstance(self.retrieval_strategy, AsyncDenseVectorStrategy)
+            and self.retrieval_strategy.hybrid
+        ):
             total_rank = sum(top_k_scores)
             top_k_scores = [total_rank - rank / total_rank for rank in top_k_scores]
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict, Optional
+
+from elasticsearch import AsyncElasticsearch, Elasticsearch
+
+
+def get_user_agent() -> str:
+    """Get user agent for Elasticsearch client."""
+    import llama_index.core
+
+    version = getattr(llama_index.core, "__version__", "")
+    return f"llama_index-py-vs/{version}"
+
+
+def get_elasticsearch_client(
+    url: Optional[str] = None,
+    cloud_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> AsyncElasticsearch:
+    if url and cloud_id:
+        raise ValueError(
+            "Both es_url and cloud_id are defined. Please provide only one."
+        )
+
+    connection_params: Dict[str, Any] = {}
+
+    if url:
+        connection_params["hosts"] = [url]
+    elif cloud_id:
+        connection_params["cloud_id"] = cloud_id
+    else:
+        raise ValueError("Please provide either elasticsearch_url or cloud_id.")
+
+    if api_key:
+        connection_params["api_key"] = api_key
+    elif username and password:
+        connection_params["basic_auth"] = (username, password)
+
+    sync_es_client = Elasticsearch(
+        **connection_params, headers={"user-agent": get_user_agent()}
+    )
+    async_es_client = AsyncElasticsearch(
+        **connection_params, headers={"user-agent": get_user_agent()}
+    )
+
+    sync_es_client.info()  # use sync client so don't have to 'await' to just get info
+
+    return async_es_client

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -33,6 +33,7 @@ version = "0.2.0"
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
 elasticsearch = "^8.13.1"
+aiohttp = "*"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.1.7"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -33,6 +33,7 @@ version = "0.2.0"
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
 elasticsearch = "^8.13.1"
+aiohttp = "^3.9.5"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.7"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-elasticsearch = "^8.12.0"
+elasticsearch = "^8.13.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -33,7 +33,6 @@ version = "0.2.0"
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
 elasticsearch = "^8.13.1"
-aiohttp = "*"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/docker-compose.yml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/docker-compose.yml
@@ -2,12 +2,11 @@ version: "3"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1 # https://www.docker.elastic.co/r/elasticsearch/elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.2
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=false # security has been disabled, so no login or password is required.
-      - xpack.security.http.ssl.enabled=false
       - xpack.license.self_generated.type=trial
+      - xpack.security.enabled=false # disable password and TLS; never do this in production!
     ports:
       - "9200:9200"
     healthcheck:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
@@ -1,3 +1,4 @@
+import aiohttp  # noqa
 import logging
 import os
 import re

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
@@ -2,10 +2,13 @@ import logging
 import os
 import re
 import uuid
-from typing import Dict, Generator, List, Union
+from typing import AsyncGenerator, List, Generator
+
+from elasticsearch import AsyncElasticsearch, ConnectionError
 
 import pandas as pd
 import pytest
+import pytest_asyncio
 
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.core.vector_stores.types import (
@@ -14,7 +17,17 @@ from llama_index.core.vector_stores.types import (
     VectorStoreQuery,
     VectorStoreQueryMode,
 )
-from llama_index.vector_stores.elasticsearch import ElasticsearchStore
+from llama_index.vector_stores.elasticsearch import (
+    ElasticsearchStore,
+    AsyncBM25Strategy,
+    AsyncDenseVectorStrategy,
+    AsyncSparseVectorStrategy,
+)
+from llama_index.vector_stores.elasticsearch.base import (
+    _mode_must_match_retrieval_strategy,
+)
+
+from llama_index.vector_stores.elasticsearch.utils import get_elasticsearch_client
 
 ##
 # Start Elasticsearch locally
@@ -28,20 +41,6 @@ from llama_index.vector_stores.elasticsearch import ElasticsearchStore
 
 logging.basicConfig(level=logging.DEBUG)
 
-try:
-    import elasticsearch
-
-    es_client = elasticsearch.Elasticsearch("http://localhost:9200")
-    es_client.info()
-
-    elasticsearch_not_available = False
-
-    es_license = es_client.license.get()
-    basic_license: bool = es_license["license"]["type"] == "basic"
-except (ImportError, Exception) as err:
-    elasticsearch_not_available = True
-    basic_license = True
-
 
 @pytest.fixture()
 def index_name() -> str:
@@ -49,39 +48,36 @@ def index_name() -> str:
     return f"test_{uuid.uuid4().hex}"
 
 
-@pytest.fixture(scope="session")
-def elasticsearch_connection() -> Union[dict, Generator[dict, None, None]]:
-    # Running this integration test with Elastic Cloud
-    # Required for in-stack inference testing (ELSER + model_id)
-    from elasticsearch import Elasticsearch
+@pytest_asyncio.fixture(scope="function")
+async def es_client() -> AsyncGenerator[AsyncElasticsearch, None]:
+    es_client = None
 
-    es_url = os.environ.get("ES_URL", "http://localhost:9200")
-    cloud_id = os.environ.get("ES_CLOUD_ID")
-    es_username = os.environ.get("ES_USERNAME", "elastic")
-    es_password = os.environ.get("ES_PASSWORD", "changeme")
+    try:
+        # Create client and test connection
+        es_client = get_elasticsearch_client(
+            url=os.environ.get("ES_URL", "http://localhost:9200"),
+            cloud_id=os.environ.get("ES_CLOUD_ID"),
+            api_key=os.environ.get("ES_API_KEY"),
+            username=os.environ.get("ES_USERNAME", "elastic"),
+            password=os.environ.get("ES_PASSWORD", "changeme"),
+        )
 
-    if cloud_id:
-        yield {
-            "es_cloud_id": cloud_id,
-            "es_user": es_username,
-            "es_password": es_password,
-        }
-        es = Elasticsearch(cloud_id=cloud_id, basic_auth=(es_username, es_password))
+        yield es_client
 
-    else:
-        # Running this integration test with local docker instance
-        yield {
-            "es_url": es_url,
-        }
-        es = Elasticsearch(hosts=es_url)
+        # Clear all indexes
+        index_response = await es_client.indices.get(index="_all")
+        index_names = index_response.keys()
+        for index_name in index_names:
+            if index_name.startswith("test_"):
+                await es_client.indices.delete(index=index_name)
+        await es_client.indices.refresh(index="_all")
 
-    # Clear all indexes
-    index_names = es.indices.get(index="_all").keys()
-    for index_name in index_names:
-        if index_name.startswith("test_"):
-            es.indices.delete(index=index_name)
-    es.indices.refresh(index="_all")
-    return {}
+    except ConnectionError as err:
+        pytest.skip(f"Could not connect to Elasticsearch: {err}")
+
+    finally:
+        if es_client:
+            await es_client.close()
 
 
 @pytest.fixture(scope="session")
@@ -114,7 +110,7 @@ def node_embeddings() -> List[TextNode]:
             metadata={
                 "director": "Christopher Nolan",
             },
-            embedding=[0.0, 0.0, 1.0],
+            embedding=[0.0, 0.5, 1.0],
         ),
         TextNode(
             text="I was taught that the way of progress was neither swift nor easy.",
@@ -152,29 +148,123 @@ def node_embeddings() -> List[TextNode]:
     ]
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
-def test_instance_creation(index_name: str, elasticsearch_connection: Dict) -> None:
+def test_instance_creation(index_name: str, es_client: AsyncElasticsearch) -> None:
+    url = os.environ.get("ES_URL", "http://localhost:9200")
+    cloud_id = os.environ.get("ES_CLOUD_ID")
+    api_key = os.environ.get("ES_API_KEY")
+    user = os.environ.get("ES_USERNAME")
+    password = os.environ.get("ES_PASSWORD")
+
     es_store = ElasticsearchStore(
-        **elasticsearch_connection,
         index_name=index_name,
+        es_url=url,
+        es_cloud_id=cloud_id,
+        es_api_key=api_key,
+        es_user=user,
+        es_password=password,
     )
     assert isinstance(es_store, ElasticsearchStore)
+    es_store.close()
+
+
+def test_mode_must_match_retrieval_strategy() -> None:
+    # DEFAULT mode should never raise any exception
+    mode = VectorStoreQueryMode.DEFAULT
+    retrieval_strategy = AsyncBM25Strategy()
+    _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
+
+    # AsyncSparseVectorStrategy with mode SPARSE should not raise any exception
+    mode = VectorStoreQueryMode.SPARSE
+    retrieval_strategy = AsyncSparseVectorStrategy()
+    _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
+
+    # AsyncBM25Strategy with TEXT_SEARCH should not raise any exception
+    mode = VectorStoreQueryMode.TEXT_SEARCH
+    retrieval_strategy = AsyncBM25Strategy()
+    _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
+
+    # AsyncDenseVectorStrategy(hybrid=True) with mode HYBRID should not raise any exception
+    mode = VectorStoreQueryMode.HYBRID
+    retrieval_strategy = AsyncDenseVectorStrategy(hybrid=True)
+    _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
+
+    # unknown mode should raise NotImplementedError
+    for mode in [
+        VectorStoreQueryMode.SEMANTIC_HYBRID,
+        VectorStoreQueryMode.SVM,
+        VectorStoreQueryMode.LOGISTIC_REGRESSION,
+        VectorStoreQueryMode.LINEAR_REGRESSION,
+        VectorStoreQueryMode.MMR,
+    ]:
+        retrieval_strategy = AsyncDenseVectorStrategy()
+        with pytest.raises(NotImplementedError):
+            _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
+
+    # if mode is SPARSE and strategy is not AsyncSparseVectorStrategy, should raise ValueError
+    mode = VectorStoreQueryMode.SPARSE
+    retrieval_strategy = AsyncDenseVectorStrategy()
+    with pytest.raises(ValueError):
+        _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
+
+    # if mode is HYBRID and strategy is not AsyncDenseVectorStrategy, should raise ValueError
+    mode = VectorStoreQueryMode.HYBRID
+    retrieval_strategy = AsyncSparseVectorStrategy()
+    with pytest.raises(ValueError):
+        _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
+
+    # if mode is HYBRID and strategy is AsyncDenseVectorStrategy but hybrid is not enabled, should raise ValueError
+    mode = VectorStoreQueryMode.HYBRID
+    retrieval_strategy = AsyncDenseVectorStrategy(hybrid=False)
+    with pytest.raises(ValueError):
+        _mode_must_match_retrieval_strategy(mode, retrieval_strategy)
 
 
 @pytest.fixture()
-def es_store(index_name: str, elasticsearch_connection: Dict) -> ElasticsearchStore:
-    return ElasticsearchStore(
-        **elasticsearch_connection,
+def es_store(
+    index_name: str, es_client: AsyncElasticsearch
+) -> Generator[ElasticsearchStore, None, None]:
+    store = ElasticsearchStore(
+        es_client=es_client,
         index_name=index_name,
         distance_strategy="EUCLIDEAN_DISTANCE",
     )
+    try:
+        yield store
+    finally:
+        store.close()
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
+@pytest.fixture()
+def es_hybrid_store(
+    index_name: str, es_client: AsyncElasticsearch
+) -> Generator[ElasticsearchStore, None, None]:
+    store = ElasticsearchStore(
+        es_client=es_client,
+        index_name=index_name,
+        distance_strategy="EUCLIDEAN_DISTANCE",
+        retrieval_strategy=AsyncDenseVectorStrategy(hybrid=True),
+    )
+    try:
+        yield store
+    finally:
+        store.close()
+
+
+@pytest.fixture()
+def es_bm25_store(
+    index_name: str, es_client: AsyncElasticsearch
+) -> Generator[ElasticsearchStore, None, None]:
+    store = ElasticsearchStore(
+        es_client=es_client,
+        index_name=index_name,
+        retrieval_strategy=AsyncBM25Strategy(),
+    )
+    try:
+        yield store
+    finally:
+        store.close()
+
+
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_and_query(
@@ -196,19 +286,16 @@ async def test_add_to_es_and_query(
     assert res.nodes[0].get_content() == "lorem ipsum"
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_and_text_query(
-    es_store: ElasticsearchStore,
+    es_bm25_store: ElasticsearchStore,
     node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
     if use_async:
-        await es_store.async_add(node_embeddings)
-        res = await es_store.aquery(
+        await es_bm25_store.async_add(node_embeddings)
+        res = await es_bm25_store.aquery(
             VectorStoreQuery(
                 query_str="lorem",
                 mode=VectorStoreQueryMode.TEXT_SEARCH,
@@ -216,8 +303,8 @@ async def test_add_to_es_and_text_query(
             )
         )
     else:
-        es_store.add(node_embeddings)
-        res = es_store.query(
+        es_bm25_store.add(node_embeddings)
+        res = es_bm25_store.query(
             VectorStoreQuery(
                 query_str="lorem",
                 mode=VectorStoreQueryMode.TEXT_SEARCH,
@@ -228,21 +315,20 @@ async def test_add_to_es_and_text_query(
     assert res.nodes[0].get_content() == "lorem ipsum"
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available,
-    basic_license,
-    reason="elasticsearch is not available or license is basic",
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_and_hybrid_query(
-    es_store: ElasticsearchStore,
+    es_client: AsyncElasticsearch,
+    es_hybrid_store: ElasticsearchStore,
     node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
+    if (await es_client.license.get())["license"]["type"] == "basic":
+        pytest.skip("This test requires a non-basic license.")
+
     if use_async:
-        await es_store.async_add(node_embeddings)
-        res = await es_store.aquery(
+        await es_hybrid_store.async_add(node_embeddings)
+        res = await es_hybrid_store.aquery(
             VectorStoreQuery(
                 query_str="lorem",
                 query_embedding=[1.0, 0.0, 0.0],
@@ -251,8 +337,8 @@ async def test_add_to_es_and_hybrid_query(
             )
         )
     else:
-        es_store.add(node_embeddings)
-        res = es_store.query(
+        es_hybrid_store.add(node_embeddings)
+        res = es_hybrid_store.query(
             VectorStoreQuery(
                 query_str="lorem",
                 query_embedding=[1.0, 0.0, 0.0],
@@ -264,9 +350,6 @@ async def test_add_to_es_and_hybrid_query(
     assert res.nodes[0].get_content() == "lorem ipsum"
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_query_with_filters(
@@ -291,9 +374,6 @@ async def test_add_to_es_query_with_filters(
     assert res.nodes[0].node_id == "c330d77f-90bd-4c51-9ed2-57d8d693b3b0"
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_query_with_es_filters(
@@ -317,9 +397,6 @@ async def test_add_to_es_query_with_es_filters(
     assert res.nodes[0].node_id == "c330d77f-90bd-4c51-9ed2-57d8d693b3b0"
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_query_and_delete(
@@ -350,9 +427,6 @@ async def test_add_to_es_query_and_delete(
     assert res.nodes[0].node_id == "f658de3b-8cef-4d1c-8bed-9a263c907251"
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_and_embed_query_ranked(
@@ -373,13 +447,10 @@ async def test_add_to_es_and_embed_query_ranked(
     )
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_and_text_query_ranked(
-    es_store: ElasticsearchStore,
+    es_bm25_store: ElasticsearchStore,
     node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
@@ -390,24 +461,21 @@ async def test_add_to_es_and_text_query_ranked(
         query_str="I was", mode=VectorStoreQueryMode.TEXT_SEARCH, similarity_top_k=2
     )
     await check_top_match(
-        es_store, node_embeddings, use_async, query_get_1_first, node1, node2
+        es_bm25_store, node_embeddings, use_async, query_get_1_first, node1, node2
     )
 
     query_get_2_first = VectorStoreQuery(
         query_str="I am", mode=VectorStoreQueryMode.TEXT_SEARCH, similarity_top_k=2
     )
     await check_top_match(
-        es_store, node_embeddings, use_async, query_get_2_first, node2, node1
+        es_bm25_store, node_embeddings, use_async, query_get_2_first, node2, node1
     )
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_and_text_query_ranked_hybrid(
-    es_store: ElasticsearchStore,
+    es_hybrid_store: ElasticsearchStore,
     node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
@@ -415,23 +483,20 @@ async def test_add_to_es_and_text_query_ranked_hybrid(
     node2 = "0b31ae71-b797-4e88-8495-031371a7752e"
 
     query_get_1_first = VectorStoreQuery(
-        query_str="I was",
+        query_str="human",
         query_embedding=[0.0, 0.0, 0.5],
         mode=VectorStoreQueryMode.HYBRID,
         similarity_top_k=2,
     )
     await check_top_match(
-        es_store, node_embeddings, use_async, query_get_1_first, node1, node2
+        es_hybrid_store, node_embeddings, use_async, query_get_1_first, node1, node2
     )
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_and_text_query_ranked_hybrid_large_top_k(
-    es_store: ElasticsearchStore,
+    es_hybrid_store: ElasticsearchStore,
     node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
@@ -439,71 +504,39 @@ async def test_add_to_es_and_text_query_ranked_hybrid_large_top_k(
     node2 = "0b31ae71-b797-4e88-8495-031371a7752e"
 
     query_get_1_first = VectorStoreQuery(
-        query_str="I was",
+        query_str="human",
         query_embedding=[0.0, 0.0, 0.5],
         mode=VectorStoreQueryMode.HYBRID,
-        similarity_top_k=100,
+        similarity_top_k=10,
     )
     await check_top_match(
-        es_store, node_embeddings, use_async, query_get_1_first, node1, node2
+        es_hybrid_store, node_embeddings, use_async, query_get_1_first, node1, node2
     )
 
 
-@pytest.mark.skipif(
-    elasticsearch_not_available, reason="elasticsearch is not available"
-)
-def test_check_user_agent(
-    index_name: str,
-    node_embeddings: List[TextNode],
-) -> None:
-    from elastic_transport import AsyncTransport
-    from elasticsearch import AsyncElasticsearch
-
-    class CustomTransport(AsyncTransport):
-        requests = []
-
-        async def perform_request(self, *args, **kwargs):  # type: ignore
-            self.requests.append(kwargs)
-            return await super().perform_request(*args, **kwargs)
-
-    es_client_instance = AsyncElasticsearch(
-        "http://localhost:9200",
-        transport_class=CustomTransport,
-    )
-
-    es_store = ElasticsearchStore(
-        es_client=es_client_instance,
-        index_name=index_name,
-        distance_strategy="EUCLIDEAN_DISTANCE",
-    )
-
-    es_store.add(node_embeddings)
-
-    user_agent = es_client_instance.transport.requests[0]["headers"][  # type: ignore
-        "user-agent"
-    ]
+def test_check_user_agent(es_store: ElasticsearchStore) -> None:
+    user_agent = es_store._store.client._headers["User-Agent"]
     pattern = r"^llama_index-py-vs/\d+\.\d+\.\d+(\.post\d+)?$"
-    match = re.match(pattern, user_agent)
-
     assert (
-        match is not None
+        re.match(pattern, user_agent) is not None
     ), f"The string '{user_agent}' does not match the expected user-agent."
 
 
 async def check_top_match(
-    es_store: ElasticsearchStore,
+    store: ElasticsearchStore,
     node_embeddings: List[TextNode],
     use_async: bool,
     query: VectorStoreQuery,
     *expected_nodes: str,
 ) -> None:
     if use_async:
-        await es_store.async_add(node_embeddings)
-        res = await es_store.aquery(query)
+        await store.async_add(node_embeddings)
+        res = await store.aquery(query)
     else:
-        es_store.add(node_embeddings)
-        res = es_store.query(query)
+        store.add(node_embeddings)
+        res = store.query(query)
     assert res.nodes
+
     # test the nodes are return in the expected order
     for i, node in enumerate(expected_nodes):
         assert res.nodes[i].node_id == node


### PR DESCRIPTION
# Description

We recently added a VectorStore abstraction to the Elasticsearch client library (https://github.com/elastic/elasticsearch-py/pull/2528, see [module](https://github.com/elastic/elasticsearch-py/tree/main/elasticsearch/helpers/vectorstore/_sync)) in order to centralize the development and ensure all GenAI library integrations work the same.

This PR integrates the new module into LlamaIndex. The LlamaIndex class keeps its existing interface, it is just extended with the option to specify more retrieval strategies.

## Type of Change

- New feature
  - non-breaking change in default usage of the vector store
  - breaking change when using query modes that do not match the retrieval mode specified at init time
  - --> I would suggest making a breaking release with version `0.2.0`
- This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Adapted existing unit and integration tests. Note that the abstract library already tests its own functionality with respect to the different retrieval strategies.
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] ~I have added Google Colab support for the newly added notebooks.~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
