### PR TITLE
Fix NLSQLTableQueryEngine response metadata

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -422,7 +422,7 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
                 query=query_bundle.query_str,
                 nodes=retrieved_nodes,
             )
-            # cast(Dict, response.metadata).update(metadata)
+            cast(Dict, response.metadata).update(metadata)
             return cast(Response, response)
         else:
             response_str = "\n".join([node.node.text for node in retrieved_nodes])

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -422,7 +422,7 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
                 query=query_bundle.query_str,
                 nodes=retrieved_nodes,
             )
-            cast(Dict, response.metadata).update(metadata)
+            # cast(Dict, response.metadata).update(metadata)
             return cast(Response, response)
         else:
             response_str = "\n".join([node.node.text for node in retrieved_nodes])

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
@@ -85,7 +85,24 @@ class SQLRetriever(BaseRetriever):
             query_bundle = str_or_query_bundle
         raw_response_str, metadata = self._sql_database.run_sql(query_bundle.query_str)
         if self._return_raw:
-            return [NodeWithScore(node=TextNode(text=raw_response_str))], metadata
+            return [
+                NodeWithScore(
+                    node=TextNode(
+                        text=raw_response_str,
+                        metadata={
+                            "sql_query": query_bundle.query_str,
+                            "result": metadata["result"],
+                            "col_keys": metadata["col_keys"],
+                        },
+                        excluded_embed_metadata_keys=[
+                            "sql_query",
+                            "result",
+                            "col_keys",
+                        ],
+                        excluded_llm_metadata_keys=["sql_query", "result", "col_keys"],
+                    )
+                )
+            ], metadata
         else:
             # return formatted
             results = metadata["result"]


### PR DESCRIPTION
# Description


Currently, the metadata in the response returned by SQLTableRetrieverQueryEngine is not correctly formatted. The code in issue #14168 results in a reponse with metadata
```
{'779576b4-46c5-4802-904a-5cf8023b7ee9': {}, 'sql_query': 'SELECT city_name, population \nFROM city_stats \nORDER BY population DESC \nLIMIT 1;', 'result': [('Tokyo', 13960000)], 'col_keys': ['city_name', 'population']}
```
While the expected metadata should be
```
{'779576b4-46c5-4802-904a-5cf8023b7ee9': {'sql_query': 'SELECT city_name, population\nFROM city_stats\nORDER BY population DESC\nLIMIT 1;', 'result': [('Tokyo', 13960000)], 'col_keys': ['city_name', 'population']}}
```
This pull request fix the issue by correctly setting the metadata of the retrived SQL node in `SQLRetriever`

Fixes #14168 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**I verified using the code in #14168 **

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
