### PR TITLE
Add support for Vespa Node's and indexing with additional fields 

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/schema/vespa/vespa_node.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/schema/vespa/vespa_node.py
@@ -1,0 +1,5 @@
+from llama_index.core.schema import TextNode
+
+
+class VespaNode(TextNode):
+    vespa_fields: dict

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/vector_stores/vespa/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/vector_stores/vespa/base.py
@@ -486,10 +486,8 @@ class VespaVectorStore(VectorStore):
             )
         logger.debug("Response:")
         logger.debug(response.json)
-        logger.info(response.json)
         logger.debug("Hits:")
         logger.debug(response.hits)
-        logger.info(response.hits)
         nodes = []
         ids: List[str] = []
         similarities: List[float] = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/vector_stores/vespa/templates.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/vector_stores/vespa/templates.py
@@ -94,3 +94,86 @@ hybrid_template = ApplicationPackage(
         )
     ],
 )
+
+# I am not sure what to name this, so I decided a name that highlights the difference with hybrid_template
+# This needs to be renamed to something more meaningful
+with_fields_template = ApplicationPackage(
+    name="withfields",
+    schema=[
+        Schema(
+            name="doc",
+            document=Document(
+                fields=[
+                    Field(name="id", type="string", indexing=["summary"]),
+                    Field(name="title", type="string", indexing=["summary"]),
+                    Field(name="author", type="string", indexing=["summary"]),
+                    Field(name="theme", type="string", indexing=["summary"]),
+                    Field(name="year", type="int", indexing=["summary"]),
+                    Field(
+                        name="text",
+                        type="string",
+                        indexing=["index", "summary"],
+                        index="enable-bm25",
+                        bolding=True,
+                    ),
+                    Field(
+                        name="embedding",
+                        type="tensor<float>(x[384])",
+                        indexing=[
+                            "input text",
+                            "embed",
+                            "index",
+                            "attribute",
+                        ],
+                        ann=HNSW(distance_metric="angular"),
+                        is_document_field=False,
+                    ),
+                ]
+            ),
+            fieldsets=[FieldSet(name="default", fields=["text", "metadata"])],
+            rank_profiles=[
+                RankProfile(
+                    name="bm25",
+                    inputs=[("query(q)", "tensor<float>(x[384])")],
+                    functions=[Function(name="bm25sum", expression="bm25(text)")],
+                    first_phase="bm25sum",
+                ),
+                RankProfile(
+                    name="semantic",
+                    inputs=[("query(q)", "tensor<float>(x[384])")],
+                    first_phase="closeness(field, embedding)",
+                ),
+                RankProfile(
+                    name="fusion",
+                    inherits="bm25",
+                    inputs=[("query(q)", "tensor<float>(x[384])")],
+                    first_phase="closeness(field, embedding)",
+                    global_phase=GlobalPhaseRanking(
+                        expression="reciprocal_rank_fusion(bm25sum, closeness(field, embedding))",
+                        rerank_count=1000,
+                    ),
+                ),
+            ],
+        )
+    ],
+    components=[
+        Component(
+            id="e5",
+            type="hugging-face-embedder",
+            parameters=[
+                Parameter(
+                    "transformer-model",
+                    {
+                        "url": "https://github.com/vespa-engine/sample-apps/raw/master/simple-semantic-search/model/e5-small-v2-int8.onnx"
+                    },
+                ),
+                Parameter(
+                    "tokenizer-model",
+                    {
+                        "url": "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/simple-semantic-search/model/tokenizer.json"
+                    },
+                ),
+            ],
+        )
+    ],
+)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/vector_stores/vespa/templates.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/llama_index/vector_stores/vespa/templates.py
@@ -109,6 +109,7 @@ with_fields_template = ApplicationPackage(
                     Field(name="author", type="string", indexing=["summary"]),
                     Field(name="theme", type="string", indexing=["summary"]),
                     Field(name="year", type="int", indexing=["summary"]),
+                    Field(name="metadata", type="string", indexing=["summary"]),
                     Field(
                         name="text",
                         type="string",

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespa_vector_store_with_vespa_nodes.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespa_vector_store_with_vespa_nodes.py
@@ -118,7 +118,32 @@ class TestTextQuery:
     def setup_method(self):
         self.text_query =  VectorStoreQuery(
             query_str="1984",  # Ensure the query matches the case used in the nodes
-            mode=VectorStoreQueryMode.DEFAULT,
+            mode=VectorStoreQueryMode.TEXT_SEARCH,
+            similarity_top_k=1,
+        )
+    @pytest.mark.skipif(not docker_available, reason="Docker not available")
+    def test_returns_hit(self, vespa_app, added_node_ids):
+        result = vespa_app.query(self.text_query)
+        assert len(result.nodes) == 1
+
+    def test_returns_vespa_node(self, vespa_app, added_node_ids):
+        result = vespa_app.query(self.text_query)
+        node = result.nodes[0]
+        assert isinstance(node, VespaNode)
+    def test_correctly_assigns_vespa_node_fields(self, vespa_app, added_node_ids):
+        result = vespa_app.query(self.text_query)
+        node = result.nodes[0]
+        assert node.vespa_fields["title"] == "1984"
+        assert node.vespa_fields["author"] == "George Orwell"
+        assert node.vespa_fields["theme"] == "Totalitarianism"
+        assert node.vespa_fields["year"] == 1949
+        assert node.vespa_fields["id"] == "5"
+
+class TestSemanticQuery:
+    def setup_method(self):
+        self.text_query =  VectorStoreQuery(
+            query_str="1984",  # Ensure the query matches the case used in the nodes
+            mode=VectorStoreQueryMode.SEMANTIC_HYBRID,
             similarity_top_k=1,
         )
     @pytest.mark.skipif(not docker_available, reason="Docker not available")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespa_vector_store_with_vespa_nodes.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespa_vector_store_with_vespa_nodes.py
@@ -1,0 +1,117 @@
+import pytest
+from llama_index.core.vector_stores import VectorStoreQuery
+from llama_index.core.vector_stores.types import VectorStoreQueryMode
+from vespa.package import ApplicationPackage
+
+from llama_index.schema.vespa.vespa_node import VespaNode
+from llama_index.vector_stores.vespa import VespaVectorStore
+from llama_index.vector_stores.vespa.templates import with_fields_template
+
+
+try:
+    # Should be installed as pyvespa-dependency
+    import docker
+
+    client = docker.from_env()
+    docker_available = client.ping()
+except Exception:
+    docker_available = False
+
+@pytest.fixture(scope="session")
+def vespa_app():
+    app_package: ApplicationPackage = with_fields_template
+    try:
+        # Try getting the local instance if available
+        return VespaVectorStore(url="http://localhost", application_package=app_package, deployment_target="local")
+    except ConnectionError:
+        return VespaVectorStore(application_package=app_package, deployment_target="local")
+@pytest.fixture(scope="session")
+def vespa_nodes() -> list:
+    return [
+        VespaNode(
+            vespa_fields={
+                "title": "The Shawshank Redemption",
+                "author": "Stephen King",
+                "theme": "Friendship",
+                "year": 1994,
+            },
+            text="The Shawshank Redemption",
+            metadata={"id": "1"},
+        ),
+        VespaNode(
+            vespa_fields={
+                "title": "The Godfather",
+                "director": "Francis Ford Coppola",
+                "theme": "Mafia",
+                "year": 1972,
+            },
+            text="The Godfather",
+            metadata={"id": "2"},
+        ),
+        VespaNode(
+            vespa_fields={
+                "title": "Inception",
+                "director": "Christopher Nolan",
+                "theme": "Fiction",
+                "year": 2010,
+            },
+            text="Inception",
+            metadata={"id": "3"},
+        ),
+        VespaNode(
+            vespa_fields={
+                "title": "To Kill a Mockingbird",
+                "author": "Harper Lee",
+                "theme": "Mafia",
+                "year": 1960,
+            },
+            text="To Kill a Mockingbird",
+            metadata={"id": "4"},
+        ),
+        VespaNode(
+            vespa_fields={
+                "title": "1984",
+                "author": "George Orwell",
+                "theme": "Totalitarianism",
+                "year": 1949,
+            },
+            text="1984",
+            metadata={"id": "5"},
+        ),
+        VespaNode(
+            vespa_fields={
+                "title": "The Great Gatsby",
+                "author": "F. Scott Fitzgerald",
+                "theme": "The American Dream",
+                "year": 1925,
+            },
+            text="The Great Gatsby",
+            metadata={"id": "6"},
+        ),
+        VespaNode(
+            vespa_fields={
+                "title": "Harry Potter and the Sorcerer's Stone",
+                "author": "J.K. Rowling",
+                "theme": "Fiction",
+                "year": 1997,
+            },
+            text="Harry Potter and the Sorcerer's Stone",
+            metadata={"id": "7"},
+        ),
+
+    ]
+
+@pytest.fixture(scope="session")
+def added_node_ids(vespa_app, vespa_nodes):
+    return vespa_app.add(vespa_nodes)
+
+@pytest.mark.skipif(not docker_available, reason="Docker not available")
+def test_vespa_node_text_query(vespa_app, added_node_ids):
+    query = VectorStoreQuery(
+        query_str="Gatsby",  # Ensure the query matches the case used in the nodes
+        mode=VectorStoreQueryMode.DEFAULT,
+        similarity_top_k=1,
+    )
+    result = vespa_app.query(query)
+    assert len(result.nodes) == 1
+    print(result.nodes[0].metadata)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespavectorstore.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespavectorstore.py
@@ -109,7 +109,7 @@ def added_node_ids(vespa_app, nodes):
 def test_query_text_search(vespa_app, added_node_ids):
     query = VectorStoreQuery(
         query_str="Inception",  # Ensure the query matches the case used in the nodes
-        mode="text_search",
+        mode=VectorStoreQueryMode.TEXT_SEARCH,
         similarity_top_k=1,
     )
     result = vespa_app.query(query)
@@ -122,7 +122,7 @@ def test_query_text_search(vespa_app, added_node_ids):
 def test_query_vector_search(vespa_app, added_node_ids):
     query = VectorStoreQuery(
         query_str="magic, wizardry",
-        mode="semantic_hybrid",
+        mode=VectorStoreQueryMode.SEMANTIC_HYBRID,
         similarity_top_k=1,
     )
     result = vespa_app.query(query)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespavectorstore.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespavectorstore.py
@@ -23,7 +23,11 @@ except Exception:
 @pytest.fixture(scope="session")
 def vespa_app():
     app_package: ApplicationPackage = hybrid_template
-    return VespaVectorStore(application_package=app_package, deployment_target="local")
+    try:
+        # Try getting the local instance if available
+        return VespaVectorStore(url="http://localhost", application_package=app_package, deployment_target="local")
+    except ConnectionError:
+        return VespaVectorStore(application_package=app_package, deployment_target="local")
 
 
 @pytest.fixture(scope="session")
@@ -130,6 +134,7 @@ def test_query_vector_search(vespa_app, added_node_ids):
 
 @pytest.mark.skipif(not docker_available, reason="Docker not available")
 def test_delete_node(vespa_app, added_node_ids):
+    print("added node ids: ", added_node_ids)
     # Testing the deletion of a node
     vespa_app.delete(ref_doc_id=added_node_ids[1])
     query = VectorStoreQuery(


### PR DESCRIPTION
# Description

This PR adds support for indexing nodes to vespa with custom fields other than text and metadata. 
Issue #13319

## Motivation

A [schema](https://docs.vespa.ai/en/reference/schema-reference.html) in Vespa has many fields that can be searched from and referenced in [ranking profiles](https://docs.vespa.ai/en/getting-started-ranking.html). This PR enables users to define the values for their vespa fields with a VespaNode. 

## Type of Change
- [✓] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?


- [ ✓] Added new unit/integration tests

## Suggested Checklist:

- [✓ ] I have performed a self-review of my own code
- [ ✓] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ✓] My changes generate no new warnings
- [ ✓] I have added tests that prove my fix is effective or that my feature works
- [ ✓] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods


# Notes

## Development decisions

- Tests now try to get the local running vespa instance rather than deploying each time when tests run. This is done to make TDD possible. A caveat is to check the locally running vespa instances to avoid making accidental changes to other instances
- Nodes are added and deleted before and after each test. This is to avoid conflicts between tests and versioning issues
- When adding a node, an isinstance check checks for whether the passed in nodes are Vespa and if so add the vespa_fields to the fields in entry 
- When querying, the fields of the hits are checked for length. If its bigger than 5, its assumed that custom fields have been added and its treated as a vespa node. This check could be made safer

## Future Considerations
- Vespa Node's only define a dictionary and doesn't do any type checking. To avoid this, support for customizing Vespa Node could be added. The fields added to new node would be treated as vespa fields. This could be done with pydantic however is out of the scope of #13319 


## Note to maintainers
Please don't merge this before @thomasht86 reviews and confirms the changes