### PR TITLE
fix pyproject email

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-deepinfra/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-deepinfra/pyproject.toml
@@ -21,7 +21,7 @@ ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Oğuz Vuruşkaner <https://github.com/ovuruska>"]
+authors = ["Your Name <you@example.com>"]
 description = "llama-index llms deepinfra integration"
 exclude = ["**/BUILD"]
 license = "MIT"


### PR DESCRIPTION
# Description

- failed to build/publish new deepinfra-llm integration to pypi (https://github.com/run-llama/llama_index/actions/runs/9219086321)
- it failed because I added an incorrect entry into author in the pyproject.toml (invalid email address)

