### PR TITLE
fix type handling with return direct

### DIFF
--- a/llama-index-core/llama_index/core/agent/function_calling/step.py
+++ b/llama-index-core/llama_index/core/agent/function_calling/step.py
@@ -304,8 +304,15 @@ class FunctionCallingAgentWorker(BaseAgentWorker):
                 else []
             )
 
+        # get response string
+        # return_direct can change the response type
+        try:
+            response_str = str(response.message.content)
+        except AttributeError:
+            response_str = str(response)
+
         agent_response = AgentChatResponse(
-            response=str(response.message.content), sources=task.extra_state["sources"]
+            response=response_str, sources=task.extra_state["sources"]
         )
 
         return TaskStepOutput(
@@ -390,8 +397,15 @@ class FunctionCallingAgentWorker(BaseAgentWorker):
                 else []
             )
 
+        # get response string
+        # return_direct can change the response type
+        try:
+            response_str = str(response.message.content)
+        except AttributeError:
+            response_str = str(response)
+
         agent_response = AgentChatResponse(
-            response=str(response.message.content), sources=task.extra_state["sources"]
+            response=response_str, sources=task.extra_state["sources"]
         )
 
         return TaskStepOutput(


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/13770

Return direct causes the type of response to change slightly, which can cause issues when getting the response string.

This fix will ensure that we get a proper response string