### PR TITLE
Let cache files like chat_store.json looks more pretty

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -100,7 +100,7 @@ class BaseComponent(BaseModel):
 
     def to_json(self, **kwargs: Any) -> str:
         data = self.to_dict(**kwargs)
-        return json.dumps(data)
+        return json.dumps(data, ensure_ascii=False, indent=4)
 
     # TODO: return type here not supported by current mypy version
     @classmethod

--- a/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
@@ -70,7 +70,7 @@ class SimpleChatStore(BaseChatStore):
         if not fs.exists(dirpath):
             fs.makedirs(dirpath)
 
-        with fs.open(persist_path, "w") as f:
+        with fs.open(persist_path, "w", encoding="utf8") as f:
             f.write(json.dumps(self.json()))
 
     @classmethod

--- a/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
@@ -84,8 +84,8 @@ class SimpleKVStore(BaseInMemoryKVStore):
         if not fs.exists(dirpath):
             fs.makedirs(dirpath)
 
-        with fs.open(persist_path, "w") as f:
-            f.write(json.dumps(self._data))
+        with fs.open(persist_path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(self._data, ensure_ascii=False, indent=4))
 
     @classmethod
     def from_persist_path(


### PR DESCRIPTION
# Description

My docs mainly are in chinese. The generated `*.json` files are full of strings begin with `\u` which cannot be read by human. 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

