### PR TITLE
🐞 fix(core): add the missing arg verbose when ReActAgent calling super().__init__

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/base.py
+++ b/llama-index-core/llama_index/core/agent/react/base.py
@@ -85,6 +85,7 @@ class ReActAgent(AgentRunner):
             memory=memory,
             llm=llm,
             callback_manager=callback_manager,
+            verbose=verbose,
         )
 
     @classmethod


### PR DESCRIPTION
# Description

When ReActAgent calls super().__init__ without passing the 'verbose' parameter, it results in a lack of information printing during execution. 

Fixes #14234 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
