### PR TITLE
Fix kwargs variables in in chat_messages_to_conversational_kwargs

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-huggingface-api/llama_index/llms/huggingface_api/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface-api/llama_index/llms/huggingface_api/base.py
@@ -34,7 +34,7 @@ def chat_messages_to_conversational_kwargs(
         raise NotImplementedError("Messages passed in must be of odd length.")
     last_message = messages[-1]
     kwargs: Dict[str, Any] = {
-        "text": last_message.content,
+        "text": last_message,
         **last_message.additional_kwargs,
     }
     if len(messages) != 1:


### PR DESCRIPTION
# Description

Fix kwargs variables in in chat_messages_to_conversational_kwargs.

AttributeError                            Traceback (most recent call last)
File <timed exec>:1

File /opt/conda/lib/python3.10/site-packages/llama_index/core/instrumentation/dispatcher.py:230, in Dispatcher.span.<locals>.wrapper(func, instance, args, kwargs)
    226 self.span_enter(
    227     id_=id_, bound_args=bound_args, instance=instance, parent_id=parent_id
    228 )
    229 try:
--> 230     result = func(*args, **kwargs)
    231 except BaseException as e:
    232     self.event(SpanDropEvent(span_id=id_, err_str=str(e)))

File /opt/conda/lib/python3.10/site-packages/llama_index/llms/huggingface_api/base.py:229, in HuggingFaceInferenceAPI.chat(self, messages, **kwargs)
    225 def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
    226     # default to conversational task as that was the previous functionality
    227     if self.task == "conversational" or self.task is None:
    228         output: "ConversationalOutput" = self._sync_client.conversational(
--> 229             **{**chat_messages_to_conversational_kwargs(messages), **kwargs}
    230         )
    231         return ChatResponse(
    232             message=ChatMessage(
    233                 role=MessageRole.ASSISTANT, content=output["generated_text"]
    234             )
    235         )
    236     else:
    237         # try and use text generation

File /opt/conda/lib/python3.10/site-packages/llama_index/llms/huggingface_api/base.py:37, in chat_messages_to_conversational_kwargs(messages)
     34     raise NotImplementedError("Messages passed in must be of odd length.")
     35 last_message = messages[-1]
     36 kwargs: Dict[str, Any] = {
---> 37     "text": last_message.content,
     38     **last_message.additional_kwargs,
     39 }
     40 if len(messages) != 1:
     41     kwargs["past_user_inputs"] = []

Former induce error
`AttributeError: 'str' object has no attribute 'content'`


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
