### PR TITLE
fix(sql_wrapper): dont mention foreign keys when theres none

### DIFF
--- a/llama-index-core/llama_index/core/utilities/sql_wrapper.py
+++ b/llama-index-core/llama_index/core/utilities/sql_wrapper.py
@@ -162,7 +162,7 @@ class SQLDatabase:
             # get_table_comment raises NotImplementedError for a dialect that does not support comments.
             pass
 
-        template += "and foreign keys: {foreign_keys}."
+        template += "{foreign_keys}."
         columns = []
         for column in self._inspector.get_columns(table_name, schema=self._schema):
             if column.get("comment"):
@@ -182,7 +182,11 @@ class SQLDatabase:
                 f"{foreign_key['constrained_columns']} -> "
                 f"{foreign_key['referred_table']}.{foreign_key['referred_columns']}"
             )
-        foreign_key_str = ", ".join(foreign_keys)
+        foreign_key_str = (
+            foreign_keys
+            and " and foreign keys: {}".format(", ".join(foreign_keys))
+            or ""
+        )
         return template.format(
             table_name=table_name, columns=column_str, foreign_keys=foreign_key_str
         )

--- a/llama-index-core/tests/utilities/test_sql_wrapper.py
+++ b/llama-index-core/tests/utilities/test_sql_wrapper.py
@@ -55,10 +55,7 @@ def test_get_table_columns(sql_database: SQLDatabase) -> None:
 # Test get_single_table_info method
 def test_get_single_table_info(sql_database: SQLDatabase) -> None:
     assert sql_database.get_single_table_info("test_table") == (
-        "Table 'test_table' has columns: "
-        "id (INTEGER), "
-        "name (VARCHAR), "
-        "and foreign keys: ."
+        "Table 'test_table' has columns: id (INTEGER), name (VARCHAR), ."
     )
 
 


### PR DESCRIPTION
In the table description, only add the foreign keys text if necessary
 
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?

Tested the template code locally

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
