### PR TITLE
Add `start_char_idx` and `end_char_idx`: `MarkdownElementNodeParser`

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
@@ -32,7 +32,9 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
         self.extract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
-        nodes = self.get_nodes_from_elements(elements, node.metadata)
+        nodes = self.get_nodes_from_elements(
+            elements, node.metadata, ref_doc_text=node.get_content()
+        )
         source_document = node.source_node or node.as_related_node_info()
         for n in nodes:
             n.relationships[NodeRelationship.SOURCE] = source_document
@@ -156,7 +158,7 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
                         elements[idx] = Element(
                             id=f"id_{node_id}_{idx}" if node_id else f"id_{idx}",
                             type="table",
-                            element=element,
+                            element=element.element,
                             table=table,
                         )
                     else:

--- a/llama-index-core/tests/node_parser/test_markdown_element.py
+++ b/llama-index-core/tests/node_parser/test_markdown_element.py
@@ -2665,3 +2665,43 @@ Hello world!
     assert len(nodes) == 1
 
     assert nodes[0].ref_doc_id == test_document.doc_id
+
+
+def test_start_end_char_idx():
+    test_document = Document(
+        text="""
+# This is a test
+
+| Year | Benefits |
+| ---- | -------- |
+| 2020 | 12,000   |
+| 2021 | 10,000   |
+| 2022 | 130,000  |
+
+""",
+    )
+
+    node_parser = MarkdownElementNodeParser(llm=MockLLM())
+
+    nodes = node_parser.get_nodes_from_documents([test_document])
+    assert len(nodes) == 3
+    assert (
+        test_document.text[nodes[0].start_char_idx : nodes[0].end_char_idx]
+        == "This is a test"
+    )
+    assert (
+        test_document.text[nodes[1].start_char_idx : nodes[1].end_char_idx]
+        == """| Year | Benefits |
+| ---- | -------- |
+| 2020 | 12,000   |
+| 2021 | 10,000   |
+| 2022 | 130,000  |"""
+    )
+    assert (
+        test_document.text[nodes[2].start_char_idx : nodes[2].end_char_idx]
+        == """| Year | Benefits |
+| ---- | -------- |
+| 2020 | 12,000   |
+| 2021 | 10,000   |
+| 2022 | 130,000  |"""
+    )


### PR DESCRIPTION
# Description

- `start_char_idx` and `end_char_idx` were missing from `IndexNode`'s as well as the related `TextNode`s when using `MarkdownElementNodeParser` on a md doc with tables.
- This PR adds these missing parms

Fixes # (issue)

## New Package?

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No
- [x] N/A (core package changed)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] Tested a previous notebook on llamaparser and using `MarkdownElementNodeParser`
- [x] I stared at the code and made sure it makes sense

