### PR TITLE
Allow querying AzureAISearch without non-null metadata field

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -51,7 +51,8 @@ class IndexManagement(int, enum.Enum):
 
 
 class AzureAISearchVectorStore(BasePydanticVectorStore):
-    """Azure AI Search vector store.
+    """
+    Azure AI Search vector store.
 
     Examples:
         `pip install llama-index-vector-stores-azureaisearch`
@@ -111,12 +112,12 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
     _language_analyzer: str = PrivateAttr()
     _field_mapping: Dict[str, str] = PrivateAttr()
     _index_management: IndexManagement = PrivateAttr()
-    _index_mapping: Callable[
-        [Dict[str, str], Dict[str, Any]], Dict[str, str]
-    ] = PrivateAttr()
-    _metadata_to_index_field_map: Dict[
-        str, Tuple[str, MetadataIndexFieldType]
-    ] = PrivateAttr()
+    _index_mapping: Callable[[Dict[str, str], Dict[str, Any]], Dict[str, str]] = (
+        PrivateAttr()
+    )
+    _metadata_to_index_field_map: Dict[str, Tuple[str, MetadataIndexFieldType]] = (
+        PrivateAttr()
+    )
     _vector_profile_name: str = PrivateAttr()
 
     def _normalise_metadata_to_index_fields(
@@ -495,7 +496,8 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         nodes: List[BaseNode],
         **add_kwargs: Any,
     ) -> List[str]:
-        """Add nodes to index associated with the configured search client.
+        """
+        Add nodes to index associated with the configured search client.
 
         Args:
             nodes: List[BaseNode]: nodes with embeddings
@@ -678,7 +680,8 @@ class AzureQueryResultSearchBase:
         score_result = []
         for result in results:
             node_id = result[self._field_mapping["id"]]
-            metadata = json.loads(result[self._field_mapping["metadata"]])
+            metadata_str = result[self._field_mapping["metadata"]]
+            metadata = json.loads(metadata_str) if metadata_str else {}
             score = result["@search.score"]
             chunk = result[self._field_mapping["chunk"]]
 
@@ -795,7 +798,8 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
         score_result = []
         for result in results:
             node_id = result[self._field_mapping["id"]]
-            metadata = json.loads(result[self._field_mapping["metadata"]])
+            metadata_str = result[self._field_mapping["metadata"]]
+            metadata = json.loads(metadata_str) if metadata_str else {}
             # use reranker_score instead of score
             score = result["@search.reranker_score"]
             chunk = result[self._field_mapping["chunk"]]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -112,12 +112,12 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
     _language_analyzer: str = PrivateAttr()
     _field_mapping: Dict[str, str] = PrivateAttr()
     _index_management: IndexManagement = PrivateAttr()
-    _index_mapping: Callable[[Dict[str, str], Dict[str, Any]], Dict[str, str]] = (
-        PrivateAttr()
-    )
-    _metadata_to_index_field_map: Dict[str, Tuple[str, MetadataIndexFieldType]] = (
-        PrivateAttr()
-    )
+    _index_mapping: Callable[
+        [Dict[str, str], Dict[str, Any]], Dict[str, str]
+    ] = PrivateAttr()
+    _metadata_to_index_field_map: Dict[
+        str, Tuple[str, MetadataIndexFieldType]
+    ] = PrivateAttr()
     _vector_profile_name: str = PrivateAttr()
 
     def _normalise_metadata_to_index_fields(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-azureaisearch"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ name = "llama-index"
 packages = [{from = "_llama-index", include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.10.38"
+version = "0.10.37"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ name = "llama-index"
 packages = [{from = "_llama-index", include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.10.37"
+version = "0.10.38"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

In our project we are indexing data with an Azure AI Search Indexer. As it's not a requirement use metadata in the project, we faced an issue when we tried to query the index with LlamaIndex. In the current codebase, it is a requirement to have a non-null metadata field. To fix this issue, we created an empty metadata field in Azure. However, this is not enough to resolve the issue as the field is still null.

We want to use LlamaIndex to query the index without committing to adding metadata to our documents.

In the PR, I am bypassing this by passing in an empty dict if metadata is null. I have tested this locally and it's working for us.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
