### PR TITLE
Fix cur depth in simple property graph store

### DIFF
--- a/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
+++ b/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
@@ -121,7 +121,7 @@ class SimplePropertyGraphStore(PropertyGraphStore):
             )
             graph_triplets = [t for t in graph_triplets if str(t) not in seen_triplets]
             seen_triplets.update([str(t) for t in graph_triplets])
-            depth += 1
+            cur_depth += 1
 
         ignore_rels = ignore_rels or []
         triplets = [t for t in triplets if t[1].id not in ignore_rels]


### PR DESCRIPTION
# Description

The `get_rel_map` method in `SimplePropertyGraphStore` increased the `depth` variable instead of the `cur_depth` leading to a potentially huge amount of loop iterations (until the whole graph is exhausted) and triplet results beyond the chosen depth.
This PR fixes this issue.

I did not fill out the PR template since it is a one line fix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
