### PR TITLE
Pass the kwargs on when build_index_from_nodes(#14299)

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -92,7 +92,8 @@ class BaseIndex(Generic[IS], ABC):
             if index_struct is None:
                 nodes = nodes or []
                 index_struct = self.build_index_from_nodes(
-                    nodes + objects  # type: ignore
+                    nodes + objects,  # type: ignore
+                    **kwargs
                 )
             self._index_struct = index_struct
             self._storage_context.index_store.add_index_struct(self._index_struct)
@@ -203,13 +204,13 @@ class BaseIndex(Generic[IS], ABC):
         self._storage_context.index_store.add_index_struct(self._index_struct)
 
     @abstractmethod
-    def _build_index_from_nodes(self, nodes: Sequence[BaseNode]) -> IS:
+    def _build_index_from_nodes(self, nodes: Sequence[BaseNode], **build_kwargs: Any) -> IS:
         """Build the index from nodes."""
 
-    def build_index_from_nodes(self, nodes: Sequence[BaseNode]) -> IS:
+    def build_index_from_nodes(self, nodes: Sequence[BaseNode], **build_kwargs: Any) -> IS:
         """Build the index from nodes."""
         self._docstore.add_documents(nodes, allow_update=True)
-        return self._build_index_from_nodes(nodes)
+        return self._build_index_from_nodes(nodes, **build_kwargs)
 
     @abstractmethod
     def _insert(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:

--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -92,8 +92,7 @@ class BaseIndex(Generic[IS], ABC):
             if index_struct is None:
                 nodes = nodes or []
                 index_struct = self.build_index_from_nodes(
-                    nodes + objects,  # type: ignore
-                    **kwargs
+                    nodes + objects, **kwargs  # type: ignore
                 )
             self._index_struct = index_struct
             self._storage_context.index_store.add_index_struct(self._index_struct)
@@ -204,10 +203,14 @@ class BaseIndex(Generic[IS], ABC):
         self._storage_context.index_store.add_index_struct(self._index_struct)
 
     @abstractmethod
-    def _build_index_from_nodes(self, nodes: Sequence[BaseNode], **build_kwargs: Any) -> IS:
+    def _build_index_from_nodes(
+        self, nodes: Sequence[BaseNode], **build_kwargs: Any
+    ) -> IS:
         """Build the index from nodes."""
 
-    def build_index_from_nodes(self, nodes: Sequence[BaseNode], **build_kwargs: Any) -> IS:
+    def build_index_from_nodes(
+        self, nodes: Sequence[BaseNode], **build_kwargs: Any
+    ) -> IS:
         """Build the index from nodes."""
         self._docstore.add_documents(nodes, allow_update=True)
         return self._build_index_from_nodes(nodes, **build_kwargs)


### PR DESCRIPTION
# Description

When i want to construct VectorStoreIndex, i use the code below
```
VectorStoreIndex.from_documents(
    documents, storage_context=storage_context, any_other_kwargs="****"
)
```
i find the **any_other_kwargs** has no effect, i can't obtain the  any_other_kwargs, so i I traced the code, i find the any_other_kwargs hasn't passed on, see the code in #14299 

Fixes #14299 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
