### PR TITLE
Feat: expand span coverage for query pipeline

### DIFF
--- a/llama-index-core/llama_index/core/query_pipeline/query.py
+++ b/llama-index-core/llama_index/core/query_pipeline/query.py
@@ -33,6 +33,9 @@ from llama_index.core.base.query_pipeline.query import (
 )
 from llama_index.core.utils import print_text
 from llama_index.core.query_pipeline.components.stateful import BaseStatefulComponent
+import llama_index.core.instrumentation as instrument
+
+dispatcher = instrument.get_dispatcher(__name__)
 
 
 # TODO: Make this (safely) pydantic?
@@ -386,6 +389,7 @@ class QueryPipeline(QueryComponent):
         for module in self.module_dict.values():
             module.set_callback_manager(callback_manager)
 
+    @dispatcher.span
     def run(
         self,
         *args: Any,
@@ -529,6 +533,7 @@ class QueryPipeline(QueryComponent):
             ) as query_event:
                 return self._run_multi(module_input_dict, show_intermediates=True)
 
+    @dispatcher.span
     async def arun(
         self,
         *args: Any,
@@ -725,6 +730,7 @@ class QueryPipeline(QueryComponent):
         else:
             return result_output
 
+    @dispatcher.span
     def _run(
         self,
         *args: Any,
@@ -780,6 +786,7 @@ class QueryPipeline(QueryComponent):
                 intermediates,
             )
 
+    @dispatcher.span
     async def _arun(
         self,
         *args: Any,
@@ -904,6 +911,7 @@ class QueryPipeline(QueryComponent):
             root_key, kwargs = self._get_root_key_and_kwargs(**pipeline_inputs)
             return RunState(self.module_dict, {root_key: kwargs})
 
+    @dispatcher.span
     def _run_multi(
         self, module_input_dict: Dict[str, Any], show_intermediates=False
     ) -> Tuple[Dict[str, Any], Dict[str, ComponentIntermediates]]:
@@ -947,6 +955,7 @@ class QueryPipeline(QueryComponent):
 
         return run_state.result_outputs, run_state.intermediate_outputs
 
+    @dispatcher.span
     async def _arun_multi(
         self, module_input_dict: Dict[str, Any], show_intermediates: bool = False
     ) -> Tuple[Dict[str, Any], Dict[str, ComponentIntermediates]]:


### PR DESCRIPTION
# Description

Expand span coverage for QueryPipeline. Needed in https://github.com/traceloop/openllmetry/pull/1546 (test_query_pipeline.py).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
