### PR TITLE
Update Astra DB vector store to use modern astrapy library

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.1.7"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
-astrapy = "^1"
+astrapy = "^1.3"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-astra-db"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
@@ -40,7 +40,7 @@ jupyter = "^1.0.0"
 mypy = "0.991"
 pre-commit = "3.2.0"
 pylint = "2.15.10"
-pytest = "7.2.1"
+pytest = "~8.0.0"
 pytest-mock = "3.11.1"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/tests/test_astra_db.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/tests/test_astra_db.py
@@ -2,17 +2,15 @@ import os
 import pytest
 from typing import Iterable
 
-import astrapy
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.core.vector_stores.types import VectorStoreQuery
 from llama_index.vector_stores.astra_db import AstraDBVectorStore
-
-print(f"astrapy detected: {astrapy.__version__}")
 
 
 # env variables
 ASTRA_DB_APPLICATION_TOKEN = os.getenv("ASTRA_DB_APPLICATION_TOKEN", "")
 ASTRA_DB_API_ENDPOINT = os.getenv("ASTRA_DB_API_ENDPOINT", "")
+ASTRA_DB_KEYSPACE = os.getenv("ASTRA_DB_KEYSPACE")
 
 
 @pytest.fixture(scope="module")
@@ -21,11 +19,13 @@ def astra_db_store() -> Iterable[AstraDBVectorStore]:
         token=ASTRA_DB_APPLICATION_TOKEN,
         api_endpoint=ASTRA_DB_API_ENDPOINT,
         collection_name="test_collection",
+        namespace=ASTRA_DB_KEYSPACE,
         embedding_dimension=2,
     )
+    store._collection.delete_many({})
     yield store
 
-    store._astra_db.delete_collection("test_collection")
+    store._collection.drop()
 
 
 @pytest.mark.skipif(
@@ -33,6 +33,7 @@ def astra_db_store() -> Iterable[AstraDBVectorStore]:
     reason="missing Astra DB credentials",
 )
 def test_astra_db_create_and_crud(astra_db_store: AstraDBVectorStore) -> None:
+    """Test basic creation and insertion/deletion of a node."""
     astra_db_store.add(
         [
             TextNode(
@@ -54,8 +55,46 @@ def test_astra_db_create_and_crud(astra_db_store: AstraDBVectorStore) -> None:
     reason="missing Astra DB credentials",
 )
 def test_astra_db_queries(astra_db_store: AstraDBVectorStore) -> None:
+    """Test basic querying."""
     query = VectorStoreQuery(query_embedding=[1, 1], similarity_top_k=3)
 
     astra_db_store.query(
         query,
     )
+
+
+@pytest.mark.skipif(
+    ASTRA_DB_APPLICATION_TOKEN == "" or ASTRA_DB_API_ENDPOINT == "",
+    reason="missing Astra DB credentials",
+)
+def test_astra_db_insertions(astra_db_store: AstraDBVectorStore) -> None:
+    """Test massive insertion with overwrites."""
+    all_ids = list(range(150))
+    nodes0 = [
+        TextNode(
+            text=f"OLD_node {idx}",
+            id_=f"n_{idx}",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="doc_0")},
+            embedding=[0.5, 0.5],
+        )
+        for idx in all_ids[60:80] + all_ids[130:140]
+    ]
+    nodes = [
+        TextNode(
+            text=f"node {idx}",
+            id_=f"n_{idx}",
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="doc_0")},
+            embedding=[0.5, 0.5],
+        )
+        for idx in all_ids
+    ]
+
+    astra_db_store.add(nodes0)
+    found_contents0 = [doc["content"] for doc in astra_db_store._collection.find({})]
+    assert all(f_content[:4] == "OLD_" for f_content in found_contents0)
+    assert len(found_contents0) == len(nodes0)
+
+    astra_db_store.add(nodes)
+    found_contents = [doc["content"] for doc in astra_db_store._collection.find({})]
+    assert all(f_content[:5] == "node " for f_content in found_contents)
+    assert len(found_contents) == len(nodes)


### PR DESCRIPTION
# Description

This PR is a nontrivial rewrite of the internals of the AstraDBVectorStore, with no user-facing changes, so that it internally uses the stable, modern version (1+) of the AstraPy client.

This is a somewhat important milestone in removing dependencies on the old (astrapy v0.*) interface and adds a strong futureproof quality to this connector.

### Additional improvements

- A slight rewording of some comments
- A warning if (unused) additional kwargs are passed to the store's delete method
- A warning if the (ignored, as was before this PR) `ttl_seconds` parameter is passed to the constructor
- A new test about "massive" (i.e. requiring chunking, internally) insertions with a subset of preexisting entries to replace
- A better set of checks to cover a slightly wider range of "collection-already-exists" errors/warnings.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense :)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
