### PR TITLE
fixes the duplicated nodes during the merge of ref kv pairs

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -125,14 +125,18 @@ class KVDocumentStore(BaseDocumentStore):
     def _merge_ref_doc_kv_pairs(self, ref_doc_kv_pairs: dict) -> List[Tuple[str, dict]]:
         merged_ref_doc_kv_pairs = []
         for key, kv_pairs in ref_doc_kv_pairs.items():
-            merged_node_ids = []
-            metadata = {}
-            for kv_pair in kv_pairs:
-                merged_node_ids.extend(kv_pair[1].get("node_ids", []))
-                metadata.update(kv_pair[1].get("metadata", {}))
-            merged_ref_doc_kv_pairs.append(
-                (key, {"node_ids": merged_node_ids, "metadata": metadata})
-            )
+            merged_ref_doc_kv_pairs = []
+            for key, kv_pairs in ref_doc_kv_pairs.items():
+                merged_node_ids = set()
+                metadata = {}
+                for kv_pair in kv_pairs:
+                    merged_node_ids = merged_node_ids.union(
+                        set(kv_pair[1].get("node_ids", []))
+                    )
+                    metadata.update(kv_pair[1].get("metadata", {}))
+                merged_ref_doc_kv_pairs.append(
+                    (key, {"node_ids": list(merged_node_ids), "metadata": metadata})
+                )
 
         return merged_ref_doc_kv_pairs
 


### PR DESCRIPTION
# Description

if the doc store is used to store multiple indexes each index will cause an exponential increase in refs. Attached is a basic [notebook](https://github.com/user-attachments/files/16042223/exponential.ipynb.zip) to see the issue.

Fixes # 13945

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (change in core)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end) (attached here)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:



- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
