### PR TITLE
Add option include_comments to GitHubRepositoryIssuesReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/github_client.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/github_client.py
@@ -29,6 +29,15 @@ class BaseGitHubIssuesClient(Protocol):
     ) -> Dict:
         ...
 
+    async def get_comments(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        page: int = 1,
+    ) -> Dict:
+        ...
+
 
 class GitHubIssuesClient:
     """
@@ -82,6 +91,7 @@ class GitHubIssuesClient:
 
         self._endpoints = {
             "getIssues": "/repos/{owner}/{repo}/issues",
+            "getIssueComments": "/repos/{owner}/{repo}/issues/{issue_number}/comments",
         }
 
         self._headers = {
@@ -187,6 +197,41 @@ class GitHubIssuesClient:
                 },
                 owner=owner,
                 repo=repo,
+            )
+        ).json()
+
+    async def get_comments(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        page: int = 1,
+    ) -> Dict:
+        """
+        List comments in an issue.
+
+        Args:
+            - `owner (str)`: Owner of the repository.
+            - `repo (str)`: Name of the repository.
+            - `issue_number (int)`: The number that identifies the issue..
+
+        Returns:
+            - See https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#list-issue-comments
+
+        Examples:
+            >>> repo_issues = client.get_comments("owner", "repo", "123")
+        """
+        return (
+            await self.request(
+                endpoint="getIssueComments",
+                method="GET",
+                params={
+                    "per_page": 100,
+                    "page": page,
+                },
+                owner=owner,
+                repo=repo,
+                issue_number=issue_number,
             )
         ).json()
 

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/tests/test_github_repository_issues_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/tests/test_github_repository_issues_reader.py
@@ -1,0 +1,108 @@
+import unittest
+from unittest.mock import MagicMock, AsyncMock
+from llama_index.readers.github.issues.base import GitHubRepositoryIssuesReader
+
+
+COMMENTS = {
+    1: [{"body": "Comment 1.1"}],
+    2: [],
+    3: [{"body": "Comment 3.1"}, {"body": "Comment 3.2"}],
+}
+
+ISSUES = [
+    {
+        "number": 1,
+        "title": "Issue 1",
+        "body": "Body 1",
+        "state": "open",
+        "created_at": "2022-01-01T00:00:00Z",
+        "closed_at": None,
+        "url": "",
+        "html_url": "",
+        "assignee": {"login": "assignee"},
+        "labels": [{"name": "label1"}, {"name": "label2"}],
+        "comments": len(COMMENTS[1]),
+    },
+    {
+        "number": 2,
+        "title": "Issue 2",
+        "body": "Body 2",
+        "state": "closed",
+        "created_at": "2022-01-01T00:00:00Z",
+        "closed_at": "2022-01-02T00:00:00Z",
+        "url": "",
+        "html_url": "",
+        "assignee": None,
+        "labels": None,
+        "comments": len(COMMENTS[2]),
+    },
+    {
+        "number": 3,
+        "title": "Issue 3",
+        "body": "Body 3",
+        "state": "open",
+        "created_at": "2022-01-01T00:00:00Z",
+        "closed_at": None,
+        "url": "",
+        "html_url": "",
+        "assignee": None,
+        "labels": None,
+        "comments": len(COMMENTS[3]),
+    },
+]
+
+
+async def mock_get_issues(
+    owner: str,
+    repo: str,
+    state: str = "open",
+    page: int = 1,
+):
+    if page > 1:
+        return {}
+    return ISSUES
+
+
+async def mock_get_comments(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    page: int = 1,
+):
+    if page > 1:
+        return []
+    return COMMENTS[issue_number]
+
+
+class TestGitHubRepositoryIssuesReader(unittest.TestCase):
+    def setUp(self):
+        # Mock the GitHub client
+        self.github_client = AsyncMock()
+        self.github_client.get_issues.side_effect = mock_get_issues
+        self.github_client.get_comments.side_effect = mock_get_comments
+
+        # Create an instance of GitHubRepositoryIssuesReader
+        self.reader = GitHubRepositoryIssuesReader(
+            github_client=self.github_client,
+            owner="foo",
+            repo="bar",
+            include_comments=True,
+            verbose=False,
+        )
+
+    def test_load_data(self):
+        documents = self.reader.load_data()
+        got = [doc.text for doc in documents]
+
+        self.assertEqual(
+            got,
+            [
+                "Issue 1\nBody 1\nComment 1.1",
+                "Issue 2\nBody 2",
+                "Issue 3\nBody 3\nComment 3.1\nComment 3.2",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 maintainers = ["ahmetkca", "moncho", "rwood-97"]
 name = "llama-index-readers-github"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Add option include_comments to GitHubRepositoryIssuesReader

    - include_comments (bool): Whether to fetch issue comments and merge them with the text.

Motivation:
- There's often the need to index both the issues and their comments.

Arguably we could take it further, e.g. add comment metadata in the extra info, allow comment filtering, etc. But this _starts small_ with something which is useful in my usecase.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
