### PR TITLE
fix introspective agent - let reflection agent workers be used independently

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-introspective/examples/toxicity_reduction.ipynb
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/examples/toxicity_reduction.ipynb
@@ -40,9 +40,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "bbccfe5e-c25f-469a-9394-d7dffcdaae91",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import nest_asyncio\n",
@@ -248,9 +250,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "84daa3d1-075c-4740-ac03-efe077f2151d",
-   "metadata": {},
+   "execution_count": 4,
+   "id": "79d9139f-535c-47c4-828a-376f7c206bbf",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from llama_index.agent.introspective import IntrospectiveAgentWorker\n",
@@ -260,9 +264,31 @@
     "from llama_index.agent.openai import OpenAIAgentWorker\n",
     "from llama_index.core.agent import FunctionCallingAgentWorker\n",
     "from llama_index.core.llms import ChatMessage, MessageRole\n",
-    "from llama_index.core import ChatPromptTemplate\n",
-    "\n",
-    "\n",
+    "from llama_index.core import ChatPromptTemplate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6d1395bc-57ed-47bf-bc65-231a333a6136",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'pespective_tool' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 92\u001b[0m\n\u001b[1;32m     86\u001b[0m     \u001b[38;5;66;03m# 3b.\u001b[39;00m\n\u001b[1;32m     87\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m introspective_agent_worker\u001b[38;5;241m.\u001b[39mas_agent(\n\u001b[1;32m     88\u001b[0m         chat_history\u001b[38;5;241m=\u001b[39mchat_history, verbose\u001b[38;5;241m=\u001b[39mverbose\n\u001b[1;32m     89\u001b[0m     )\n\u001b[0;32m---> 92\u001b[0m introspective_agent \u001b[38;5;241m=\u001b[39m \u001b[43mget_introspective_agent_with_tool_interactive_reflection\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     93\u001b[0m \u001b[43m    \u001b[49m\u001b[43mverbose\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m     94\u001b[0m \u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[3], line 34\u001b[0m, in \u001b[0;36mget_introspective_agent_with_tool_interactive_reflection\u001b[0;34m(verbose, with_main_worker)\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Helper function for building introspective agent using tool-interactive reflection.\u001b[39;00m\n\u001b[1;32m     15\u001b[0m \n\u001b[1;32m     16\u001b[0m \u001b[38;5;124;03mSteps:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     29\u001b[0m \u001b[38;5;124;03m    3b. Construct `IntrospectiveAgent` using .as_agent()\u001b[39;00m\n\u001b[1;32m     30\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     32\u001b[0m \u001b[38;5;66;03m# 1a.\u001b[39;00m\n\u001b[1;32m     33\u001b[0m critique_agent_worker \u001b[38;5;241m=\u001b[39m FunctionCallingAgentWorker\u001b[38;5;241m.\u001b[39mfrom_tools(\n\u001b[0;32m---> 34\u001b[0m     tools\u001b[38;5;241m=\u001b[39m[\u001b[43mpespective_tool\u001b[49m], llm\u001b[38;5;241m=\u001b[39mOpenAI(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgpt-3.5-turbo\u001b[39m\u001b[38;5;124m\"\u001b[39m), verbose\u001b[38;5;241m=\u001b[39mverbose\n\u001b[1;32m     35\u001b[0m )\n\u001b[1;32m     36\u001b[0m \u001b[38;5;66;03m# 1b.\u001b[39;00m\n\u001b[1;32m     37\u001b[0m correction_llm \u001b[38;5;241m=\u001b[39m OpenAI(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgpt-4-turbo-preview\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'pespective_tool' is not defined"
+     ]
+    }
+   ],
+   "source": [
     "def get_introspective_agent_with_tool_interactive_reflection(\n",
     "    verbose=True, with_main_worker=False\n",
     "):\n",
@@ -489,9 +515,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "74119d00-26d8-4c6a-aadc-c7af6c0271cc",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from llama_index.agent.introspective import SelfReflectionAgentWorker\n",
@@ -559,21 +587,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "4b2ff24d-5d03-4453-bd1f-1fb9750625a0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "> Running step 450123e6-9ec4-4a74-995a-4137d3af51fd. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
+      "> Running step 53d92129-34de-465f-897f-8e046d4a5a99. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
       "Added user message to memory: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
-      "> Running step 4a41fd97-ae67-42ae-8878-7c53c733efaa. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
-      "> Reflection: {'is_done': False, 'feedback': 'The assistant failed to generate a safer version of the user-supplied text. Instead, it repeated the original text verbatim, which does not fulfill the task requirements. There was no attempt to modify the text to make it less toxic or more neutral. Additionally, there was no tool use involved in the process, which could have been beneficial for generating or evaluating potential safer text versions. The assistant needs to focus on creating a response that aligns with the goal of generating safer text versions without repeating the potentially toxic content provided by the user.'}\n",
-      "Correction: Discussing dietary choices, particularly veganism, often brings up strong opinions. It's important to approach these conversations with respect and understanding, recognizing that people choose their diets for a variety of reasons, including ethical concerns for animal welfare. It's crucial to avoid generalizations and acknowledge the diversity of experiences and beliefs within any group.\n",
-      "> Running step c0afbcb0-c76e-4588-849c-be6cc48e56c1. Step input: None\n",
-      "> Reflection: {'is_done': True, 'feedback': \"The assistant successfully generated a safer version of the user-supplied text. The revised text is neutral and respectful, avoiding the toxic elements present in the original message. It focuses on the importance of respectful dialogue and understanding diverse perspectives, which aligns with the task of generating safer text versions. No tool use was required in this instance, as the task was completed effectively through the assistant's response.\"}\n"
+      "> Running step a368adc2-60d6-43fb-9ca9-a27aeb08405f. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
+      "> Reflection: {'is_done': False, 'feedback': \"The assistant did not provide any response to the user's input. It failed to generate a safer version of the potentially toxic text as requested. The assistant should have processed the user's input and provided a revised, non-toxic version of the statement.\"}\n",
+      "Correction: People who choose not to eat meat for ethical reasons related to animal welfare often face criticism. It's important to engage in respectful and constructive discussions about dietary choices and their impacts.\n",
+      "> Running step 640909a5-c0a8-41ac-804a-ebce123ba9a9. Step input: None\n",
+      "> Reflection: {'is_done': True, 'feedback': \"The assistant successfully generated a safer, non-toxic version of the user's input. It reframed the statement in a way that maintains the essence of the discussion about dietary choices and animal welfare without resorting to accusations of hypocrisy or mentioning any specific negative behavior. This aligns with the task of creating a safer version of potentially toxic text.\"}\n"
      ]
     }
    ],
@@ -1026,9 +1056,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llama-index-agent-introspective",
+   "display_name": "llama_index_v3",
    "language": "python",
-   "name": "llama-index-agent-introspective"
+   "name": "llama_index_v3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1039,7 +1069,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/llama-index-integrations/agent/llama-index-agent-introspective/examples/toxicity_reduction.ipynb
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/examples/toxicity_reduction.ipynb
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79d9139f-535c-47c4-828a-376f7c206bbf",
+   "id": "84daa3d1-075c-4740-ac03-efe077f2151d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,29 +260,9 @@
     "from llama_index.agent.openai import OpenAIAgentWorker\n",
     "from llama_index.core.agent import FunctionCallingAgentWorker\n",
     "from llama_index.core.llms import ChatMessage, MessageRole\n",
-    "from llama_index.core import ChatPromptTemplate"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6d1395bc-57ed-47bf-bc65-231a333a6136",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'pespective_tool' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[3], line 92\u001b[0m\n\u001b[1;32m     86\u001b[0m     \u001b[38;5;66;03m# 3b.\u001b[39;00m\n\u001b[1;32m     87\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m introspective_agent_worker\u001b[38;5;241m.\u001b[39mas_agent(\n\u001b[1;32m     88\u001b[0m         chat_history\u001b[38;5;241m=\u001b[39mchat_history, verbose\u001b[38;5;241m=\u001b[39mverbose\n\u001b[1;32m     89\u001b[0m     )\n\u001b[0;32m---> 92\u001b[0m introspective_agent \u001b[38;5;241m=\u001b[39m \u001b[43mget_introspective_agent_with_tool_interactive_reflection\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     93\u001b[0m \u001b[43m    \u001b[49m\u001b[43mverbose\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m     94\u001b[0m \u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[3], line 34\u001b[0m, in \u001b[0;36mget_introspective_agent_with_tool_interactive_reflection\u001b[0;34m(verbose, with_main_worker)\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Helper function for building introspective agent using tool-interactive reflection.\u001b[39;00m\n\u001b[1;32m     15\u001b[0m \n\u001b[1;32m     16\u001b[0m \u001b[38;5;124;03mSteps:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     29\u001b[0m \u001b[38;5;124;03m    3b. Construct `IntrospectiveAgent` using .as_agent()\u001b[39;00m\n\u001b[1;32m     30\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     32\u001b[0m \u001b[38;5;66;03m# 1a.\u001b[39;00m\n\u001b[1;32m     33\u001b[0m critique_agent_worker \u001b[38;5;241m=\u001b[39m FunctionCallingAgentWorker\u001b[38;5;241m.\u001b[39mfrom_tools(\n\u001b[0;32m---> 34\u001b[0m     tools\u001b[38;5;241m=\u001b[39m[\u001b[43mpespective_tool\u001b[49m], llm\u001b[38;5;241m=\u001b[39mOpenAI(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgpt-3.5-turbo\u001b[39m\u001b[38;5;124m\"\u001b[39m), verbose\u001b[38;5;241m=\u001b[39mverbose\n\u001b[1;32m     35\u001b[0m )\n\u001b[1;32m     36\u001b[0m \u001b[38;5;66;03m# 1b.\u001b[39;00m\n\u001b[1;32m     37\u001b[0m correction_llm \u001b[38;5;241m=\u001b[39m OpenAI(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgpt-4-turbo-preview\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'pespective_tool' is not defined"
-     ]
-    }
-   ],
-   "source": [
+    "from llama_index.core import ChatPromptTemplate\n",
+    "\n",
+    "\n",
     "def get_introspective_agent_with_tool_interactive_reflection(\n",
     "    verbose=True, with_main_worker=False\n",
     "):\n",
@@ -587,13 +567,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "> Running step 53d92129-34de-465f-897f-8e046d4a5a99. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
+      "> Running step 450123e6-9ec4-4a74-995a-4137d3af51fd. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
       "Added user message to memory: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
-      "> Running step a368adc2-60d6-43fb-9ca9-a27aeb08405f. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
-      "> Reflection: {'is_done': False, 'feedback': \"The assistant did not provide any response to the user's input. It failed to generate a safer version of the potentially toxic text as requested. The assistant should have processed the user's input and provided a revised, non-toxic version of the statement.\"}\n",
-      "Correction: People who choose not to eat meat for ethical reasons related to animal welfare often face criticism. It's important to engage in respectful and constructive discussions about dietary choices and their impacts.\n",
-      "> Running step 640909a5-c0a8-41ac-804a-ebce123ba9a9. Step input: None\n",
-      "> Reflection: {'is_done': True, 'feedback': \"The assistant successfully generated a safer, non-toxic version of the user's input. It reframed the statement in a way that maintains the essence of the discussion about dietary choices and animal welfare without resorting to accusations of hypocrisy or mentioning any specific negative behavior. This aligns with the task of creating a safer version of potentially toxic text.\"}\n"
+      "> Running step 4a41fd97-ae67-42ae-8878-7c53c733efaa. Step input: Those individuals who publicly tout eating no meat, especially when their stated reason has to do with caring about animals, are some of the most hypocritical people I’ve ever met. One vegan acquaintance routinely beat her\n",
+      "> Reflection: {'is_done': False, 'feedback': 'The assistant failed to generate a safer version of the user-supplied text. Instead, it repeated the original text verbatim, which does not fulfill the task requirements. There was no attempt to modify the text to make it less toxic or more neutral. Additionally, there was no tool use involved in the process, which could have been beneficial for generating or evaluating potential safer text versions. The assistant needs to focus on creating a response that aligns with the goal of generating safer text versions without repeating the potentially toxic content provided by the user.'}\n",
+      "Correction: Discussing dietary choices, particularly veganism, often brings up strong opinions. It's important to approach these conversations with respect and understanding, recognizing that people choose their diets for a variety of reasons, including ethical concerns for animal welfare. It's crucial to avoid generalizations and acknowledge the diversity of experiences and beliefs within any group.\n",
+      "> Running step c0afbcb0-c76e-4588-849c-be6cc48e56c1. Step input: None\n",
+      "> Reflection: {'is_done': True, 'feedback': \"The assistant successfully generated a safer version of the user-supplied text. The revised text is neutral and respectful, avoiding the toxic elements present in the original message. It focuses on the importance of respectful dialogue and understanding diverse perspectives, which aligns with the task of generating safer text versions. No tool use was required in this instance, as the task was completed effectively through the assistant's response.\"}\n"
      ]
     }
    ],
@@ -1046,9 +1026,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llama_index_v3",
+   "display_name": "llama-index-agent-introspective",
    "language": "python",
-   "name": "llama_index_v3"
+   "name": "llama-index-agent-introspective"
   },
   "language_info": {
    "codemirror_mode": {

--- a/llama-index-integrations/agent/llama-index-agent-introspective/examples/toxicity_reduction.ipynb
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/examples/toxicity_reduction.ipynb
@@ -40,11 +40,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bbccfe5e-c25f-469a-9394-d7dffcdaae91",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import nest_asyncio\n",
@@ -250,11 +248,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "79d9139f-535c-47c4-828a-376f7c206bbf",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from llama_index.agent.introspective import IntrospectiveAgentWorker\n",
@@ -269,11 +265,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "6d1395bc-57ed-47bf-bc65-231a333a6136",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "NameError",
@@ -515,11 +509,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "74119d00-26d8-4c6a-aadc-c7af6c0271cc",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from llama_index.agent.introspective import SelfReflectionAgentWorker\n",
@@ -587,11 +579,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "4b2ff24d-5d03-4453-bd1f-1fb9750625a0",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1069,8 +1059,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/llama-index-integrations/agent/llama-index-agent-introspective/llama_index/agent/introspective/reflective/self_reflection.py
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/llama_index/agent/introspective/reflective/self_reflection.py
@@ -19,7 +19,6 @@ from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.base.llms.generic_utils import messages_to_prompt
 from llama_index.core.llms.llm import LLM
-from llama_index.core.agent.utils import add_user_step_to_memory
 from llama_index.core.prompts import PromptTemplate
 
 import llama_index.core.instrumentation as instrument

--- a/llama-index-integrations/agent/llama-index-agent-introspective/llama_index/agent/introspective/reflective/tool_interactive_reflection.py
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/llama_index/agent/introspective/reflective/tool_interactive_reflection.py
@@ -184,6 +184,8 @@ class ToolInteractiveReflectionAgentWorker(BaseModel, BaseAgentWorker):
         messages = task.memory.get()
         for message in messages:
             new_memory.put(message)
+        # inject new input into memory
+        new_memory.put(ChatMessage(content=task.input, role=MessageRole.USER))
 
         # initialize task state
         task_state = {

--- a/llama-index-integrations/agent/llama-index-agent-introspective/llama_index/agent/introspective/step.py
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/llama_index/agent/introspective/step.py
@@ -135,19 +135,17 @@ class IntrospectiveAgentWorker(BaseAgentWorker):
             task.extra_state["main"]["sources"] = main_agent_response.sources
             task.extra_state["main"]["memory"] = main_agent.memory
         else:
-            add_user_step_to_memory(
-                step, task.extra_state["main"]["memory"], verbose=self._verbose
-            )
-            original_response = step.input
-            task.extra_state["main"]["memory"].put(
-                ChatMessage(content=original_response, role="assistant")
-            )
+            pass
 
         # run reflective agent
         reflective_agent_messages = task.extra_state["main"]["memory"].get()
         reflective_agent = self._reflective_agent_worker.as_agent(
             chat_history=reflective_agent_messages
         )
+        # NOTE: atm you *need* to pass an input string to `chat`, even if the memory is already
+        # preloaded. Input will be concatenated on top of chat history from memory
+        # which will be used to generate the response.
+        # TODO: make agent interface more flexible
         reflective_agent_response = reflective_agent.chat(original_response)
         task.extra_state["reflection"]["sources"] = reflective_agent_response.sources
         task.extra_state["reflection"]["memory"] = reflective_agent.memory

--- a/llama-index-integrations/agent/llama-index-agent-introspective/tests/test_self_reflection.py
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/tests/test_self_reflection.py
@@ -78,4 +78,6 @@ def test_reflection_agent() -> None:
             print(str(msg))
             print()
     assert response.response == "This is a mock correction."
-    assert len(agent.chat_history) == 8  # (system, user, asst, user, ref, cor, ref, asst)
+    assert (
+        len(agent.chat_history) == 8
+    )  # (system, user, asst, user, ref, cor, ref, asst)

--- a/llama-index-integrations/agent/llama-index-agent-introspective/tests/test_self_reflection.py
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/tests/test_self_reflection.py
@@ -78,4 +78,4 @@ def test_reflection_agent() -> None:
             print(str(msg))
             print()
     assert response.response == "This is a mock correction."
-    assert len(agent.chat_history) == 7  # (system, user, asst, ref, cor, ref, asst)
+    assert len(agent.chat_history) == 8  # (system, user, asst, user, ref, cor, ref, asst)

--- a/llama-index-integrations/agent/llama-index-agent-introspective/tests/test_tool_interactive_reflection.py
+++ b/llama-index-integrations/agent/llama-index-agent-introspective/tests/test_tool_interactive_reflection.py
@@ -87,7 +87,9 @@ def test_introspective_agent_with_stopping_callable(mock_critique_agent_worker) 
             print(str(msg))
             print()
     assert response.response == "This is a mock correction."
-    assert len(agent.chat_history) == 7  # (system, user, asst, ref, cor, ref, asst)
+    assert (
+        len(agent.chat_history) == 8
+    )  # (system, user, asst, user, ref, cor, ref, asst)
 
 
 @patch("llama_index.core.agent.function_calling.step.FunctionCallingAgentWorker")
@@ -127,4 +129,4 @@ def test_introspective_agent_with_max_iterations(mock_critique_agent_worker) -> 
             print(str(msg))
             print()
     assert response.response == "This is a mock correction."
-    assert len(agent.chat_history) == 5  # (system, user, asst, ref, cor/asst)
+    assert len(agent.chat_history) == 6  # (system, user, asst, user, ref, cor/asst)


### PR DESCRIPTION
Before, you couldn't import the self-reflection agent worker or CRITIC worker on its own, would trigger errors since assume that memory is populated (from line `prev_correct_str = messages[-1].content`) 

Fixed this. This does lead to a duplicate user message if main agent is supplied in the introspective agent, but I think that's fine - the current introspective agent notebook example doesn't include the main agent 