### PR TITLE
[bandaid] disable instrumentation from logging genrators

### DIFF
--- a/docs/docs/examples/instrumentation/instrumentation_observability_rundown.ipynb
+++ b/docs/docs/examples/instrumentation/instrumentation_observability_rundown.ipynb
@@ -220,8 +220,6 @@
     "            print(event.query)\n",
     "        if isinstance(event, GetResponseStartEvent):\n",
     "            print(event.query_str)\n",
-    "        if isinstance(event, GetResponseEndEvent):\n",
-    "            print(event.response)\n",
     "\n",
     "        self.events.append(event)\n",
     "        print(\"-----------------------\")\n",

--- a/llama-index-core/llama_index/core/instrumentation/events/synthesis.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/synthesis.py
@@ -3,7 +3,6 @@ from typing import List
 from llama_index.core.instrumentation.events.base import BaseEvent
 from llama_index.core.base.response.schema import RESPONSE_TYPE
 from llama_index.core.schema import QueryType
-from llama_index.core.types import RESPONSE_TEXT_TYPE
 
 
 class SynthesizeStartEvent(BaseEvent):
@@ -56,14 +55,10 @@ class GetResponseStartEvent(BaseEvent):
 
 
 class GetResponseEndEvent(BaseEvent):
-    """GetResponseEndEvent.
+    """GetResponseEndEvent."""
 
-    Args:
-        query (str): Query string.
-        response (RESPONSE_TEXT_TYPE): Response.
-    """
-
-    response: RESPONSE_TEXT_TYPE
+    # TODO: consumes the first chunk of generators??
+    # response: RESPONSE_TEXT_TYPE
 
     @classmethod
     def class_name(cls):

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -196,7 +196,7 @@ class Refine(BaseSynthesizer):
                 response = response or "Empty Response"
         else:
             response = cast(Generator, response)
-        dispatcher.event(GetResponseEndEvent(response=response))
+        dispatcher.event(GetResponseEndEvent())
         return response
 
     def _default_program_factory(self, prompt: PromptTemplate) -> BasePydanticProgram:
@@ -377,7 +377,7 @@ class Refine(BaseSynthesizer):
                 response = response or "Empty Response"
         else:
             response = cast(AsyncGenerator, response)
-        dispatcher.event(GetResponseEndEvent(response=response))
+        dispatcher.event(GetResponseEndEvent())
         return response
 
     async def _arefine_response_single(


### PR DESCRIPTION
Pydantic seems to be stripping out the first item in generators.

I tried a custom validator and root validator, both didn't help.

Disabling logging of this for now.

Fixes https://github.com/run-llama/llama_index/issues/13873