### PR TITLE
fix: SimpleMongoReader should allow optional fields in metadata

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -99,7 +99,7 @@ class SimpleMongoReader(BaseReader):
                 yield Document(text=text)
             else:
                 try:
-                    metadata = {name: item[name] for name in metadata_names}
+                    metadata = {name: item.get(name) for name in metadata_names}
                 except KeyError as err:
                     raise ValueError(
                         f"{err.args[0]} field not found in Mongo document."

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-mongodb"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Not all metadata fields should be mandatorily present in all Mongo DB documents. If some fields are missing, take None as their value instead of crashing.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
