### PR TITLE
Add function calling for Ollama

### DIFF
--- a/docs/docs/examples/llm/ollama.ipynb
+++ b/docs/docs/examples/llm/ollama.ipynb
@@ -14,7 +14,7 @@
    "id": "2e33dced-e587-4397-81b3-d6606aa1738a",
    "metadata": {},
    "source": [
-    "# Ollama - Llama 3"
+    "# Ollama - Llama 3.1"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = Ollama(model=\"llama3\", request_timeout=120.0)"
+    "llm = Ollama(model=\"llama3.1:latest\", request_timeout=120.0)"
    ]
   },
   {
@@ -91,15 +91,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Paul Graham (1924-2011) was a British Anglican priest and Christian theologian. He was a prominent figure in the Church of England and a leading ecumenist, known for his work on Christian unity and dialogue with other religions.\n",
+      "Paul Graham is a British-American computer scientist, entrepreneur, and writer. He's best known for co-founding several successful startups, including viaweb (which later became Yahoo!'s shopping site), O'Reilly Media's online bookstore, and Y Combinator, a well-known startup accelerator.\n",
       "\n",
-      "Graham served as a parish priest in Yorkshire, England, before becoming Dean of York Cathedral from 1966 to 1984. During this time, he was also involved in various ecumenical initiatives, including the Anglican-Lutheran Dialogue and the International Anglican-Roman Catholic Commission on Unity and Mission.\n",
+      "Here are some interesting facts about Paul Graham:\n",
       "\n",
-      "One of Graham's most notable contributions was his work on Christian-Jewish relations. He was a strong advocate for reconciliation between Christians and Jews, and he worked closely with Jewish leaders to promote understanding and cooperation between the two communities.\n",
+      "1. **Computer science background**: Graham has a Ph.D. in computer science from Harvard University.\n",
+      "2. **Startup success**: He co-founded viaweb, which was acquired by Yahoo! for $49 million, and later became the foundation of Yahoo!'s shopping site.\n",
+      "3. **Y Combinator**: In 2005, Graham co-founded Y Combinator, a startup accelerator that has funded over 2,000 companies, including Dropbox, Airbnb, Reddit, and Stripe.\n",
+      "4. **Writing career**: Graham is also a talented writer and has published several essays on entrepreneurship, startups, and programming. His writing is known for its clarity, humor, and insight.\n",
+      "5. **Philosophical views**: Graham has expressed interest in philosophical ideas related to startup culture, such as the importance of experimentation, iteration, and individual freedom.\n",
       "\n",
-      "Graham was also a prolific writer and published several books on theology, ecumenism, and Christian-Jewish relations. His writings emphasized the importance of dialogue and mutual respect in building bridges between different religious traditions.\n",
+      "Some popular writings by Paul Graham include:\n",
       "\n",
-      "Throughout his career, Graham received numerous awards and honors for his contributions to ecumenism and interfaith understanding. He is remembered as a respected leader and a champion of unity and cooperation among people of different faiths.\n"
+      "* \"How To Make Wealth\" ( essay on building wealth through startups)\n",
+      "* \"The Three Colors of Money\" (essay on how money influences people's behavior)\n",
+      "* \"Startup = Growth\" (essay on the key characteristics of successful startups)\n",
+      "\n",
+      "Overall, Paul Graham is a respected figure in the tech industry and startup world, known for his entrepreneurial spirit, writing talent, and commitment to helping others succeed.\n"
      ]
     }
    ],
@@ -144,7 +152,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "assistant: Arrr, me hearty! Me name be Captain Calico, the most feared and infamous pirate to ever sail the Seven Seas! Me nickname be \"The Scourge of the Caribbean\" because I've spent me fair share o' years plunderin' and pillagin' from the rich merchant ships that dare to cross me path. Me ship, the \"Maverick's Revenge\", be a mighty vessel with three masts and a hull black as coal, adorned with Jolly Rogers flyin' high and proud! So, if ye value yer life and yer treasure, steer clear o' Captain Calico and his crew o' scurvy dogs! Arrr!\n"
+      "assistant: Me hearty! Me name be Captain Zara \"Blackheart\" McSnazz, the most feared and infamous pirate to ever sail the Seven Seas! *adjusts eye patch*\n",
+      "\n",
+      "Me ship, the \"Maverick's Revenge\", be a sturdy galleon with three masts and a hull as black as me heart. She's fast, she's fierce, and she's got more cannons than a small army!\n",
+      "\n",
+      "So, what brings ye to these fair waters? Are ye lookin' for adventure, treasure, or just a good swabbin' of the decks?\n"
      ]
     }
    ],
@@ -190,15 +202,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Paul Graham (1922-2009) was a British Anglican priest who served as the Bishop of Meath in Ireland from 1975 to 1993. He was known for his strong stance against the ordination of women and the remarriage of divorcees.\n",
+      "Paul Graham is a British-American entrepreneur, programmer, and essayist. He's best known for co-founding the online startup accelerator Y Combinator (YC) with his partner Jessica Livingston in 2005.\n",
       "\n",
-      "Graham was a prominent figure within the Irish Church and was involved in various ecumenical efforts, particularly with the Roman Catholic Church. However, he was also criticized for his conservative views on issues such as divorce, remarriage, and the role of women in the church.\n",
+      "Graham was born in London, England in 1964. He developed an interest in computer programming at a young age and attended the University of California, Berkeley, where he earned a degree in Applied Math. After college, he worked as a programmer for several companies, including Bell Labs.\n",
       "\n",
-      "One of Graham's most notable controversies arose when he publicly opposed the ordination of women to the priesthood in the Anglican Communion. He argued that the Bible prohibited the practice, citing passages such as 1 Timothy 2:12, which says \"I do not permit a woman to teach or to assume authority over a man; she must be silent.\"\n",
+      "In the early 1990s, Graham became interested in online communities and started a website called \"The Daily WTF\" (an acronym for \"There's Probably Not A God\"). However, it was his essay \"How to Make Wealth History,\" written in 2002, that really caught attention. In the essay, he argued that the Internet had made it possible for entrepreneurs to create wealth without needing to be wealthy themselves.\n",
       "\n",
-      "Graham's views on these issues were highly influential within certain conservative circles in the Anglican Communion, and he was seen by some as a champion of traditional Christian values. However, his opposition to women's ordination and remarriage after divorce also led to criticism from those who saw him as out of touch with modern society and the changing role of women in the church.\n",
+      "Encouraged by this idea, Graham and Livingston started Y Combinator (YC) as a way to support and fund startups with innovative ideas. The program's goal was to provide seed funding, mentorship, and resources to help young companies grow quickly. Since its inception, YC has invested in over 2,000 companies, including well-known successes like Airbnb, Dropbox, Reddit, and Twitch.\n",
       "\n",
-      "Despite these controversies, Graham remained a respected figure within the Irish Church until his retirement in 1993. He passed away in 2009 at the age of 87."
+      "Today, Graham is a respected voice on the topic of entrepreneurship, innovation, and startup success. His essays and writings have been widely read and discussed online, and he's often invited to speak at conferences and events around the world.\n",
+      "\n",
+      "Some popular essays by Paul Graham include:\n",
+      "\n",
+      "* \"How to Make Wealth History\" (2002)\n",
+      "* \"The 100-Year Buy\" (2013) - an essay about the impact of Moore's Law on innovation\n",
+      "* \"What You'll Do\"\n",
+      "* \"Startup = Growth\""
      ]
     }
    ],
@@ -244,7 +263,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Arrrr, me hearty! Me name be Captain Calico \"The Cunning\" Cutlass. I be the most feared and respected pirate on the seven seas! Me reputation precedes me like a treasure map leads to hidden booty. Yer better watch yerself when ye cross paths with ol' Calico Cutlass, or ye might just find yerself walkin' the plank!"
+      "Yer lookin' fer me name, eh? Well, matey, I be Captain Calico Blackbeak, the most feared and infamous pirate to ever sail the seven seas! Me name's as colorful as me parrot, Polly, and me reputation's as black as me trusty cutlass.\n",
+      "\n",
+      "Now, don't ye be thinkin' that just 'cause me name's got \"Blackbeak\" in it, I'm a scurvy dog with a heart o' stone. No sir! I've got a heart o' gold, hidden deep beneath me tough exterior, and I'd do anything to protect me crew and me ship, the \"Maverick's Revenge\".\n",
+      "\n",
+      "So, what be yer business here, matey? Are ye lookin' fer a swashbucklin' adventure or just wantin' to hear tales o' the high seas?"
      ]
     }
    ],
@@ -272,7 +295,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = Ollama(model=\"llama3\", request_timeout=120.0, json_mode=True)"
+    "llm = Ollama(model=\"llama3.1:latest\", request_timeout=120.0, json_mode=True)"
    ]
   },
   {
@@ -285,75 +308,134 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{ \"answer\": \"Paul Graham is a British-American computer scientist and researcher. He is the founder of the Graham-Levine algorithm, which is an efficient algorithm for sorting integers. Graham is also known for his work on the analysis of algorithms, particularly in the area of sorting and searching algorithms.\" } \n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "  \n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n"
+      "{ \n",
+      "\"Name\": \"Paul Graham\",\n",
+      "\"Wikipedia_URL\": \"https://en.wikipedia.org/wiki/Paul_Graham_(programmer)\",\n",
+      "\"Brief_Description\": \"American computer programmer, entrepreneur, venture capitalist, and essayist.\",\n",
+      "\"Occupations\":\n",
+      "  [\n",
+      "    {\"Year\":null,\"Job\":\"Programmer\",\"Company\":null},\n",
+      "    {\"Year\":1997,\"Job\":\"Founder\",\"Company\":\"Viaweb\"},\n",
+      "    {\"Year\":2005,\"Job\":\"Founder\",\"Company\":\"Y Combinator\"}\n",
+      "  ],\n",
+      "\"Education\":\n",
+      "  [\n",
+      "     {\"Institution\": \"University of California, Berkeley\", \"Degree\": \"Bachelor of Arts\"},\n",
+      "     {\"Institution\": \"Harvard University\", \"Degree\": \"Master of Arts\"}\n",
+      "  ],\n",
+      "\"Awards\":\n",
+      "[\n",
+      "  {\"Name\": null,\"Year\":null}\n",
+      "],\n",
+      "\"Notable_Algorithms\":\n",
+      "[\n",
+      "  {\"Algorithm_name\":\"Viaweb algorithm\",\"Year\":1997}\n",
+      "]\n",
+      "}\n"
      ]
     }
    ],
    "source": [
-    "response = llm.complete(\"Who is Paul Graham?\")\n",
+    "response = llm.complete(\n",
+    "    \"Who is Paul Graham? Output as a structured JSON object.\"\n",
+    ")\n",
     "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1377e244",
+   "metadata": {},
+   "source": [
+    "## Structured Outputs\n",
+    "\n",
+    "We can also attach a pyndatic class to the LLM to ensure structured outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a5b94ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.bridge.pydantic import BaseModel\n",
+    "from llama_index.core.tools import FunctionTool\n",
+    "\n",
+    "\n",
+    "class Song(BaseModel):\n",
+    "    \"\"\"A song with name and artist.\"\"\"\n",
+    "\n",
+    "    name: str\n",
+    "    artist: str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c837c03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = Ollama(model=\"llama3.1:latest\", request_timeout=120.0)\n",
+    "\n",
+    "sllm = llm.as_structured_llm(Song)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "247e033d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"name\": \"Yesterday\", \"artist\": \"The Beatles\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = sllm.chat([ChatMessage(role=\"user\", content=\"Name a random song!\")])\n",
+    "print(response.message.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dca7636",
+   "metadata": {},
+   "source": [
+    "Or with async"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fb526f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"name\": \"Happy Birthday to You\", \"artist\": \"Traditional\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = await sllm.achat(\n",
+    "    [ChatMessage(role=\"user\", content=\"Name a random song!\")]\n",
+    ")\n",
+    "print(response.message.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4b224c6",
+   "metadata": {},
+   "source": [
+    "Currently, Ollama does not support streaming structured objects. But hopefully soon!"
    ]
   }
  ],

--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -1,8 +1,7 @@
-import json
-from typing import Any, Dict, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-import httpx
-from httpx import Timeout
+from ollama import Client, AsyncClient
+from ollama import ChatResponse as OllamaChatResponse
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
@@ -12,12 +11,18 @@ from llama_index.core.base.llms.types import (
     CompletionResponseAsyncGen,
     CompletionResponseGen,
     LLMMetadata,
-    MessageRole,
 )
-from llama_index.core.bridge.pydantic import Field
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.custom import CustomLLM
+from llama_index.core.base.llms.generic_utils import (
+    chat_to_completion_decorator,
+    achat_to_completion_decorator,
+    stream_chat_to_completion_decorator,
+    astream_chat_to_completion_decorator,
+)
+from llama_index.core.tools import ToolSelection
 
 DEFAULT_REQUEST_TIMEOUT = 30.0
 
@@ -82,6 +87,36 @@ class Ollama(CustomLLM):
         description="Additional model parameters for the Ollama API.",
     )
 
+    _client: Optional[Client] = PrivateAttr()
+    _async_client: Optional[AsyncClient] = PrivateAttr()
+
+    def __init__(
+        self,
+        model: str,
+        base_url: str = "http://localhost:11434",
+        temperature: float = 0.75,
+        context_window: int = DEFAULT_CONTEXT_WINDOW,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        prompt_key: str = "prompt",
+        json_mode: bool = False,
+        additional_kwargs: Dict[str, Any] = {},
+        client: Optional[Client] = None,
+        async_client: Optional[AsyncClient] = None,
+    ) -> None:
+        super().__init__(
+            model=model,
+            base_url=base_url,
+            temperature=temperature,
+            context_window=context_window,
+            request_timeout=request_timeout,
+            prompt_key=prompt_key,
+            json_mode=json_mode,
+            additional_kwargs=additional_kwargs,
+        )
+
+        self._client = client
+        self._async_client = async_client
+
     @classmethod
     def class_name(cls) -> str:
         return "Ollama_llm"
@@ -97,6 +132,20 @@ class Ollama(CustomLLM):
         )
 
     @property
+    def client(self) -> Client:
+        if self._client is None:
+            self._client = Client(host=self.base_url, timeout=self.request_timeout)
+        return self._client
+
+    @property
+    def async_client(self) -> AsyncClient:
+        if self._async_client is None:
+            self._async_client = AsyncClient(
+                host=self.base_url, timeout=self.request_timeout
+            )
+        return self._async_client
+
+    @property
     def _model_kwargs(self) -> Dict[str, Any]:
         base_kwargs = {
             "temperature": self.temperature,
@@ -107,154 +156,112 @@ class Ollama(CustomLLM):
             **self.additional_kwargs,
         }
 
+    def _convert_to_ollama_messages(self, messages: Sequence[ChatMessage]) -> Dict:
+        return [
+            {
+                "role": message.role.value,
+                "content": message.content or "",
+            }
+            for message in messages
+        ]
+
+    def _parse_tool_calls_from_response(
+        response: OllamaChatResponse,
+    ) -> List[ToolSelection]:
+        return None
+
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
-        payload = {
-            "model": self.model,
-            "messages": [
-                {
-                    "role": message.role.value,
-                    "content": message.content,
-                    **message.additional_kwargs,
-                }
-                for message in messages
-            ],
-            "options": self._model_kwargs,
-            "stream": False,
-            **kwargs,
-        }
+        ollama_messages = self._convert_to_ollama_messages(messages)
 
-        if self.json_mode:
-            payload["format"] = "json"
+        tools = kwargs.pop("tools", None)
 
-        with httpx.Client(timeout=Timeout(self.request_timeout)) as client:
-            response = client.post(
-                url=f"{self.base_url}/api/chat",
-                json=payload,
-            )
-            response.raise_for_status()
-            raw = response.json()
-            message = raw["message"]
-            return ChatResponse(
-                message=ChatMessage(
-                    content=message.get("content"),
-                    role=MessageRole(message.get("role")),
-                    additional_kwargs=get_additional_kwargs(
-                        message, ("content", "role")
-                    ),
-                ),
-                raw=raw,
-                additional_kwargs=get_additional_kwargs(raw, ("message",)),
-            )
+        response = self.client.chat(
+            model=self.model,
+            messages=ollama_messages,
+            stream=False,
+            format="json" if self.json_mode else "",
+            tools=tools,
+            options=self._model_kwargs,
+        )
+
+        return ChatResponse(
+            message=ChatMessage(
+                content=response["message"]["content"],
+                role=response["message"]["role"],
+            ),
+            raw=response,
+        )
 
     @llm_chat_callback()
     def stream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
-        payload = {
-            "model": self.model,
-            "messages": [
-                {
-                    "role": message.role.value,
-                    "content": message.content,
-                    **message.additional_kwargs,
-                }
-                for message in messages
-            ],
-            "options": self._model_kwargs,
-            "stream": True,
-            **kwargs,
-        }
+        ollama_messages = self._convert_to_ollama_messages(messages)
 
-        if self.json_mode:
-            payload["format"] = "json"
+        tools = kwargs.pop("tools", None)
 
-        with httpx.Client(timeout=Timeout(self.request_timeout)) as client:
-            with client.stream(
-                method="POST",
-                url=f"{self.base_url}/api/chat",
-                json=payload,
-            ) as response:
-                response.raise_for_status()
-                text = ""
-                for line in response.iter_lines():
-                    if line:
-                        chunk = json.loads(line)
-                        message = chunk["message"]
-                        delta = message.get("content")
-                        text += delta
-                        yield ChatResponse(
-                            message=ChatMessage(
-                                content=text,
-                                role=MessageRole(message.get("role")),
-                                additional_kwargs=get_additional_kwargs(
-                                    message, ("content", "role")
-                                ),
-                            ),
-                            delta=delta,
-                            raw=chunk,
-                            additional_kwargs=get_additional_kwargs(
-                                chunk, ("message",)
-                            ),
-                        )
-                        if "done" in chunk and chunk["done"]:
-                            break
+        def gen() -> ChatResponseGen:
+            response = self.client.chat(
+                model=self.model,
+                messages=ollama_messages,
+                stream=True,
+                format="json" if self.json_mode else "",
+                tools=tools,
+                options=self._model_kwargs,
+            )
+
+            response_txt = ""
+
+            for r in response:
+                if r["message"]["content"] is None:
+                    continue
+
+                response_txt += r["message"]["content"]
+                yield ChatResponse(
+                    message=ChatMessage(
+                        content=response_txt,
+                        role=r["message"]["role"],
+                    ),
+                    delta=r["message"]["content"],
+                    raw=r,
+                )
+
+        return gen()
 
     @llm_chat_callback()
     async def astream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
-        payload = {
-            "model": self.model,
-            "messages": [
-                {
-                    "role": message.role.value,
-                    "content": message.content,
-                    **message.additional_kwargs,
-                }
-                for message in messages
-            ],
-            "options": self._model_kwargs,
-            "stream": True,
-            **kwargs,
-        }
+        ollama_messages = self._convert_to_ollama_messages(messages)
 
-        if self.json_mode:
-            payload["format"] = "json"
+        tools = kwargs.pop("tools", None)
 
-        async def gen() -> CompletionResponseAsyncGen:
-            text = ""
+        async def gen() -> ChatResponseAsyncGen:
+            response = await self.async_client.chat(
+                model=self.model,
+                messages=ollama_messages,
+                stream=True,
+                format="json" if self.json_mode else "",
+                tools=tools,
+                options=self._model_kwargs,
+            )
 
-            async with httpx.AsyncClient(
-                timeout=Timeout(self.request_timeout)
-            ) as client:
-                async with client.stream(
-                    method="POST",
-                    url=f"{self.base_url}/api/chat",
-                    json=payload,
-                ) as response:
-                    async for line in response.aiter_lines():
-                        if line:
-                            chunk = json.loads(line)
-                            message = chunk["message"]
-                            delta = message.get("content")
-                            text += delta
-                            yield ChatResponse(
-                                message=ChatMessage(
-                                    content=text,
-                                    role=MessageRole(message.get("role")),
-                                    additional_kwargs=get_additional_kwargs(
-                                        message, ("content", "role")
-                                    ),
-                                ),
-                                delta=delta,
-                                raw=chunk,
-                                additional_kwargs=get_additional_kwargs(
-                                    chunk, ("message",)
-                                ),
-                            )
-                            if "done" in chunk and chunk["done"]:
-                                break
+            response_txt = ""
+
+            async for r in response:
+                if r["message"]["content"] is None:
+                    continue
+
+                response_txt += r["message"]["content"]
+                yield ChatResponse(
+                    message=ChatMessage(
+                        content=response_txt,
+                        role=r["message"]["role"],
+                    ),
+                    delta=r["message"]["content"],
+                    raw=r,
+                )
 
         return gen()
 
@@ -262,174 +269,49 @@ class Ollama(CustomLLM):
     async def achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
-        payload = {
-            "model": self.model,
-            "messages": [
-                {
-                    "role": message.role.value,
-                    "content": message.content,
-                    **message.additional_kwargs,
-                }
-                for message in messages
-            ],
-            "options": self._model_kwargs,
-            "stream": False,
-            **kwargs,
-        }
+        ollama_messages = self._convert_to_ollama_messages(messages)
 
-        if self.json_mode:
-            payload["format"] = "json"
+        tools = kwargs.pop("tools", None)
 
-        async with httpx.AsyncClient(timeout=Timeout(self.request_timeout)) as client:
-            response = await client.post(
-                url=f"{self.base_url}/api/chat",
-                json=payload,
-            )
-            response.raise_for_status()
-            raw = response.json()
-            message = raw["message"]
-            return ChatResponse(
-                message=ChatMessage(
-                    content=message.get("content"),
-                    role=MessageRole(message.get("role")),
-                    additional_kwargs=get_additional_kwargs(
-                        message, ("content", "role")
-                    ),
-                ),
-                raw=raw,
-                additional_kwargs=get_additional_kwargs(raw, ("message",)),
-            )
+        response = await self.async_client.chat(
+            model=self.model,
+            messages=ollama_messages,
+            stream=False,
+            format="json" if self.json_mode else "",
+            tools=tools,
+            options=self._model_kwargs,
+        )
+
+        return ChatResponse(
+            message=ChatMessage(
+                content=response["message"]["content"],
+                role=response["message"]["role"],
+            ),
+            raw=response,
+        )
 
     @llm_completion_callback()
     def complete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponse:
-        payload = {
-            self.prompt_key: prompt,
-            "model": self.model,
-            "options": self._model_kwargs,
-            "stream": False,
-            **kwargs,
-        }
-
-        if self.json_mode:
-            payload["format"] = "json"
-
-        with httpx.Client(timeout=Timeout(self.request_timeout)) as client:
-            response = client.post(
-                url=f"{self.base_url}/api/generate",
-                json=payload,
-            )
-            response.raise_for_status()
-            raw = response.json()
-            text = raw.get("response")
-            return CompletionResponse(
-                text=text,
-                raw=raw,
-                additional_kwargs=get_additional_kwargs(raw, ("response",)),
-            )
+        return chat_to_completion_decorator(self.chat)(prompt, **kwargs)
 
     @llm_completion_callback()
     async def acomplete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponse:
-        payload = {
-            self.prompt_key: prompt,
-            "model": self.model,
-            "options": self._model_kwargs,
-            "stream": False,
-            **kwargs,
-        }
-
-        if self.json_mode:
-            payload["format"] = "json"
-
-        async with httpx.AsyncClient(timeout=Timeout(self.request_timeout)) as client:
-            response = await client.post(
-                url=f"{self.base_url}/api/generate",
-                json=payload,
-            )
-            response.raise_for_status()
-            raw = response.json()
-            text = raw.get("response")
-            return CompletionResponse(
-                text=text,
-                raw=raw,
-                additional_kwargs=get_additional_kwargs(raw, ("response",)),
-            )
+        return await achat_to_completion_decorator(self.achat)(prompt, **kwargs)
 
     @llm_completion_callback()
     def stream_complete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponseGen:
-        payload = {
-            self.prompt_key: prompt,
-            "model": self.model,
-            "options": self._model_kwargs,
-            "stream": True,
-            **kwargs,
-        }
-
-        if self.json_mode:
-            payload["format"] = "json"
-
-        with httpx.Client(timeout=Timeout(self.request_timeout)) as client:
-            with client.stream(
-                method="POST",
-                url=f"{self.base_url}/api/generate",
-                json=payload,
-            ) as response:
-                response.raise_for_status()
-                text = ""
-                for line in response.iter_lines():
-                    if line:
-                        chunk = json.loads(line)
-                        delta = chunk.get("response")
-                        text += delta
-                        yield CompletionResponse(
-                            delta=delta,
-                            text=text,
-                            raw=chunk,
-                            additional_kwargs=get_additional_kwargs(
-                                chunk, ("response",)
-                            ),
-                        )
+        return stream_chat_to_completion_decorator(self.stream_chat)(prompt, **kwargs)
 
     @llm_completion_callback()
     async def astream_complete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponseAsyncGen:
-        payload = {
-            self.prompt_key: prompt,
-            "model": self.model,
-            "options": self._model_kwargs,
-            "stream": True,
-            **kwargs,
-        }
-
-        if self.json_mode:
-            payload["format"] = "json"
-
-        async def gen() -> CompletionResponseAsyncGen:
-            async with httpx.AsyncClient(
-                timeout=Timeout(self.request_timeout)
-            ) as client:
-                async with client.stream(
-                    method="POST",
-                    url=f"{self.base_url}/api/generate",
-                    json=payload,
-                ) as response:
-                    async for line in response.aiter_lines():
-                        if line:
-                            chunk = json.loads(line)
-                            delta = chunk.get("response")
-                            yield CompletionResponse(
-                                delta=delta,
-                                text=delta,
-                                raw=chunk,
-                                additional_kwargs=get_additional_kwargs(
-                                    chunk, ("response",)
-                                ),
-                            )
-
-        return gen()
+        return await astream_chat_to_completion_decorator(self.astream_chat)(
+            prompt, **kwargs
+        )

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,11 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ollama"
 readme = "README.md"
-version = "0.1.6"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 llama-index-core = "^0.10.1"
+ollama = ">=0.3.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -1,13 +1,15 @@
 import pytest
 import os
 
+from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.core.llms import ChatMessage
+from llama_index.core.tools import FunctionTool
 from llama_index.llms.ollama import Ollama
 from ollama import Client
 
 
-test_model = os.environ.get("OLLAMA_TEST_MODEL", "llama3:latest")
+test_model = os.environ.get("OLLAMA_TEST_MODEL", "llama3.1:latest")
 try:
     client = Client()
     models = client.list()
@@ -22,6 +24,21 @@ try:
         client = None
 except Exception:
     client = None
+
+
+class Song(BaseModel):
+    """A song with name and artist."""
+
+    name: str
+    artist: str
+
+
+def generate_song(name: str, artist: str) -> Song:
+    """Generates a song with provided name and artist."""
+    return Song(name=name, artist=artist)
+
+
+tool = FunctionTool.from_defaults(fn=generate_song)
 
 
 def test_embedding_class() -> None:
@@ -119,3 +136,34 @@ async def test_ollama_async_stream_complete() -> None:
         assert r is not None
         assert r.delta is not None
         assert str(r).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+def test_chat_with_tools() -> None:
+    llm = Ollama(model=test_model)
+    response = llm.chat_with_tools([tool], user_msg="Hello!")
+    tool_calls = llm.get_tool_calls_from_response(response)
+    assert len(tool_calls) == 1
+    assert tool_calls[0].tool_name == tool.metadata.name
+
+    tool_result = tool(**tool_calls[0].tool_kwargs)
+    assert tool_result.raw_output is not None
+    assert isinstance(tool_result.raw_output, Song)
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+@pytest.mark.asyncio()
+async def test_async_chat_with_tools() -> None:
+    llm = Ollama(model=test_model)
+    response = await llm.achat_with_tools([tool], user_msg="Hello!")
+    tool_calls = llm.get_tool_calls_from_response(response)
+    assert len(tool_calls) == 1
+    assert tool_calls[0].tool_name == tool.metadata.name
+
+    tool_result = tool(**tool_calls[0].tool_kwargs)
+    assert tool_result.raw_output is not None
+    assert isinstance(tool_result.raw_output, Song)

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -1,7 +1,121 @@
+import pytest
+import os
+
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.llms import ChatMessage
 from llama_index.llms.ollama import Ollama
+from ollama import Client
 
 
-def test_embedding_class():
+test_model = os.environ.get("OLLAMA_TEST_MODEL", "llama3:latest")
+try:
+    client = Client()
+    models = client.list()
+
+    model_found = False
+    for model in models["models"]:
+        if model["name"] == test_model:
+            model_found = True
+            break
+
+    if not model_found:
+        client = None
+except Exception:
+    client = None
+
+
+def test_embedding_class() -> None:
     names_of_base_classes = [b.__name__ for b in Ollama.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+def test_ollama_chat() -> None:
+    llm = Ollama(model=test_model)
+    response = llm.chat([ChatMessage(role="user", content="Hello!")])
+    assert response is not None
+    assert str(response).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+def test_ollama_complete() -> None:
+    llm = Ollama(model=test_model)
+    response = llm.complete("Hello!")
+    assert response is not None
+    assert str(response).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+def test_ollama_stream_chat() -> None:
+    llm = Ollama(model=test_model)
+    response = llm.stream_chat([ChatMessage(role="user", content="Hello!")])
+    for r in response:
+        assert r is not None
+        assert r.delta is not None
+        assert str(r).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+def test_ollama_stream_complete() -> None:
+    llm = Ollama(model=test_model)
+    response = llm.stream_complete("Hello!")
+    for r in response:
+        assert r is not None
+        assert r.delta is not None
+        assert str(r).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+@pytest.mark.asyncio()
+async def test_ollama_async_chat() -> None:
+    llm = Ollama(model=test_model)
+    response = await llm.achat([ChatMessage(role="user", content="Hello!")])
+    assert response is not None
+    assert str(response).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+@pytest.mark.asyncio()
+async def test_ollama_async_complete() -> None:
+    llm = Ollama(model=test_model)
+    response = await llm.acomplete("Hello!")
+    assert response is not None
+    assert str(response).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+@pytest.mark.asyncio()
+async def test_ollama_async_stream_chat() -> None:
+    llm = Ollama(model=test_model)
+    response = await llm.astream_chat([ChatMessage(role="user", content="Hello!")])
+    async for r in response:
+        assert r is not None
+        assert r.delta is not None
+        assert str(r).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+@pytest.mark.asyncio()
+async def test_ollama_async_stream_complete() -> None:
+    llm = Ollama(model=test_model)
+    response = await llm.astream_complete("Hello!")
+    async for r in response:
+        assert r is not None
+        assert r.delta is not None
+        assert str(r).strip() != ""


### PR DESCRIPTION
This PR
- swaps out raw API calls for the Ollama clients
- makes the complete logic just call chat methods to simplify
- adds tests (that can only run locally for now... if Ollama has a test instance they can share, that'd be cool 😉)
- implements `FunctionCallingLLM`

Some unknowns
- haven't tested StructuredLLM yet
- not 100% if streaming with tools will even work either