### PR TITLE
Add an optimized evaluation prompt for Llama3:8B

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/faithfulness.py
+++ b/llama-index-core/llama_index/core/evaluation/faithfulness.py
@@ -58,9 +58,47 @@ DEFAULT_REFINE_TEMPLATE = PromptTemplate(
     "Otherwise answer NO.\n"
 )
 
+LLAMA3_8B_EVAL_TEMPLATE = PromptTemplate(
+    """Please tell if a given piece of information is supported by the context.
+You need to answer with either YES or NO.
+Answer YES if **any part** of the context supports the information, even if most of the context is unrelated.
+Answer NO if the context does not support the information at all.
+Be sure to read all provided context segments carefully before making your decision.
+
+Some examples are provided below:
+
+Example 1:
+Information: The Eiffel Tower is located in Paris.
+Context: The Eiffel Tower, a symbol of French culture, stands prominently in the city of Paris.
+Answer: YES
+
+Example 2:
+Information: Bananas are a type of berry.
+Context: Bananas are a popular fruit enjoyed worldwide and are rich in potassium.
+Answer: NO
+
+Example 3:
+Information: Cats are reptiles.
+Context: Cats are domesticated felines known for their agility and companionship.
+Answer: NO
+
+Example 4:
+Information: Amazon started as an online bookstore.
+Context: Amazon initially launched as an online store for books but has since expanded into a global e-commerce giant
+offering various products and services.
+Answer: YES
+
+Information: {query}
+Context: {reference_contexts}
+Answer:"""
+)
+
+TEMPLATES_CATALOG = {"llama3:8b": LLAMA3_8B_EVAL_TEMPLATE}
+
 
 class FaithfulnessEvaluator(BaseEvaluator):
-    """Faithfulness evaluator.
+    """
+    Faithfulness evaluator.
 
     Evaluates whether a response is faithful to the contexts
     (i.e. whether the response is supported by the contexts or hallucinated.)
@@ -95,7 +133,10 @@ class FaithfulnessEvaluator(BaseEvaluator):
         if isinstance(eval_template, str):
             self._eval_template = PromptTemplate(eval_template)
         else:
-            self._eval_template = eval_template or DEFAULT_EVAL_TEMPLATE
+            model_name = self._llm.metadata.model_name
+            self._eval_template = eval_template or TEMPLATES_CATALOG.get(
+                model_name, DEFAULT_EVAL_TEMPLATE
+            )
 
         self._refine_template: BasePromptTemplate
         if isinstance(refine_template, str):


### PR DESCRIPTION
# Description

Outcome of the project presented at the RAG 2.0 hackathon at AGI House on 6/29

The default prompt provided by the `FaithfulnessEvaluator` fails ~40% of the times on the Uber 10K Dataset 2021 when used on Llama3:8B. The prompt in this PR scored ~95% on the same dataset.

Notes for the reviewer:
- I'm not replacing the default template because I'm not sure the score would be as good on other models. 
- The `FaithfulnessEvaluator` will pick the optimised prompt when a custom prompt was not passed and the llm model name is `llama3:8b`. The old default will be used otherwise.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
