### PR TITLE
Integration: Improve Chunk splitter + Relationships between chunks for python files / repositories

### DIFF
--- a/docs/docs/examples/node_parsers/python_files_parser.ipynb
+++ b/docs/docs/examples/node_parsers/python_files_parser.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.node_parser.relational.llama_parse_python_files import LlamaParsePythonFile\n",
+    "from llama_index.core.schema import NodeRelationship"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parse = LlamaParsePythonFile()\n",
+    "\n",
+    "try:\n",
+    "    nodes = parse.get_nodes_from_python_files(files=\"./\")\n",
+    "except FileNotFoundError:\n",
+    "    print(f\"You are too far from the .venv folder. Create one in the directory you are currently in...\")\n",
+    "    raise FileNotFoundError\n",
+    "\n",
+    "for node in nodes:\n",
+    "    if not NodeRelationship.REFERENCE in node.relationships: continue\n",
+    "    print(node.relationships[NodeRelationship.REFERENCE])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/llama-index-core/llama_index/core/node_parser/relational/llama_parse_python_files.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/llama_parse_python_files.py
@@ -1,21 +1,35 @@
-try:
-  from pychunk.chunkers.python_chunker import PythonChunker
-  from pychunk.parser.llama_index_parser import LlamaIndexParser
-  from pychunk.nodes.base import BaseNode as PychunkBaseNode
-except ModuleNotFoundError as :
-  raise e("You need to install pychunk first: pip install rag-pychunk")
+from typing import List
 
-from llama_index.core.schema import NodeRelationship, BaseNode
+try:
+    from pychunk.chunkers.python_chunker import PythonChunker
+    from pychunk.parser.llama_index_parser import LlamaIndexParser
+except ModuleNotFoundError as e:
+    raise e("You need to install pychunk first: pip install rag-pychunk")
+
+from llama_index.core.schema import NodeRelationship, BaseNode, RelatedNodeInfo
 from llama_index.core.node_parser.interface import NodeParser
 
 
 class LlamaParsePythonFile(NodeParser):
-
-  def get_nodes_from_python_files(self, files: List[str]) -> List[BaseNode]:
-    ...
     
-  def _create_relationsihps_of_nodes(self, nodes: List[PyhunkBaseNode]) -> List[BaseNode]:
-    ...
+    def get_nodes_from_python_files(self, files: List[str]) -> List[BaseNode]:
+        """Convert pychunk nodes into LlamaIndex BaseNode"""
+        _chunker = PythonChunker(files_path=files)
+        _nodes = _chunker.find_relationships()
+        nodes = []
+        for _, nodes_of_file in _nodes.items():
+          nodes.extend(list(nodes_of_file.values()))
+          
+        base_nodes = LlamaIndexParser(nodes=nodes).parse_to_llama_index()
 
-llama_index_parser = LlamaIndexParser(nodes=list(all_nodes.values()))
-llama_index_nodes = llama_index_parser.parse_to_llama_index()
+        for node in base_nodes:
+            metadata = node.metadata
+            other_relationships = metadata.get('other_relationships')
+            if other_relationships is None or len(other_relationships) < 1:
+                continue
+            node.relationships[NodeRelationship.REFERENCE] = [RelatedNodeInfo(node_id=id) for id in other_relationships]
+
+        return base_nodes
+      
+    def _parse_nodes(self):
+      ...

--- a/llama-index-core/llama_index/core/node_parser/relational/llama_parse_python_files.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/llama_parse_python_files.py
@@ -1,0 +1,21 @@
+try:
+  from pychunk.chunkers.python_chunker import PythonChunker
+  from pychunk.parser.llama_index_parser import LlamaIndexParser
+  from pychunk.nodes.base import BaseNode as PychunkBaseNode
+except ModuleNotFoundError as :
+  raise e("You need to install pychunk first: pip install rag-pychunk")
+
+from llama_index.core.schema import NodeRelationship, BaseNode
+from llama_index.core.node_parser.interface import NodeParser
+
+
+class LlamaParsePythonFile(NodeParser):
+
+  def get_nodes_from_python_files(self, files: List[str]) -> List[BaseNode]:
+    ...
+    
+  def _create_relationsihps_of_nodes(self, nodes: List[PyhunkBaseNode]) -> List[BaseNode]:
+    ...
+
+llama_index_parser = LlamaIndexParser(nodes=list(all_nodes.values()))
+llama_index_nodes = llama_index_parser.parse_to_llama_index()

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -312,7 +312,18 @@ class BaseNode(BaseComponent):
         if not isinstance(relation, list):
             raise ValueError("Child objects must be a list of RelatedNodeInfo objects.")
         return relation
+    
+    @property
+    def reference_nodes(self) -> Optional[List[RelatedNodeInfo]]:
+        """Reference nodes."""
+        if NodeRelationship.REFERENCE not in self.relationships:
+            return None
 
+        relation = self.relationships[NodeRelationship.REFERENCE]
+        if not isinstance(relation, list):
+            raise ValueError("Reference objects must be a list of RelatedNodeInfo objects.")
+        return relation
+    
     @property
     def ref_doc_id(self) -> Optional[str]:
         """Deprecated: Get ref doc id."""

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -148,6 +148,7 @@ class NodeRelationship(str, Enum):
     NEXT = auto()
     PARENT = auto()
     CHILD = auto()
+    REFERENCE = auto()
 
 
 class ObjectType(str, Enum):

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -81,6 +81,7 @@ networkx = ">=3.0"
 psycopg2-binary = {optional = true, version = "^2.9.9"}
 dirtyjson = "^1.0.8"
 tqdm = "^4.66.1"
+rag-pychunk = "1.0.4"
 pillow = ">=9.0.0"
 PyYAML = ">=6.0.1"
 llamaindex-py-client = "^0.1.18"


### PR DESCRIPTION
# Description

A new feature has been added using rag-pychunk: Python Library to chunk your python files levereging the python programming language to improve two things:

- Chunk size: make your chunk size dynamic, keeping in the same chunk a hole funcion, a hole class method, a hole class and block of code.
- Chunk relationships: create relationships between your chunks other than Parent-Child and Prev-Next. NodeRelationship.REFERENCE has been created, which will include these relationships. These type of relationship can be used as well for example in pdfs when a chunk is referencing another chunk (example: In section 3.7 there is an explanation ... -> section 3.7 will need to be a NodeRelationship.REFERENCE for "self" node). 

Motivation: leverage python programming language syntax to improve the Chunking + relationship part of the RAG pipeline. This logic can be used for all programming languages, since all of them have a defined syntax. 

New dependency: rag-pychunk library. 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new notebook (that tests end-to-end)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
