### PR TITLE
Fixed load_data method removed reassignment of database_ids

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-notion/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-notion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.1.9] - 2024-07-02
+
+### Bug Fixes
+
+- **Fixed `load_data` method**: Removed reassignment of `database_ids`, allowing the function to correctly check the else condition when `database_ids` is `None`.
+
 ## [0.1.8] - 2024-07-01
 
 ### New Features

--- a/llama-index-integrations/readers/llama-index-readers-notion/llama_index/readers/notion/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-notion/llama_index/readers/notion/base.py
@@ -196,14 +196,12 @@ class NotionPageReader(BasePydanticReader):
 
         Args:
             page_ids (List[str]): List of page ids to load.
-            database_id (str): Database_id from which to load page ids.
+            database_ids Optional (List[str]): List database ids from which to load page ids.
 
         Returns:
             List[Document]: List of documents.
 
         """
-        database_ids = database_ids or []
-
         if not page_ids and not database_ids:
             raise ValueError("Must specify either `page_ids` or `database_ids`.")
         docs = []

--- a/llama-index-integrations/readers/llama-index-readers-notion/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-notion/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-notion"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Fixed `load_data` method: Removed reassignment of `database_ids`, allowing the function to correctly check the else condition when `database_ids` is `None`.

Fixes # (issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods
