### PR TITLE
Remove sentence-transformers dependency from HuggingFace utils package

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.0"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-llama-index-utils-huggingface = "^0.1.0"
+llama-index-utils-huggingface = "^0.1.1"
 
 [tool.poetry.dependencies.huggingface-hub]
 extras = ["inference"]

--- a/llama-index-utils/llama-index-utils-huggingface/pyproject.toml
+++ b/llama-index-utils/llama-index-utils-huggingface/pyproject.toml
@@ -24,12 +24,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-utils-huggingface"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-sentence-transformers = "^2.6.1"
 
 [tool.poetry.dependencies.huggingface-hub]
 extras = ["inference"]


### PR DESCRIPTION
# Description

Remove sentence-transformers dependency from HuggingFace utils package.

It is a heavy dependency (also depends on torch) and is unnecessary.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
