### PR TITLE
Adds option to construct PGVectorStore with a HNSW index

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -173,6 +173,24 @@ class PGVectorStore(BasePydanticVectorStore):
         use_jsonb: bool = False,
         hnsw_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
+        """Constructor.
+
+        Args:
+            connection_string (Union[str, sqlalchemy.engine.URL]): Connection string to postgres db.
+            async_connection_string (Union[str, sqlalchemy.engine.URL]): Connection string to async pg db.
+            table_name (str): Table name.
+            schema_name (str): Schema name.
+            hybrid_search (bool, optional): Enable hybrid search. Defaults to False.
+            text_search_config (str, optional): Text search configuration. Defaults to "english".
+            embed_dim (int, optional): Embedding dimensions. Defaults to 1536.
+            cache_ok (bool, optional): Enable cache. Defaults to False.
+            perform_setup (bool, optional): If db should be set up. Defaults to True.
+            debug (bool, optional): Debug mode. Defaults to False.
+            use_jsonb (bool, optional): Use JSONB instead of JSON. Defaults to False.
+            hnsw_kwargs (Optional[Dict[str, Any]], optional): HNSW kwargs, a dict that
+                contains "hnsw_ef_construction", "hnsw_ef_search", "hnsw_m", and optionally "hnsw_dist_method". Defaults to None,
+                which turns off HNSW search.
+        """
         table_name = table_name.lower()
         schema_name = schema_name.lower()
 
@@ -246,7 +264,32 @@ class PGVectorStore(BasePydanticVectorStore):
         use_jsonb: bool = False,
         hnsw_kwargs: Optional[Dict[str, Any]] = None,
     ) -> "PGVectorStore":
-        """Return connection string from database parameters."""
+        """Construct from params.
+
+        Args:
+            host (Optional[str], optional): Host of postgres connection. Defaults to None.
+            port (Optional[str], optional): Port of postgres connection. Defaults to None.
+            database (Optional[str], optional): Postgres DB name. Defaults to None.
+            user (Optional[str], optional): Postgres username. Defaults to None.
+            password (Optional[str], optional): Postgres password. Defaults to None.
+            table_name (str): Table name. Defaults to "llamaindex".
+            schema_name (str): Schema name. Defaults to "public".
+            connection_string (Union[str, sqlalchemy.engine.URL]): Connection string to postgres db
+            async_connection_string (Union[str, sqlalchemy.engine.URL]): Connection string to async pg db
+            hybrid_search (bool, optional): Enable hybrid search. Defaults to False.
+            text_search_config (str, optional): Text search configuration. Defaults to "english".
+            embed_dim (int, optional): Embedding dimensions. Defaults to 1536.
+            cache_ok (bool, optional): Enable cache. Defaults to False.
+            perform_setup (bool, optional): If db should be set up. Defaults to True.
+            debug (bool, optional): Debug mode. Defaults to False.
+            use_jsonb (bool, optional): Use JSONB instead of JSON. Defaults to False.
+            hnsw_kwargs (Optional[Dict[str, Any]], optional): HNSW kwargs, a dict that
+                contains "hnsw_ef_construction", "hnsw_ef_search", "hnsw_m", and optionally "hnsw_dist_method". Defaults to None,
+                which turns off HNSW search.
+
+        Returns:
+            PGVectorStore: Instance of PGVectorStore constructed from params.
+        """
         conn_str = (
             connection_string
             or f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -557,7 +557,7 @@ class PGVectorStore(BasePydanticVectorStore):
             from sqlalchemy import text
 
             if self.hnsw_kwargs:
-                hnsw_ef_search = str(
+                hnsw_ef_search = (
                     kwargs.get("hnsw_ef_search") or self.hnsw_kwargs["hnsw_ef_search"]
                 )
                 await async_session.execute(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.1.12"
+version = "0.1.13"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -29,6 +29,7 @@ PARAMS: Dict[str, Union[str, int]] = {
     "port": 5432,
 }
 TEST_DB = "test_vector_db"
+TEST_DB_HNSW = "test_vector_db_hnsw"
 TEST_TABLE_NAME = "lorem_ipsum"
 TEST_SCHEMA_NAME = "test"
 TEST_EMBED_DIM = 2
@@ -79,6 +80,20 @@ def db(conn: Any) -> Generator:
 
 
 @pytest.fixture()
+def db_hnsw(conn: Any) -> Generator:
+    conn.autocommit = True
+
+    with conn.cursor() as c:
+        c.execute(f"DROP DATABASE IF EXISTS {TEST_DB_HNSW}")
+        c.execute(f"CREATE DATABASE {TEST_DB_HNSW}")
+        conn.commit()
+    yield
+    with conn.cursor() as c:
+        c.execute(f"DROP DATABASE {TEST_DB_HNSW}")
+        conn.commit()
+
+
+@pytest.fixture()
 def pg(db: None) -> Any:
     pg = PGVectorStore.from_params(
         **PARAMS,  # type: ignore
@@ -102,6 +117,39 @@ def pg_hybrid(db: None) -> Any:
         schema_name=TEST_SCHEMA_NAME,
         hybrid_search=True,
         embed_dim=TEST_EMBED_DIM,
+    )
+
+    yield pg
+
+    asyncio.run(pg.close())
+
+
+@pytest.fixture()
+def pg_hnsw(db_hnsw: None) -> Any:
+    pg = PGVectorStore.from_params(
+        **PARAMS,  # type: ignore
+        database=TEST_DB_HNSW,
+        table_name=TEST_TABLE_NAME,
+        schema_name=TEST_SCHEMA_NAME,
+        embed_dim=TEST_EMBED_DIM,
+        hnsw_kwargs={"hnsw_m": 16, "hnsw_ef_construction": 64, "hnsw_ef_search": 40},
+    )
+
+    yield pg
+
+    asyncio.run(pg.close())
+
+
+@pytest.fixture()
+def pg_hnsw_hybrid(db_hnsw: None) -> Any:
+    pg = PGVectorStore.from_params(
+        **PARAMS,  # type: ignore
+        database=TEST_DB_HNSW,
+        table_name=TEST_TABLE_NAME,
+        schema_name=TEST_SCHEMA_NAME,
+        embed_dim=TEST_EMBED_DIM,
+        hybrid_search=True,
+        hnsw_kwargs={"hnsw_m": 16, "hnsw_ef_construction": 64, "hnsw_ef_search": 40},
     )
 
     yield pg
@@ -230,6 +278,30 @@ async def test_add_to_db_and_query(
         res = await pg.aquery(q)
     else:
         res = pg.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 1
+    assert res.nodes[0].node_id == "aaa"
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_query_hnsw(
+    pg_hnsw: PGVectorStore, node_embeddings: List[TextNode], use_async: bool
+):
+    if use_async:
+        await pg_hnsw.async_add(node_embeddings)
+    else:
+        pg_hnsw.add(node_embeddings)
+
+    assert isinstance(pg_hnsw, PGVectorStore)
+    assert hasattr(pg_hnsw, "_engine")
+
+    q = VectorStoreQuery(query_embedding=_get_sample_vector(1.0), similarity_top_k=1)
+    if use_async:
+        res = await pg_hnsw.aquery(q)
+    else:
+        res = pg_hnsw.query(q)
     assert res.nodes
     assert len(res.nodes) == 1
     assert res.nodes[0].node_id == "aaa"
@@ -482,6 +554,78 @@ async def test_hybrid_query(
         res = await pg_hybrid.aquery(q)
     else:
         res = pg_hybrid.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 4
+    assert res.nodes[0].node_id == "aaa"
+    assert res.nodes[1].node_id == "bbb"
+    assert res.nodes[2].node_id == "ccc"
+    assert res.nodes[3].node_id == "ddd"
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_hybrid_query(
+    pg_hnsw_hybrid: PGVectorStore,
+    hybrid_node_embeddings: List[TextNode],
+    use_async: bool,
+) -> None:
+    if use_async:
+        await pg_hnsw_hybrid.async_add(hybrid_node_embeddings)
+    else:
+        pg_hnsw_hybrid.add(hybrid_node_embeddings)
+    assert isinstance(pg_hnsw_hybrid, PGVectorStore)
+    assert hasattr(pg_hnsw_hybrid, "_engine")
+
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.1),
+        query_str="fox",
+        similarity_top_k=2,
+        mode=VectorStoreQueryMode.HYBRID,
+        sparse_top_k=1,
+    )
+
+    if use_async:
+        res = await pg_hnsw_hybrid.aquery(q)
+    else:
+        res = pg_hnsw_hybrid.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 3
+    assert res.nodes[0].node_id == "aaa"
+    assert res.nodes[1].node_id == "bbb"
+    assert res.nodes[2].node_id == "ccc"
+
+    # if sparse_top_k is not specified, it should default to similarity_top_k
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.1),
+        query_str="fox",
+        similarity_top_k=2,
+        mode=VectorStoreQueryMode.HYBRID,
+    )
+
+    if use_async:
+        res = await pg_hnsw_hybrid.aquery(q)
+    else:
+        res = pg_hnsw_hybrid.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 4
+    assert res.nodes[0].node_id == "aaa"
+    assert res.nodes[1].node_id == "bbb"
+    assert res.nodes[2].node_id == "ccc"
+    assert res.nodes[3].node_id == "ddd"
+
+    # text search should work when query is a sentence and not just a single word
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.1),
+        query_str="who is the fox?",
+        similarity_top_k=2,
+        mode=VectorStoreQueryMode.HYBRID,
+    )
+
+    if use_async:
+        res = await pg_hnsw_hybrid.aquery(q)
+    else:
+        res = pg_hnsw_hybrid.query(q)
     assert res.nodes
     assert len(res.nodes) == 4
     assert res.nodes[0].node_id == "aaa"


### PR DESCRIPTION
# Description

Adds option to initialize a PGVectorStore with HNSW index options such as `m`, `ef_construction`, and `ef_search` using `hnsw_kwargs`.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

Not a new package

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
