### PR TITLE
fix for batch_gather

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -61,6 +61,7 @@ async def batch_gather(
 ) -> List[Any]:
     output: List[Any] = []
     for task_chunk in chunks(tasks, batch_size):
+        task_chunk = (task for task in task_chunk if task is not None)
         output_chunk = await asyncio.gather(*task_chunk)
         output.extend(output_chunk)
         if verbose:

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -2,14 +2,15 @@ import asyncio
 from llama_index.core.async_utils import batch_gather
 
 
-def test_batch_gather_uneven_task_list() -> None:
+def test_batch_gather_indivisible_task_list() -> None:
     """
-    Test that batch_gather works with an uneven task list.
+    Test that batch_gather works with an task list of a
+    length that is not cleanly divisible by the batch size.
     """
 
-    async def async_method():
-        return 1
+    async def async_method(n: int) -> int:
+        return n
 
-    coroutines = [async_method() for _ in range(5)]
+    coroutines = [async_method(n) for n in range(5)]
     results = asyncio.run(batch_gather(coroutines, batch_size=2))
-    assert results == [1] * len(coroutines)
+    assert results == list(range(len(coroutines)))

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,0 +1,15 @@
+import asyncio
+from llama_index.core.async_utils import batch_gather
+
+
+def test_batch_gather_uneven_task_list() -> None:
+    """
+    Test that batch_gather works with an uneven task list.
+    """
+
+    async def async_method():
+        return 1
+
+    coroutines = [async_method() for _ in range(5)]
+    results = asyncio.run(batch_gather(coroutines, batch_size=2))
+    assert results == [1] * len(coroutines)


### PR DESCRIPTION
# Description

fix for `batch_gather` from async_utils when task list size isn't cleanly divisible by `batch_size`

The unit test I added was able to reproduce the error I was seeing and passes now with the fix I added to the `batch_gather` method.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
