### PR TITLE
fix: update minimum version dependency on `llama-index-core` (^0.10.41)

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-openai-legacy/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-openai-legacy/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 llama-index-llms-openai = "^0.1.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.2.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 llama-index-llms-openai = "^0.1.5"
 openai = ">=1.14.0"
 

--- a/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.39"
+llama-index-core = "^0.10.41"
 huggingface-hub = "^0.23.0"
 torch = "^2.1.2"
 text-generation = "^0.7.0"

--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
@@ -34,7 +34,7 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-llama-index-core = "^0.10.0"
+llama-index-core = "^0.10.41"
 ipex-llm = {allow-prereleases = true, extras = ["llama-index"], version = ">=2.1.0b20240514"}
 torch = {optional = true, source = "ipex-xpu-src-us", version = "2.1.0a0"}
 torchvision = {optional = true, source = "ipex-xpu-src-us", version = "0.16.0a0"}

--- a/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.1"
+llama-index-core = "^0.10.41"
 llama-index-llms-anyscale = "^0.1.1"
 langchain = "^0.1.3"
 llama-index-llms-openai = "^0.1.1"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 cohere = "^5.1.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/pyproject.toml
@@ -35,7 +35,7 @@ version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 torch = "^2.2.0"
 transformers = "^4.37.2"
 

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.0"
+llama-index-core = "^0.10.41"
 dashscope = ">=1.17.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-flag-embedding-reranker/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-flag-embedding-reranker/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
@@ -34,7 +34,7 @@ version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 
 [tool.poetry.group.dev.dependencies]
 black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-openvino-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-openvino-rerank/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 huggingface-hub = "^0.20.3"
 
 [tool.poetry.dependencies.optimum]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankgpt-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankgpt-rerank/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -35,7 +35,7 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 
 [tool.poetry.group.dev.dependencies]
 black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-sbert-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-sbert-rerank/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-voyageai-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-voyageai-rerank/pyproject.toml
@@ -34,7 +34,7 @@ version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 voyageai = "^0.2.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-packs/llama-index-packs-cohere-citation-chat/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-cohere-citation-chat/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.35"
+llama-index-core = "^0.10.41"
 llama-index-llms-cohere = ">=0.1.2"
 llama-index-embeddings-cohere = "^0.1.2"
 


### PR DESCRIPTION
This is a follow-up to https://github.com/run-llama/llama_index/pull/13700 which introduced the following new wrapper class. 
```python
from llama_index.core.types import Thread
```

cc @nerdai 

File change comparison with the predecessor PR.

<img width="1294" alt="Screenshot 2024-05-29 at 7 55 34 AM" src="https://github.com/run-llama/llama_index/assets/80478925/cea3157e-e3a6-497d-85f8-788098fb44ad">
