### PR TITLE
Update schema_llm

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -251,16 +251,13 @@ class SchemaLLMPathExtractor(TransformComponent):
                 isinstance(self.kg_validation_schema, dict)
                 and "relationships" in self.kg_validation_schema
             ):
-                # Schema is a dictionary with a 'relationships' key
+                # Schema is a dictionary with a 'relationships' key and triples as values
                 if (subject_type, relation, obj_type) not in self.kg_validation_schema[
                     "relationships"
                 ]:
-                    print(
-                        f"\nThe following triplet is skipped as it isn't in the validation schema: ({subject_type}, {relation}, {obj_type})"
-                    )
                     continue
             else:
-                # Schema is the original format
+                # Schema is the backwards-compat format
                 if relation not in self.kg_validation_schema.get(
                     subject_type, [relation]
                 ) and relation not in self.kg_validation_schema.get(

--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 try:
     from typing import TypeAlias
@@ -47,62 +47,37 @@ DEFAULT_RELATIONS = Literal[
     "HAS_ALIAS",
 ]
 
-# Which entities can be connected to which relations
-DEFAULT_VALIDATION_SCHEMA: Dict[str, Any] = {
-    "PRODUCT": (
-        "USED_BY",
-        "USED_FOR",
-        "LOCATED_IN",
-        "PART_OF",
-        "WORKED_ON",
-        "HAS",
-        "IS_A",
-    ),
-    "MARKET": ("LOCATED_IN", "PART_OF", "WORKED_ON", "HAS", "IS_A"),
-    "TECHNOLOGY": (
-        "USED_BY",
-        "USED_FOR",
-        "LOCATED_IN",
-        "PART_OF",
-        "WORKED_ON",
-        "HAS",
-        "IS_A",
-    ),
-    "EVENT": ("LOCATED_IN", "PART_OF", "WORKED_ON", "HAS", "IS_A"),
-    "CONCEPT": ("USE_BY", "USED_FOR", "PART_OF", "WORKED_ON", "HAS", "IS_A"),
-    "ORGANIZATION": ("LOCATED_IN", "PART_OF", "HAS", "IS_A"),
-    "PERSON": (
-        "BORN_IN",
-        "DIED_IN",
-        "LOCATED_IN",
-        "PART_OF",
-        "WORKED_ON",
-        "HAS",
-        "IS_A",
-    ),
-    "LOCATION": (
-        "LOCATED_IN",
-        "PART_OF",
-        "HAS",
-        "IS_A",
-        "DIED_IN",
-        "BORN_IN",
-        "USED_BY",
-        "USED_FOR",
-    ),
-    "TIME": ("BORN_IN", "DIED_IN", "LOCATED_IN", "PART_OF", "HAS", "IS_A"),
-    "MISCELLANEOUS": (
-        "USED_BY",
-        "USED_FOR",
-        "LOCATED_IN",
-        "PART_OF",
-        "WORKED_ON",
-        "HAS",
-        "IS_A",
-        "BORN_IN",
-        "DIED_IN",
-    ),
-}
+# Convert the above dict schema into a list of triples
+Triple = Tuple[str, str, str]
+DEFAULT_VALIDATION_SCHEMA: List[Triple] = [
+    ("PRODUCT", "USED_BY", "PRODUCT"),
+    ("PRODUCT", "USED_FOR", "MARKET"),
+    ("PRODUCT", "HAS", "TECHNOLOGY"),
+    ("MARKET", "LOCATED_IN", "LOCATION"),
+    ("MARKET", "HAS", "TECHNOLOGY"),
+    ("TECHNOLOGY", "USED_BY", "PRODUCT"),
+    ("TECHNOLOGY", "USED_FOR", "MARKET"),
+    ("TECHNOLOGY", "LOCATED_IN", "LOCATION"),
+    ("TECHNOLOGY", "PART_OF", "ORGANIZATION"),
+    ("TECHNOLOGY", "IS_A", "PRODUCT"),
+    ("EVENT", "LOCATED_IN", "LOCATION"),
+    ("EVENT", "PART_OF", "ORGANIZATION"),
+    ("CONCEPT", "USED_BY", "TECHNOLOGY"),
+    ("CONCEPT", "USED_FOR", "PRODUCT"),
+    ("ORGANIZATION", "LOCATED_IN", "LOCATION"),
+    ("ORGANIZATION", "PART_OF", "ORGANIZATION"),
+    ("ORGANIZATION", "PART_OF", "MARKET"),
+    ("PERSON", "BORN_IN", "LOCATION"),
+    ("PERSON", "BORN_IN", "TIME"),
+    ("PERSON", "DIED_IN", "LOCATION"),
+    ("PERSON", "DIED_IN", "TIME"),
+    ("PERSON", "WORKED_ON", "EVENT"),
+    ("PERSON", "WORKED_ON", "PRODUCT"),
+    ("PERSON", "WORKED_ON", "CONCEPT"),
+    ("PERSON", "WORKED_ON", "TECHNOLOGY"),
+    ("LOCATION", "LOCATED_IN", "LOCATION"),
+    ("LOCATION", "PART_OF", "LOCATION"),
+]
 
 DEFAULT_SCHEMA_PATH_EXTRACT_PROMPT = PromptTemplate(
     "Give the following text, extract the knowledge graph according to the provided schema. "
@@ -114,7 +89,8 @@ DEFAULT_SCHEMA_PATH_EXTRACT_PROMPT = PromptTemplate(
 
 
 class SchemaLLMPathExtractor(TransformComponent):
-    """Extract paths from a graph using a schema.
+    """
+    Extract paths from a graph using a schema.
 
     Args:
         llm (LLM):
@@ -154,7 +130,7 @@ class SchemaLLMPathExtractor(TransformComponent):
         possible_relations: Optional[TypeAlias] = None,
         strict: bool = True,
         kg_schema_cls: Any = None,
-        kg_validation_schema: Dict[str, str] = None,
+        kg_validation_schema: Union[Dict[str, str], List[Triple]] = None,
         max_triplets_per_chunk: int = 10,
         num_workers: int = 4,
     ) -> None:
@@ -230,11 +206,17 @@ class SchemaLLMPathExtractor(TransformComponent):
             )
             kg_schema_cls.__doc__ = "Knowledge Graph Schema."
 
+        # Get validation schema
+        kg_validation_schema = kg_validation_schema or DEFAULT_VALIDATION_SCHEMA
+        # TODO: Remove this in a future version & encourage List[Triple] for validation schema
+        if isinstance(kg_validation_schema, list):
+            kg_validation_schema = {"relationships": kg_validation_schema}
+
         super().__init__(
             llm=llm,
             extract_prompt=extract_prompt or DEFAULT_SCHEMA_PATH_EXTRACT_PROMPT,
             kg_schema_cls=kg_schema_cls,
-            kg_validation_schema=kg_validation_schema or DEFAULT_VALIDATION_SCHEMA,
+            kg_validation_schema=kg_validation_schema,
             num_workers=num_workers,
             max_triplets_per_chunk=max_triplets_per_chunk,
             strict=strict,

--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -247,10 +247,21 @@ class SchemaLLMPathExtractor(TransformComponent):
             obj_type = triplet.object.type
 
             # check relations
-            if relation not in self.kg_validation_schema.get(
-                subject_type, [relation]
-            ) and relation not in self.kg_validation_schema.get(obj_type, [relation]):
-                continue
+            if self.kg_validation_schema.get("relationships"):
+                # This is only hit if the schema is a list of triples
+                schema_relationships = [
+                    triple[1]
+                    for triple in self.kg_validation_schema.get("relationships", [])
+                ]
+                if relation not in schema_relationships:
+                    continue
+            else:
+                if relation not in self.kg_validation_schema.get(
+                    subject_type, [relation]
+                ) and relation not in self.kg_validation_schema.get(
+                    obj_type, [relation]
+                ):
+                    continue
 
             # remove self-references
             if subject.lower() == obj.lower():

--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -246,16 +246,21 @@ class SchemaLLMPathExtractor(TransformComponent):
             obj = triplet.object.name
             obj_type = triplet.object.type
 
-            # check relations
-            if self.kg_validation_schema.get("relationships"):
-                # This is only hit if the schema is a list of triples
-                schema_relationships = [
-                    triple[1]
-                    for triple in self.kg_validation_schema.get("relationships", [])
-                ]
-                if relation not in schema_relationships:
+            # Check if the triplet is valid based on the schema format
+            if (
+                isinstance(self.kg_validation_schema, dict)
+                and "relationships" in self.kg_validation_schema
+            ):
+                # Schema is a dictionary with a 'relationships' key
+                if (subject_type, relation, obj_type) not in self.kg_validation_schema[
+                    "relationships"
+                ]:
+                    print(
+                        f"\nThe following triplet is skipped as it isn't in the validation schema: ({subject_type}, {relation}, {obj_type})"
+                    )
                     continue
             else:
+                # Schema is the original format
                 if relation not in self.kg_validation_schema.get(
                     subject_type, [relation]
                 ) and relation not in self.kg_validation_schema.get(
@@ -263,7 +268,7 @@ class SchemaLLMPathExtractor(TransformComponent):
                 ):
                     continue
 
-            # remove self-references
+            # Remove self-references
             if subject.lower() == obj.lower():
                 continue
 


### PR DESCRIPTION
# Description

Fixes #14324.

This PR makes an update to `SchemaLLMPathExtractor` to allow the specification of relationship direction as a list of triples. The previous version of the `validation_schema` only had a dict of allowed relationships, so the proposed change here allows downstream graph stores to process the validation schema while considering relationship direction.

To do:
- [ ] Update any relevant docs/guidelines where necessary

## New Package?

No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods

## Additional checks

To ensure that the fix worked, I used the following text input file in `data/sample.txt`

```
Tim Cook is the CEO of Apple. Apple has its headquarters in Cupertino, California.
```

And the following code on Neo4j to test the schema constraints.

```py
import os
import nest_asyncio
from dotenv import load_dotenv
from llama_index.core import SimpleDirectoryReader, PropertyGraphIndex
from llama_index.core.indices.property_graph import SchemaLLMPathExtractor
from llama_index.embeddings.openai import OpenAIEmbedding
from llama_index.graph_stores.neo4j import Neo4jPGStore
from llama_index.llms.openai import OpenAI

nest_asyncio.apply()
load_dotenv()
OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")

# Set up the embedding model and LLM
embed_model = OpenAIEmbedding(model_name="text-embedding-3-small")
extraction_llm = OpenAI(model="gpt-3.5-turbo", temperature=0.0)

# Get documents
documents = SimpleDirectoryReader("./data").load_data()

graph_store = Neo4jPGStore(
    username="neo4j",
    password="llama-test",
    url="bolt://localhost:7687",
)

from typing import Literal

entities = Literal["PERSON", "ORGANIZATION", "LOCATION"]
relations = Literal["IS_CEO_OF", "IN_LOCATION"]

# # This works too, but doesn't help with relationship directions
# validation_schema = {
#     "Person": ["IS_CEO_OF"],
#     "Organization": ["IN_LOCATION"],
#     "Location": ["IN_LOCATION"],
# }

# Alternative: Define relationship directions as a list of triples
# Can be used by graph stores downstream to only accept relationships
# in the specified direction
validation_schema = [
    ("PERSON", "IS_CEO_OF", "ORGANIZATION"),
    ("ORGANIZATION", "IN_LOCATION", "LOCATION"),
]

schema_path_extractor = SchemaLLMPathExtractor(
    llm=extraction_llm,
    possible_entities=entities,
    possible_relations=relations,
    kg_validation_schema=validation_schema,
    strict=True,  # if false, will allow triples outside of the schema
)

index = PropertyGraphIndex.from_documents(
    documents,
    embed_model=embed_model,
    kg_extractors=[schema_path_extractor],
    property_graph_store=graph_store,
    show_progress=True,
)
```

When there are no `possible_entities`, `possible_relations` and `kg_validation_schema` specified, it uses the `DEFAULT_` entities and relations as specified in the core and produces this graph:
<img width="684" alt="graph-2" src="https://github.com/run-llama/llama_index/assets/35005448/9f5ca1ca-06e0-435d-991d-201c4b3a702f">

When `possible_entities`, `possible_relations` and `kg_validation_schema` specified, this is the graph produced that respects the given list of entities and relations.
<img width="623" alt="graph-1" src="https://github.com/run-llama/llama_index/assets/35005448/a7204d2c-15f4-4c60-bd87-9128324c03a1">

@logan-markewich looking forward to your feedback.