### PR TITLE
fix: typo in awsdocdb

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-awsdocdb/llama_index/vector_stores/awsdocdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-awsdocdb/llama_index/vector_stores/awsdocdb/base.py
@@ -3,6 +3,7 @@
 An index that that is built on top of an existing vector store.
 
 """
+
 import logging
 from enum import Enum
 from typing import Any, Dict, List, Optional, cast
@@ -315,4 +316,4 @@ class AWSDocDbVectorStore(BasePydanticVectorStore):
         return self._index_crud.delete_index()
 
     def __del__(self) -> None:
-        self.docdb_client.close()
+        self._docdb_client.close()

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-awsdocdb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-awsdocdb/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-awsdocdb"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

fix typo in awsdocdb

self.docdb_client.close() => self._docdb_client.close()

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [v] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [v ] No

## Type of Change

- [v ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
