### PR TITLE
Broaden SQLAlchemy support in llama-index-vector-stores-postgres to 1.4+

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -281,11 +281,8 @@ class PGVectorStore(BasePydanticVectorStore):
         self._async_session = sessionmaker(self._async_engine, class_=AsyncSession)  # type: ignore
 
     def _create_schema_if_not_exists(self) -> None:
-
         if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", self.schema_name):
-            raise ValueError(
-                f"Invalid schema_name: {self.schema_name}"
-            )
+            raise ValueError(f"Invalid schema_name: {self.schema_name}")
         with self._session() as session, session.begin():
             # Check if the specified schema exists with "CREATE" statement
             check_schema_statement = sqlalchemy.text(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -135,8 +135,8 @@ class PGVectorStore(BasePydanticVectorStore):
     stores_text = True
     flat_metadata = False
 
-    connection_string: Union[str, sqlalchemy.URL]
-    async_connection_string: Union[str, sqlalchemy.URL]
+    connection_string: str
+    async_connection_string: Union[str, sqlalchemy.engine.URL]
     table_name: str
     schema_name: str
     embed_dim: int
@@ -157,8 +157,8 @@ class PGVectorStore(BasePydanticVectorStore):
 
     def __init__(
         self,
-        connection_string: Union[str, sqlalchemy.URL],
-        async_connection_string: Union[str, sqlalchemy.URL],
+        connection_string: Union[str, sqlalchemy.engine.URL],
+        async_connection_string: Union[str, sqlalchemy.engine.URL],
         table_name: str,
         schema_name: str,
         hybrid_search: bool = False,
@@ -230,8 +230,8 @@ class PGVectorStore(BasePydanticVectorStore):
         password: Optional[str] = None,
         table_name: str = "llamaindex",
         schema_name: str = "public",
-        connection_string: Optional[Union[str, sqlalchemy.URL]] = None,
-        async_connection_string: Optional[Union[str, sqlalchemy.URL]] = None,
+        connection_string: Optional[Union[str, sqlalchemy.engine.URL]] = None,
+        async_connection_string: Optional[Union[str, sqlalchemy.engine.URL]] = None,
         hybrid_search: bool = False,
         text_search_config: str = "english",
         embed_dim: int = 1536,
@@ -281,24 +281,22 @@ class PGVectorStore(BasePydanticVectorStore):
 
     def _create_schema_if_not_exists(self) -> None:
         with self._session() as session, session.begin():
-            from sqlalchemy import text
 
             # Check if the specified schema exists with "CREATE" statement
-            check_schema_statement = text(
+            check_schema_statement = sqlalchemy.text(
                 f"SELECT schema_name FROM information_schema.schemata WHERE schema_name = :schema_name"
-            )
+            ).bindparams(schema_name=self.schema_name)
             result = session.execute(
-                check_schema_statement, {"schema_name": self.schema_name}
+                check_schema_statement
             ).fetchone()
 
             # If the schema does not exist, then create it
             if not result:
-                create_schema_statement = text(
-                    f"CREATE SCHEMA IF NOT EXISTS :schema_name"
+                create_schema_statement = sqlalchemy.text(
+                    # DDL won't tolerate quoted string literal here for schema_name, so use format string
+                    f"CREATE SCHEMA IF NOT EXISTS {self.schema_name}"
                 )
-                session.execute(
-                    create_schema_statement, {"schema_name": self.schema_name}
-                )
+                session.execute(create_schema_statement)
 
             session.commit()
 
@@ -381,13 +379,13 @@ class PGVectorStore(BasePydanticVectorStore):
             return "="
 
     def _build_filter_clause(self, filter_: MetadataFilter) -> Any:
-        from sqlalchemy import text
+        from sqlalchemy import text, bindparam
 
         if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
             # Expects a single value in the metadata, and a list to compare
             return text(
                 f"metadata_->>'{filter_.key}' {self._to_postgres_operator(filter_.operator)} :values"
-            ).bindparams(values=tuple(filter_.value))
+            ).bindparams(bindparam('values', expanding=True)).bindparams(values=tuple(filter_.value))
         elif filter_.operator == FilterOperator.CONTAINS:
             # Expects a list stored in the metadata, and a single value to compare
             return text(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -38,7 +38,7 @@ asyncpg = "^0.29.0"
 
 [tool.poetry.dependencies.sqlalchemy]
 extras = ["asyncio"]
-version = "^1.4.52"
+version = ">=1.4.49,<2.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -38,7 +38,7 @@ asyncpg = "^0.29.0"
 
 [tool.poetry.dependencies.sqlalchemy]
 extras = ["asyncio"]
-version = "^2.0.25"
+version = "^1.4.52"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"
@@ -67,3 +67,12 @@ version = ">=v2.2.6"
 
 [[tool.poetry.packages]]
 include = "llama_index/"
+
+[tool.pytest.ini_options]
+markers = [
+    "asyncio",
+]
+asyncio_mode = "auto"
+filterwarnings = [
+    "ignore::DeprecationWarning:"
+]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -69,10 +69,10 @@ version = ">=v2.2.6"
 include = "llama_index/"
 
 [tool.pytest.ini_options]
-markers = [
-    "asyncio",
-]
 asyncio_mode = "auto"
 filterwarnings = [
-    "ignore::DeprecationWarning:"
+    "ignore::DeprecationWarning:",
+]
+markers = [
+    "asyncio",
 ]


### PR DESCRIPTION
# Description

`llama-index-vector-stores-postgres` currently has a dependency on SQLALchemy 2.0.
However, there is a large body of existing code written for SQLAlchemy `1.4.x`, which is still maintained and in active use.
This PR allows `llama-index-vector-stores-postgres` to be used with both versions, making is vastly easier to integrate into existing codebases. It also harmonises the repo with `llama-index-core` which currently depends on `1.4.49`.
Added input validation for `schema_name` to allow safe usage of format string instead of an SQL param for schema creation.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] Re-ran existing tests, all passed with 100% pass rate, using a `pgvector/pgvector:pg14` docker container as back-end:
```
docker run -d \
  --name pgvector_container \
  -e POSTGRES_PASSWORD=mark90 \
  -p 5432:5432 \
  pgvector/pgvector:pg14
```

- [X] 100% passing tests for both SQLAlchemy `1.4.49` and `2.0.25`
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings (existing, unrelated deprecation warnings have been suppressed for clarity
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
