### PR TITLE
feat(instrumentation): new spans for llms

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/base.py
+++ b/llama-index-core/llama_index/core/base/llms/base.py
@@ -256,6 +256,10 @@ class BaseLLM(ChainableMixin, BaseComponent):
         """
 
     def __init_subclass__(cls, **kwargs) -> None:
+        """
+        Decorate the abstract methods' implementations for each subclass.
+        `__init_subclass__` is analogous to `__init__` because classes are also objects.
+        """
         super().__init_subclass__(**kwargs)
         dispatcher = instrumentation.get_dispatcher(cls.__module__)
         for attr in (

--- a/llama-index-core/llama_index/core/base/llms/base.py
+++ b/llama-index-core/llama_index/core/base/llms/base.py
@@ -258,7 +258,7 @@ class BaseLLM(ChainableMixin, BaseComponent):
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         dispatcher = instrumentation.get_dispatcher(cls.__module__)
-        for name in (
+        for attr in (
             "chat",
             "complete",
             "stream_chat",
@@ -268,5 +268,5 @@ class BaseLLM(ChainableMixin, BaseComponent):
             "astream_chat",
             "astream_complete",
         ):
-            if (method := cls.__dict__.get(name)) and callable(method):
-                setattr(cls, name, dispatcher.span(method))
+            if callable(method := cls.__dict__.get(attr)):
+                setattr(cls, attr, dispatcher.span(method))

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -209,12 +209,15 @@ def llm_chat_callback() -> Callable:
         if not is_wrapped:
             f.__wrapped__ = True  # type: ignore
 
+        # Update the wrapper function to look like the wrapped function.
+        # See e.g. https://github.com/python/cpython/blob/0abf997e75bd3a8b76d920d33cc64d5e6c2d380f/Lib/functools.py#L57
         for attr in (
             "__module__",
             "__name__",
             "__qualname__",
             "__doc__",
             "__annotations__",
+            "__type_params__",
         ):
             if v := getattr(f, attr, None):
                 setattr(async_dummy_wrapper, attr, v)
@@ -407,12 +410,15 @@ def llm_completion_callback() -> Callable:
         if not is_wrapped:
             f.__wrapped__ = True  # type: ignore
 
+        # Update the wrapper function to look like the wrapped function.
+        # See e.g. https://github.com/python/cpython/blob/0abf997e75bd3a8b76d920d33cc64d5e6c2d380f/Lib/functools.py#L57
         for attr in (
             "__module__",
             "__name__",
             "__qualname__",
             "__doc__",
             "__annotations__",
+            "__type_params__",
         ):
             if v := getattr(f, attr, None):
                 setattr(async_dummy_wrapper, attr, v)

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -209,6 +209,19 @@ def llm_chat_callback() -> Callable:
         if not is_wrapped:
             f.__wrapped__ = True  # type: ignore
 
+        for attr in (
+            "__module__",
+            "__name__",
+            "__qualname__",
+            "__doc__",
+            "__annotations__",
+        ):
+            if v := getattr(f, attr, None):
+                setattr(async_dummy_wrapper, attr, v)
+                setattr(wrapped_async_llm_chat, attr, v)
+                setattr(dummy_wrapper, attr, v)
+                setattr(wrapped_llm_chat, attr, v)
+
         if asyncio.iscoroutinefunction(f):
             if is_wrapped:
                 return async_dummy_wrapper
@@ -393,6 +406,19 @@ def llm_completion_callback() -> Callable:
         is_wrapped = getattr(f, "__wrapped__", False)
         if not is_wrapped:
             f.__wrapped__ = True  # type: ignore
+
+        for attr in (
+            "__module__",
+            "__name__",
+            "__qualname__",
+            "__doc__",
+            "__annotations__",
+        ):
+            if v := getattr(f, attr, None):
+                setattr(async_dummy_wrapper, attr, v)
+                setattr(wrapped_async_llm_predict, attr, v)
+                setattr(dummy_wrapper, attr, v)
+                setattr(wrapped_llm_predict, attr, v)
 
         if asyncio.iscoroutinefunction(f):
             if is_wrapped:


### PR DESCRIPTION
## Before
<img width="750" alt="Screenshot 2024-05-17 at 7 17 43 AM" src="https://github.com/run-llama/llama_index/assets/80478925/7958533a-85fb-4797-9533-634751751b97">

## After
<img width="700" alt="Screenshot 2024-05-17 at 7 39 40 AM" src="https://github.com/run-llama/llama_index/assets/80478925/2217db11-8217-4c11-98d3-93d365690002">

## Code

```python
def multiply(a: int, b: int) -> int:
    """Multiple two integers and returns the result integer"""
    return a * b


def add(a: int, b: int) -> int:
    """Add two integers and returns the result integer"""
    return a + b


multiply_tool = FunctionTool.from_defaults(fn=multiply)
add_tool = FunctionTool.from_defaults(fn=add)
agent = OpenAIAgent.from_tools([multiply_tool, add_tool])
Settings.llm = OpenAI(model="gpt-3.5-turbo")

if __name__ == "__main__":
    response = agent.query("What is (121 * 3) + 42?")
    print(response)
```