### PR TITLE
fix llama-index-multi-modal-llms-gemini 0.1.7 release

### DIFF
--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
@@ -32,9 +32,8 @@ version = "0.1.7"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.10.11.post1"
-llama-index-llms-gemini = "^0.1.7"
+llama-index-llms-gemini = "^0.1.9"
 pillow = "^10.2.0"
-google-generativeai = "^0.5.2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description
Follow up of #13647

The release action failed here: https://github.com/run-llama/llama_index/actions/runs/9193219577  

Now both needs 0.5.x of google-generativeai.

This will trigger the 0.1.7 release of llama-index-multi-modal-llms-gemini, plus should fix the same problem in the future since it only depends on the llm integration directly now.
