### PR TITLE
Fix pip install command for Jina Rerank module

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/README.md
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-jinaai-rerank/README.md
@@ -5,4 +5,4 @@ Jina Rerank is based on [Jina Reranking](), which is a state-of-the-art rerankin
 1. Input context length - Jina Reranking is capable of accepting 8K-length input context
 2. Reranking performance - Jina Reranking outperforms other models on Mean Reciprocal Rank (MRR) and hit-rate, as shown in these [benchmarks]().
 
-Please pip install llama-index-postprocessor-jine-rerank to install Jina Rerank package.
+Please `pip install llama-index-postprocessor-jinaai-rerank` to install Jina Rerank package.


### PR DESCRIPTION
# Description

The current instruction for installing the pip package is wrong. This PR fixes it by correcting it to the correct package name.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)