### PR TITLE
Fix Issue #14014: ChatSummaryMemoryBuffer fails to summary chat history with tool callings

### DIFF
--- a/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
@@ -269,7 +269,7 @@ class ChatSummaryMemoryBuffer(BaseMemory):
                 prompt += (
                     "\n".join(
                         [
-                            f"Calling function: {call.function.name} with args: {call.function.arguments}"
+                            f"Calling a function: {call!s}"
                             for call in msg.additional_kwargs.get("tool_calls", [])
                         ]
                     )

--- a/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
@@ -263,7 +263,18 @@ class ChatSummaryMemoryBuffer(BaseMemory):
         prompt = '"Transcript so far: '
         for msg in chat_history_to_be_summarized:
             prompt += msg.role + ": "
-            prompt += msg.content + "\n\n"
+            if msg.content:
+                prompt += msg.content + "\n\n"
+            else:
+                prompt += (
+                    "\n".join(
+                        [
+                            f"Calling function: {call.function.name} with args: {call.function.arguments}"
+                            for call in msg.additional_kwargs.get("tool_calls", [])
+                        ]
+                    )
+                    + "\n\n"
+                )
         prompt += '"\n\n'
         prompt += self.summarize_prompt
         return prompt
@@ -280,9 +291,8 @@ class ChatSummaryMemoryBuffer(BaseMemory):
         Therefore, we switch messages to summarized list until the first message is
         not an ASSISTANT or TOOL message.
         """
-        if len(chat_history_full_text) > 0:
-            while chat_history_full_text[0].role in (
-                MessageRole.ASSISTANT,
-                MessageRole.TOOL,
-            ):
-                chat_history_to_be_summarized.append(chat_history_full_text.pop(0))
+        while chat_history_full_text and chat_history_full_text[0].role in (
+            MessageRole.ASSISTANT,
+            MessageRole.TOOL,
+        ):
+            chat_history_to_be_summarized.append(chat_history_full_text.pop(0))


### PR DESCRIPTION
# Description

Two changes are made to two functions in "llama-index-core\llama_index\core\memory\chat_summary_memory_buffer.py":
1. Changes made to `_get_prompt_to_summarize`: Fixed #14014 by handling the tool callings made by ASSISTANT with `content=None`;
2. Changes made to `_handle_assistant_and_tool_messages`: Fixed the IndexError trigger by the situation when `chat_history_full_text` only contains TOOL or ASSISTANT messages.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
