### PR TITLE
Fix/OpenSearch filter logic

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -239,12 +239,12 @@ class OpensearchVectorClient:
         Returns:
             Up to k docs closest to query_embedding
         """
-        if filters is None or len(filters.filters) == 0:
+        pre_filter = self._parse_filters(filters)
+        if not pre_filter:
             search_query = self._default_approximate_search_query(
                 query_embedding, k, vector_field=embedding_field
             )
         else:
-            pre_filter = self._parse_filters(filters)
             # https://opensearch.org/docs/latest/search-plugins/knn/painless-functions/
             search_query = self._default_painless_scripting_query(
                 query_embedding,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -398,6 +398,10 @@ class OpensearchVectorClient:
         res = await self._os_client.search(
             index=self._index, body=search_query, params=params
         )
+
+        return self._to_query_result(res)
+
+    def _to_query_result(self, res) -> VectorStoreQueryResult:
         nodes = []
         ids = []
         scores = []
@@ -432,6 +436,7 @@ class OpensearchVectorClient:
             ids.append(node_id)
             nodes.append(node)
             scores.append(hit["_score"])
+
         return VectorStoreQueryResult(nodes=nodes, ids=ids, similarities=scores)
 
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -239,7 +239,7 @@ class OpensearchVectorClient:
         Returns:
             Up to k docs closest to query_embedding
         """
-        if filters is None:
+        if filters is None or len(filters.filters) == 0:
             search_query = self._default_approximate_search_query(
                 query_embedding, k, vector_field=embedding_field
             )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -388,13 +388,12 @@ class OpensearchVectorClient:
             )
             params = {
                 "search_pipeline": self._search_pipeline,
-                "_source_excludes": ["embedding"],
             }
         else:
             search_query = self._knn_search_query(
                 self._embedding_field, query_embedding, k, filters=filters
             )
-            params = {"_source_excludes": ["embedding"]}
+            params = None
 
         res = await self._os_client.search(
             index=self._index, body=search_query, params=params

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-opensearch"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

OpenSearch filter logic, check for both `MetadataFilters` object and `MetadataFilters.filters` length (MetadataFilters object can still be non-None even if the filters property is null)

Additional: revert the exclude embedding field from the response, let user pick by themself

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
