### PR TITLE
 Changing BM25Retriever _retrieve to use numpy methods 

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -77,22 +77,19 @@ class BM25Retriever(BaseRetriever):
             verbose=verbose,
         )
 
-    def _get_scored_nodes(self, query: str) -> List[NodeWithScore]:
-        tokenized_query = self._tokenizer(query)
-        doc_scores = self.bm25.get_scores(tokenized_query)
-
-        nodes: List[NodeWithScore] = []
-        for i, node in enumerate(self._nodes):
-            nodes.append(NodeWithScore(node=node, score=float(doc_scores[i])))
-
-        return nodes
-
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         if query_bundle.custom_embedding_strs or query_bundle.embedding:
             logger.warning("BM25Retriever does not support embeddings, skipping...")
+        
+        query = query_bundle.query_str
+        tokenized_query = self._tokenizer(query)
+        scores = self.bm25.get_scores(tokenized_query)
+        
+        top_n = scores.argsort()[::-1][:self._similarity_top_k]
+        
+        nodes: List[NodeWithScore] = []
+        for ix, score in zip(top_n, scores):
+            nodes.append(NodeWithScore(node = self._nodes[ix],
+                                       score = float(score)))
 
-        scored_nodes = self._get_scored_nodes(query_bundle.query_str)
-
-        # Sort and get top_k nodes, score range => 0..1, closer to 1 means more relevant
-        nodes = sorted(scored_nodes, key=lambda x: x.score or 0.0, reverse=True)
-        return nodes[: self._similarity_top_k]
+        return nodes

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -80,16 +80,15 @@ class BM25Retriever(BaseRetriever):
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         if query_bundle.custom_embedding_strs or query_bundle.embedding:
             logger.warning("BM25Retriever does not support embeddings, skipping...")
-        
+
         query = query_bundle.query_str
         tokenized_query = self._tokenizer(query)
         scores = self.bm25.get_scores(tokenized_query)
-        
-        top_n = scores.argsort()[::-1][:self._similarity_top_k]
-        
+
+        top_n = scores.argsort()[::-1][: self._similarity_top_k]
+
         nodes: List[NodeWithScore] = []
         for ix, score in zip(top_n, scores):
-            nodes.append(NodeWithScore(node = self._nodes[ix],
-                                       score = float(score)))
+            nodes.append(NodeWithScore(node=self._nodes[ix], score=float(score)))
 
         return nodes

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-retrievers-bm25"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Using BM25Retriever with a modest  amount of data(~40000 short nodes) was taking several seconds, which seemed odd.

Apparently, after computing the scores of the nodes, the sorting is done with python's sorted, which is slow compared to numpy's argsort and sort. The supporting library rank_bm25 has a get_top_n function that can be adapted to do the _retrieve's work using these functions.

Fixes # BM25Retrieve retrieval performance

## New Package?

No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

make test, this little benchmark and checking the computed scores match in my use case.

```
import random
import string
from llama_index.retrievers.bm25 import BM25Retriever
from llama_index.core.schema import TextNode


nodes = []
for i in range(100000):
    nodes.append(TextNode( text= ''.join(random.choices(string.ascii_lowercase, k=20))))

bm25retriever = BM25Retriever.from_defaults(nodes=nodes,
                                            similarity_top_k= 5)

bm25retriever.retrieve("foobar")
```

before
```
In [5]: %timeit bm25retriever.retrieve("foobar")
746 ms ± 39.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
after
```
: %timeit bm25retriever.retrieve("foobar")
20.2 ms ± 536 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
````
## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
