### PR TITLE
restrict python version to enable publish of pandasai reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-pandas-ai/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-pandas-ai/pyproject.toml
@@ -32,7 +32,7 @@ readme = "README.md"
 version = "0.1.4"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 llama-index-core = "^0.10.1"
 pandasai = ">=2.2.12"
 


### PR DESCRIPTION
pandasai reader couldn't publish because of the python version in the toml, this should fix it