### PR TITLE
Add more embeddings to configurable transformations

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/transformations.py
+++ b/llama-index-core/llama_index/core/ingestion/transformations.py
@@ -267,6 +267,24 @@ def build_configurable_transformation_enum():
         pass
 
     try:
+        from llama_index.embeddings.bedrock import (
+            BedrockEmbedding,
+        )  # pants: no-infer-dep
+
+        enum_members.append(
+            (
+                "BEDROCK_EMBEDDING",
+                ConfigurableTransformation(
+                    name="Bedrock Embedding",
+                    transformation_category=TransformationCategories.EMBEDDING,
+                    component_type=BedrockEmbedding,
+                ),
+            )
+        )
+    except (ImportError, ValidationError):
+        pass
+
+    try:
         from llama_index.embeddings.huggingface import (
             HuggingFaceInferenceAPIEmbedding,
         )  # pants: no-infer-dep
@@ -278,6 +296,42 @@ def build_configurable_transformation_enum():
                     name="HuggingFace API Embedding",
                     transformation_category=TransformationCategories.EMBEDDING,
                     component_type=HuggingFaceInferenceAPIEmbedding,
+                ),
+            )
+        )
+    except (ImportError, ValidationError):
+        pass
+
+    try:
+        from llama_index.embeddings.gemini import (
+            GeminiEmbedding,
+        )  # pants: no-infer-dep
+
+        enum_members.append(
+            (
+                "GEMINI_EMBEDDING",
+                ConfigurableTransformation(
+                    name="Gemini Embedding",
+                    transformation_category=TransformationCategories.EMBEDDING,
+                    component_type=GeminiEmbedding,
+                ),
+            )
+        )
+    except (ImportError, ValidationError):
+        pass
+
+    try:
+        from llama_index.embeddings.mistralai import (
+            MistralAIEmbedding,
+        )  # pants: no-infer-dep
+
+        enum_members.append(
+            (
+                "MISTRALAI_EMBEDDING",
+                ConfigurableTransformation(
+                    name="MistralAI Embedding",
+                    transformation_category=TransformationCategories.EMBEDDING,
+                    component_type=MistralAIEmbedding,
                 ),
             )
         )


### PR DESCRIPTION
# Description

Add Bedrock, Gemini and MistralAI embeddings to configurable transformations

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
