### PR TITLE
🐞 fix(Core): fix KnowledgeGraphIndex  arg 'kg_triple_extract_template' typo error

### DIFF
--- a/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/base.py
@@ -49,7 +49,7 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
     Build a KG by extracting triplets, and leveraging the KG during query-time.
 
     Args:
-        kg_triple_extract_template (BasePromptTemplate): The prompt to use for
+        kg_triplet_extract_template (BasePromptTemplate): The prompt to use for
             extracting triplets.
         max_triplets_per_chunk (int): The maximum number of triplets to extract.
         service_context (Optional[ServiceContext]): The service context to use.
@@ -75,7 +75,7 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
         llm: Optional[LLM] = None,
         embed_model: Optional[BaseEmbedding] = None,
         storage_context: Optional[StorageContext] = None,
-        kg_triple_extract_template: Optional[BasePromptTemplate] = None,
+        kg_triplet_extract_template: Optional[BasePromptTemplate] = None,
         max_triplets_per_chunk: int = 10,
         include_embeddings: bool = False,
         show_progress: bool = False,
@@ -89,12 +89,12 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
         # need to set parameters before building index in base class.
         self.include_embeddings = include_embeddings
         self.max_triplets_per_chunk = max_triplets_per_chunk
-        self.kg_triple_extract_template = (
-            kg_triple_extract_template or DEFAULT_KG_TRIPLET_EXTRACT_PROMPT
+        self.kg_triplet_extract_template = (
+            kg_triplet_extract_template or DEFAULT_KG_TRIPLET_EXTRACT_PROMPT
         )
         # NOTE: Partially format keyword extract template here.
-        self.kg_triple_extract_template = (
-            self.kg_triple_extract_template.partial_format(
+        self.kg_triplet_extract_template = (
+            self.kg_triplet_extract_template.partial_format(
                 max_knowledge_triplets=self.max_triplets_per_chunk
             )
         )
@@ -161,7 +161,7 @@ class KnowledgeGraphIndex(BaseIndex[KG]):
     def _llm_extract_triplets(self, text: str) -> List[Tuple[str, str, str]]:
         """Extract keywords from text."""
         response = self._llm.predict(
-            self.kg_triple_extract_template,
+            self.kg_triplet_extract_template,
             text=text,
         )
         return self._parse_triplet_response(

--- a/llama-index-core/tests/indices/knowledge_graph/test_base.py
+++ b/llama-index-core/tests/indices/knowledge_graph/test_base.py
@@ -60,7 +60,7 @@ class MockEmbedding(BaseEmbedding):
 def struct_kwargs() -> Tuple[Dict, Dict]:
     """Index kwargs."""
     index_kwargs = {
-        "kg_triple_extract_template": MOCK_KG_TRIPLET_EXTRACT_PROMPT,
+        "kg_triplet_extract_template": MOCK_KG_TRIPLET_EXTRACT_PROMPT,
     }
     query_kwargs = {
         "query_keyword_extract_template": MOCK_QUERY_KEYWORD_EXTRACT_PROMPT,


### PR DESCRIPTION
# Description

1. Rename KnowledgeGraphIndex argument 'kg_triple_extract_template' to 'kg_triplet_extract_template'
2. I haven't made any modifications to the legacy module. Should it be modified?

Fixes #12579 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
