### PR TITLE
🐞 fix(core): fix file reader bug

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -428,8 +428,10 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         raise_on_error = kwargs.get("raise_on_error", self.raise_on_error)
         fs = kwargs.get("fs", self.fs)
 
+        path_func = Path if is_default_fs(fs) else PurePosixPath
+
         return SimpleDirectoryReader.load_file(
-            input_file=Path(resource_id),
+            input_file=path_func(resource_id),
             file_metadata=file_metadata,
             file_extractor=file_extractor,
             filename_as_id=filename_as_id,


### PR DESCRIPTION
# Description

when I run S3Reader Test in Windows, func test_list_and_read_file_workflow cause error, then I found the resaon and fix SimpleDirectoryReader.load_resource, select right path function to resource_id

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

run core/readers test and S3Reader test

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
