### PR TITLE
Add multiline support for ReAct output parser

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/output_parser.py
+++ b/llama-index-core/llama_index/core/agent/react/output_parser.py
@@ -15,7 +15,7 @@ from llama_index.core.types import BaseOutputParser
 
 def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
     pattern = (
-        r"\s*Thought: (.*?)\nAction: ([a-zA-Z0-9_]+).*?\nAction Input: .*?(\{.*\})"
+        r"\s*Thought: (.*?)\n+Action: ([a-zA-Z0-9_]+).*?\n+Action Input: .*?(\{.*\})"
     )
 
     match = re.search(pattern, input_text, re.DOTALL)

--- a/llama-index-core/tests/agent/react/test_react_output_parser.py
+++ b/llama-index-core/tests/agent/react/test_react_output_parser.py
@@ -30,6 +30,22 @@ Action Input: {"a": 1, "b": 1}
     assert action_input == '{"a": 1, "b": 1}'
 
 
+def test_extract_tool_use_multiline() -> None:
+    mock_input_text = """\
+Thought: I need to use a tool to help me answer the question.
+
+Action: add
+
+
+
+Action Input: {"a": 1, "b": 1}
+"""
+    thought, action, action_input = extract_tool_use(mock_input_text)
+    assert thought == "I need to use a tool to help me answer the question."
+    assert action == "add"
+    assert action_input == '{"a": 1, "b": 1}'
+
+
 def test_extract_tool_use_with_nested_dicts() -> None:
     mock_input_text = """\
 Thought: Gotta use a tool.

--- a/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
@@ -28,12 +28,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-huggingface"
 readme = "README.md"
-version = "0.1.5"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-huggingface-hub = "^0.20.3"
+huggingface-hub = "^0.23.0"
 torch = "^2.1.2"
 text-generation = "^0.7.0"
 

--- a/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
@@ -28,12 +28,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-huggingface"
 readme = "README.md"
-version = "0.2.0"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-huggingface-hub = "^0.23.0"
+huggingface-hub = "^0.20.3"
 torch = "^2.1.2"
 text-generation = "^0.7.0"
 


### PR DESCRIPTION
# Description

Current ReAct output parsing does not allow new lines between any one of "Thought", "Action", or "Action Input", thereby rendering it unnecessarily brittle.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
