### PR TITLE
Fix: Limit the number of generated questions

### DIFF
--- a/llama-index-core/llama_index/core/llama_dataset/generator.py
+++ b/llama-index-core/llama_index/core/llama_dataset/generator.py
@@ -78,6 +78,7 @@ class RagDatasetGenerator(PromptMixin):
     ) -> None:
         """Init params."""
         self._llm = llm or llm_from_settings_or_context(Settings, service_context)
+        self.num_questions_per_chunk = num_questions_per_chunk
         self.text_question_template = text_question_template or PromptTemplate(
             DEFAULT_QUESTION_GENERATION_PROMPT
         )
@@ -184,7 +185,7 @@ class RagDatasetGenerator(PromptMixin):
             ]
             cleaned_questions = [
                 question for question in cleaned_questions if len(question) > 0
-            ]
+            ][: self.num_questions_per_chunk]
             index = summary_indices[idx]
             reference_context = nodes[idx].text
             model_name = self._llm.metadata.model_name

--- a/llama-index-core/llama_index/core/llama_dataset/generator.py
+++ b/llama-index-core/llama_index/core/llama_dataset/generator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from typing import List, Optional
 
 from llama_index.core import Document, ServiceContext, SummaryIndex
@@ -186,6 +187,14 @@ class RagDatasetGenerator(PromptMixin):
             cleaned_questions = [
                 question for question in cleaned_questions if len(question) > 0
             ][: self.num_questions_per_chunk]
+
+            num_questions_generated = len(cleaned_questions)
+            if num_questions_generated < self.num_questions_per_chunk:
+                warnings.warn(
+                    f"Fewer questions generated ({num_questions_generated}) "
+                    f"than requested ({self.num_questions_per_chunk})."
+                )
+
             index = summary_indices[idx]
             reference_context = nodes[idx].text
             model_name = self._llm.metadata.model_name

--- a/llama-index-core/llama_index/core/llama_dataset/legacy/embedding.py
+++ b/llama-index-core/llama_index/core/llama_dataset/legacy/embedding.py
@@ -89,7 +89,9 @@ def generate_qa_embedding_pairs(
         questions = [
             re.sub(r"^\d+[\).\s]", "", question).strip() for question in result
         ]
-        questions = [question for question in questions if len(question) > 0]
+        questions = [question for question in questions if len(question) > 0][
+            :num_questions_per_chunk
+        ]
 
         for question in questions:
             question_id = str(uuid.uuid4())

--- a/llama-index-core/llama_index/core/llama_dataset/legacy/embedding.py
+++ b/llama-index-core/llama_index/core/llama_dataset/legacy/embedding.py
@@ -2,6 +2,7 @@
 import json
 import re
 import uuid
+import warnings
 from typing import Dict, List, Tuple
 
 from llama_index.core.bridge.pydantic import BaseModel
@@ -92,6 +93,13 @@ def generate_qa_embedding_pairs(
         questions = [question for question in questions if len(question) > 0][
             :num_questions_per_chunk
         ]
+
+        num_questions_generated = len(questions)
+        if num_questions_generated < num_questions_per_chunk:
+            warnings.warn(
+                f"Fewer questions generated ({num_questions_generated}) "
+                f"than requested ({num_questions_per_chunk})."
+            )
 
         for question in questions:
             question_id = str(uuid.uuid4())

--- a/llama-index-finetuning/llama_index/finetuning/cross_encoders/dataset_gen.py
+++ b/llama-index-finetuning/llama_index/finetuning/cross_encoders/dataset_gen.py
@@ -1,5 +1,6 @@
 """Dataset Generator for Cross Encoder Finetuning."""
 import re
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -73,6 +74,14 @@ def generate_synthetic_queries_over_documents(
         )
         response_questions = re.split(";|\n", response_content)
         response_questions = response_questions[:num_questions_per_chunk]
+
+        num_questions_generated = len(response_questions)
+        if num_questions_generated < num_questions_per_chunk:
+            warnings.warn(
+                f"Fewer questions generated ({num_questions_generated}) "
+                f"than requested ({num_questions_per_chunk})."
+            )
+
         questions.extend(response_questions)
 
     return questions

--- a/llama-index-finetuning/llama_index/finetuning/cross_encoders/dataset_gen.py
+++ b/llama-index-finetuning/llama_index/finetuning/cross_encoders/dataset_gen.py
@@ -72,6 +72,7 @@ def generate_synthetic_queries_over_documents(
             response.message.content if response.message.content is not None else ""
         )
         response_questions = re.split(";|\n", response_content)
+        response_questions = response_questions[:num_questions_per_chunk]
         questions.extend(response_questions)
 
     return questions

--- a/llama-index-finetuning/llama_index/finetuning/embeddings/common.py
+++ b/llama-index-finetuning/llama_index/finetuning/embeddings/common.py
@@ -89,7 +89,9 @@ def generate_qa_embedding_pairs(
         questions = [
             re.sub(r"^\d+[\).\s]", "", question).strip() for question in result
         ]
-        questions = [question for question in questions if len(question) > 0]
+        questions = [question for question in questions if len(question) > 0][
+            :num_questions_per_chunk
+        ]
 
         for question in questions:
             question_id = str(uuid.uuid4())

--- a/llama-index-finetuning/llama_index/finetuning/embeddings/common.py
+++ b/llama-index-finetuning/llama_index/finetuning/embeddings/common.py
@@ -2,6 +2,7 @@
 import json
 import re
 import uuid
+import warnings
 from typing import Dict, List, Tuple
 
 from llama_index.core.bridge.pydantic import BaseModel
@@ -92,6 +93,13 @@ def generate_qa_embedding_pairs(
         questions = [question for question in questions if len(question) > 0][
             :num_questions_per_chunk
         ]
+
+        num_questions_generated = len(questions)
+        if num_questions_generated < num_questions_per_chunk:
+            warnings.warn(
+                f"Fewer questions generated ({num_questions_generated}) "
+                f"than requested ({num_questions_per_chunk})."
+            )
 
         for question in questions:
             question_id = str(uuid.uuid4())

--- a/llama-index-finetuning/pyproject.toml
+++ b/llama-index-finetuning/pyproject.toml
@@ -25,7 +25,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-finetuning"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-raft-dataset/llama_index/packs/raft_dataset/base.py
+++ b/llama-index-packs/llama-index-packs-raft-dataset/llama_index/packs/raft_dataset/base.py
@@ -5,6 +5,8 @@
 from typing import Any, List
 import random
 import logging
+import warnings
+
 from datasets import Dataset
 
 # Configure logging to output to the console, with messages of level DEBUG and above
@@ -108,8 +110,17 @@ class RAFTDatasetPack(BaseLlamaPack):
         ]
 
         queries = str(self.llm.chat(messages)).split("\n")
-        queries = [self.strip_str(q) for q in queries]
-        return [q for q in queries if any(c.isalpha() for c in q)][:x]
+        questions = [self.strip_str(q) for q in queries]
+        questions = [q for q in questions if any(c.isalpha() for c in q)][:x]
+
+        num_questions_generated = len(questions)
+        if num_questions_generated < x:
+            warnings.warn(
+                f"Fewer questions generated ({num_questions_generated}) "
+                f"than requested ({x})."
+            )
+
+        return questions
 
     def get_chunks(self, file_path: str, chunk_size: int) -> List[str]:
         """

--- a/llama-index-packs/llama-index-packs-raft-dataset/llama_index/packs/raft_dataset/base.py
+++ b/llama-index-packs/llama-index-packs-raft-dataset/llama_index/packs/raft_dataset/base.py
@@ -109,7 +109,7 @@ class RAFTDatasetPack(BaseLlamaPack):
 
         queries = str(self.llm.chat(messages)).split("\n")
         queries = [self.strip_str(q) for q in queries]
-        return [q for q in queries if any(c.isalpha() for c in q)]
+        return [q for q in queries if any(c.isalpha() for c in q)][:x]
 
     def get_chunks(self, file_path: str, chunk_size: int) -> List[str]:
         """

--- a/llama-index-packs/llama-index-packs-raft-dataset/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-raft-dataset/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["ravi-theja"]
 name = "llama-index-packs-raft-dataset"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Limit the number of generated questions to avoid cases where more questions are generated than requested by the parameter `num_questions_per_chunk`.

Fixes #10694 and #10089

Added the fix to all the modules mentioning `num_questions_per_chunk` except the following modules that contain deprecated classes that possibly do not have this issue due to their `num` parameter in `_agenerate_dataset` method:
* `llama-index-core/llama_index/core/evaluation/dataset_generation.py`
  * The module implements `QueryResponseDataset` that is deprecated in favor of `LabelledRagDataset`
* `llama-index-legacy/llama_index/legacy/evaluation/dataset_generation.py`
  * The module implements `DatasetGenerator` that is deprecated in favor of `RagDatasetGenerator`

## New Package?

- [ ] Yes
- [X] No

## Version Bump?

- [X] Yes
- [ ] No

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```python
from llama_index.core.llama_dataset.generator import RagDatasetGenerator
from llama_index.llms.ollama import Ollama
from llama_index.core.schema import TextNode

node = TextNode(
    text="New York, often called New York City or simply NYC, "
    "is the most populous city in the United States, located at the "
    "southern tip of New York State on one of the world's largest "
    "natural harbors. The city comprises five boroughs, each of which "
    "is coextensive with a respective county. New York is a global center "
    "of finance and commerce, culture and technology, entertainment and "
    "media, academics and scientific output, and the arts and fashion, and, "
    "as home to the headquarters of the United Nations, is an important "
    "center for international diplomacy. New York City is the center of "
    "the world's principal metropolitan economy."
)

llm = Ollama(model="gemma:2b", request_timeout=60.0)
num_questions_per_chunk = 1
for i in range(10):
    gen = RagDatasetGenerator(
        nodes=[node],
        llm=llm,
        num_questions_per_chunk=num_questions_per_chunk,
    )
    generated_questions = gen.generate_questions_from_nodes()
    print(
        f"Number of questions expected: {num_questions_per_chunk} - "
        f"Number of questions generated: {len(generated_questions.examples)}"
    )
```

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I ran `make format; make lint` to appease the lint gods
