### PR TITLE
fix: text format for mongodb reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/llama_index/readers/mongodb/base.py
@@ -86,7 +86,7 @@ class SimpleMongoReader(BaseReader):
 
         for item in cursor:
             try:
-                texts = [f"{name}: " + str(item[name]) for name in field_names]
+                texts = [str(item[name]) for name in field_names]
             except KeyError as err:
                 raise ValueError(
                     f"{err.args[0]} field not found in Mongo document."

--- a/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mongodb/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-mongodb"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

- Fixes the backward compatibility of `text` in #14123.

  Assume the data is `{'text': 'sample text'}`

  - Before v0.1.6, `text` will be `'sample text1'`
  - In v0.1.7, `text` will be `'text': 'sample text'`
  
  I think it could provide a `text_template` param (with signature `text_template(name: str, entry: Any) -> str`) to format the fields fetched from mongodb for a better customization.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
