### PR TITLE
Add `image_documents` at call time for `MultiModalLLMCompletionProgram`

### DIFF
--- a/llama-index-core/llama_index/core/program/multi_modal_llm_program.py
+++ b/llama-index-core/llama_index/core/program/multi_modal_llm_program.py
@@ -94,6 +94,7 @@ class MultiModalLLMCompletionProgram(BasePydanticProgram[BaseModel]):
     def __call__(
         self,
         llm_kwargs: Optional[Dict[str, Any]] = None,
+        image_documents: Optional[Sequence[ImageDocument]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> BaseModel:
@@ -102,7 +103,7 @@ class MultiModalLLMCompletionProgram(BasePydanticProgram[BaseModel]):
 
         response = self._multi_modal_llm.complete(
             formatted_prompt,
-            image_documents=self._image_documents,
+            image_documents=image_documents or self._image_documents,
             **llm_kwargs,
         )
 
@@ -115,6 +116,7 @@ class MultiModalLLMCompletionProgram(BasePydanticProgram[BaseModel]):
     async def acall(
         self,
         llm_kwargs: Optional[Dict[str, Any]] = None,
+        image_documents: Optional[Sequence[ImageDocument]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> BaseModel:
@@ -123,7 +125,7 @@ class MultiModalLLMCompletionProgram(BasePydanticProgram[BaseModel]):
 
         response = await self._multi_modal_llm.acomplete(
             formatted_prompt,
-            image_documents=self._image_documents,
+            image_documents=image_documents or self._image_documents,
             **llm_kwargs,
         )
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/pyproject.toml
@@ -32,7 +32,6 @@ version = "0.1.9"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-llama-index-embeddings-huggingface = "^0.2.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/pyproject.toml
@@ -32,6 +32,7 @@ version = "0.1.9"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
+llama-index-embeddings-huggingface = "^0.2.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

- For `MultiModalLLMCompletionProgram`, only images passed during construction time are used for program execution
- This PR adds the ability to supply a sequence of images at call/execution time
- Supplied images at call time will take precedence to any images defined at construction time

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] NA (modification to core)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new notebook (that tests end-to-end) (to be published in a separate PR)
- [x] I stared at the code and made sure it makes sense

