### PR TITLE
MongoDB Atlas Vector Search: Enhanced Metadata Filtering

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/CHANGELOG.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [v0.1.8]
+
+### Changed
+
+- Refactored `filters_to_mql` function for handling metadata key and error handling
+- Improved `map_lc_mql_filter_operators` for better type safety
+
+### Fixed
+
+- Edge case handling in `filters_to_mql` function
+- Potential issues with filter operator mapping
+
+### Improved
+
+- Type safety and static analysis support

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-mongodb"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR introduces changes in `filter_to_mql` function to add `metadata_key` in filter keys, and some minor changes for type hinting and error handling.
Also removed `_to_mongodb_filter` as it is not being used anymore.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

Yes

## Type of Change

New feature (non-breaking change which adds functionality)


