### PR TITLE
Decorate free functions

### DIFF
--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -7,6 +7,7 @@ from typing import (
     Optional,
     Union,
     Callable,
+    Dict,
     get_type_hints,
 )
 
@@ -54,7 +55,7 @@ def validate_step_signature(fn: Callable) -> None:
         raise WorkflowValidationError(msg)
 
 
-def get_steps_from_class(_class: object) -> dict:
+def get_steps_from_class(_class: object) -> Dict[str, Callable]:
     """Given a class, return the list of its methods that were defined as steps."""
     step_methods = {}
     all_methods = inspect.getmembers(_class, predicate=inspect.ismethod)

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -28,13 +28,22 @@ class Workflow:
         self._step_flags: Dict[str, asyncio.Event] = {}
         self._accepted_events: List[Tuple[str, str]] = []
         self._retval: Any = None
+        self._step_functions: Dict[str, Callable] = {}
+
+    def add_step(self, func: Callable) -> None:
+        """Adds a free function as step for this workflow instance."""
+        self._step_functions[func.__name__] = func
+
+    def _get_steps(self) -> Dict[str, Callable]:
+        """Returns all the steps, whether defined as methods or free functions."""
+        return {**get_steps_from_class(self), **self._step_functions}
 
     def _start(self, stepwise: bool = False) -> None:
         """Sets up the queues and tasks for each declared step.
 
         This method also launches each step as an async task.
         """
-        for name, step_func in get_steps_from_class(self).items():
+        for name, step_func in self._get_steps().items():
             self._queues[name] = asyncio.Queue()
             self._step_flags[name] = asyncio.Event()
             step_config: Optional[StepConfig] = getattr(


### PR DESCRIPTION
# Description

Add the ability to decorate free functions. The requirement in order to do so is to pass a workflow instance to the decorator like 
```
@step(workflow=my_workflow)
def my_step(ev: Event) -> Event:
  return Event()
```

The decorator is just syntactic sugar for a new method in the workflow `my_workflow.add_step(my_step)`.