### PR TITLE
Bugfix: AzureOpenAI may fail with custom azure_ad_token_provider

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -211,8 +211,11 @@ class AzureOpenAI(OpenAI):
         self, is_async: bool = False, **kwargs: Any
     ) -> Dict[str, Any]:
         if self.use_azure_ad:
-            self._azure_ad_token = refresh_openai_azuread_token(self._azure_ad_token)
-            self.api_key = self._azure_ad_token.token
+            if self.azure_ad_token_provider:
+                self.api_key = self.azure_ad_token_provider()
+            else:
+                self._azure_ad_token = refresh_openai_azuread_token(self._azure_ad_token)
+                self.api_key = self._azure_ad_token.token
         else:
             import os
 

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py
@@ -214,7 +214,9 @@ class AzureOpenAI(OpenAI):
             if self.azure_ad_token_provider:
                 self.api_key = self.azure_ad_token_provider()
             else:
-                self._azure_ad_token = refresh_openai_azuread_token(self._azure_ad_token)
+                self._azure_ad_token = refresh_openai_azuread_token(
+                    self._azure_ad_token
+                )
                 self.api_key = self._azure_ad_token.token
         else:
             import os

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-azure-openai"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
@@ -48,3 +48,22 @@ def test_custom_http_client(sync_azure_openai_mock: MagicMock) -> None:
     kwargs = sync_azure_openai_mock.call_args.kwargs
     assert "http_client" in kwargs
     assert kwargs["http_client"] == custom_http_client
+
+
+@patch("llama_index.llms.azure_openai.base.SyncAzureOpenAI")
+def test_custom_azure_ad_token_provider(sync_azure_openai_mock: MagicMock):
+    """
+    Verify that a custom azure ad token provider set for AzureOpenAI.
+    """
+    def custom_azure_ad_token_provider() -> str:
+        return "mock_api_key"
+    mock_instance = sync_azure_openai_mock.return_value
+    # Valid mocked result required to not run into another error
+    mock_instance.chat.completions.create.return_value = mock_chat_completion_v1()
+    azure_openai = AzureOpenAI(
+        engine="foo bar",
+        use_azure_ad=True,
+        azure_ad_token_provider=custom_azure_ad_token_provider,
+    )
+    azure_openai.complete("test prompt")
+    assert azure_openai.api_key == "mock_api_key"

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
@@ -55,8 +55,10 @@ def test_custom_azure_ad_token_provider(sync_azure_openai_mock: MagicMock):
     """
     Verify that a custom azure ad token provider set for AzureOpenAI.
     """
+
     def custom_azure_ad_token_provider() -> str:
         return "mock_api_key"
+
     mock_instance = sync_azure_openai_mock.return_value
     # Valid mocked result required to not run into another error
     mock_instance.chat.completions.create.return_value = mock_chat_completion_v1()


### PR DESCRIPTION
# Description

This PR fixes a bug: Even with a custom azure ad token provider provided, llama index will still request token from default azure credential endpoint `https://cognitiveservices.azure.com/.default`. This may cause error on enterprise Azure OpenAI, for most of them are using different credential endpoint in a inner network.

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- I stared at the code and made sure it makes sense

## Suggested Checklist:

- I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
