### PR TITLE
Safety setting for Pydantic Error for Vertex Integration

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -68,9 +68,6 @@ class Vertex(LLM):
         description="Example messages for the chat model."
     )
     max_retries: int = Field(default=10, description="The maximum number of retries.")
-    safety_settings: Optional[SafetySettingsType] = Field(
-        default=None, description="Safety settings for the Vertex AI model."
-    )
     additional_kwargs: Dict[str, Any] = Field(
         default_factory=dict, description="Additional kwargs for the Vertex."
     )
@@ -146,7 +143,6 @@ class Vertex(LLM):
             model=model,
             examples=examples,
             iscode=iscode,
-            safety_settings=safety_settings,
             callback_manager=callback_manager,
             system_prompt=system_prompt,
             messages_to_prompt=messages_to_prompt,

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -146,6 +146,7 @@ class Vertex(LLM):
             model=model,
             examples=examples,
             iscode=iscode,
+            safety_settings=safety_settings,
             callback_manager=callback_manager,
             system_prompt=system_prompt,
             messages_to_prompt=messages_to_prompt,

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -146,7 +146,6 @@ class Vertex(LLM):
             model=model,
             examples=examples,
             iscode=iscode,
-            safety_settings=safety_settings,
             callback_manager=callback_manager,
             system_prompt=system_prompt,
             messages_to_prompt=messages_to_prompt,

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vertex"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vertex"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This  changes fixes a minor issue caused due to a previous [PR HERE](https://github.com/run-llama/llama_index/pull/13568/files). 


Fixes # (issue)
Removes the line [here](https://github.com/run-llama/llama_index/blob/8dd2268c7f60698dda9fd44fea99ba81df90a74e/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py#L149)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Code works even without removing it on my local llama-index feature branch, but when imported as an library I was seeing `update_forward_refs()` error.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
