### PR TITLE
Fixed a bug causing an infinite loop in GoogleDriveReader.

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -230,6 +230,7 @@ class GoogleDriveReader(BasePydanticReader):
                     )
 
                 items = []
+                page_token = ""
                 # get files taking into account that the results are paginated
                 while True:
                     if drive_id:
@@ -242,6 +243,7 @@ class GoogleDriveReader(BasePydanticReader):
                                 includeItemsFromAllDrives=True,
                                 supportsAllDrives=True,
                                 fields="*",
+                                pageToken=page_token,
                             )
                             .execute()
                         )
@@ -253,6 +255,7 @@ class GoogleDriveReader(BasePydanticReader):
                                 includeItemsFromAllDrives=True,
                                 supportsAllDrives=True,
                                 fields="*",
+                                pageToken=page_token,
                             )
                             .execute()
                         )

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -45,7 +45,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

By not refreshing the pageToken, the implementation falls into an infinite loop when referencing a large amount of data.

cf. more info: https://developers.google.com/calendar/api/guides/pagination

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
