### PR TITLE
Chore: restrict the scipy verstion to 1.12.0 to fix the error cannot import name triu from scipy.linalg

### DIFF
--- a/docs/docs/examples/cookbooks/GraphRAG_v1.ipynb
+++ b/docs/docs/examples/cookbooks/GraphRAG_v1.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install llama-index graspologic numpy==1.24.4"
+    "!pip install llama-index graspologic numpy==1.24.4 scipy==1.12.0"
    ]
   },
   {


### PR DESCRIPTION

# Description

When I try to run `GraphRAG_v1.ipynb`, the error comes up `ImportError: cannot import name 'triu' from 'scipy.linalg' `

After investigation, 
> The [`scipy.linalg`][1] functions `tri`, `triu` & `tril` are deprecated and will be removed in SciPy 1.13.

 [SciPy 1.11.0 Release Notes &sect; Deprecated features](https://docs.scipy.org/doc/scipy/release/1.11.0-notes.html#deprecated-features)

The version `1.13.1` of scipy was installed. After downgrade the version of scipy to 1.12.0, the issue was fixed.

Fixes # (issue)

Restrict the version of scipy to `1.12.0`

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
