### PR TITLE
fix: sec_filings reader when making requests to sec.gov

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/sec_filings.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/sec_filings.py
@@ -332,6 +332,7 @@ class SECExtractor:
             {
                 "User-Agent": f"{company} {email}",
                 "Content-Type": "text/html",
+                "Host": "www.sec.gov",
             }
         )
         return session

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["Athe-kunal"]
 name = "llama-index-readers-sec-filings"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Added header to request for sec filings to fix status code 403 issue.  According to https://www.sec.gov/os/accessing-edgar-data, `host` header is required

Fixes # (issue)
https://github.com/run-llama/llama_index/issues/12651

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [x ] I ran `make format; make lint` to appease the lint gods
