### PR TITLE
feat: add spans to ingestion pipline

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -36,6 +36,7 @@ from llama_index.core.ingestion.data_sources import (
 from llama_index.core.ingestion.transformations import (
     ConfigurableTransformations,
 )
+from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.readers.base import ReaderConfig
 from llama_index.core.schema import (
@@ -53,6 +54,8 @@ from llama_index.core.storage.docstore import (
 from llama_index.core.storage.storage_context import DOCSTORE_FNAME
 from llama_index.core.utils import concat_dirs
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
+
+dispatcher = get_dispatcher(__name__)
 
 
 def deserialize_transformation_component(
@@ -640,6 +643,7 @@ class IngestionPipeline(BaseModel):
         for i in range(0, len(nodes), batch_size):
             yield nodes[i : i + batch_size]
 
+    @dispatcher.span
     def run(
         self,
         show_progress: bool = False,
@@ -816,6 +820,7 @@ class IngestionPipeline(BaseModel):
 
         return nodes_to_run
 
+    @dispatcher.span
     async def arun(
         self,
         show_progress: bool = False,

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from dataclasses_json import DataClassJsonMixin
 from llama_index.core.bridge.pydantic import BaseModel, Field
+from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.utils import SAMPLE_TEXT, truncate_text
 from typing_extensions import Self
 
@@ -116,7 +117,7 @@ class BaseComponent(BaseModel):
         return cls.from_dict(data, **kwargs)
 
 
-class TransformComponent(BaseComponent):
+class TransformComponent(BaseComponent, DispatcherSpanMixin):
     """Base class for transform components."""
 
     class Config:


### PR DESCRIPTION
## Code
```python
import tempfile
from urllib.request import urlretrieve

from llama_index.core import SimpleDirectoryReader
from llama_index.core.extractors import SummaryExtractor, TitleExtractor
from llama_index.core.ingestion import IngestionPipeline
from llama_index.core.instrumentation import get_dispatcher
from llama_index.core.instrumentation.span_handlers import SimpleSpanHandler
from llama_index.core.node_parser import SentenceSplitter
from llama_index.core.schema import MetadataMode
from llama_index.embeddings.openai import OpenAIEmbedding
from llama_index.llms.openai import OpenAI

handler = SimpleSpanHandler()
get_dispatcher().add_span_handler(handler)

with tempfile.NamedTemporaryFile() as tf:
    urlretrieve(
        "https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt",
        tf.name,
    )
    documents = SimpleDirectoryReader(input_files=[tf.name]).load_data()
llm = OpenAI(model="gpt-3.5-turbo", temperature=0.1)
pipline = IngestionPipeline(
    transformations=[
        SentenceSplitter(chunk_size=2048, chunk_overlap=20),
        TitleExtractor(llm=llm, metadata_mode=MetadataMode.EMBED, num_workers=8),
        SummaryExtractor(llm=llm, metadata_mode=MetadataMode.EMBED, num_workers=8),
        OpenAIEmbedding(),
    ]
)

if __name__ == "__main__":
    nodes = pipline.run(documents=documents)
    handler.print_trace_trees()
```
## Spans
```
IngestionPipeline.run-43adce41-ff63-4233-acbb-f4d1dce91d75 (6.303315)
├── NodeParser.__call__-cf49d166-fc79-4dd5-9c47-bc958ea5eda9 (0.046295)
│   └── MetadataAwareTextSplitter._parse_nodes-0e867617-4fd6-4019-b71b-13ab0e3ba8ed (0.044899)
│       └── SentenceSplitter.split_text_metadata_aware-7e4b46c6-3495-44b6-ac3b-e4b2e8c48989 (0.043471)
├── BaseExtractor.__call__-efd12925-b8f2-401c-b2b3-f708155ebbc7 (1.517921)
│   └── TitleExtractor.aextract-826538e6-089e-46af-969a-e9d7de6c769a (1.515966)
│       ├── run_jobs-de55dde8-3dbc-47d1-b13a-36519b76084b (0.853806)
│       │   ├── run_jobs.<locals>.worker-841af7d3-2110-4771-b867-739e8acedd03 (0.709453)
│       │   │   └── LLM.apredict-cfec6e25-4037-4f26-8dac-cf3a10d5e037 (0.709286)
│       │   │       └── OpenAI.achat-19df220a-7dae-463b-87d7-4f50ae1122a6 (0.708609)
│       │   ├── run_jobs.<locals>.worker-fa4d31d0-7752-4103-b99b-b35da0213469 (0.771226)
│       │   │   └── LLM.apredict-e9439478-5b90-4028-a6a5-81f7b68eb103 (0.771067)
│       │   │       └── OpenAI.achat-7f7ac1a1-4510-47d0-8ddf-52954707582d (0.770601)
│       │   ├── run_jobs.<locals>.worker-ad913466-3418-4f07-98ee-5fae3d8ad116 (0.699085)
│       │   │   └── LLM.apredict-f465e916-9cd1-4dbe-aa80-b7afd4883414 (0.698974)
│       │   │       └── OpenAI.achat-3d297b9b-5ff0-4dc4-a502-5d81159aeb92 (0.698683)
│       │   ├── run_jobs.<locals>.worker-d800fee4-a81f-44f1-811a-c15d2b1326fe (0.753433)
│       │   │   └── LLM.apredict-b5d3e0d9-5d64-49dc-a39d-b80b5e1916e4 (0.753321)
│       │   │       └── OpenAI.achat-b3560b05-10d9-46e9-a562-154752d2e766 (0.753037)
│       │   └── run_jobs.<locals>.worker-eb26e147-0e57-4f47-8c01-9775d78bb91b (0.776795)
│       │       └── LLM.apredict-1bcff495-c333-436b-aeae-bfb8c51c9d79 (0.776675)
│       │           └── OpenAI.achat-cfcbb00f-0c2a-496e-80f0-a0c3fd05d701 (0.776392)
│       └── LLM.apredict-f464ec09-cba6-4a0c-8f12-a394f2151ed9 (0.661468)
│           └── OpenAI.achat-9cae37f4-c27a-40f3-8745-903ae6ea0565 (0.661089)
├── BaseExtractor.__call__-f93067ec-2671-4c1f-954d-fd30bec43357 (4.224565)
│   └── SummaryExtractor.aextract-9da7cec0-1f03-444d-b2c3-08c1b20dc2ab (4.223626)
│       └── run_jobs-a260d8f2-f3c9-42ae-a3fa-a798c8df8f7b (4.223452)
│           ├── run_jobs.<locals>.worker-da3649fe-9521-47d7-b1ff-00542e31edc1 (2.833868)
│           │   └── LLM.apredict-d5bcabd1-626a-4dc1-82d3-c6c53448b37a (2.833603)
│           │       └── OpenAI.achat-5414241d-f62b-4f9e-8092-fc0e1c416f49 (2.833192)
│           ├── run_jobs.<locals>.worker-6a7db7ba-0cac-40d8-ab57-abc78d5b882c (1.785676)
│           │   └── LLM.apredict-9f5a7efe-47ea-456e-97be-8644bbdf3e6a (1.785416)
│           │       └── OpenAI.achat-428e2354-bf9c-440d-9873-3d2fecfd5009 (1.785045)
│           ├── run_jobs.<locals>.worker-7a52e361-d7ce-4deb-a00d-d33db7ff6abc (1.981206)
│           │   └── LLM.apredict-7ac5ea37-5163-4268-b15e-c43add0d2579 (1.980988)
│           │       └── OpenAI.achat-fe3664a9-a93b-4d11-a736-1d2a4e2a328b (1.980632)
│           ├── run_jobs.<locals>.worker-fe2edf6c-01b7-42ec-b5b6-5143c6167dcb (4.194281)
│           │   └── LLM.apredict-4f8963b6-71e4-476c-9a04-563390a32db0 (4.19405)
│           │       └── OpenAI.achat-95a9729a-8564-4cf0-8c38-9b2c119c6561 (4.193693)
│           ├── run_jobs.<locals>.worker-0c91f49b-55ac-43e3-b0f5-a135971972ba (2.094101)
│           │   └── LLM.apredict-36d89a18-1241-4f3f-80b8-9b5c0cbc6227 (2.09389)
│           │       └── OpenAI.achat-a0faaf6f-afc7-4831-b1aa-26c533fa3b6b (2.093597)
│           ├── run_jobs.<locals>.worker-604d98b5-12f4-4f4f-80d8-f75f06f804d8 (2.579819)
│           │   └── LLM.apredict-7500e479-edbd-4be7-b0b8-a84eed01c828 (2.579593)
│           │       └── OpenAI.achat-be96735d-a538-4304-88d3-4a1b95aaa197 (2.579224)
│           ├── run_jobs.<locals>.worker-3bbf3fb6-ca1e-48b3-999c-670226305a08 (2.076285)
│           │   └── LLM.apredict-2fc4e4e6-ff53-4f11-a71e-262110dff62a (2.076081)
│           │       └── OpenAI.achat-1a0244f0-a91b-45ce-b45a-174168f30912 (2.07579)
│           ├── run_jobs.<locals>.worker-b761375c-b812-4fcd-b16e-789ab047dc03 (4.113125)
│           │   └── LLM.apredict-c2ab1b55-8cb3-4db3-affe-13406a62b927 (4.112921)
│           │       └── OpenAI.achat-8e45d72c-7db3-4198-b0c0-fdcdbedc78b8 (4.112584)
│           └── run_jobs.<locals>.worker-fe5d5904-5f53-4bc2-ade3-c6ec5a8401c1 (3.980656)
│               └── LLM.apredict-c7b6fde3-0798-4eb0-910f-bc93bb14c15f (2.245384)
│                   └── OpenAI.achat-a46b001e-aeb7-4ced-ad5c-1b2da00f68ee (2.244737)
└── BaseEmbedding.__call__-bffd8d67-1d91-4a36-b362-d48d6632b2c0 (0.463568)
    └── BaseEmbedding.get_text_embedding_batch-1cbb1a44-c51f-4b27-b0cd-d4bcf7e00649 (0.409416)
```