### PR TITLE
Fix add llama-3 models to Anyscale class

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anyscale/llama_index/llms/anyscale/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anyscale/llama_index/llms/anyscale/utils.py
@@ -7,6 +7,8 @@ DEFAULT_ANYSCALE_API_BASE = "https://api.endpoints.anyscale.com/v1"
 DEFAULT_ANYSCALE_API_VERSION = ""
 
 LLAMA_MODELS = {
+    "meta-llama/Meta-Llama-3-70B-Instruct": 8192,
+    "meta-llama/Meta-Llama-3-8B-Instruct": 8192,
     "meta-llama/Llama-2-7b-chat-hf": 4096,
     "meta-llama/Llama-2-13b-chat-hf": 4096,
     "meta-llama/Llama-2-70b-chat-hf": 4096,

--- a/llama-index-integrations/llms/llama-index-llms-anyscale/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anyscale/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-anyscale"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Adding the ability to use Llama-3-8B-Instruct and Llama-3-70B-Instruct models on Anyscale endpoints. These models work on Anyscale, but were not passing the model name check in the Anyscale() class.

Fixes # (issue)
None existing.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x ] No

## Type of Change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

- Tested with local copy of the Anyscale package for both 8B and 70B

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x ] I ran `make format; make lint` to appease the lint gods
