### PR TITLE
refactor: Don't swallow exceptions from Qdrant collection_exists

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -35,7 +35,6 @@ from llama_index.vector_stores.qdrant.utils import (
     fastembed_sparse_encoder,
 )
 from qdrant_client.http import models as rest
-from qdrant_client.http.exceptions import UnexpectedResponse
 from qdrant_client.http.models import (
     FieldCondition,
     Filter,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -654,17 +654,11 @@ class QdrantVectorStore(BasePydanticVectorStore):
 
     def _collection_exists(self, collection_name: str) -> bool:
         """Check if a collection exists."""
-        try:
-            return self._client.collection_exists(collection_name)
-        except (RpcError, UnexpectedResponse, ValueError):
-            return False
+        return self._client.collection_exists(collection_name)
 
     async def _acollection_exists(self, collection_name: str) -> bool:
         """Asynchronous method to check if a collection exists."""
-        try:
-            return await self._aclient.collection_exists(collection_name)
-        except (RpcError, UnexpectedResponse, ValueError):
-            return False
+        return await self._aclient.collection_exists(collection_name)
 
     def query(
         self,


### PR DESCRIPTION
# Description

The current implementation of Qdrant assumes a collection doesn't exist if `collection_exists` raises an exception. It isn't the appropriate behaviour since the API could run into other unexpected issues, while the collection may exist.

This PR fixes the behaviour by not swallowing the exception and propagating it above.
