### PR TITLE
Neo4j vector context retriever bug fix

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -463,38 +463,37 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
         triples = []
 
         ids = [node.id for node in graph_nodes]
-
-        responses = []
-        for id in ids:
-            if limit <= 0:
-                break
-            # Needs some optimization
-            response = self.structured_query(
-                f"""
-                MATCH (e:`__Entity__`)
-                WHERE e.id=$id
-                MATCH p=(e)-[r*1..{depth}]-(other)
-                WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
-                UNWIND relationships(p) AS rel
-                WITH distinct rel
-                WITH startNode(rel) AS source,
-                    type(rel) AS type,
-                    endNode(rel) AS endNode
-                RETURN source.id AS source_id, [l in labels(source) WHERE l <> '__Entity__' | l][0] AS source_type,
-                        source{{.* , embedding: Null, id: Null}} AS source_properties,
-                        type,
-                        endNode.id AS target_id, [l in labels(endNode) WHERE l <> '__Entity__' | l][0] AS target_type,
-                        endNode{{.* , embedding: Null, id: Null}} AS target_properties
-                LIMIT toInteger($limit)
-                """,
-                param_map={"id": id, "limit": limit},
-            )
-            response = response if response else []
-            limit -= len(response)
-            responses += response
+        # Needs some optimization
+        response = self.structured_query(
+            f"""
+            WITH $ids AS id_list
+            UNWIND range(0, size(id_list) - 1) AS idx
+            MATCH (e:`__Entity__`)
+            WHERE e.id = id_list[idx]
+            MATCH p=(e)-[r*1..{depth}]-(other)
+            WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
+            UNWIND relationships(p) AS rel
+            WITH distinct rel, idx
+            WITH startNode(rel) AS source,
+                type(rel) AS type,
+                endNode(rel) AS endNode,
+                idx
+            LIMIT toInteger($limit)
+            RETURN source.id AS source_id, [l in labels(source) WHERE l <> '__Entity__' | l][0] AS source_type,
+                source{{.* , embedding: Null, id: Null}} AS source_properties,
+                type,
+                endNode.id AS target_id, [l in labels(endNode) WHERE l <> '__Entity__' | l][0] AS target_type,
+                endNode{{.* , embedding: Null, id: Null}} AS target_properties,
+                idx
+            ORDER BY idx
+            LIMIT toInteger($limit)
+            """,
+            param_map={"ids": ids, "limit": limit},
+        )
+        response = response if response else []
 
         ignore_rels = ignore_rels or []
-        for record in responses:
+        for record in response:
             if record["type"] in ignore_rels:
                 continue
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -472,7 +472,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
             response = self.structured_query(
                 f"""
                 MATCH (e:`__Entity__`)
-                WHERE e.id='{id}'
+                WHERE e.id=$id
                 MATCH p=(e)-[r*1..{depth}]-(other)
                 WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
                 UNWIND relationships(p) AS rel
@@ -487,7 +487,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
                         endNode{{.* , embedding: Null, id: Null}} AS target_properties
                 LIMIT toInteger($limit)
                 """,
-                param_map={"limit": limit},
+                param_map={"id": id, "limit": limit},
             )
             response = response if response else []
             limit -= len(response)

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.2.6"
+version = "0.2.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
Previously, when using the `VectorContextRetriever` with the `Neo4jPropertyGraphStore`, the `VectorContextRetriever`would call `avector_query` to get the `similarity_top_k` nodes and return the list of nodes with the first node being ranked with the highest similarity score, and the last being least similar. However, when we pass the nodes found from `avector_query` to `aget_rel_map`, the nodes returned could be in any order of similarity. So we need to fix this issue. For example, if I have a query: `nodes = retriever.retrieve("Andres Mendez")`, then then resulting node ids from `avector_query` could look like the following: ['Andres Mendez', 'Andres', 'Miguel Mendez', 'Joe Mamma']. But then the results from `aget_rel_map` could provide only the top 30 results from the relationships of Joe Mamma. This is not expected behaviour, as we are querying for Andres Mendez, not Joe Mamma. The issue here is that we don't take similarity score into account when when calling aget_rel_map, but we need to.

Fixes # (issue)
I modified the cypher query in `aget_rel_map` to return results based on the order of the node ids passed into this function. This will preserve the scores of the input nodes in the response of this function.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I also tested this by running different cases to make sure this works as expected.
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
