### PR TITLE
Fix hidden temp directory issue for arxiv reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-papers/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-papers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.1.5] - 2024-05-07
+
+### Bug Fixes
+
+- Fix issues with hidden temporary folder (#13165)
+
 ## [0.1.2] - 2024-02-13
 
 - Add maintainers and keywords from library.json (llamahub)

--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -75,7 +75,7 @@ class ArxivReader(BaseReader):
         arxiv_documents = SimpleDirectoryReader(
             papers_dir,
             file_metadata=get_paper_metadata,
-            exclude_hidden=False # default directory is hidden ".papers"
+            exclude_hidden=False  # default directory is hidden ".papers"
         ).load_data()
         # Include extra documents containing the abstracts
         abstract_documents = []

--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -73,7 +73,7 @@ class ArxivReader(BaseReader):
             return paper_lookup[os.path.basename(filename)]
 
         arxiv_documents = SimpleDirectoryReader(
-            papers_dir, file_metadata=get_paper_metadata
+            papers_dir, file_metadata=get_paper_metadata, exclude_hidden=False
         ).load_data()
         # Include extra documents containing the abstracts
         abstract_documents = []

--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -75,7 +75,7 @@ class ArxivReader(BaseReader):
         arxiv_documents = SimpleDirectoryReader(
             papers_dir,
             file_metadata=get_paper_metadata,
-            exclude_hidden=False  # default directory is hidden ".papers"
+            exclude_hidden=False,  # default directory is hidden ".papers"
         ).load_data()
         # Include extra documents containing the abstracts
         abstract_documents = []

--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -73,7 +73,9 @@ class ArxivReader(BaseReader):
             return paper_lookup[os.path.basename(filename)]
 
         arxiv_documents = SimpleDirectoryReader(
-            papers_dir, file_metadata=get_paper_metadata, exclude_hidden=False
+            papers_dir,
+            file_metadata=get_paper_metadata,
+            exclude_hidden=False # default directory is hidden ".papers"
         ).load_data()
         # Include extra documents containing the abstracts
         abstract_documents = []

--- a/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["thejessezhang"]
 name = "llama-index-readers-papers"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Default directory for PDFs downloading is ".papers", which considered to be hidden (`.` prefix). The SimpleDirectoryReader ignores hidden files, thus arXiv reader doesn't work without providing directory to hold temporary files.

Fixes #13165

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
