### PR TITLE
Fix `ChatMessage` not considered as stringable in query pipeline

### DIFF
--- a/llama-index-core/llama_index/core/base/query_pipeline/query.py
+++ b/llama-index-core/llama_index/core/base/query_pipeline/query.py
@@ -16,6 +16,7 @@ from typing import (
 
 from llama_index.core.base.llms.types import (
     ChatResponse,
+    ChatMessage,
     CompletionResponse,
 )
 from llama_index.core.base.response.schema import Response
@@ -27,6 +28,7 @@ from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 StringableInput = Union[
     CompletionResponse,
     ChatResponse,
+    ChatMessage,
     str,
     QueryBundle,
     Response,

--- a/llama-index-core/tests/query_pipeline/test_utils.py
+++ b/llama-index-core/tests/query_pipeline/test_utils.py
@@ -1,0 +1,8 @@
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.base.query_pipeline.query import validate_and_convert_stringable
+
+
+def test_validate_and_convert_stringable() -> None:
+    """Test conversion of stringable object into string."""
+    message = ChatMessage(role=MessageRole.USER, content="hello")
+    assert validate_and_convert_stringable(message) == "user: hello"


### PR DESCRIPTION
# Description

This adds `ChatMessage` to the objects that were considered stringable in query pipeline. Without this, there would be an issue with implementing ReAct agent in query pipeline where the previous chat history would be presented to the LLM. This involves converting `ChatMessage` objects to strings, which would fail if they were not considered as stringable.

Fixes #12268

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
