### PR TITLE
fix issue 14240 incorrect casting to str of text nodes in sql retreiver

### DIFF
--- a/llama-index-core/llama_index/core/base/query_pipeline/query.py
+++ b/llama-index-core/llama_index/core/base/query_pipeline/query.py
@@ -58,6 +58,8 @@ def validate_and_convert_stringable(input: Any) -> str:
         return str(new_input_list)
     elif isinstance(input, ChatResponse):
         return input.message.content or ""
+    elif isinstance(input, NodeWithScore) and isinstance(input.node, TextNode):
+        return input.get_content()
     elif isinstance(input, get_args(StringableInput)):
         return str(input)
     else:


### PR DESCRIPTION
# Description

When calling sql_retriever = SQLRetriever(sql_database) the resulting output contained ... instead of the full text contained in the node with the sql response. This code was from the intro sql tutorial online. In the code run within the SQLRetreiver we hit [this code](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/base/query_pipeline/query.py#L61-L62) in the validate and convert stringable method which calls the str(Node) which as a text node performs truncation.

Fixes # (14240)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
