### PR TITLE
feat: add exception events for streaming errors

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/events/exception.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/exception.py
@@ -1,0 +1,16 @@
+from llama_index.core.instrumentation.events import BaseEvent
+
+
+class ExceptionEvent(BaseEvent):
+    """ExceptionEvent.
+
+    Args:
+        exception (BaseException): exception.
+    """
+
+    exception: BaseException
+
+    @classmethod
+    def class_name(cls):
+        """Class name."""
+        return "ExceptionEvent"


### PR DESCRIPTION
When streaming encounters an error, there may not be a parent span to drop. Below is an example.

Note that before fetching the first token, the original span has already ended (returning a generator object).

```python
from llama_index.core.base.llms.types import ChatMessage
from llama_index.llms.openai import OpenAI

if __name__ == "__main__":
    response_gen = OpenAI(model="gpt-3.5-turbo").stream_chat([ChatMessage(content="hello")])
    for response in response_gen:
        print(response, end="")
```