### PR TITLE
fix: coherence model name for gemini

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -170,7 +170,7 @@ class Gemini(CustomLLM):
         return LLMMetadata(
             context_window=total_tokens,
             num_output=self.max_tokens,
-            model_name=self.model_name,
+            model_name=self.model,
             is_chat_model=True,
         )
 

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -59,7 +59,7 @@ class Gemini(CustomLLM):
         ```python
         from llama_index.llms.gemini import Gemini
 
-        llm = Gemini(model_name="models/gemini-ultra", api_key="YOUR_API_KEY")
+        llm = Gemini(model="models/gemini-ultra", api_key="YOUR_API_KEY")
         resp = llm.complete("Write a poem about a magic backpack")
         print(resp)
         ```

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -89,7 +89,7 @@ class Gemini(CustomLLM):
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: Optional[str] = GEMINI_MODELS[0],
+        model: Optional[str] = GEMINI_MODELS[0],
         temperature: float = DEFAULT_TEMPERATURE,
         max_tokens: Optional[int] = None,
         generation_config: Optional["genai.types.GenerationConfigDict"] = None,
@@ -125,17 +125,17 @@ class Gemini(CustomLLM):
         final_gen_config = {"temperature": temperature, **base_gen_config}
 
         self._model = genai.GenerativeModel(
-            model_name=model_name,
+            model_name=model,
             generation_config=final_gen_config,
             safety_settings=safety_settings,
         )
 
-        self._model_meta = genai.get_model(model_name)
+        self._model_meta = genai.get_model(model)
 
         supported_methods = self._model_meta.supported_generation_methods
         if "generateContent" not in supported_methods:
             raise ValueError(
-                f"Model {model_name} does not support content generation, only "
+                f"Model {model} does not support content generation, only "
                 f"{supported_methods}."
             )
 
@@ -145,7 +145,7 @@ class Gemini(CustomLLM):
             max_tokens = min(max_tokens, self._model_meta.output_token_limit)
 
         super().__init__(
-            model_name=model_name,
+            model_name=model,
             temperature=temperature,
             max_tokens=max_tokens,
             generate_kwargs=generate_kwargs,

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -3,6 +3,7 @@
 import os
 import typing
 from typing import Any, Dict, Optional, Sequence
+import warnings
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -51,7 +52,8 @@ GEMINI_MODELS = (
 
 
 class Gemini(CustomLLM):
-    """Gemini LLM.
+    """
+    Gemini LLM.
 
     Examples:
         `pip install llama-index-llms-gemini`
@@ -65,9 +67,7 @@ class Gemini(CustomLLM):
         ```
     """
 
-    model_name: str = Field(
-        default=GEMINI_MODELS[0], description="The Gemini model to use."
-    )
+    model: str = Field(default=GEMINI_MODELS[0], description="The Gemini model to use.")
     temperature: float = Field(
         default=DEFAULT_TEMPERATURE,
         description="The temperature to use during generation.",
@@ -97,6 +97,7 @@ class Gemini(CustomLLM):
         callback_manager: Optional[CallbackManager] = None,
         api_base: Optional[str] = None,
         transport: Optional[str] = None,
+        model_name: Optional[str] = None,
         **generate_kwargs: Any,
     ):
         """Creates a new Gemini model interface."""
@@ -107,6 +108,13 @@ class Gemini(CustomLLM):
                 "Gemini is not installed. Please install it with "
                 "`pip install 'google-generativeai>=0.3.0'`."
             )
+        if model_name is not None:
+            warnings.warn(
+                "model_name is deprecated, please use model instead",
+                DeprecationWarning,
+            )
+
+            model = model_name
 
         # API keys are optional. The API can be authorised via OAuth (detected
         # environmentally) or by the GOOGLE_API_KEY environment variable.
@@ -145,7 +153,7 @@ class Gemini(CustomLLM):
             max_tokens = min(max_tokens, self._model_meta.output_token_limit)
 
         super().__init__(
-            model_name=model,
+            model=model,
             temperature=temperature,
             max_tokens=max_tokens,
             generate_kwargs=generate_kwargs,


### PR DESCRIPTION
# Description

Coherence fix, seems like most of the integrations llms have an init with `model` for the name of the model used by the integration.
Gemini seems to not be following that rule, using `model_name` instead which is pretty disturbing for user wanting to change models or simply use it(as reported in the followind issue)

This seems to be a breaking change for all actual user of the gemini integration

Fixes #13573 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
