### PR TITLE
fix async streaming in condense question

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/utils.py
+++ b/llama-index-core/llama_index/core/chat_engine/utils.py
@@ -2,14 +2,27 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
     ChatResponseGen,
+    ChatResponseAsyncGen,
     MessageRole,
 )
-from llama_index.core.types import TokenGen
+from llama_index.core.types import TokenGen, TokenAsyncGen
 
 
 def response_gen_from_query_engine(response_gen: TokenGen) -> ChatResponseGen:
     response_str = ""
     for token in response_gen:
+        response_str += token
+        yield ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content=response_str),
+            delta=token,
+        )
+
+
+async def aresponse_gen_from_query_engine(
+    response_gen: TokenAsyncGen,
+) -> ChatResponseAsyncGen:
+    response_str = ""
+    async for token in response_gen:
         response_str += token
         yield ChatResponse(
             message=ChatMessage(role=MessageRole.ASSISTANT, content=response_str),


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/13305

Ensures async responses from query engines are properly handled

Code to reproduce:
```python
from llama_index.core import VectorStoreIndex, Document

index = VectorStoreIndex.from_documents([Document.example()])

chat_engine = index.as_chat_engine(chat_mode="condense_question")

async def run():
  response = await chat_engine.astream_chat("Tell me a fact about LLMs?")
  async for token in response.async_response_gen():
    print(str(token), end="", flush=True)
  print()

import asyncio
asyncio.run(run())
```