### PR TITLE
Invalidate s3fs cache in S3Reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
@@ -67,6 +67,7 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
     aws_session_token: Optional[str] = None
     s3_endpoint_url: Optional[str] = None
     custom_reader_path: Optional[str] = None
+    invalidate_s3fs_cache: bool = True
 
     @classmethod
     def class_name(cls) -> str:
@@ -75,12 +76,16 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
     def _get_s3fs(self):
         from s3fs import S3FileSystem
 
-        return S3FileSystem(
+        s3fs = S3FileSystem(
             key=self.aws_access_id,
             endpoint_url=self.s3_endpoint_url,
             secret=self.aws_access_secret,
             token=self.aws_session_token,
         )
+        if self.invalidate_s3fs_cache:
+            s3fs.invalidate_cache()
+
+        return s3fs
 
     def _get_simple_directory_reader(self) -> SimpleDirectoryReader:
         # we don't want to keep the reader as a field in the class to keep it serializable

--- a/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
@@ -29,12 +29,12 @@ license = "MIT"
 maintainers = ["thejessezhang"]
 name = "llama-index-readers-s3"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-index-core = "^0.10.37.post1"
-llama-index-readers-file = "^0.1.12"
+llama-index-core = "^0.10.50.post1"
+llama-index-readers-file = "^0.1.25"
 s3fs = ">=2024.3.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

Adds a param to invalidate s3fs cache in S3Reader. It helps to make sure the data we get from s3 is up to date.