### PR TITLE
Improve output format system prompt in ReAct agent

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/templates/system_header_template.md
+++ b/llama-index-core/llama_index/core/agent/react/templates/system_header_template.md
@@ -21,6 +21,8 @@ Action Input: the input to the tool, in a JSON format representing the kwargs (e
 
 Please ALWAYS start with a Thought.
 
+NEVER surround your response with markdown code markers. You may use code markers within your response if you need to.
+
 Please use a valid JSON format for the Action Input. Do NOT do this {{'input': 'hello world', 'num_beams': 5}}.
 
 If this format is used, the user will respond in the following format:


### PR DESCRIPTION
# Description

I noticed that the current system prompt for some models, including Gemma 2 27b (weirdly enough not 9b) sometimes include markdown code markers in their response, which deviates from the expected reasoning format. This PR adds an explicit instruction to supress this.

Example, before:

<img width="1033" alt="grafik" src="https://github.com/user-attachments/assets/6467f09d-db9b-41f3-a098-9d754a03e645">

Example, after:

<img width="1036" alt="grafik" src="https://github.com/user-attachments/assets/3da8f89a-52b1-427b-88d4-27aa7677d06c">

(Sorry about the screenshots. The response messes with the formatting of this issue. 😅)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
