### PR TITLE
Fix #9522 - SQLAlchemy warning when using hybrid search on postgres or lantern vector-store integration #9522

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
@@ -472,6 +472,9 @@ class LanternVectorStore(BasePydanticVectorStore):
         from sqlalchemy.types import UserDefinedType
 
         class REGCONFIG(UserDefinedType):
+            # The TypeDecorator.cache_ok class-level flag indicates if this custom TypeDecorator is safe to be used as part of a cache key.
+            # If the TypeDecorator is not guaranteed to produce the same bind/result behavior and SQL generation every time,
+            # this flag should be set to False; otherwise if the class produces the same behavior each time, it may be set to True.
             cache_ok = True
 
             def get_col_spec(self, **kw: Any) -> str:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
@@ -472,6 +472,8 @@ class LanternVectorStore(BasePydanticVectorStore):
         from sqlalchemy.types import UserDefinedType
 
         class REGCONFIG(UserDefinedType):
+            cache_ok = True
+
             def get_col_spec(self, **kw: Any) -> str:
                 return "regconfig"
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-lantern"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -553,6 +553,9 @@ class PGVectorStore(BasePydanticVectorStore):
         from sqlalchemy.types import UserDefinedType
 
         class REGCONFIG(UserDefinedType):
+            # The TypeDecorator.cache_ok class-level flag indicates if this custom TypeDecorator is safe to be used as part of a cache key.
+            # If the TypeDecorator is not guaranteed to produce the same bind/result behavior and SQL generation every time,
+            # this flag should be set to False; otherwise if the class produces the same behavior each time, it may be set to True.
             cache_ok = True
 
             def get_col_spec(self, **kw: Any) -> str:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -553,6 +553,8 @@ class PGVectorStore(BasePydanticVectorStore):
         from sqlalchemy.types import UserDefinedType
 
         class REGCONFIG(UserDefinedType):
+            cache_ok = True
+
             def get_col_spec(self, **kw: Any) -> str:
                 return "regconfig"
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Modified the UserDefinedType REGCONFIG() in 'vector_stores/postgres/base.py' & 'vector_stores/lantern/base.py' to address the SAWarning from SQLAlchemy that appears when using hybrid search with the current version of the 'llama-index-vector-stores-postgres'  and 'llama-index-vector-stores-lantern'  integrations in the latest version of LlamaIndex

Change
- added key `cache_ok = True` within the UserDefinedType REGCONFIG()

Fixes #9522  
There was [a suggested fix from @dosubot](https://github.com/run-llama/llama_index/issues/9522#issuecomment-1855536469
), which I implemented then tested in my work project (which is using LanternVectorStore as our vector database)


Example of error I see when using hybrid search in LanternVectorStore without this fix: 
```/usr/local/lib/python3.12/site-packages/llama_index/vector_stores/lantern/base.py:523: SAWarning: UserDefinedType REGCONFIG() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this warning at: https://sqlalche.me/e/20/cprf)```

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No (N/A)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] Tested my update to the 'llama-index-vector-stores-lantern' integration in my project (which is using hybrid search to query a LanternVectorStore and llama_index==v0.10.35). 

How I tested this fix:
- imported my modified version of the 'llama-index-vector-stores-lantern'  package into a private git repo by adding the following line in my requirements.txt:
`-e git+https://github.com/nataliachodelski/llama_index.git@nataliachodelski/BUG-9522-fix-sqalchemy-warning-postgres-vector-stores#subdirectory=llama-index-integrations/vector_stores/llama-index-vector-stores-lantern&egg=llama-index-vector-stores-lantern`
- I tested inserting and querying the vector store and confirmed that the SAWarning from SQLAlchemy I'd previously seen in my logs each time I performed a hybrid search in LanternVectorStore is no longer showing up. 
- I also tested inserting and querying my vector store with LanternVectorStore's `cache_ok` argument set to both True and False, individually of course.
    - I didn't notice any difference in performance/speed when passing the `cache_ok=True` flag in my LanternVectorStore instance, but hybrid search worked as expected.
-  Note: I didn't directly test the 'llama-index-vector-stores-postgres' changes in a project setting, but from my explorations, the lantern and postgres integrations appear very similar so I am confident my change will fix the error for both packages. I was experiencing an identical error message to that described in issue #9522 (which was made by a user of the postgres integration).


## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
