### PR TITLE
proper async element node parsers

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -26,6 +26,7 @@ def asyncio_run(coro: Coroutine) -> Any:
     If there is no existing event loop, creates a new one.
     """
     try:
+        # this will fail if the event loop is already running
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(coro)
     except RuntimeError:

--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -156,6 +156,9 @@ class NodeParser(TransformComponent, ABC):
     def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
         return self.get_nodes_from_documents(nodes, **kwargs)
 
+    async def acall(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        return await self.aget_nodes_from_documents(nodes, **kwargs)
+
 
 class TextSplitter(NodeParser):
     @abstractmethod

--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -1,7 +1,7 @@
 """Node parser interface."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List, Sequence
+from typing import Any, Callable, Dict, List, Sequence
 
 from llama_index.core.bridge.pydantic import Field, validator
 from llama_index.core.callbacks import CallbackManager, CBEventType, EventPayload
@@ -55,6 +55,59 @@ class NodeParser(TransformComponent, ABC):
     ) -> List[BaseNode]:
         ...
 
+    async def _aparse_nodes(
+        self,
+        nodes: Sequence[BaseNode],
+        show_progress: bool = False,
+        **kwargs: Any,
+    ) -> List[BaseNode]:
+        return self._parse_nodes(nodes, show_progress=show_progress, **kwargs)
+
+    def _postprocess_parsed_nodes(
+        self, nodes: List[BaseNode], parent_doc_map: Dict[str, Document]
+    ) -> List[BaseNode]:
+        for i, node in enumerate(nodes):
+            parent_doc = parent_doc_map.get(node.ref_doc_id, None)
+
+            if parent_doc is not None:
+                start_char_idx = parent_doc.text.find(
+                    node.get_content(metadata_mode=MetadataMode.NONE)
+                )
+
+                # update start/end char idx
+                if start_char_idx >= 0:
+                    node.start_char_idx = start_char_idx
+                    node.end_char_idx = start_char_idx + len(
+                        node.get_content(metadata_mode=MetadataMode.NONE)
+                    )
+
+                # update metadata
+                if self.include_metadata:
+                    node.metadata.update(parent_doc.metadata)
+
+            if self.include_prev_next_rel:
+                # establish prev/next relationships if nodes share the same source_node
+                if (
+                    i > 0
+                    and node.source_node
+                    and nodes[i - 1].source_node
+                    and nodes[i - 1].source_node.node_id == node.source_node.node_id
+                ):
+                    node.relationships[NodeRelationship.PREVIOUS] = nodes[
+                        i - 1
+                    ].as_related_node_info()
+                if (
+                    i < len(nodes) - 1
+                    and node.source_node
+                    and nodes[i + 1].source_node
+                    and nodes[i + 1].source_node.node_id == node.source_node.node_id
+                ):
+                    node.relationships[NodeRelationship.NEXT] = nodes[
+                        i + 1
+                    ].as_related_node_info()
+
+        return nodes
+
     def get_nodes_from_documents(
         self,
         documents: Sequence[Document],
@@ -74,50 +127,27 @@ class NodeParser(TransformComponent, ABC):
             CBEventType.NODE_PARSING, payload={EventPayload.DOCUMENTS: documents}
         ) as event:
             nodes = self._parse_nodes(documents, show_progress=show_progress, **kwargs)
+            nodes = self._postprocess_parsed_nodes(nodes, doc_id_to_document)
 
-            for i, node in enumerate(nodes):
-                if (
-                    node.ref_doc_id is not None
-                    and node.ref_doc_id in doc_id_to_document
-                ):
-                    ref_doc = doc_id_to_document[node.ref_doc_id]
-                    start_char_idx = ref_doc.text.find(
-                        node.get_content(metadata_mode=MetadataMode.NONE)
-                    )
+            event.on_end({EventPayload.NODES: nodes})
 
-                    # update start/end char idx
-                    if start_char_idx >= 0:
-                        node.start_char_idx = start_char_idx
-                        node.end_char_idx = start_char_idx + len(
-                            node.get_content(metadata_mode=MetadataMode.NONE)
-                        )
+        return nodes
 
-                    # update metadata
-                    if self.include_metadata:
-                        node.metadata.update(
-                            doc_id_to_document[node.ref_doc_id].metadata
-                        )
+    async def aget_nodes_from_documents(
+        self,
+        documents: Sequence[Document],
+        show_progress: bool = False,
+        **kwargs: Any,
+    ) -> List[BaseNode]:
+        doc_id_to_document = {doc.id_: doc for doc in documents}
 
-                if self.include_prev_next_rel:
-                    # establish prev/next relationships if nodes share the same source_node
-                    if (
-                        i > 0
-                        and node.source_node
-                        and nodes[i - 1].source_node
-                        and nodes[i - 1].source_node.node_id == node.source_node.node_id
-                    ):
-                        node.relationships[NodeRelationship.PREVIOUS] = nodes[
-                            i - 1
-                        ].as_related_node_info()
-                    if (
-                        i < len(nodes) - 1
-                        and node.source_node
-                        and nodes[i + 1].source_node
-                        and nodes[i + 1].source_node.node_id == node.source_node.node_id
-                    ):
-                        node.relationships[NodeRelationship.NEXT] = nodes[
-                            i + 1
-                        ].as_related_node_info()
+        with self.callback_manager.event(
+            CBEventType.NODE_PARSING, payload={EventPayload.DOCUMENTS: documents}
+        ) as event:
+            nodes = await self._aparse_nodes(
+                documents, show_progress=show_progress, **kwargs
+            )
+            nodes = self._postprocess_parsed_nodes(nodes, doc_id_to_document)
 
             event.on_end({EventPayload.NODES: nodes})
 

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -122,9 +122,29 @@ class BaseElementNodeParser(NodeParser):
 
         return all_nodes
 
+    async def _aparse_nodes(
+        self,
+        nodes: Sequence[BaseNode],
+        show_progress: bool = False,
+        **kwargs: Any,
+    ) -> List[BaseNode]:
+        all_nodes: List[BaseNode] = []
+        nodes_with_progress = get_tqdm_iterable(nodes, show_progress, "Parsing nodes")
+
+        for node in nodes_with_progress:
+            nodes = await self.aget_nodes_from_node(node)
+            all_nodes.extend(nodes)
+
+        return all_nodes
+
     @abstractmethod
     def get_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
         """Get nodes from node."""
+        ...
+
+    async def aget_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
+        """Get nodes from node."""
+        return self.get_nodes_from_node(node)
 
     @abstractmethod
     def extract_elements(self, text: str, **kwargs: Any) -> List[Element]:
@@ -186,6 +206,54 @@ class BaseElementNodeParser(NodeParser):
             summary_jobs, show_progress=self.show_progress, workers=self.num_workers
         )
         summary_outputs = asyncio_run(summary_co)
+        for element, summary_output in zip(elements, summary_outputs):
+            element.table_output = summary_output
+
+    async def aextract_table_summaries(self, elements: List[Element]) -> None:
+        """Go through elements, extract out summaries that are tables."""
+        from llama_index.core.indices.list.base import SummaryIndex
+        from llama_index.core.settings import Settings
+
+        llm = self.llm or Settings.llm
+
+        table_context_list = []
+        for idx, element in tqdm(enumerate(elements)):
+            if element.type not in ("table", "table_text"):
+                continue
+            table_context = str(element.element)
+            if idx > 0 and str(elements[idx - 1].element).lower().strip().startswith(
+                "table"
+            ):
+                table_context = str(elements[idx - 1].element) + "\n" + table_context
+            if idx < len(elements) + 1 and str(
+                elements[idx - 1].element
+            ).lower().strip().startswith("table"):
+                table_context += "\n" + str(elements[idx + 1].element)
+
+            table_context_list.append(table_context)
+
+        async def _get_table_output(table_context: str, summary_query_str: str) -> Any:
+            index = SummaryIndex.from_documents(
+                [Document(text=table_context)],
+            )
+            query_engine = index.as_query_engine(llm=llm, output_cls=TableOutput)
+            try:
+                response = await query_engine.aquery(summary_query_str)
+                return cast(PydanticResponse, response).response
+            except (ValidationError, ValueError):
+                # There was a pydantic validation error, so we will run with text completion
+                # fill in the summary and leave other fields blank
+                query_engine = index.as_query_engine(llm=llm)
+                response_txt = await query_engine.aquery(summary_query_str)
+                return TableOutput(summary=str(response_txt), columns=[])
+
+        summary_jobs = [
+            _get_table_output(table_context, self.summary_query_str)
+            for table_context in table_context_list
+        ]
+        summary_outputs = await run_jobs(
+            summary_jobs, show_progress=self.show_progress, workers=self.num_workers
+        )
         for element, summary_output in zip(elements, summary_outputs):
             element.table_output = summary_output
 
@@ -374,5 +442,10 @@ class BaseElementNodeParser(NodeParser):
 
     def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
         nodes = self.get_nodes_from_documents(nodes, **kwargs)
+        nodes, objects = self.get_nodes_and_objects(nodes)
+        return nodes + objects
+
+    async def acall(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        nodes = await self.aget_nodes_from_documents(nodes, **kwargs)
         nodes, objects = self.get_nodes_and_objects(nodes)
         return nodes + objects

--- a/llama-index-core/llama_index/core/node_parser/relational/llama_parse_json_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/llama_parse_json_element.py
@@ -37,6 +37,23 @@ class LlamaParseJsonNodeParser(BaseElementNodeParser):
             elements, node, ref_doc_text=node.get_content()
         )
 
+    async def aget_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
+        """Get nodes from node."""
+        elements = self.extract_elements(
+            node.get_content(),
+            table_filters=[self.filter_table],
+            node_id=node.id_,
+            node_metadata=node.metadata,
+        )
+        table_elements = self.get_table_elements(elements)
+        # extract summaries over table elements
+        await self.aextract_table_summaries(table_elements)
+        # convert into nodes
+        # will return a list of Nodes and Index Nodes
+        return self.get_nodes_from_elements(
+            elements, node, ref_doc_text=node.get_content()
+        )
+
     def extract_elements(
         self,
         text: str,

--- a/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/markdown_element.py
@@ -23,13 +23,30 @@ class MarkdownElementNodeParser(BaseElementNodeParser):
     def get_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
         """Get nodes from node."""
         elements = self.extract_elements(
-            node.get_content(),
-            table_filters=[self.filter_table],
-            node_id=node.id_,
+            node.get_content(), table_filters=[self.filter_table], node_id=node.node_id
         )
         table_elements = self.get_table_elements(elements)
         # extract summaries over table elements
         self.extract_table_summaries(table_elements)
+        # convert into nodes
+        # will return a list of Nodes and Index Nodes
+        nodes = self.get_nodes_from_elements(
+            elements, node, ref_doc_text=node.get_content()
+        )
+        source_document = node.source_node or node.as_related_node_info()
+        for n in nodes:
+            n.relationships[NodeRelationship.SOURCE] = source_document
+            n.metadata.update(node.metadata)
+        return nodes
+
+    async def aget_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
+        """Get nodes from node."""
+        elements = self.extract_elements(
+            node.get_content(), table_filters=[self.filter_table], node_id=node.node_id
+        )
+        table_elements = self.get_table_elements(elements)
+        # extract summaries over table elements
+        await self.aextract_table_summaries(table_elements)
         # convert into nodes
         # will return a list of Nodes and Index Nodes
         nodes = self.get_nodes_from_elements(

--- a/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/unstructured_element.py
@@ -77,6 +77,26 @@ class UnstructuredElementNodeParser(BaseElementNodeParser):
             n.metadata.update(node.metadata)
         return nodes
 
+    async def aget_nodes_from_node(self, node: TextNode) -> List[BaseNode]:
+        """Get nodes from node."""
+        elements = self.extract_elements(
+            node.get_content(), table_filters=[self.filter_table]
+        )
+        table_elements = self.get_table_elements(elements)
+        # extract summaries over table elements
+        await self.aextract_table_summaries(table_elements)
+        # convert into nodes
+        # will return a list of Nodes and Index Nodes
+        nodes = self.get_nodes_from_elements(
+            elements, node, ref_doc_text=node.get_content()
+        )
+
+        source_document = node.source_node or node.as_related_node_info()
+        for n in nodes:
+            n.relationships[NodeRelationship.SOURCE] = source_document
+            n.metadata.update(node.metadata)
+        return nodes
+
     def extract_elements(
         self, text: str, table_filters: Optional[List[Callable]] = None, **kwargs: Any
     ) -> List[Element]:


### PR DESCRIPTION
The element node parsers did not have a proper async entry point, which causes nest_asyncio to be required when running an ingestion pipeline

This change adds those async entry points, at the cost of some code duplication. Definitely open to other ideas. Originally I was using the `asyncio_run()` helper more often to reduce code duplication. But once these are nested, you need nest_asyncio

.... asyncio is a pain to work with