### PR TITLE
Add missing type in `breakpoint_percentile_threshold` field

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
@@ -56,7 +56,7 @@ class SemanticSplitterNodeParser(NodeParser):
         ),
     )
 
-    breakpoint_percentile_threshold = Field(
+    breakpoint_percentile_threshold: int = Field(
         default=95,
         description=(
             "The percentile of cosine dissimilarity that must be exceeded between a "


### PR DESCRIPTION
# Description

`SemanticSplitterNodeParser.breakpoint_percentile_threshold` didn't have a type. Both `mypy` and VSCode are not able to recognise this as a possible argument

Before:
![Screenshot 2024-05-15 at 19 05 34](https://github.com/run-llama/llama_index/assets/29585319/1d856d0e-4ebc-496f-bd59-6ae9a60dffbe)


After:
![Screenshot 2024-05-15 at 19 06 10](https://github.com/run-llama/llama_index/assets/29585319/d53851ab-1388-4640-b9d4-078dafe65ff2)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I ran the tests locally. I don't think I should add another test for this (please let me know :) )

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
