### PR TITLE
Try-catch in case the ._client attribute is not present

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
@@ -83,7 +83,7 @@ class SupabaseVectorStore(BasePydanticVectorStore):
 
     def __del__(self) -> None:
         """Close the client when the object is deleted."""
-        try: # try-catch in case the attribute is not present
+        try:  # try-catch in case the attribute is not present
             self._client.disconnect()
         except AttributeError:
             pass

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/llama_index/vector_stores/supabase/base.py
@@ -83,8 +83,10 @@ class SupabaseVectorStore(BasePydanticVectorStore):
 
     def __del__(self) -> None:
         """Close the client when the object is deleted."""
-        if self._client is not None:
+        try: # try-catch in case the attribute is not present
             self._client.disconnect()
+        except AttributeError:
+            pass
 
     @property
     def client(self) -> None:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-supabase/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-supabase"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

In my unit tests (outside of this repo), I found that sometimes the ._client attribute is not present, leading to failed tests when it calls the __del__ function. This is a bugfix on #13611.


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I ran my unit tests that uses llama_index outside of the repo.

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
