### PR TITLE
fix: crash LLMMetadata

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
@@ -179,7 +179,7 @@ class TextGenerationInference(FunctionCallingLLM):
             timeout=timeout,
             max_retries=max_retries,
             seed=seed,
-            model=model_name,
+            model_name=model_name,
             is_function_calling_model=is_function_calling_model,
             callback_manager=callback_manager,
             system_prompt=system_prompt,

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-text-generation-inference"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

When using the Text Generation Inference implementation, a crash occurs when trying to get the `metadata` property because the `LLMMetadata` type has defined like mandatory `model_name` property and, it is not being saved. This PR fixes the problem that the `model_name` is not saved and crashes with athis `ValidationException`.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
