### PR TITLE
Add backwards compatibility to `Dispatcher.get_dispatch_event()` method

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -2,6 +2,7 @@ from contextvars import Token
 from typing import Any, List, Optional, Dict, Protocol
 import inspect
 import uuid
+from deprecated import deprecated
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.instrumentation.event_handlers import BaseEventHandler
 from llama_index.core.instrumentation.span import active_span_id
@@ -108,6 +109,14 @@ class Dispatcher(BaseModel):
             else:
                 c = c.parent
 
+    @deprecated(
+        version="0.10.41",
+        reason=(
+            "`get_dispatch_event()` has been deprecated in favor of using `event()` directly."
+            " If running into this warning through an integration package, then please "
+            "update your integration to the latest version."
+        ),
+    )
     def get_dispatch_event(self) -> EventDispatcher:
         """Keep for backwards compatibility.
 

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -1,5 +1,5 @@
 from contextvars import Token
-from typing import Any, List, Optional, Dict
+from typing import Any, List, Optional, Dict, Protocol
 import inspect
 import uuid
 from llama_index.core.bridge.pydantic import BaseModel, Field
@@ -12,6 +12,12 @@ from llama_index.core.instrumentation.span_handlers import (
 from llama_index.core.instrumentation.events.base import BaseEvent
 from llama_index.core.instrumentation.events.span import SpanDropEvent
 import wrapt
+
+
+# Keep for backwards compatibility
+class EventDispatcher(Protocol):
+    def __call__(self, event: BaseEvent, **kwargs) -> None:
+        ...
 
 
 class Dispatcher(BaseModel):
@@ -101,6 +107,16 @@ class Dispatcher(BaseModel):
                 c = None
             else:
                 c = c.parent
+
+    def get_dispatch_event(self) -> EventDispatcher:
+        """Keep for backwards compatibility.
+
+        In llama-index-core v0.10.41, we removed this method and made changes to
+        integrations or packs that relied on this method. Adding back this method
+        in case any integrations or apps have not been upgraded. That is, they
+        still rely on this method.
+        """
+        return self.event
 
     def span_enter(
         self,


### PR DESCRIPTION
# Description

The `Dispatcher.get_dispatch_event()` method was removed in #13700. In that same PR, we did a string search and replace of all extension packages that used this method and replaced it with the appropriate code. However, I didn't account for the case where users may still be using an older version of the extension package.

- This PR adds the method `get_dispatch_event` method back for backwards compatibility
- I've marked the method as deprecated so that new packages know not to use it. I also included a message to folks running into this error thru an extension package, that they should upgrade to the latest version of the extension (which shouldn't rely on `get_dispatch_event`).

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
