### PR TITLE
fix: :bug: Fix Bedrock Converse's tool use blocks, when there are multiple consecutive function calls

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -136,6 +136,9 @@ def messages_to_converse_messages(
                     }
                 )
         # convert tool calls to the AWS Bedrock Converse format
+        # NOTE tool calls might show up within any message,
+        # e.g. within assistant message or in consecutive tool calls,
+        # thus this tool call check is done for all messages
         tool_calls = message.additional_kwargs.get("tool_calls", [])
         content = []
         for tool_call in tool_calls:

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -120,28 +120,36 @@ def messages_to_converse_messages(
             status = message.additional_kwargs.get("status")
             if status:
                 content["toolResult"]["status"] = status
-            converse_message = {
-                "role": "user",
-                "content": [content],
-            }
-            converse_messages.append(converse_message)
+            converse_messages.append(
+                {
+                    "role": "user",
+                    "content": [content],
+                }
+            )
         else:
-            content = []
             if message.content:
                 # get the text of the message
-                content.append({"text": message.content})
-            # convert tool calls to the AWS Bedrock Converse format
-            tool_calls = message.additional_kwargs.get("tool_calls", [])
-            for tool_call in tool_calls:
-                assert "toolUseId" in tool_call, f"`toolUseId` not found in {tool_call}"
-                assert "input" in tool_call, f"`input` not found in {tool_call}"
-                assert "name" in tool_call, f"`name` not found in {tool_call}"
-                content.append({"toolUse": tool_call})
-            converse_message = {
-                "role": message.role.value,
-                "content": content,
-            }
-            converse_messages.append(converse_message)
+                converse_messages.append(
+                    {
+                        "role": message.role.value,
+                        "content": [{"text": message.content}],
+                    }
+                )
+        # convert tool calls to the AWS Bedrock Converse format
+        tool_calls = message.additional_kwargs.get("tool_calls", [])
+        content = []
+        for tool_call in tool_calls:
+            assert "toolUseId" in tool_call, f"`toolUseId` not found in {tool_call}"
+            assert "input" in tool_call, f"`input` not found in {tool_call}"
+            assert "name" in tool_call, f"`name` not found in {tool_call}"
+            content.append({"toolUse": tool_call})
+        if len(content) > 0:
+            converse_messages.append(
+                {
+                    "role": "assistant",  # tool calls are always from the assistant
+                    "content": content,
+                }
+            )
 
     return __merge_common_role_msgs(converse_messages), system_prompt.strip()
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock-converse"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Sometimes `BedrockConverse` would fail when trying to load a chat history that had consecutive function calls. This is because function calls weren't being checked in messages that are tool results.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
