### PR TITLE
fix: tools are required for attachments in openai api

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/openai_assistant_agent.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/openai_assistant_agent.py
@@ -162,10 +162,13 @@ def _process_files(client: Any, files: List[str]) -> Dict[str, str]:
     return file_dict
 
 
-def format_attachments(file_ids: Optional[List[str]] = None) -> List[Dict[str, str]]:
-    """Create attachments from file_ids."""
+def format_attachments(
+    file_ids: Optional[List[str]] = None, tools: Optional[List[Dict[str, Any]]] = None
+) -> List[Dict[str, Any]]:
+    """Create attachments from file_ids and include tools."""
     file_ids = file_ids or []
-    return [{"file_id": file_id} for file_id in file_ids]
+    tools = tools or [{"type": "file_search"}]  # Default tool if none provided
+    return [{"file_id": file_id, "tools": tools} for file_id in file_ids]
 
 
 class OpenAIAssistantAgent(BaseAgent):
@@ -365,9 +368,14 @@ class OpenAIAssistantAgent(BaseAgent):
         """Upload files."""
         return _process_files(self._client, files)
 
-    def add_message(self, message: str, file_ids: Optional[List[str]] = None) -> Any:
+    def add_message(
+        self,
+        message: str,
+        file_ids: Optional[List[str]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> Any:
         """Add message to assistant."""
-        attachments = format_attachments(file_ids=file_ids)
+        attachments = format_attachments(file_ids=file_ids, tools=tools)
         return self._client.beta.threads.messages.create(
             thread_id=self._thread_id,
             role="user",

--- a/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-agent-openai"
 readme = "README.md"
-version = "0.2.7"
+version = "0.2.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
Implemented the suggested changes to update the openai integration for the current openai api spec, adding a default value for tools if none are provided. Wasn't 100% sure if that would be the desired fallback, so let me know if an error should be thrown instead.


Fixes #14517

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
Also followed the reproduction steps from issue #14517 and confirmed the error no longer occurs

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added Google Colab support for the newly added notebooks. N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
