### PR TITLE
deprecate knowledgegraphindex, tweak docs

### DIFF
--- a/docs/docs/community/integrations.md
+++ b/docs/docs/community/integrations.md
@@ -35,7 +35,6 @@ for full tracing integrations.
 ## Storage and Managed Indexes
 
 - [Vector Stores](integrations/vector_stores.md)
-- [Graph Stores](integrations/graph_stores.md)
 - [Managed Indices](integrations/managed_indices.md)
 
 ## Application Frameworks

--- a/docs/docs/module_guides/storing/index.md
+++ b/docs/docs/module_guides/storing/index.md
@@ -9,7 +9,7 @@ Under the hood, LlamaIndex also supports swappable **storage components** that a
 - **Document stores**: where ingested documents (i.e., `Node` objects) are stored,
 - **Index stores**: where index metadata are stored,
 - **Vector stores**: where embedding vectors are stored.
-- **Graph stores**: where knowledge graphs are stored (i.e. for `KnowledgeGraphIndex`).
+- **Property Graph stores**: where knowledge graphs are stored (i.e. for `PropertyGraphIndex`).
 - **Chat Stores**: where chat messages are stored and organized.
 
 The Document/Index stores rely on a common Key-Value store abstraction, which is also detailed below.
@@ -76,5 +76,5 @@ We offer in-depth guides on the different storage components.
 - [Docstores](./docstores.md)
 - [Index Stores](./index_stores.md)
 - [Key-Val Stores](./kv_stores.md)
-- [Graph Stores](../../community/integrations/graph_stores.md)
+- [Property Graph Stores](../indexing/lpg_index_guide.md#storage)
 - [ChatStores](./chat_stores.md)

--- a/docs/docs/understanding/putting_it_all_together/graphs.md
+++ b/docs/docs/understanding/putting_it_all_together/graphs.md
@@ -1,8 +1,0 @@
-# Knowledge Graphs
-
-LlamaIndex contains some fantastic guides for building with knowledge graphs.
-
-Check out the end-to-end tutorials/workshops below. Also check out our [knowledge graph query engine guides](../../module_guides/deploying/query_engine/modules.md).
-
-- LlamaIndex Workshop: Building RAG with Knowledge Graphs <https://colab.research.google.com/drive/1tLjOg2ZQuIClfuWrAC2LdiZHCov8oUbs>
-- REBEL + Knowledge Graph Index <https://colab.research.google.com/drive/1G6pcR0pXvSkdMQlAK_P-IrYgo-_staxd?usp=sharing>

--- a/docs/docs/understanding/putting_it_all_together/index.md
+++ b/docs/docs/understanding/putting_it_all_together/index.md
@@ -5,10 +5,10 @@ Congratulations! You've loaded your data, indexed it, stored your index, and que
 - In [Q&A Patterns](q_and_a.md) we'll go into some of the more advanced and subtle ways you can build a query engine beyond the basics.
   - The [terms definition tutorial](q_and_a/terms_definitions_tutorial.md) is a detailed, step-by-step tutorial on creating a subtle query application including defining your prompts and supporting images as input.
   - We have a guide to [creating a unified query framework over your indexes](../../examples/retrievers/reciprocal_rerank_fusion.ipynb) which shows you how to run queries across multiple indexes.
-  - We talk about how to build queries over [knowledge graphs](graphs.md)
   - And also over [structured data like SQL](structured_data.md)
 - We have a guide on [how to build a chatbot](chatbots/building_a_chatbot.md)
 - We talk about [building agents in LlamaIndex](agents.md)
+- We have a complete guide to using [property graphs for indexing and retrieval](../../module_guides/indexing/lpg_index_guide.md)
 - And last but not least we show you how to build [a full stack web application](apps.md) using LlamaIndex
 
 LlamaIndex also provides some tools / project templates to help you build a full-stack template. For instance, [`create-llama`](https://github.com/run-llama/LlamaIndexTS/tree/main/packages/create-llama) spins up a full-stack scaffold for you.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -58,7 +58,6 @@ nav:
           - Chatbots: ./understanding/putting_it_all_together/chatbots/
           - Structured data: ./understanding/putting_it_all_together/structured_data/
           - Agents: ./understanding/putting_it_all_together/agents.md
-          - Graphs: ./understanding/putting_it_all_together/graphs.md
   - Use Cases:
       - ./use_cases/index.md
       - Prompting: ./use_cases/prompting.md

--- a/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
@@ -5,6 +5,7 @@ Build a KG by extracting triplets, and leveraging the KG during query-time.
 """
 
 import logging
+import deprecated
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from llama_index.core.base.base_retriever import BaseRetriever
@@ -33,6 +34,15 @@ from llama_index.core.utils import get_tqdm_iterable
 logger = logging.getLogger(__name__)
 
 
+@deprecated.deprecated(
+    version="0.10.53",
+    reason=(
+        "The KnowledgeGraphIndex class has been deprecated. "
+        "Please use the new PropertyGraphIndex class instead. "
+        "If a certain graph store integration is missing in the new class, "
+        "please open an issue on the GitHub repository or contribute it!"
+    ),
+)
 class KnowledgeGraphIndex(BaseIndex[KG]):
     """Knowledge Graph Index.
 

--- a/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
@@ -1,5 +1,6 @@
 """KG Retrievers."""
 
+import deprecated
 import logging
 from collections import defaultdict
 from enum import Enum
@@ -61,6 +62,13 @@ class KGRetrieverMode(str, Enum):
     HYBRID = "hybrid"
 
 
+@deprecated.deprecated(
+    version="0.10.53",
+    reason=(
+        "KGTableRetriever is deprecated, it is recommended to use "
+        "PropertyGraphIndex and associated retrievers instead."
+    ),
+)
 class KGTableRetriever(BaseRetriever):
     """KG Table Retriever.
 
@@ -407,6 +415,13 @@ DEFAULT_SYNONYM_EXPAND_PROMPT = PromptTemplate(
 )
 
 
+@deprecated.deprecated(
+    version="0.10.53",
+    reason=(
+        "KnowledgeGraphRAGRetriever is deprecated, it is recommended to use "
+        "PropertyGraphIndex and associated retrievers instead."
+    ),
+)
 class KnowledgeGraphRAGRetriever(BaseRetriever):
     """
     Knowledge Graph RAG retriever.

--- a/llama-index-core/llama_index/core/query_engine/knowledge_graph_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/knowledge_graph_query_engine.py
@@ -1,5 +1,6 @@
 """ Knowledge Graph Query Engine."""
 
+import deprecated
 import logging
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -47,6 +48,13 @@ DEFAULT_KG_RESPONSE_ANSWER_PROMPT = PromptTemplate(
 )
 
 
+@deprecated.deprecated(
+    version="0.10.53",
+    reason=(
+        "KnowledgeGraphQueryEngine is deprecated. It is recommended to use "
+        "the PropertyGraphIndex and associated retrievers instead."
+    ),
+)
 class KnowledgeGraphQueryEngine(BaseQueryEngine):
     """Knowledge graph query engine.
 


### PR DESCRIPTION
We should be pushing users to the newer (and maintained) property graph index.

The knowledge graph index should be removed at some point, but will deprecate for now.