### PR TITLE
refactor: add spans to `abstractmethods` via mixin

### DIFF
--- a/llama-index-core/llama_index/core/base/agent/types.py
+++ b/llama-index-core/llama_index/core/base/agent/types.py
@@ -13,6 +13,7 @@ from llama_index.core.chat_engine.types import (
     BaseChatEngine,
     StreamingAgentChatResponse,
 )
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.memory.types import BaseMemory
 from llama_index.core.prompts.mixin import PromptDictType, PromptMixin, PromptMixinType
 from llama_index.core.schema import QueryBundle
@@ -186,7 +187,7 @@ class Task(BaseModel):
     )
 
 
-class BaseAgentWorker(PromptMixin):
+class BaseAgentWorker(PromptMixin, DispatcherSpanMixin):
     """Base agent worker."""
 
     class Config:

--- a/llama-index-core/llama_index/core/base/base_query_engine.py
+++ b/llama-index-core/llama_index/core/base/base_query_engine.py
@@ -16,6 +16,7 @@ from llama_index.core.bridge.pydantic import Field
 from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.prompts.mixin import PromptDictType, PromptMixin
 from llama_index.core.schema import NodeWithScore, QueryBundle, QueryType
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.instrumentation.events.query import (
     QueryEndEvent,
     QueryStartEvent,
@@ -26,7 +27,7 @@ dispatcher = instrument.get_dispatcher(__name__)
 logger = logging.getLogger(__name__)
 
 
-class BaseQueryEngine(ChainableMixin, PromptMixin):
+class BaseQueryEngine(ChainableMixin, PromptMixin, DispatcherSpanMixin):
     """Base query engine."""
 
     def __init__(

--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -30,6 +30,7 @@ from llama_index.core.schema import (
 from llama_index.core.service_context import ServiceContext
 from llama_index.core.settings import Settings
 from llama_index.core.utils import print_text
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.instrumentation.events.retrieval import (
     RetrievalEndEvent,
     RetrievalStartEvent,
@@ -39,7 +40,7 @@ import llama_index.core.instrumentation as instrument
 dispatcher = instrument.get_dispatcher(__name__)
 
 
-class BaseRetriever(ChainableMixin, PromptMixin):
+class BaseRetriever(ChainableMixin, PromptMixin, DispatcherSpanMixin):
     """Base retriever."""
 
     def __init__(

--- a/llama-index-core/llama_index/core/base/base_selector.py
+++ b/llama-index-core/llama_index/core/base/base_selector.py
@@ -6,6 +6,7 @@ from llama_index.core.base.query_pipeline.query import (
     QueryComponent,
 )
 from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.prompts.mixin import PromptMixin, PromptMixinType
 from llama_index.core.schema import QueryBundle, QueryType
 from llama_index.core.tools.types import ToolMetadata
@@ -72,7 +73,7 @@ def _wrap_query(query: QueryType) -> QueryBundle:
         raise ValueError(f"Unexpected type: {type(query)}")
 
 
-class BaseSelector(PromptMixin, ChainableMixin):
+class BaseSelector(PromptMixin, ChainableMixin, DispatcherSpanMixin):
     """Base selector."""
 
     def _get_prompt_modules(self) -> PromptMixinType:

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -12,6 +12,7 @@ from llama_index.core.callbacks.schema import CBEventType, EventPayload
 from llama_index.core.constants import (
     DEFAULT_EMBED_BATCH_SIZE,
 )
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.schema import BaseNode, MetadataMode, TransformComponent
 from llama_index.core.utils import get_tqdm_iterable
 from llama_index.core.async_utils import run_jobs
@@ -59,7 +60,7 @@ def similarity(
         return product / norm
 
 
-class BaseEmbedding(TransformComponent):
+class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
     """Base class for embeddings."""
 
     model_name: str = Field(

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -17,6 +17,7 @@ from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
 from llama_index.core.schema import NodeWithScore
 from llama_index.core.tools import ToolOutput
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.instrumentation.events.chat_engine import (
     StreamChatErrorEvent,
     StreamChatEndEvent,
@@ -296,7 +297,7 @@ class StreamingAgentChatResponse:
 AGENT_CHAT_RESPONSE_TYPE = Union[AgentChatResponse, StreamingAgentChatResponse]
 
 
-class BaseChatEngine(ABC):
+class BaseChatEngine(DispatcherSpanMixin, ABC):
     """Base Chat Engine."""
 
     @abstractmethod

--- a/llama-index-core/llama_index/core/image_retriever.py
+++ b/llama-index-core/llama_index/core/image_retriever.py
@@ -2,11 +2,12 @@ from abc import abstractmethod
 from typing import List
 
 from llama_index.core.indices.query.schema import QueryBundle, QueryType
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.prompts.mixin import PromptMixin
 from llama_index.core.schema import NodeWithScore
 
 
-class BaseImageRetriever(PromptMixin):
+class BaseImageRetriever(PromptMixin, DispatcherSpanMixin):
     """Base Image Retriever Abstraction."""
 
     def text_to_image_retrieve(

--- a/llama-index-core/llama_index/core/indices/query/query_transform/base.py
+++ b/llama-index-core/llama_index/core/indices/query/query_transform/base.py
@@ -21,6 +21,7 @@ from llama_index.core.indices.query.query_transform.prompts import (
     ImageOutputQueryTransformPrompt,
     StepDecomposeQueryTransformPrompt,
 )
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.prompts import BasePromptTemplate
 from llama_index.core.prompts.default_prompts import DEFAULT_HYDE_PROMPT
 from llama_index.core.prompts.mixin import (
@@ -36,7 +37,7 @@ from llama_index.core.settings import Settings
 from llama_index.core.utils import print_text
 
 
-class BaseQueryTransform(ChainableMixin, PromptMixin):
+class BaseQueryTransform(ChainableMixin, PromptMixin, DispatcherSpanMixin):
     """
     Base class for query transform.
 

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.callbacks.base import CallbackManager
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.llms.llm import LLM
 from llama_index.core.objects.base import ObjectRetriever
 from llama_index.core.objects.table_node_mapping import SQLTableSchema
@@ -109,7 +110,7 @@ class SQLParserMode(str, Enum):
     PGVECTOR = "pgvector"
 
 
-class BaseSQLParser(ABC):
+class BaseSQLParser(DispatcherSpanMixin, ABC):
     """Base SQL Parser."""
 
     @abstractmethod

--- a/llama-index-core/llama_index/core/instrumentation/__init__.py
+++ b/llama-index-core/llama_index/core/instrumentation/__init__.py
@@ -43,8 +43,10 @@ def get_dispatcher(name: str = "root") -> Dispatcher:
 
 class DispatcherSpanMixin(ABC):
     """
-    Apply dispatcher.span decorator to implementations of abstract methods
-    as well as any previously decorated methods that have been overridden.
+    Apply the `dispatcher.span` decorator to implementations of abstract methods, as well
+    as any methods previously decorated (in any base class) that are being overridden by
+    the subclass. Note that users can still manually decorate the methods in their custom
+    subclasses because the `dispatcher.span` decorator is idempotent.
     """
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/llama-index-core/llama_index/core/instrumentation/__init__.py
+++ b/llama-index-core/llama_index/core/instrumentation/__init__.py
@@ -38,6 +38,10 @@ def get_dispatcher(name: str = "root") -> Dispatcher:
 
 
 class DispatcherSpanMixin(ABC):
+    """
+    Apply dispatcher.span to implementations of abstract methods.
+    """
+
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         abstract_methods: List[str] = []

--- a/llama-index-core/llama_index/core/instrumentation/__init__.py
+++ b/llama-index-core/llama_index/core/instrumentation/__init__.py
@@ -45,8 +45,13 @@ class DispatcherSpanMixin(ABC):
     """
     Apply the `dispatcher.span` decorator to implementations of abstract methods, as well
     as any methods previously decorated (in any base class) that are being overridden by
-    the subclass. Note that users can still manually decorate the methods in their custom
-    subclasses because the `dispatcher.span` decorator is idempotent.
+    a subclass. For example, if class `A` has abstract method `f`, and class `B` inherits
+    from `A` and provides an implementation of `f`, then `B.f` will be decorated by the mixin.
+    Furthermore, if `B` has a non-abstract method `g` that is decorated by `dispatcher.span`
+    and new class `C` inherits from `B` and overrides `g`, then `C.g` will also be decorated
+    by the mixin. Note that users can still manually apply `dispatcher.span` to the methods
+    in their custom subclasses without creating duplicate spans because the `dispatcher.span`
+    decorator should be idempotent.
     """
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -211,6 +211,7 @@ class Dispatcher(BaseModel):
                 c = c.parent
 
     def span(self, func):
+        # The `span` decorator should be idempotent.
         if hasattr(func, DISPATCHER_SPAN_DECORATED_ATTR):
             return func
         setattr(func, DISPATCHER_SPAN_DECORATED_ATTR, True)

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -209,6 +209,10 @@ class Dispatcher(BaseModel):
                 c = c.parent
 
     def span(self, func):
+        if hasattr(func, "__dispatcher_span_decorated__"):
+            return func
+        func.__dispatcher_span_decorated__ = True
+
         @wrapt.decorator
         def wrapper(func, instance, args, kwargs):
             bound_args = inspect.signature(func).bind(*args, **kwargs)

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -14,6 +14,8 @@ from llama_index.core.instrumentation.events.base import BaseEvent
 from llama_index.core.instrumentation.events.span import SpanDropEvent
 import wrapt
 
+DISPATCHER_SPAN_DECORATED_ATTR = "__dispatcher_span_decorated__"
+
 
 # Keep for backwards compatibility
 class EventDispatcher(Protocol):
@@ -209,9 +211,9 @@ class Dispatcher(BaseModel):
                 c = c.parent
 
     def span(self, func):
-        if hasattr(func, "__dispatcher_span_decorated__"):
+        if hasattr(func, DISPATCHER_SPAN_DECORATED_ATTR):
             return func
-        func.__dispatcher_span_decorated__ = True
+        setattr(func, DISPATCHER_SPAN_DECORATED_ATTR, True)
 
         @wrapt.decorator
         def wrapper(func, instance, args, kwargs):

--- a/llama-index-core/llama_index/core/multi_modal_llms/base.py
+++ b/llama-index-core/llama_index/core/multi_modal_llms/base.py
@@ -1,8 +1,6 @@
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Sequence, get_args
 
-from llama_index.core import instrumentation
-
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
@@ -26,6 +24,7 @@ from llama_index.core.constants import (
     DEFAULT_NUM_INPUT_FILES,
     DEFAULT_NUM_OUTPUTS,
 )
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.llms.callbacks import llm_completion_callback, llm_chat_callback
 from llama_index.core.schema import BaseComponent, ImageDocument
 
@@ -74,7 +73,7 @@ class MultiModalLLMMetadata(BaseModel):
     )
 
 
-class MultiModalLLM(ChainableMixin, BaseComponent):
+class MultiModalLLM(ChainableMixin, BaseComponent, DispatcherSpanMixin):
     """Multi-Modal LLM interface."""
 
     callback_manager: CallbackManager = Field(
@@ -163,11 +162,9 @@ class MultiModalLLM(ChainableMixin, BaseComponent):
 
     def __init_subclass__(cls, **kwargs) -> None:
         """
-        Decorate the abstract methods' implementations for each subclass.
-        `__init_subclass__` is analogous to `__init__` because classes are also objects.
+        The callback decorators installs events, so they must be applied before
+        the span decorators, otherwise the spans wouldn't contain the events.
         """
-        super().__init_subclass__(**kwargs)
-        dispatcher = instrumentation.get_dispatcher(cls.__module__)
         for attr in (
             "complete",
             "acomplete",
@@ -180,10 +177,10 @@ class MultiModalLLM(ChainableMixin, BaseComponent):
         ):
             if callable(method := cls.__dict__.get(attr)):
                 if attr.endswith("chat"):
-                    method = llm_chat_callback()(method)
+                    setattr(cls, attr, llm_chat_callback()(method))
                 else:
-                    method = llm_completion_callback()(method)
-                setattr(cls, attr, dispatcher.span(method))
+                    setattr(cls, attr, llm_completion_callback()(method))
+        super().__init_subclass__(**kwargs)
 
 
 class BaseMultiModalComponent(QueryComponent):

--- a/llama-index-core/llama_index/core/postprocessor/types.py
+++ b/llama-index-core/llama_index/core/postprocessor/types.py
@@ -10,11 +10,12 @@ from llama_index.core.base.query_pipeline.query import (
 )
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.callbacks import CallbackManager
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.prompts.mixin import PromptDictType, PromptMixinType
 from llama_index.core.schema import BaseComponent, NodeWithScore, QueryBundle
 
 
-class BaseNodePostprocessor(ChainableMixin, BaseComponent, ABC):
+class BaseNodePostprocessor(ChainableMixin, BaseComponent, DispatcherSpanMixin, ABC):
     callback_manager: CallbackManager = Field(
         default_factory=CallbackManager, exclude=True
     )

--- a/llama-index-core/llama_index/core/question_gen/types.py
+++ b/llama-index-core/llama_index/core/question_gen/types.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from typing import List, Sequence
 
 from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.prompts.mixin import PromptMixin, PromptMixinType
 from llama_index.core.schema import QueryBundle
 from llama_index.core.tools.types import ToolMetadata
@@ -21,7 +22,7 @@ class SubQuestionList(BaseModel):
     items: List[SubQuestion]
 
 
-class BaseQuestionGenerator(PromptMixin):
+class BaseQuestionGenerator(PromptMixin, DispatcherSpanMixin):
     def _get_prompt_modules(self) -> PromptMixinType:
         """Get prompt modules."""
         return {}

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -46,6 +46,7 @@ from llama_index.core.settings import (
     llm_from_settings_or_context,
 )
 from llama_index.core.types import RESPONSE_TEXT_TYPE
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.instrumentation.events.synthesis import (
     SynthesizeStartEvent,
     SynthesizeEndEvent,
@@ -67,7 +68,7 @@ async def empty_response_agenerator() -> AsyncGenerator[str, None]:
     yield "Empty Response"
 
 
-class BaseSynthesizer(ChainableMixin, PromptMixin):
+class BaseSynthesizer(ChainableMixin, PromptMixin, DispatcherSpanMixin):
     """Response builder class."""
 
     def __init__(

--- a/llama-index-core/llama_index/core/selectors/types.py
+++ b/llama-index-core/llama_index/core/selectors/types.py
@@ -6,6 +6,7 @@ from llama_index.core.base.query_pipeline.query import (
     QueryComponent,
 )
 from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.prompts.mixin import PromptMixin, PromptMixinType
 from llama_index.core.schema import QueryBundle, QueryType
 from llama_index.core.tools.types import ToolMetadata
@@ -72,7 +73,7 @@ def _wrap_query(query: QueryType) -> QueryBundle:
         raise ValueError(f"Unexpected type: {type(query)}")
 
 
-class BaseSelector(PromptMixin, ChainableMixin):
+class BaseSelector(PromptMixin, ChainableMixin, DispatcherSpanMixin):
     """Base selector."""
 
     def _get_prompt_modules(self) -> PromptMixinType:

--- a/llama-index-core/llama_index/core/service_context_elements/llm_predictor.py
+++ b/llama-index-core/llama_index/core/service_context_elements/llm_predictor.py
@@ -13,6 +13,7 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.bridge.pydantic import BaseModel, PrivateAttr
 from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.callbacks.schema import CBEventType, EventPayload
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.llms.llm import (
     LLM,
     astream_chat_response_to_tokens,
@@ -29,7 +30,7 @@ from typing_extensions import Self
 logger = logging.getLogger(__name__)
 
 
-class BaseLLMPredictor(BaseComponent, ABC):
+class BaseLLMPredictor(BaseComponent, DispatcherSpanMixin, ABC):
     """Base LLM Predictor."""
 
     def dict(self, **kwargs: Any) -> Dict[str, Any]:

--- a/llama-index-core/llama_index/core/tools/types.py
+++ b/llama-index-core/llama_index/core/tools/types.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
-from llama_index.core import instrumentation
+from llama_index.core.instrumentation import DispatcherSpanMixin
 
 if TYPE_CHECKING:
     from llama_index.core.bridge.langchain import StructuredTool, Tool
@@ -101,7 +101,7 @@ class ToolOutput(BaseModel):
         return str(self.content)
 
 
-class BaseTool:
+class BaseTool(DispatcherSpanMixin):
     @property
     @abstractmethod
     def metadata(self) -> ToolMetadata:
@@ -177,17 +177,6 @@ class AsyncBaseTool(BaseTool):
         Should also be implemented by the tool developer as an
         async-compatible implementation.
         """
-
-    def __init_subclass__(cls, **kwargs) -> None:
-        """
-        Decorate the abstract methods' implementations for each subclass.
-        `__init_subclass__` is analogous to `__init__` because classes are also objects.
-        """
-        super().__init_subclass__(**kwargs)
-        dispatcher = instrumentation.get_dispatcher(cls.__module__)
-        for attr in ("call", "acall"):
-            if callable(method := cls.__dict__.get(attr)):
-                setattr(cls, attr, dispatcher.span(method))
 
 
 class BaseToolAsyncAdapter(AsyncBaseTool):

--- a/llama-index-core/llama_index/core/types.py
+++ b/llama-index-core/llama_index/core/types.py
@@ -10,11 +10,9 @@ from typing import (
     Generator,
     Generic,
     List,
-    Protocol,
     Type,
     TypeVar,
     Union,
-    runtime_checkable,
 )
 
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
@@ -30,8 +28,7 @@ RESPONSE_TEXT_TYPE = Union[BaseModel, str, TokenGen, TokenAsyncGen]
 
 # TODO: move into a `core` folder
 # NOTE: this is necessary to make it compatible with pydantic
-@runtime_checkable
-class BaseOutputParser(Protocol):
+class BaseOutputParser(DispatcherSpanMixin, ABC):
     """Output parser class."""
 
     @classmethod

--- a/llama-index-core/llama_index/core/types.py
+++ b/llama-index-core/llama_index/core/types.py
@@ -19,6 +19,7 @@ from typing import (
 
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.instrumentation import DispatcherSpanMixin
 
 Model = TypeVar("Model", bound=BaseModel)
 
@@ -59,7 +60,7 @@ class BaseOutputParser(Protocol):
         return messages
 
 
-class BasePydanticProgram(ABC, Generic[Model]):
+class BasePydanticProgram(DispatcherSpanMixin, ABC, Generic[Model]):
     """A base class for LLM-powered function that return a pydantic model.
 
     Note: this interface is not yet stable.

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -16,6 +16,8 @@ from threading import Lock
 from typing import Callable, Optional, Any, Dict, List
 
 import pytest
+import wrapt
+
 import llama_index.core.instrumentation as instrument
 from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.instrumentation.dispatcher import Dispatcher
@@ -759,6 +761,14 @@ def test_dispatcher_fire_event_with_instance_backwards_compat(
 @patch.object(Dispatcher, "span_enter")
 def test_span_decorator_is_idempotent(mock_span_enter):
     dispatcher.span(dispatcher.span(lambda: ...))()
+    mock_span_enter.assert_called_once()
+
+
+@patch.object(Dispatcher, "span_enter")
+def test_span_decorator_is_idempotent_with_pass_through(mock_span_enter):
+    a, b, c, d = (wrapt.decorator(lambda f, *_: f()) for _ in range(4))
+    s = dispatcher.span
+    s(a(b(s(c(d(s(lambda: ...)))))))()
     mock_span_enter.assert_called_once()
 
 

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -780,7 +780,7 @@ def test_mixin_decorates_abstract_method(mock_span_enter):
     A = type("A", (DispatcherSpanMixin,), {"f": z(lambda _: ...)})
     B = type("B", (A,), {"f": lambda _: x + 0})
     C = type("C", (B,), {"f": lambda _: x + 1})
-    D = type("D", (C,), {"f": lambda _: x + 2})
+    D = type("D", (C, B), {"f": lambda _: x + 2})
     for i, T in enumerate((B, C, D)):
         assert T().f() - i == pytest.approx(x)
         assert mock_span_enter.call_count - i == 1
@@ -792,7 +792,7 @@ def test_mixin_decorates_overridden_method(mock_span_enter):
     A = type("A", (DispatcherSpanMixin,), {"f": z(lambda _: x)})
     B = type("B", (A,), {"f": lambda _: x + 1})
     C = type("C", (B,), {"f": lambda _: x + 2})
-    D = type("D", (C,), {"f": lambda _: x + 3})
+    D = type("D", (C, B), {"f": lambda _: x + 3})
     for i, T in enumerate((A, B, C, D)):
         assert T().f() - i == pytest.approx(x)
         assert mock_span_enter.call_count - i == 1

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -758,7 +758,6 @@ def test_dispatcher_fire_event_with_instance_backwards_compat(
 
 @patch.object(Dispatcher, "span_enter")
 def test_span_decorator_is_idempotent(mock_span_enter):
-    dispatcher = Dispatcher(propagate=False)
     dispatcher.span(dispatcher.span(lambda: ...))()
     mock_span_enter.assert_called_once()
 


### PR DESCRIPTION
Below are some example traces.

Some notable additions are:
- CohereRerank._postprocess_nodes
- QueryPipelineAgentWorker
- OpenAIAgentWorker
- BaseSQLTableQueryEngine
- DefaultSQLParser

```
AgentRunner.chat-3fbb79de-eac4-4e2b-b8cb-f3f7a71f8af4 (5.590771)
└── AgentRunner._chat-cd411d12-c089-4155-b0e7-d5c4aa3460b8 (5.586031)
    ├── AgentRunner.create_task-e29fab98-bb24-429e-ad01-7fdb5496cb23 (0.012346)
    │   └── QueryPipelineAgentWorker.initialize_step-11b89184-cf18-4ef9-86ac-7b29b2e37b38 (0.00627)
    ├── AgentRunner._run_step-7b02f58c-2f6e-476c-a682-37cd72e5b07a (4.42781)
    │   └── QueryPipelineAgentWorker.run_step-8ca6705a-31a7-478a-820c-89e06ad9106b (4.418534)
    │       ├── OpenAI.chat-74b9fab9-090d-4862-94ca-dabc56f9f6d6 (1.547405)
    │       └── AsyncBaseTool.__call__-81b109ac-9a87-4ffe-ae94-ebbbb0118b8a (2.845362)
    │           └── QueryEngineTool.call-247fd78a-d034-466e-853e-a8c973a647a0 (2.837434)
    │               └── BaseQueryEngine.query-8fa8aed3-df8e-463a-9c01-c98fadea1fde (2.827988)
    │                   └── BaseSQLTableQueryEngine._query-8557eada-5c07-4498-a196-86f96ad02a22 (2.820028)
    │                       ├── LLM.predict-091ad607-c09e-42ab-bafc-3a2590625725 (1.475589)
    │                       │   └── OpenAI.chat-57fbbb4a-6c1f-4a55-816d-e29aabe2682c (1.463062)
    │                       ├── DefaultSQLParser.parse_response_to_sql-6d51a5b5-95cd-42bb-97f4-b5b837fe0ab6 (0.0092)
    │                       └── BaseSynthesizer.synthesize-48ec36d8-78b1-4bc7-acd9-5f0c41dc9854 (1.31615)
    │                           └── CompactAndRefine.get_response-f2f1ca19-8042-4b40-ad42-d7d9b0c4b80c (1.306054)
    │                               └── Refine.get_response-4e26150b-6bbb-4d03-a311-fa7d0d6553c8 (1.294871)
    │                                   └── DefaultRefineProgram.__call__-6ed8b622-f998-4139-8dc1-882f95032109 (1.282369)
    │                                       └── LLM.predict-0eb415e8-e8c1-4da3-8e91-9d5758039bd2 (1.270015)
    │                                           └── OpenAI.chat-be3c843b-2c0e-4986-af08-c8364a282544 (1.257479)
    ├── AgentRunner._run_step-41d73fa3-3f3e-414f-8097-301b8d494f1c (1.130354)
    │   └── QueryPipelineAgentWorker.run_step-99e68b98-2193-4aba-b247-fbe5425aea55 (1.122337)
    │       └── OpenAI.chat-6c04756c-308a-4b9e-9abb-888ec5a21d42 (1.105373)
    └── AgentRunner.finalize_response-dd1f5f66-e77f-479c-bd1a-dc562b62761a (0.008917)
        └── QueryPipelineAgentWorker.finalize_task-086846ce-a62b-4c22-b0d5-147e1451bed1 (0.004365)
```

```
BaseQueryEngine.query-0c66cd63-205d-415b-adcf-ce7c9d96a405 (2.445758)
└── BaseAgent._query-f6fa1c95-1240-45e4-a65e-acc1954f8ecd (2.435344)
    └── AgentRunner.chat-d19c7e6b-c647-4cf8-9c98-8be77ef8e495 (2.428691)
        └── AgentRunner._chat-43bd88c2-05a9-4bbf-8fc3-afe7103e5d51 (2.421467)
            ├── AgentRunner.create_task-b3681c26-501e-4cf6-a8fb-ac1abe20b82f (0.028377)
            │   └── OpenAIAgentWorker.initialize_step-096860f5-2c18-4835-9b7e-b9e0f6eb52d8 (0.019724)
            ├── AgentRunner._run_step-2315d8ce-ae3d-4990-b3da-1033f2c1fe8e (1.406516)
            │   └── OpenAIAgentWorker.run_step-6c0541af-bb25-4722-a52e-10555bee3a53 (1.398332)
            │       ├── OpenAI.chat-9708e8b0-f58a-4e11-ba57-b1852c263cbc (1.350972)
            │       ├── AsyncBaseTool.__call__-91a6dc84-f1a0-4715-932f-7c915a476cee (0.017867)
            │       │   └── FunctionTool.call-f1b879bc-874d-4e7c-a301-434d70a43bf8 (0.009431)
            │       └── AsyncBaseTool.__call__-39efcf72-c2b5-4132-9d84-e9fa732d981a (0.015824)
            │           └── FunctionTool.call-f76a3134-09c0-4a37-856e-5988d41b9e06 (0.008213)
            ├── AgentRunner._run_step-0b950665-1e09-4e11-879e-fc0d37b9ea14 (0.958572)
            │   └── OpenAIAgentWorker.run_step-bb0ded4b-ef65-4134-8f49-f71ef2c36a56 (0.945576)
            │       └── OpenAI.chat-cf156ead-f205-4672-91cb-e3f64e949191 (0.933454)
            └── AgentRunner.finalize_response-e5f3a8e4-5cb5-48e5-80d8-b32591dbfa69 (0.017403)
                └── OpenAIAgentWorker.finalize_task-7e51e173-9382-4ff4-b076-41bfbd0ca2f1 (0.009128)
```

```
BaseQueryEngine.query-6be82c49-d528-4f76-b254-d4fe85ea4779 (1.558146)
└── RetrieverQueryEngine._query-ff96f75b-28e9-4528-b73e-2f8786904bb4 (1.549901)
    ├── BaseRetriever.retrieve-4ff493c5-fda9-4501-a1fb-9cefcc9e6c9c (0.196804)
    │   └── VectorIndexRetriever._retrieve-4b538dae-7507-4d72-8bf4-2b823eba62bb (0.188733)
    │       └── BaseEmbedding.get_query_embedding-db53fc42-ac57-46f1-9785-20a32a3912ef (0.174152)
    │           └── OpenAIEmbedding._get_query_embedding-7a6cfae6-3b78-404a-b978-381a7bb96650 (0.148271)
    ├── CohereRerank._postprocess_nodes-2b295fd6-2208-4e2a-a4c3-303e247979e0 (0.285681)
    └── BaseSynthesizer.synthesize-c6d48bef-b793-47ac-ad7d-8deb26a4baa9 (1.053777)
        └── CompactAndRefine.get_response-7903ce44-bc4e-4461-a726-19f9ab89ef0d (1.022936)
            └── Refine.get_response-f08bbda6-fb3a-4bb8-9535-1dff77dd8c13 (1.008193)
                └── DefaultRefineProgram.__call__-7e6f2b3c-c242-4b87-b73b-4be458eda620 (0.993426)
                    └── LLM.predict-3e8534ca-d53e-4c92-84c5-4be921f4bfab (0.980833)
                        └── OpenAI.chat-34ab3b33-799d-44bf-898e-017f38377b78 (0.967677)
```