### PR TITLE
use proper stemmer in bm25 tokenize

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -77,7 +77,7 @@ class BM25Retriever(BaseRetriever):
             corpus_tokens = bm25s.tokenize(
                 [node.get_content() for node in nodes],
                 stopwords=language,
-                stemmer=stemmer,
+                stemmer=self.stemmer,
                 show_progress=verbose,
             )
             self.bm25 = bm25s.BM25()

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-retrievers-bm25"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/14960

Should be using `self.stemmer` 