### PR TITLE
Bug fixes and updates for KibelaReader

### DIFF
--- a/llama-index-core/llama_index/core/bridge/pydantic.py
+++ b/llama-index-core/llama_index/core/bridge/pydantic.py
@@ -11,6 +11,7 @@ try:
         create_model,
         root_validator,
         validator,
+        parse_obj_as,
     )
     from pydantic.v1.error_wrappers import ValidationError
     from pydantic.v1.fields import FieldInfo
@@ -28,6 +29,7 @@ except ImportError:
         create_model,
         root_validator,
         validator,
+        parse_obj_as,
     )
     from pydantic.error_wrappers import ValidationError
     from pydantic.fields import FieldInfo
@@ -48,4 +50,5 @@ __all__ = [
     "ValidationError",
     "GenericModel",
     "BaseConfig",
+    "parse_obj_as",
 ]

--- a/llama-index-integrations/readers/llama-index-readers-kibela/llama_index/readers/kibela/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-kibela/llama_index/readers/kibela/base.py
@@ -3,8 +3,7 @@ from typing import Dict, Generic, List, Optional, TypeVar
 
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
-from pydantic import BaseModel, parse_obj_as
-from pydantic.generics import GenericModel
+from llama_index.core.bridge.pydantic import BaseModel, GenericModel, parse_obj_as
 
 NodeType = TypeVar("NodeType")
 

--- a/llama-index-integrations/readers/llama-index-readers-kibela/llama_index/readers/kibela/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-kibela/llama_index/readers/kibela/base.py
@@ -21,7 +21,7 @@ class PageInfo(BaseModel):
 
 
 class Connection(GenericModel, Generic[NodeType]):
-    nodes: Optional[List[NodeType]]
+    nodes: Optional[List[NodeType]] = None
     edges: Optional[List[Edge[NodeType]]]
     pageInfo: Optional[PageInfo]
     totalCount: Optional[int]


### PR DESCRIPTION
# Description
-  Replace for llama_index.core.bridge.pydantic
- When acquiring data with Graph QL, it does not expect nodes to be included, but Validate expects nodes to be included, which causes the problem to fail.This can be avoided by setting None as the initial value.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
