### PR TITLE
Add check for repeated messages in secondary history

### DIFF
--- a/docs/docs/examples/agent/memory/composable_memory.ipynb
+++ b/docs/docs/examples/agent/memory/composable_memory.ipynb
@@ -62,6 +62,7 @@
     "    SimpleComposableMemory,\n",
     "    ChatMemoryBuffer,\n",
     ")\n",
+    "from llama_index.core.llms import ChatMessage\n",
     "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "\n",
     "vector_memory = VectorMemory.from_defaults(\n",
@@ -69,6 +70,15 @@
     "    embed_model=OpenAIEmbedding(),\n",
     "    retriever_kwargs={\"similarity_top_k\": 1},\n",
     ")\n",
+    "\n",
+    "# let's set some initial messages in our secondary vector memory\n",
+    "msgs = [\n",
+    "    ChatMessage.from_str(\"You are a SOMEWHAT helpful assistant.\", \"system\"),\n",
+    "    ChatMessage.from_str(\"Bob likes burgers.\", \"user\"),\n",
+    "    ChatMessage.from_str(\"Indeed, Bob likes apples.\", \"assistant\"),\n",
+    "    ChatMessage.from_str(\"Alice likes apples.\", \"user\"),\n",
+    "]\n",
+    "vector_memory.set(msgs)\n",
     "\n",
     "chat_memory_buffer = ChatMemoryBuffer.from_defaults()\n",
     "\n",
@@ -108,7 +118,7 @@
     {
      "data": {
       "text/plain": [
-       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x154894b20>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, chat_store=SimpleChatStore(store={}), chat_store_key='chat_history', cur_user_msg_key='cur_user_msg')]"
+       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x11cd954e0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, chat_store=SimpleChatStore(store={'chat_history': [ChatMessage(role=<MessageRole.USER: 'user'>, content='0f215058-7285-4f00-af28-ee8a9f7aead5', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='4a5172e1-15d5-4853-b98f-11af3a3d720a', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='3db1ba8d-2439-4094-82ff-31862d872f07', additional_kwargs={})], 'cur_user_msg': [ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]}), chat_store_key='chat_history', cur_user_msg_key='cur_user_msg')]"
       ]
      },
      "execution_count": null,
@@ -125,7 +135,7 @@
    "id": "0aa65eb4-7c00-4d25-bbc7-5e7d8d5794e2",
    "metadata": {},
    "source": [
-    "### `Put` messages into memory"
+    "### `put()` messages into memory"
    ]
   },
   {
@@ -139,24 +149,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5cffe2cd-66f8-40ba-927e-5ade80b2284a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index.core.llms import ChatMessage"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "6fd78f09-1bbb-4e5c-9535-a222cce9190e",
    "metadata": {},
    "outputs": [],
    "source": [
     "msgs = [\n",
+    "    ChatMessage.from_str(\"You are a REALLY helpful assistant.\", \"system\"),\n",
     "    ChatMessage.from_str(\"Jerry likes juice.\", \"user\"),\n",
-    "    ChatMessage.from_str(\"Bob likes burgers.\", \"user\"),\n",
-    "    ChatMessage.from_str(\"Alice likes apples.\", \"user\"),\n",
     "]"
    ]
   },
@@ -177,7 +176,7 @@
    "id": "049e59b8-2df7-411f-9529-58c1bc77cfd8",
    "metadata": {},
    "source": [
-    "### `Get` messages from memory"
+    "### `get()` messages from memory"
    ]
   },
   {
@@ -187,7 +186,7 @@
    "source": [
     "When `.get()` is invoked, we similarly execute all of the `.get()` methods of `primary` memory as well as all of the `secondary` sources. This leaves us with sequence of lists of messages that we have to must \"compose\" into a sensible single set of messages (to pass downstream to our agents). Special care must be applied here in general to ensure that the final sequence of messages are both sensible and conform to the chat APIs of the LLM provider.\n",
     "\n",
-    "For `SimpleComposableMemory`, we inject the messages from the `secondary` sources in the system message of the `primary` memory. The rest of the message history of the `primary` source is left intact, and this composition is what is ultimately returned."
+    "For `SimpleComposableMemory`, we **inject the messages from the `secondary` sources in the system message of the `primary` memory**. The rest of the message history of the `primary` source is left intact, and this composition is what is ultimately returned."
    ]
   },
   {
@@ -199,10 +198,8 @@
     {
      "data": {
       "text/plain": [
-       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Jerry likes juice.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Jerry likes juice.', additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Bob likes burgers.', additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]"
+       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a REALLY helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Bob likes burgers.\\n\\tASSISTANT: Indeed, Bob likes apples.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={}),\n",
+       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Jerry likes juice.', additional_kwargs={})]"
       ]
      },
      "execution_count": null,
@@ -211,7 +208,7 @@
     }
    ],
    "source": [
-    "msgs = composable_memory.get(\"What does Jerry like?\")\n",
+    "msgs = composable_memory.get(\"What does Bob like?\")\n",
     "msgs"
    ]
   },
@@ -225,13 +222,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "system: You are a helpful assistant.\n",
+      "system: You are a REALLY helpful assistant.\n",
       "\n",
       "Below are a set of relevant dialogues retrieved from potentially several memory sources:\n",
       "\n",
       "=====Relevant messages from memory source 1=====\n",
       "\n",
-      "\tUSER: Jerry likes juice.\n",
+      "\tUSER: Bob likes burgers.\n",
+      "\tASSISTANT: Indeed, Bob likes apples.\n",
       "\n",
       "=====End of relevant messages from memory source 1======\n",
       "\n",
@@ -240,7 +238,7 @@
     }
    ],
    "source": [
-    "# see the memory injected into the system message\n",
+    "# see the memory injected into the system message of the primary memory\n",
     "print(msgs[0])"
    ]
   },
@@ -249,7 +247,7 @@
    "id": "3cb966da-b5cb-4744-b189-ef139e0972cf",
    "metadata": {},
    "source": [
-    "### Successive calls to `Get()`"
+    "### Successive calls to `get()`"
    ]
   },
   {
@@ -269,10 +267,8 @@
     {
      "data": {
       "text/plain": [
-       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Alice likes apples.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Jerry likes juice.', additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Bob likes burgers.', additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]"
+       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a REALLY helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Alice likes apples.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={}),\n",
+       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Jerry likes juice.', additional_kwargs={})]"
       ]
      },
      "execution_count": null,
@@ -295,7 +291,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "system: You are a helpful assistant.\n",
+      "system: You are a REALLY helpful assistant.\n",
       "\n",
       "Below are a set of relevant dialogues retrieved from potentially several memory sources:\n",
       "\n",
@@ -310,8 +306,47 @@
     }
    ],
    "source": [
-    "# see the memory injected into the system message\n",
+    "# see the memory injected into the system message of the primary memory\n",
     "print(msgs[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfce6b59-21ba-4e6f-b9bf-1a19dbacfe21",
+   "metadata": {},
+   "source": [
+    "### What if `get()` retrieves `secondary` messages that already exist in `primary` memory?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b2839b2-40da-4714-92ee-eb6c795d92bb",
+   "metadata": {},
+   "source": [
+    "In the event that messages retrieved from `secondary` memory already exist in `primary` memory, then these rather redundant secondary messages will not get added to the system message. In the below example, the message \"Jerry likes juice.\" was `put` into all memory sources, so the system message is not altered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c96604e4-3b4e-490f-a196-f046d28c13f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a REALLY helpful assistant.', additional_kwargs={}),\n",
+       " ChatMessage(role=<MessageRole.USER: 'user'>, content='Jerry likes juice.', additional_kwargs={})]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "msgs = composable_memory.get(\"What does Jerry like?\")\n",
+    "msgs"
    ]
   },
   {
@@ -586,14 +621,12 @@
       "=== Function Output ===\n",
       "-11\n",
       "=== LLM Response ===\n",
-      "The mystery function on 5 and 6 returns -11.\n",
-      "assistant: The mystery function on 5 and 6 returns -11.\n"
+      "The mystery function on 5 and 6 returns -11.\n"
      ]
     }
    ],
    "source": [
-    "response = agent.chat(\"What is the mystery function on 5 and 6?\")\n",
-    "print(str(response))"
+    "response = agent.chat(\"What is the mystery function on 5 and 6?\")"
    ]
   },
   {
@@ -828,8 +861,7 @@
     {
      "data": {
       "text/plain": [
-       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content=\"You are a helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: What was the output of the mystery function on 5 and 6 again? Don't recompute.\\n\\tASSISTANT: The output of the mystery function on 5 and 6 is -11.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.\", additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content=\"What was the output of the mystery function on 5 and 6 again? Don't recompute.\", additional_kwargs={}),\n",
+       "[ChatMessage(role=<MessageRole.USER: 'user'>, content=\"What was the output of the mystery function on 5 and 6 again? Don't recompute.\", additional_kwargs={}),\n",
        " ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content='The output of the mystery function on 5 and 6 is -11.', additional_kwargs={}),\n",
        " ChatMessage(role=<MessageRole.USER: 'user'>, content=\"What was the output of the multiply function on 2 and 3 again? Don't recompute.\", additional_kwargs={}),\n",
        " ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content='The output of the multiply function on 2 and 3 is 6.', additional_kwargs={})]"

--- a/docs/docs/examples/agent/memory/composable_memory.ipynb
+++ b/docs/docs/examples/agent/memory/composable_memory.ipynb
@@ -118,7 +118,7 @@
     {
      "data": {
       "text/plain": [
-       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x13f5912d0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, chat_store=SimpleChatStore(store={'chat_history': [ChatMessage(role=<MessageRole.USER: 'user'>, content='1392bc95-9e08-4268-9676-214d95deaf16', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='a396a24c-316b-46a5-98ac-587e343aa16b', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='6312af32-63e1-4295-a362-0a585720a995', additional_kwargs={})], 'cur_user_msg': [ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]}), chat_store_key='chat_history', cur_user_msg_key='cur_user_msg')]"
+       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x15d2952d0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, chat_store=SimpleChatStore(store={'chat_history': [ChatMessage(role=<MessageRole.USER: 'user'>, content='468f6fd1-b7b9-4a0a-bd22-b70fea1f1527', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='061fef4a-fb09-4002-9ef3-4c796bdf2840', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='2dc15e75-5072-4eba-ad54-7e7a9ec6219c', additional_kwargs={})], 'cur_user_msg': [ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]}), chat_store_key='chat_history', cur_user_msg_key='cur_user_msg')]"
       ]
      },
      "execution_count": null,
@@ -867,7 +867,10 @@
     "composable_memory = SimpleComposableMemory.from_defaults(\n",
     "    primary_memory=ChatMemoryBuffer.from_defaults(),\n",
     "    secondary_memory_sources=[\n",
-    "        vector_memory.copy(deep=True)  # copy for illustrative purposes\n",
+    "        vector_memory.copy(\n",
+    "            deep=True\n",
+    "        )  # copy for illustrative purposes to explain what\n",
+    "        # happened under the hood from previous subsection\n",
     "    ],\n",
     ")\n",
     "agent_with_memory = agent_worker.as_agent(memory=composable_memory)"
@@ -892,7 +895,7 @@
    ],
    "source": [
     "agent_with_memory.memory.get(\n",
-    "    \"What is the mystery function on 5 and 6? Don't recompute.\"\n",
+    "    \"What was the output of the mystery function on 5 and 6 again? Don't recompute.\"\n",
     ")"
    ]
   },
@@ -926,7 +929,7 @@
    "source": [
     "print(\n",
     "    agent_with_memory.memory.get(\n",
-    "        \"What is the mystery function on 5 and 6? Don't recompute.\"\n",
+    "        \"What was the output of the mystery function on 5 and 6 again? Don't recompute.\"\n",
     "    )[0]\n",
     ")"
    ]

--- a/docs/docs/examples/agent/memory/composable_memory.ipynb
+++ b/docs/docs/examples/agent/memory/composable_memory.ipynb
@@ -118,7 +118,7 @@
     {
      "data": {
       "text/plain": [
-       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x11cd954e0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, chat_store=SimpleChatStore(store={'chat_history': [ChatMessage(role=<MessageRole.USER: 'user'>, content='0f215058-7285-4f00-af28-ee8a9f7aead5', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='4a5172e1-15d5-4853-b98f-11af3a3d720a', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='3db1ba8d-2439-4094-82ff-31862d872f07', additional_kwargs={})], 'cur_user_msg': [ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]}), chat_store_key='chat_history', cur_user_msg_key='cur_user_msg')]"
+       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x13f5912d0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, chat_store=SimpleChatStore(store={'chat_history': [ChatMessage(role=<MessageRole.USER: 'user'>, content='1392bc95-9e08-4268-9676-214d95deaf16', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='a396a24c-316b-46a5-98ac-587e343aa16b', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='6312af32-63e1-4295-a362-0a585720a995', additional_kwargs={})], 'cur_user_msg': [ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]}), chat_store_key='chat_history', cur_user_msg_key='cur_user_msg')]"
       ]
      },
      "execution_count": null,
@@ -742,7 +742,12 @@
     ")\n",
     "composable_memory = SimpleComposableMemory.from_defaults(\n",
     "    primary_memory=ChatMemoryBuffer.from_defaults(),\n",
-    "    secondary_memory_sources=[vector_memory],\n",
+    "    secondary_memory_sources=[\n",
+    "        vector_memory.copy(\n",
+    "            deep=True\n",
+    "        )  # using a copy here for illustration purposes\n",
+    "        # later will use original vector_memory again\n",
+    "    ],\n",
     ")\n",
     "agent_with_memory = agent_worker.as_agent(memory=composable_memory)"
    ]
@@ -855,16 +860,29 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "96f42289-e7cb-463a-b10b-44696bf3dc9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "composable_memory = SimpleComposableMemory.from_defaults(\n",
+    "    primary_memory=ChatMemoryBuffer.from_defaults(),\n",
+    "    secondary_memory_sources=[\n",
+    "        vector_memory.copy(deep=True)  # copy for illustrative purposes\n",
+    "    ],\n",
+    ")\n",
+    "agent_with_memory = agent_worker.as_agent(memory=composable_memory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b3040fea-ba11-4703-a47b-395c3fd68d2e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[ChatMessage(role=<MessageRole.USER: 'user'>, content=\"What was the output of the mystery function on 5 and 6 again? Don't recompute.\", additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content='The output of the mystery function on 5 and 6 is -11.', additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.USER: 'user'>, content=\"What was the output of the multiply function on 2 and 3 again? Don't recompute.\", additional_kwargs={}),\n",
-       " ChatMessage(role=<MessageRole.ASSISTANT: 'assistant'>, content='The output of the multiply function on 2 and 3 is 6.', additional_kwargs={})]"
+       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: What is the mystery function on 5 and 6?\\n\\tASSISTANT: None\\n\\tTOOL: -11\\n\\tASSISTANT: The mystery function on 5 and 6 returns -11.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={})]"
       ]
      },
      "execution_count": null,
@@ -874,7 +892,7 @@
    ],
    "source": [
     "agent_with_memory.memory.get(\n",
-    "    \"What was the output of the mystery function on 5 and 6 again? Don't recompute.\"\n",
+    "    \"What is the mystery function on 5 and 6? Don't recompute.\"\n",
     ")"
    ]
   },
@@ -894,8 +912,10 @@
       "\n",
       "=====Relevant messages from memory source 1=====\n",
       "\n",
-      "\tUSER: What was the output of the mystery function on 5 and 6 again? Don't recompute.\n",
-      "\tASSISTANT: The output of the mystery function on 5 and 6 is -11.\n",
+      "\tUSER: What is the mystery function on 5 and 6?\n",
+      "\tASSISTANT: None\n",
+      "\tTOOL: -11\n",
+      "\tASSISTANT: The mystery function on 5 and 6 returns -11.\n",
       "\n",
       "=====End of relevant messages from memory source 1======\n",
       "\n",
@@ -905,8 +925,8 @@
    ],
    "source": [
     "print(\n",
-    "    agent.memory.get(\n",
-    "        \"What was the output of the mystery function on 5 and 6 again? Don't recompute.\"\n",
+    "    agent_with_memory.memory.get(\n",
+    "        \"What is the mystery function on 5 and 6? Don't recompute.\"\n",
     "    )[0]\n",
     ")"
    ]

--- a/llama-index-core/llama_index/core/memory/simple_composable_memory.py
+++ b/llama-index-core/llama_index/core/memory/simple_composable_memory.py
@@ -81,16 +81,15 @@ class SimpleComposableMemory(BaseMemory):
         """Get chat history."""
         # get from primary
         messages = self.primary_memory.get(input=input, **kwargs)
-        messages_text = " ".join(m.content or "" for m in messages)
 
         # get from secondary
         # TODO: remove any repeated messages in secondary and primary memory
         secondary_histories = []
         for mem in self.secondary_memory_sources:
             secondary_history = mem.get(input, **kwargs)
-            secondary_text = " ".join(m.content or "" for m in secondary_history)
+            secondary_history = [m for m in secondary_history if m not in messages]
 
-            if len(secondary_history) > 0 and secondary_text not in messages_text:
+            if len(secondary_history) > 0:
                 secondary_histories.append(secondary_history)
 
         # format secondary memory

--- a/llama-index-core/llama_index/core/memory/simple_composable_memory.py
+++ b/llama-index-core/llama_index/core/memory/simple_composable_memory.py
@@ -81,13 +81,16 @@ class SimpleComposableMemory(BaseMemory):
         """Get chat history."""
         # get from primary
         messages = self.primary_memory.get(input=input, **kwargs)
+        messages_text = " ".join(m.content or "" for m in messages)
 
         # get from secondary
         # TODO: remove any repeated messages in secondary and primary memory
         secondary_histories = []
         for mem in self.secondary_memory_sources:
             secondary_history = mem.get(input, **kwargs)
-            if len(secondary_history) > 0:
+            secondary_text = " ".join(m.content or "" for m in secondary_history)
+
+            if len(secondary_history) > 0 and secondary_text not in messages_text:
                 secondary_histories.append(secondary_history)
 
         # format secondary memory

--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -184,7 +184,10 @@ class VectorMemory(BaseMemory):
 
     def put(self, message: ChatMessage) -> None:
         """Put chat history."""
-        if not self.batch_by_user_message or message.role == MessageRole.USER:
+        if not self.batch_by_user_message or message.role in [
+            MessageRole.USER,
+            MessageRole.SYSTEM,
+        ]:
             # if not batching by user message, commit to vector store immediately after adding
             self.chat_store.delete_messages(self.cur_user_msg_key)
             self.chat_store.add_message(self.cur_user_msg_key, message)

--- a/llama-index-core/tests/agent/memory/test_simple_composable.py
+++ b/llama-index-core/tests/agent/memory/test_simple_composable.py
@@ -1,5 +1,6 @@
 """Test simple composable memory."""
 
+import pytest
 from typing import Any, List
 from llama_index.core.memory import (
     VectorMemory,
@@ -9,6 +10,14 @@ from llama_index.core.memory import (
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from unittest.mock import patch
 from llama_index.core.llms import ChatMessage
+
+
+@pytest.fixture()
+def vector_memory_initial_msgs() -> List[ChatMessage]:
+    return [
+        ChatMessage.from_str("Jerry likes juice.", "user"),
+        ChatMessage.from_str("That's nice.", "assistant"),
+    ]
 
 
 def mock_get_text_embedding(text: str) -> List[float]:
@@ -39,24 +48,25 @@ def mock_get_text_embeddings(texts: List[str]) -> List[List[float]]:
 @patch.object(
     MockEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
 )
-def test_vector_memory(
-    _mock_get_text_embeddings: Any, _mock_get_text_embedding: Any
+def test_simple_composable_memory(
+    _mock_get_text_embeddings: Any,
+    _mock_get_text_embedding: Any,
+    vector_memory_initial_msgs: List[ChatMessage],
 ) -> None:
     """Test vector memory."""
-    # arrange
+    # Arrange
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=None,
+        embed_model=MockEmbedding(embed_dim=5),
+        retriever_kwargs={"similarity_top_k": 1},
+    )
+    vector_memory.set(vector_memory_initial_msgs)
+
     composable_memory = SimpleComposableMemory.from_defaults(
         primary_memory=ChatMemoryBuffer.from_defaults(),
-        secondary_memory_sources=[
-            VectorMemory.from_defaults(
-                vector_store=None,
-                embed_model=MockEmbedding(embed_dim=5),
-                retriever_kwargs={"similarity_top_k": 1},
-            ),
-        ],
+        secondary_memory_sources=[vector_memory],
     )
     msgs = [
-        ChatMessage.from_str("Jerry likes juice.", "user"),
-        ChatMessage.from_str("That's nice.", "assistant"),
         ChatMessage.from_str("Bob likes burgers.", "user"),
         ChatMessage.from_str("Alice likes apples.", "user"),
     ]
@@ -67,9 +77,40 @@ def test_vector_memory(
     retrieved_msgs = composable_memory.get("What does Jerry like?")
 
     # assert
-    assert len(retrieved_msgs) == 5
+    assert len(retrieved_msgs) == 3
     assert retrieved_msgs[0].role == "system"
     expected_system_string = """You are a helpful assistant.\n\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\n\n=====Relevant messages from memory source 1=====\n\n\tUSER: Jerry likes juice.\n\tASSISTANT: That's nice.\n\n=====End of relevant messages from memory source 1======\n\nThis is the end of the of retrieved message dialogues."""
     assert expected_system_string == retrieved_msgs[0].content
 
     assert retrieved_msgs[1:] == msgs
+
+
+@patch.object(MockEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding)
+@patch.object(
+    MockEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+def test_repeated_secondary_history(
+    _mock_get_text_embeddings: Any,
+    _mock_get_text_embedding: Any,
+    vector_memory_initial_msgs: List[ChatMessage],
+) -> None:
+    """Test event where historical messages exist in both secondary and primary."""
+    # Arrange
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=None,
+        embed_model=MockEmbedding(embed_dim=5),
+        retriever_kwargs={"similarity_top_k": 1},
+    )
+    vector_memory.set(vector_memory_initial_msgs)
+    composable_memory = SimpleComposableMemory.from_defaults(
+        primary_memory=ChatMemoryBuffer.from_defaults(),
+        secondary_memory_sources=[vector_memory],
+    )
+    composable_memory.set(vector_memory_initial_msgs)
+
+    # act
+    retrieved_msgs = composable_memory.get("What does Jerry like?")
+
+    # assert
+    assert len(retrieved_msgs) == 2
+    assert retrieved_msgs == vector_memory_initial_msgs


### PR DESCRIPTION
# Description

For `SimpleComposableMemory` the secondary historical messages get added to the system prompt. In the event that the secondary history retrieves messages already included in the primary history, then this becomes wasteful (wrt token counts).

- This PR adds check to see if the secondary history messages is contained in the primary chat history; if it is, then we don't redundantly add it to a system prompt of the primary chat history.
- This PR also adds a small fix to `VectorMemory` that batches by "USER" and "SYSTEM" messages. Effectively, this means `VectorMemory` can put system messages to memory.

Fixes # (issue)


## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] Revised notebook still runs end to end
- [x] I stared at the code and made sure it makes sense
