### PR TITLE
[Core][Retrieval] Improve efficiency of average precision

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
@@ -282,13 +282,16 @@ class AveragePrecision(BaseRetrievalMetric):
             raise ValueError("Retrieved ids and expected ids must be provided")
 
         expected_set = set(expected_ids)
-        ap = sum(
-            len(expected_set.intersection(retrieved_ids[:i])) / i
-            for i in range(1, len(retrieved_ids) + 1)
-            if retrieved_ids[i - 1] in expected_set
-        ) / len(expected_set)
 
-        return RetrievalMetricResult(score=ap)
+        relevant_count, total_precision = 0, 0.0
+        for i, retrieved_id in enumerate(retrieved_ids, start=1):
+            if retrieved_id in expected_set:
+                relevant_count += 1
+                total_precision += relevant_count / i
+
+        average_precision = total_precision / len(expected_set)
+
+        return RetrievalMetricResult(score=average_precision)
 
 
 DiscountedGainMode = Literal["linear", "exponential"]


### PR DESCRIPTION
# Description

This PR improves the efficiency of computing Average Precision (AP). Originally, set difference was applied for each relevant document which made the computation `O(n^2)`. By keeping track of the running total, set difference is no longer necessary, reducing the complexity to `O(n)`.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
