### PR TITLE
Update jina embedding notebook to include multimodal capability

### DIFF
--- a/docs/docs/examples/embeddings/jinaai_embeddings.ipynb
+++ b/docs/docs/examples/embeddings/jinaai_embeddings.ipynb
@@ -107,20 +107,68 @@
     ")\n",
     "\n",
     "embeddings = embed_model.get_text_embedding(\"This is the text to embed\")\n",
-    "\n",
-    "print(len(embeddings))\n",
-    "print(embeddings[:5])\n",
+    "print(\"Text dim:\", len(embeddings))\n",
+    "print(\"Text embed:\", embeddings[:5])\n",
     "\n",
     "embeddings = embed_model.get_query_embedding(\"This is the query to embed\")\n",
-    "print(len(embeddings))\n",
-    "print(embeddings[:5])"
+    "print(\"Query dim:\", len(embeddings))\n",
+    "print(\"Query embed:\", embeddings[:5])"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Embed images and queries with Jina CLIP through JinaAI API"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Embed in batches"
+    "You can also encode your images and your queries using the JinaEmbedding class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.embeddings.jinaai import JinaEmbedding\n",
+    "from PIL import Image\n",
+    "import requests\n",
+    "from numpy import dot\n",
+    "from numpy.linalg import norm\n",
+    "\n",
+    "embed_model = JinaEmbedding(\n",
+    "    api_key=jinaai_api_key,\n",
+    "    model=\"jina-clip-v1\",\n",
+    ")\n",
+    "\n",
+    "image_url = \"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcStMP8S3VbNCqOQd7QQQcbvC_FLa1HlftCiJw&s\"\n",
+    "im = Image.open(requests.get(image_url, stream=True).raw)\n",
+    "print(\"Image:\")\n",
+    "display(im)\n",
+    "\n",
+    "image_embeddings = embed_model.get_image_embedding(image_url)\n",
+    "print(\"Image dim:\", len(image_embeddings))\n",
+    "print(\"Image embed:\", image_embeddings[:5])\n",
+    "\n",
+    "text_embeddings = embed_model.get_text_embedding(\"Logo of a pink blue llama on dark background\")\n",
+    "print(\"Text dim:\", len(text_embeddings))\n",
+    "print(\"Text embed:\", text_embeddings[:5])\n",
+    "\n",
+    "cos_sim = dot(image_embeddings, text_embeddings)/(norm(image_embeddings)*norm(text_embeddings))\n",
+    "print(\"Cosine similarity:\", cos_sim)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Embed in batches"
    ]
   },
   {
@@ -272,50 +320,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "**Node ID:** d8db9dfe-ab7a-4709-9863-877b68d2210d<br>**Similarity:** 0.7698250992788241<br>**Text:** There were some surplus Xerox Dandelions floating around the computer lab at one point. Anyone who wanted one to play around with could have one. I was briefly tempted, but they were so slow by present standards; what was the point? No one else wanted one either, so off they went. That was what happened to systems work.\n",
-       "\n",
-       "I wanted not just to build things, but to build things that would last.\n",
-       "\n",
-       "In this dissatisfied state I went in 1988 to visit Rich Draves at CMU, where he was in grad school. One day I went to visit the Carnegie Institute, where I'd spent a lot of time as a kid. While looking at a painting there I realized something that might seem obvious, but was a big surprise to me. There, right on the wall, was something you could make that would last. Paintings didn't become obsolete. Some of the best ones were hundreds of years old.\n",
-       "\n",
-       "And moreover this was something you could make a living doing. Not as easily as you could by writing software, of course, but I thought if you were really industrious and lived really cheaply, it had to be possible to make enough to survive. And as an artist you could be truly independent. You wouldn't have a boss, or even need to get research funding.\n",
-       "\n",
-       "I had always liked looking at paintings. Could I make them? I had no idea. I'd never imagined it was even possible. I knew intellectually that people made art — that it didn't just appear spontaneously — but it was as if the people who made it were a different species. They either lived long ago or were mysterious geniuses doing strange things in profiles in Life magazine. The idea of actually being able to make art, to put that verb before that noun, seemed almost miraculous.\n",
-       "\n",
-       "That fall I started taking art classes at Harvard. Grad students could take classes in any department, and my advisor, Tom Cheatham, was very easy going. If he even knew about the strange classes I was taking, he never said anything.\n",
-       "\n",
-       "So now I was in a PhD program in computer science, yet planning to be an...<br>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "**Node ID:** 848bb0f8-629c-4491-b539-85f3ff5b77a2<br>**Similarity:** 0.7679106002573213<br>**Text:** Our teacher, professor Ulivi, was a nice guy. He could see I worked hard, and gave me a good grade, which he wrote down in a sort of passport each student had. But the Accademia wasn't teaching me anything except Italian, and my money was running out, so at the end of the first year I went back to the US.\n",
-       "\n",
-       "I wanted to go back to RISD, but I was now broke and RISD was very expensive, so I decided to get a job for a year and then return to RISD the next fall. I got one at a company called Interleaf, which made software for creating documents. You mean like Microsoft Word? Exactly. That was how I learned that low end software tends to eat high end software. But Interleaf still had a few years to live yet. [5]\n",
-       "\n",
-       "Interleaf had done something pretty bold. Inspired by Emacs, they'd added a scripting language, and even made the scripting language a dialect of Lisp. Now they wanted a Lisp hacker to write things in it. This was the closest thing I've had to a normal job, and I hereby apologize to my boss and coworkers, because I was a bad employee. Their Lisp was the thinnest icing on a giant C cake, and since I didn't know C and didn't want to learn it, I never understood most of the software. Plus I was terribly irresponsible. This was back when a programming job meant showing up every day during certain working hours. That seemed unnatural to me, and on this point the rest of the world is coming around to my way of thinking, but at the time it caused a lot of friction. Toward the end of the year I spent much of my time surreptitiously working on On Lisp, which I had by this time gotten a contract to publish.\n",
-       "\n",
-       "The good part was that I got paid huge amounts of money, especially by art student standards. In Florence, after paying my part of the rent, my budget for everything else had been $7 a day. Now I was getting paid more than 4 times that every hour, even when I was just sitting in a meeting. By living cheaply I not only managed to save enough to go back to RISD, but a...<br>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "for n in search_query_retrieved_nodes:\n",
     "    display_source_node(n, source_length=2000)"
@@ -337,7 +342,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
   },
   "vscode": {
    "interpreter": {

--- a/docs/docs/examples/embeddings/jinaai_embeddings.ipynb
+++ b/docs/docs/examples/embeddings/jinaai_embeddings.ipynb
@@ -156,11 +156,15 @@
     "print(\"Image dim:\", len(image_embeddings))\n",
     "print(\"Image embed:\", image_embeddings[:5])\n",
     "\n",
-    "text_embeddings = embed_model.get_text_embedding(\"Logo of a pink blue llama on dark background\")\n",
+    "text_embeddings = embed_model.get_text_embedding(\n",
+    "    \"Logo of a pink blue llama on dark background\"\n",
+    ")\n",
     "print(\"Text dim:\", len(text_embeddings))\n",
     "print(\"Text embed:\", text_embeddings[:5])\n",
     "\n",
-    "cos_sim = dot(image_embeddings, text_embeddings)/(norm(image_embeddings)*norm(text_embeddings))\n",
+    "cos_sim = dot(image_embeddings, text_embeddings) / (\n",
+    "    norm(image_embeddings) * norm(text_embeddings)\n",
+    ")\n",
     "print(\"Cosine similarity:\", cos_sim)"
    ]
   },
@@ -342,8 +346,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "pygments_lexer": "ipython3"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
After merging the [PR #13861 to include Jina AI multimodal capabilities](https://github.com/run-llama/llama_index/pull/13861), we updated the Jina AI embedding notebook accordingly.
