### PR TITLE
Add Azure Devops Repository Integration

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/.gitignore
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/BUILD
@@ -1,1 +1,3 @@
-python_sources()
+poetry_requirements(
+    name="poetry",
+)

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/README.md
@@ -1,0 +1,30 @@
+# LlamaIndex Readers Integration: Azure Devops
+
+`pip install llama-index-readers-azure-devops`
+
+The Azure Devops readers package enables you to read files from your azure devops repositories
+
+The reader will require a personal access token (which you can generate under your account settings).
+
+## Usage
+
+This reader will read through a repo, with options to specifically filter directories and file extensions.
+
+Here is an example of how to use it
+
+```python
+from llama_index.readers.azure_devops import AzureDevopsReader
+
+az_devops_loader = AzureDevopsLoader(
+    access_token="<your-access-token>",
+    organization_name="<organization-name>",
+    project_name="<project-name>",
+    repo="<repository-name>",
+    file_filter=lambda file_path: file_path.endswith(".py"),
+)  # Optional: you can provide any callable that returns a boolean to filter files of your choice
+
+documents = az_devops_loader.load_data(
+    folder="<folder-path>",  # The folder to load documents from, defaults to root.
+    branch="<branch-name>",
+)  # The branch to load documents from, defaults to head of the repo
+```

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/__init__.py
@@ -1,0 +1,4 @@
+from llama_index.readers.azure_devops.base import AzureDevopsReader
+
+
+__all__ = ["AzureDevopsReader"]

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/base.py
@@ -53,7 +53,6 @@ class AzureDevopsReader(BaseReader):
             The Git client object for Azure DevOps.
         """
         try:
-            print("in try")
             from azure.devops.connection import Connection
             from msrest.authentication import BasicAuthentication
         except ImportError:

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/llama_index/readers/azure_devops/base.py
@@ -1,0 +1,183 @@
+from typing import Dict, List, Optional, Callable
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+
+class AzureDevopsReader(BaseReader):
+    """
+    A loader class for Azure DevOps repositories. This class provides methods to authenticate with Azure DevOps,
+    access repositories, and retrieve file content.
+
+    Attributes:
+        access_token (str): The personal access token for Azure DevOps.
+        organization_name (str): The name of the organization in Azure DevOps.
+        project_name (str): The name of the project in Azure DevOps.
+        repo (str): The name of the repository in the project.
+        organization_url (str): The URL to the organization in Azure DevOps.
+        git_client: The Git client for interacting with Azure DevOps.
+        repository_id: The ID of the repository in Azure DevOps.
+    """
+
+    def __init__(
+        self,
+        access_token: str,
+        organization_name: str,
+        project_name: str,
+        repo: str,
+        file_filter: Optional[Callable[[str], bool]] = False,
+    ):
+        """
+        Initializes the AzureDevopsLoader with the necessary details to interact with an Azure DevOps repository.
+
+        Parameters:
+            access_token (str): The personal access token for Azure DevOps.
+            organization_name (str): The name of the organization in Azure DevOps.
+            project_name (str): The name of the project in Azure DevOps.
+            repo (str): The name of the repository in the project.
+            file_filter(callable): A function that can be used as file filter ex: `lambda file_path: file_path.endswith(".py")`
+        """
+        self.access_token = access_token
+        self.project_name = project_name
+        self.repo = repo
+        self.organization_url = f"https://dev.azure.com/{organization_name}/"
+        self.file_filter = file_filter
+
+        self.git_client = self.create_git_client()
+        self.repository_id = self._get_repository_id(repo_name=self.repo)
+
+    def create_git_client(self):
+        """
+        Creates and returns a Git client for interacting with Azure DevOps.
+
+        Returns:
+            The Git client object for Azure DevOps.
+        """
+        try:
+            print("in try")
+            from azure.devops.connection import Connection
+            from msrest.authentication import BasicAuthentication
+        except ImportError:
+            raise ImportError(
+                "Please install azure-devops to use the AzureDevopsLoader. "
+                "You can do so by running `pip install azure-devops`."
+            )
+        credentials = BasicAuthentication("", self.access_token)
+        connection = Connection(base_url=self.organization_url, creds=credentials)
+        return connection.clients.get_git_client()
+
+    def _get_repository_id(self, repo_name: str):
+        """
+        Retrieves the repository ID for a given repository name.
+
+        Parameters:
+            repo_name (str): The name of the repository.
+
+        Returns:
+            The ID of the repository.
+        """
+        repositories = self.git_client.get_repositories(project=self.project_name)
+        return next((repo.id for repo in repositories if repo.name == repo_name), None)
+
+    def _create_version_descriptor(self, branch: Optional[str]):
+        """
+        Creates a version descriptor for a given branch.
+
+        Parameters:
+            branch (Optional[str]): The name of the branch to create a version descriptor for.
+
+        Returns:
+            A version descriptor if a branch is specified, otherwise None.
+        """
+        if branch:
+            from azure.devops.v7_0.git.models import GitVersionDescriptor
+
+            version_descriptor = GitVersionDescriptor(
+                version=branch, version_type="branch"
+            )
+        else:
+            version_descriptor = None
+        return version_descriptor
+
+    def get_file_paths(self, folder: str = "/", version_descriptor=None) -> List[Dict]:
+        """
+        Retrieves the paths of all files within a given folder in the repository.
+
+        Parameters:
+            folder (str): The folder to retrieve file paths from, defaults to root.
+            version_descriptor (Optional): The version descriptor to specify a version or branch.
+
+        Returns:
+            A list of paths of the files.
+        """
+        items = self.git_client.get_items(
+            repository_id=self.repository_id,
+            project=self.project_name,
+            scope_path=folder,
+            recursion_level="Full",
+            version_descriptor=version_descriptor,
+        )
+        return [
+            {"path": item.path, "url": item.url}
+            for item in items
+            if not (self.file_filter and not self.file_filter(item.path))
+            and (item.git_object_type == "blob")
+        ]
+
+    def get_file_content_by_path(self, path: str, version_descriptor=None):
+        """
+        Retrieves the content of a file by its path in the repository.
+
+        Parameters:
+            path (str): The path of the file in the repository.
+            version_descriptor (Optional): The version descriptor to specify a version or branch.
+
+        Returns:
+            The content of the file as a string.
+        """
+        try:
+            stream = self.git_client.get_item_text(
+                repository_id=self.repository_id,
+                path=path,
+                project=self.project_name,
+                download=True,
+                version_descriptor=version_descriptor,
+            )
+            file_content = ""
+            # Iterate over the generator object
+            for chunk in stream:
+                # Assuming the content is encoded in UTF-8, decode each chunk and append to the file_content string
+                file_content += chunk.decode("utf-8")
+            return file_content
+        except Exception as e:
+            print(f"failed loading {path}")
+            return None
+
+    def load_data(self, folder: Optional[str] = "/", branch: Optional[str] = None):
+        """
+        Loads the documents from a specified folder and branch in the repository.
+
+        Parameters:
+            folder (Optional[str]): The folder to load documents from, defaults to root.
+            branch (Optional[str]): The branch to load documents from.
+
+        Returns:
+            A list of Document objects representing the loaded documents.
+        """
+        documents = []
+        version_descriptor = self._create_version_descriptor(branch=branch)
+        files = self.get_file_paths(
+            folder=folder, version_descriptor=version_descriptor
+        )
+        for file in files:
+            path = file["path"]
+            content = self.get_file_content_by_path(
+                path=path, version_descriptor=version_descriptor
+            )
+            if content:
+                metadata = {
+                    "path": path,
+                    "extension": path.split(".")[-1],
+                    "source": file["url"],
+                }
+                documents.append(Document(text=content, extra_info=metadata))
+        return documents

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+# Feel free to un-skip examples, and experimental, you will just need to
+# work through many typos (--write-changes and --interactive will help)
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.mypy]
+disallow_untyped_defs = true
+# Remove venv skip when integrated with pre-commit
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"
+
+[tool.poetry]
+authors = ["Your Name <you@example.com>"]
+description = "llama-index readers azure devops integration"
+license = "MIT"
+name = "llama-index-readers-azure-devops"
+packages = [{include = "llama_index/"}]
+readme = "README.md"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = ">=3.8.1,<4.0"
+llama-index-core = "^0.10.0"
+azure-devops = "7.1.0b4"
+
+[tool.poetry.group.dev.dependencies]
+black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
+codespell = {extras = ["toml"], version = ">=v2.2.6"}
+ipython = "8.10.0"
+jupyter = "^1.0.0"
+mypy = "0.991"
+pre-commit = "3.2.0"
+pylint = "2.15.10"
+pytest = "7.2.1"
+pytest-mock = "3.11.1"
+ruff = "0.0.292"
+tree-sitter-languages = "^1.8.0"
+types-Deprecated = ">=0.1.0"
+types-PyYAML = "^6.0.12.12"
+types-protobuf = "^4.24.0.4"
+types-redis = "4.5.5.0"
+types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-setuptools = "67.1.0.0"

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/pyproject.toml
@@ -9,6 +9,13 @@ check-hidden = true
 # work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.azure_devops"
+
+[tool.llamahub.class_authors]
+AzureDevopsReader = "saurabhgssingh"
+
 [tool.mypy]
 disallow_untyped_defs = true
 # Remove venv skip when integrated with pre-commit

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/llama-index-integrations/readers/llama-index-readers-azure-devops/tests/test_readers_azure_devops.py
+++ b/llama-index-integrations/readers/llama-index-readers-azure-devops/tests/test_readers_azure_devops.py
@@ -1,0 +1,7 @@
+from llama_index.core.readers.base import BaseReader
+from llama_index.readers.azure_devops import AzureDevopsReader
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in AzureDevopsReader.__mro__]
+    assert BaseReader.__name__ in names_of_base_classes


### PR DESCRIPTION
# Description

Integration to read azure devops repository.  No readily available reader to load and index codebase from a repo on Azure Devops. Most of the organizations working on Microsoft Azure techstack use Azure Devops as their primary source control

Dependencies:
- azure-devops = "7.1.0b4"

## New Package

Yes, Reader

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?
-  Yes


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- Yes


## Type of Change

- New feature (non-breaking change which adds functionality)


## Suggested Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- I ran `make format; make lint` to appease the lint gods
