### PR TITLE
nit: fix multimodal query engine 

### DIFF
--- a/docs/docs/examples/data_connectors/NotionDemo.ipynb
+++ b/docs/docs/examples/data_connectors/NotionDemo.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c5ed0f4c",
    "metadata": {},
@@ -43,7 +42,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c98912d5",
    "metadata": {},
@@ -176,7 +174,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
   },
   "vscode": {
    "interpreter": {

--- a/docs/docs/examples/data_connectors/NotionDemo.ipynb
+++ b/docs/docs/examples/data_connectors/NotionDemo.ipynb
@@ -174,8 +174,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "pygments_lexer": "ipython3"
   },
   "vscode": {
    "interpreter": {

--- a/llama-index-core/llama_index/core/query_engine/multi_modal.py
+++ b/llama-index-core/llama_index/core/query_engine/multi_modal.py
@@ -11,7 +11,7 @@ from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.prompts import BasePromptTemplate
 from llama_index.core.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
 from llama_index.core.prompts.mixin import PromptMixinType
-from llama_index.core.schema import ImageNode, NodeWithScore
+from llama_index.core.schema import ImageNode, NodeWithScore, MetadataMode
 
 
 def _get_image_and_text_nodes(
@@ -110,7 +110,9 @@ class SimpleMultiModalQueryEngine(BaseQueryEngine):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
     ) -> RESPONSE_TYPE:
         image_nodes, text_nodes = _get_image_and_text_nodes(nodes)
-        context_str = "\n\n".join([r.get_content() for r in text_nodes])
+        context_str = "\n\n".join(
+            [r.get_content(metadata_mode=MetadataMode.LLM) for r in text_nodes]
+        )
         fmt_prompt = self._text_qa_template.format(
             context_str=context_str, query_str=query_bundle.query_str
         )
@@ -151,7 +153,9 @@ class SimpleMultiModalQueryEngine(BaseQueryEngine):
         additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
     ) -> RESPONSE_TYPE:
         image_nodes, text_nodes = _get_image_and_text_nodes(nodes)
-        context_str = "\n\n".join([r.get_content() for r in text_nodes])
+        context_str = "\n\n".join(
+            [r.get_content(metadata_mode=MetadataMode.LLM) for r in text_nodes]
+        )
         fmt_prompt = self._text_qa_template.format(
             context_str=context_str, query_str=query_bundle.query_str
         )


### PR DESCRIPTION
the simple MM query engine wasn't taking in LLM metadata during synthesis 