### PR TITLE
Fix TaskStepOutput sources bug

### DIFF
--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -551,6 +551,11 @@ class AgentRunner(BaseAgentRunner):
         if self.delete_task_on_finish:
             self.delete_task(task_id)
 
+        # Attach all sources generated across all steps
+        step_output.output.sources = self.get_task(task_id).extra_state.get(
+            "sources", []
+        )
+
         return cast(AGENT_CHAT_RESPONSE_TYPE, step_output.output)
 
     @dispatcher.span

--- a/llama-index-core/tests/agent/function_calling/test_step.py
+++ b/llama-index-core/tests/agent/function_calling/test_step.py
@@ -1,3 +1,4 @@
+import uuid
 import pytest
 from typing import Any, AsyncGenerator, Coroutine, List, Optional, Sequence, Union
 from llama_index.core.agent.function_calling.step import (
@@ -32,8 +33,21 @@ NONEXISTENT_TOOL_SELECTION = ToolSelection(
 )
 NONEXISTENT_TOOL_OUTPUT = build_missing_tool_output(NONEXISTENT_TOOL_SELECTION)
 
+TOOL_1_NAME = "Tool 1"
+TOOL_1 = FunctionTool(lambda: None, ToolMetadata("", TOOL_1_NAME))
+TOOL_1_SELECTION = ToolSelection(
+    tool_id=TOOL_1_NAME,
+    tool_name=TOOL_1_NAME,
+    tool_kwargs={},
+)
 
-class MockBadFunctionCallingLLM(FunctionCallingLLM):
+TOOL_2_NAME = "Tool 2"
+TOOL_2 = FunctionTool(lambda x: None, ToolMetadata("", TOOL_2_NAME))
+
+
+class MockFunctionCallingLLM(FunctionCallingLLM):
+    use_nonexistent_tool: bool = False
+
     def achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> Coroutine[Any, Any, ChatResponse]:
@@ -104,27 +118,35 @@ class MockBadFunctionCallingLLM(FunctionCallingLLM):
         error_on_no_tool_call: bool = True,
         **kwargs: Any
     ) -> List[ToolSelection]:
-        return [NONEXISTENT_TOOL_SELECTION]
+        return [
+            (
+                NONEXISTENT_TOOL_SELECTION
+                if self.use_nonexistent_tool
+                else TOOL_1_SELECTION
+            )
+        ]
+
+
+@pytest.fixture()
+def agent_worker() -> FunctionCallingAgentWorker:
+    llm = MockFunctionCallingLLM(use_nonexistent_tool=False)
+    return FunctionCallingAgentWorker([TOOL_1], llm, [])
 
 
 @pytest.fixture()
 def missing_function_agent_worker() -> FunctionCallingAgentWorker:
-    llm = MockBadFunctionCallingLLM()
-    tool = FunctionTool(lambda x: x, ToolMetadata("", "Tool 1"))
-    return FunctionCallingAgentWorker([tool], llm, [])
+    llm = MockFunctionCallingLLM(use_nonexistent_tool=True)
+    return FunctionCallingAgentWorker([TOOL_1], llm, [])
 
 
 def test_get_function_by_name_finds_existing_tool() -> None:
-    first_tool = FunctionTool(lambda x: x, ToolMetadata("", "Tool 1"))
-    second_tool = FunctionTool(lambda x: x, ToolMetadata("", "Tool 2"))
-    tools = [first_tool, second_tool]
-    assert get_function_by_name(tools, first_tool.metadata.name) == first_tool
-    assert get_function_by_name(tools, first_tool.metadata.name) == first_tool
+    tools = [TOOL_1, TOOL_2]
+    assert get_function_by_name(tools, TOOL_1.metadata.name) == TOOL_1
+    assert get_function_by_name(tools, TOOL_1.metadata.name) == TOOL_1
 
 
 def test_get_function_by_name_returns_none_for_nonexistent_tool() -> None:
-    tool = FunctionTool(lambda x: x, ToolMetadata("", "Tool 1"))
-    assert get_function_by_name([tool], "Name of a Nonexistent Tool") is None
+    assert get_function_by_name([TOOL_1], "Name of a Nonexistent Tool") is None
     assert get_function_by_name([], "Name of a Nonexistent Tool") is None
 
 
@@ -155,3 +177,36 @@ async def test_arun_step_returns_message_if_function_not_found(
     assert len(output.next_steps) == 1
     assert len(output_chat_response.sources) == 1
     assert output_chat_response.sources[0] == NONEXISTENT_TOOL_OUTPUT
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("method", ["run_step", "arun_step"])
+async def test_run_step_returns_correct_sources_history(
+    method: str,
+    agent_worker: FunctionCallingAgentWorker,
+) -> None:
+    num_steps = 4
+    task = Task(input="", memory=ChatMemoryBuffer.from_defaults(), extra_state={})
+    step_outputs: List[TaskStepOutput] = []
+
+    # Create steps
+    steps = [agent_worker.initialize_step(task)]
+    for step_idx in range(num_steps - 1):
+        steps.append(
+            steps[-1].get_next_step(
+                step_id=str(uuid.uuid4()),
+                input=None,
+            )
+        )
+
+    # Run each step, invoking a single tool call each time
+    for step_idx in range(num_steps):
+        step_outputs.append(
+            agent_worker.run_step(steps[step_idx], task)
+            if method == "run_step"
+            else await agent_worker.arun_step(steps[step_idx], task)
+        )
+
+    # Ensure that each step only has one source for its one tool call
+    for step_idx in range(num_steps):
+        assert len(step_outputs[step_idx].output.sources) == 1

--- a/llama-index-integrations/agent/llama-index-agent-openai/tests/test_openai_agent.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/tests/test_openai_agent.py
@@ -1,17 +1,28 @@
-from typing import Any, AsyncGenerator, Generator, List, Sequence
+import json
+import uuid
+from typing import (
+    Any,
+    AsyncGenerator,
+    Generator,
+    List,
+    Sequence,
+)
 from unittest.mock import MagicMock, patch
-
 from llama_index.core.agent.function_calling.step import (
     build_error_tool_output,
     build_missing_tool_message,
 )
+from llama_index.core.base.agent.types import TaskStepOutput
 import pytest
 from llama_index.agent.openai.base import OpenAIAgent
 from llama_index.agent.openai.step import (
     call_tool_with_error_handling,
     advanced_tool_call_parser,
 )
-from llama_index.core.base.llms.types import ChatMessage, ChatResponse
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+)
 from llama_index.core.chat_engine.types import (
     AgentChatResponse,
     StreamingAgentChatResponse,
@@ -19,7 +30,6 @@ from llama_index.core.chat_engine.types import (
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.llms.openai import OpenAI
-
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk, ChoiceDelta
@@ -166,9 +176,15 @@ def echo_tool() -> FunctionTool:
 
 
 @pytest.fixture()
-def echo_function() -> Function:
+def malformed_echo_function() -> Function:
     test_result: str = "This is a test"
     return Function(name="echo", arguments=f'query = "{test_result}"')
+
+
+@pytest.fixture()
+def echo_function() -> Function:
+    test_result: str = "This is a test"
+    return Function(name="echo", arguments=json.dumps({"query": test_result}))
 
 
 class MockChatLLM(MockLLM):
@@ -322,12 +338,12 @@ def test_call_tool_with_error_handling() -> None:
 def test_call_tool_with_malformed_function_call(
     MockSyncOpenAI: MagicMock,
     echo_tool: FunctionTool,
-    echo_function: Function,
+    malformed_echo_function: Function,
 ) -> None:
     """Test add step."""
     mock_instance = MockSyncOpenAI.return_value
     mock_instance.chat.completions.create.return_value = mock_chat_completion_tool_call(
-        function=echo_function
+        function=malformed_echo_function
     )
 
     llm = OpenAI(model="gpt-3.5-turbo")
@@ -339,7 +355,7 @@ def test_call_tool_with_malformed_function_call(
     ## NOTE: can only take a single step before finishing,
     # since mocked chat output does not call any tools
     task = agent.create_task(
-        f"This happens if tool call is malformed like:\n{echo_function.arguments}"
+        f"This happens if tool call is malformed like:\n{malformed_echo_function.arguments}"
     )
     step_output = agent.run_step(task.task_id)
     assert (
@@ -352,13 +368,13 @@ def test_call_tool_with_malformed_function_call(
 def test_call_tool_with_malformed_function_call_and_parser(
     MockSyncOpenAI: MagicMock,
     echo_tool: FunctionTool,
-    echo_function: Function,
+    malformed_echo_function: Function,
 ) -> None:
     """Test add step."""
     mock_instance = MockSyncOpenAI.return_value
     test_result: str = "This is a test"
     mock_instance.chat.completions.create.return_value = mock_chat_completion_tool_call(
-        function=echo_function
+        function=malformed_echo_function
     )
 
     llm = OpenAI(model="gpt-3.5-turbo")
@@ -371,7 +387,7 @@ def test_call_tool_with_malformed_function_call_and_parser(
     ## NOTE: can only take a single step before finishing,
     # since mocked chat output does not call any tools
     task = agent.create_task(
-        f"This happens if tool call is malformed like:\n{echo_function.arguments}"
+        f"This happens if tool call is malformed like:\n{malformed_echo_function.arguments}"
     )
     step_output = agent.run_step(task.task_id)
     assert str(step_output.output.sources[0]) == test_result
@@ -468,11 +484,11 @@ async def test_async_add_step(
 @patch("llama_index.llms.openai.base.SyncOpenAI")
 def test_run_step_returns_message_if_tool_not_found(
     MockSyncOpenAI: MagicMock,
-    echo_function: Function,
+    malformed_echo_function: Function,
 ) -> None:
     mock_instance = MockSyncOpenAI.return_value
     mock_instance.chat.completions.create.return_value = mock_chat_completion_tool_call(
-        function=echo_function
+        function=malformed_echo_function
     )
     llm = OpenAI(model="gpt-3.5-turbo")
     agent = OpenAIAgent.from_tools(tools=[], llm=llm)
@@ -485,9 +501,9 @@ def test_run_step_returns_message_if_tool_not_found(
     assert len(step_output.next_steps) == 1
     assert len(output_chat_response.sources) == 1
     assert output_chat_response.sources[0] == build_error_tool_output(
-        echo_function.name,
-        echo_function.arguments,
-        build_missing_tool_message(echo_function.name),
+        malformed_echo_function.name,
+        malformed_echo_function.arguments,
+        build_missing_tool_message(malformed_echo_function.name),
     )
 
 
@@ -517,3 +533,57 @@ async def test_arun_step_returns_message_if_tool_not_found(
         echo_function.arguments,
         build_missing_tool_message(echo_function.name),
     )
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("method", ["run_step", "arun_step"])
+@patch("llama_index.llms.openai.base.SyncOpenAI")
+@patch("llama_index.llms.openai.base.AsyncOpenAI")
+async def test_run_step_returns_correct_sources_history(
+    MockAsyncOpenAI: MagicMock,
+    MockSyncOpenAI: MagicMock,
+    method: str,
+    echo_tool: FunctionTool,
+    echo_function: Function,
+) -> None:
+    num_steps = 4
+    llm = OpenAI(model="gpt-3.5-turbo")
+    agent = OpenAIAgent.from_tools(
+        tools=[echo_tool],
+        llm=llm,
+    )
+    task = agent.create_task("")
+    step_outputs: List[TaskStepOutput] = []
+
+    if method == "run_step":
+        mock_instance = MockSyncOpenAI.return_value
+        mock_instance.chat.completions.create.return_value = (
+            mock_chat_completion_tool_call(echo_function)
+        )
+    else:
+        mock_instance = MockAsyncOpenAI.return_value
+        mock_instance.chat.completions.create.side_effect = [
+            mock_achat_completion_tool_call(echo_function) for _ in range(num_steps)
+        ]
+
+    # Create steps
+    steps = [agent.agent_worker.initialize_step(task)]
+    for step_idx in range(num_steps - 1):
+        steps.append(
+            steps[-1].get_next_step(
+                step_id=str(uuid.uuid4()),
+                input=None,
+            )
+        )
+
+    # Run each step, invoking a single tool call each time
+    for step_idx in range(num_steps):
+        step_outputs.append(
+            agent.agent_worker.run_step(steps[step_idx], task)
+            if method == "run_step"
+            else await agent.agent_worker.arun_step(steps[step_idx], task)
+        )
+
+    # Ensure that each step only has one source for its one tool call
+    for step_idx in range(num_steps):
+        assert len(step_outputs[step_idx].output.sources) == 1


### PR DESCRIPTION
# Description

Fixing an issue where the stepwise sources returned in function calling agents' `TaskStepOutput` may include `ToolOutput` from other steps. I updated the handling of these sources to ensure that references to `task.extra_state["sources"]` are no longer inserted into `TaskStepOutput`, which should ensure that each step's sources actually represent the tool calls executed by said step. I also added a few tests to ensure that this works for sync and async.

Fixes #14884 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
