### PR TITLE
Also use ref_doc_id to dedup in _ahandle_recursive_retrieval

### DIFF
--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -208,12 +208,12 @@ class BaseRetriever(ChainableMixin, PromptMixin, DispatcherSpanMixin):
             else:
                 retrieved_nodes.append(n)
 
-        # remove any duplicates based on hash
+        # remove any duplicates based on hash and ref_doc_id
         seen = set()
         return [
             n
             for n in retrieved_nodes
-            if not (n.node.hash in seen or seen.add(n.node.hash))  # type: ignore[func-returns-value]
+            if not ((n.node.hash, n.node.ref_doc_id) in seen or seen.add((n.node.hash, n.node.ref_doc_id)))  # type: ignore[func-returns-value]
         ]
 
     @dispatcher.span

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -43,7 +43,7 @@ name = "llama-index-core"
 packages = [{include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.10.50"
+version = "0.10.50.post1"
 
 [tool.poetry.dependencies]
 SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}


### PR DESCRIPTION
# Description

when doing retrieval from a vector store, in the `_ahandle_recursive_retrieval` step we dedup the nodes we get based on the node hash. This node hash is a function of its text and metadata.

However, if we ingest two different docs with the same metadata, in that ingestion process we may end up with nodes that have the same text and metadata, but different `ref_doc_id`.

We think that we don't want to dedup those for citation purposes.

## Version Bump?
- [x] Yes

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
