### PR TITLE
Fix: follow up with kwargs propagation due to change in parent class

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-colbert/llama_index/indices/managed/colbert/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-colbert/llama_index/indices/managed/colbert/base.py
@@ -105,7 +105,9 @@ class ColbertIndex(BaseIndex[IndexDict]):
     def ref_doc_info(self) -> Dict[str, RefDocInfo]:
         raise NotImplementedError("ColbertStoreIndex does not support ref_doc_info.")
 
-    def _build_index_from_nodes(self, nodes: Sequence[BaseNode]) -> IndexDict:
+    def _build_index_from_nodes(
+        self, nodes: Sequence[BaseNode], **kwargs: Any
+    ) -> IndexDict:
         """Generate a PLAID index from the ColBERT checkpoint via its hugging face
         model_name.
         """


### PR DESCRIPTION
# Description

Fixes #14398: `index_name` is passed into the constructor. Since it is not a keyword argument in the parent constructor, it is moved into `kwargs`. However, #14341 passes these `kwargs` into `build_index_from_nodes`, so this needs to be done for the child implementation as well in `_build_index_from_nodes`.

Fixes #14398 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
- [x] the provided in example in #14398 does not fail anymore

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
