### PR TITLE
add option to avoid loading nodes into context that has them already

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -52,6 +52,7 @@ class BaseIndex(Generic[IS], ABC):
         show_progress: bool = False,
         # deprecated
         service_context: Optional[ServiceContext] = None,
+        load_nodes_into_storage_context: Optional[bool] = True,
         **kwargs: Any,
     ) -> None:
         """Initialize with parameters."""
@@ -76,6 +77,7 @@ class BaseIndex(Generic[IS], ABC):
 
         self._docstore = self._storage_context.docstore
         self._show_progress = show_progress
+        self._load_nodes_into_storage_context = load_nodes_into_storage_context
         self._vector_store = self._storage_context.vector_store
         self._graph_store = self._storage_context.graph_store
         self._callback_manager = (
@@ -212,7 +214,8 @@ class BaseIndex(Generic[IS], ABC):
         self, nodes: Sequence[BaseNode], **build_kwargs: Any
     ) -> IS:
         """Build the index from nodes."""
-        self._docstore.add_documents(nodes, allow_update=True)
+        if self._load_nodes_into_storage_context:
+            self._docstore.add_documents(nodes, allow_update=True)
         return self._build_index_from_nodes(nodes, **build_kwargs)
 
     @abstractmethod


### PR DESCRIPTION
I noticed when running the original version that it was very slow, so I looked in the code and saw that it is trying to populate the storage context docstore again for no apparent reason.
To make it quicker I overrode the build_index_from_nodes in a child class as:

```
class QuickerSimpleKeywordTableIndex(SimpleKeywordTableIndex):
    def build_index_from_nodes(self, nodes):
        """Build the index from nodes."""
        return self._build_index_from_nodes(nodes)
```
    
This helped a lot, so I thought it should be an option in the base class.


This comes in handy when loading the nodes from the storage context, for example:

```
nodes = list(storage_context.docstore.docs.values())
keyword_index = QuickerSimpleKeywordTableIndex(nodes=nodes, storage_context=storage_context, show_progress=True)
```