### PR TITLE
Added feature to stream_chat allowing previous chunks to be inserted into the current context window

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -154,7 +154,10 @@ class ContextChatEngine(BaseChatEngine):
 
     @trace_method("chat")
     def chat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None, prev_chunks = None
+        self,
+        message: str,
+        chat_history: Optional[List[ChatMessage]] = None,
+        prev_chunks=None,
     ) -> AgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
@@ -166,12 +169,16 @@ class ContextChatEngine(BaseChatEngine):
         if len(nodes) == 0 and prev_chunks is not None:
             nodes = [j for i in prev_chunks for j in i]
             context_str = "\n\n".join(
-                [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
+                [
+                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
+                    for n in nodes
+                ]
             )
 
             # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(context_str=context_str)
-
+            context_str_template = self._context_template.format(
+                context_str=context_str
+            )
 
         prefix_messages = self._get_prefix_messages_with_context(context_str_template)
         prefix_messages_token_count = len(
@@ -201,7 +208,10 @@ class ContextChatEngine(BaseChatEngine):
 
     @trace_method("chat")
     def stream_chat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None,  prev_chunks = None
+        self,
+        message: str,
+        chat_history: Optional[List[ChatMessage]] = None,
+        prev_chunks=None,
     ) -> StreamingAgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
@@ -214,11 +224,16 @@ class ContextChatEngine(BaseChatEngine):
         if len(nodes) == 0 and prev_chunks is not None:
             nodes = [j for i in prev_chunks for j in i]
             context_str = "\n\n".join(
-                [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
+                [
+                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
+                    for n in nodes
+                ]
             )
 
             # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(context_str=context_str)
+            context_str_template = self._context_template.format(
+                context_str=context_str
+            )
 
         prefix_messages = self._get_prefix_messages_with_context(context_str_template)
         initial_token_count = len(
@@ -249,11 +264,12 @@ class ContextChatEngine(BaseChatEngine):
 
         return chat_response
 
-
-
     @trace_method("chat")
     async def achat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None, prev_chunks = None
+        self,
+        message: str,
+        chat_history: Optional[List[ChatMessage]] = None,
+        prev_chunks=None,
     ) -> AgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
@@ -265,12 +281,16 @@ class ContextChatEngine(BaseChatEngine):
         if len(nodes) == 0 and prev_chunks is not None:
             nodes = [j for i in prev_chunks for j in i]
             context_str = "\n\n".join(
-                [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
+                [
+                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
+                    for n in nodes
+                ]
             )
 
             # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(context_str=context_str)
-
+            context_str_template = self._context_template.format(
+                context_str=context_str
+            )
 
         prefix_messages = self._get_prefix_messages_with_context(context_str_template)
         initial_token_count = len(
@@ -301,7 +321,10 @@ class ContextChatEngine(BaseChatEngine):
 
     @trace_method("chat")
     async def astream_chat(
-        self, message: str, chat_history: Optional[List[ChatMessage]] = None, prev_chunks = None
+        self,
+        message: str,
+        chat_history: Optional[List[ChatMessage]] = None,
+        prev_chunks=None,
     ) -> StreamingAgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
@@ -313,11 +336,16 @@ class ContextChatEngine(BaseChatEngine):
         if len(nodes) == 0 and prev_chunks is not None:
             nodes = [j for i in prev_chunks for j in i]
             context_str = "\n\n".join(
-                [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
+                [
+                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
+                    for n in nodes
+                ]
             )
 
             # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(context_str=context_str)
+            context_str_template = self._context_template.format(
+                context_str=context_str
+            )
 
         prefix_messages = self._get_prefix_messages_with_context(context_str_template)
         initial_token_count = len(


### PR DESCRIPTION
# Description

When using various RAG pipelines. oftentimes questions such as "Can you elaborate?" or "Can you explain further?" are unable to be answered. This is due to the fact that the embedding model will search for chunks in the documents that match this exact query instead of reusing the chunks from the previous questions, and therefore the LLM will claim that this question is out of context.

To fix this, I maintained a history of the previous chunks fetched from previous queries and used the SimilarityProcessor to ensure all chunks with scores below 0.05 are not added to the context. This ensures that questions such as "Can you elaborate" have empty context windows since all the chunks found have scores of around 0.001. Then, I passed in a list of previous chunks into the stream_chat function as an optional parameter, and if the context window is empty, I insert hose previous chunks into the current context window by editing the context string. 

I am using PrivateGPT, so the code that handles the SimilarityProcessor and the history of previous chunks is handled in PrivateGPT's codebase.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tested this in my local PrivateGPT setup by asking various questions like "Can you elaborate?" and "Can you repeat that?" and ensured that the LLM was receiving the right chunks.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
