### PR TITLE
Fix DuckDBVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
@@ -13,6 +13,7 @@ from llama_index.core.vector_stores.types import (
     VectorStoreQueryResult,
 )
 from llama_index.core.vector_stores.utils import (
+    metadata_dict_to_node,
     node_to_metadata_dict,
 )
 
@@ -260,6 +261,9 @@ class DuckDBVectorStore(BasePydanticVectorStore):
                 flat_metadata=self.flat_metadata,
             ),
         )
+    
+    def _table_row_to_node(self, row: Any) -> BaseNode:
+        return metadata_dict_to_node(json.loads(row[3]), row[1])
 
     def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add nodes to index.
@@ -391,12 +395,7 @@ class DuckDBVectorStore(BasePydanticVectorStore):
                 _final_results = _conn.execute(_ddb_query).fetchall()
 
         for _row in _final_results:
-            node = TextNode(
-                id_=_row[0],
-                text=_row[1],
-                embedding=_row[2],
-                metadata=json.loads(_row[3]),
-            )
+            node = self._table_row_to_node(_row)
             nodes.append(node)
             similarities.append(_row[4])
             ids.append(_row[0])

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
@@ -153,7 +153,21 @@ class DuckDBVectorStore(BasePydanticVectorStore):
 
     @classmethod
     def from_local(
-        cls, database_path: str, table_name: str = "documents"
+        cls, 
+        database_path: str,
+        table_name: Optional[str] = "documents",
+        # schema_name: Optional[str] = "main",
+        embed_dim: Optional[int] = None,
+        # hybrid_search: Optional[bool] = False,
+        text_search_config: Optional[dict] = {
+            "stemmer": "english",
+            "stopwords": "english",
+            "ignore": "(\\.|[^a-z])+",
+            "strip_accents": True,
+            "lower": True,
+            "overwrite": False,
+        },
+        **kwargs: Any,
     ) -> "DuckDBVectorStore":
         """Load a DuckDB vector store from a local file."""
         with DuckDBLocalContext(database_path) as _conn:
@@ -173,7 +187,10 @@ class DuckDBVectorStore(BasePydanticVectorStore):
         _cls = cls(
             database_name=os.path.basename(database_path),
             table_name=table_name,
+            embed_dim=embed_dim,
+            text_search_config=text_search_config,
             persist_dir=os.path.dirname(database_path),
+            **kwargs,
         )
         _cls._is_initialized = True
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
@@ -5,7 +5,7 @@ import json
 from typing import Any, List, Optional
 import os
 from llama_index.core.bridge.pydantic import PrivateAttr
-from llama_index.core.schema import BaseNode, MetadataMode, TextNode
+from llama_index.core.schema import BaseNode, MetadataMode
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
     MetadataFilters,
@@ -153,7 +153,7 @@ class DuckDBVectorStore(BasePydanticVectorStore):
 
     @classmethod
     def from_local(
-        cls, 
+        cls,
         database_path: str,
         table_name: Optional[str] = "documents",
         # schema_name: Optional[str] = "main",
@@ -278,7 +278,7 @@ class DuckDBVectorStore(BasePydanticVectorStore):
                 flat_metadata=self.flat_metadata,
             ),
         )
-    
+
     def _table_row_to_node(self, row: Any) -> BaseNode:
         return metadata_dict_to_node(json.loads(row[3]), row[1])
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["krish-adi"]
 name = "llama-index-vector-stores-duckdb"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
@@ -78,9 +78,7 @@ def text_node_list() -> List[TextNode]:
             embedding=[0.0, 0.0, 0.3],
         ),
         TextNode(
-            text=(
-                "中文用户来了。"
-            ),
+            text=("中文用户来了。"),
             id_="943ef4e5-b5bc-4b85-b0d7-bc4fb25417db",
             relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-6")},
             metadata={
@@ -99,7 +97,7 @@ def text_node_list() -> List[TextNode]:
             },
             embedding=[0.9, 0.3, 0.3],
             excluded_embed_metadata_keys=["excluded_embed"],
-            excluded_llm_metadata_keys=["excluded_llm", "metadata", "keys"]
+            excluded_llm_metadata_keys=["excluded_llm", "metadata", "keys"],
         ),
     ]
 
@@ -132,14 +130,21 @@ def test_duckdb_add_and_query(
     assert res.nodes[0].excluded_embed_metadata_keys == []
     assert res.nodes[0].excluded_llm_metadata_keys == []
     assert res.nodes[0].source_node.node_id == "test-0"
-    
+
     res = vector_store.query(
         VectorStoreQuery(query_embedding=[0.9, 0.3, 0.3], similarity_top_k=1)
     )
     assert res.nodes
     assert res.nodes[0].node_id == "e8f0c6cb-8d35-4240-a60a-b57070b3960f"
-    assert res.nodes[0].get_content() == "Vector stores contain embedding vectors of ingested document chunks (and sometimes the document chunks as well)."
+    assert (
+        res.nodes[0].get_content()
+        == "Vector stores contain embedding vectors of ingested document chunks (and sometimes the document chunks as well)."
+    )
     assert res.nodes[0].metadata.get("author") == "Emma Johnson"
     assert res.nodes[0].excluded_embed_metadata_keys == ["excluded_embed"]
-    assert res.nodes[0].excluded_llm_metadata_keys == ["excluded_llm", "metadata", "keys"]
+    assert res.nodes[0].excluded_llm_metadata_keys == [
+        "excluded_llm",
+        "metadata",
+        "keys",
+    ]
     assert res.nodes[0].source_node.node_id == "test-7"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
@@ -47,7 +47,7 @@ def text_node_list() -> List[TextNode]:
         TextNode(
             text="I was taught that the way of progress was neither swift nor easy.",
             id_="0b31ae71-b797-4e88-8495-031371a7752e",
-            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="text-3")},
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-3")},
             metadata={
                 "author": "Marie Curie",
             },
@@ -59,7 +59,7 @@ def text_node_list() -> List[TextNode]:
                 + " Curiosity has its own reason for existing."
             ),
             id_="bd2e080b-159a-4030-acc3-d98afd2ba49b",
-            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="text-4")},
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-4")},
             metadata={
                 "author": "Albert Einstein",
             },
@@ -71,11 +71,35 @@ def text_node_list() -> List[TextNode]:
                 + " I am a free human being with an independent will."
             ),
             id_="f658de3b-8cef-4d1c-8bed-9a263c907251",
-            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="text-5")},
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-5")},
             metadata={
                 "author": "Charlotte Bronte",
             },
             embedding=[0.0, 0.0, 0.3],
+        ),
+        TextNode(
+            text=(
+                "中文用户来了。"
+            ),
+            id_="943ef4e5-b5bc-4b85-b0d7-bc4fb25417db",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-6")},
+            metadata={
+                "author": "Ava Wilson",
+            },
+            embedding=[0.3, 0.3, 0.3],
+        ),
+        TextNode(
+            text=(
+                "Vector stores contain embedding vectors of ingested document chunks (and sometimes the document chunks as well)."
+            ),
+            id_="e8f0c6cb-8d35-4240-a60a-b57070b3960f",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-7")},
+            metadata={
+                "author": "Emma Johnson",
+            },
+            embedding=[0.9, 0.3, 0.3],
+            excluded_embed_metadata_keys=["excluded_embed"],
+            excluded_llm_metadata_keys=["excluded_llm", "metadata", "keys"]
         ),
     ]
 
@@ -96,8 +120,26 @@ def test_duckdb_add_and_query(
     vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
 ) -> None:
     vector_store.add(text_node_list)
+
     res = vector_store.query(
-        VectorStoreQuery(query_embedding=[1.0, 0.0, 0.0], similarity_top_k=1)
+        VectorStoreQuery(query_embedding=[1.1, 0.0, 0.0], similarity_top_k=1)
     )
     assert res.nodes
+    assert res.nodes[0].node_id == "c330d77f-90bd-4c51-9ed2-57d8d693b3b0"
     assert res.nodes[0].get_content() == "lorem ipsum"
+    assert res.nodes[0].metadata.get("author") == "Stephen King"
+    assert res.nodes[0].metadata.get("theme") == "Friendship"
+    assert res.nodes[0].excluded_embed_metadata_keys == []
+    assert res.nodes[0].excluded_llm_metadata_keys == []
+    assert res.nodes[0].source_node.node_id == "test-0"
+    
+    res = vector_store.query(
+        VectorStoreQuery(query_embedding=[0.9, 0.3, 0.3], similarity_top_k=1)
+    )
+    assert res.nodes
+    assert res.nodes[0].node_id == "e8f0c6cb-8d35-4240-a60a-b57070b3960f"
+    assert res.nodes[0].get_content() == "Vector stores contain embedding vectors of ingested document chunks (and sometimes the document chunks as well)."
+    assert res.nodes[0].metadata.get("author") == "Emma Johnson"
+    assert res.nodes[0].excluded_embed_metadata_keys == ["excluded_embed"]
+    assert res.nodes[0].excluded_llm_metadata_keys == ["excluded_llm", "metadata", "keys"]
+    assert res.nodes[0].source_node.node_id == "test-7"


### PR DESCRIPTION
# Description

@krish-adi 
I encountered two issues while using DuckDBVectorStore:

DuckDBVectorStore.from_local does not support specifying embed_dim, causing my code to malfunction.

DuckDBVectorStore only loads the main fields of the Node.

This PR addresses the aforementioned issues.


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
