### PR TITLE
Feature/azure docstore hotfix

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -206,7 +206,7 @@ class KVDocumentStore(BaseDocumentStore):
 
     def add_documents(
         self,
-        nodes: Sequence[BaseNode],
+        docs: Sequence[BaseNode],
         allow_update: bool = True,
         batch_size: Optional[int] = None,
         store_text: bool = True,
@@ -221,7 +221,7 @@ class KVDocumentStore(BaseDocumentStore):
         batch_size = batch_size or self._batch_size
 
         node_kv_pairs, metadata_kv_pairs, ref_doc_kv_pairs = self._prepare_kv_pairs(
-            nodes, allow_update, store_text
+            docs, allow_update, store_text
         )
 
         self._kvstore.put_all(
@@ -308,7 +308,7 @@ class KVDocumentStore(BaseDocumentStore):
 
     async def async_add_documents(
         self,
-        nodes: Sequence[BaseNode],
+        docs: Sequence[BaseNode],
         allow_update: bool = True,
         batch_size: Optional[int] = None,
         store_text: bool = True,
@@ -326,7 +326,7 @@ class KVDocumentStore(BaseDocumentStore):
             node_kv_pairs,
             metadata_kv_pairs,
             ref_doc_kv_pairs,
-        ) = await self._async_prepare_kv_pairs(nodes, allow_update, store_text)
+        ) = await self._async_prepare_kv_pairs(docs, allow_update, store_text)
 
         await asyncio.gather(
             self._kvstore.aput_all(

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/llama_index/storage/docstore/azure/base.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/llama_index/storage/docstore/azure/base.py
@@ -175,7 +175,7 @@ class AzureDocumentStore(KVDocumentStore):
 
     def add_documents(
         self,
-        nodes: Sequence[BaseNode],
+        docs: Sequence[BaseNode],
         allow_update: bool = True,
         batch_size: Optional[int] = None,
         store_text: bool = True,
@@ -184,7 +184,7 @@ class AzureDocumentStore(KVDocumentStore):
         batch_size = batch_size or self._batch_size
 
         node_kv_pairs, metadata_kv_pairs, ref_doc_kv_pairs = super()._prepare_kv_pairs(
-            nodes, allow_update, store_text
+            docs, allow_update, store_text
         )
 
         # Change ref_doc_kv_pairs
@@ -210,7 +210,7 @@ class AzureDocumentStore(KVDocumentStore):
 
     async def async_add_documents(
         self,
-        nodes: Sequence[BaseNode],
+        docs: Sequence[BaseNode],
         allow_update: bool = True,
         batch_size: Optional[int] = None,
         store_text: bool = True,
@@ -222,7 +222,7 @@ class AzureDocumentStore(KVDocumentStore):
             node_kv_pairs,
             metadata_kv_pairs,
             ref_doc_kv_pairs,
-        ) = await super()._async_prepare_kv_pairs(nodes, allow_update, store_text)
+        ) = await super()._async_prepare_kv_pairs(docs, allow_update, store_text)
 
         # Change ref_doc_kv_pairs
         ref_doc_kv_pairs = self._extract_doc_metadatas(ref_doc_kv_pairs)

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/pyproject.toml
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-docstore-azure"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Fixes aget_ref_doc_info which was using the wrong column and not properly checking for empty results.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
- [x] Ran it on my own infrastructure

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
