### PR TITLE
Update `llama-index-llms-huggingface` dependency

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
@@ -28,12 +28,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-huggingface"
 readme = "README.md"
-version = "0.1.5"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-huggingface-hub = "^0.20.3"
+huggingface-hub = "^0.23.0"
 torch = "^2.1.2"
 text-generation = "^0.7.0"
 

--- a/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
@@ -28,12 +28,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-huggingface"
 readme = "README.md"
-version = "0.2.0"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-huggingface-hub = "^0.23.0"
+huggingface-hub = "^0.20.3"
 torch = "^2.1.2"
 text-generation = "^0.7.0"
 


### PR DESCRIPTION
# Description

The `huggingface-hub` dependency from `llama-index-llms-huggingface` is requiring `0.20.*`, which is from January 2024 and has since been superseded.  That dependency is resulting in conflicts with other packages, such as Gradio, and pinning those other packages results in high risk security vulnerabilities.  

This updates the required `huggingface-hub`  minimum version to `0.23.0`, which resolves the issues.  Bumped the minor version of `llama-index-llms-huggingface` to `0.2.0` accordingly.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
