### PR TITLE
integrations: update apify reader to attribute API activity to llamaindex

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-apify/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-apify/README.md
@@ -25,27 +25,21 @@ and set your [Apify API token](https://console.apify.com/account/integrations) i
 
 ```python
 from llama_index.core import Document
-
-
-# Converts a single record from the Actor's resulting dataset to the LlamaIndex format
-def tranform_dataset_item(item):
-    return Document(
-        text=item.get("text"),
-        extra_info={
-            "url": item.get("url"),
-        },
-    )
-
-
 from llama_index.readers.apify import ApifyActor
 
 reader = ApifyActor("<My Apify API token>")
+
 documents = reader.load_data(
     actor_id="apify/website-content-crawler",
     run_input={
-        "startUrls": [{"url": "https://gpt-index.readthedocs.io/en/latest"}]
+        "startUrls": [{"url": "https://docs.llamaindex.ai/en/latest/"}]
     },
-    dataset_mapping_function=tranform_dataset_item,
+    dataset_mapping_function=lambda item: Document(
+        text=item.get("text"),
+        metadata={
+            "url": item.get("url"),
+        },
+    ),
 )
 ```
 
@@ -75,23 +69,16 @@ and set your [Apify API token](https://console.apify.com/account/integrations) i
 
 ```python
 from llama_index.core import Document
-
-
-# Converts a single record from the Apify dataset to the LlamaIndex format
-def tranform_dataset_item(item):
-    return Document(
-        text=item.get("text"),
-        extra_info={
-            "url": item.get("url"),
-        },
-    )
-
-
 from llama_index.readers.apify import ApifyDataset
 
 reader = ApifyDataset("<Your Apify API token>")
 documents = reader.load_data(
     dataset_id="<Apify Dataset ID>",
-    dataset_mapping_function=tranform_dataset_item,
+    dataset_mapping_function=lambda item: Document(
+        text=item.get("text"),
+        metadata={
+            "url": item.get("url"),
+        },
+    ),
 )
 ```

--- a/llama-index-integrations/readers/llama-index-readers-apify/llama_index/readers/apify/actor/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-apify/llama_index/readers/apify/actor/base.py
@@ -20,7 +20,13 @@ class ApifyActor(BaseReader):
         from apify_client import ApifyClient
 
         self.apify_api_token = apify_api_token
-        self.apify_client = ApifyClient(apify_api_token)
+
+        client = ApifyClient(apify_api_token)
+        if hasattr(client.http_client, "httpx_client"):
+            client.http_client.httpx_client.headers[
+                "user-agent"
+            ] += "; Origin/llama_index"
+        self.apify_client = client
 
     def load_data(
         self,

--- a/llama-index-integrations/readers/llama-index-readers-apify/llama_index/readers/apify/dataset/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-apify/llama_index/readers/apify/dataset/base.py
@@ -17,7 +17,13 @@ class ApifyDataset(BaseReader):
         """Initialize Apify dataset reader."""
         from apify_client import ApifyClient
 
-        self.apify_client = ApifyClient(apify_api_token)
+        client = ApifyClient(apify_api_token)
+        if hasattr(client.http_client, "httpx_client"):
+            client.http_client.httpx_client.headers[
+                "user-agent"
+            ] += "; Origin/llama_index"
+
+        self.apify_client = client
 
     def load_data(
         self, dataset_id: str, dataset_mapping_function: Callable[[Dict], Document]

--- a/llama-index-integrations/readers/llama-index-readers-apify/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-apify/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 maintainers = ["drobnikj"]
 name = "llama-index-readers-apify"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Add `Origin/llama_index` to Apify's client's user-agent to attribute API activity to LlamaIndex (at Apify, we aim to monitor our integrations to evaluate whether we should invest more in the LlamaIndex integration regarding functionality and content)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
