### PR TITLE
feat(openllm): 0.5 integrations update

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openllm/llama_index/llms/openllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openllm/llama_index/llms/openllm/base.py
@@ -37,7 +37,7 @@ from llama_index.core.llms.llm import LLM
 from llama_index.core.types import PydanticProgramMode
 from openllm_client import AsyncHTTPClient, HTTPClient
 
-import openllm
+import openllm, openllm_core as core
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,8 @@ if TYPE_CHECKING:
 
 
 class OpenLLM(LLM):
-    """OpenLLM LLM.
+    """
+    OpenLLM LLM.
 
     Examples:
         `pip install llama-index-llms-openllm`
@@ -73,19 +74,7 @@ class OpenLLM(LLM):
     model_id: str = Field(
         description="Given Model ID from HuggingFace Hub. This can be either a pretrained ID or local path. This is synonymous to HuggingFace's '.from_pretrained' first argument"
     )
-    model_version: Optional[str] = Field(
-        description="Optional model version to save the model as."
-    )
-    model_tag: Optional[str] = Field(
-        description="Optional tag to save to BentoML store."
-    )
-    prompt_template: Optional[str] = Field(
-        description="Optional prompt template to pass for this LLM."
-    )
-    backend: Optional[Literal["vllm", "pt"]] = Field(
-        description="Optional backend to pass for this LLM. By default, it will use vLLM if vLLM is available in local system. Otherwise, it will fallback to PyTorch."
-    )
-    quantize: Optional[Literal["awq", "gptq", "int8", "int4", "squeezellm"]] = Field(
+    quantize: Optional[Literal["awq", "gptq", "squeezellm"]] = Field(
         description="Optional quantization methods to use with this LLM. See OpenLLM's --quantize options from `openllm start` for more information."
     )
     serialization: Literal["safetensors", "legacy"] = Field(
@@ -94,7 +83,20 @@ class OpenLLM(LLM):
     trust_remote_code: bool = Field(
         description="Optional flag to trust remote code. This is synonymous to Transformers' `trust_remote_code`. Default to False."
     )
-    _llm: openllm.LLM[Any, Any] = PrivateAttr()
+    model_version: Optional[str] = Field(
+        description="(DEPRECATED) Optional model version to save the model as."
+    )
+    model_tag: Optional[str] = Field(
+        description="(DEPRECATED) Optional tag to save to BentoML store."
+    )
+    prompt_template: Optional[str] = Field(
+        description="(DEPRECATED) Optional prompt template to pass for this LLM."
+    )
+    backend: Optional[Literal["vllm", "pt"]] = Field(
+        description="(DEPRECATED) Optional backend to pass for this LLM. Default to use vLLM."
+    )
+    _llm: openllm.LLM = PrivateAttr()
+    _engine_args: Dict[str, Any] = PrivateAttr()
 
     def __init__(
         self,
@@ -103,8 +105,9 @@ class OpenLLM(LLM):
         model_tag: Optional[str] = None,
         prompt_template: Optional[str] = None,
         backend: Optional[Literal["vllm", "pt"]] = None,
+        dtype: str = "auto",
         *args: Any,
-        quantize: Optional[Literal["awq", "gptq", "int8", "int4", "squeezellm"]] = None,
+        quantize: Optional[Literal["awq", "gptq", "squeezellm"]] = None,
         serialization: Literal["safetensors", "legacy"] = "safetensors",
         trust_remote_code: bool = False,
         callback_manager: Optional[CallbackManager] = None,
@@ -114,33 +117,36 @@ class OpenLLM(LLM):
         pydantic_program_mode: PydanticProgramMode = PydanticProgramMode.DEFAULT,
         **attrs: Any,
     ):
-        self._llm = openllm.LLM[Any, Any](
+        if backend and backend != "vllm":
+            logger.warning(
+                "backend has been deprecated in OpenLLM 0.5 and above and will be default to vllm."
+            )
+        if model_version or model_tag or prompt_template:
+            logger.warning("This option is now deprecated and won't be used")
+        self._llm = openllm.LLM.from_model(
             model_id,
-            model_version=model_version,
-            model_tag=model_tag,
-            prompt_template=prompt_template,
-            system_message=system_prompt,
-            backend=backend,
-            quantize=quantize,
+            dtype=dtype,
+            llm_config=core.AutoConfig.from_id(
+                model_id, trust_remote_code=trust_remote_code
+            ),
+            quantise=quantize,
             serialisation=serialization,
             trust_remote_code=trust_remote_code,
-            embedded=True,
             **attrs,
         )
         if messages_to_prompt is None:
             messages_to_prompt = self._tokenizer_messages_to_prompt
 
-        # NOTE: We need to do this here to ensure model is saved and revision is set correctly.
-        assert self._llm.bentomodel
+        self._engine_args = self._llm.engine_args
 
         super().__init__(
             model_id=model_id,
-            model_version=self._llm.revision,
-            model_tag=str(self._llm.tag),
-            prompt_template=prompt_template,
-            backend=self._llm.__llm_backend__,
+            model_version="",
+            model_tag="",
+            backend="vllm",
+            prompt_template=None,
             quantize=self._llm.quantise,
-            serialization=self._llm._serialisation,
+            serialization=self._llm.serialisation,
             trust_remote_code=self._llm.trust_remote_code,
             callback_manager=callback_manager,
             system_prompt=system_prompt,
@@ -265,10 +271,11 @@ class OpenLLM(LLM):
         texts: List[List[str]] = [[]] * config["n"]
 
         async for response_chunk in self._llm.generate_iterator(prompt, **kwargs):
+            print(response_chunk)
             for output in response_chunk.outputs:
                 texts[output.index].append(output.text)
             yield CompletionResponse(
-                text=response_chunk.outputs[0].text,
+                text="".join(texts[0]),
                 delta=response_chunk.outputs[0].text,
                 raw=response_chunk.model_dump(),
                 additional_kwargs={

--- a/llama-index-integrations/llms/llama-index-llms-openllm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openllm/pyproject.toml
@@ -12,8 +12,8 @@ contains_example = false
 import_path = "llama_index.llms.openllm"
 
 [tool.llamahub.class_authors]
-OpenLLM = "llama-index"
-OpenLLMAPI = "llama-index"
+OpenLLM = "aarnphm"
+OpenLLMAPI = "aarnphm"
 
 [tool.mypy]
 disallow_untyped_defs = true
@@ -22,19 +22,19 @@ ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = ["Aaron Pham <aarnphm@bentoml.com>"]
 description = "llama-index llms openllm integration"
 exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openllm"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-openllm-client = "^0.4.41"
-openllm = "^0.4.41"
+openllm-client = "^0.5.3"
+openllm = "^0.5.3"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

I have updated the internal OpenLLM integrations to the new 0.5 releases.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Even though OpenLLM 0.5 is breaking, most of the API won't be breaking as I have updated accordingly.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
