### PR TITLE
fix: update operator logic for simple vector store filter 

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/simple.py
+++ b/llama-index-core/llama_index/core/vector_stores/simple.py
@@ -73,9 +73,9 @@ def _build_metadata_filter_fn(
             if operator == FilterOperator.LTE:
                 return metadata_value <= value
             if operator == FilterOperator.IN:
-                return value in metadata_value
+                return metadata_value in value
             if operator == FilterOperator.NIN:
-                return value not in metadata_value
+                return metadata_value not in value
             if operator == FilterOperator.CONTAINS:
                 return value in metadata_value
             if operator == FilterOperator.TEXT_MATCH:

--- a/llama-index-core/tests/vector_stores/test_simple.py
+++ b/llama-index-core/tests/vector_stores/test_simple.py
@@ -300,7 +300,7 @@ class SimpleVectorStoreTest(unittest.TestCase):
 
         filters = MetadataFilters(
             filters=[
-                MetadataFilter(key="quality", operator=FilterOperator.IN, value="high")
+                MetadataFilter(key="rank", operator=FilterOperator.IN, value=["a", "c"])
             ]
         )
         query = VectorStoreQuery(
@@ -308,7 +308,7 @@ class SimpleVectorStoreTest(unittest.TestCase):
         )
         result = simple_vector_store.query(query)
         assert result.ids is not None
-        self.assertEqual(len(result.ids), 2)
+        self.assertEqual(len(result.ids), 3)
 
     def test_query_with_notin_filter_returns_matches(self) -> None:
         simple_vector_store = SimpleVectorStore()
@@ -316,7 +316,7 @@ class SimpleVectorStoreTest(unittest.TestCase):
 
         filters = MetadataFilters(
             filters=[
-                MetadataFilter(key="quality", operator=FilterOperator.NIN, value="high")
+                MetadataFilter(key="rank", operator=FilterOperator.NIN, value=["c"])
             ]
         )
         query = VectorStoreQuery(


### PR DESCRIPTION
# Description

The `IN` and `NIN` filters in SimpleVectorStore seem to work opposite to how they do in other vector stores. Normally, you'd expect them to check if the given value exists/doesn't exist in the metadata (which should be an array).

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
- [x] I updated the unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
