### PR TITLE
honor exclusion keys when creating the index nodes

### DIFF
--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -200,21 +200,16 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
                 nodes=nodes_with_scores,
             )
             summary_response = cast(Response, summary_response)
-            metadata = doc_id_to_nodes.get(doc_id, [TextNode()])[0].metadata
-            excluded_embed_metadata_keys = doc_id_to_nodes.get(doc_id, [TextNode()])[
-                0
-            ].excluded_embed_metadata_keys
-            excluded_llm_metadata_keys = doc_id_to_nodes.get(doc_id, [TextNode()])[
-                0
-            ].excluded_llm_metadata_keys
+            docid_first_node = doc_id_to_nodes.get(doc_id, [TextNode()])[0]
+            metadata = docid_first_node.metadata
             summary_node_dict[doc_id] = TextNode(
                 text=summary_response.response,
                 relationships={
                     NodeRelationship.SOURCE: RelatedNodeInfo(node_id=doc_id)
                 },
                 metadata=metadata,
-                excluded_embed_metadata_keys=excluded_embed_metadata_keys,
-                excluded_llm_metadata_keys=excluded_llm_metadata_keys,
+                excluded_embed_metadata_keys=docid_first_node.excluded_embed_metadata_keys,
+                excluded_llm_metadata_keys=docid_first_node.excluded_llm_metadata_keys,
             )
             self.docstore.add_documents([summary_node_dict[doc_id]])
             logger.info(

--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -201,13 +201,12 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
             )
             summary_response = cast(Response, summary_response)
             docid_first_node = doc_id_to_nodes.get(doc_id, [TextNode()])[0]
-            metadata = docid_first_node.metadata
             summary_node_dict[doc_id] = TextNode(
                 text=summary_response.response,
                 relationships={
                     NodeRelationship.SOURCE: RelatedNodeInfo(node_id=doc_id)
                 },
-                metadata=metadata,
+                metadata=docid_first_node.metadata,
                 excluded_embed_metadata_keys=docid_first_node.excluded_embed_metadata_keys,
                 excluded_llm_metadata_keys=docid_first_node.excluded_llm_metadata_keys,
             )

--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -228,9 +228,6 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
             for node in summary_nodes:
                 node_with_embedding = node.copy()
                 node_with_embedding.embedding = id_to_embed_map[node.node_id]
-                for k in node_with_embedding.excluded_embed_metadata_keys:
-                    if node_with_embedding.metadata.get(k):
-                        node_with_embedding.metadata.pop(k)
                 summary_nodes_with_embedding.append(node_with_embedding)
             self._vector_store.add(summary_nodes_with_embedding)
 


### PR DESCRIPTION
# Description

This fixes `_add_nodes_to_index` to add the `excluded_embed_metadata_keys` and `excluded_llm_metadata_keys` on the source nodes to the metadata and to honor the exclusion when appending the nodes to the vector store.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (core update)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
