### PR TITLE
Fixes TypeError: sequence item : expected str instance, int found

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-mongodb/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/README.md
@@ -21,6 +21,7 @@ from llama_index.readers.mongo import SimpleMongoReader
 reader = SimpleMongoReader(
     host="<Mongo Host>",  # Mongo host address
     port=27017,  # Mongo port (default: 27017)
+    uri="<Mongo Connection String>",  # Provide the URI if not using host and port
 )
 
 # Lazy load data from MongoDB

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -86,7 +86,7 @@ class SimpleMongoReader(BaseReader):
 
         for item in cursor:
             try:
-                texts = [item[name] for name in field_names]
+                texts = [f"{name}: " + str(item[name]) for name in field_names]
             except KeyError as err:
                 raise ValueError(
                     f"{err.args[0]} field not found in Mongo document."

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-mongodb"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This change fixes the `TypeError: sequence item : expected str instance, int found` as the `join` function tries to concatenate a list of strings, but it gets an integer in the list. 

Such an error occurs when the field value in the MongoDB document is not a string. 

Fixes #14122 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
