### PR TITLE
Bugfix: ollama streaming response would not return last object that i…

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -180,11 +180,6 @@ class Ollama(CustomLLM):
                 for line in response.iter_lines():
                     if line:
                         chunk = json.loads(line)
-                        if "done" in chunk and chunk["done"]:
-                            break
-                        message = chunk["message"]
-                        delta = message.get("content")
-                        text += delta
                         yield ChatResponse(
                             message=ChatMessage(
                                 content=text,
@@ -199,6 +194,11 @@ class Ollama(CustomLLM):
                                 chunk, ("message",)
                             ),
                         )
+                        if "done" in chunk and chunk["done"]:
+                            break
+                        message = chunk["message"]
+                        delta = message.get("content")
+                        text += delta
 
     @llm_chat_callback()
     async def achat(

--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -179,7 +179,10 @@ class Ollama(CustomLLM):
                 text = ""
                 for line in response.iter_lines():
                     if line:
-                        chunk = json.loads(line)
+                        chunk = json.loads(line)                        
+                        message = chunk["message"]
+                        delta = message.get("content")
+                        text += delta
                         yield ChatResponse(
                             message=ChatMessage(
                                 content=text,
@@ -196,9 +199,6 @@ class Ollama(CustomLLM):
                         )
                         if "done" in chunk and chunk["done"]:
                             break
-                        message = chunk["message"]
-                        delta = message.get("content")
-                        text += delta
 
     @llm_chat_callback()
     async def achat(

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ollama"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
…ncludes done: 'true' message

# Description

Currently the ollama.stream_chat would not return the last data packet where "done": "true", which includes important metadata

Fixes # (issue)


## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
