### PR TITLE
Fix None type error when using Neo4jPropertyGraphStore

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -156,7 +156,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
     @property
     def client(self):
         return self._driver
-    
+
     def close(self) -> None:
         self._driver.close()
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -117,6 +117,9 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
             documents,
             property_graph_store=graph_store,
         )
+
+        # Close the neo4j connection explicitly.
+        graph_store.close()
         ```
     """
 
@@ -153,6 +156,9 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
     @property
     def client(self):
         return self._driver
+    
+    def close(self) -> None:
+        self._driver.close()
 
     def refresh_schema(self) -> None:
         """Refresh the schema."""

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.2.8"
+version = "0.2.9"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Add explicit close for Neo4jPropertyGraphStore to solve "AttributeError: 'NoneType' object has no attribute 'debug'" bug.

Run the code:
```Python
from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore
graph_store = Neo4jPropertyGraphStore(
    username="neo4j",
    password="neo4j1234",
    url="bolt://localhost:7687",
)
```
It will raise the error when the code exit:
```
Exception ignored in: <function Driver.__del__ at 0x7fa71059d2d0>
Traceback (most recent call last):
  File "/home/sunyaqiang/anaconda3/envs/llmkg/lib/python3.10/site-packages/neo4j/_sync/driver.py", line 544, in __del__
  File "/home/sunyaqiang/anaconda3/envs/llmkg/lib/python3.10/site-packages/neo4j/_sync/driver.py", line 640, in close
  File "/home/sunyaqiang/anaconda3/envs/llmkg/lib/python3.10/site-packages/neo4j/_sync/io/_pool.py", line 480, in close
  File "/home/sunyaqiang/anaconda3/envs/llmkg/lib/python3.10/site-packages/neo4j/_sync/io/_pool.py", line 414, in _close_connections
  File "/home/sunyaqiang/anaconda3/envs/llmkg/lib/python3.10/site-packages/neo4j/_sync/io/_bolt.py", line 950, in close
  File "/home/sunyaqiang/anaconda3/envs/llmkg/lib/python3.10/site-packages/neo4j/_sync/io/_bolt5.py", line 328, in goodbye
AttributeError: 'NoneType' object has no attribute 'debug'
```

This PR adds a `close` function for `Neo4jPropertyGraphStore` class, and updates usage annotation for the class.

Usage annotation:
```python
from llama_index.core.indices.property_graph import PropertyGraphIndex
from llama_index.graph_stores.neo4j import Neo4jPropertyGraphStore

# Create a Neo4jPropertyGraphStore instance
graph_store = Neo4jPropertyGraphStore(
    username="neo4j",
    password="neo4j",
    url="bolt://localhost:7687",
    database="neo4j"
)

# create the index
index = PropertyGraphIndex.from_documents(
    documents,
    property_graph_store=graph_store,
)

# Close the neo4j connection explicitly.
graph_store.close()
```

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
