### PR TITLE
Fix: Incorrect naming of acreate_plan in StructuredPlannerAgent

### DIFF
--- a/llama-index-core/llama_index/core/agent/runner/planner.py
+++ b/llama-index-core/llama_index/core/agent/runner/planner.py
@@ -268,7 +268,7 @@ class StructuredPlannerAgent(BasePlanningAgentRunner):
 
         return plan_id
 
-    async def acreate_tasks(self, input: str, **kwargs: Any) -> str:
+    async def acreate_plan(self, input: str, **kwargs: Any) -> str:
         """Create plan (async). Returns the plan_id."""
         tools = self.get_tools(input)
         tools_str = ""


### PR DESCRIPTION
# Description

- The `acreate_tasks()` method of StructuredPlannerAgent is incorrectly named. It should be `acreate_plan()` instead to conform to `BasePlanningAgentRunner` super class.

Fixes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

