### PR TITLE
Integration: Fix MessageRole import from the wrong package in AI21 Package

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ai21/llama_index/llms/ai21/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ai21/llama_index/llms/ai21/base.py
@@ -18,13 +18,13 @@ from llama_index.core.base.llms.types import (
     LLMMetadata,
     ChatResponseAsyncGen,
     CompletionResponseAsyncGen,
+    MessageRole,
 )
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.custom import CustomLLM
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
-from llama_cloud import MessageRole
 
 from llama_index.llms.ai21.utils import (
     ai21_model_to_context_size,

--- a/llama-index-integrations/llms/llama-index-llms-ai21/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ai21/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ai21"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

There was a bad import for `MessageRole` which forced an internal llama-index-client dependency installation.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update