### PR TITLE
Update docstring for gmailtoolspec's search_messages tool

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/gmail/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/gmail/base.py
@@ -82,6 +82,15 @@ class GmailToolSpec(BaseToolSpec):
         return creds
 
     def search_messages(self, query: str, max_results: Optional[int] = None):
+        """Searches email messages given a query string and the maximum number
+        of results requested by the user
+           Returns: List of relevant message objects up to the maximum number of results.
+
+        Args:
+            query[str]: The user's query
+            max_results (Optional[int]): The maximum number of search results
+            to return.
+        """
         if not max_results:
             max_results = self.max_results
 

--- a/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 maintainers = ["ajhofmann"]
 name = "llama-index-tools-google"
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
One of the tools in the GmailToolSpec (search_messages) is missing a docstring. So when the tool is converted to a tool list and used by a FunctionCallingAgent there will be an error trying to get the agent to use the tool.

## Type of Change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [X ] Tested in notebook (but not committed)
- [ ] I stared at the code and made sure it makes sense

I instantiated a FunctionCalling Agent to run the tool after adding the docstring to "search_messages"

## Suggested Checklist:

- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
