### PR TITLE
Fix: Token counter expecting response.raw as dict, got ChatCompletionChunk 

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/token_counting.py
+++ b/llama-index-core/llama_index/core/callbacks/token_counting.py
@@ -53,11 +53,14 @@ def get_llm_token_counts(
             response_tokens = 0
 
             if response is not None and response.raw is not None:
-                usage = response.raw.get("usage", None)
+                if isinstance(response.raw, dict):
+                    raw_dict = response.raw
+                else:
+                    raw_dict = response.raw.model_dump()
+
+                usage = raw_dict.get("usage", None)
 
                 if usage is not None:
-                    if not isinstance(usage, dict):
-                        usage = dict(usage)
                     messages_tokens = usage.get("prompt_tokens", 0)
                     response_tokens = usage.get("completion_tokens", 0)
 


### PR DESCRIPTION
# Description

Cast response.raw to dict in token counter, ensuring unified access to usage.

Fixes #14908

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
