### PR TITLE
Add extra_info to metadata field on document in RTFReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
@@ -12,7 +12,7 @@ class RTFReader(BaseReader):
     def load_data(
         self,
         input_file: Union[Path, str],
-        extra_info=Dict[str, Any],
+        extra_info=Dict[str, Any] | None = None,
         **load_kwargs: Any
     ) -> List[Document]:
         """Load data from RTF file.

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
@@ -1,6 +1,6 @@
 """RTF (Rich Text Format) reader."""
 from pathlib import Path
-from typing import List, Union, Any, Dict
+from typing import List, Union, Any, Dict, Optional
 
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
@@ -12,7 +12,7 @@ class RTFReader(BaseReader):
     def load_data(
         self,
         input_file: Union[Path, str],
-        extra_info=Dict[str, Any] | None = None,
+        extra_info=Optional[Dict[str, Any]] = None,
         **load_kwargs: Any
     ) -> List[Document]:
         """Load data from RTF file.

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
@@ -12,7 +12,7 @@ class RTFReader(BaseReader):
     def load_data(
         self,
         input_file: Union[Path, str],
-        extra_info=Optional[Dict[str, Any]] = None,
+        extra_info: Optional[Dict[str, Any]] = None,
         **load_kwargs: Any
     ) -> List[Document]:
         """Load data from RTF file.

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/rtf/base.py
@@ -31,4 +31,4 @@ class RTFReader(BaseReader):
 
         with open(str(input_file)) as f:
             text = rtf_to_text(f.read())
-            return [Document(text=text.strip())]
+            return [Document(text=text.strip(), metadata=extra_info or {})]

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -51,7 +51,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.1.31"
+version = "0.1.32"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Fixes bug where metadata is not passed into document when using RTFReader reader

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

