### PR TITLE
Bugfix: Use aiter_lines function to iterate over lines in ollama integration

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -361,7 +361,7 @@ class Ollama(CustomLLM):
                     url=f"{self.base_url}/api/generate",
                     json=payload,
                 ) as response:
-                    async for line in response.aiter_text():
+                    async for line in response.aiter_lines():
                         if line:
                             chunk = json.loads(line)
                             delta = chunk.get("response")


### PR DESCRIPTION
# Description

The ollama integration uses the function `aiter_text` to iterate over text chunks returned by ollama and decodes the chunk as a json object.  
This code fails if the json payload is big enough that the line containing the json string is split over two (or more) chunks as the code tries (and fails) to decode a partial json object.

This change changes the function used to `aiter_lines` which parses the returned chunks into individual lines and returns those instead.

See https://www.python-httpx.org/api/#response for the documentation and https://github.com/encode/httpx/blob/master/httpx/_models.py#L962 for the implementation of the `aiter_lines` function

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] I applied the fix to a running docker container and verified that it no longer caused an error after that
