### PR TITLE
fix score in nodes returned by the BM25 retriever

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -88,7 +88,8 @@ class BM25Retriever(BaseRetriever):
         top_n = scores.argsort()[::-1][: self._similarity_top_k]
 
         nodes: List[NodeWithScore] = []
-        for ix, score in zip(top_n, scores):
-            nodes.append(NodeWithScore(node=self._nodes[ix], score=float(score)))
+        for ix in top_n:
+            print(ix, scores[ix])
+            nodes.append(NodeWithScore(node=self._nodes[ix], score=float(scores[ix])))
 
         return nodes

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -89,7 +89,6 @@ class BM25Retriever(BaseRetriever):
 
         nodes: List[NodeWithScore] = []
         for ix in top_n:
-            print(ix, scores[ix])
             nodes.append(NodeWithScore(node=self._nodes[ix], score=float(scores[ix])))
 
         return nodes

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-retrievers-bm25"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
@@ -1,7 +1,27 @@
+from llama_index.core import Document
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.retrievers.bm25.base import BM25Retriever
+from llama_index.core.node_parser import SentenceSplitter
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in BM25Retriever.__mro__]
     assert BaseRetriever.__name__ in names_of_base_classes
+
+
+def test_scores():
+    documents = [
+        Document(text="Large Language Model"),
+        Document(text="LlamaIndex is a data framework for your LLM application"),
+        Document(text="How to use LlamaIndex"),
+    ]
+
+    splitter = SentenceSplitter(chunk_size=1024)
+    nodes = splitter.get_nodes_from_documents(documents)
+
+    retriever = BM25Retriever.from_defaults(nodes=nodes, similarity_top_k=2)
+    result_nodes = retriever.retrieve("llamaindex llm")
+    assert len(result_nodes) == 2
+    for node in result_nodes:
+        assert node.score is not None
+        assert node.score > 0.0


### PR DESCRIPTION
# Description

Correctly assign the score to each node returned by the retriever

Fixes #14442

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
