### PR TITLE
remove optional deps from core

### DIFF
--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -43,7 +43,7 @@ name = "llama-index-core"
 packages = [{include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.10.38.post1"
+version = "0.10.38.post2"
 
 [tool.poetry.dependencies]
 SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}
@@ -62,8 +62,6 @@ tiktoken = ">=0.3.3"
 typing-extensions = ">=4.5.0"
 typing-inspect = ">=0.8.0"
 requests = ">=2.31.0"  # Pin to avoid CVE-2023-32681 in requests 2.3 to 2.30
-jsonpath-ng = {optional = true, version = "*"}
-spacy = {optional = true, version = "*"}
 aiohttp = "^3.8.6"
 networkx = ">=3.0"
 dirtyjson = "^1.0.8"

--- a/llama-index-integrations/program/llama-index-program-guidance/llama_index/program/guidance/base.py
+++ b/llama-index-integrations/program/llama-index-program-guidance/llama_index/program/guidance/base.py
@@ -10,7 +10,7 @@ from llama_index.program.guidance.utils import (
 
 from guidance import assistant, gen, user
 from guidance.models import Model as GuidanceLLM
-from guidance.models import OpenAIChat
+from guidance.models import OpenAI
 
 
 class GuidancePydanticProgram(BaseLLMFunctionProgram["GuidanceLLM"]):
@@ -30,7 +30,7 @@ class GuidancePydanticProgram(BaseLLMFunctionProgram["GuidanceLLM"]):
         if not guidance_llm:
             llm = guidance_llm
         else:
-            llm = OpenAIChat("gpt-3.5-turbo")
+            llm = OpenAI("gpt-3.5-turbo")
 
         full_str = prompt_template_str + "\n"
         self._full_str = full_str

--- a/llama-index-integrations/readers/llama-index-readers-pebblo/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-pebblo/pyproject.toml
@@ -35,6 +35,7 @@ version = "0.1.1"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.0"
+langchain-community = ">=0.0.303"
 langchain = ">=0.0.303"
 requests = "^2"
 

--- a/llama-index-integrations/readers/llama-index-readers-pebblo/tests/test_readers_pebblo.py
+++ b/llama-index-integrations/readers/llama-index-readers-pebblo/tests/test_readers_pebblo.py
@@ -2,6 +2,7 @@ import pytest
 import os
 
 import langchain  # noqa
+import langchain_community  # noqa
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.pebblo import PebbloSafeReader
 from pathlib import Path


### PR DESCRIPTION
These deps (spacy, jsonpath-ng) are optional, but still get pulled in by `pip` since it doesn't respect the syntax

Lets just remove these altogether