### PR TITLE
Fix JinaRerank

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/llama_index/postprocessor/jinaai_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/llama_index/postprocessor/jinaai_rerank/base.py
@@ -39,7 +39,7 @@ class JinaRerank(BaseNodePostprocessor):
         self.model = model
         self._session = requests.Session()
         self._session.headers.update(
-            {"Authorization": f"Bearer {api_key}", "Accept-Encoding": "identity"}
+            {"Authorization": f"Bearer {self.api_key}", "Accept-Encoding": "identity"}
         )
 
     @classmethod

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-postprocessor-jinaai-rerank"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR makes `JinaRerank` can read api_key from env as expected.

Fixes # (issue)


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
