### PR TITLE
fix: QueryTransformComponent incorrect call `self._query_transform`

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/query_transform/base.py
+++ b/llama-index-core/llama_index/core/indices/query/query_transform/base.py
@@ -37,7 +37,8 @@ from llama_index.core.utils import print_text
 
 
 class BaseQueryTransform(ChainableMixin, PromptMixin):
-    """Base class for query transform.
+    """
+    Base class for query transform.
 
     A query transform augments a raw query string with associated transformations
     to improve index querying.
@@ -86,7 +87,8 @@ class BaseQueryTransform(ChainableMixin, PromptMixin):
 
 
 class IdentityQueryTransform(BaseQueryTransform):
-    """Identity query transform.
+    """
+    Identity query transform.
 
     Do nothing to the query.
 
@@ -105,7 +107,8 @@ class IdentityQueryTransform(BaseQueryTransform):
 
 
 class HyDEQueryTransform(BaseQueryTransform):
-    """Hypothetical Document Embeddings (HyDE) query transform.
+    """
+    Hypothetical Document Embeddings (HyDE) query transform.
 
     It uses an LLM to generate hypothetical answer(s) to a given query,
     and use the resulting documents as embedding strings.
@@ -120,7 +123,8 @@ class HyDEQueryTransform(BaseQueryTransform):
         hyde_prompt: Optional[BasePromptTemplate] = None,
         include_original: bool = True,
     ) -> None:
-        """Initialize HyDEQueryTransform.
+        """
+        Initialize HyDEQueryTransform.
 
         Args:
             llm_predictor (Optional[LLM]): LLM for generating
@@ -159,7 +163,8 @@ class HyDEQueryTransform(BaseQueryTransform):
 
 
 class DecomposeQueryTransform(BaseQueryTransform):
-    """Decompose query transform.
+    """
+    Decompose query transform.
 
     Decomposes query into a subquery given the current index struct.
     Performs a single step transformation.
@@ -218,7 +223,8 @@ class DecomposeQueryTransform(BaseQueryTransform):
 
 
 class ImageOutputQueryTransform(BaseQueryTransform):
-    """Image output query transform.
+    """
+    Image output query transform.
 
     Adds instructions for formatting image output.
     By default, this prompts the LLM to format image output as an HTML <img> tag,
@@ -230,7 +236,8 @@ class ImageOutputQueryTransform(BaseQueryTransform):
         width: int = 400,
         query_prompt: Optional[ImageOutputQueryTransformPrompt] = None,
     ) -> None:
-        """Init ImageOutputQueryTransform.
+        """
+        Init ImageOutputQueryTransform.
 
         Args:
             width (int): desired image display width in pixels
@@ -259,7 +266,8 @@ class ImageOutputQueryTransform(BaseQueryTransform):
 
 
 class StepDecomposeQueryTransform(BaseQueryTransform):
-    """Step decompose query transform.
+    """
+    Step decompose query transform.
 
     Decomposes query into a subquery given the current index struct
     and previous reasoning.
@@ -346,7 +354,7 @@ class QueryTransformComponent(QueryComponent):
 
     def _run_component(self, **kwargs: Any) -> Any:
         """Run component."""
-        output = self._query_transform.run(
+        output = self.query_transform.run(
             kwargs["query_str"],
             metadata=kwargs["metadata"],
         )


### PR DESCRIPTION
# Description
Internally QueryTransformComponent was calling a method with an incorrect name. `self._query_transform` rather than `self.query_transform`

Fixes #13757

## New Package?
Not a new 
Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No - not a new package

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No - updates llama-index-core

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense (run with my application where I was getting the hard error before)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
