### PR TITLE
Bugfix: Don't pass empty list of embeddings to elasticsearch store when using sparse strategy

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -350,6 +350,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
         if not self._store.num_dimensions:
             self._store.num_dimensions = len(embeddings[0])
 
+        # Omit the vectors argument entirely if embeddings aren't generated.
         if not any(embeddings):
             embeddings = None
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -350,6 +350,9 @@ class ElasticsearchStore(BasePydanticVectorStore):
         if not self._store.num_dimensions:
             self._store.num_dimensions = len(embeddings[0])
 
+        if not any(embeddings):
+            embeddings = None
+
         return await self._store.add_texts(
             texts=texts,
             metadatas=metadatas,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

When using an elasticsearch-based vector store with the `AsyncSparseVectorStrategy`, embeddings do not need to be generated, as they are created within elasticsearch using the ELSER pipeline. In the llamaindex elasticsearch store, when inserting documents we call `embeddings.append(node.get_embedding())` for each node we're attempting to index, resulting in a list of Nones.

This list of Nones gets passed to the elasticsearch vector store [here](https://github.com/elastic/elasticsearch-py/blob/3073f9c195c88e6d9ecaadbae6aee05b6a3f2867/elasticsearch/helpers/vectorstore/_async/vectorstore.py#L154) where it erroneously evaluates as truthy, causing the `vector_field` value on the indexing request to be set to `None` instead of being omitted. This, in turn, causes an `illegal_argument_exception`. 

To fix, simply check if the list of embeddings generated for the documents we're indexing is all Nones, and if so, omit the vector argument to the elasticsearch client.

Fixes [#14821](https://github.com/run-llama/llama_index/issues/14821)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
