### PR TITLE
+ DuckDBRetriever

### DIFF
--- a/docs/docs/api_reference/retrievers/duckdb_retriever.md
+++ b/docs/docs/api_reference/retrievers/duckdb_retriever.md
@@ -1,0 +1,4 @@
+::: llama_index.retrievers.duckdb_retriever
+    options:
+      members:
+        - DuckDBRetriever

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1238,6 +1238,7 @@ nav:
           - ./api_reference/retrievers/auto_merging.md
           - ./api_reference/retrievers/bedrock.md
           - ./api_reference/retrievers/bm25.md
+          - ./api_reference/retrievers/duckdb_retriever.md
           - ./api_reference/retrievers/index.md
           - ./api_reference/retrievers/keyword.md
           - ./api_reference/retrievers/knowledge_graph.md
@@ -1957,6 +1958,7 @@ plugins:
             - ../llama-index-integrations/readers/llama-index-readers-dashscope
             - ../llama-index-integrations/llms/llama-index-llms-oci-genai
             - ../llama-index-integrations/readers/llama-index-readers-azure-devops
+            - ../llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever
   - redirects:
       redirect_maps:
         ./api/llama_index.vector_stores.MongoDBAtlasVectorSearch.html: api_reference/storage/vector_store/mongodb.md

--- a/llama-index-cli/llama_index/cli/upgrade/mappings.json
+++ b/llama-index-cli/llama_index/cli/upgrade/mappings.json
@@ -431,6 +431,7 @@
   "PathwayRetriever": "llama_index.retrievers.pathway",
   "AmazonKnowledgeBasesRetriever": "llama_index.retrievers.bedrock",
   "MongoDBAtlasBM25Retriever": "llama_index.retrievers.mongodb_atlas_bm25_retriever",
+  "DuckDBRetriever": "llama_index.retrievers.duckdb_retriever",
   "VideoDBRetriever": "llama_index.retrievers.videodb",
   "YouRetriever": "llama_index.retrievers.you",
   "ZillizCloudPipelineIndex": "llama_index.indices.managed.zilliz",

--- a/llama-index-core/llama_index/core/command_line/mappings.json
+++ b/llama-index-core/llama_index/core/command_line/mappings.json
@@ -431,6 +431,7 @@
   "PathwayRetriever": "llama_index.retrievers.pathway",
   "AmazonKnowledgeBasesRetriever": "llama_index.retrievers.bedrock",
   "MongoDBAtlasBM25Retriever": "llama_index.retrievers.mongodb_atlas_bm25_retriever",
+  "DuckDBRetriever": "llama_index.retrievers.duckdb_retriever",
   "VideoDBRetriever": "llama_index.retrievers.videodb",
   "YouRetriever": "llama_index.retrievers.you",
   "ZillizCloudPipelineIndex": "llama_index.indices.managed.zilliz",

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/.gitignore
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/BUILD
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/BUILD
@@ -1,0 +1,3 @@
+poetry_requirements(
+    name="poetry",
+)

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/Makefile
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/README.md
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/README.md
@@ -1,0 +1,23 @@
+# LlamaIndex Retrievers Integration: DuckDBRetriever
+
+## What is this?
+
+This is a BM25 Retriever for DuckDB that can be used with LlamaIndex.
+
+## How to use
+
+This was created with reference to [DuckDB Full-Text Search Extension](https://duckdb.org/docs/extensions/full_text_search), so it's mostly the same.
+
+Please refer to that.
+
+However, while `DuckDBVectorStore` is an VectorStore, `DuckDBRetriever` is a Retriever.
+
+DuckDBRetriever Example:
+
+```python
+vector_store = DuckDBVectorStore(embed_dim=embed_dim,database_name="vector.db",persist_dir="duckdb")
+
+
+retriever = DuckDBRetriever(vector_store=vector_store)
+nodes = retriever.retrieve("retrieve_query")
+```

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/README.md
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/README.md
@@ -1,8 +1,10 @@
 # LlamaIndex Retrievers Integration: DuckDBRetriever
 
+`pip install llama-index-retrievers-duckdb-retriever.`
+
 ## What is this?
 
-This is a BM25 Retriever for DuckDB that can be used with LlamaIndex.
+This is a BM25 Retriever for DuckDB that can be used with LlamaIndex to enable full-text search.
 
 ## How to use
 
@@ -15,6 +17,8 @@ However, while `DuckDBVectorStore` is an VectorStore, `DuckDBRetriever` is a Ret
 DuckDBRetriever Example:
 
 ```python
-retriever = DuckDBRetriever(database_name="vector.db",persist_dir="duckdb")
+from llama_index.retrievers.duckdb_retriever import DuckDBRetriever
+
+retriever = DuckDBRetriever(database_name="vector.db", persist_dir="duckdb")
 nodes = retriever.retrieve("retrieve_query")
 ```

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/README.md
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/README.md
@@ -15,9 +15,6 @@ However, while `DuckDBVectorStore` is an VectorStore, `DuckDBRetriever` is a Ret
 DuckDBRetriever Example:
 
 ```python
-vector_store = DuckDBVectorStore(embed_dim=embed_dim,database_name="vector.db",persist_dir="duckdb")
-
-
-retriever = DuckDBRetriever(vector_store=vector_store)
+retriever = DuckDBRetriever(database_name="vector.db",persist_dir="duckdb")
 nodes = retriever.retrieve("retrieve_query")
 ```

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/BUILD
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/__init__.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/__init__.py
@@ -1,0 +1,5 @@
+from llama_index.retrievers.duckdb_retriever.base import (
+    DuckDBRetriever,
+)
+
+__all__ = ["DuckDBRetriever"]

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/base.py
@@ -1,0 +1,80 @@
+import logging
+from typing import List, Optional
+
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.callbacks.base import CallbackManager
+from llama_index.core.constants import DEFAULT_SIMILARITY_TOP_K
+from llama_index.core.schema import TextNode, NodeWithScore, QueryBundle
+
+from llama_index.vector_stores.duckdb import DuckDBVectorStore
+from llama_index.vector_stores.duckdb.base import DuckDBLocalContext
+
+logger = logging.getLogger(__name__)
+
+class DuckDBRetriever(BaseRetriever):
+    def __init__(
+        self,
+        vector_store: DuckDBVectorStore,
+        text_search_config: Optional[dict] = {
+            "stemmer": "english",
+            "stopwords": "english",
+            "ignore": r"(\\.|[^a-z])+",
+            "strip_accents": True,
+            "lower": True,
+            "overwrite": True,
+        },
+        # TODO: Add more options for FTS index creation
+
+        similarity_top_k: int = DEFAULT_SIMILARITY_TOP_K,
+        callback_manager: Optional[CallbackManager] = None,
+        verbose: bool = False,
+    ) -> None:
+        self._vector_store = vector_store
+        self._similarity_top_k = similarity_top_k
+        self._callback_manager = callback_manager
+        self._verbose = verbose
+        
+        # TODO: Check if the vector store already has data
+
+        # Create an FTS index on the 'text' column if it doesn't already exist
+        if self._vector_store.database_name==':memory:':
+            self._db_path = ':memory:'
+        else:
+            self._db_path= self._vector_store._database_path
+
+        strip_accents =1 if text_search_config["strip_accents"] else 0
+        lower = 1 if text_search_config["lower"] else 0
+        overwrite = 1 if text_search_config["overwrite"] else 0
+        ignore = text_search_config["ignore"]
+        
+        sql = f"""
+            PRAGMA create_fts_index({vector_store.table_name}, node_id, text, 
+                            stemmer = '{text_search_config["stemmer"]}',
+                            stopwords = '{text_search_config["stopwords"]}', ignore = '{ignore}',
+                            strip_accents = {strip_accents}, lower = {lower}, overwrite = {overwrite})      
+                        """
+        with DuckDBLocalContext(self._db_path) as conn:
+            conn.execute(sql)
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        if self._verbose:
+            logger.info(f"Searching for: {query_bundle.query_str}")
+        query = query_bundle.query_str
+        sql =f"""
+                SELECT
+                    fts_main_{self._vector_store.table_name}.match_bm25(node_id, '{query}') AS score,
+                    node_id, text
+                FROM {self._vector_store.table_name}
+                WHERE score IS NOT NULL
+                ORDER BY score DESC
+                LIMIT {self._similarity_top_k};
+            """
+        with DuckDBLocalContext(self._db_path) as conn:
+            query_result = conn.execute(sql).fetchall()
+        # Convert query result to NodeWithScore objects
+        retrieve_nodes = []
+        for row in query_result:
+            score,node_id, text = row
+            node = TextNode(id=node_id, text=text)
+            retrieve_nodes.append(NodeWithScore(node=node, score=float(score)))
+
+        return retrieve_nodes

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/llama_index/retrievers/duckdb_retriever/base.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import List, Optional
 
 from llama_index.core.base.base_retriever import BaseRetriever
@@ -6,15 +7,49 @@ from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.constants import DEFAULT_SIMILARITY_TOP_K
 from llama_index.core.schema import TextNode, NodeWithScore, QueryBundle
 
-from llama_index.vector_stores.duckdb import DuckDBVectorStore
-from llama_index.vector_stores.duckdb.base import DuckDBLocalContext
-
 logger = logging.getLogger(__name__)
+import_err_msg = "`duckdb` package not found, please run `pip install duckdb`"
 
+
+class DuckDBLocalContext:
+    def __init__(self, database_path: str):
+        self.database_path = database_path
+        self._conn = None
+        self._home_dir = os.path.expanduser("~")
+
+    def __enter__(self) -> "duckdb.DuckDBPyConnection":
+        try:
+            import duckdb
+        except ImportError:
+            raise ImportError(import_err_msg)
+
+        if not os.path.exists(os.path.dirname(self.database_path)):
+            raise ValueError(
+                f"Directory {os.path.dirname(self.database_path)} does not exist."
+            )
+
+        # if not os.path.isfile(self.database_path):
+        #     raise ValueError(f"Database path {self.database_path} is not a valid file.")
+
+        self._conn = duckdb.connect(self.database_path)
+        self._conn.execute(f"SET home_directory='{self._home_dir}';")
+
+        self._conn.install_extension("fts")
+        self._conn.load_extension("fts")
+
+        return self._conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._conn.close()
+
+        if self._conn:
+            self._conn.close()
+            
 class DuckDBRetriever(BaseRetriever):
     def __init__(
         self,
-        vector_store: DuckDBVectorStore,
+        database_name: Optional[str] = ":memory:",
+        table_name: Optional[str] = "documents",        
         text_search_config: Optional[dict] = {
             "stemmer": "english",
             "stopwords": "english",
@@ -23,24 +58,29 @@ class DuckDBRetriever(BaseRetriever):
             "lower": True,
             "overwrite": True,
         },
+        persist_dir: Optional[str] = "./storage",
+        node_id_column: Optional[str] = "node_id",
+        text_column: Optional[str] = "text",
         # TODO: Add more options for FTS index creation
 
         similarity_top_k: int = DEFAULT_SIMILARITY_TOP_K,
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
     ) -> None:
-        self._vector_store = vector_store
         self._similarity_top_k = similarity_top_k
         self._callback_manager = callback_manager
         self._verbose = verbose
+        self._table_name = table_name
+        self._node_id_column = node_id_column
+        self._text_column = text_column
         
         # TODO: Check if the vector store already has data
 
         # Create an FTS index on the 'text' column if it doesn't already exist
-        if self._vector_store.database_name==':memory:':
-            self._db_path = ':memory:'
+        if database_name==':memory:':
+            self._database_path = ':memory:'
         else:
-            self._db_path= self._vector_store._database_path
+            self._database_path=  os.path.join(persist_dir, database_name)
 
         strip_accents =1 if text_search_config["strip_accents"] else 0
         lower = 1 if text_search_config["lower"] else 0
@@ -48,12 +88,12 @@ class DuckDBRetriever(BaseRetriever):
         ignore = text_search_config["ignore"]
         
         sql = f"""
-            PRAGMA create_fts_index({vector_store.table_name}, node_id, text, 
+            PRAGMA create_fts_index({self._table_name}, {self._node_id_column}, {self._text_column}, 
                             stemmer = '{text_search_config["stemmer"]}',
                             stopwords = '{text_search_config["stopwords"]}', ignore = '{ignore}',
                             strip_accents = {strip_accents}, lower = {lower}, overwrite = {overwrite})      
                         """
-        with DuckDBLocalContext(self._db_path) as conn:
+        with DuckDBLocalContext(self._database_path) as conn:
             conn.execute(sql)
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         if self._verbose:
@@ -61,14 +101,14 @@ class DuckDBRetriever(BaseRetriever):
         query = query_bundle.query_str
         sql =f"""
                 SELECT
-                    fts_main_{self._vector_store.table_name}.match_bm25(node_id, '{query}') AS score,
-                    node_id, text
-                FROM {self._vector_store.table_name}
+                    fts_main_{self._table_name}.match_bm25({self._node_id_column}, '{query}') AS score,
+                    {self._node_id_column}, {self._text_column}
+                FROM {self._table_name}
                 WHERE score IS NOT NULL
                 ORDER BY score DESC
                 LIMIT {self._similarity_top_k};
             """
-        with DuckDBLocalContext(self._db_path) as conn:
+        with DuckDBLocalContext(self._database_path) as conn:
             query_result = conn.execute(sql).fetchall()
         # Convert query result to NodeWithScore objects
         retrieve_nodes = []

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.retrievers.duckdb_retriever"
+
+[tool.llamahub.class_authors]
+DuckDBRetriever = "llama-index"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"
+
+[tool.poetry]
+authors = ["Your Name <you@example.com>"]
+description = "llama-index retrievers duckdb-retriever integration"
+exclude = ["**/BUILD"]
+license = "MIT"
+name = "llama-index-retrievers-duckdb-retriever"
+readme = "README.md"
+version = "0.1.4"
+
+[tool.poetry.dependencies]
+python = ">=3.8.1,<4.0"
+llama-index-core = "^0.10.1"
+pymongo = "^4.6.1"
+
+[tool.poetry.group.dev.dependencies]
+ipython = "8.10.0"
+jupyter = "^1.0.0"
+mypy = "0.991"
+pre-commit = "3.2.0"
+pylint = "2.15.10"
+pytest = "7.2.1"
+pytest-mock = "3.11.1"
+ruff = "0.0.292"
+tree-sitter-languages = "^1.8.0"
+types-Deprecated = ">=0.1.0"
+types-PyYAML = "^6.0.12.12"
+types-protobuf = "^4.24.0.4"
+types-redis = "4.5.5.0"
+types-requests = "2.28.11.8"
+types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = ["jupyter"]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = ["toml"]
+version = ">=v2.2.6"
+
+[[tool.poetry.packages]]
+include = "llama_index/"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/tests/BUILD
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/tests/test_retrievers_bm25_retriever.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-duckdb-retriever/tests/test_retrievers_bm25_retriever.py
@@ -1,0 +1,9 @@
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.retrievers.duckdb_retriever.base import (
+    DuckDBRetriever,
+)
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in DuckDBRetriever.__mro__]
+    assert BaseRetriever.__name__ in names_of_base_classes


### PR DESCRIPTION
implement a retriever bases on DuckDB fts.

here is the example

```python
bm25_retriever = DuckDBRetriever(database_name="paul.duck",
                                 persist_dir="duckdb",similarity_top_k=5)

query = "What happened at Viaweb and Interleaf?"
from llama_index.core.response.notebook_utils import display_source_node

# will retrieve context from specific companies
nodes_bm25 = bm25_retriever.retrieve(query)
for node in nodes_bm25:
    display_source_node(node)
```
