### PR TITLE
Update GIF in Unify Demo

### DIFF
--- a/docs/docs/examples/llm/unify.ipynb
+++ b/docs/docs/examples/llm/unify.ipynb
@@ -158,7 +158,7 @@
     "\n",
     "The router is benchmarked on various different data-sets such as `Open Hermes`, `GSM8K`, `HellaSwag`, `MMLU` and `MT-Bench` revealing that it can peform better than indivudal endpoints on average as explained [here](https://unify.ai/docs/concepts/routing.html#quality-routing). One can choose various different configurations of the router for a particular data-set from the [chat-interface](https://unify.ai/chat) as shown below:\n",
     "\n",
-    "![Router Selection](unify.gif)"
+    "<img src = \"unify.gif\">"
    ]
   },
   {


### PR DESCRIPTION
Looks like the GIF isn't rendering in the docs properly (https://docs.llamaindex.ai/en/stable/examples/llm/unify/#quality-routing). Updated the code use the html `img src` tag which fixed the issue on our docs, hopefully it fixes the issue on your side too!