### PR TITLE
fix: synchronous run of coroutines (`async_utils.asyncio_run`)

### DIFF
--- a/llama-index-core/llama_index/core/base/response/schema.py
+++ b/llama-index-core/llama_index/core/base/response/schema.py
@@ -180,7 +180,7 @@ class AsyncStreamingResponse:
 
     def __str__(self) -> str:
         """Convert to string representation."""
-        return asyncio_run(self._async_str)
+        return asyncio_run(self._async_str())
 
     async def _async_str(self) -> str:
         """Convert to string representation."""

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import pytest
+
+from llama_index.core.async_utils import asyncio_run
+
+
+def test_asyncio_run() -> None:
+    async def foo() -> int:
+        return 0
+
+    assert asyncio_run(foo()) == 0
+
+
+def test_asyncio_run_existing_event_loop() -> None:
+    async def foo(x: int) -> int:
+        return asyncio_run(foo(x - 1)) if x else 0
+
+    assert asyncio.run(foo(2)) == 0
+
+
+def test_asyncio_run_with_exception() -> None:
+    async def foo(x: int) -> int:
+        if x:
+            return asyncio_run(foo(x - 1))
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        assert asyncio_run(foo(0))
+
+    with pytest.raises(asyncio.CancelledError):
+        assert asyncio.run(foo(2))


### PR DESCRIPTION
Current implementation fails when an event loop is active due to the following error.

```
RuntimeError: asyncio.run() cannot be called from a running event loop
```