### PR TITLE
added JSONReader to file mappings

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -62,6 +62,7 @@ def _try_loading_included_file_formats() -> Dict[str, Type[BaseReader]]:
             PDFReader,
             PptxReader,
             VideoAudioReader,
+            JSONReader,
         )  # pants: no-infer-dep
     except ImportError:
         raise ImportError("`llama-index-readers-file` package not found")
@@ -87,6 +88,7 @@ def _try_loading_included_file_formats() -> Dict[str, Type[BaseReader]]:
         ".ipynb": IPYNBReader,
         ".xls": PandasExcelReader,
         ".xlsx": PandasExcelReader,
+        ".json": JSONReader,
     }
     return default_file_reader_cls
 


### PR DESCRIPTION
# Description

The `default_file_reader_cls` dict that maps file extensions to the proper XReader, did not include a mapping for the new JSONreader.  This PR adds the mapping for `.json` files to the JSONReader

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ x ] No

## Type of Change

Bugfix 

Please delete options that are not relevant.

- [ x  ] Bug fix (non-breaking change which fixes an issue)
- [ x ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ x ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I ran `make format; make lint` to appease the lint gods
