### PR TITLE
ensure cypher returns list before iterating

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Some cypher queries will return a `None` value instead of an empty list. Lets make sure we have a list before trying to iterate over it 