### PR TITLE
Fixing the issue where the _apply_node_postprocessors function was ca…

### DIFF
--- a/llama-index-core/llama_index/core/tools/retriever_tool.py
+++ b/llama-index-core/llama_index/core/tools/retriever_tool.py
@@ -77,7 +77,7 @@ class RetrieverTool(AsyncBaseTool):
             raise ValueError("Cannot call query engine without inputs")
 
         docs = self._retriever.retrieve(query_str)
-        docs = self._apply_node_postprocessors(docs, query_str)
+        docs = self._apply_node_postprocessors(docs, QueryBundle(query_str))
         content = ""
         for doc in docs:
             node_copy = doc.node.copy()
@@ -103,7 +103,7 @@ class RetrieverTool(AsyncBaseTool):
             raise ValueError("Cannot call query engine without inputs")
         docs = await self._retriever.aretrieve(query_str)
         content = ""
-        docs = self._apply_node_postprocessors(docs, query_str)
+        docs = self._apply_node_postprocessors(docs, QueryBundle(query_str))
         for doc in docs:
             node_copy = doc.node.copy()
             node_copy.text_template = "{metadata_str}\n{content}"


### PR DESCRIPTION
Fixing the issue where the _apply_node_postprocessors function was called
without passing in a correctly typed object, leading to an inability to convert the object passed into subsequent deeper functions into a QueryBundle and consequently throwing an exception.

# Description

![image](https://github.com/user-attachments/assets/b7ab47e3-3f26-4e22-bd1b-55240e60c916)
![image](https://github.com/user-attachments/assets/ea958181-fa4f-4dd2-a478-261684723c05)
![image](https://github.com/user-attachments/assets/b15430ef-746e-4288-beb8-780b41cd6d40)


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
