### PR TITLE
follow odata.nextLink

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -142,33 +142,39 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
 
         self._authorization_headers = {"Authorization": f"Bearer {access_token}"}
 
-        response = requests.get(
-            url=site_information_endpoint,
-            headers=self._authorization_headers,
-        )
+        while site_information_endpoint:
+            response = requests.get(
+                url=site_information_endpoint,
+                headers=self._authorization_headers,
+            )
 
-        if response.status_code == 200 and "value" in response.json():
-            if (
-                len(response.json()["value"]) > 0
-                and "id" in response.json()["value"][0]
-            ):
-                # find the site with the specified name
-                for site in response.json()["value"]:
-                    if site["name"].lower() == sharepoint_site_name.lower():
-                        return site["id"]
-
-                raise ValueError(
-                    f"The specified sharepoint site {sharepoint_site_name} is not found."
-                )
+            json_response = response.json()
+            if response.status_code == 200 and "value" in json_response:
+                if (
+                    len(json_response["value"]) > 0
+                    and "id" in json_response["value"][0]
+                ):
+                    # find the site with the specified name
+                    for site in json_response["value"]:
+                        if site["name"].lower() == sharepoint_site_name.lower():
+                            print(f"looks like i found the site {sharepoint_site_name}")
+                            return site["id"]
+                    site_information_endpoint = json_response.get(
+                        "@odata.nextLink", None
+                    )
+                else:
+                    raise ValueError(
+                        f"The specified sharepoint site {sharepoint_site_name} is not found."
+                    )
             else:
-                raise ValueError(
-                    f"The specified sharepoint site {sharepoint_site_name} is not found."
-                )
-        else:
-            if "error_description" in response.json():
-                logger.error(response.json()["error"])
-                raise ValueError(response.json()["error_description"])
-            raise ValueError(response.json()["error"])
+                if "error_description" in json_response:
+                    logger.error(json_response["error"])
+                    raise ValueError(json_response["error_description"])
+                raise ValueError(json_response["error"])
+
+        raise ValueError(
+            f"The specified sharepoint site {sharepoint_site_name} is not found."
+        )
 
     def _get_drive_id(self) -> str:
         """

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -157,7 +157,6 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
                     # find the site with the specified name
                     for site in json_response["value"]:
                         if site["name"].lower() == sharepoint_site_name.lower():
-                            print(f"looks like i found the site {sharepoint_site_name}")
                             return site["id"]
                     site_information_endpoint = json_response.get(
                         "@odata.nextLink", None

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["arun-soliton"]
 name = "llama-index-readers-microsoft-sharepoint"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
jsonify response once

# Description

_get_site_id_with_host_name() in base.py did not read multiple pages.

Fixes #14702

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense.  I tested against a large Sharepoint site

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
