### PR TITLE
[FIX] Issues with `llama-index-readers-box` pyproject.toml

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
@@ -30,7 +30,7 @@ python_version = "3.12"
 authors = ["Box Developer Relations <dx@box.com>"]
 description = "llama-index readers box integration"
 license = "MIT"
-mainteners = [
+maintainers = [
     "barduinor",
     "shurrey",
 ]


### PR DESCRIPTION
# Description

Spelling error of `maintainers` section in `pyproject.toml` prevented the integration packaged from being built/published to PyPi. This PR quickly fixes that.


