### PR TITLE
Fix RuntimeError by switching to asyncio from threading

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from threading import Thread
 from typing import Any, List, Optional, Tuple
@@ -357,12 +358,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             sources=[context_source],
             source_nodes=context_nodes,
         )
-        thread = Thread(
-            target=lambda x: asyncio_run(chat_response.awrite_response_to_history(x)),
-            args=(self._memory,),
-        )
-        thread.start()
-
+        asyncio.create_task(chat_response.awrite_response_to_history(self._memory))
         return chat_response
 
     def reset(self) -> None:

--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -3,7 +3,6 @@ import logging
 from threading import Thread
 from typing import Any, List, Optional, Tuple
 
-from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.callbacks import CallbackManager, trace_method
 from llama_index.core.chat_engine.types import (
@@ -55,7 +54,8 @@ DEFAULT_CONDENSE_PROMPT_TEMPLATE = """
 
 
 class CondensePlusContextChatEngine(BaseChatEngine):
-    """Condensed Conversation & Context Chat Engine.
+    """
+    Condensed Conversation & Context Chat Engine.
 
     First condense a conversation and latest user message to a standalone question
     Then build a context for the standalone question from a retriever,

--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -366,11 +366,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
                 ),
                 sources=[tool_output],
             )
-            thread = Thread(
-                target=lambda x: asyncio.run(response.awrite_response_to_history(x)),
-                args=(self._memory,),
-            )
-            thread.start()
+            asyncio.create_task(response.awrite_response_to_history(self._memory))
         else:
             raise ValueError("Streaming is not enabled. Please use achat() instead.")
         return response

--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -54,7 +54,8 @@ DEFAULT_PROMPT = PromptTemplate(DEFAULT_TEMPLATE)
 
 
 class CondenseQuestionChatEngine(BaseChatEngine):
-    """Condense Question Chat Engine.
+    """
+    Condense Question Chat Engine.
 
     First generate a standalone question from conversation context and last message,
     then query the query engine for a response.

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -1,3 +1,4 @@
+import asyncio
 from threading import Thread
 from typing import Any, List, Optional, Tuple
 
@@ -291,11 +292,7 @@ class ContextChatEngine(BaseChatEngine):
             ],
             source_nodes=nodes,
         )
-        thread = Thread(
-            target=lambda x: asyncio_run(chat_response.awrite_response_to_history(x)),
-            args=(self._memory,),
-        )
-        thread.start()
+        asyncio.create_task(chat_response.awrite_response_to_history(self._memory))
 
         return chat_response
 

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -2,7 +2,6 @@ import asyncio
 from threading import Thread
 from typing import Any, List, Optional, Tuple
 
-from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.callbacks import CallbackManager, trace_method
@@ -32,7 +31,8 @@ DEFAULT_CONTEXT_TEMPLATE = (
 
 
 class ContextChatEngine(BaseChatEngine):
-    """Context Chat Engine.
+    """
+    Context Chat Engine.
 
     Uses a retriever to retrieve a context, set the context in the system prompt,
     and then uses an LLM to generate a response, for a fluid chat experience.

--- a/llama-index-core/llama_index/core/chat_engine/simple.py
+++ b/llama-index-core/llama_index/core/chat_engine/simple.py
@@ -1,3 +1,4 @@
+import asyncio
 from threading import Thread
 from typing import Any, List, Optional, Type
 
@@ -166,11 +167,7 @@ class SimpleChatEngine(BaseChatEngine):
         chat_response = StreamingAgentChatResponse(
             achat_stream=await self._llm.astream_chat(all_messages)
         )
-        thread = Thread(
-            target=lambda x: asyncio_run(chat_response.awrite_response_to_history(x)),
-            args=(self._memory,),
-        )
-        thread.start()
+        asyncio.create_task(chat_response.awrite_response_to_history(self._memory))
 
         return chat_response
 

--- a/llama-index-core/llama_index/core/chat_engine/simple.py
+++ b/llama-index-core/llama_index/core/chat_engine/simple.py
@@ -2,7 +2,6 @@ import asyncio
 from threading import Thread
 from typing import Any, List, Optional, Type
 
-from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.llms.types import ChatMessage
 from llama_index.core.callbacks import CallbackManager, trace_method
 from llama_index.core.chat_engine.types import (
@@ -21,7 +20,8 @@ from llama_index.core.settings import (
 
 
 class SimpleChatEngine(BaseChatEngine):
-    """Simple Chat Engine.
+    """
+    Simple Chat Engine.
 
     Have a conversation with the LLM.
     This does not make use of a knowledge base.


### PR DESCRIPTION
# Description

When interacting with the Mistral API, every alternate call fails with the error message "RuntimeError: Event loop is closed". This issue has been traced back to the use of threading to handle asynchronous operations. 

This PR replaces the threading model with asyncio tasks to handle API calls asynchronously.

I've conducted tests with the local LLM and the Mistral API, where the error no longer occurs, confirming that the migration to asyncio resolves the issue. However, the integration has not yet been tested with the OpenAI API.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
