### PR TITLE
Update tests for Github readers

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-github/tests/test_github_repository_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/tests/test_github_repository_reader.py
@@ -18,7 +18,7 @@ BRANCH_JSON = '{"name":"main","commit":{"sha":"a11a953e738cbda93335ede83f012914d
 
 TREE_JSON = '{"sha":"01d1b2024af28c7d5abf2a66108e7ed5611c6308","url":"https://api.github.com/repos/run-llama/llama_index/git/trees/01d1b2024af28c7d5abf2a66108e7ed5611c6308","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"0bbd4e1720494e30e267c11dc9967c100b86bad8","size":10101,"url":"https://api.github.com/repos/run-llama/llama_index/git/blobs/0bbd4e1720494e30e267c11dc9967c100b86bad8"}],"truncated":false}'
 
-github_token = os.environ.get("GITHUB_TOKEN", None)
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 
 
 @pytest.fixture()
@@ -47,10 +47,8 @@ def mock_error(monkeypatch):
     monkeypatch.setattr(GithubClient, "get_tree", mock_get_tree)
 
 
-@pytest.mark.skipif(not github_token, reason="No github token")
 def test_fail_on_http_error_true(mock_error):
-    token = os.getenv("GITHUB_TOKEN")
-    gh_client = GithubClient(token, fail_on_http_error=True)
+    gh_client = GithubClient(GITHUB_TOKEN, fail_on_http_error=True)
     reader = GithubRepositoryReader(gh_client, "run-llama", "llama_index")
     # test for branch
     with pytest.raises(HTTPError):
@@ -60,10 +58,8 @@ def test_fail_on_http_error_true(mock_error):
         reader.load_data(commit_sha="a11a953e738cbda93335ede83f012914d53dc4f7")
 
 
-@pytest.mark.skipif(not github_token, reason="No github token")
 def test_fail_on_http_error_false(mock_error):
-    token = os.getenv("GITHUB_TOKEN")
-    gh_client = GithubClient(token, fail_on_http_error=False)
+    gh_client = GithubClient(GITHUB_TOKEN, fail_on_http_error=False)
     reader = GithubRepositoryReader(gh_client, "run-llama", "llama_index")
     # test for branch
     documents = reader.load_data(branch="main")


### PR DESCRIPTION
# Description

Relates to #13366 

Allows tests to run with no github token.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Update tests

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
