### PR TITLE
Restore Nomic Embed einops dependency

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nomic/pyproject.toml
@@ -27,12 +27,13 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-nomic"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.0.post1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.11.post1"
 llama-index-embeddings-huggingface = "^0.1.3"
+einops = "^0.7.0"
 nomic = "^3.0.30"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Sorry for clearing the PR template, but this is a small follow-up to #13607 that re-adds the einops dependency, which was accidentally removed. It is required by NomicHFEmbedding.