### PR TITLE
Fix asyncio.run() in async context.

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -728,7 +728,7 @@ class ReActAgentWorker(BaseAgentWorker):
             # wait until response writing is done
             agent_response._ensure_async_setup()
 
-            await agent_response._is_function_false_event.wait()
+            await agent_response.is_function_false_event.wait()
 
         return self._get_task_step_response(agent_response, step, is_done)
 

--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 from abc import abstractmethod
 from collections import deque
@@ -11,7 +10,7 @@ from llama_index.core.agent.types import (
     TaskStep,
     TaskStepOutput,
 )
-from llama_index.core.async_utils import run_jobs
+from llama_index.core.async_utils import asyncio_run, run_jobs
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.callbacks import (
     CallbackManager,
@@ -799,7 +798,7 @@ class BasePlanningAgentRunner(AgentRunner):
                 self.arun_task(sub_task_id, mode=mode, tool_choice=tool_choice)
                 for sub_task_id in next_task_ids
             ]
-            results = asyncio.run(run_jobs(jobs, workers=len(jobs)))
+            results = asyncio_run(run_jobs(jobs, workers=len(jobs)))
 
             for sub_task_id in next_task_ids:
                 self.mark_task_complete(plan_id, sub_task_id)

--- a/llama-index-core/llama_index/core/agent/runner/parallel.py
+++ b/llama-index-core/llama_index/core/agent/runner/parallel.py
@@ -11,6 +11,7 @@ from llama_index.core.agent.types import (
     TaskStep,
     TaskStepOutput,
 )
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.callbacks import (
     CallbackManager,
@@ -183,7 +184,7 @@ class ParallelAgentRunner(BaseAgentRunner):
         Assume that all steps can be run in parallel.
 
         """
-        return asyncio.run(self.arun_steps_in_queue(task_id, mode=mode, **kwargs))
+        return asyncio_run(self.arun_steps_in_queue(task_id, mode=mode, **kwargs))
 
     async def arun_steps_in_queue(
         self,

--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -20,6 +20,18 @@ def asyncio_module(show_progress: bool = False) -> Any:
     return module
 
 
+def asyncio_run(coro: Coroutine) -> Any:
+    try:
+        loop = asyncio.get_running_loop()
+        return (
+            asyncio.ensure_future(coro)
+            if loop.is_running()
+            else loop.run_until_complete(coro)
+        )
+    except RuntimeError:
+        return asyncio.run(coro)
+
+
 def run_async_tasks(
     tasks: List[Coroutine],
     show_progress: bool = False,
@@ -51,7 +63,7 @@ def run_async_tasks(
     async def _gather() -> List[Any]:
         return await asyncio.gather(*tasks_to_execute)
 
-    outputs: List[Any] = asyncio.run(_gather())
+    outputs: List[Any] = asyncio_run(_gather())
     return outputs
 
 

--- a/llama-index-core/llama_index/core/base/response/schema.py
+++ b/llama-index-core/llama_index/core/base/response/schema.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.schema import NodeWithScore
 from llama_index.core.types import TokenGen, TokenAsyncGen
@@ -179,7 +180,7 @@ class AsyncStreamingResponse:
 
     def __str__(self) -> str:
         """Convert to string representation."""
-        return asyncio.run(self._async_str)
+        return asyncio_run(self._async_str)
 
     async def _async_str(self) -> str:
         """Convert to string representation."""

--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -1,8 +1,8 @@
-import asyncio
 import logging
 from threading import Thread
 from typing import Any, List, Optional, Tuple
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.callbacks import CallbackManager, trace_method
 from llama_index.core.chat_engine.types import (
@@ -358,7 +358,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             source_nodes=context_nodes,
         )
         thread = Thread(
-            target=lambda x: asyncio.run(chat_response.awrite_response_to_history(x)),
+            target=lambda x: asyncio_run(chat_response.awrite_response_to_history(x)),
             args=(self._memory,),
         )
         thread.start()

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -1,7 +1,7 @@
-import asyncio
 from threading import Thread
 from typing import Any, List, Optional, Tuple
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.callbacks import CallbackManager, trace_method
@@ -292,7 +292,7 @@ class ContextChatEngine(BaseChatEngine):
             source_nodes=nodes,
         )
         thread = Thread(
-            target=lambda x: asyncio.run(chat_response.awrite_response_to_history(x)),
+            target=lambda x: asyncio_run(chat_response.awrite_response_to_history(x)),
             args=(self._memory,),
         )
         thread.start()

--- a/llama-index-core/llama_index/core/chat_engine/simple.py
+++ b/llama-index-core/llama_index/core/chat_engine/simple.py
@@ -1,7 +1,7 @@
-import asyncio
 from threading import Thread
 from typing import Any, List, Optional, Type
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.llms.types import ChatMessage
 from llama_index.core.callbacks import CallbackManager, trace_method
 from llama_index.core.chat_engine.types import (
@@ -167,7 +167,7 @@ class SimpleChatEngine(BaseChatEngine):
             achat_stream=await self._llm.astream_chat(all_messages)
         )
         thread = Thread(
-            target=lambda x: asyncio.run(chat_response.awrite_response_to_history(x)),
+            target=lambda x: asyncio_run(chat_response.awrite_response_to_history(x)),
             args=(self._memory,),
         )
         thread.start()

--- a/llama-index-core/llama_index/core/evaluation/base.py
+++ b/llama-index-core/llama_index/core/evaluation/base.py
@@ -1,8 +1,8 @@
 """Evaluator."""
-import asyncio
 from abc import abstractmethod
 from typing import Any, Optional, Sequence
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.response.schema import Response
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.prompts.mixin import PromptMixin, PromptMixinType
@@ -59,7 +59,7 @@ class BaseEvaluator(PromptMixin):
         Subclasses can override this method to provide custom evaluation logic and
         take in additional arguments.
         """
-        return asyncio.run(
+        return asyncio_run(
             self.aevaluate(
                 query=query,
                 response=response,

--- a/llama-index-core/llama_index/core/evaluation/batch_runner.py
+++ b/llama-index-core/llama_index/core/evaluation/batch_runner.py
@@ -2,7 +2,7 @@ import asyncio
 from tenacity import retry, stop_after_attempt, wait_exponential
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 
-from llama_index.core.async_utils import asyncio_module
+from llama_index.core.async_utils import asyncio_module, asyncio_run
 from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.base.response.schema import RESPONSE_TYPE, Response
 from llama_index.core.evaluation.base import BaseEvaluator, EvaluationResult
@@ -360,7 +360,7 @@ class BatchEvalRunner:
         Sync version of aevaluate_response_strs.
 
         """
-        return asyncio.run(
+        return asyncio_run(
             self.aevaluate_response_strs(
                 queries=queries,
                 response_strs=response_strs,
@@ -381,7 +381,7 @@ class BatchEvalRunner:
         Sync version of aevaluate_responses.
 
         """
-        return asyncio.run(
+        return asyncio_run(
             self.aevaluate_responses(
                 queries=queries,
                 responses=responses,
@@ -401,7 +401,7 @@ class BatchEvalRunner:
         Sync version of aevaluate_queries.
 
         """
-        return asyncio.run(
+        return asyncio_run(
             self.aevaluate_queries(
                 query_engine=query_engine,
                 queries=queries,

--- a/llama-index-core/llama_index/core/evaluation/dataset_generation.py
+++ b/llama-index-core/llama_index/core/evaluation/dataset_generation.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Coroutine, Dict, List, Optional, Tuple
 
 from deprecated import deprecated
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core import Document, ServiceContext, SummaryIndex
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.callbacks.base import CallbackManager
@@ -325,13 +326,13 @@ class DatasetGenerator(PromptMixin):
 
     def generate_questions_from_nodes(self, num: int | None = None) -> List[str]:
         """Generates questions for each document."""
-        return asyncio.run(self.agenerate_questions_from_nodes(num=num))
+        return asyncio_run(self.agenerate_questions_from_nodes(num=num))
 
     def generate_dataset_from_nodes(
         self, num: int | None = None
     ) -> QueryResponseDataset:
         """Generates questions for each document."""
-        return asyncio.run(self.agenerate_dataset_from_nodes(num=num))
+        return asyncio_run(self.agenerate_dataset_from_nodes(num=num))
 
     def _get_prompts(self) -> PromptDictType:
         """Get prompts."""

--- a/llama-index-core/llama_index/core/evaluation/eval_utils.py
+++ b/llama-index-core/llama_index/core/evaluation/eval_utils.py
@@ -4,7 +4,6 @@ NOTE: These are beta functions, might change.
 
 """
 
-import asyncio
 import subprocess
 import tempfile
 from collections import defaultdict
@@ -16,7 +15,7 @@ import pandas as pd
 from llama_index_client import ProjectCreate
 from llama_index_client.types.eval_question_create import EvalQuestionCreate
 
-from llama_index.core.async_utils import asyncio_module
+from llama_index.core.async_utils import asyncio_module, asyncio_run
 from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.constants import DEFAULT_PROJECT_NAME
 from llama_index.core.evaluation.base import EvaluationResult
@@ -46,7 +45,7 @@ def get_responses(
     Sync version of aget_responses.
 
     """
-    return asyncio.run(aget_responses(*args, **kwargs))
+    return asyncio_run(aget_responses(*args, **kwargs))
 
 
 def get_results_df(

--- a/llama-index-core/llama_index/core/evaluation/retrieval/base.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/base.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.evaluation.retrieval.metrics import resolve_metrics
 from llama_index.core.evaluation.retrieval.metrics_base import (
@@ -123,7 +124,7 @@ class BaseRetrievalEvaluator(BaseModel):
             RetrievalEvalResult: Evaluation result
 
         """
-        return asyncio.run(
+        return asyncio_run(
             self.aevaluate(
                 query=query,
                 expected_ids=expected_ids,

--- a/llama-index-core/llama_index/core/extractors/interface.py
+++ b/llama-index-core/llama_index/core/extractors/interface.py
@@ -1,9 +1,9 @@
 """Node parser interface."""
-import asyncio
 from abc import abstractmethod
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Sequence, cast
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.schema import (
     BaseNode,
@@ -92,7 +92,7 @@ class BaseExtractor(TransformComponent):
             nodes (Sequence[Document]): nodes to extract metadata from
 
         """
-        return asyncio.run(self.aextract(nodes))
+        return asyncio_run(self.aextract(nodes))
 
     async def aprocess_nodes(
         self,
@@ -139,7 +139,7 @@ class BaseExtractor(TransformComponent):
         excluded_llm_metadata_keys: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> List[BaseNode]:
-        return asyncio.run(
+        return asyncio_run(
             self.aprocess_nodes(
                 nodes,
                 excluded_embed_metadata_keys=excluded_embed_metadata_keys,

--- a/llama-index-core/llama_index/core/llama_dataset/generator.py
+++ b/llama-index-core/llama_index/core/llama_dataset/generator.py
@@ -1,12 +1,11 @@
 """Dataset generation from documents."""
 from __future__ import annotations
 
-import asyncio
 import re
 from typing import List, Optional
 
 from llama_index.core import Document, ServiceContext, SummaryIndex
-from llama_index.core.async_utils import DEFAULT_NUM_WORKERS, run_jobs
+from llama_index.core.async_utils import DEFAULT_NUM_WORKERS, run_jobs, asyncio_run
 from llama_index.core.base.response.schema import RESPONSE_TYPE
 from llama_index.core.ingestion import run_transformations
 from llama_index.core.llama_dataset import (
@@ -239,11 +238,11 @@ class RagDatasetGenerator(PromptMixin):
 
     def generate_questions_from_nodes(self) -> LabelledRagDataset:
         """Generates questions but not the reference answers."""
-        return asyncio.run(self.agenerate_questions_from_nodes())
+        return asyncio_run(self.agenerate_questions_from_nodes())
 
     def generate_dataset_from_nodes(self) -> LabelledRagDataset:
         """Generates questions for each document."""
-        return asyncio.run(self.agenerate_dataset_from_nodes())
+        return asyncio_run(self.agenerate_dataset_from_nodes())
 
     def _get_prompts(self) -> PromptDictType:
         """Get prompts."""

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 import pandas as pd
 from tqdm import tqdm
 
-from llama_index.core.async_utils import DEFAULT_NUM_WORKERS, run_jobs
+from llama_index.core.async_utils import DEFAULT_NUM_WORKERS, run_jobs, asyncio_run
 from llama_index.core.base.response.schema import PydanticResponse
 from llama_index.core.bridge.pydantic import BaseModel, Field, ValidationError
 from llama_index.core.callbacks.base import CallbackManager
@@ -194,7 +194,7 @@ class BaseElementNodeParser(NodeParser):
                 else loop.run_until_complete(summary_co)
             )
         except RuntimeError:
-            summary_outputs = asyncio.run(summary_co)
+            summary_outputs = asyncio_run(summary_co)
         for element, summary_output in zip(elements, summary_outputs):
             element.table_output = summary_output
 

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -1,4 +1,3 @@
-import asyncio
 import uuid
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
@@ -186,15 +185,7 @@ class BaseElementNodeParser(NodeParser):
         summary_co = run_jobs(
             summary_jobs, show_progress=self.show_progress, workers=self.num_workers
         )
-        try:
-            loop = asyncio.get_running_loop()
-            summary_outputs = (
-                asyncio.ensure_future(summary_co)
-                if loop.is_running()
-                else loop.run_until_complete(summary_co)
-            )
-        except RuntimeError:
-            summary_outputs = asyncio_run(summary_co)
+        summary_outputs = asyncio_run(summary_co)
         for element, summary_output in zip(elements, summary_outputs):
             element.table_output = summary_output
 

--- a/llama-index-core/tests/indices/query/test_compose_vector.py
+++ b/llama-index-core/tests/indices/query/test_compose_vector.py
@@ -1,9 +1,9 @@
 """Test recursive queries."""
 
-import asyncio
 from typing import Any, Dict, List
 
 import pytest
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.data_structs.data_structs import IndexStruct
 from llama_index.core.indices.composability.graph import ComposableGraph
@@ -258,7 +258,7 @@ def test_recursive_query_vector_table_async(
 
     query_engine = graph.as_query_engine(custom_query_engines=custom_query_engines)
     task = query_engine.aquery("Cat?")
-    response = asyncio.run(task)
+    response = asyncio_run(task)
     assert str(response) == ("Cat?:Cat?:This is a test v2.")
 
 

--- a/llama-index-core/tests/indices/response/test_response_builder.py
+++ b/llama-index-core/tests/indices/response/test_response_builder.py
@@ -1,8 +1,8 @@
 """Test response utils."""
 
-import asyncio
 from typing import List
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
 from llama_index.core.indices.prompt_helper import PromptHelper
 from llama_index.core.prompts.base import PromptTemplate
@@ -266,7 +266,7 @@ def test_accumulate_response_aget(
         response_mode=ResponseMode.ACCUMULATE,
     )
 
-    response = asyncio.run(
+    response = asyncio_run(
         builder.aget_response(
             text_chunks=texts,
             query_str=query_str,

--- a/llama-index-core/tests/indices/struct_store/test_json_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_json_query.py
@@ -1,11 +1,11 @@
 """Test json index."""
 
-import asyncio
 import json
 from typing import Any, Dict, cast
 from unittest.mock import patch
 
 import pytest
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.response.schema import Response
 from llama_index.core.indices.struct_store.json_query import (
     JSONQueryEngine,
@@ -79,7 +79,7 @@ def test_json_query_engine(
 
     if call_apredict:
         task = query_engine.aquery(QueryBundle("test_nl_query"))
-        response: Response = cast(Response, asyncio.run(task))
+        response: Response = cast(Response, asyncio_run(task))
     else:
         response = cast(Response, query_engine.query(QueryBundle("test_nl_query")))
 

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -1,7 +1,7 @@
-import asyncio
 from typing import Any, Dict, Tuple
 
 import pytest
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.indices.struct_store.base import default_output_parser
 from llama_index.core.indices.struct_store.sql import SQLStructStoreIndex
 from llama_index.core.indices.struct_store.sql_query import (
@@ -116,40 +116,40 @@ def test_sql_index_async_query(
     # query the index with SQL
     sql_query_engine = SQLStructStoreQueryEngine(index, **query_kwargs)
     task = sql_query_engine.aquery(sql_to_test)
-    response = asyncio.run(task)
+    response = asyncio_run(task)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
 
     # query the index with natural language
     nl_query_engine = NLStructStoreQueryEngine(index, **query_kwargs)
     task = nl_query_engine.aquery("test_table:user_id,foo")
-    response = asyncio.run(task)
+    response = asyncio_run(task)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
 
     nl_table_engine = NLSQLTableQueryEngine(
         index.sql_database, service_context=mock_service_context
     )
     task = nl_table_engine.aquery("test_table:user_id,foo")
-    response = asyncio.run(task)
+    response = asyncio_run(task)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
 
     ## sql_only = True  ###
     # query the index with SQL
     sql_query_engine = SQLStructStoreQueryEngine(index, sql_only=True, **query_kwargs)
     task = sql_query_engine.aquery(sql_to_test)
-    response = asyncio.run(task)
+    response = asyncio_run(task)
     assert str(response) == sql_to_test
 
     # query the index with natural language
     nl_query_engine = NLStructStoreQueryEngine(index, sql_only=True, **query_kwargs)
     task = nl_query_engine.aquery("test_table:user_id,foo")
-    response = asyncio.run(task)
+    response = asyncio_run(task)
     assert str(response) == sql_to_test
 
     nl_table_engine = NLSQLTableQueryEngine(
         index.sql_database, service_context=mock_service_context, sql_only=True
     )
     task = nl_table_engine.aquery("test_table:user_id,foo")
-    response = asyncio.run(task)
+    response = asyncio_run(task)
     assert str(response) == sql_to_test
 
 


### PR DESCRIPTION
# Description

Ideally, throughout the repository, we should be checking for running event loops before creating any. In this example, neither `unstructured_element.py` nor `base_element.py` can be run within an asynchronous context otherwise.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)