### PR TITLE
LanceDB: removed mode from the add statement since mode should be append

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/llama_index/vector_stores/lancedb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/llama_index/vector_stores/lancedb/base.py
@@ -348,7 +348,7 @@ class LanceDBVectorStore(BasePydanticVectorStore):
                     self._table_name, data, mode=self.mode
                 )
 
-            self._table.add(data, mode=self.mode)
+            self._table.add(data)
             self._fts_index = None  # reset fts index
 
         return ids

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/llama_index/vector_stores/lancedb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/llama_index/vector_stores/lancedb/base.py
@@ -348,7 +348,7 @@ class LanceDBVectorStore(BasePydanticVectorStore):
                     self._table_name, data, mode=self.mode
                 )
 
-            self._table.add(data)
+            self._table.add(data, **add_kwargs)
             self._fts_index = None  # reset fts index
 
         return ids


### PR DESCRIPTION
Really small update to remove the `mode` option from the lancedb `add` statement since it was sharing the mode option with `create_table`, and I think the wrapper was intending it mainly for create_table.  Two issues with sharing the mode with `add`:

1. The options for mode are different for `add` than they are for `create_table`: for add, the valid values are "append" and "overwrite" whereas for `create_table` they are "create" and "overwrite". 

2. There is an unintended behavior when the value "overwrite" is specified for mode and is shared by the two methods: it will always overwrite the table thereby not allow you to build up the vector database with new embeddings.  

Removing the `mode` from `add` reverts the value to it's default which is "append", which should be what most situations will warrant.  Alternatively, there could be a separate parameter to control the mode for add, but it really doesn't seem necessary.