### PR TITLE
Rip out chat_store from VectorMemory

### DIFF
--- a/docs/docs/examples/agent/memory/composable_memory.ipynb
+++ b/docs/docs/examples/agent/memory/composable_memory.ipynb
@@ -118,7 +118,7 @@
     {
      "data": {
       "text/plain": [
-       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x15d2952d0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, chat_store=SimpleChatStore(store={'chat_history': [ChatMessage(role=<MessageRole.USER: 'user'>, content='468f6fd1-b7b9-4a0a-bd22-b70fea1f1527', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='061fef4a-fb09-4002-9ef3-4c796bdf2840', additional_kwargs={}), ChatMessage(role=<MessageRole.USER: 'user'>, content='2dc15e75-5072-4eba-ad54-7e7a9ec6219c', additional_kwargs={})], 'cur_user_msg': [ChatMessage(role=<MessageRole.USER: 'user'>, content='Alice likes apples.', additional_kwargs={})]}), chat_store_key='chat_history', cur_user_msg_key='cur_user_msg')]"
+       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x11db953f0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, cur_user_msg_key='cur_user_msg', cur_batch_textnode=TextNode(id_='b5558134-38d3-4bed-bb2a-a483cab454cd', embedding=None, metadata={'sub_dicts': [{'role': <MessageRole.USER: 'user'>, 'content': 'Alice likes apples.', 'additional_kwargs': {}}]}, excluded_embed_metadata_keys=['sub_dicts'], excluded_llm_metadata_keys=['sub_dicts'], relationships={}, text='Alice likes apples.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'))]"
       ]
      },
      "execution_count": null,

--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -16,9 +16,6 @@ from llama_index.core.memory.types import BaseMemory
 from llama_index.core.embeddings.utils import EmbedType
 
 
-CUR_USER_MSG_KEY = "cur_user_msg"
-
-
 def _stringify_obj(d: Any):
     """Utility function to convert all keys in a dictionary to strings."""
     if isinstance(d, list):
@@ -61,7 +58,6 @@ class VectorMemory(BaseMemory):
     # in the vector store.
     batch_by_user_message: bool = True
 
-    cur_user_msg_key: str = Field(default=CUR_USER_MSG_KEY)
     cur_batch_textnode: TextNode = Field(
         default_factory=_get_starter_node_for_new_batch,
         description="The super node for the current active user-message batch.",

--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -163,7 +163,6 @@ class VectorMemory(BaseMemory):
 
     def put(self, message: ChatMessage) -> None:
         """Put chat history."""
-        sub_dict = _stringify_chat_message(message)
         if not self.batch_by_user_message or message.role in [
             MessageRole.USER,
             MessageRole.SYSTEM,
@@ -172,6 +171,7 @@ class VectorMemory(BaseMemory):
             self.cur_batch_textnode = _get_starter_node_for_new_batch()
 
         # update current batch textnode
+        sub_dict = _stringify_chat_message(message)
         if self.cur_batch_textnode.text == "":
             self.cur_batch_textnode.text += sub_dict["content"] or ""
         else:

--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -12,13 +12,11 @@ from llama_index.core.schema import TextNode
 from llama_index.core.vector_stores.types import VectorStore
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.bridge.pydantic import Field
-from llama_index.core.memory.types import DEFAULT_CHAT_STORE_KEY, BaseMemory
-from llama_index.core.storage.chat_store import BaseChatStore, SimpleChatStore
+from llama_index.core.memory.types import BaseMemory
 from llama_index.core.embeddings.utils import EmbedType
 
 
-DEFAULT_TOKEN_LIMIT_RATIO = 0.75
-DEFAULT_TOKEN_LIMIT = 3000
+CUR_USER_MSG_KEY = "cur_user_msg"
 
 
 def _stringify_obj(d: Any):
@@ -38,7 +36,15 @@ def _stringify_chat_message(msg: ChatMessage) -> Dict:
     return msg_dict
 
 
-CUR_USER_MSG_KEY = "cur_user_msg"
+def _get_starter_node_for_new_batch() -> TextNode:
+    """Generates a new starter node for a new batch or group of messages."""
+    return TextNode(
+        id_=str(uuid.uuid4()),
+        text="",
+        metadata={"sub_dicts": []},
+        excluded_embed_metadata_keys=["sub_dicts"],
+        excluded_llm_metadata_keys=["sub_dicts"],
+    )
 
 
 class VectorMemory(BaseMemory):
@@ -55,14 +61,11 @@ class VectorMemory(BaseMemory):
     # in the vector store.
     batch_by_user_message: bool = True
 
-    chat_store: BaseChatStore = Field(default_factory=SimpleChatStore)
-    # NOTE/TODO: we need this to store id's for the messages
-    # This is not needed once vector stores implement delete_all capabilities
-    chat_store_key: str = Field(default=DEFAULT_CHAT_STORE_KEY)
-    # NOTE: this is to store the current user message batch (if `batch_by_user_message` is True)
-    # allows us to keep track of the current user message batch
-    # so we can delete it when we commit a new node
     cur_user_msg_key: str = Field(default=CUR_USER_MSG_KEY)
+    cur_batch_textnode: TextNode = Field(
+        default_factory=_get_starter_node_for_new_batch,
+        description="The super node for the current active user-message batch.",
+    )
 
     @validator("vector_index")
     def validate_vector_index(cls, value: Any) -> Any:
@@ -144,28 +147,8 @@ class VectorMemory(BaseMemory):
 
     def _commit_node(self, override_last: bool = False) -> None:
         """Commit new node to vector store."""
-        # commit to vector store
-        node_id = str(uuid.uuid4())
-        # create subnodes for each message
-        sub_dicts = []
-        for msg in self.chat_store.get_messages(self.cur_user_msg_key):
-            sub_dicts.append(_stringify_chat_message(msg))
-
-        if not sub_dicts:
+        if self.cur_batch_textnode.text == "":
             return
-
-        # now create a "super" node that contains all subnodes as metadata
-        # this metadata is excluded from embedding and LLM synthesis
-        # the concatenated text is put into the super node text field
-        super_node = TextNode(
-            text=" ".join(
-                [str(sub_dicts[i]["content"]) for i in range(len(sub_dicts))]
-            ),
-            id_=node_id,
-            metadata={"sub_dicts": sub_dicts},
-            excluded_embed_metadata_keys=["sub_dicts"],
-            excluded_llm_metadata_keys=["sub_dicts"],
-        )
 
         if override_last:
             # delete the last node
@@ -174,28 +157,27 @@ class VectorMemory(BaseMemory):
             # we already will have the last user message group committed to the
             # vector store index and so we don't need to override_last (i.e. see
             # logic in self.put().)
-            last_node_id = self.chat_store.delete_last_message(
-                self.chat_store_key
-            ).content
-            self.vector_index.delete_nodes([last_node_id])
+            self.vector_index.delete_nodes([self.cur_batch_textnode.id_])
 
-        self.vector_index.insert_nodes([super_node])
-        self.chat_store.add_message(self.chat_store_key, ChatMessage(content=node_id))
+        self.vector_index.insert_nodes([self.cur_batch_textnode])
 
     def put(self, message: ChatMessage) -> None:
         """Put chat history."""
+        sub_dict = _stringify_chat_message(message)
         if not self.batch_by_user_message or message.role in [
             MessageRole.USER,
             MessageRole.SYSTEM,
         ]:
             # if not batching by user message, commit to vector store immediately after adding
-            self.chat_store.delete_messages(self.cur_user_msg_key)
-            self.chat_store.add_message(self.cur_user_msg_key, message)
-            self._commit_node()
+            self.cur_batch_textnode = _get_starter_node_for_new_batch()
+
+        # update current batch textnode
+        if self.cur_batch_textnode.text == "":
+            self.cur_batch_textnode.text += sub_dict["content"] or ""
         else:
-            # if not user message, add to holding queue i.e. the chat_store
-            self.chat_store.add_message(self.cur_user_msg_key, message)
-            self._commit_node(override_last=True)
+            self.cur_batch_textnode.text += " " + (sub_dict["content"] or "")
+        self.cur_batch_textnode.metadata["sub_dicts"].append(sub_dict)
+        self._commit_node(override_last=True)
 
     def set(self, messages: List[ChatMessage]) -> None:
         """Set chat history."""
@@ -205,12 +187,7 @@ class VectorMemory(BaseMemory):
 
     def reset(self) -> None:
         """Reset chat history."""
-        node_id_msgs = self.chat_store.get_messages(self.chat_store_key)
-        node_ids = [msg.content for msg in node_id_msgs]
-        self.vector_index.delete_nodes(node_ids)
-
-        # delete from chat history
-        self.chat_store.delete_messages(self.chat_store_key)
+        self.vector_index.vector_store.clear()
 
 
 VectorMemory.update_forward_refs()

--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -45,7 +45,12 @@ def _get_starter_node_for_new_batch() -> TextNode:
 
 
 class VectorMemory(BaseMemory):
-    """Memory backed by a vector index."""
+    """Memory backed by a vector index.
+
+    NOTE: This class requires the `delete_nodes` method to be implemented
+    by the vector store underlying the vector index. At time of writing (May 2024),
+    Chroma, Qdrant and SimpleVectorStore all support delete_nodes.
+    """
 
     vector_index: Any
     retriever_kwargs: Dict[str, Any] = Field(default_factory=dict)
@@ -92,7 +97,9 @@ class VectorMemory(BaseMemory):
         """Create vector memory.
 
         Args:
-            vector_store (Optional[VectorStore]): vector store
+            vector_store (Optional[VectorStore]): vector store (note: delete_nodes must
+                be implemented. At time of writing (May 2024), Chroma, Qdrant and
+                SimpleVectorStore all support delete_nodes.
             embed_model (Optional[EmbedType]): embedding model
             index_kwargs (Optional[Dict]): kwargs for initializing the index
             retriever_kwargs (Optional[Dict]): kwargs for initializing the retriever


### PR DESCRIPTION
# Description

Currently, `VectorMemory` relies on a `BaseChatStore` to manage the running user-message batch (i.e., leveraging it to store node ids).

- This PR removes the reliance on `BaseChatStore` in favour of managing the running user-message batch directly via a running (super) `TextNode`

## Type of Change

Please delete options that are not relevant.

- [x] Re-factor (non-breaking change)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Checked vector_memory and composable_memory notebooks still run end-to-end
- [x] I stared at the code and made sure it makes sense