### PR TITLE
Qdrant: Create payload index for doc_id

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -56,6 +56,7 @@ import_err_msg = (
 DENSE_VECTOR_NAME = "text-dense"
 SPARSE_VECTOR_NAME_OLD = "text-sparse"
 SPARSE_VECTOR_NAME = "text-sparse-new"
+DOCUMENT_ID_KEY = "doc_id"
 
 
 class QdrantVectorStore(BasePydanticVectorStore):
@@ -82,6 +83,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         sparse_doc_fn (Optional[SparseEncoderCallable]): function to encode sparse vectors
         sparse_query_fn (Optional[SparseEncoderCallable]): function to encode sparse queries
         hybrid_fusion_fn (Optional[HybridFusionCallable]): function to fuse hybrid search results
+        index_doc_id (bool): whether to create a payload index for the document ID. Defaults to True
 
     Examples:
         `pip install llama-index-vector-stores-qdrant`
@@ -102,7 +104,6 @@ class QdrantVectorStore(BasePydanticVectorStore):
     flat_metadata: bool = False
 
     collection_name: str
-    path: Optional[str]
     url: Optional[str]
     api_key: Optional[str]
     batch_size: int
@@ -110,6 +111,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
     max_retries: int
     client_kwargs: dict = Field(default_factory=dict)
     enable_hybrid: bool
+    index_doc_id: bool
 
     _client: qdrant_client.QdrantClient = PrivateAttr()
     _aclient: qdrant_client.AsyncQdrantClient = PrivateAttr()
@@ -133,6 +135,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         sparse_doc_fn: Optional[SparseEncoderCallable] = None,
         sparse_query_fn: Optional[SparseEncoderCallable] = None,
         hybrid_fusion_fn: Optional[HybridFusionCallable] = None,
+        index_doc_id: bool = True,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -191,6 +194,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
             max_retries=max_retries,
             client_kwargs=client_kwargs or {},
             enable_hybrid=enable_hybrid,
+            index_doc_id=index_doc_id,
         )
 
     @classmethod
@@ -429,7 +433,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
             points_selector=rest.Filter(
                 must=[
                     rest.FieldCondition(
-                        key="doc_id", match=rest.MatchValue(value=ref_doc_id)
+                        key=DOCUMENT_ID_KEY, match=rest.MatchValue(value=ref_doc_id)
                     )
                 ]
             ),
@@ -448,7 +452,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
             points_selector=rest.Filter(
                 must=[
                     rest.FieldCondition(
-                        key="doc_id", match=rest.MatchValue(value=ref_doc_id)
+                        key=DOCUMENT_ID_KEY, match=rest.MatchValue(value=ref_doc_id)
                     )
                 ]
             ),
@@ -573,6 +577,16 @@ class QdrantVectorStore(BasePydanticVectorStore):
                         distance=rest.Distance.COSINE,
                     ),
                 )
+
+            # To improve search performance Qdrant recommends setting up
+            # a payload index for fields used in filters.
+            # https://qdrant.tech/documentation/concepts/indexing
+            if self.index_doc_id:
+                self._client.create_payload_index(
+                    collection_name=collection_name,
+                    field_name=DOCUMENT_ID_KEY,
+                    field_schema=rest.PayloadSchemaType.KEYWORD,
+                )
         except (RpcError, ValueError, UnexpectedResponse) as exc:
             if "already exists" not in str(exc):
                 raise exc  # noqa: TRY201
@@ -610,6 +624,15 @@ class QdrantVectorStore(BasePydanticVectorStore):
                         size=vector_size,
                         distance=rest.Distance.COSINE,
                     ),
+                )
+            # To improve search performance Qdrant recommends setting up
+            # a payload index for fields used in filters.
+            # https://qdrant.tech/documentation/concepts/indexing
+            if self.index_doc_id:
+                await self._aclient.create_payload_index(
+                    collection_name=collection_name,
+                    field_name=DOCUMENT_ID_KEY,
+                    field_schema=rest.PayloadSchemaType.KEYWORD,
                 )
         except (RpcError, ValueError, UnexpectedResponse) as exc:
             if "already exists" not in str(exc):
@@ -1036,7 +1059,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         if query.doc_ids:
             must_conditions.append(
                 FieldCondition(
-                    key="doc_id",
+                    key=DOCUMENT_ID_KEY,
                     match=MatchAny(any=query.doc_ids),
                 )
             )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-qdrant"
 readme = "README.md"
-version = "0.2.8"
+version = "0.2.9"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
# Description

This PR updates the `QdrantVectorStore` implementation to create an optional payload index for the `doc_id` field.

Qdrant recommends creating payload indexes for regularly filtered fields to improve performance.

https://qdrant.tech/documentation/concepts/indexing

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
