### PR TITLE
fix: documentation where parameters in load_index_from_storage function call were invalid

### DIFF
--- a/docs/docs/examples/docstore/MongoDocstoreDemo.ipynb
+++ b/docs/docs/examples/docstore/MongoDocstoreDemo.ipynb
@@ -306,10 +306,10 @@
     "    storage_context=storage_context, index_id=list_id\n",
     ")\n",
     "vector_index = load_index_from_storage(\n",
-    "    storage_context=storage_context, vector_id=vector_id\n",
+    "    storage_context=storage_context, index_id=vector_id\n",
     ")\n",
     "keyword_table_index = load_index_from_storage(\n",
-    "    storage_context=storage_context, keyword_id=keyword_id\n",
+    "    storage_context=storage_context, index_id=keyword_id\n",
     ")"
    ]
   },


### PR DESCRIPTION
# Description

The sample code for the MongoDocstoreDemo had some errors when calling load_index_from_storage that results in the runtime error:

```
ValueError: Expected to load a single index, but got 3 instead. Please specify index_id.
```

Fixes # (issue)
n/a


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
 n/a

## Type of Change

Please delete options that are not relevant.

-[x] Fixing errors in documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
