### PR TITLE
fixed import error regarding OpenAIAgent in the code_interpreter example notebook

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-code-interpreter/examples/code_interpreter.ipynb
+++ b/llama-index-integrations/tools/llama-index-tools-code-interpreter/examples/code_interpreter.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.agent import OpenAIAgent"
+    "from llama_index.agent.openai import OpenAIAgent"
    ]
   },
   {


### PR DESCRIPTION
# Description

There was a small import error in the code_interpreter example notebook it should be 'from llama_index.agent.openai import OpenAIAgent' instead of 'from llama_index.agent import OpenAIAgent' 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [*] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [*] I have performed a self-review of my own code

