### PR TITLE
add back kwargs to Ollama

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -111,6 +111,7 @@ class Ollama(FunctionCallingLLM):
         additional_kwargs: Dict[str, Any] = {},
         client: Optional[Client] = None,
         async_client: Optional[AsyncClient] = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             model=model,
@@ -121,6 +122,7 @@ class Ollama(FunctionCallingLLM):
             prompt_key=prompt_key,
             json_mode=json_mode,
             additional_kwargs=additional_kwargs,
+            **kwargs,
         )
 
         self._client = client

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ollama"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Since adding an actual constructor to Ollama, we need kwargs to allow passing in parent class attributes