### PR TITLE
🐞 fix(integrations): add fs arg to PandasExcelReader.load_data

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/tabular/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/tabular/base.py
@@ -164,7 +164,10 @@ class PandasExcelReader(BaseReader):
         self._pandas_config = pandas_config
 
     def load_data(
-        self, file: Path, extra_info: Optional[Dict] = None
+        self,
+        file: Path,
+        extra_info: Optional[Dict] = None,
+        fs: Optional[AbstractFileSystem] = None,
     ) -> List[Document]:
         """Parse file."""
         openpyxl_spec = importlib.util.find_spec("openpyxl")
@@ -176,7 +179,11 @@ class PandasExcelReader(BaseReader):
             )
 
         # sheet_name of None is all sheets, otherwise indexing starts at 0
-        dfs = pd.read_excel(file, self._sheet_name, **self._pandas_config)
+        if fs:
+            with fs.open(file) as f:
+                dfs = pd.read_excel(f, self._sheet_name, **self._pandas_config)
+        else:
+            dfs = pd.read_excel(file, self._sheet_name, **self._pandas_config)
 
         documents = []
 

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -51,7 +51,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.26"
+version = "0.1.27"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
@@ -1,6 +1,7 @@
 """Test file reader."""
 
 from multiprocessing import cpu_count
+import os
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 import hashlib
@@ -389,11 +390,11 @@ def test_filename_as_doc_id() -> None:
         documents = reader.load_data()
 
         doc_paths = [
-            f"{tmp_dir}/test1.txt",
-            f"{tmp_dir}/test2.txt",
-            f"{tmp_dir}/test3.txt",
-            f"{tmp_dir}/test4.md",
-            f"{tmp_dir}/test5.json",
+            f"{tmp_dir}{os.sep}test1.txt",
+            f"{tmp_dir}{os.sep}test2.txt",
+            f"{tmp_dir}{os.sep}test3.txt",
+            f"{tmp_dir}{os.sep}test4.md",
+            f"{tmp_dir}{os.sep}test5.json",
         ]
 
         # check paths. Split handles path_part_X doc_ids from md and json files
@@ -422,10 +423,10 @@ def test_specifying_encoding() -> None:
         documents = reader.load_data()
 
         doc_paths = [
-            f"{tmp_dir}/test1.txt",
-            f"{tmp_dir}/test2.txt",
-            f"{tmp_dir}/test3.txt",
-            f"{tmp_dir}/test4.json",
+            f"{tmp_dir}{os.sep}test1.txt",
+            f"{tmp_dir}{os.sep}test2.txt",
+            f"{tmp_dir}{os.sep}test3.txt",
+            f"{tmp_dir}{os.sep}test4.json",
         ]
 
         # check paths. Split handles path_part_X doc_ids from md and json files
@@ -464,11 +465,11 @@ def test_parallel_load() -> None:
         documents = reader.load_data(num_workers=num_workers)
 
         doc_paths = [
-            f"{tmp_dir}/test1.txt",
-            f"{tmp_dir}/test2.md",
-            f"{tmp_dir}/test3.tmp",
-            f"{tmp_dir}/test4.json",
-            f"{tmp_dir}/test5.json",
+            f"{tmp_dir}{os.sep}test1.txt",
+            f"{tmp_dir}{os.sep}test2.md",
+            f"{tmp_dir}{os.sep}test3.tmp",
+            f"{tmp_dir}{os.sep}test4.json",
+            f"{tmp_dir}{os.sep}test5.json",
         ]
 
         # check paths. Split handles path_part_X doc_ids from md and json files


### PR DESCRIPTION
# Description

1. add fs arg to PandasExcelReader
2. test_file replace '/' to 'os.sep', is was cause error in Windows before

Fixes #14529 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
