### PR TITLE
fix(deepinfrallm): default max_tokens

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-deepinfra/llama_index/llms/deepinfra/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-deepinfra/llama_index/llms/deepinfra/base.py
@@ -7,7 +7,7 @@ from typing import (
 )
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.llms.llm import LLM
-from llama_index.core.constants import DEFAULT_TEMPERATURE, DEFAULT_MAX_TOKENS
+from llama_index.core.constants import DEFAULT_TEMPERATURE
 
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.core.callbacks import CallbackManager
@@ -40,6 +40,7 @@ from llama_index.llms.deepinfra.constants import (
     CHAT_API_ENDPOINT,
     ENV_VARIABLE,
     DEFAULT_MODEL_NAME,
+    DEFAULT_MAX_TOKENS,
 )
 
 from llama_index.llms.deepinfra.client import DeepInfraClient

--- a/llama-index-integrations/llms/llama-index-llms-deepinfra/llama_index/llms/deepinfra/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-deepinfra/llama_index/llms/deepinfra/base.py
@@ -7,7 +7,7 @@ from typing import (
 )
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.llms.llm import LLM
-from llama_index.core.constants import DEFAULT_TEMPERATURE
+from llama_index.core.constants import DEFAULT_TEMPERATURE, DEFAULT_MAX_TOKENS
 
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.core.callbacks import CallbackManager
@@ -78,6 +78,7 @@ class DeepInfraLLM(LLM):
         lte=1.0,
     )
     max_tokens: Optional[int] = Field(
+        default=DEFAULT_MAX_TOKENS,
         description="The maximum number of tokens to generate.",
         gt=0,
     )
@@ -102,7 +103,7 @@ class DeepInfraLLM(LLM):
         model: str = DEFAULT_MODEL_NAME,
         additional_kwargs: Optional[Dict[str, Any]] = None,
         temperature: float = DEFAULT_TEMPERATURE,
-        max_tokens: Optional[int] = None,
+        max_tokens: Optional[int] = DEFAULT_MAX_TOKENS,
         max_retries: int = 10,
         api_base: str = API_BASE,
         timeout: Optional[float] = None,

--- a/llama-index-integrations/llms/llama-index-llms-deepinfra/llama_index/llms/deepinfra/constants.py
+++ b/llama-index-integrations/llms/llama-index-llms-deepinfra/llama_index/llms/deepinfra/constants.py
@@ -8,3 +8,5 @@ CHAT_API_ENDPOINT = "v1/openai/chat/completions"
 ENV_VARIABLE = "DEEPINFRA_API_TOKEN"
 """Default model name for DeepInfra embeddings."""
 DEFAULT_MODEL_NAME = "mistralai/Mixtral-8x22B-Instruct-v0.1"
+"""Default max tokens. DeepInfra documentation constant is set."""
+DEFAULT_MAX_TOKENS = 512

--- a/llama-index-integrations/llms/llama-index-llms-deepinfra/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-deepinfra/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-deepinfra"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Agents require non-null max_tokens value. When `DeepInfraLLM` class is constructed without `max_tokens` value, it raises 

`pydantic.v1.error_wrappers.ValidationError: 1 validation error for LLMMetadata
num_output
  none is not an allowed value (type=type_error.none.not_allowed)`

This PR is intented to fix this issue, by setting max_tokens to a default value.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
