### PR TITLE
feat(schema): Add mimetype field to TextNode

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -357,6 +357,9 @@ class BaseNode(BaseComponent):
 
 class TextNode(BaseNode):
     text: str = Field(default="", description="Text content of the node.")
+    mimetype: str = Field(
+        default="text/plain", description="MIME type of the node content."
+    )
     start_char_idx: Optional[int] = Field(
         default=None, description="Start char index of the node."
     )


### PR DESCRIPTION
This commit adds a new field, `mimetype`, to the `TextNode` class in the schema module. The `mimetype` field represents the MIME type of the node content. This change enhances the functionality and flexibility of the `TextNode` class by allowing it to store and retrieve information about the MIME type associated with its content.
