### PR TITLE
added possibility to run local embedding model in RAG evaluation packages

### DIFF
--- a/llama-index-packs/llama-index-packs-rag-evaluator/llama_index/packs/rag_evaluator/base.py
+++ b/llama-index-packs/llama-index-packs-rag-evaluator/llama_index/packs/rag_evaluator/base.py
@@ -22,7 +22,7 @@ from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.llms import LLM
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.query_engine import BaseQueryEngine
-from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.core.settings import Settings
 from llama_index.llms.openai import OpenAI
 from openai import RateLimitError
 from tqdm.asyncio import tqdm_asyncio
@@ -42,7 +42,7 @@ class RagEvaluatorPack(BaseLlamaPack):
         query_engine: BaseQueryEngine,
         rag_dataset: BaseLlamaDataset,
         judge_llm: Optional[LLM] = None,
-        embedding_llm: Optional[BaseEmbedding] = None,
+        embed_model: Optional[BaseEmbedding] = None,
         show_progress: bool = True,
     ):
         self.query_engine = query_engine
@@ -54,11 +54,7 @@ class RagEvaluatorPack(BaseLlamaPack):
             assert isinstance(judge_llm, LLM)
             self.judge_llm = judge_llm
 
-        if embedding_llm is None:
-            self.embedding_llm = OpenAIEmbedding()
-        else:
-            assert isinstance(embedding_llm, BaseEmbedding)
-            self.embedding_llm = embedding_llm
+        embed_model = embed_model or Settings.embed_model
         self.show_progress = show_progress
         self.evals = {
             "correctness": [],

--- a/llama-index-packs/llama-index-packs-rag-evaluator/llama_index/packs/rag_evaluator/base.py
+++ b/llama-index-packs/llama-index-packs-rag-evaluator/llama_index/packs/rag_evaluator/base.py
@@ -20,6 +20,7 @@ from llama_index.core.evaluation.notebook_utils import (
 from llama_index.core.llama_dataset import BaseLlamaDataset, BaseLlamaPredictionDataset
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.llms import LLM
+from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.query_engine import BaseQueryEngine
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.openai import OpenAI
@@ -41,6 +42,7 @@ class RagEvaluatorPack(BaseLlamaPack):
         query_engine: BaseQueryEngine,
         rag_dataset: BaseLlamaDataset,
         judge_llm: Optional[LLM] = None,
+        embedding_llm: Optional[BaseEmbedding] = None,
         show_progress: bool = True,
     ):
         self.query_engine = query_engine
@@ -51,6 +53,12 @@ class RagEvaluatorPack(BaseLlamaPack):
         else:
             assert isinstance(judge_llm, LLM)
             self.judge_llm = judge_llm
+
+        if embedding_llm is None:
+            self.embedding_llm = OpenAIEmbedding()
+        else:
+            assert isinstance(embedding_llm, BaseEmbedding)
+            self.embedding_llm = embedding_llm
         self.show_progress = show_progress
         self.evals = {
             "correctness": [],
@@ -104,7 +112,7 @@ class RagEvaluatorPack(BaseLlamaPack):
             llm=self.judge_llm,
         )
         judges["semantic_similarity"] = SemanticSimilarityEvaluator(
-            embed_model=OpenAIEmbedding()
+            embed_model=self.embedding_llm
         )
         return judges
 

--- a/llama-index-packs/llama-index-packs-rag-evaluator/llama_index/packs/rag_evaluator/base.py
+++ b/llama-index-packs/llama-index-packs-rag-evaluator/llama_index/packs/rag_evaluator/base.py
@@ -54,7 +54,7 @@ class RagEvaluatorPack(BaseLlamaPack):
             assert isinstance(judge_llm, LLM)
             self.judge_llm = judge_llm
 
-        embed_model = embed_model or Settings.embed_model
+        self.embed_model = embed_model or Settings.embed_model
         self.show_progress = show_progress
         self.evals = {
             "correctness": [],
@@ -108,7 +108,7 @@ class RagEvaluatorPack(BaseLlamaPack):
             llm=self.judge_llm,
         )
         judges["semantic_similarity"] = SemanticSimilarityEvaluator(
-            embed_model=self.embedding_llm
+            embed_model=self.embed_model
         )
         return judges
 

--- a/llama-index-packs/llama-index-packs-rag-evaluator/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-rag-evaluator/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["nerdai"]
 name = "llama-index-packs-rag-evaluator"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION

# Description


Added small change that allows users to run rag evaluation locally by using a local embedding model. 
Before, required OpenAI API access, now you can pass in any BaseEmbedding model from llama_index.core.embeddings

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
- [x] I tested it in a local notebook. 

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
