### PR TITLE
Improve MarkdownReader to ignore headers in code blocks

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
@@ -44,10 +44,15 @@ class MarkdownReader(BaseReader):
 
         current_header = None
         current_lines = []
+        in_code_block = False
 
         for line in lines:
+            if line.startswith("```"):
+                # This is the end of a code block if we are already in it, and vice versa.
+                in_code_block = not in_code_block
+
             header_match = re.match(r"^#+\s", line)
-            if header_match:
+            if not in_code_block and header_match:
                 # Upon first header, skip if current text chunk is empty
                 if current_header is not None or len(current_lines) > 0:
                     markdown_tups.append((current_header, "\n".join(current_lines)))

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -50,7 +50,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.22"
+version = "0.1.23"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_markdown.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_markdown.py
@@ -36,6 +36,22 @@ def test_parse_markdown_with_only_headers() -> None:
     assert reader.markdown_to_tups(markdown_text) == expected_tups
 
 
+def test_parse_markdown_with_headers_in_code_block() -> None:
+    reader = MarkdownReader()
+    markdown_text = """# ABC
+```python
+# This is a comment
+print("hello")
+```
+# DEF
+"""
+    expected_tups = [
+        ("ABC", '```python\n# This is a comment\nprint("hello")\n```'),
+        ("DEF", ""),
+    ]
+    assert reader.markdown_to_tups(markdown_text) == expected_tups
+
+
 def test_parse_empty_markdown() -> None:
     reader = MarkdownReader()
     markdown_text = ""


### PR DESCRIPTION
For details, see the newly added test case `test_parse_markdown_with_headers_in_code_block()`. As a comparison, the corresponding tuples generated by the old `MarkdownReader` are as below:

```
[('ABC', '```python'), ('This is a comment', 'print("hello")\n```'), ('DEF', '')]
```