### PR TITLE
fix undefined variable

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-feishu-wiki/llama_index/readers/feishu_wiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-feishu-wiki/llama_index/readers/feishu_wiki/base.py
@@ -78,7 +78,7 @@ class FeishuWikiReader(BaseReader):
             "Content-Type": "application/json; charset=utf-8",
         }
 
-        url = self.host + self.wiki_spaces_url_path.format(space_id)
+        url = self.host + self.wiki_nodes_url_path.format(space_id)
         if parent_node_token:
             url += f"?parent_node_token={parent_node_token}"
         try:

--- a/llama-index-integrations/readers/llama-index-readers-feishu-wiki/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-feishu-wiki/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["zhourunlai"]
 name = "llama-index-readers-feishu-wiki"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

In the Feishu wiki integration, an instance variable (`wiki_nodes_url_path`) is defined and unused. Where it should be used, however, has an undefined semantically similar variable name. 
Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
