### PR TITLE
Update kuzu version for new storage layer

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-kuzu"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.3"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-kuzu = "^0.1.0"
+kuzu = "^0.4.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

Updates the version of Kùzu used for the `KuzuGraphStore` integration. This version has our new storage layer and offers users the means to visualize their graphs externally. 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Version bump only.

## How Has This Been Tested?

Ran example notebook from the local directory by importing the latest version of Kùzu and the workflow ran (end-to-end).

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
