### PR TITLE
fix: llamaindex agent chat function will lose external args

### DIFF
--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -645,7 +645,7 @@ class AgentRunner(BaseAgentRunner):
                 chat_history=chat_history,
                 tool_choice=tool_choice,
                 mode=ChatResponseMode.WAIT,
-                **kwargs
+                **kwargs,
             )
             assert isinstance(chat_response, AgentChatResponse)
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
@@ -672,7 +672,7 @@ class AgentRunner(BaseAgentRunner):
                 chat_history=chat_history,
                 tool_choice=tool_choice,
                 mode=ChatResponseMode.WAIT,
-                **kwargs
+                **kwargs,
             )
             assert isinstance(chat_response, AgentChatResponse)
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
@@ -695,7 +695,11 @@ class AgentRunner(BaseAgentRunner):
             payload={EventPayload.MESSAGES: [message]},
         ) as e:
             chat_response = self._chat(
-                message, chat_history, tool_choice, mode=ChatResponseMode.STREAM, **kwargs
+                message,
+                chat_history,
+                tool_choice,
+                mode=ChatResponseMode.STREAM,
+                **kwargs,
             )
             assert isinstance(chat_response, StreamingAgentChatResponse) or (
                 isinstance(chat_response, AgentChatResponse)
@@ -721,7 +725,11 @@ class AgentRunner(BaseAgentRunner):
             payload={EventPayload.MESSAGES: [message]},
         ) as e:
             chat_response = await self._achat(
-                message, chat_history, tool_choice, mode=ChatResponseMode.STREAM, **kwargs
+                message,
+                chat_history,
+                tool_choice,
+                mode=ChatResponseMode.STREAM,
+                **kwargs,
             )
             assert isinstance(chat_response, StreamingAgentChatResponse) or (
                 isinstance(chat_response, AgentChatResponse)

--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -559,6 +559,7 @@ class AgentRunner(BaseAgentRunner):
         chat_history: Optional[List[ChatMessage]] = None,
         tool_choice: Union[str, dict] = "auto",
         mode: ChatResponseMode = ChatResponseMode.WAIT,
+        **kwargs: Any,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
         if chat_history is not None:
@@ -570,7 +571,7 @@ class AgentRunner(BaseAgentRunner):
         while True:
             # pass step queue in as argument, assume step executor is stateless
             cur_step_output = self._run_step(
-                task.task_id, mode=mode, tool_choice=tool_choice
+                task.task_id, mode=mode, tool_choice=tool_choice, **kwargs
             )
 
             if cur_step_output.is_last:
@@ -594,6 +595,7 @@ class AgentRunner(BaseAgentRunner):
         chat_history: Optional[List[ChatMessage]] = None,
         tool_choice: Union[str, dict] = "auto",
         mode: ChatResponseMode = ChatResponseMode.WAIT,
+        **kwargs: Any,
     ) -> AGENT_CHAT_RESPONSE_TYPE:
         """Chat with step executor."""
         if chat_history is not None:
@@ -629,6 +631,7 @@ class AgentRunner(BaseAgentRunner):
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
         tool_choice: Optional[Union[str, dict]] = None,
+        **kwargs: Any,
     ) -> AgentChatResponse:
         # override tool choice is provided as input.
         if tool_choice is None:
@@ -642,6 +645,7 @@ class AgentRunner(BaseAgentRunner):
                 chat_history=chat_history,
                 tool_choice=tool_choice,
                 mode=ChatResponseMode.WAIT,
+                **kwargs
             )
             assert isinstance(chat_response, AgentChatResponse)
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
@@ -654,6 +658,7 @@ class AgentRunner(BaseAgentRunner):
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
         tool_choice: Optional[Union[str, dict]] = None,
+        **kwargs: Any,
     ) -> AgentChatResponse:
         # override tool choice is provided as input.
         if tool_choice is None:
@@ -667,6 +672,7 @@ class AgentRunner(BaseAgentRunner):
                 chat_history=chat_history,
                 tool_choice=tool_choice,
                 mode=ChatResponseMode.WAIT,
+                **kwargs
             )
             assert isinstance(chat_response, AgentChatResponse)
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
@@ -679,6 +685,7 @@ class AgentRunner(BaseAgentRunner):
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
         tool_choice: Optional[Union[str, dict]] = None,
+        **kwargs: Any,
     ) -> StreamingAgentChatResponse:
         # override tool choice is provided as input.
         if tool_choice is None:
@@ -688,7 +695,7 @@ class AgentRunner(BaseAgentRunner):
             payload={EventPayload.MESSAGES: [message]},
         ) as e:
             chat_response = self._chat(
-                message, chat_history, tool_choice, mode=ChatResponseMode.STREAM
+                message, chat_history, tool_choice, mode=ChatResponseMode.STREAM, **kwargs
             )
             assert isinstance(chat_response, StreamingAgentChatResponse) or (
                 isinstance(chat_response, AgentChatResponse)
@@ -704,6 +711,7 @@ class AgentRunner(BaseAgentRunner):
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
         tool_choice: Optional[Union[str, dict]] = None,
+        **kwargs: Any,
     ) -> StreamingAgentChatResponse:
         # override tool choice is provided as input.
         if tool_choice is None:
@@ -713,7 +721,7 @@ class AgentRunner(BaseAgentRunner):
             payload={EventPayload.MESSAGES: [message]},
         ) as e:
             chat_response = await self._achat(
-                message, chat_history, tool_choice, mode=ChatResponseMode.STREAM
+                message, chat_history, tool_choice, mode=ChatResponseMode.STREAM, **kwargs
             )
             assert isinstance(chat_response, StreamingAgentChatResponse) or (
                 isinstance(chat_response, AgentChatResponse)

--- a/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
@@ -234,7 +234,9 @@ class OpenAIAgentWorker(BaseAgentWorker):
         llm_chat_kwargs: dict = {"messages": self.get_all_messages(task)}
         if openai_tools:
             llm_chat_kwargs.update(
-                tools=openai_tools, tool_choice=resolve_tool_choice(tool_choice), **kwargs
+                tools=openai_tools,
+                tool_choice=resolve_tool_choice(tool_choice),
+                **kwargs,
             )
         return llm_chat_kwargs
 

--- a/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
@@ -229,11 +229,12 @@ class OpenAIAgentWorker(BaseAgentWorker):
         task: Task,
         openai_tools: List[dict],
         tool_choice: Union[str, dict] = "auto",
+        **kwargs: Any,
     ) -> Dict[str, Any]:
         llm_chat_kwargs: dict = {"messages": self.get_all_messages(task)}
         if openai_tools:
             llm_chat_kwargs.update(
-                tools=openai_tools, tool_choice=resolve_tool_choice(tool_choice)
+                tools=openai_tools, tool_choice=resolve_tool_choice(tool_choice), **kwargs
             )
         return llm_chat_kwargs
 
@@ -558,6 +559,7 @@ class OpenAIAgentWorker(BaseAgentWorker):
         task: Task,
         mode: ChatResponseMode = ChatResponseMode.WAIT,
         tool_choice: Union[str, dict] = "auto",
+        **kwargs: Any,
     ) -> TaskStepOutput:
         """Run step."""
         if step.input is not None:
@@ -570,7 +572,7 @@ class OpenAIAgentWorker(BaseAgentWorker):
 
         llm_chat_kwargs = self._get_llm_chat_kwargs(task, openai_tools, tool_choice)
         agent_chat_response = self._get_agent_response(
-            task, mode=mode, **llm_chat_kwargs
+            task, mode=mode, **llm_chat_kwargs, **kwargs
         )
 
         # TODO: implement _should_continue
@@ -726,9 +728,9 @@ class OpenAIAgentWorker(BaseAgentWorker):
     @trace_method("run_step")
     def run_step(self, step: TaskStep, task: Task, **kwargs: Any) -> TaskStepOutput:
         """Run step."""
-        tool_choice = kwargs.get("tool_choice", "auto")
+        tool_choice = kwargs.pop("tool_choice", "auto")
         return self._run_step(
-            step, task, mode=ChatResponseMode.WAIT, tool_choice=tool_choice
+            step, task, mode=ChatResponseMode.WAIT, tool_choice=tool_choice, **kwargs
         )
 
     @trace_method("run_step")


### PR DESCRIPTION
# Description

This PR fixes a bug that llamaindex agent losing external chat args.

For example, AzureOpenAI chat() supports `user` parameter:
```
from llama_index.llms.azure_openai import AzureOpenAI
llm = AzureOpenAI(
    engine="simon-llm", model="gpt-35-turbo-16k", temperature=0.0
)
messages = [
    ChatMessage(
        role="system", content="You are a pirate with colorful personality."
    ),
    ChatMessage(role="user", content="Hello"),
]
llm.chat(messages, user="my_user_id")
```

However, OpenAIAgent cannot chat() with `user` parameter:

```
from llama_index.llms.azure_openai import AzureOpenAI
from llama_index.agent.openai import OpenAIAgent
llm = AzureOpenAI(
    engine="simon-llm", model="gpt-35-turbo-16k", temperature=0.0
)
agent = OpenAIAgent.from_tools(
    [multiply_tool, add_tool], llm=llm, verbose=True
)
# will cause error
agent.chat("What is (121 * 3) + 42?", user="my_user_id")
```

If an LLM endpoint requires certain argument to start a chat (i.e. some Azure OpenAI enterprise endpoints will only allow whitelisted user id), user will not be able to use llamindex agent.

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- I stared at the code and made sure it makes sense

## Suggested Checklist:

- I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
