### PR TITLE
undo incompatible kwarg in elasticsearch vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -216,7 +216,6 @@ class ElasticsearchStore(BasePydanticVectorStore):
         distance_strategy: Optional[DISTANCE_STRATEGIES] = "COSINE",
         retrieval_strategy: Optional[AsyncRetrievalStrategy] = None,
         metadata_mappings: Optional[Dict[str, Any]] = None,
-        custom_index_settings: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         nest_asyncio.apply()
@@ -252,7 +251,6 @@ class ElasticsearchStore(BasePydanticVectorStore):
             text_field=text_field,
             vector_field=vector_field,
             metadata_mappings=metadata_mappings,
-            custom_index_settings=custom_index_settings,
         )
 
         super().__init__(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
This kwarg isn't available until v8.15 releases (which currently its not out, so this breaks usage)