### PR TITLE
Add MetadataFilters to neo4j_property_graph

### DIFF
--- a/docs/docs/examples/property_graph/property_graph_advanced.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_advanced.ipynb
@@ -47,7 +47,25 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--2024-06-26 11:12:16--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.110.133, 185.199.109.133, 185.199.111.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.110.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 75042 (73K) [text/plain]\n",
+      "Saving to: ‘data/paul_graham/paul_graham_essay.txt’\n",
+      "\n",
+      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.007s  \n",
+      "\n",
+      "2024-06-26 11:12:16 (10.4 MB/s) - ‘data/paul_graham/paul_graham_essay.txt’ saved [75042/75042]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "!mkdir -p 'data/paul_graham/'\n",
     "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
@@ -106,6 +124,15 @@
     "    \"PLACE\": [\"HAS\", \"PART_OF\", \"WORKED_AT\"],\n",
     "    \"ORGANIZATION\": [\"HAS\", \"PART_OF\", \"WORKED_WITH\"],\n",
     "}\n",
+    "validation_schema = [\n",
+    "    (\"ORGANIZATION\", \"HAS\", \"PERSON\"),\n",
+    "    (\"PERSON\", \"WORKED_AT\", \"ORGANIZATION\"),\n",
+    "    (\"PERSON\", \"WORKED_WITH\", \"PERSON\"),\n",
+    "    (\"PERSON\", \"WORKED_ON\", \"ORGANIZATION\"),\n",
+    "    (\"PERSON\", \"PART_OF\", \"ORGANIZATION\"),\n",
+    "    (\"ORGANIZATION\", \"PART_OF\", \"ORGANIZATION\"),\n",
+    "    (\"PERSON\", \"WORKED_AT\", \"PLACE\"),\n",
+    "]\n",
     "\n",
     "kg_extractor = SchemaLLMPathExtractor(\n",
     "    llm=Ollama(model=\"llama3\", json_mode=True, request_timeout=3600),\n",

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/text_to_cypher.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/text_to_cypher.py
@@ -72,8 +72,8 @@ class TextToCypherRetriever(BasePGRetriever):
             filtered = {}
             for key, value in query_output.items():
                 if (
-                    key in self.allowed_output_fields
-                    or self.allowed_output_fields is None
+                    self.allowed_output_fields is None
+                    or key in self.allowed_output_fields
                 ):
                     filtered[key] = value
                 elif isinstance(value, (dict, list)):
@@ -101,6 +101,7 @@ class TextToCypherRetriever(BasePGRetriever):
             question=question,
         )
 
+        parsed_cypher_query = response
         if self.allowed_output_fields is not None:
             parsed_cypher_query = self._parse_generated_cyher(response)
 
@@ -134,6 +135,7 @@ class TextToCypherRetriever(BasePGRetriever):
             question=question,
         )
 
+        parsed_cypher_query = response
         if self.allowed_output_fields is not None:
             parsed_cypher_query = self._parse_generated_cyher(response)
 

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
@@ -11,7 +11,7 @@ from llama_index.core.graph_stores.types import (
 )
 from llama_index.core.settings import Settings
 from llama_index.core.schema import BaseNode, NodeWithScore, QueryBundle
-from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStore
+from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStore, MetadataFilters
 
 
 class VectorContextRetriever(BasePGRetriever):
@@ -41,6 +41,7 @@ class VectorContextRetriever(BasePGRetriever):
         vector_store: Optional[VectorStore] = None,
         similarity_top_k: int = 4,
         path_depth: int = 1,
+        filters: Optional[MetadataFilters] = None,
         **kwargs: Any
     ) -> None:
         self._retriever_kwargs = kwargs or {}
@@ -48,6 +49,7 @@ class VectorContextRetriever(BasePGRetriever):
         self._similarity_top_k = similarity_top_k
         self._vector_store = vector_store
         self._path_depth = path_depth
+        self._filters = filters
 
         super().__init__(graph_store=graph_store, include_text=include_text, **kwargs)
 
@@ -60,6 +62,7 @@ class VectorContextRetriever(BasePGRetriever):
         return VectorStoreQuery(
             query_embedding=query_bundle.embedding,
             similarity_top_k=self._similarity_top_k,
+            filters=self._filters,
             **self._retriever_kwargs,
         )
 
@@ -80,6 +83,7 @@ class VectorContextRetriever(BasePGRetriever):
         return VectorStoreQuery(
             query_embedding=query_bundle.embedding,
             similarity_top_k=self._similarity_top_k,
+            filters=self._filters,
             **self._retriever_kwargs,
         )
 

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
@@ -11,7 +11,11 @@ from llama_index.core.graph_stores.types import (
 )
 from llama_index.core.settings import Settings
 from llama_index.core.schema import BaseNode, NodeWithScore, QueryBundle
-from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStore, MetadataFilters
+from llama_index.core.vector_stores.types import (
+    VectorStoreQuery,
+    VectorStore,
+    MetadataFilters,
+)
 
 
 class VectorContextRetriever(BasePGRetriever):

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -528,14 +528,19 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
         self, query: VectorStoreQuery, **kwargs: Any
     ) -> Tuple[List[LabelledNode], List[float]]:
         """Query the graph store with a vector store query."""
+        conditions = None
+        if (query.filters):
+            conditions = [f"e.{filter.key} {filter.operator.value} {filter.value}" for filter in query.filters.filters]
+        filters = f' {query.filters.condition.value} '.join(conditions).replace("==", "=") if conditions != None else '1 = 1'
+        
         data = self.structured_query(
-            """MATCH (e:`__Entity__`)
-            WHERE e.embedding IS NOT NULL AND size(e.embedding) = $dimension
+            f"""MATCH (e:`__Entity__`)
+            WHERE e.embedding IS NOT NULL AND size(e.embedding) = $dimension AND ({filters})
             WITH e, vector.similarity.cosine(e.embedding, $embedding) AS score
             ORDER BY score DESC LIMIT toInteger($limit)
             RETURN e.id AS name,
                [l in labels(e) WHERE l <> '__Entity__' | l][0] AS type,
-               e{.* , embedding: Null, name: Null, id: Null} AS properties,
+               e{{.* , embedding: Null, name: Null, id: Null}} AS properties,
                score""",
             param_map={
                 "embedding": query.query_embedding,

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -529,10 +529,17 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
     ) -> Tuple[List[LabelledNode], List[float]]:
         """Query the graph store with a vector store query."""
         conditions = None
-        if (query.filters):
-            conditions = [f"e.{filter.key} {filter.operator.value} {filter.value}" for filter in query.filters.filters]
-        filters = f' {query.filters.condition.value} '.join(conditions).replace("==", "=") if conditions != None else '1 = 1'
-        
+        if query.filters:
+            conditions = [
+                f"e.{filter.key} {filter.operator.value} {filter.value}"
+                for filter in query.filters.filters
+            ]
+        filters = (
+            f" {query.filters.condition.value} ".join(conditions).replace("==", "=")
+            if conditions is not None
+            else "1 = 1"
+        )
+
         data = self.structured_query(
             f"""MATCH (e:`__Entity__`)
             WHERE e.embedding IS NOT NULL AND size(e.embedding) = $dimension AND ({filters})

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Summary for new feature**: Added filters for neo4j_property_graph since they weren't supported previously even though neo4j property graph supports vector queries. So I modified the code path to support vector filters.

**Summary for bug fix**: bug occurs when you provide TextToCypherRetriever with `self.allowed_output_fields=None`. In that case the code path fails in two places:
1. _clean_query_output: python fails on the first condition because you cannot iterate over a none type (so we need to swap these two conditions):
```python
if (
    key in self.allowed_output_fields
    or self.allowed_output_fields is None
):
```

2. retrieve_from_graph: the following code will fail if `self.allowed_output_fields=None` (so we need to fix this)
```python
if self.allowed_output_fields is not None:
    parsed_cypher_query = self._parse_generated_cyher(response)

query_output = self._graph_store.structured_query(parsed_cypher_query)
```

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
I created another python project and imported the forked changes. In the main script:
```python
from llama_helpers import create_index
from dotenv import load_dotenv
from llama_index.llms.openai import OpenAI
from llama_index.embeddings.openai import OpenAIEmbedding
from llama_index.core.vector_stores import (
    MetadataFilter,
    MetadataFilters,
    FilterOperator,
)
from llama_index.core.retrievers import TextToCypherRetriever, VectorContextRetriever
load_dotenv()

index = create_index("gpt-4o")
llm = OpenAI(model="gpt-4o", temperature=0)
embed_model = OpenAIEmbedding(model_name="text-embedding-3-small")

pg_store = index.property_graph_store

filters = MetadataFilters(filters=
[
    MetadataFilter(key="orgId", operator=FilterOperator.EQ, value=3),
])

vector_retriever = VectorContextRetriever(
    index.property_graph_store,
    include_text=True,
    embed_model=embed_model,
    similarity_top_k=10,
    path_depth=4,
    filters=filters
)

cypher_retriever = TextToCypherRetriever(
    index.property_graph_store,
    llm=llm,
    allowed_output_fields=None,
    text_to_cypher_template = '<Text to cypher template>',
    response_template="<Response template>"
)

print("=== Vector Response ===")
response = vector_retriever.retrieve("Who is Kristiana Powell?")
print(response)

print("=== Cypher Response ===")
response = cypher_retriever.retrieve("Who is Kristiana Powell?")
print(response)
```

I created two retrievers, one for the vector retriever and one for the cypher retriever. Each retriever is passed in index.property_graph_store which is an instance of the class `Neo4jPropertyGraphStore`. For the cypher retriever, I pass in allowed_output_fields=None and this tests the bug fix. As for the VectorContextRetriever, I have an existing graph, with nodes that have different org ids, and I am able to query the different sections of nodes depending on the filter. This is helpful for multi-tenant scenarios.

Even though the example above uses only one filter, you can add multiple filters and that will work as well. 

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
