### PR TITLE
Pass 'exclude_llm_metadata_keys' and 'exclude_embed_metadata_keys'  in Node Parsers

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -245,7 +245,7 @@ class BaseElementNodeParser(NodeParser):
     def get_nodes_from_elements(
         self,
         elements: List[Element],
-        metadata_inherited: Optional[Dict[str, Any]] = None,
+        node_inherited: Optional[TextNode] = None,
         ref_doc_text: Optional[str] = None,
     ) -> List[BaseNode]:
         """Get nodes and mappings."""
@@ -357,8 +357,14 @@ class BaseElementNodeParser(NodeParser):
 
         # remove empty nodes and keep node original metadata inherited from parent nodes
         for node in nodes:
-            if metadata_inherited:
-                node.metadata.update(metadata_inherited)
+            if node_inherited and node_inherited.metadata:
+                node.metadata.update(node_inherited.metadata)
+                node.excluded_embed_metadata_keys = (
+                    node_inherited.excluded_embed_metadata_keys
+                )
+                node.excluded_llm_metadata_keys = (
+                    node_inherited.excluded_llm_metadata_keys
+                )
         return [node for node in nodes if len(node.text) > 0]
 
     def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:

--- a/llama-index-core/llama_index/core/node_parser/relational/llama_parse_json_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/llama_parse_json_element.py
@@ -33,7 +33,7 @@ class LlamaParseJsonNodeParser(BaseElementNodeParser):
         self.extract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
-        return self.get_nodes_from_elements(elements, node.metadata)
+        return self.get_nodes_from_elements(elements, node)
 
     def extract_elements(
         self,

--- a/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
@@ -33,7 +33,7 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
         # convert into nodes
         # will return a list of Nodes and Index Nodes
         nodes = self.get_nodes_from_elements(
-            elements, node.metadata, ref_doc_text=node.get_content()
+            elements, node, ref_doc_text=node.get_content()
         )
         source_document = node.source_node or node.as_related_node_info()
         for n in nodes:

--- a/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
@@ -67,7 +67,7 @@ class UnstructuredElementNodeParser(BaseElementNodeParser):
         self.extract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
-        nodes = self.get_nodes_from_elements(elements, node.metadata)
+        nodes = self.get_nodes_from_elements(elements, node)
 
         source_document = node.source_node or node.as_related_node_info()
         for n in nodes:


### PR DESCRIPTION

# Description

Pass 'exclude_llm_metadata_keys' and 'exclude_embed_metadata_keys' from Nodes to MarkdownElementNodeProcessor and UnstructuredElementNodeParser

Fixes #13468 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

The code is manually tested on the case mentioned in the issue and other cases.

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
