### PR TITLE
Handle cases where type is missing (neo4j property graph)

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -353,8 +353,10 @@ class Neo4jPGStore(PropertyGraphStore):
 
         nodes = []
         for record in response:
-            if "text" in record["properties"]:
-                text = record["properties"].pop("text")
+            # text indicates a chunk node
+            # none on the type indicates an implicit node, likely a chunk node
+            if "text" in record["properties"] or record["type"] is None:
+                text = record["properties"].pop("text", "")
                 nodes.append(
                     ChunkNode(
                         id_=record["name"],

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Some extractors can causes nodes to be created automatically, leading to some nodes without some attributes required by pydantic models.

This fix adds some extra checks for this, specifically for when the ImplicitPathExtractor finds a node with a missing label