### PR TITLE
Fix/confluence reader sort auth parameters priority

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## [0.1.7] - 2024-07-23
+
+- Sort order of authentication parameters and environment variables as:
+  1. `oauth2`
+  2. `api_token`
+  3. `user_name` and `password`
+  4. Environment variable `CONFLUENCE_API_TOKEN`
+  5. Environment variable `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD`
+
 ## [0.1.2] - 2024-02-13
 
 - Add maintainers and keywords from library.json (llamahub)

--- a/llama-index-integrations/readers/llama-index-readers-confluence/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/README.md
@@ -5,10 +5,22 @@ pip install llama-index-readers-confluence
 ```
 
 This loader loads pages from a given Confluence cloud instance. The user needs to specify the base URL for a Confluence
-instance to initialize the ConfluenceReader - base URL needs to end with `/wiki`. The user can optionally specify
-OAuth 2.0 credentials to authenticate with the Confluence instance. If no credentials are specified, the loader will
-look for `CONFLUENCE_API_TOKEN` or `CONFLUENCE_USERNAME`/`CONFLUENCE_PASSWORD` environment variables to proceed with basic authentication.
-Keep in mind `CONFLUENCE_PASSWORD` is not your actual password, but an API Token obtained here: https://id.atlassian.com/manage-profile/security/api-tokens.
+instance to initialize the ConfluenceReader - base URL needs to end with `/wiki`.
+
+The user can optionally specify OAuth 2.0 credentials to authenticate with the Confluence instance. If no credentials are
+specified, the loader will look for `CONFLUENCE_API_TOKEN` or `CONFLUENCE_USERNAME`/`CONFLUENCE_PASSWORD` environment variables
+to proceed with basic authentication.
+
+> [!NOTE]
+> Keep in mind `CONFLUENCE_PASSWORD` is not your actual password, but an API Token obtained here: https://id.atlassian.com/manage-profile/security/api-tokens.
+
+The following order is used for checking authentication credentials:
+
+1. `oauth2`
+2. `api_token`
+3. `user_name` and `password`
+4. Environment variable `CONFLUENCE_API_TOKEN`
+5. Environment variable `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD`
 
 For more on authenticating using OAuth 2.0, checkout:
 
@@ -98,7 +110,7 @@ documents.extend(
 ```
 
 ```python
-# Example that fetches the first 5 results froma cql query, the uses the cursor to pick up on the next element
+# Example that fetches the first 5 results from a cql query, the uses the cursor to pick up on the next element
 from llama_index.readers.confluence import ConfluenceReader
 
 token = {"access_token": "<access_token>", "token_type": "<token_type>"}

--- a/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
@@ -61,25 +61,34 @@ class ConfluenceReader(BaseReader):
         if oauth2:
             self.confluence = Confluence(url=base_url, oauth2=oauth2, cloud=cloud)
         else:
-            api_token = api_token or os.getenv(CONFLUENCE_API_TOKEN)
             if api_token is not None:
                 self.confluence = Confluence(url=base_url, token=api_token, cloud=cloud)
-            else:
-                user_name = user_name or os.getenv(CONFLUENCE_USERNAME)
-                if user_name is None:
-                    raise ValueError(
-                        "Must set environment variable `CONFLUENCE_USERNAME` if oauth,"
-                        " oauth2, or `CONFLUENCE_API_TOKEN` are not provided."
-                    )
-                password = password or os.getenv(CONFLUENCE_PASSWORD)
-                if password is None:
-                    raise ValueError(
-                        "Must set environment variable `CONFLUENCE_PASSWORD` if oauth,"
-                        " oauth2, or `CONFLUENCE_API_TOKEN` are not provided."
-                    )
+            elif user_name is not None and password is not None:
                 self.confluence = Confluence(
                     url=base_url, username=user_name, password=password, cloud=cloud
                 )
+            else:
+                api_token = os.getenv(CONFLUENCE_API_TOKEN)
+                if api_token is not None:
+                    self.confluence = Confluence(
+                        url=base_url, token=api_token, cloud=cloud
+                    )
+                else:
+                    user_name = os.getenv(CONFLUENCE_USERNAME)
+                    password = os.getenv(CONFLUENCE_PASSWORD)
+                    if user_name is not None and password is not None:
+                        self.confluence = Confluence(
+                            url=base_url,
+                            username=user_name,
+                            password=password,
+                            cloud=cloud,
+                        )
+                    else:
+                        raise ValueError(
+                            "Must set one of environment variables `CONFLUENCE_API_KEY`, or"
+                            " `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD`, if oauth2, or"
+                            " api_token, or user_name and password parameters are not provided"
+                        )
 
         self._next_cursor = None
 

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["zywilliamli"]
 name = "llama-index-readers-confluence"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    dependencies=["llama-index-integrations/readers/llama-index-readers-confluence:poetry"],
+)

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
@@ -1,0 +1,80 @@
+import pytest
+from llama_index.readers.confluence import ConfluenceReader
+
+
+class MockConfluence:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def mock_atlassian_confluence(monkeypatch):
+    monkeypatch.setattr("llama_index.readers.confluence", MockConfluence)
+
+
+def test_confluence_reader_with_oauth2():
+    reader = ConfluenceReader(
+        base_url="https://example.atlassian.net/wiki",
+        oauth2={
+            "client_id": "example_client_id",
+            "token": {"access_token": "example_token", "token_type": "Bearer"},
+        },
+    )
+    assert reader.confluence is not None
+
+
+def test_confluence_reader_with_api_token():
+    reader = ConfluenceReader(
+        base_url="https://example.atlassian.net/wiki",
+        api_token="example_api_token",
+    )
+    assert reader.confluence is not None
+
+
+def test_confluence_reader_with_basic_auth():
+    reader = ConfluenceReader(
+        base_url="https://example.atlassian.net/wiki",
+        user_name="example_user",
+        password="example_password",
+    )
+    assert reader.confluence is not None
+
+
+def test_confluence_reader_with_env_api_token(monkeypatch):
+    monkeypatch.setenv("CONFLUENCE_API_TOKEN", "env_api_token")
+    reader = ConfluenceReader(
+        base_url="https://example.atlassian.net/wiki",
+    )
+    assert reader.confluence is not None
+    monkeypatch.delenv("CONFLUENCE_API_TOKEN")
+
+
+def test_confluence_reader_with_env_basic_auth(monkeypatch):
+    monkeypatch.setenv("CONFLUENCE_USERNAME", "env_user")
+    monkeypatch.setenv("CONFLUENCE_PASSWORD", "env_password")
+    reader = ConfluenceReader(
+        base_url="https://example.atlassian.net/wiki",
+    )
+    assert reader.confluence is not None
+    monkeypatch.delenv("CONFLUENCE_USERNAME")
+    monkeypatch.delenv("CONFLUENCE_PASSWORD")
+
+
+def test_confluence_reader_without_credentials():
+    with pytest.raises(ValueError) as excinfo:
+        ConfluenceReader(base_url="https://example.atlassian.net/wiki")
+    assert "Must set one of environment variables" in str(excinfo.value)
+
+
+def test_confluence_reader_with_incomplete_basic_auth():
+    with pytest.raises(ValueError) as excinfo:
+        ConfluenceReader(
+            base_url="https://example.atlassian.net/wiki", user_name="example_user"
+        )
+    assert "Must set one of environment variables" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        ConfluenceReader(
+            base_url="https://example.atlassian.net/wiki", password="example_password"
+        )
+    assert "Must set one of environment variables" in str(excinfo.value)


### PR DESCRIPTION
# Description

This change sorts the priority of authentication parameters and environment variables for the Confluence reader.

Fixes # (issue)

https://github.com/run-llama/llama_index/issues/14836

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
