### PR TITLE
Remove "Truncate" parameter from Bedrock Cohere invoke model request.

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -382,8 +382,7 @@ class BedrockEmbedding(BaseEmbedding):
             Sample Payload of type dict of following format
             {
                 'texts': ["This is a test document", "This is another document"],
-                'input_type': 'search_document',
-                'truncate': 'NONE'
+                'input_type': 'search_document'
             }
 
         """
@@ -402,7 +401,6 @@ class BedrockEmbedding(BaseEmbedding):
                 {
                     "texts": payload,
                     "input_type": input_types[input_type],
-                    "truncate": "NONE",
                 }
             )
         else:

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

You can see a description of the problem here:

https://github.com/run-llama/llama_index/issues/13376

This is probably a Bedrock bug, but removing the Truncate parameter is an acceptable solution because it would take the default value, which (in theory) is also 'NONE'. However, when it is explicitly specified, it does not work as expected.

Fixes # 13376

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
