### PR TITLE
fix dropped tokens in ReActAgentWorker._arun_step_stream

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -617,7 +617,7 @@ class ReActAgentWorker(BaseAgentWorker):
 
         # iterate over stream, break out if is final answer after the "Answer: "
         full_response = ChatResponse(
-            message=ChatMessage(content=None, role="assistant")
+            message=ChatMessage(content=None, role=MessageRole.ASSISTANT)
         )
         is_done = False
         for latest_chunk in chat_stream:
@@ -689,13 +689,14 @@ class ReActAgentWorker(BaseAgentWorker):
 
         # iterate over stream, break out if is final answer after the "Answer: "
         full_response = ChatResponse(
-            message=ChatMessage(content=None, role="assistant")
+            message=ChatMessage(content=None, role=MessageRole.ASSISTANT)
         )
         is_done = False
         async for latest_chunk in chat_stream:
             full_response = latest_chunk
             is_done = self._infer_stream_chunk_is_final(latest_chunk)
             if is_done:
+                full_response.delta = full_response.message.content
                 break
 
         if not is_done:
@@ -719,7 +720,7 @@ class ReActAgentWorker(BaseAgentWorker):
         else:
             # Get the response in a separate thread so we can yield the response
             response_stream = self._async_add_back_chunk_to_stream(
-                chunk=latest_chunk, chat_stream=chat_stream
+                chunk=full_response, chat_stream=chat_stream
             )
 
             agent_response = StreamingAgentChatResponse(


### PR DESCRIPTION
# Description

The `ReActAgentWorker._arun_step_stream` method drops any tokens generated before the is_done condition triggers.

Fixes https://github.com/run-llama/llama_index/issues/14307

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
