### PR TITLE
Implement local Nomic Embed with the inference_mode parameter

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-nomic/llama_index/embeddings/nomic/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nomic/llama_index/embeddings/nomic/base.py
@@ -1,48 +1,41 @@
 from enum import Enum
 from typing import Any, List, Optional, Union
 
+import nomic
+import nomic.embed
+import torch
 from llama_index.core.base.embeddings.base import (
     BaseEmbedding,
     DEFAULT_EMBED_BATCH_SIZE,
 )
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
-
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
-
-from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.embeddings.huggingface.pooling import Pooling
-import torch
-import logging
 
 DEFAULT_HUGGINGFACE_LENGTH = 512
-logger = logging.getLogger(__name__)
 
 
-class NomicAITaskType(str, Enum):
+class NomicTaskType(str, Enum):
     SEARCH_QUERY = "search_query"
     SEARCH_DOCUMENT = "search_document"
     CLUSTERING = "clustering"
     CLASSIFICATION = "classification"
 
 
-TASK_TYPES = [
-    NomicAITaskType.SEARCH_QUERY,
-    NomicAITaskType.SEARCH_DOCUMENT,
-    NomicAITaskType.CLUSTERING,
-    NomicAITaskType.CLASSIFICATION,
-]
-
-
 class NomicEmbedding(BaseEmbedding):
     """NomicEmbedding uses the Nomic API to generate embeddings."""
 
-    # Instance variables initialized via Pydantic's mechanism
-    query_task_type: Optional[str] = Field(description="Query Embedding prefix")
-    document_task_type: Optional[str] = Field(description="Document Embedding prefix")
-    dimensionality: Optional[int] = Field(description="Dimension of the Embedding")
+    query_task_type: Optional[NomicTaskType] = Field(
+        description="Task type for queries",
+    )
+    document_task_type: Optional[NomicTaskType] = Field(
+        description="Task type for documents",
+    )
+    dimensionality: Optional[int] = Field(
+        description="Embedding dimension, for use with Matryoshka-capable models",
+    )
     model_name: str = Field(description="Embedding model name")
-    _model: Any = PrivateAttr()
 
     def __init__(
         self,
@@ -53,39 +46,18 @@ class NomicEmbedding(BaseEmbedding):
         query_task_type: Optional[str] = "search_query",
         document_task_type: Optional[str] = "search_document",
         dimensionality: Optional[int] = 768,
-        **kwargs: Any,
-    ) -> None:
-        if query_task_type not in TASK_TYPES or document_task_type not in TASK_TYPES:
-            raise ValueError(
-                f"Invalid task type {query_task_type}, {document_task_type}. Must be one of {TASK_TYPES}"
-            )
-
-        try:
-            import nomic
-            from nomic import embed
-        except ImportError:
-            raise ImportError(
-                "NomicEmbedding requires the 'nomic' package to be installed.\n"
-                "Please install it with `pip install nomic`."
-            )
-
+    ):
         if api_key is not None:
-            nomic.cli.login(api_key)
+            nomic.login(api_key)
+
         super().__init__(
             model_name=model_name,
             embed_batch_size=embed_batch_size,
             callback_manager=callback_manager,
-            _model=embed,
             query_task_type=query_task_type,
             document_task_type=document_task_type,
             dimensionality=dimensionality,
-            **kwargs,
         )
-        self._model = embed
-        self.model_name = model_name
-        self.query_task_type = query_task_type
-        self.document_task_type = document_task_type
-        self.dimensionality = dimensionality
 
     @classmethod
     def class_name(cls) -> str:
@@ -94,8 +66,7 @@ class NomicEmbedding(BaseEmbedding):
     def _embed(
         self, texts: List[str], task_type: Optional[str] = None
     ) -> List[List[float]]:
-        """Embed sentences using NomicAI."""
-        result = self._model.text(
+        result = nomic.embed.text(
             texts,
             model=self.model_name,
             task_type=task_type,
@@ -104,24 +75,26 @@ class NomicEmbedding(BaseEmbedding):
         return result["embeddings"]
 
     def _get_query_embedding(self, query: str) -> List[float]:
-        """Get query embedding."""
         return self._embed([query], task_type=self.query_task_type)[0]
 
     async def _aget_query_embedding(self, query: str) -> List[float]:
-        """Get query embedding async."""
+        self._warn_async()
         return self._get_query_embedding(query)
 
     def _get_text_embedding(self, text: str) -> List[float]:
-        """Get text embedding."""
         return self._embed([text], task_type=self.document_task_type)[0]
 
     async def _aget_text_embedding(self, text: str) -> List[float]:
-        """Get text embedding async."""
+        self._warn_async()
         return self._get_text_embedding(text)
 
     def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
-        """Get text embeddings."""
         return self._embed(texts, task_type=self.document_task_type)
+
+    def _warn_async() -> None:
+        warnings.warn(
+            f"{self.class_name()} does not implement async embeddings, falling back to sync method.",
+        )
 
 
 class NomicHFEmbedding(HuggingFaceEmbedding):

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nomic/llama_index/embeddings/nomic/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nomic/llama_index/embeddings/nomic/base.py
@@ -23,6 +23,12 @@ class NomicTaskType(str, Enum):
     CLASSIFICATION = "classification"
 
 
+class NomicInferenceMode(str, Enum):
+    REMOTE = "remote"
+    LOCAL = "local"
+    DYNAMIC = "dynamic"
+
+
 class NomicEmbedding(BaseEmbedding):
     """NomicEmbedding uses the Nomic API to generate embeddings."""
 
@@ -36,6 +42,10 @@ class NomicEmbedding(BaseEmbedding):
         description="Embedding dimension, for use with Matryoshka-capable models",
     )
     model_name: str = Field(description="Embedding model name")
+    inference_mode: NomicInferenceMode = Field(
+        description="Whether to generate embeddings locally",
+    )
+    device: Optional[str] = Field(description="Device to use for local embeddings")
 
     def __init__(
         self,
@@ -46,6 +56,8 @@ class NomicEmbedding(BaseEmbedding):
         query_task_type: Optional[str] = "search_query",
         document_task_type: Optional[str] = "search_document",
         dimensionality: Optional[int] = 768,
+        inference_mode: str = "remote",
+        device: Optional[str] = None,
     ):
         if api_key is not None:
             nomic.login(api_key)
@@ -57,6 +69,8 @@ class NomicEmbedding(BaseEmbedding):
             query_task_type=query_task_type,
             document_task_type=document_task_type,
             dimensionality=dimensionality,
+            inference_mode=inference_mode,
+            device=device,
         )
 
     @classmethod
@@ -71,6 +85,8 @@ class NomicEmbedding(BaseEmbedding):
             model=self.model_name,
             task_type=task_type,
             dimensionality=self.dimensionality,
+            inference_mode=self.inference_mode,
+            device=self.device,
         )
         return result["embeddings"]
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
@@ -21,7 +21,7 @@ ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = ["Jared Van Bortel <jared@nomic.ai>", "Zach Nussbaum <zach@nomic.ai>"]
 description = "llama-index embeddings nomic integration"
 exclude = ["**/BUILD"]
 license = "MIT"
@@ -33,7 +33,6 @@ version = "0.1.6"
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.11.post1"
 llama-index-embeddings-huggingface = "^0.1.3"
-einops = "^0.7.0"
 nomic = "^3.0.12"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-nomic"
 readme = "README.md"
-version = "0.1.6"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.6"
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.11.post1"
 llama-index-embeddings-huggingface = "^0.1.3"
-nomic = "^3.0.12"
+nomic = "^3.0.29"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

This PR implements local and dynamic mode in the Nomic Embed integration using the inference_mode and device parameters. They work as documented [here](https://docs.nomic.ai/reference/python-api/embeddings#local-inference).

It also cleans up the existing NomicEmbedding implementation (misuse of pydantic, unhelpful docstrings, unused imports).

I added a warning when the async methods are called as they are not actually async, which is based on what is done for LangchainEmbedding[^1]. Is there any situation in which the async methods are called unconditionally that would make this warning too annoying?

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

`make test` still passes. I instantiated NomicEmbedding with a few different inference_mode and device options, with and without GPT4All installed, and tried get_text_embedding on it. When GPT4All is installed and `inference_mode='local'` is passed, embeddings are generated on the expected local device - you can tell because the results are slightly different depending on the backend used to compute the embeddings.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods[^2]

[^1]: The one for LangchainEmbedding cannot be suppressed by the caller, is printed up to once per LangchainEmbedding instance instead of once per interpreter instance, and is obsolete since https://github.com/langchain-ai/langchain/pull/11141, but I don't think any of that is in scope for this PR
[^2]: I ran this and it sorted the list of authors to put me first, even though Zach wrote most of this code. This means I will be credited as the sole author in package metadata and on PyPI. Is enforcing toml-sort-fix really a good idea?