### PR TITLE
Added support for Bedrock Titan Embeddings v2 

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -39,7 +39,7 @@ PROVIDER_SPECIFIC_IDENTIFIERS = {
 
 
 class BedrockEmbedding(BaseEmbedding):
-    model: str = Field(description="The modelId of the Bedrock model to use.")
+    model_name: str = Field(description="The modelId of the Bedrock model to use.")
     profile_name: Optional[str] = Field(
         description="The name of aws profile to use. If not given, then the default profile is used.",
         exclude=True,
@@ -345,12 +345,12 @@ class BedrockEmbedding(BaseEmbedding):
         if self._client is None:
             raise ValueError("Client not set")
 
-        provider = self.model.split(".")[0]
+        provider = self.model_name.split(".")[0]
         request_body = self._get_request_body(provider, payload, type)
 
         response = self._client.invoke_model(
             body=request_body,
-            modelId=self.model,
+            modelId=self.model_name,
             accept="application/json",
             contentType="application/json",
         )
@@ -368,7 +368,7 @@ class BedrockEmbedding(BaseEmbedding):
         return self._get_embedding(text, "text")
 
     def _get_text_embeddings(self, texts: List[str]) -> List[Embedding]:
-        provider = self.model.split(".")[0]
+        provider = self.model_name.split(".")[0]
         if provider == PROVIDERS.COHERE:
             return self._get_embedding(texts, "text")
         return super()._get_text_embeddings(texts)
@@ -398,7 +398,7 @@ class BedrockEmbedding(BaseEmbedding):
             if isinstance(payload, list):
                 raise ValueError("Amazon provider does not support list of texts")
             # Titan Embedding V2.0 has additional body parameters
-            if self.model == Models.TITAN_EMBEDDING_V2_0:
+            if self.model_name == Models.TITAN_EMBEDDING_V2_0:
                 request_body = json.dumps(
                     {"inputText": payload, **self.titan_body_kwargs}
                 )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -89,7 +89,6 @@ class BedrockEmbedding(BaseEmbedding):
         botocore_session: Optional[Any] = None,
         botocore_config: Optional[Any] = None,
         additional_kwargs: Optional[Dict[str, Any]] = None,
-        titan_body_kwargs: Optional[Dict[str, Any]] = None,
         max_retries: int = 10,
         timeout: float = 60.0,
         callback_manager: Optional[CallbackManager] = None,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -76,7 +76,8 @@ class BedrockEmbedding(BaseEmbedding):
         default_factory=dict, description="Additional kwargs for the bedrock client."
     )
     titan_body_kwargs: Dict[str, Any] = Field(
-        description="Additional kwargs for the Titan embed model request body.", exclude=True
+        description="Additional kwargs for the Titan embed model request body.",
+        exclude=True,
     )
     _client: Any = PrivateAttr()
 
@@ -398,7 +399,9 @@ class BedrockEmbedding(BaseEmbedding):
                 raise ValueError("Amazon provider does not support list of texts")
             # Titan Embedding V2.0 has additional body parameters
             if self.model == Models.TITAN_EMBEDDING_V2_0:
-                request_body = json.dumps({"inputText": payload, **self.titan_body_kwargs})
+                request_body = json.dumps(
+                    {"inputText": payload, **self.titan_body_kwargs}
+                )
             else:
                 request_body = json.dumps({"inputText": payload})
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -173,7 +173,9 @@ class BedrockEmbedding(BaseEmbedding):
     def list_supported_models() -> Dict[str, List[str]]:
         list_models = {}
         for provider in PROVIDERS:
-            list_models[provider.value] = [m.value for m in Models]
+            list_models[provider.value] = [
+                m.value for m in Models if provider.value in m.value
+            ]
         return list_models
 
     @classmethod

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-bedrock"
 readme = "README.md"
-version = "0.1.6"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-bedrock"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -152,4 +152,18 @@ class TestBedrockEmbedding(TestCase):
             self.assertEqual(embedding[i], mock_response["embeddings"][i])
 
     def test_list_supported_models(self):
-        pass
+        exp_dict = {
+            "amazon": [
+                "amazon.titan-embed-text-v1",
+                "amazon.titan-embed-text-v2:0",
+                "amazon.titan-embed-g1-text-02",
+            ],
+            "cohere": ["cohere.embed-english-v3", "cohere.embed-multilingual-v3"],
+        }
+
+        bedrock_embedding = BedrockEmbedding(
+            model_name=Models.COHERE_EMBED_ENGLISH_V3,
+            client=self.bedrock_client,
+        )
+
+        assert bedrock_embedding.list_supported_models() == exp_dict

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -1,6 +1,7 @@
 import json
 from io import BytesIO
 from unittest import TestCase
+from typing import Dict, Any
 
 import boto3
 from botocore.response import StreamingBody
@@ -12,7 +13,9 @@ class TestBedrockEmbedding(TestCase):
     bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
     bedrock_stubber = Stubber(bedrock_client)
 
-    def _test_get_text_embedding(self, model, titan_body_kwargs=None):
+    def _test_get_text_embedding(
+        self, model: str, titan_body_kwargs: Dict[str, Any] = None
+    ):
         mock_response = {
             "embedding": [
                 0.017410278,
@@ -34,10 +37,11 @@ class TestBedrockEmbedding(TestCase):
         )
 
         bedrock_embedding = BedrockEmbedding(
-            model=model,
+            model_name=model,
             client=self.bedrock_client,
             titan_body_kwargs=titan_body_kwargs,
         )
+        assert bedrock_embedding.model_name == model
 
         self.bedrock_stubber.activate()
         embedding = bedrock_embedding.get_text_embedding(text="foo bar baz")
@@ -51,7 +55,7 @@ class TestBedrockEmbedding(TestCase):
 
     def test_get_text_embedding_titan_v2(self) -> None:
         self._test_get_text_embedding(
-            Models.TITAN_EMBEDDING,
+            Models.TITAN_EMBEDDING_V2_0,
             titan_body_kwargs={"dimensions": 512, "normalize": True},
         )
 
@@ -73,7 +77,7 @@ class TestBedrockEmbedding(TestCase):
         )
 
         bedrock_embedding = BedrockEmbedding(
-            model=Models.COHERE_EMBED_ENGLISH_V3,
+            model_name=Models.COHERE_EMBED_ENGLISH_V3,
             client=self.bedrock_client,
         )
 
@@ -104,7 +108,7 @@ class TestBedrockEmbedding(TestCase):
         )
 
         bedrock_embedding = BedrockEmbedding(
-            model=Models.COHERE_EMBED_ENGLISH_V3,
+            model_name=Models.COHERE_EMBED_ENGLISH_V3,
             client=self.bedrock_client,
         )
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -1,6 +1,6 @@
 import json
 from io import BytesIO
-from unittest import TestCase, mock
+from unittest import TestCase
 
 import boto3
 from botocore.response import StreamingBody
@@ -50,10 +50,10 @@ class TestBedrockEmbedding(TestCase):
         self._test_get_text_embedding(Models.TITAN_EMBEDDING)
 
     def test_get_text_embedding_titan_v2(self) -> None:
-        self._test_get_text_embedding(Models.TITAN_EMBEDDING, titan_body_kwargs={
-            "dimensions": 512,
-            "normalize": True
-        })
+        self._test_get_text_embedding(
+            Models.TITAN_EMBEDDING,
+            titan_body_kwargs={"dimensions": 512, "normalize": True},
+        )
 
     def test_get_text_embedding_cohere(self) -> None:
         mock_response = {


### PR DESCRIPTION
# Description

* Added support for Bedrock Titan Embeddings v2.  This version introduces new parameters to the request body, `dimensions` and `normalize`, so added new field, `titan_body_kwargs`, to support.
* Renamed `model` field to `model_name` to adhere to that used in parent class, `BaseEmbedding`.  Bumped to `0.2.0` consequently.
* Fixed bugs with provider mappings.
* Improved unit test quality.


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
