### PR TITLE
fix: ipex-llms broken CD build

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
@@ -33,7 +33,7 @@ readme = "README.md"
 version = "0.1.6"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.41"
 ipex-llm = {allow-prereleases = true, extras = ["llama-index"], version = ">=2.1.0b20240529"}
 torch = {optional = true, source = "ipex-xpu-src-us", version = "2.1.0a0"}

--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
@@ -33,7 +33,7 @@ readme = "README.md"
 version = "0.1.6"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<3.12"
 llama-index-core = "^0.10.41"
 ipex-llm = {allow-prereleases = true, extras = ["llama-index"], version = ">=2.1.0b20240529"}
 torch = {optional = true, source = "ipex-xpu-src-us", version = "2.1.0a0"}


### PR DESCRIPTION
# Description

- Failed to publish `llama-index-llms-ipex-llm`
- In the error logs (https://github.com/run-llama/llama_index/actions/runs/9339235565/job/25703360084#step:6:764), it suggested revising the python dependency
