### PR TITLE
Remove FlagEmbedding as Milvus's dependency.

### DIFF
--- a/docs/docs/examples/vector_stores/MilvusHybridIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/MilvusHybridIndexDemo.ipynb
@@ -47,13 +47,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "df3ddfc5",
+   "metadata": {},
+   "source": [
+    "BGE-M3 from FlagEmbedding is used as the default sparse embedding method, so it needs to be installed along with llama-index."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "6b80700a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install llama-index"
+    "! pip install llama-index\n",
+    "! pip install FlagEmbedding"
    ]
   },
   {

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import List, Dict
-from FlagEmbedding import BGEM3FlagModel
+import sys
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class BaseSparseEmbeddingFunction(ABC):
@@ -15,7 +18,18 @@ class BaseSparseEmbeddingFunction(ABC):
 
 class BGEM3SparseEmbeddingFunction(BaseSparseEmbeddingFunction):
     def __init__(self) -> None:
-        self.model = BGEM3FlagModel("BAAI/bge-m3", use_fp16=False)
+        try:
+            from FlagEmbedding import BGEM3FlagModel
+
+            self.model = BGEM3FlagModel("BAAI/bge-m3", use_fp16=False)
+        except Exception as ImportError:
+            error_info = (
+                "Cannot import BGEM3FlagModel from FlagEmbedding. It seems it is not installed. "
+                "Please install it using:\n"
+                "pip install FlagEmbedding\n"
+            )
+            logger.fatal(error_info)
+            sys.exit(1)
 
     def encode_queries(self, queries: List[str]):
         outputs = self.model.encode(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.1.15"
+version = "0.1.16"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,13 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.1.14"
+version = "0.1.15"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
 pymilvus = "^2.3.6"
-FlagEmbedding = ">=1.2.9"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/BUILD
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/BUILD
@@ -1,5 +1,1 @@
-python_tests(
-    dependencies=[
-        "llama-index-integrations/vector_stores/llama-index-vector-stores-milvus:poetry#FlagEmbedding"
-    ]
-)
+python_tests()


### PR DESCRIPTION
# Description
According to https://github.com/run-llama/llama_index/pull/13122, The user does not want FlagEmbedding as a dependency for Milvus. It has been removed, and now installation needs to be done manually for hybrid retrieval scene.


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
