### PR TITLE
docs: Fix wrong Qdrant_metadata_filter doc

### DIFF
--- a/docs/docs/examples/vector_stores/Qdrant_metadata_filter.ipynb
+++ b/docs/docs/examples/vector_stores/Qdrant_metadata_filter.ipynb
@@ -53,7 +53,7 @@
    "id": "f7010b1d-d1bb-4f08-9309-a328bb4ea396",
    "metadata": {},
    "source": [
-    "Build a Pinecone Index and connect to it"
+    "Build the Qdrant VectorStore Client"
    ]
   },
   {
@@ -85,7 +85,7 @@
    "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
    "metadata": {},
    "source": [
-    "Build the PineconeVectorStore and VectorStoreIndex"
+    "Build the QdrantVectorStore and create a Qdrant Index"
    ]
   },
   {
@@ -301,7 +301,7 @@
    "id": "1a57e62f",
    "metadata": {},
    "source": [
-    "Use keyword arguments specific to pinecone"
+    "Use keyword arguments specific to Qdrant"
    ]
   },
   {


### PR DESCRIPTION
# Description

The original Qdrant_metadata_filter doc has some spelling mistakes, such as using Pinecone VectorStoreIndex to describe the code.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
