### PR TITLE
avoid empty or duplicate inserts in property graph index

### DIFF
--- a/docs/docs/api_reference/storage/graph_stores/neo4j.md
+++ b/docs/docs/api_reference/storage/graph_stores/neo4j.md
@@ -2,4 +2,4 @@
     options:
       members:
         - Neo4jGraphStore
-        - Neo4jPGStore
+        - Neo4jPropertyGraphStore

--- a/docs/docs/examples/property_graph/graph_store.ipynb
+++ b/docs/docs/examples/property_graph/graph_store.ipynb
@@ -48,9 +48,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.graph_stores.neo4j import Neo4jPGStore\n",
+    "from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore\n",
     "\n",
-    "pg_store = Neo4jPGStore(\n",
+    "pg_store = Neo4jPropertyGraphStore(\n",
     "    username=\"neo4j\",\n",
     "    password=\"llamaindex\",\n",
     "    url=\"bolt://localhost:7687\",\n",

--- a/docs/docs/examples/property_graph/property_graph_advanced.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_advanced.ipynb
@@ -153,9 +153,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.graph_stores.neo4j import Neo4jPGStore\n",
+    "from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore\n",
     "\n",
-    "graph_store = Neo4jPGStore(\n",
+    "graph_store = Neo4jPropertyGraphStore(\n",
     "    username=\"neo4j\",\n",
     "    password=\"<password>\",\n",
     "    url=\"bolt://localhost:7687\",\n",

--- a/docs/docs/examples/property_graph/property_graph_basic.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_basic.ipynb
@@ -382,7 +382,7 @@
    "source": [
     "index = PropertyGraphIndex.from_existing(\n",
     "    SimplePropertyGraphStore.from_persist_dir(\"./storage\"),\n",
-    "    vector_store=ChromaVectorStore(collection=collection),\n",
+    "    vector_store=ChromaVectorStore(chroma_collection=collection),\n",
     "    llm=OpenAI(model=\"gpt-3.5-turbo\", temperature=0.3),\n",
     ")"
    ]

--- a/docs/docs/examples/property_graph/property_graph_custom_retriever.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_custom_retriever.ipynb
@@ -163,9 +163,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.graph_stores.neo4j import Neo4jPGStore\n",
+    "from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore\n",
     "\n",
-    "graph_store = Neo4jPGStore(\n",
+    "graph_store = Neo4jPropertyGraphStore(\n",
     "    username=\"neo4j\",\n",
     "    password=\"llamaindex\",\n",
     "    url=\"bolt://localhost:7687\",\n",

--- a/docs/docs/examples/property_graph/property_graph_neo4j.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_neo4j.ipynb
@@ -99,7 +99,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/loganmarkewich/Library/Caches/pypoetry/virtualenvs/llama-index-caVs7DDe-py3.11/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "from llama_index.core import SimpleDirectoryReader\n",
     "\n",
@@ -119,11 +128,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.graph_stores.neo4j import Neo4jPGStore\n",
+    "from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore\n",
     "\n",
-    "graph_store = Neo4jPGStore(\n",
+    "# Note: used to be `Neo4jPGStore`\n",
+    "graph_store = Neo4jPropertyGraphStore(\n",
     "    username=\"neo4j\",\n",
-    "    password=\"<password>\",\n",
+    "    password=\"llamaindex\",\n",
     "    url=\"bolt://localhost:7687\",\n",
     ")"
    ]
@@ -137,13 +147,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/loganmarkewich/Library/Caches/pypoetry/virtualenvs/llama-index-bXUwlEfH-py3.11/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "Parsing nodes: 100%|██████████| 1/1 [00:00<00:00, 26.07it/s]\n",
-      "Extracting paths from text: 100%|██████████| 22/22 [00:10<00:00,  2.10it/s]\n",
-      "Extracting implicit paths: 100%|██████████| 22/22 [00:00<00:00, 31418.01it/s]\n",
-      "Generating embeddings: 100%|██████████| 1/1 [00:00<00:00,  1.22it/s]\n",
-      "Generating embeddings: 100%|██████████| 5/5 [00:00<00:00,  7.05it/s]\n"
+      "Parsing nodes: 100%|██████████| 1/1 [00:00<00:00, 21.63it/s]\n",
+      "Extracting paths from text with schema: 100%|██████████| 22/22 [01:06<00:00,  3.02s/it]\n",
+      "Generating embeddings: 100%|██████████| 1/1 [00:00<00:00,  1.06it/s]\n",
+      "Generating embeddings: 100%|██████████| 1/1 [00:00<00:00,  1.89it/s]\n"
      ]
     }
    ],
@@ -151,11 +158,16 @@
     "from llama_index.core import PropertyGraphIndex\n",
     "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core.indices.property_graph import SchemaLLMPathExtractor\n",
     "\n",
     "index = PropertyGraphIndex.from_documents(\n",
     "    documents,\n",
-    "    llm=OpenAI(model=\"gpt-3.5-turbo\", temperature=0.3),\n",
     "    embed_model=OpenAIEmbedding(model_name=\"text-embedding-3-small\"),\n",
+    "    kg_extractors=[\n",
+    "        SchemaLLMPathExtractor(\n",
+    "            llm=OpenAI(model=\"gpt-3.5-turbo\", temperature=0.0)\n",
+    "        )\n",
+    "    ],\n",
     "    property_graph_store=graph_store,\n",
     "    show_progress=True,\n",
     ")"
@@ -256,12 +268,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.graph_stores.neo4j import Neo4jPGStore\n",
+    "from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore\n",
     "from llama_index.core import PropertyGraphIndex\n",
     "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "from llama_index.llms.openai import OpenAI\n",
     "\n",
-    "graph_store = Neo4jPGStore(\n",
+    "graph_store = Neo4jPropertyGraphStore(\n",
     "    username=\"neo4j\",\n",
     "    password=\"794613852\",\n",
     "    url=\"bolt://localhost:7687\",\n",

--- a/docs/docs/module_guides/indexing/lpg_index_guide.md
+++ b/docs/docs/module_guides/indexing/lpg_index_guide.md
@@ -393,7 +393,7 @@ This example shows how you might save/load a property graph index using Neo4j an
 ```python
 from llama_index.core import StorageContext, load_index_from_storage
 from llama_index.core.indices import PropertyGraphIndex
-from llama_index.graph_stores.neo4j import Neo4jPGStore
+from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore
 from llama_index.vector_stores.qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient, AsyncQdrantClient
 
@@ -403,7 +403,7 @@ vector_store = QdrantVectorStore(
     aclient=AsyncQdrantClient(...),
 )
 
-graph_store = Neo4jPGStore(
+graph_store = Neo4jPropertyGraphStore(
     username="neo4j",
     password="<password>",
     url="bolt://localhost:7687",
@@ -606,6 +606,7 @@ Below, you can find some example notebooks showcasing the `PropertyGraphIndex`
 
 - [Basic Usage](../../examples/property_graph/property_graph_basic.ipynb)
 - [Using Neo4j](../../examples/property_graph/property_graph_neo4j.ipynb)
+- [Using Nebula](../../examples/property_graph/property_graph_nebula.ipynb)
 - [Advanced Usage with Neo4j and local models](../../examples/property_graph/property_graph_advanced.ipynb)
 - [Using a Property Graph Store](../../examples/property_graph/graph_store.ipynb)
 - [Creating a Custom Graph Retriever](../../examples/property_graph/property_graph_custom_retriever.ipynb)

--- a/llama-index-core/llama_index/core/indices/property_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/base.py
@@ -190,6 +190,9 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
 
     def _insert_nodes(self, nodes: Sequence[BaseNode]) -> Sequence[BaseNode]:
         """Insert nodes to the index struct."""
+        if len(nodes) == 0:
+            return nodes
+
         # run transformations on nodes to extract triplets
         if self._use_async:
             nodes = asyncio.run(
@@ -225,6 +228,21 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
             # add nodes and relations to insert lists
             kg_nodes_to_insert.extend(kg_nodes)
             kg_rels_to_insert.extend(kg_rels)
+
+        # filter out duplicate kg nodes
+        kg_node_ids = {node.id for node in kg_nodes_to_insert}
+        existing_kg_nodes = self.property_graph_store.get(ids=list(kg_node_ids))
+        existing_kg_node_ids = {node.id for node in existing_kg_nodes}
+        kg_nodes_to_insert = [
+            node for node in kg_nodes_to_insert if node.id not in existing_kg_node_ids
+        ]
+
+        # filter out duplicate llama nodes
+        existing_nodes = self.property_graph_store.get_llama_nodes(
+            [node.id_ for node in nodes]
+        )
+        existing_node_ids = {node.id_ for node in existing_nodes}
+        nodes = [node for node in nodes if node.id_ not in existing_node_ids]
 
         # embed nodes (if needed)
         if self._embed_kg_nodes:
@@ -266,14 +284,18 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
                 kg_node.embedding = embedding
 
         # if graph store doesn't support vectors, or the vector index was provided, use it
-        if self.vector_store is not None:
+        if self.vector_store is not None and len(kg_nodes_to_insert) > 0:
             self._insert_nodes_to_vector_index(kg_nodes_to_insert)
 
-        self.property_graph_store.upsert_llama_nodes(nodes)
-        self.property_graph_store.upsert_nodes(kg_nodes_to_insert)
+        if len(nodes) > 0:
+            self.property_graph_store.upsert_llama_nodes(nodes)
+
+        if len(kg_nodes_to_insert) > 0:
+            self.property_graph_store.upsert_nodes(kg_nodes_to_insert)
 
         # important: upsert relations after nodes
-        self.property_graph_store.upsert_relations(kg_rels_to_insert)
+        if len(kg_rels_to_insert) > 0:
+            self.property_graph_store.upsert_relations(kg_rels_to_insert)
 
         # refresh schema if needed
         if self.property_graph_store.supports_structured_queries:

--- a/llama-index-core/llama_index/core/indices/property_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/base.py
@@ -241,8 +241,8 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
         existing_nodes = self.property_graph_store.get_llama_nodes(
             [node.id_ for node in nodes]
         )
-        existing_node_ids = {node.id_ for node in existing_nodes}
-        nodes = [node for node in nodes if node.id_ not in existing_node_ids]
+        existing_node_hashes = {node.hash for node in existing_nodes}
+        nodes = [node for node in nodes if node.hash not in existing_node_hashes]
 
         # embed nodes (if needed)
         if self._embed_kg_nodes:

--- a/llama-index-core/tests/indices/property_graph/BUILD
+++ b/llama-index-core/tests/indices/property_graph/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/llama-index-core/tests/indices/property_graph/test_property_graph.py
+++ b/llama-index-core/tests/indices/property_graph/test_property_graph.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock
+from typing import Any, List
+
+from llama_index.core import PropertyGraphIndex, Document, MockEmbedding
+from llama_index.core.graph_stores.simple_labelled import SimplePropertyGraphStore
+from llama_index.core.graph_stores.types import (
+    EntityNode,
+    Relation,
+    KG_NODES_KEY,
+    KG_RELATIONS_KEY,
+)
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.schema import BaseNode, TextNode, TransformComponent
+from llama_index.core.vector_stores.simple import SimpleVectorStore
+
+
+class MockKGExtractor(TransformComponent):
+    """A mock knowledge graph extractor that extracts a simple relation from a text."""
+
+    def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        entity1 = EntityNode(name="Logan", label="PERSON")
+        entity2 = EntityNode(name="Canada", label="LOCATION")
+        relation = Relation(label="BORN_IN", source_id=entity1.id, target_id=entity2.id)
+
+        return [
+            TextNode(
+                id_="test",
+                text="Logan was born in Canada",
+                metadata={
+                    KG_NODES_KEY: [entity1, entity2],
+                    KG_RELATIONS_KEY: [relation],
+                },
+            ),
+        ]
+
+
+def test_construction() -> None:
+    graph_store = SimplePropertyGraphStore()
+    vector_store = SimpleVectorStore()
+    kg_extractor = MockKGExtractor()
+
+    # test construction
+    index = PropertyGraphIndex.from_documents(
+        [Document.example()],
+        property_graph_store=graph_store,
+        vector_store=vector_store,
+        llm=MockLLM(),
+        embed_model=MockEmbedding(embed_dim=256),
+        kg_extractors=[kg_extractor],
+    )
+
+    embeddings = vector_store.get("Logan")
+    assert len(embeddings) == 256
+
+    embeddings = vector_store.get("Canada")
+    assert len(embeddings) == 256
+
+    kg_nodes = graph_store.get(ids=["Logan", "Canada"])
+    assert kg_nodes is not None
+    assert len(kg_nodes) == 2
+    assert kg_nodes[0].embedding is None
+    assert kg_nodes[0].embedding is None
+
+    # test inserting a duplicate node (should not insert)
+    index._insert_nodes_to_vector_index = MagicMock()
+    index.insert_nodes(kg_extractor([]))
+
+    assert index._insert_nodes_to_vector_index.call_count == 0

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/__init__.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/__init__.py
@@ -1,4 +1,7 @@
 from llama_index.graph_stores.neo4j.base import Neo4jGraphStore
-from llama_index.graph_stores.neo4j.neo4j_property_graph import Neo4jPGStore
+from llama_index.graph_stores.neo4j.neo4j_property_graph import (
+    Neo4jPGStore,
+    Neo4jPropertyGraphStore,
+)
 
-__all__ = ["Neo4jGraphStore", "Neo4jPGStore"]
+__all__ = ["Neo4jGraphStore", "Neo4jPGStore", "Neo4jPropertyGraphStore"]

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -70,7 +70,7 @@ RETURN {start: label, type: property, end: toString(other_node)} AS output
 """
 
 
-class Neo4jPGStore(PropertyGraphStore):
+class Neo4jPropertyGraphStore(PropertyGraphStore):
     r"""
     Neo4j Property Graph Store.
 
@@ -102,10 +102,10 @@ class Neo4jPGStore(PropertyGraphStore):
 
         ```python
         from llama_index.core.indices.property_graph import PropertyGraphIndex
-        from llama_index.graph_stores.neo4j import Neo4jLPGStore
+        from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore
 
-        # Create a Neo4jLPGStore instance
-        graph_store = Neo4jLPGStore(
+        # Create a Neo4jPropertyGraphStore instance
+        graph_store = Neo4jPropertyGraphStore(
             username="neo4j",
             password="neo4j",
             url="bolt://localhost:7687",
@@ -865,3 +865,6 @@ class Neo4jPGStore(PropertyGraphStore):
                 "\n".join(formatted_rels),
             ]
         )
+
+
+Neo4jPGStore = Neo4jPropertyGraphStore

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -13,7 +13,7 @@ import_path = "llama_index.graph_stores.neo4j"
 
 [tool.llamahub.class_authors]
 Neo4jGraphStore = "llama-index"
-Neo4jPGStore = "llama-index"
+Neo4jPropertyGraphStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/tests/test_pg_stores_neo4j.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/tests/test_pg_stores_neo4j.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from llama_index.graph_stores.neo4j import Neo4jPGStore
+from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore
 from llama_index.core.graph_stores.types import Relation, EntityNode
 from llama_index.core.schema import TextNode
 
@@ -16,15 +16,17 @@ else:
 
 
 @pytest.fixture()
-def pg_store() -> Neo4jPGStore:
+def pg_store() -> Neo4jPropertyGraphStore:
     if not neo4j_available:
         pytest.skip("No Neo4j credentials provided")
-    pg_store = Neo4jPGStore(username=neo4j_user, password=neo4j_password, url=neo4j_url)
+    pg_store = Neo4jPropertyGraphStore(
+        username=neo4j_user, password=neo4j_password, url=neo4j_url
+    )
     pg_store.structured_query("MATCH (n) DETACH DELETE n")
     return pg_store
 
 
-def test_neo4j_pg_store(pg_store: Neo4jPGStore) -> None:
+def test_neo4j_pg_store(pg_store: Neo4jPropertyGraphStore) -> None:
     # Create a two entity nodes
     entity1 = EntityNode(label="PERSON", name="Logan", properties={"age": 28})
     entity2 = EntityNode(label="ORGANIZATION", name="LlamaIndex")


### PR DESCRIPTION
The property graph would too easily allow for 
- empty inserts (causing issues!)
- duplicate inserts

This PR aims to avoid this

Fixes https://github.com/run-llama/llama_index/issues/13900

Fixes https://github.com/run-llama/llama_index/issues/13889