### PR TITLE
feature: add missing openai model token context

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -42,6 +42,7 @@ GPT4_MODELS: Dict[str, int] = {
     "gpt-4-turbo-preview": 128000,
     # multimodal model
     "gpt-4-vision-preview": 128000,
+    "gpt-4-1106-vision-preview": 128000,
     "gpt-4-turbo-2024-04-09": 128000,
     "gpt-4-turbo": 128000,
     # 0613 models (function calling):


### PR DESCRIPTION
# Description

Add missing `gpt-4-1106-vision-preview` model from OpenAI documentation ([link](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4)).

Fixes #13333 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Version was nicely copied and pasted from the documentation site.
Also I did a request using `openai` SDK and everything worked.

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
