### PR TITLE
Make MetadataReplacementDemo.ipynb Clearer

### DIFF
--- a/docs/docs/examples/node_postprocessor/MetadataReplacementDemo.ipynb
+++ b/docs/docs/examples/node_postprocessor/MetadataReplacementDemo.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "In this notebook, we use the `SentenceWindowNodeParser` to parse documents into single sentences per node. Each node also contains a \"window\" with the sentences on either side of the node sentence.\n",
     "\n",
-    "Then, during retrieval, before passing the retrieved sentences to the LLM, the single sentences are replaced with a window containing the surrounding sentences using the `MetadataReplacementNodePostProcessor`.\n",
+    "Then, after retrieval, before passing the retrieved sentences to the LLM, the single sentences are replaced with a window containing the surrounding sentences using the `MetadataReplacementNodePostProcessor`.\n",
     "\n",
     "This is most useful for large documents/indexes, as it helps to retrieve more fine-grained details.\n",
     "\n",


### PR DESCRIPTION
Current wording suggests sentences are replaced with the window "during retrieval" whereas the replacement happens after retrieval