### PR TITLE
make re-raising error skip constructor

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -42,10 +42,6 @@ def asyncio_run(coro: Coroutine) -> Any:
                 "Or, use async entry methods like `aquery()`, `aretriever`, `achat`, etc."
             )
 
-    except Exception as e:
-        # Catch any other exceptions and re-raise with more context
-        raise type(e)(f"Error running coroutine: {e!s}") from e
-
 
 def run_async_tasks(
     tasks: List[Coroutine],


### PR DESCRIPTION
When `asyncio_run()` catches any exception other than `RuntimeError`, it tries to re-construct it with a new message.

Instead, we should just let it raise as normal to make the error message clearer, and avoid issues with libraries that use custom exceptions