### PR TITLE
fix fastembed python version

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-fastembed/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-fastembed/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-fastembed"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-fastembed/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-fastembed/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 version = "0.1.5"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.8.1,<3.13"
 llama-index-core = "^0.10.11.post1"
 fastembed = "^0.2.2"
 


### PR DESCRIPTION
# Description

Fix the previous PR use python version conflicted with fastembed's constraint. Tested and works locally.

Fixes https://github.com/run-llama/llama_index/pull/14677

cc @nerdai 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
