### PR TITLE
[`docs`] Recommend the superior BAAI/bge-base-en-v1.5 model

### DIFF
--- a/docs/docs/getting_started/starter_example_local.md
+++ b/docs/docs/getting_started/starter_example_local.md
@@ -3,7 +3,7 @@
 !!! tip
     Make sure you've followed the [custom installation](installation.md) steps first.
 
-This is our famous "5 lines of code" starter example with local LLM and embedding models. We will use `nomic-embed-text` as our embedding model and `Llama3`, both served through `Ollama`.
+This is our famous "5 lines of code" starter example with local LLM and embedding models. We will use [`BAAI/bge-base-en-v1.5`](https://huggingface.co/BAAI/bge-base-en-v1.5) as our embedding model and `Llama3` served through `Ollama`.
 
 ## Download data
 
@@ -19,15 +19,13 @@ Follow the [README](https://github.com/jmorganca/ollama) to learn how to install
 
 To download the Llama3 model just do `ollama pull llama3`.
 
-To download the nomic embeddings, just do `ollama pull nomic-embed-text`
-
 **NOTE**: You will need a machine with at least 32GB of RAM.
 
 To import `llama_index.llms.ollama`, you should run `pip install llama-index-llms-ollama`.
 
-To import `llama_index.embeddings.ollama`, you should run `pip install llama-index-embeddings-ollama`.
+To import `llama_index.embeddings.huggingface`, you should run `pip install llama-index-embeddings-huggingface`.
 
-More integrations are all listed on https://llamahub.ai.
+More integrations are all listed on [https://llamahub.ai](https://llamahub.ai).
 
 ## Load data and build an index
 
@@ -35,13 +33,13 @@ In the same folder where you created the `data` folder, create a file called `st
 
 ```python
 from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, Settings
-from llama_index.embeddings.ollama import OllamaEmbedding
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.llms.ollama import Ollama
 
 documents = SimpleDirectoryReader("data").load_data()
 
-# nomic embedding model
-Settings.embed_model = OllamaEmbedding(model_name="nomic-embed-text")
+# bge-base embedding model
+Settings.embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-base-en-v1.5")
 
 # ollama
 Settings.llm = Ollama(model="llama3", request_timeout=360.0)
@@ -61,7 +59,7 @@ Your directory structure should look like this:
     └── paul_graham_essay.txt
 </pre>
 
-We use the `nomic-embed-text` from our `Ollama` embedding wrapper. We also use our `Ollama` LLM wrapper to load in the Llama3 model.
+We use the `BAAI/bge-base-en-v1.5` model through our [`HuggingFaceEmbedding`](../api_reference/embeddings/huggingface.md#llama_index.embeddings.huggingface.HuggingFaceEmbedding) class and our `Ollama` LLM wrapper to load in the Llama3 model. Learn more in the [Local Embedding Models](../module_guides/models/embeddings.md#local-embedding-models) page.
 
 ## Query your data
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Recommend the stronger BAAI/bge-base-en-v1.5 model
* Link users deeper into the LlamaIndex documentation
* Fix the link to https://llamahub.ai

# Description
I've updated the default model shown in the starter example to [BAAI/bge-base-en-v1.5](https://huggingface.co/BAAI/bge-base-en-v1.5), a commonly used and reputable model that outperforms Nomic on the MTEB leaderboard despite being smaller/faster to run:
![Schermafbeelding 2024-05-24 105809](https://github.com/run-llama/llama_index/assets/37621491/1f266a31-0834-444a-9592-0aecc9ed5461)

The correct prompt/prefix is automatically used.

Also, I've linked users further to the API Reference and Local Embedding Models, this should help direct users deeper into the documentation natively. I think this is rather important as the main documentation page (with only a few items in the sidebar) can now be a bit hard to "escape" from.

I also fixed the link to https://llamahub.ai, which was previously not a link.

---

On an unrelated note, I'm considering adding an "Integrations" section below the [Usage section](https://huggingface.co/tomaarsen/stsb-distilbert-base-mnrl#usage) in the automatically generated model cards for all future [Sentence Transformer models](https://huggingface.co/models?library=sentence-transformers). Would you be interested in having LlamaIndex mentioned there? If there's enough interest by tools that integrate with Hugging Face Embedding Models, then I can set up a template of sorts that you can fill in with some details on LlamaIndex, e.g.:
* Name (LlamaIndex in your case)
* URL to documentation showing how to use a Sentence Transformer model with LlamaIndex
* Arbitrary Markdown text to explain your project
* A bash script for installation (e.g. `pip install llama-index llama-index-embeddings-huggingface`)
* A python script for usage (e.g. an initialization with `HuggingFaceEmbeddings`

What do you think? 

- Tom Aarsen
