### PR TITLE
feat: allow to limit how many elements retrieve (qdrant)

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -298,6 +298,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         self,
         node_ids: Optional[List[str]] = None,
         filters: Optional[MetadataFilters] = None,
+        limit: Optional[int] = None,
     ) -> List[BaseNode]:
         """
         Get nodes from the index.
@@ -316,6 +317,10 @@ class QdrantVectorStore(BasePydanticVectorStore):
                     has_id=node_ids,
                 )
             ]
+            # If we pass a node_ids list,
+            # we can limit the search to only those nodes
+            # or less if limit is provided
+            limit = len(node_ids) if limit is None else min(len(node_ids), limit)
 
         if filters is not None:
             filter = self._build_subfilter(filters)
@@ -337,7 +342,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
 
         response = self._client.scroll(
             collection_name=self.collection_name,
-            limit=9999,
+            limit=limit or 9999,
             scroll_filter=filter,
         )
 
@@ -347,6 +352,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         self,
         node_ids: Optional[List[str]] = None,
         filters: Optional[MetadataFilters] = None,
+        limit: Optional[int] = None,
     ) -> List[BaseNode]:
         """
         Asynchronous method to get nodes from the index.
@@ -365,6 +371,10 @@ class QdrantVectorStore(BasePydanticVectorStore):
                     has_id=node_ids,
                 )
             ]
+            # If we pass a node_ids list,
+            # we can limit the search to only those nodes
+            # or less if limit is provided
+            limit = len(node_ids) if limit is None else min(len(node_ids), limit)
 
         if filters is not None:
             filter = self._build_subfilter(filters)
@@ -377,7 +387,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
 
         response = await self._aclient.scroll(
             collection_name=self.collection_name,
-            limit=9999,
+            limit=limit or 9999,
             scroll_filter=filter,
         )
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-qdrant"
 readme = "README.md"
-version = "0.2.13"
+version = "0.2.14"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
# Description

When using `get_nodes`, you cannot limit how many nodes you want to retrieve. For example, when you want to check if a node exists, limiting the search to 1 would be enough to find out. Also, if there is a list of node in the filter, we can say that at most we will retrieve that number if they all exist.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
