### PR TITLE
correct __del__ Vllm

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -247,16 +247,14 @@ class Vllm(LLM):
         }
         return {**base_kwargs}
 
-    def __del__(self) -> None:
+        def __del__(self) -> None:
         import torch
-
+        import gc
+        
         if torch.cuda.is_available():
-            from vllm.model_executor.parallel_utils.parallel_state import (
-                destroy_model_parallel,
-            )
-
-            destroy_model_parallel()
             del self._client
+            gc.collect()
+            torch.cuda.empty_cache()
             torch.cuda.synchronize()
 
     def _get_all_kwargs(self, **kwargs: Any) -> Dict[str, Any]:

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -247,7 +247,7 @@ class Vllm(LLM):
         }
         return {**base_kwargs}
 
-        def __del__(self) -> None:
+    def __del__(self) -> None:
         import torch
         import gc
         

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -250,7 +250,7 @@ class Vllm(LLM):
     def __del__(self) -> None:
         import torch
         import gc
-        
+
         if torch.cuda.is_available():
             del self._client
             gc.collect()

--- a/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vllm"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
the module doesn' t exist anymore in vllm so i did an other way to delete the Vllm object. i use gc.collect() and torch.cuda.empty_cache()

Fixes #14048

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
 
i tested on my side with loading and deleting the object

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
