### PR TITLE
fix from_defaults erasing summary buffer history

### DIFF
--- a/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
@@ -87,8 +87,9 @@ class ChatSummaryMemoryBuffer(BaseMemory):
             token_limit = DEFAULT_TOKEN_LIMIT
 
         chat_store = chat_store or SimpleChatStore()
-        chat_history = chat_history or []
-        chat_store.set_messages(chat_store_key, chat_history)
+
+        if chat_history is not None:
+            chat_store.set_messages(chat_store_key, chat_history)
 
         summarize_prompt = summarize_prompt or SUMMARIZE_PROMPT
         return cls(


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/13308

`from_defaults` in the summary memory buffer was erasing chat history 