### PR TITLE
📃 docs(unserstanding): typo link error

### DIFF
--- a/docs/docs/getting_started/installation.md
+++ b/docs/docs/getting_started/installation.md
@@ -56,7 +56,7 @@ A full guide to using and configuring embedding models is available [here](../mo
 
 ## Installation from Source
 
-Git clone this repository: `git clone https://github.com/jerryjliu/llama_index.git`. Then do the following:
+Git clone this repository: `git clone https://github.com/run-llama/llama_index.git`. Then do the following:
 
 - [Install poetry](https://python-poetry.org/docs/#installation) - this will help you manage package dependencies
 - `poetry shell` - this command creates a virtual environment, which keeps installed packages contained to this project

--- a/docs/docs/understanding/putting_it_all_together/index.md
+++ b/docs/docs/understanding/putting_it_all_together/index.md
@@ -9,7 +9,7 @@ Congratulations! You've loaded your data, indexed it, stored your index, and que
 - We have a guide on [how to build a chatbot](chatbots/building_a_chatbot.md)
 - We talk about [building agents in LlamaIndex](agents.md)
 - We have a complete guide to using [property graphs for indexing and retrieval](../../module_guides/indexing/lpg_index_guide.md)
-- And last but not least we show you how to build [a full stack web application](apps.md) using LlamaIndex
+- And last but not least we show you how to build [a full stack web application](apps/index.md) using LlamaIndex
 
 LlamaIndex also provides some tools / project templates to help you build a full-stack template. For instance, [`create-llama`](https://github.com/run-llama/LlamaIndexTS/tree/main/packages/create-llama) spins up a full-stack scaffold for you.
 


### PR DESCRIPTION
# Description

1. `getting_started`: change `https://github.com/jerryjliu/llama_index.git` to `https://github.com/run-llama/llama_index.git`
2. `putting_it_all_together`: change link `apps.md` to `apps/index.md`

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
