### PR TITLE
Fixed Import Error in PandasAIReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-pandas-ai/llama_index/readers/pandas_ai/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-pandas-ai/llama_index/readers/pandas_ai/base.py
@@ -10,6 +10,10 @@ from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
 from llama_index.readers.file import PandasCSVReader
 
+from pandasai.llm.openai import OpenAI
+from pandasai.llm import LLM as PandasLLM
+from pandasai import SmartDataframe
+
 
 class PandasAIReader(BaseReader):
     r"""Pandas AI reader.
@@ -39,19 +43,14 @@ class PandasAIReader(BaseReader):
 
     def __init__(
         self,
-        llm: Optional[Any] = None,
+        pandas_llm: Optional[PandasLLM] = None,
         concat_rows: bool = True,
         col_joiner: str = ", ",
         row_joiner: str = "\n",
         pandas_config: dict = {},
     ) -> None:
         """Init params."""
-        try:
-            from pandasai.llm.openai import OpenAI
-        except ImportError:
-            raise ImportError("Please install pandasai to use this reader.")
-
-        self._llm = llm or OpenAI()
+        self._llm = pandas_llm or OpenAI()
         self._pandasai_config = {"llm": self._llm}
 
         self._concat_rows = concat_rows
@@ -66,8 +65,7 @@ class PandasAIReader(BaseReader):
         is_conversational_answer: bool = False,
     ) -> Any:
         """Load dataframe."""
-        from pandasai import SmartDataframe
-        smart_df = SmartDataframe(initial_df, config = self._pandasai_config)
+        smart_df = SmartDataframe(initial_df, config=self._pandasai_config)
         return smart_df.chat(query=query)
 
     def load_data(

--- a/llama-index-integrations/readers/llama-index-readers-pandas-ai/llama_index/readers/pandas_ai/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-pandas-ai/llama_index/readers/pandas_ai/base.py
@@ -47,13 +47,13 @@ class PandasAIReader(BaseReader):
     ) -> None:
         """Init params."""
         try:
-            from pandasai import PandasAI
+            from pandasai import SmartDataframe
             from pandasai.llm.openai import OpenAI
         except ImportError:
             raise ImportError("Please install pandasai to use this reader.")
 
         self._llm = llm or OpenAI()
-        self._pandas_ai = PandasAI(llm)
+        self._pandasai_config = {"llm": self._llm}
 
         self._concat_rows = concat_rows
         self._col_joiner = col_joiner
@@ -67,9 +67,9 @@ class PandasAIReader(BaseReader):
         is_conversational_answer: bool = False,
     ) -> Any:
         """Load dataframe."""
-        return self._pandas_ai.run(
-            initial_df, prompt=query, is_conversational_answer=is_conversational_answer
-        )
+        from pandasai import SmartDataframe
+        smart_df = SmartDataframe(initial_df, config = self._pandasai_config)
+        return smart_df.chat(query=query)
 
     def load_data(
         self,

--- a/llama-index-integrations/readers/llama-index-readers-pandas-ai/llama_index/readers/pandas_ai/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-pandas-ai/llama_index/readers/pandas_ai/base.py
@@ -47,7 +47,6 @@ class PandasAIReader(BaseReader):
     ) -> None:
         """Init params."""
         try:
-            from pandasai import SmartDataframe
             from pandasai.llm.openai import OpenAI
         except ImportError:
             raise ImportError("Please install pandasai to use this reader.")

--- a/llama-index-integrations/readers/llama-index-readers-pandas-ai/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-pandas-ai/pyproject.toml
@@ -29,11 +29,12 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-pandas-ai"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
+pandasai = ">=2.2.12"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/readers/llama-index-readers-pandas-ai/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-pandas-ai/tests/BUILD
@@ -1,3 +1,4 @@
 python_tests(
     interpreter_constraints=["==3.9.*", "==3.10.*"],
+    dependencies=["llama-index-integrations/readers/llama-index-readers-pandas-ai:poetry#pandasai"],
 )


### PR DESCRIPTION
# Description

Fixes the import error while using `PandasAIReader`. According to this [warning](https://github.com/Sinaptik-AI/pandas-ai/commit/8345b2208db7ca959a81e54a9d719b40113f50ff#diff-62b472d83558337a7726ff6758a8c431481784a74add715c96e2fed8bedbbd63L141), a `SmartDataframe` object should be used instead of a `PandasAI` object in the new version of `pandas-ai`.

Fixes #14878 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
