### PR TITLE
Better handling of Vectara API exceptions

### DIFF
--- a/llama-index-packs/llama-index-packs-vectara-rag/README.md
+++ b/llama-index-packs/llama-index-packs-vectara-rag/README.md
@@ -56,7 +56,8 @@ Additional optional arguments to VectaraRAG:
 - `similarity_top_k`: determines the number of results to return. Defaults to 5.
 - `n_sentences_before` and `n_sentences_after`: determine the number of sentences before/after the
   matching fact to use with the summarization LLM. defaults to 2.
-- `reranker`: 'none' or 'mmr' or 'slingshot' (slingshot is Scale only)
+- `reranker`: 'none' or 'mmr' or 'multilingual_reranker_v1' (multilingual_reranker_v1 is Scale only)
+  The reranker name 'slingshot' is the same as 'multilingual_reranker_v1' (backwards compatible)
 - `summary_enabled`: whether to generate summaries or not. Defaults to True.
 - When summary_enabled is True, you can set the following:
   - `summary_response_lang`: language to use (ISO 639-2 code) for summary generation. defaults to "eng".


### PR DESCRIPTION
# Description

Added a check for additional errors returned by Vectara API as a statusDetail and handled them properly
We name our new reranker multilingual_reranker_v1 so adding that as an additional valid name to provide (equivalent to "slingshot"). Added this in docs as well.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [X] Tested this with local code that created the issue

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I ran `make format; make lint` to appease the lint gods
