### PR TITLE
Small grammar nit to `SimpleComposableMemory` system template

### DIFF
--- a/docs/docs/examples/agent/memory/composable_memory.ipynb
+++ b/docs/docs/examples/agent/memory/composable_memory.ipynb
@@ -118,7 +118,7 @@
     {
      "data": {
       "text/plain": [
-       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x11db953f0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, cur_user_msg_key='cur_user_msg', cur_batch_textnode=TextNode(id_='b5558134-38d3-4bed-bb2a-a483cab454cd', embedding=None, metadata={'sub_dicts': [{'role': <MessageRole.USER: 'user'>, 'content': 'Alice likes apples.', 'additional_kwargs': {}}]}, excluded_embed_metadata_keys=['sub_dicts'], excluded_llm_metadata_keys=['sub_dicts'], relationships={}, text='Alice likes apples.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'))]"
+       "[VectorMemory(vector_index=<llama_index.core.indices.vector_store.base.VectorStoreIndex object at 0x137b912a0>, retriever_kwargs={'similarity_top_k': 1}, batch_by_user_message=True, cur_batch_textnode=TextNode(id_='288b0ef3-570e-4698-a1ae-b3531df66361', embedding=None, metadata={'sub_dicts': [{'role': <MessageRole.USER: 'user'>, 'content': 'Alice likes apples.', 'additional_kwargs': {}}]}, excluded_embed_metadata_keys=['sub_dicts'], excluded_llm_metadata_keys=['sub_dicts'], relationships={}, text='Alice likes apples.', start_char_idx=None, end_char_idx=None, text_template='{metadata_str}\\n\\n{content}', metadata_template='{key}: {value}', metadata_seperator='\\n'))]"
       ]
      },
      "execution_count": null,
@@ -198,7 +198,7 @@
     {
      "data": {
       "text/plain": [
-       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a REALLY helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Bob likes burgers.\\n\\tASSISTANT: Indeed, Bob likes apples.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={}),\n",
+       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a REALLY helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Bob likes burgers.\\n\\tASSISTANT: Indeed, Bob likes apples.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the retrieved message dialogues.', additional_kwargs={}),\n",
        " ChatMessage(role=<MessageRole.USER: 'user'>, content='Jerry likes juice.', additional_kwargs={})]"
       ]
      },
@@ -233,7 +233,7 @@
       "\n",
       "=====End of relevant messages from memory source 1======\n",
       "\n",
-      "This is the end of the of retrieved message dialogues.\n"
+      "This is the end of the retrieved message dialogues.\n"
      ]
     }
    ],
@@ -267,7 +267,7 @@
     {
      "data": {
       "text/plain": [
-       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a REALLY helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Alice likes apples.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={}),\n",
+       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a REALLY helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: Alice likes apples.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the retrieved message dialogues.', additional_kwargs={}),\n",
        " ChatMessage(role=<MessageRole.USER: 'user'>, content='Jerry likes juice.', additional_kwargs={})]"
       ]
      },
@@ -301,7 +301,7 @@
       "\n",
       "=====End of relevant messages from memory source 1======\n",
       "\n",
-      "This is the end of the of retrieved message dialogues.\n"
+      "This is the end of the retrieved message dialogues.\n"
      ]
     }
    ],
@@ -854,7 +854,7 @@
    "id": "e20ed139-c7a9-44ac-a455-d2f1c96122eb",
    "metadata": {},
    "source": [
-    "Under the hood, `.chat(user_input)` call effectively will call the memory's `.get()` method with `user_input` as the argument. As we learned in the previous section, this will ultimately return a composition of the `primary` and all of the `secondary` memory sources. These composed messages are what being passed to the LLM's chat API as the chat history."
+    "Under the hood, `.chat(user_input)` call effectively will call the memory's `.get()` method with `user_input` as the argument. As we learned in the previous section, this will ultimately return a composition of the `primary` and all of the `secondary` memory sources. These composed messages are what is being passed to the LLM's chat API as the chat history."
    ]
   },
   {
@@ -885,7 +885,7 @@
     {
      "data": {
       "text/plain": [
-       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: What is the mystery function on 5 and 6?\\n\\tASSISTANT: None\\n\\tTOOL: -11\\n\\tASSISTANT: The mystery function on 5 and 6 returns -11.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the of retrieved message dialogues.', additional_kwargs={})]"
+       "[ChatMessage(role=<MessageRole.SYSTEM: 'system'>, content='You are a helpful assistant.\\n\\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\\n\\n=====Relevant messages from memory source 1=====\\n\\n\\tUSER: What is the mystery function on 5 and 6?\\n\\tASSISTANT: None\\n\\tTOOL: -11\\n\\tASSISTANT: The mystery function on 5 and 6 returns -11.\\n\\n=====End of relevant messages from memory source 1======\\n\\nThis is the end of the retrieved message dialogues.', additional_kwargs={})]"
       ]
      },
      "execution_count": null,
@@ -922,7 +922,7 @@
       "\n",
       "=====End of relevant messages from memory source 1======\n",
       "\n",
-      "This is the end of the of retrieved message dialogues.\n"
+      "This is the end of the retrieved message dialogues.\n"
      ]
     }
    ],

--- a/llama-index-core/llama_index/core/memory/simple_composable_memory.py
+++ b/llama-index-core/llama_index/core/memory/simple_composable_memory.py
@@ -8,7 +8,7 @@ from llama_index.core.memory.types import (
 from llama_index.core.memory import ChatMemoryBuffer
 
 DEFAULT_INTRO_HISTORY_MESSAGE = "Below are a set of relevant dialogues retrieved from potentially several memory sources:"
-DEFAULT_OUTRO_HISTORY_MESSAGE = "This is the end of the of retrieved message dialogues."
+DEFAULT_OUTRO_HISTORY_MESSAGE = "This is the end of the retrieved message dialogues."
 
 
 class SimpleComposableMemory(BaseMemory):

--- a/llama-index-core/tests/agent/memory/test_simple_composable.py
+++ b/llama-index-core/tests/agent/memory/test_simple_composable.py
@@ -79,7 +79,7 @@ def test_simple_composable_memory(
     # assert
     assert len(retrieved_msgs) == 3
     assert retrieved_msgs[0].role == "system"
-    expected_system_string = """You are a helpful assistant.\n\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\n\n=====Relevant messages from memory source 1=====\n\n\tUSER: Jerry likes juice.\n\tASSISTANT: That's nice.\n\n=====End of relevant messages from memory source 1======\n\nThis is the end of the of retrieved message dialogues."""
+    expected_system_string = """You are a helpful assistant.\n\nBelow are a set of relevant dialogues retrieved from potentially several memory sources:\n\n=====Relevant messages from memory source 1=====\n\n\tUSER: Jerry likes juice.\n\tASSISTANT: That's nice.\n\n=====End of relevant messages from memory source 1======\n\nThis is the end of the retrieved message dialogues."""
     assert expected_system_string == retrieved_msgs[0].content
 
     assert retrieved_msgs[1:] == msgs


### PR DESCRIPTION
# Description

- grammar fix to system "template" string of `SimpleComposableMemory`


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

