### PR TITLE
fix: update example models to Llama 3 70B

### DIFF
--- a/docs/docs/examples/llm/groq.ipynb
+++ b/docs/docs/examples/llm/groq.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = Groq(model=\"mixtral-8x7b-32768\", api_key=\"your_api_key\")"
+    "llm = Groq(model=\"llama3-70b-8192\", api_key=\"your_api_key\")"
    ]
   },
   {

--- a/llama-index-integrations/llms/llama-index-llms-groq/llama_index/llms/groq/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-groq/llama_index/llms/groq/base.py
@@ -5,7 +5,8 @@ from llama_index.llms.openai_like import OpenAILike
 
 
 class Groq(OpenAILike):
-    """Groq LLM.
+    """
+    Groq LLM.
 
     Examples:
         `pip install llama-index-llms-groq`
@@ -14,7 +15,7 @@ class Groq(OpenAILike):
         from llama_index.llms.groq import Groq
 
         # Set up the Groq class with the required model and API key
-        llm = Groq(model="mixtral-8x7b-32768", api_key="your_api_key")
+        llm = Groq(model="llama3-70b-8192", api_key="your_api_key")
 
         # Call the complete method with a query
         response = llm.complete("Explain the importance of low latency LLMs")

--- a/llama-index-integrations/llms/llama-index-llms-groq/tests/test_integration_groq.py
+++ b/llama-index-integrations/llms/llama-index-llms-groq/tests/test_integration_groq.py
@@ -7,14 +7,14 @@ from llama_index.llms.groq import Groq
 
 @pytest.mark.skipif("GROQ_API_KEY" not in os.environ, reason="No Groq API key")
 def test_completion():
-    groq = Groq(model="mixtral-8x7b-32768", temperature=0, max_tokens=2)
+    groq = Groq(model="llama3-70b-8192", temperature=0, max_tokens=2)
     resp = groq.complete("hello")
     assert resp.text == "Hello"
 
 
 @pytest.mark.skipif("GROQ_API_KEY" not in os.environ, reason="No Groq API key")
 def test_stream_completion():
-    groq = Groq(model="mixtral-8x7b-32768", temperature=0, max_tokens=2)
+    groq = Groq(model="llama3-70b-8192", temperature=0, max_tokens=2)
     stream = groq.stream_complete("hello")
     text = None
     for chunk in stream:


### PR DESCRIPTION
# Description

Change default model in examples to Llama 3 70B for Groq examples. 



## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
