### PR TITLE
Update ReAct Step to solve issue with uncomplete generation

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -451,7 +451,9 @@ class ReActAgentWorker(BaseAgentWorker):
             next_steps=new_steps,
         )
 
-    def _infer_stream_chunk_is_final(self, chunk: ChatResponse, missed_chunks_storage: list) -> bool:
+    def _infer_stream_chunk_is_final(
+        self, chunk: ChatResponse, missed_chunks_storage: list
+    ) -> bool:
         """Infers if a chunk from a live stream is the start of the final
         reasoning step. (i.e., and should eventually become
         ResponseReasoningStep — not part of this function's logic tho.).
@@ -477,7 +479,9 @@ class ReActAgentWorker(BaseAgentWorker):
         return False
 
     def _add_back_chunk_to_stream(
-        self, chunks: List[ChatResponse], chat_stream: Generator[ChatResponse, None, None]
+        self,
+        chunks: List[ChatResponse],
+        chat_stream: Generator[ChatResponse, None, None],
     ) -> Generator[ChatResponse, None, None]:
         """Helper method for adding back initial chunk stream of final response
         back to the rest of the chat_stream.
@@ -497,7 +501,9 @@ class ReActAgentWorker(BaseAgentWorker):
         return gen()
 
     async def _async_add_back_chunk_to_stream(
-        self, chunks: List[ChatResponse], chat_stream: AsyncGenerator[ChatResponse, None]
+        self,
+        chunks: List[ChatResponse],
+        chat_stream: AsyncGenerator[ChatResponse, None],
     ) -> AsyncGenerator[ChatResponse, None]:
         """Helper method for adding back initial chunk stream of final response
         back to the rest of the chat_stream.
@@ -513,7 +519,7 @@ class ReActAgentWorker(BaseAgentWorker):
         """
         for chunk in chunks:
             yield chunk
-        
+
         async for item in chat_stream:
             yield item
 
@@ -628,7 +634,9 @@ class ReActAgentWorker(BaseAgentWorker):
         is_done = False
         for latest_chunk in chat_stream:
             full_response = latest_chunk
-            is_done = self._infer_stream_chunk_is_final(latest_chunk, missed_chunks_storage)
+            is_done = self._infer_stream_chunk_is_final(
+                latest_chunk, missed_chunks_storage
+            )
             if is_done:
                 break
 
@@ -701,7 +709,9 @@ class ReActAgentWorker(BaseAgentWorker):
         is_done = False
         async for latest_chunk in chat_stream:
             full_response = latest_chunk
-            is_done = self._infer_stream_chunk_is_final(latest_chunk, missed_chunks_storage)
+            is_done = self._infer_stream_chunk_is_final(
+                latest_chunk, missed_chunks_storage
+            )
             if is_done:
                 break
 

--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -451,13 +451,14 @@ class ReActAgentWorker(BaseAgentWorker):
             next_steps=new_steps,
         )
 
-    def _infer_stream_chunk_is_final(self, chunk: ChatResponse) -> bool:
+    def _infer_stream_chunk_is_final(self, chunk: ChatResponse, missed_chunks_storage: list) -> bool:
         """Infers if a chunk from a live stream is the start of the final
         reasoning step. (i.e., and should eventually become
         ResponseReasoningStep — not part of this function's logic tho.).
 
         Args:
             chunk (ChatResponse): the current chunk stream to check
+            missed_chunks_storage (list): list to store missed chunks
 
         Returns:
             bool: Boolean on whether the chunk is the start of the final response
@@ -465,22 +466,24 @@ class ReActAgentWorker(BaseAgentWorker):
         latest_content = chunk.message.content
         if latest_content:
             # doesn't follow thought-action format
-            if len(latest_content) > len("Thought") and not latest_content.startswith(
-                "Thought"
-            ):
+            # keep first chunks
+            if len(latest_content) < len("Thought"):
+                missed_chunks_storage.append(chunk)
+            elif not latest_content.startswith("Thought"):
                 return True
             elif "Answer: " in latest_content:
+                missed_chunks_storage.clear()
                 return True
         return False
 
     def _add_back_chunk_to_stream(
-        self, chunk: ChatResponse, chat_stream: Generator[ChatResponse, None, None]
+        self, chunks: List[ChatResponse], chat_stream: Generator[ChatResponse, None, None]
     ) -> Generator[ChatResponse, None, None]:
         """Helper method for adding back initial chunk stream of final response
         back to the rest of the chat_stream.
 
         Args:
-            chunk (ChatResponse): the chunk to add back to the beginning of the
+            chunks List[ChatResponse]: the chunks to add back to the beginning of the
                                     chat_stream.
 
         Return:
@@ -488,13 +491,13 @@ class ReActAgentWorker(BaseAgentWorker):
         """
 
         def gen() -> Generator[ChatResponse, None, None]:
-            yield chunk
+            yield from chunks
             yield from chat_stream
 
         return gen()
 
     async def _async_add_back_chunk_to_stream(
-        self, chunk: ChatResponse, chat_stream: AsyncGenerator[ChatResponse, None]
+        self, chunks: List[ChatResponse], chat_stream: AsyncGenerator[ChatResponse, None]
     ) -> AsyncGenerator[ChatResponse, None]:
         """Helper method for adding back initial chunk stream of final response
         back to the rest of the chat_stream.
@@ -502,13 +505,15 @@ class ReActAgentWorker(BaseAgentWorker):
         NOTE: this itself is not an async function.
 
         Args:
-            chunk (ChatResponse): the chunk to add back to the beginning of the
+            chunks List[ChatResponse]: the chunks to add back to the beginning of the
                                     chat_stream.
 
         Return:
             AsyncGenerator[ChatResponse, None]: the updated async chat_stream
         """
-        yield chunk
+        for chunk in chunks:
+            yield chunk
+        
         async for item in chat_stream:
             yield item
 
@@ -619,10 +624,11 @@ class ReActAgentWorker(BaseAgentWorker):
         full_response = ChatResponse(
             message=ChatMessage(content=None, role="assistant")
         )
+        missed_chunks_storage = []
         is_done = False
         for latest_chunk in chat_stream:
             full_response = latest_chunk
-            is_done = self._infer_stream_chunk_is_final(latest_chunk)
+            is_done = self._infer_stream_chunk_is_final(latest_chunk, missed_chunks_storage)
             if is_done:
                 break
 
@@ -646,7 +652,7 @@ class ReActAgentWorker(BaseAgentWorker):
         else:
             # Get the response in a separate thread so we can yield the response
             response_stream = self._add_back_chunk_to_stream(
-                chunk=latest_chunk, chat_stream=chat_stream
+                chunks=[*missed_chunks_storage, latest_chunk], chat_stream=chat_stream
             )
 
             agent_response = StreamingAgentChatResponse(
@@ -691,10 +697,11 @@ class ReActAgentWorker(BaseAgentWorker):
         full_response = ChatResponse(
             message=ChatMessage(content=None, role="assistant")
         )
+        missed_chunks_storage = []
         is_done = False
         async for latest_chunk in chat_stream:
             full_response = latest_chunk
-            is_done = self._infer_stream_chunk_is_final(latest_chunk)
+            is_done = self._infer_stream_chunk_is_final(latest_chunk, missed_chunks_storage)
             if is_done:
                 break
 
@@ -719,7 +726,7 @@ class ReActAgentWorker(BaseAgentWorker):
         else:
             # Get the response in a separate thread so we can yield the response
             response_stream = self._async_add_back_chunk_to_stream(
-                chunk=latest_chunk, chat_stream=chat_stream
+                chunks=[*missed_chunks_storage, latest_chunk], chat_stream=chat_stream
             )
 
             agent_response = StreamingAgentChatResponse(


### PR DESCRIPTION
This solves issue of missing initial words in text when using 'stream' and 'astream'.

# Description

This issue happens when agent tries to answer implicitly(doesn't follow thought-action format) when streaming.
For example user asks agent:
```python
chat_stream = await agent.astream_chat("How are you?")
async for chunk in chat_stream.async_response_gen():
    print(chunk)
```
The expected answer should be implicit answer which is:
_I'm an AI assistant, so I don't have feelings_
But as result we come up with following text:
_AI assistant, so I don't have feelings_
As we can see we miss the _"I'm an"_ part of text. Let's see why it happens.

Problem happens here:
```python
async def _arun_step_stream(
        self,
        step: TaskStep,
        task: Task,
    ) -> TaskStepOutput:
    ...
    for latest_chunk in chat_stream:
          full_response = latest_chunk
          is_done = self._infer_stream_chunk_is_final(latest_chunk)
          if is_done:
              break
    ...
    response_stream = self._add_back_chunk_to_stream(
          chunk=latest_chunk, chat_stream=chat_stream
      )
    ...
``` 
```python
def _infer_stream_chunk_is_final(self, chunk: ChatResponse) -> bool:
    ...
    latest_content = chunk.message.content
        if latest_content:
            # doesn't follow thought-action format
            if len(latest_content) > len("Thought") and not latest_content.startswith(
                "Thought"
            ):
            return True
    ...
```
So, when code starts to iterate through `chat_stream` first 3 chunks that enter to `_infer_stream_chunk_is_final` method are _("I", "'m", "an")_.
And if we will look inside of `_infer_stream_chunk_is_final` method, we see that content _"I'm an"_  length is not greater than _"Thought"_ so all that three chunks will be skipped and missed. 
On the next iteration, content(at that iteration content is  _"I'm an AI"_ and chunk is _"AI"_) exceeds length of word _"Thought"_ and True is returned. And when `_add_back_chunk_to_stream` method is called only last chunk is added to stream(last chunk is _"AI"_), so previous _("I", "'m", "an")_ chunks are skipped and missed.
So, the same applies to `achat_stream`.

As the solution I store first chunks in list(until content does not exceed length of word _"Thought"_), then if case if true(it does not follow follow thought-action format) those missed chunks will be passed to `_add_back_chunk_to_stream` method along with `latest_chunk`.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
