### PR TITLE
use default UUIDs when possible for pg vector stores

### DIFF
--- a/llama-index-core/llama_index/core/graph_stores/types.py
+++ b/llama-index-core/llama_index/core/graph_stores/types.py
@@ -17,6 +17,7 @@ DEFAULT_PERSIST_FNAME = "graph_store.json"
 DEFUALT_PG_PERSIST_FNAME = "property_graph_store.json"
 
 TRIPLET_SOURCE_KEY = "triplet_source_id"
+VECTOR_SOURCE_KEY = "vector_source_id"
 KG_NODES_KEY = "nodes"
 KG_RELATIONS_KEY = "relations"
 KG_SOURCE_REL = "SOURCE"

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
@@ -4,9 +4,13 @@ from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.indices.property_graph.sub_retrievers.base import (
     BasePGRetriever,
 )
-from llama_index.core.graph_stores.types import PropertyGraphStore, KG_SOURCE_REL
+from llama_index.core.graph_stores.types import (
+    PropertyGraphStore,
+    KG_SOURCE_REL,
+    VECTOR_SOURCE_KEY,
+)
 from llama_index.core.settings import Settings
-from llama_index.core.schema import NodeWithScore, QueryBundle
+from llama_index.core.schema import BaseNode, NodeWithScore, QueryBundle
 from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStore
 
 
@@ -59,6 +63,10 @@ class VectorContextRetriever(BasePGRetriever):
             **self._retriever_kwargs,
         )
 
+    def _get_kg_ids(self, kg_nodes: List[BaseNode]) -> List[str]:
+        """Backward compatibility method to get kg_ids from kg_nodes."""
+        return [node.metadata.get(VECTOR_SOURCE_KEY, node.id_) for node in kg_nodes]
+
     async def _aget_vector_store_query(
         self, query_bundle: QueryBundle
     ) -> VectorStoreQuery:
@@ -95,7 +103,7 @@ class VectorContextRetriever(BasePGRetriever):
         elif self._vector_store is not None:
             query_result = self._vector_store.query(vector_store_query)
             if query_result.nodes is not None and query_result.similarities is not None:
-                kg_ids = [node.node_id for node in query_result.nodes if node.node_id]
+                kg_ids = self._get_kg_ids(query_result.nodes)
                 scores = query_result.similarities
                 kg_nodes = self._graph_store.get(ids=kg_ids)
                 triplets = self._graph_store.get_rel_map(
@@ -148,7 +156,7 @@ class VectorContextRetriever(BasePGRetriever):
         elif self._vector_store is not None:
             query_result = await self._vector_store.aquery(vector_store_query)
             if query_result.nodes is not None and query_result.similarities is not None:
-                kg_ids = [node.node_id for node in query_result.nodes]
+                kg_ids = self._get_kg_ids(query_result.nodes)
                 scores = query_result.similarities
                 kg_nodes = await self._graph_store.aget(ids=kg_ids)
                 triplets = await self._graph_store.aget_rel_map(


### PR DESCRIPTION
The current approach of using vector stores with a property graph has some issues
- some dbs will complain about duplicate ids
- some dbs will complain about non-uuid ids

This fix addresses both, by keeping the node id as a unique UUID where possible.

If a vector store does not store text (like simple vector store), we keep the old approach.

This change should be non-breaking, and is backwards compatible 