### PR TITLE
Improve the retry mechanism of OpenAI

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -83,17 +83,17 @@ def llm_retry_decorator(f: Callable[[Any], Any]) -> Callable[[Any], Any]:
     @functools.wraps(f)
     def wrapper(self, *args: Any, **kwargs: Any) -> Any:
         max_retries = getattr(self, "max_retries", 0)
-        if max_retries > 0:
-            retry = create_retry_decorator(
-                max_retries=max_retries,
-                random_exponential=True,
-                stop_after_delay_seconds=60,
-                min_seconds=1,
-                max_seconds=20,
-            )
-            nonlocal f
-            f = retry(f)
-        return f(self, *args, **kwargs)
+        if max_retries <= 0:
+            return f(self, *args, **kwargs)
+
+        retry = create_retry_decorator(
+            max_retries=max_retries,
+            random_exponential=True,
+            stop_after_delay_seconds=60,
+            min_seconds=1,
+            max_seconds=20,
+        )
+        return retry(f)(self, *args, **kwargs)
 
     return wrapper
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -1,3 +1,4 @@
+import functools
 import json
 from typing import (
     TYPE_CHECKING,
@@ -77,13 +78,24 @@ if TYPE_CHECKING:
 
 DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo"
 
-llm_retry_decorator = create_retry_decorator(
-    max_retries=6,
-    random_exponential=True,
-    stop_after_delay_seconds=60,
-    min_seconds=1,
-    max_seconds=20,
-)
+
+def llm_retry_decorator(f: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    @functools.wraps(f)
+    def wrapper(self, *args: Any, **kwargs: Any) -> Any:
+        max_retries = getattr(self, "max_retries", 0)
+        if max_retries > 0:
+            retry = create_retry_decorator(
+                max_retries=max_retries,
+                random_exponential=True,
+                stop_after_delay_seconds=60,
+                min_seconds=1,
+                max_seconds=20,
+            )
+            nonlocal f
+            f = retry(f)
+        return f(self, *args, **kwargs)
+
+    return wrapper
 
 
 @runtime_checkable

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.1.21"
+version = "0.1.22"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Closes #13826.

Note that there is [an issue with tenacity](https://github.com/jd/tenacity/issues/459), which causes the retry count to be `max_retires-1`.