### PR TITLE
Handle ValueError in extract_table_summaries

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -172,7 +172,7 @@ class BaseElementNodeParser(NodeParser):
             try:
                 response = await query_engine.aquery(summary_query_str)
                 return cast(PydanticResponse, response).response
-            except ValidationError:
+            except (ValidationError, ValueError):
                 # There was a pydantic validation error, so we will run with text completion
                 # fill in the summary and leave other fields blank
                 query_engine = index.as_query_engine(llm=llm)


### PR DESCRIPTION
# Description

Fixes https://github.com/run-llama/llama_index/issues/13316

In the function [extract_table_summaries](https://github.com/run-llama/llama_index/blob/abfd92a289ce459ce4b7960f9542439e1c796171/llama-index-core/llama_index/core/node_parser/relational/base_element.py#L144), it attempts to retrieve the summary in a TableOutput format. However, because the response relies on the LLM, there's no assurance that the response will always be in TableOutput format. If the response isn't in JSON format, a ValueError is raised at [extract_json_str](https://github.com/run-llama/llama_index/blob/abfd92a289ce459ce4b7960f9542439e1c796171/llama-index-core/llama_index/core/output_parsers/utils.py#L111-L112). This situation should also be handled so that TableOutput can still be returned despite the ValueError.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
