### PR TITLE
fix handling of react agent worker for llama-agents

### DIFF
--- a/llama-index-core/llama_index/core/__init__.py
+++ b/llama-index-core/llama_index/core/__init__.py
@@ -1,6 +1,6 @@
 """Init file of LlamaIndex."""
 
-__version__ = "0.10.52.post1"
+__version__ = "0.10.52.post2"
 
 import logging
 from logging import NullHandler

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -613,6 +613,12 @@ class LLM(BaseLLM):
 
         if isinstance(user_msg, ChatMessage):
             user_msg = user_msg.content
+        elif isinstance(user_msg, str):
+            pass
+        elif not user_msg and chat_history is not None and len(chat_history) > 0:
+            user_msg = chat_history[-1].content
+        else:
+            raise ValueError("No user message provided or found in chat history.")
 
         task = Task(
             input=user_msg,
@@ -665,6 +671,12 @@ class LLM(BaseLLM):
 
         if isinstance(user_msg, ChatMessage):
             user_msg = user_msg.content
+        elif isinstance(user_msg, str):
+            pass
+        elif not user_msg and chat_history is not None and len(chat_history) > 0:
+            user_msg = chat_history[-1].content
+        else:
+            raise ValueError("No user message provided or found in chat history.")
 
         task = Task(
             input=user_msg,
@@ -675,7 +687,7 @@ class LLM(BaseLLM):
         step = worker.initialize_step(task)
 
         try:
-            output = await worker.arun_step(step, task).output
+            output = (await worker.arun_step(step, task)).output
 
             # react agent worker inserts a "Observation: " prefix to the response
             if output.response and output.response.startswith("Observation: "):

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -43,7 +43,7 @@ name = "llama-index-core"
 packages = [{include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.10.52.post1"
+version = "0.10.52.post2"
 
 [tool.poetry.dependencies]
 SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama-agents/issues/96

Two issues
- not properly handling awaits in the async version of predict_and_call
- not properly using the chat history to define the task object for the react agent worker