### PR TITLE
fix: (ArxivReader) set exclude_hidden to False when reading data from hidden directory

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-papers/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-papers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.1.6] - 2024-05-19
 
-- Fix issue with hidden temporary foler (#13577)
+- Fix issue with hidden temporary folder (#13577)
 
 ## [0.1.5] - 2024-05-07
 

--- a/llama-index-integrations/readers/llama-index-readers-papers/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-papers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.1.6] - 2024-05-19
+
+- Fix issue with hidden temporary foler (#13577)
+
 ## [0.1.5] - 2024-05-07
 
 ### Bug Fixes

--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -147,7 +147,9 @@ class ArxivReader(BaseReader):
             return paper_lookup[os.path.basename(filename)]
 
         arxiv_documents = SimpleDirectoryReader(
-            papers_dir, file_metadata=get_paper_metadata
+            papers_dir,
+            file_metadata=get_paper_metadata,
+            exclude_hidden=False,  # default directory is hidden ".papers"
         ).load_data()
         # Include extra documents containing the abstracts
         abstract_documents = []

--- a/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["thejessezhang"]
 name = "llama-index-readers-papers"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

ArxivReader.load_papers_and_abstracts is using SimpleDirectoryReader to read documents with default directory ".paper", and the param "exclude_hidden" is not set to False. This causes error: "ValueError: No files found in .papers."

Fixes #13577 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
