### PR TITLE
feat: Add metadata field "collection_name" to SimpleMongoReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -100,6 +100,7 @@ class SimpleMongoReader(BaseReader):
             else:
                 try:
                     metadata = {name: item.get(name) for name in metadata_names}
+                    metadata["collection"] = collection_name
                 except KeyError as err:
                     raise ValueError(
                         f"{err.args[0]} field not found in Mongo document."

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-mongodb"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This commit adds a new metadata field "collection_name" to the SimpleMongoReader class in base.py. The field is populated with the name of the MongoDB collection being read. This change allows for easier tracking and identification of the collection associated with each document which allows for easier metadata filtering.

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
