### PR TITLE
Jira personal access token with hosted instances

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-jira/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-jira/README.md
@@ -5,7 +5,7 @@ pip install llama-index-readers-jira
 ```
 
 The Jira loader returns a set of issues based on the query provided to the dataloader.
-We can follow two methods to initialize the loader-
+We can follow three methods to initialize the loader-
 1- basic_auth -> this takes a dict with the following keys
 `basic_auth:{
 "email": "email",
@@ -15,6 +15,11 @@ We can follow two methods to initialize the loader-
 2- Oauth2 -> this takes a dict with the following keys
 `oauth:{
 "cloud_id": "cloud_id",
+"api_token": "token"
+}`
+3- Personal access Token with Server hosted instance
+`PATauth:{
+"server_url": "server_url",
 "api_token": "token"
 }`
 

--- a/llama-index-integrations/readers/llama-index-readers-jira/llama_index/readers/jira/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-jira/llama_index/readers/jira/base.py
@@ -63,14 +63,12 @@ class JiraReader(BaseReader):
                 "headers": {"Authorization": f"Bearer {Oauth2['api_token']}"},
             }
             self.jira = JIRA(options=options)
-
-        if PATauth:
+        elif PATauth:
             options = {
                 "server": PATauth["server_url"],
                 "headers": {"Authorization": f"Bearer {PATauth['api_token']}"},
             }
             self.jira = JIRA(options=options)
-
         else:
             self.jira = JIRA(
                 basic_auth=(BasicAuth["email"], BasicAuth["api_token"]),

--- a/llama-index-integrations/readers/llama-index-readers-jira/llama_index/readers/jira/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-jira/llama_index/readers/jira/base.py
@@ -15,6 +15,11 @@ class Oauth2(TypedDict):
     api_token: str
 
 
+class PATauth(TypedDict):
+    server_url: str
+    api_token: str
+
+
 class JiraReader(BaseReader):
     """Jira reader. Reads data from Jira issues from passed query.
 
@@ -28,6 +33,10 @@ class JiraReader(BaseReader):
             "cloud_id": "cloud_id",
             "api_token": "token"
         }
+        Optional patauth:{
+            "server_url": "server_url",
+            "api_token": "token"
+        }
     """
 
     def __init__(
@@ -37,6 +46,7 @@ class JiraReader(BaseReader):
         server_url: Optional[str] = None,
         BasicAuth: Optional[BasicAuth] = None,
         Oauth2: Optional[Oauth2] = None,
+        PATauth: Optional[PATauth] = None,
     ) -> None:
         from jira import JIRA
 
@@ -53,6 +63,14 @@ class JiraReader(BaseReader):
                 "headers": {"Authorization": f"Bearer {Oauth2['api_token']}"},
             }
             self.jira = JIRA(options=options)
+
+        if PATauth:
+            options = {
+                "server": PATauth["server_url"],
+                "headers": {"Authorization": f"Bearer {PATauth['api_token']}"},
+            }
+            self.jira = JIRA(options=options)
+
         else:
             self.jira = JIRA(
                 basic_auth=(BasicAuth["email"], BasicAuth["api_token"]),

--- a/llama-index-integrations/readers/llama-index-readers-jira/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-jira/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["bearguy"]
 name = "llama-index-readers-jira"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This pull requests adds the functionality to use the Personal Acces Token for a specified server_url of a hosted Jira issue.
The two already available methods allow the user to read with BasicAuth and Oauth2, but there is also a third case that I experienced at company work. In this way specifying a dictionary with server_url and token_api it's possible to use the Jira API with this third model.
I provide a github issue answer to the related topic (from Jira API repo) https://github.com/pycontribs/jira/issues/989#issuecomment-772683446
Where it is explained how to access with Personal Access Token in this case

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (not needed)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (added explanation on Readme.md)
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
