### PR TITLE
fix: missing authorized_user_info check on GoogleDriveReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -121,8 +121,14 @@ class GoogleDriveReader(BasePydanticReader):
             with open(service_account_key_path, encoding="utf-8") as json_file:
                 service_account_key = json.load(json_file)
 
-        if client_config is None and service_account_key is None and authorized_user_info is None:
-            raise ValueError("Must specify `client_config` or `service_account_key` or `authorized_user_info`.")
+        if (
+            client_config is None
+            and service_account_key is None
+            and authorized_user_info is None
+        ):
+            raise ValueError(
+                "Must specify `client_config` or `service_account_key` or `authorized_user_info`."
+            )
 
         super().__init__(
             drive_id=drive_id,

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -121,8 +121,8 @@ class GoogleDriveReader(BasePydanticReader):
             with open(service_account_key_path, encoding="utf-8") as json_file:
                 service_account_key = json.load(json_file)
 
-        if client_config is None and service_account_key is None:
-            raise ValueError("Must specify `client_config` or `service_account_key`.")
+        if client_config is None and service_account_key is None and authorized_user_info is None:
+            raise ValueError("Must specify `client_config` or `service_account_key` or `authorized_user_info`.")
 
         super().__init__(
             drive_id=drive_id,


### PR DESCRIPTION
# Description

Fixing missing check statement when initializing `GoogleDriveReader` integration.

Fixes
#13393 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
