### PR TITLE
Update MarkdownReader to parse text before first header

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
@@ -8,8 +8,7 @@ import re
 from pathlib import Path
 from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
-from typing import Any, Dict, List, Optional, Tuple, cast
-
+from typing import Any, Dict, List, Optional, Tuple
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
 
@@ -44,34 +43,30 @@ class MarkdownReader(BaseReader):
         lines = markdown_text.split("\n")
 
         current_header = None
-        current_text = ""
+        current_lines = []
 
         for line in lines:
             header_match = re.match(r"^#+\s", line)
             if header_match:
-                if current_header is not None:
-                    if current_text == "" or None:
-                        continue
-                    markdown_tups.append((current_header, current_text))
+                if current_header is not None or len(current_lines) > 0:
+                    markdown_tups.append((current_header, "\n".join(current_lines)))
 
                 current_header = line
-                current_text = ""
+                current_lines.clear()
             else:
-                current_text += line + "\n"
-        markdown_tups.append((current_header, current_text))
+                current_lines.append(line)
 
-        if current_header is not None:
-            # pass linting, assert keys are defined
-            markdown_tups = [
-                (re.sub(r"#", "", cast(str, key)).strip(), re.sub(r"<.*?>", "", value))
-                for key, value in markdown_tups
-            ]
-        else:
-            markdown_tups = [
-                (key, re.sub("<.*?>", "", value)) for key, value in markdown_tups
-            ]
+        # Append final text chunk
+        markdown_tups.append((current_header, "\n".join(current_lines)))
 
-        return markdown_tups
+        # Postprocess the tuples before returning
+        return [
+            (
+                key if key is None else re.sub(r"#", "", key).strip(),
+                re.sub(r"<.*?>", "", value),
+            )
+            for key, value in markdown_tups
+        ]
 
     def remove_images(self, content: str) -> str:
         """Remove images in markdown content."""

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
@@ -48,6 +48,7 @@ class MarkdownReader(BaseReader):
         for line in lines:
             header_match = re.match(r"^#+\s", line)
             if header_match:
+                # Upon first header, skip if current text chunk is empty
                 if current_header is not None or len(current_lines) > 0:
                     markdown_tups.append((current_header, "\n".join(current_lines)))
 

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -50,7 +50,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.20"
+version = "0.1.21"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_markdown.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_markdown.py
@@ -1,0 +1,59 @@
+from llama_index.readers.file import MarkdownReader
+
+
+def test_parse_markdown_starting_with_header() -> None:
+    reader = MarkdownReader()
+    markdown_text = "# ABC\nabc\n# DEF\ndef"
+    expected_tups = [("ABC", "abc"), ("DEF", "def")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+
+def test_parse_markdown_with_text_before_first_header() -> None:
+    reader = MarkdownReader()
+    markdown_text = "abc\n# ABC\ndef"
+    expected_tups = [(None, "abc"), ("ABC", "def")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+
+def test_parse_markdown_with_empty_lines_before_first_header() -> None:
+    reader = MarkdownReader()
+    markdown_text = "\n\n\n# ABC\ndef"
+    expected_tups = [(None, "\n\n"), ("ABC", "def")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+
+def test_parse_markdown_with_no_headers() -> None:
+    reader = MarkdownReader()
+    markdown_text = "abc\ndef"
+    expected_tups = [(None, "abc\ndef")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+
+def test_parse_markdown_with_only_headers() -> None:
+    reader = MarkdownReader()
+    markdown_text = "# ABC\n# DEF"
+    expected_tups = [("ABC", ""), ("DEF", "")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+
+def test_parse_empty_markdown() -> None:
+    reader = MarkdownReader()
+    markdown_text = ""
+    expected_tups = [(None, "")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+
+def test_parse_omits_trailing_newline_before_new_header() -> None:
+    reader = MarkdownReader()
+
+    markdown_text = ("\n" * 4) + "# ABC\nabc"
+    expected_tups = [(None, "\n" * 3), ("ABC", "abc")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+    markdown_text = ("\n" * 4) + "# ABC\nabc\n"
+    expected_tups = [(None, "\n" * 3), ("ABC", "abc\n")]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+    markdown_text = "\n" * 4
+    expected_tups = [(None, "\n" * 4)]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups


### PR DESCRIPTION
# Description

Fixing an issue in MarkdownReader where text that occurs before the first header in a markdown file is ignored. Also fixed an apparent bug where, due to naive concatenation, a trailing newline is added to the end of every text chunk (if this is intentional, please let me know, however no documentation nor tests seem to indicate). I've added tests to clarify these MarkdownReader behaviors and others.

Fixes #13283 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods