### PR TITLE
[Python-4342]  Adds Hybrid and Full-Text Search to MongoDBAtlasVectorSearch

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/llama_index/vector_stores/mongodb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/llama_index/vector_stores/mongodb/base.py
@@ -34,6 +34,8 @@ from llama_index.vector_stores.mongodb.pipelines import (
 )
 from pymongo import MongoClient
 from pymongo.driver_info import DriverInfo
+from pymongo.collection import Collection
+
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +67,7 @@ class MongoDBAtlasVectorSearch(BasePydanticVectorStore):
 
     ```
     {
-        "name": "index_name",
+        "name": "vector_index",
         "type": "vectorSearch",
         "fields":[
             {
@@ -169,7 +171,7 @@ class MongoDBAtlasVectorSearch(BasePydanticVectorStore):
                     "vector_index_name and index_name both specified. Will use vector_index_name"
                 )
 
-        self._collection = self._mongodb_client[db_name][collection_name]
+        self._collection: Collection = self._mongodb_client[db_name][collection_name]
         self._vector_index_name = vector_index_name
         self._embedding_key = embedding_key
         self._id_key = id_key

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/llama_index/vector_stores/mongodb/pipelines.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/llama_index/vector_stores/mongodb/pipelines.py
@@ -56,13 +56,11 @@ def filters_to_mql(filters: MetadataFilters) -> Dict[str, Any]:
 
     See: See https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/#atlas-vector-search-pre-filter
 
-
     Args:
         filters:
 
     Returns:
         MQL version of the filter.
-
     """
     if filters is None:
         return {}
@@ -213,8 +211,8 @@ def final_hybrid_stage(
             "$addFields": {
                 "score": {
                     "$add": [
-                        {"$mult": [alpha, "$vector_score"]},
-                        {"$mult": [{"$sub": [1.0, alpha]}, "$fulltext_score"]},
+                        {"$multiply": [alpha, "$vector_score"]},
+                        {"$multiply": [{"$subtract": [1.0, alpha]}, "$fulltext_score"]},
                     ]
                 }
             }

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/llama_index/vector_stores/mongodb/pipelines.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/llama_index/vector_stores/mongodb/pipelines.py
@@ -1,0 +1,207 @@
+"""Aggregation pipeline components used in Atlas Full-Text, Vector, and Hybrid Search.
+
+"""
+from typing import Any, Dict, List, TypeVar
+from llama_index.core.vector_stores.types import MetadataFilters, FilterOperator
+
+
+MongoDBDocumentType = TypeVar("MongoDBDocumentType", bound=Dict[str, Any])
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def fulltext_search_stage(
+    query: str, search_field, index_name: str, operator: str = "text", **kwargs: Any
+) -> Dict[str, Any]:
+    """Full-Text search.
+
+    Args:
+        query: Input text to search for
+        search_field: Field in Collection that will be searched
+        index_name: Atlas Search Index name
+        operator: A number of operators are available in the text search stage.
+
+    Returns:
+        Dictionary defining the $search
+
+    See Also:
+        - MongoDB Full-Text Search <https://www.mongodb.com/docs/atlas/atlas-search/aggregation-stages/search/#mongodb-pipeline-pipe.-search>
+        - MongoDB Operators <https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#std-label-operators-ref>
+    """
+    return {
+        "$search": {
+            "index": index_name,
+            operator: {"query": query, "path": search_field},
+        }
+    }
+
+
+def filters_to_mql(filters: MetadataFilters) -> Dict[str, Any]:
+    """Converts Langchain's MetadatFilters into the MQL expected by $vectorSearch query.
+
+    We are looking for something like
+
+    "filter": {
+            "$and": [
+                { "genres": { "$eq": "Comedy" } },
+                { "year": { "$gt": 2010 } }
+            ]
+    },
+
+    See: See https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/#atlas-vector-search-pre-filter
+
+
+    Args:
+        filters:
+
+    Returns:
+        MQL version of the filter.
+
+    """
+    if filters is None:
+        return {}
+    if filters.condition.AND:
+        mql = {"$and": [{mf.key: mf.value} for mf in filters]}
+    elif filters.condition.OR:
+        mql = {"$or": [{mf.key: mf.value} for mf in filters]}
+    else:
+        assert len(filters) == 1
+        mql = {"$or": {filters[0].key: filters[0].value}}
+
+    return mql
+
+
+def vector_search_stage(
+    query_vector: List[float],
+    search_field: str,
+    index_name: str,
+    limit: int = 4,
+    filter: MongoDBDocumentType = None,
+    oversampling_factor=10,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Vector Search Stage without Scores.
+
+    Scoring is applied later depending on strategy.
+    vector search includes a vectorSearchScore that is typically used.
+    hybrid uses Reciprocal Rank Fusion.
+
+    Args:
+        query_vector: List of embedding vector
+        search_field: Field in Collection containing embedding vectors
+        index_name: Name of Atlas Vector Search Index tied to Collection
+        limit: Number of documents to return
+        oversampling_factor: this times limit is the number of candidates
+        filters: Any MQL match expression comparing an indexed field
+
+    Returns:
+        Dictionary defining the $vectorSearch
+    """
+    return {
+        "$vectorSearch": {
+            "index": index_name,
+            "path": search_field,
+            "queryVector": query_vector,
+            "numCandidates": limit * oversampling_factor,
+            "limit": limit,
+            "filter": filter,
+        }
+    }
+
+
+def combine_pipelines(
+    pipeline: List[Any], stage: List[Dict[str, Any]], collection_name: str
+):
+    """Combines two aggregations into a single result set."""
+    if pipeline:
+        pipeline.append({"$unionWith": {"coll": collection_name, "pipeline": stage}})
+    else:
+        pipeline.extend(stage)
+    return pipeline
+
+
+def map_lc_mql_filter_operators(operator: str) -> str:
+    """Maps LangChain FilterOperators to MongoDB Query Language."""
+    map = {
+        FilterOperator.EQ: "$eq",  # = "=="  # default operator (string, int, float)
+        FilterOperator.GT: "$gt",  # ">"  greater than (int, float)
+        FilterOperator.LT: "$lt",  # = # "<"  # less than (int, float)
+        FilterOperator.NE: "$ne",  # "!="  # not equal to (string, int, float)
+        FilterOperator.GTE: "$gte",  # = ">="  # greater than or equal to (int, float)
+        FilterOperator.LTE: "$lte",  # = "<="  # less than or equal to (int, float)
+        FilterOperator.IN: "$in",  # = "in"  # metadata in value array (string or number)
+        FilterOperator.NIN: "$nin",  # = "nin"  metadata not in value array (string, number)
+        # FilterOperator.TEXT_MATCH: "NA", #  not supported as filter. See $text
+        # FilterOperator.CONTAINS: "NA", # not supported as filter. Try $in
+    }
+    try:
+        return map(operator)
+    except KeyError:
+        if operator in [FilterOperator.TEXT_MATCH, FilterOperator.CONTAINS]:
+            logger.error(f"operator not supported as a filter. See $text")
+        raise
+
+
+def reciprocal_rank_stage(score_field: str, penalty: float = 0) -> List[Dict[str, Any]]:
+    r"""Stage adds Reciprocal Rank Fusion weighting.
+
+        First, it pushes documents retrieved from previous stage
+        into a temporary sub-document. It then unwinds to establish
+        the rank to each and applies the penalty.
+
+    Args:
+        score_field: A unique string to identify the search being ranked.
+        penalty: One method to weight scores in RRF.
+
+    Returns:
+        RRF score := \frac{1}{rank + penalty} with rank in [1,2,..,n]
+    """
+    return [
+        {"$group": {"_id": None, "docs": {"$push": "$$ROOT"}}},
+        {"$unwind": {"path": "$docs", "includeArrayIndex": "rank"}},
+        {
+            "$addFields": {
+                f"docs.{score_field}": {
+                    "$divide": [1.0, {"$add": ["$rank", penalty, 1]}]
+                },
+                "docs.rank": "$rank",
+                "_id": "$docs._id",
+            }
+        },
+        {"$replaceRoot": {"newRoot": "$docs"}},
+    ]
+
+
+def final_hybrid_stage(
+    scores_fields: List[str], limit: int, alpha: float = 0.5
+) -> List[Dict[str, Any]]:
+    """Sum weighted scores, sort, and apply limit.
+
+    Args:
+        scores_fields: List of fields given to scores of vector and text searches
+        limit: Number of documents to return
+
+    Returns:
+        Final aggregation stages
+    """
+    assert set(scores_fields) == {"vector_score", "fulltext_score"}
+
+    return [
+        {"$group": {"_id": "$_id", "docs": {"$mergeObjects": "$$ROOT"}}},
+        {"$replaceRoot": {"newRoot": "$docs"}},
+        {"$set": {score: {"$ifNull": [f"${score}", 0]} for score in scores_fields}},
+        {
+            "$addFields": {
+                "score": {
+                    "$add": [
+                        {"$mult": [alpha, "$vector_score"]},
+                        {"$mult": [{"$sub": [1.0, alpha]}, "$fulltext_score"]},
+                    ]
+                }
+            }
+        },
+        {"$sort": {"score": -1}},
+        {"$limit": limit},
+    ]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-mongodb"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/conftest.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/conftest.py
@@ -43,7 +43,7 @@ def nodes(documents) -> List[TextNode]:
 
 db_name = os.environ.get("MONGODB_DATABASE", "llama_index_test_db")
 collection_name = os.environ.get("MONGODB_COLLECTION", "llama_index_test_vectorstore")
-index_name = os.environ.get("MONGODB_INDEX", "vector_index")
+vector_index_name = os.environ.get("MONGODB_INDEX", "vector_index")
 MONGODB_URI = os.environ.get("MONGODB_URI")
 
 
@@ -58,7 +58,7 @@ def atlas_client() -> MongoClient:
     assert collection_name in client[db_name].list_collection_names()
 
     # TODO error: $listSearchIndexes is not allowed or the syntax is incorrect
-    # assert index_name in [
+    # assert vector_index_name in [
     #    idx["name"] for idx in client[db_name][collection_name].list_search_indexes()
     # ]
 
@@ -77,5 +77,6 @@ def vector_store(atlas_client: MongoClient) -> MongoDBAtlasVectorSearch:
         mongodb_client=atlas_client,
         db_name=db_name,
         collection_name=collection_name,
-        index_name=index_name,
+        vector_index_name=vector_index_name,
+        fulltext_index_name="fulltext_index",
     )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/test_vectorstore.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/test_vectorstore.py
@@ -10,6 +10,7 @@ from llama_index.core.vector_stores.types import (
     MetadataFilters,
     FilterOperator,
     FilterCondition,
+    VectorStoreQueryMode,
 )
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.vector_stores.mongodb import MongoDBAtlasVectorSearch
@@ -50,7 +51,7 @@ def test_vectorstore(
         ids = vector_store.add(nodes)
         assert set(ids) == {node.node_id for node in nodes}
 
-        # 2a. test default query()
+        # 2a. test query(): default (vector search)
         query_str = "What are LLMs useful for?"
         n_similar = 2
         query_embedding = OpenAIEmbedding().get_text_embedding(query_str)
@@ -74,7 +75,7 @@ def test_vectorstore(
         assert any("LLM" in node.text for node in query_responses.nodes)
         assert all(id_res in ids for id_res in query_responses.ids)
 
-        # 2b. test query() with simple filter
+        # 2b. test query() default with simple filter
 
         # In order to filter within $vectorSearch,
         # one needs to have an index on the field.  # TODO Check whether separate index is ok, or just within vector index
@@ -102,7 +103,7 @@ def test_vectorstore(
             for node in responses_with_filter.nodes
         )
 
-        # 2c. test query() with multiple filters
+        # 2c. test query() default with compound filters
         filter_out_texts = [
             "How do we best augment LLMs with our own private data?",
             "easily used with LLMs.",
@@ -132,6 +133,40 @@ def test_vectorstore(
             for ftext in filter_out_texts
         )
         assert set(responses_with_filter_compound.ids) != set(responses_with_filter.ids)
+
+        # 2d. test query() full-text search
+        #   - no embedding
+
+        query = VectorStoreQuery(
+            query_str="llamaindex",
+            similarity_top_k=4,
+            mode=VectorStoreQueryMode.TEXT_SEARCH,
+        )
+        result_found = False
+        retries = 5
+        while retries and not result_found:
+            fulltext_result = vector_store.query(query=query)
+            if len(fulltext_result.nodes) == n_similar:
+                result_found = True
+            else:
+                sleep(2)
+                retries -= 1
+        assert len(fulltext_result.ids) == 3
+        assert all("LlamaIndex" in node.text for node in fulltext_result.nodes)
+
+        # 2e. test query() hybrid search
+        n_similar = 10
+        query = VectorStoreQuery(
+            query_str="llamaindex",
+            query_embedding=query_embedding,  # "What are LLMs useful for?"
+            hybrid_top_k=n_similar,
+            mode=VectorStoreQueryMode.HYBRID,
+            alpha=0.5,
+        )
+        hybrid_result = vector_store.query(query=query)
+        assert len(hybrid_result.ids) == n_similar
+        assert not all("LlamaIndex" in node.text for node in hybrid_result.nodes[:3])
+        assert not all("LLM" in node.text for node in hybrid_result.nodes[:3])
 
         # 3. Test delete()
         # Remember, the current API deletes by *ref_doc_id*, not *node_id*.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/test_vectorstore.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/test_vectorstore.py
@@ -56,7 +56,6 @@ def test_vectorstore(
         n_similar = 2
         query_embedding = OpenAIEmbedding().get_text_embedding(query_str)
         query = VectorStoreQuery(
-            query_str="",  # query_str, Is this used in default search?
             query_embedding=query_embedding,
             similarity_top_k=n_similar,
         )
@@ -78,7 +77,7 @@ def test_vectorstore(
         # 2b. test query() default with simple filter
 
         # In order to filter within $vectorSearch,
-        # one needs to have an index on the field.  # TODO Check whether separate index is ok, or just within vector index
+        # one needs to have an index on the field.
         # One can do this by adding an additional member to "fields" list of vector index
         # like so: { "type": "filter", "path": "text }
         filters = MetadataFilters(
@@ -146,7 +145,7 @@ def test_vectorstore(
         retries = 5
         while retries and not result_found:
             fulltext_result = vector_store.query(query=query)
-            if len(fulltext_result.nodes) == n_similar:
+            if fulltext_result.ids:  # if len(fulltext_result.nodes) == n_similar:
                 result_found = True
             else:
                 sleep(2)


### PR DESCRIPTION
# Description

This pull request adds Hybrid and full-text search to `MongoDBAtlasVectorSearch

No llama_index issue, but our internal ticket is [PYTHON-4342](https://jira.mongodb.org/browse/PYTHON-4342)



## New Package? 

No.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests

In addition to adding unit/integration tests for the new features, the instructions to run against one's own version of Atlas are described in the README. We also run overnight CI workflows against llama_index's main branch (with a running cluster and openai_api_key) to ensure our changes or within pymongo do not break anything.

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
