### PR TITLE
Adding example and docs note about Azure Entra ID 

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -30,11 +30,13 @@ class AzureOpenAI(OpenAI):
         for your deployment when you deployed a model.
 
     You must have the following environment variables set:
+
     - `OPENAI_API_VERSION`: set this to `2023-07-01-preview` or newer.
         This may change in the future.
     - `AZURE_OPENAI_ENDPOINT`: your endpoint should look like the following
         https://YOUR_RESOURCE_NAME.openai.azure.com/
-    - `AZURE_OPENAI_API_KEY`: your API key if the api type is `azure`
+    - `AZURE_OPENAI_API_KEY`: your API key if the api type is `azure`| Or pass through `AZURE_AD_TOKEN_PROVIDER` 
+        and set `use_azure_ad = True` to use managed identity with Azure Entra ID 
 
     More information can be found here:
         https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart?tabs=command-line&pivots=programming-language-python
@@ -50,9 +52,30 @@ class AzureOpenAI(OpenAI):
         aoai_api_version = "2023-07-01-preview"
 
         llm = AzureOpenAI(
+            engine="AZURE_AZURE_OPENAI_DEPLOYMENT_NAME",
             model="YOUR_AZURE_OPENAI_COMPLETION_MODEL_NAME",
-            deployment_name="YOUR_AZURE_OPENAI_COMPLETION_DEPLOYMENT_NAME",
             api_key=aoai_api_key,
+            azure_endpoint=aoai_endpoint,
+            api_version=aoai_api_version,
+        )
+        ```
+        
+        Using managed identity (passing a token provider instead of an API key):
+
+        ```python
+        from llama_index.llms.azure_openai import AzureOpenAI
+
+        aoai_endpoint = "YOUR_AZURE_OPENAI_ENDPOINT"
+        aoai_api_version = "2023-07-01-preview"
+
+        credential = DefaultAzureCredential()
+        token_provider = get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default")
+
+        llm = AzureOpenAI(
+            engine = llm_deployment
+            model="YOUR_AZURE_OPENAI_COMPLETION_MODEL_NAME",
+            azure_ad_token_provider=token_provider,
+            use_azure_ad=True,
             azure_endpoint=aoai_endpoint,
             api_version=aoai_api_version,
         )
@@ -71,7 +94,7 @@ class AzureOpenAI(OpenAI):
     )
 
     azure_ad_token_provider: AzureADTokenProvider = Field(
-        default=None, description="Callback function to provide Azure AD token."
+        default=None, description="Callback function to provide Azure Entra ID token."
     )
 
     _azure_ad_token: Any = PrivateAttr(default=None)

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -35,8 +35,8 @@ class AzureOpenAI(OpenAI):
         This may change in the future.
     - `AZURE_OPENAI_ENDPOINT`: your endpoint should look like the following
         https://YOUR_RESOURCE_NAME.openai.azure.com/
-    - `AZURE_OPENAI_API_KEY`: your API key if the api type is `azure`| Or pass through `AZURE_AD_TOKEN_PROVIDER` 
-        and set `use_azure_ad = True` to use managed identity with Azure Entra ID 
+    - `AZURE_OPENAI_API_KEY`: your API key if the api type is `azure`| Or pass through `AZURE_AD_TOKEN_PROVIDER`
+        and set `use_azure_ad = True` to use managed identity with Azure Entra ID
 
     More information can be found here:
         https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart?tabs=command-line&pivots=programming-language-python
@@ -59,10 +59,10 @@ class AzureOpenAI(OpenAI):
             api_version=aoai_api_version,
         )
         ```
-        
+
         Using managed identity (passing a token provider instead of an API key):
 
-        ```python
+         ```python
         from llama_index.llms.azure_openai import AzureOpenAI
 
         aoai_endpoint = "YOUR_AZURE_OPENAI_ENDPOINT"


### PR DESCRIPTION
# Description

I've add an example and note in the docs of using AzureOpenAI with Azure Entra ID. This PR clarifies that the user can pass either a key or a token to the AzureOpenAI API. This also adds in an example to show the user what they need to pass in to utilise managed identity with Entra ID. It also updates the docs to reflect that an engine parameter needs to be set. Using keyless authentication is now what we recommend for creating secure apps. 

## Type of Change

Please delete options that are not relevant.


-New feature (non-breaking change which adds functionality)
-This change updates the documentation

## How Has This Been Tested?
- I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
