### PR TITLE
Integration: Bump duckduckgo-search package 

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-duckduckgo/llama_index/tools/duckduckgo/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-duckduckgo/llama_index/tools/duckduckgo/base.py
@@ -28,7 +28,10 @@ class DuckDuckGoSearchToolSpec(BaseToolSpec):
             return list(ddg.answers(query))
 
     def duckduckgo_full_search(
-        self, query: str, region: Optional[str] = None, max_results: Optional[int] = 10
+        self,
+        query: str,
+        region: Optional[str] = "wt-wt",
+        max_results: Optional[int] = 10,
     ) -> List[Dict]:
         """
         Make a query to DuckDuckGo search to receive a full search results.
@@ -40,5 +43,11 @@ class DuckDuckGoSearchToolSpec(BaseToolSpec):
         """
         from duckduckgo_search import DDGS
 
+        params = {
+            "keywords": query,
+            "region": region,
+            "max_results": max_results,
+        }
+
         with DDGS() as ddg:
-            return list(ddg.text(query, region=region, max_results=max_results))
+            return list(ddg.text(**params))

--- a/llama-index-integrations/tools/llama-index-tools-duckduckgo/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-duckduckgo/pyproject.toml
@@ -32,7 +32,7 @@ readme = "README.md"
 version = "0.1.1"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<3.12"
+python = ">=3.8.1,<4.0"
 llama-index = "^0.10.1"
 duckduckgo-search = "^6.1.0"
 

--- a/llama-index-integrations/tools/llama-index-tools-duckduckgo/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-duckduckgo/pyproject.toml
@@ -29,12 +29,12 @@ license = "MIT"
 maintainers = ["leehuwuj"]
 name = "llama-index-tools-duckduckgo"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"
 llama-index = "^0.10.1"
-duckduckgo-search = "4.5.0"
+duckduckgo-search = "^6.1.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

- Update llama-index-tools-duckduckgo tool with newer duckduckgo-search version (v6.1.0). The older version has a rate limit exception.
- Bump `llama-index-tools-duckduckgo` to v0.1.1

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
