### PR TITLE
Use typical include llama_index/

### DIFF
--- a/llama-index-utils/llama-index-utils-azure/pyproject.toml
+++ b/llama-index-utils/llama-index-utils-azure/pyproject.toml
@@ -57,5 +57,4 @@ extras = ["toml"]
 version = ">=v2.2.6"
 
 [[tool.poetry.packages]]
-from = "llama-index-utils-azure/llama_index/utils/azure"
-include = "llama_index.utils.azure"
+include = "llama_index/"


### PR DESCRIPTION
# Description

- Publishing `llama-index-utils-azure` failed due to `include` path in `pyproject.toml (see [here](https://github.com/run-llama/llama_index/actions/runs/9549714663/job/26319924469#step:6:77))

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (this package failed to publish, so this fix should help release this now)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
