### PR TITLE
fix: :bug: Call sync methods while async isn't implemented for `BedrockConverse`

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -385,32 +385,30 @@ class BedrockConverse(FunctionCallingLLM):
     @llm_chat_callback()
     async def achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> NotImplementedError:
-        raise NotImplementedError("Async chat is not supported for Bedrock Converse.")
+    ) -> ChatResponse:
+        # TODO convert to async; do synchronous chat for now
+        return self.chat(messages, **kwargs)
 
     @llm_completion_callback()
     async def acomplete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
-    ) -> NotImplementedError:
-        raise NotImplementedError(
-            "Async completion is not supported for Bedrock Converse."
-        )
+    ) -> CompletionResponse:
+        # TODO convert to async; do synchronous completion for now
+        return self.complete(prompt, formatted=formatted, **kwargs)
 
     @llm_chat_callback()
     async def astream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> NotImplementedError:
-        raise NotImplementedError(
-            "Async stream chat is not supported for Bedrock Converse."
-        )
+    ) -> ChatResponseGen:
+        # TODO convert to async; do synchronous chat for now
+        return self.stream_chat(messages, **kwargs)
 
     @llm_completion_callback()
     async def astream_complete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
-    ) -> NotImplementedError:
-        raise NotImplementedError(
-            "Async stream completion is not supported for Bedrock Converse."
-        )
+    ) -> CompletionResponseGen:
+        # TODO convert to async; do synchronous completion for now
+        return self.stream_complete(prompt, formatted=formatted, **kwargs)
 
     def chat_with_tools(
         self,
@@ -446,9 +444,15 @@ class BedrockConverse(FunctionCallingLLM):
         verbose: bool = False,
         allow_parallel_tool_calls: bool = False,
         **kwargs: Any,
-    ) -> NotImplementedError:
-        raise NotImplementedError(
-            "Async chat with tools is not supported for Bedrock Converse."
+    ) -> ChatResponse:
+        # TODO convert to async; do synchronous chat for now
+        return self.chat_with_tools(
+            tools=tools,
+            user_msg=user_msg,
+            chat_history=chat_history,
+            verbose=verbose,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
+            **kwargs,
         )
 
     def get_tool_calls_from_response(

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock-converse"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

`BedrockConverse` LLMs would fail if we tried to use it in anything that requires the async methods, e.g. evaluators. This PR doesn't implement the async functionality yet, but at least let's `BedrockConverse` LLMs to work in a synchronous fashion.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [X] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
