### PR TITLE
Adds no SSL option to Trafilatura Web Loader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/trafilatura_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/trafilatura_web/base.py
@@ -29,6 +29,7 @@ class TrafilaturaWebReader(BasePydanticReader):
         include_formatting=False,
         include_links=False,
         show_progress=False,
+        no_ssl=False,
         **kwargs,
     ) -> List[Document]:
         """Load data from the urls.
@@ -42,6 +43,7 @@ class TrafilaturaWebReader(BasePydanticReader):
             include_formatting (bool, optional): Include formatting in the output. Defaults to False.
             include_links (bool, optional): Include links in the output. Defaults to False.
             show_progress (bool, optional): Show progress bar. Defaults to False
+            no_ssl (bool, optional): Bypass SSL verification. Defaults to False.
             kwargs: Additional keyword arguments for the `trafilatura.extract` function.
 
         Returns:
@@ -61,7 +63,7 @@ class TrafilaturaWebReader(BasePydanticReader):
         else:
             iterator = urls
         for url in iterator:
-            downloaded = trafilatura.fetch_url(url)
+            downloaded = trafilatura.fetch_url(url, no_ssl=no_ssl)
             response = trafilatura.extract(
                 downloaded,
                 include_comments=include_comments,

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -44,7 +44,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.1.18"
+version = "0.1.19"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR adds a parameter in `TrafilaturaWebReader`'s `load_data()` method which allows the user to bypass SSL verification, enabling users to load documents from websites using Trafilatura even in scenarios where SSL verification fails.

Fixes #11374

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
