### PR TITLE
Add `LLMChatStartEvent` for `complete` and `stream_complete`

### DIFF
--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openai/llama_index/multi_modal_llms/openai/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openai/llama_index/multi_modal_llms/openai/base.py
@@ -22,9 +22,7 @@ from llama_index.core.constants import (
     DEFAULT_TEMPERATURE,
 )
 from llama_index.core.instrumentation import get_dispatcher
-from llama_index.core.instrumentation.events.llm import (
-    LLMChatStartEvent,
-)
+from llama_index.core.instrumentation.events.llm import LLMChatStartEvent
 from llama_index.core.multi_modal_llms import MultiModalLLM, MultiModalLLMMetadata
 from llama_index.core.schema import ImageDocument
 from llama_index.llms.openai.utils import (

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openai/llama_index/multi_modal_llms/openai/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openai/llama_index/multi_modal_llms/openai/base.py
@@ -23,12 +23,7 @@ from llama_index.core.constants import (
 )
 from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.instrumentation.events.llm import (
-    LLMChatEndEvent,
-    LLMChatInProgressEvent,
     LLMChatStartEvent,
-    LLMCompletionEndEvent,
-    LLMCompletionInProgressEvent,
-    LLMCompletionStartEvent,
 )
 from llama_index.core.multi_modal_llms import MultiModalLLM, MultiModalLLMMetadata
 from llama_index.core.schema import ImageDocument

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openai/llama_index/multi_modal_llms/openai/utils.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openai/llama_index/multi_modal_llms/openai/utils.py
@@ -54,7 +54,10 @@ def generate_openai_multi_modal_chat_message(
         elif image_document.image_url and image_document.image_url != "":
             image_content = {
                 "type": "image_url",
-                "image_url": image_document.image_url,
+                "image_url": {
+                    "url": image_document.image_url,
+                    "detail": image_detail,
+                },
             }
         elif image_document.image_path and image_document.image_path != "":
             base64_image = encode_image(image_document.image_path)


### PR DESCRIPTION
Raise `LLMChatStartEvent` since the OpenAI chat module is used. Only the Chat Completions API supports images as far as I know (see https://platform.openai.com/docs/guides/vision). In addition, raising this event helps us with the autoinstrumentation
 
fix: 