### PR TITLE
GitLab reader integration

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-gitlab/.gitignore
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/BUILD
@@ -1,1 +1,7 @@
-python_sources()
+poetry_requirements(
+    name="poetry",
+)
+
+python_requirements(
+    name="reqs",
+)

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/BUILD
@@ -1,7 +1,4 @@
 poetry_requirements(
     name="poetry",
-)
-
-python_requirements(
-    name="reqs",
+    module_mapping={"python-gitlab": ["gitlab"]}
 )

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/README.md
@@ -18,6 +18,14 @@ import gitlab
 from llama_index.readers.github import GitLabRepositoryReader
 
 gitlab_client = gitlab.Gitlab("https://gitlab.com")
+
+project_repo_reader = GitLabRepositoryReader(
+    gitlab_client=gitlab_client,
+    project_id=project_id,
+    verbose=True,
+)
+
+docs = project_repo_reader.load_data(file_path="README.rst", ref="develop")
 ```
 
 ## Issues Reader

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/README.md
@@ -1,0 +1,50 @@
+# LlamaIndex Readers Integration: Gitlab
+
+`pip install llama-index-readers-gitlab`
+
+The gitlab readers package leverages [python-gitlab](https://python-gitlab.readthedocs.io/en/stable/index.html) to fetch contents from gitlab projects. It consists of two separate readers:
+
+1. Repository Reader
+2. Issues Reader
+
+Access token or oauth token is required for private groups and projects.
+
+## Repository Reader
+
+This reader will read through files in a repo based on branch or commit.
+
+```python
+import gitlab
+from llama_index.readers.github import GitLabRepositoryReader
+
+gitlab_client = gitlab.Gitlab("https://gitlab.com")
+```
+
+## Issues Reader
+
+```python
+import gitlab
+from llama_index.readers.github import GitLabIssuesReader
+
+gitlab_client = gitlab.Gitlab("https://gitlab.com")
+
+# load issues by project id
+project_issues_reader = GitLabIssuesReader(
+    gitlab_client=gitlab_client,
+    project_id=project_id,
+    verbose=True,
+)
+
+docs = project_issues_reader.load_data(
+    state=GitLabIssuesReader.IssueState.OPEN
+)
+
+# load issues by group id
+group_issues_reader = GitLabIssuesReader(
+    gitlab_client=gitlab_client,
+    group_id=group_id,
+    verbose=True,
+)
+
+docs = group_issues_reader.load_data(state=GitLabIssuesReader.IssueState.OPEN)
+```

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/__init__.py
@@ -1,6 +1,8 @@
 from llama_index.readers.gitlab.issues.base import GitLabIssuesReader
+from llama_index.readers.gitlab.repository.base import GitLabRepositoryReader
 
 
 __all__ = [
     "GitLabIssuesReader",
+    "GitLabRepositoryReader",
 ]

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/__init__.py
@@ -1,0 +1,6 @@
+from llama_index.readers.gitlab.issues.base import GitLabIssuesReader
+
+
+__all__ = [
+    "GitLabIssuesReader",
+]

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/base.py
@@ -1,0 +1,220 @@
+""" GitLab issues reader. """
+
+from datetime import datetime
+import enum
+from typing import Any, List, Optional, Union
+
+import gitlab
+from gitlab.v4.objects import Issue as GitLabIssue
+from llama_index.core import Document
+from llama_index.core.readers.base import BaseReader
+
+
+class GitLabIssuesReader(BaseReader):
+    """
+    GitLab issues reader.
+    """
+
+    class IssueState(enum.Enum):
+        """
+        Issue type.
+
+        Used to decide what issues to retrieve.
+
+        Attributes:
+            - OPEN: Issues that are open.
+            - CLOSED: Issues that are closed.
+            - ALL: All issues, open and closed.
+        """
+
+        OPEN = "opened"
+        CLOSED = "closed"
+        ALL = "all"
+
+    class IssueType(enum.Enum):
+        """
+        Issue type.
+
+        Used to decide what issues to retrieve.
+
+        Attributes:
+            - ISSUE: Issues.
+            - INCIDENT: Incident.
+            - TEST_CASE: Test case.
+            - TASK: Task.
+        """
+
+        ISSUE = "issue"
+        INCIDENT = "incident"
+        TEST_CASE = "test_case"
+        TASK = "task"
+
+    class Scope(enum.Enum):
+        """
+        Scope.
+
+        Used to determine the scope of the issue.
+
+        Attributes:
+            - CREATED_BY_ME: Issues created by the authenticated user.
+            - ASSIGNED_TO_ME: Issues assigned to the authenticated user.
+            - ALL: All issues.
+        """
+
+        CREATED_BY_ME = "created_by_me"
+        ASSIGNED_TO_ME = "assigned_to_me"
+        ALL = "all"
+
+    def __init__(
+        self,
+        gitlab_client: gitlab.Gitlab,
+        project_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        verbose: bool = False,
+    ):
+        super().__init__()
+
+        self._gl = gitlab_client
+        self._project_id = project_id
+        self._group_id = group_id
+        self._verbose = verbose
+
+    def _build_document_from_issue(self, issue: GitLabIssue) -> Document:
+        issue_dict = issue.asdict()
+        title = issue_dict["title"]
+        description = issue_dict["description"]
+        document = Document(
+            doc_id=issue_dict["iid"],
+            text=f"{title}\n{description}",
+        )
+        extra_info = {
+            "state": issue_dict["state"],
+            "labels": issue_dict["labels"],
+            "created_at": issue_dict["created_at"],
+            "closed_at": issue_dict["closed_at"],
+            "url": issue_dict["_links"]["self"],  # API URL
+            "source": issue_dict["web_url"],  # HTML URL, more convenient for humans
+        }
+        if issue_dict["assignee"]:
+            extra_info["assignee"] = issue_dict["assignee"]["username"]
+        if issue_dict["author"]:
+            extra_info["author"] = issue_dict["author"]["username"]
+        document.extra_info = extra_info
+        return document
+
+    def _get_project_issues(self, **kwargs: Any) -> List[Document]:
+        project = self._gl.projects.get(self._project_id)
+        issues = project.issues.list(**kwargs)
+        return [self._build_document_from_issue(issue) for issue in issues]
+
+    def _get_group_issues(self, **kwargs: Any) -> List[Document]:
+        group = self._gl.groups.get(self._group_id)
+        issues = group.issues.list(**kwargs)
+        return [self._build_document_from_issue(issue) for issue in issues]
+
+    def _to_gitlab_datetime_format(self, dt: Optional[datetime]) -> str:
+        return dt.strftime("%Y-%m-%dT%H:%M:%S") if dt else None
+
+    def load_data(
+        self,
+        assignee: Optional[Union[str, int]] = None,
+        author: Optional[Union[str, int]] = None,
+        confidential: Optional[bool] = None,
+        created_after: Optional[datetime] = None,
+        created_before: Optional[datetime] = None,
+        iids: Optional[List[int]] = None,
+        issue_type: Optional[IssueType] = None,
+        labels: Optional[List[str]] = None,
+        milestone: Optional[str] = None,
+        non_archived: Optional[bool] = None,
+        scope: Optional[Scope] = None,
+        search: Optional[str] = None,
+        state: Optional[IssueState] = IssueState.OPEN,
+        updated_after: Optional[datetime] = None,
+        updated_before: Optional[datetime] = None,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """
+        Load group or project issues and converts them to documents. Please refer to the GitLab API documentation for the full list of parameters.
+
+        Each issue is converted to a document by doing the following:
+
+            - The doc_id of the document is the issue number.
+            - The text of the document is the concatenation of the title and the description of the issue.
+            - The extra_info of the document is a dictionary with the following keys:
+                - state: State of the issue.
+                - labels: List of labels of the issue.
+                - created_at: Date when the issue was created.
+                - closed_at: Date when the issue was closed. Only present if the issue is closed.
+                - url: URL of the issue.
+                - source: URL of the issue. More convenient for humans.
+                - assignee: username of the user assigned to the issue. Only present if the issue is assigned.
+
+        Args:
+            - assignee: Username or ID of the user assigned to the issue.
+            - author: Username or ID of the user that created the issue.
+            - confidential: Filter confidential issues.
+            - created_after: Filter issues created after the specified date.
+            - created_before: Filter issues created before the specified date.
+            - iids: Return only the issues having the given iid.
+            - issue_type: Filter issues by type.
+            - labels: List of label names, issues must have all labels to be returned.
+            - milestone: The milestone title.
+            - non_archived: Return issues from non archived projects.
+            - scope: Return issues for the given scope.
+            - search: Search issues against their title and description.
+            - state: State of the issues to retrieve.
+            - updated_after: Filter issues updated after the specified date.
+            - updated_before: Filter issues updated before the specified date.
+
+
+        Returns:
+            List[Document]: List of documents.
+        """
+        to_gitlab_datetime_format = self._to_gitlab_datetime_format
+        params = {
+            "confidential": confidential,
+            "created_after": to_gitlab_datetime_format(created_after),
+            "created_before": to_gitlab_datetime_format(created_before),
+            "iids": iids,
+            "issue_type": issue_type.value if issue_type else None,
+            "labels": labels,
+            "milestone": milestone,
+            "non_archived": non_archived,
+            "scope": scope.value if scope else None,
+            "search": search,
+            "state": state.value if state else None,
+            "updated_after": to_gitlab_datetime_format(updated_after),
+            "updated_before": to_gitlab_datetime_format(updated_before),
+        }
+
+        if isinstance(assignee, str):
+            params["assignee_username"] = assignee
+        elif isinstance(assignee, int):
+            params["assignee_id"] = assignee
+
+        if isinstance(author, str):
+            params["author_username"] = author
+        elif isinstance(author, int):
+            params["author_id"] = author
+
+        filtered_params = {k: v for k, v in params.items() if v is not None}
+
+        filtered_params.update(kwargs)
+
+        if self._project_id:
+            return self._get_project_issues(**filtered_params)
+        if self._group_id:
+            return self._get_group_issues(**filtered_params)
+        return []
+
+
+if __name__ == "__main__":
+    reader = GitLabIssuesReader(
+        gitlab_client=gitlab.Gitlab("https://gitlab.com"),
+        project_id=48082128,
+        group_id=10707808,
+        verbose=True,
+    )
+    docs = reader.load_data(state=GitLabIssuesReader.IssueState.OPEN)
+    print(docs)

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/base.py
@@ -102,15 +102,13 @@ class GitLabIssuesReader(BaseReader):
         document.extra_info = extra_info
         return document
 
-    def _get_project_issues(self, **kwargs: Any) -> List[Document]:
+    def _get_project_issues(self, **kwargs):
         project = self._gl.projects.get(self._project_id)
-        issues = project.issues.list(**kwargs)
-        return [self._build_document_from_issue(issue) for issue in issues]
+        return project.issues.list(**kwargs)
 
-    def _get_group_issues(self, **kwargs: Any) -> List[Document]:
+    def _get_group_issues(self, **kwargs):
         group = self._gl.groups.get(self._group_id)
-        issues = group.issues.list(**kwargs)
-        return [self._build_document_from_issue(issue) for issue in issues]
+        return group.issues.list(**kwargs)
 
     def _to_gitlab_datetime_format(self, dt: Optional[datetime]) -> str:
         return dt.strftime("%Y-%m-%dT%H:%M:%S") if dt else None
@@ -202,11 +200,14 @@ class GitLabIssuesReader(BaseReader):
 
         filtered_params.update(kwargs)
 
+        issues = []
+
         if self._project_id:
-            return self._get_project_issues(**filtered_params)
+            issues = self._get_project_issues(**filtered_params)
         if self._group_id:
-            return self._get_group_issues(**filtered_params)
-        return []
+            issues = self._get_group_issues(**filtered_params)
+
+        return [self._build_document_from_issue(issue) for issue in issues]
 
 
 if __name__ == "__main__":

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
@@ -24,6 +24,9 @@ class GitLabRepositoryReader(BaseReader):
 
         self._project = gitlab_client.projects.get(project_id)
 
+    def _parse_file_content(self, file_properties: dict, file_content: str) -> Document:
+        raise NotImplementedError
+
     def _load_single_file(self, file_path: str, ref: Optional[str] = None) -> Document:
         file = self._project.files.get(file_path=file_path, ref=ref)
         file_properties = file.asdict()

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
@@ -1,0 +1,98 @@
+""" GitLab repository reader. """
+
+from typing import List, Optional
+
+import gitlab
+from llama_index.core import Document
+from llama_index.core.readers.base import BaseReader
+
+
+class GitLabRepositoryReader(BaseReader):
+    def __init__(
+        self,
+        gitlab_client: gitlab.Gitlab,
+        project_id: int,
+        use_parser: bool = False,
+        verbose: bool = False,
+    ):
+        super().__init__()
+
+        self._gl = gitlab_client
+        self._use_parser = use_parser
+        self._verbose = verbose
+        self._project_url = f"{gitlab_client.api_url}/projects/{project_id}"
+
+        self._project = gitlab_client.projects.get(project_id)
+
+    def _load_single_file(self, file_path: str, ref: Optional[str] = None) -> Document:
+        file = self._project.files.get(file_path=file_path, ref=ref)
+        file_properties = file.asdict()
+        file_content = file.decode()
+
+        if self._use_parser:
+            return self._parse_file_content(file_properties, file_content)
+
+        return Document(
+            doc_id=file_properties["blob_id"],
+            text=file_content,
+            extra_info={
+                "file_path": file_properties["file_path"],
+                "file_name": file_properties["file_name"],
+                "size": file_properties["size"],
+                "url": f"{self._project_url}/projects/repository/files/{file_properties['file_path']}/raw",
+            },
+        )
+
+    def load_data(
+        self,
+        ref: str,
+        file_path: Optional[str] = None,
+        path: Optional[str] = None,
+        recursive: bool = False,
+    ) -> List[Document]:
+        """
+        Load data from a GitLab repository.
+
+        Args:
+            ref: The name of a repository branch or commit id
+            file_path: Path to the file to load.
+            path: Path to the directory to load.
+            recursive: Whether to load files recursively.
+
+        Returns:
+            List[Document]: List of documents loaded from the repository
+        """
+        if file_path:
+            return [self._load_single_file(file_path, ref)]
+
+        project = self._project
+
+        params = {
+            "ref": ref,
+            "path": path,
+            "recursive": recursive,
+        }
+
+        filtered_params = {k: v for k, v in params.items() if v is not None}
+
+        repo_items = project.repository_tree(**filtered_params)
+
+        documents = []
+
+        for item in repo_items:
+            if item["type"] == "blob":
+                document = self._load_single_file(item["path"], ref)
+
+            documents.append(document)
+
+        return documents
+
+
+if __name__ == "__main__":
+    reader = GitLabRepositoryReader(
+        gitlab_client=gitlab.Gitlab("https://gitlab.com"),
+        project_id=25527353,
+        verbose=True,
+    )
+    docs = reader.load_data(file_path="README.rst", ref="develop")
+    print(docs)

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
@@ -15,6 +15,7 @@ import_path = "llama_index.readers.gitlab"
 
 [tool.llamahub.class_authors]
 GitLabIssuesReader = "jiachengzhang1"
+GitLabRepositoryReader = "jiachengzhang1"
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+# Feel free to un-skip examples, and experimental, you will just need to
+# work through many typos (--write-changes and --interactive will help)
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.gitlab"
+
+[tool.llamahub.class_authors]
+GitLabIssuesReader = "jiachengzhang1"
+
+[tool.mypy]
+disallow_untyped_defs = true
+# Remove venv skip when integrated with pre-commit
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"
+
+[tool.poetry]
+authors = ["Jiacheng Zhang <jiachengzz@outlook.com>"]
+description = "llama-index readers gitlab integration"
+license = "MIT"
+maintainers = ["jiachengzhang1"]
+name = "llama-index-readers-gitlab"
+packages = [{include = "llama_index/"}]
+readme = "README.md"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = ">=3.8.1,<4.0"
+llama-index-core = "^0.10.0"
+python-gitlab = "^4.8.0"
+
+[tool.poetry.group.dev.dependencies]
+black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
+codespell = {extras = ["toml"], version = ">=v2.2.6"}
+ipython = "8.10.0"
+jupyter = "^1.0.0"
+mypy = "0.991"
+pre-commit = "3.2.0"
+pylint = "2.15.10"
+pytest = "7.2.1"
+pytest-mock = "3.11.1"
+ruff = "0.0.292"
+tree-sitter-languages = "^1.8.0"
+types-Deprecated = ">=0.1.0"
+types-PyYAML = "^6.0.12.12"
+types-protobuf = "^4.24.0.4"
+types-redis = "4.5.5.0"
+types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-setuptools = "67.1.0.0"

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/requirements.txt
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/requirements.txt
@@ -1,0 +1,1 @@
+python-gitlab

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/requirements.txt
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/requirements.txt
@@ -1,1 +1,0 @@
-python-gitlab

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/tests/BUILD
@@ -1,0 +1,6 @@
+python_tests(
+    name="tests",
+    dependencies=[
+        "llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/__init__.py"
+    ],
+)

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
@@ -3,6 +3,9 @@ from unittest.mock import MagicMock
 from llama_index.readers.gitlab import GitLabIssuesReader
 import gitlab
 
+# import so that pants sees it as a dependency
+import pytest_mock  # noqa
+
 
 @pytest.fixture()
 def gitlab_client_mock():

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
-from llama_index.readers.gitlab import GitLabIssuesReader, gitlab
+from llama_index.readers.gitlab import GitLabIssuesReader
+import gitlab
 
 
 @pytest.fixture()
@@ -30,14 +31,15 @@ def test_load_data_project_issues(gitlab_issues_reader, mocker):
         "assignee": {"username": "assignee_user"},
         "author": {"username": "author_user"},
     }
-    mock_project = MagicMock()
-    mock_project.issues.list.return_value = [mock_issue]
-    gitlab_issues_reader._gl.projects.get.return_value = mock_project
+
+    mocker.patch.object(
+        gitlab_issues_reader, "_get_project_issues", return_value=[mock_issue]
+    )
 
     documents = gitlab_issues_reader.load_data()
 
     assert len(documents) == 1
-    assert documents[0].doc_id == 1
+    assert documents[0].doc_id == "1"
     assert documents[0].text == "Issue title\nIssue description"
     assert documents[0].extra_info["state"] == "opened"
     assert documents[0].extra_info["labels"] == ["bug"]
@@ -66,14 +68,15 @@ def test_load_data_group_issues(gitlab_issues_reader, mocker):
         "assignee": {"username": "group_assignee_user"},
         "author": {"username": "group_author_user"},
     }
-    mock_group = MagicMock()
-    mock_group.issues.list.return_value = [mock_issue]
-    gitlab_issues_reader._gl.groups.get.return_value = mock_group
+
+    mocker.patch.object(
+        gitlab_issues_reader, "_get_group_issues", return_value=[mock_issue]
+    )
 
     documents = gitlab_issues_reader.load_data()
 
     assert len(documents) == 1
-    assert documents[0].doc_id == 2
+    assert documents[0].doc_id == "2"
     assert documents[0].text == "Group issue title\nGroup issue description"
     assert documents[0].extra_info["state"] == "closed"
     assert documents[0].extra_info["labels"] == ["enhancement"]

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import MagicMock
+from llama_index.readers.gitlab import GitLabIssuesReader, gitlab
+
+
+@pytest.fixture()
+def gitlab_client_mock():
+    return MagicMock(spec=gitlab.Gitlab)
+
+
+@pytest.fixture()
+def gitlab_issues_reader(gitlab_client_mock):
+    return GitLabIssuesReader(
+        gitlab_client=gitlab_client_mock, project_id=123, verbose=True
+    )
+
+
+def test_load_data_project_issues(gitlab_issues_reader, mocker):
+    mock_issue = MagicMock()
+    mock_issue.asdict.return_value = {
+        "iid": 1,
+        "title": "Issue title",
+        "description": "Issue description",
+        "state": "opened",
+        "labels": ["bug"],
+        "created_at": "2023-01-01T00:00:00",
+        "closed_at": None,
+        "_links": {"self": "http://api.url"},
+        "web_url": "http://web.url",
+        "assignee": {"username": "assignee_user"},
+        "author": {"username": "author_user"},
+    }
+    mock_project = MagicMock()
+    mock_project.issues.list.return_value = [mock_issue]
+    gitlab_issues_reader._gl.projects.get.return_value = mock_project
+
+    documents = gitlab_issues_reader.load_data()
+
+    assert len(documents) == 1
+    assert documents[0].doc_id == 1
+    assert documents[0].text == "Issue title\nIssue description"
+    assert documents[0].extra_info["state"] == "opened"
+    assert documents[0].extra_info["labels"] == ["bug"]
+    assert documents[0].extra_info["created_at"] == "2023-01-01T00:00:00"
+    assert documents[0].extra_info["url"] == "http://api.url"
+    assert documents[0].extra_info["source"] == "http://web.url"
+    assert documents[0].extra_info["assignee"] == "assignee_user"
+    assert documents[0].extra_info["author"] == "author_user"
+
+
+def test_load_data_group_issues(gitlab_issues_reader, mocker):
+    gitlab_issues_reader._project_id = None
+    gitlab_issues_reader._group_id = 456
+
+    mock_issue = MagicMock()
+    mock_issue.asdict.return_value = {
+        "iid": 2,
+        "title": "Group issue title",
+        "description": "Group issue description",
+        "state": "closed",
+        "labels": ["enhancement"],
+        "created_at": "2023-02-01T00:00:00",
+        "closed_at": "2023-02-02T00:00:00",
+        "_links": {"self": "http://api.group.url"},
+        "web_url": "http://web.group.url",
+        "assignee": {"username": "group_assignee_user"},
+        "author": {"username": "group_author_user"},
+    }
+    mock_group = MagicMock()
+    mock_group.issues.list.return_value = [mock_issue]
+    gitlab_issues_reader._gl.groups.get.return_value = mock_group
+
+    documents = gitlab_issues_reader.load_data()
+
+    assert len(documents) == 1
+    assert documents[0].doc_id == 2
+    assert documents[0].text == "Group issue title\nGroup issue description"
+    assert documents[0].extra_info["state"] == "closed"
+    assert documents[0].extra_info["labels"] == ["enhancement"]
+    assert documents[0].extra_info["created_at"] == "2023-02-01T00:00:00"
+    assert documents[0].extra_info["closed_at"] == "2023-02-02T00:00:00"
+    assert documents[0].extra_info["url"] == "http://api.group.url"
+    assert documents[0].extra_info["source"] == "http://web.group.url"
+    assert documents[0].extra_info["assignee"] == "group_assignee_user"
+    assert documents[0].extra_info["author"] == "group_author_user"

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_repository.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_repository.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest import mock
+from llama_index.readers.gitlab import GitLabRepositoryReader
+from llama_index.core import Document
+
+
+@pytest.fixture()
+def mock_gitlab_client():
+    client = mock.Mock()
+    client.api_url = "https://gitlab.com/api/v4"
+    client.projects.get.return_value = mock.Mock()
+    return client
+
+
+def test_initialization(mock_gitlab_client):
+    reader = GitLabRepositoryReader(gitlab_client=mock_gitlab_client, project_id=12345)
+    assert reader._gl == mock_gitlab_client
+    assert reader._project_url == "https://gitlab.com/api/v4/projects/12345"
+    assert reader._project == mock_gitlab_client.projects.get.return_value
+
+
+def test_load_single_file(mock_gitlab_client):
+    mock_project = mock_gitlab_client.projects.get.return_value
+    mock_file = mock.Mock()
+    mock_file.asdict.return_value = {
+        "blob_id": "123",
+        "file_path": "path/to/file",
+        "file_name": "file",
+        "size": 100,
+    }
+    mock_file.decode.return_value = "file content"
+    mock_project.files.get.return_value = mock_file
+
+    reader = GitLabRepositoryReader(gitlab_client=mock_gitlab_client, project_id=12345)
+    document = reader._load_single_file("path/to/file", "main")
+
+    assert document.doc_id == "123"
+    assert document.text == "file content"
+    assert document.extra_info["file_path"] == "path/to/file"
+    assert document.extra_info["file_name"] == "file"
+    assert document.extra_info["size"] == 100
+    assert (
+        document.extra_info["url"]
+        == "https://gitlab.com/api/v4/projects/12345/projects/repository/files/path/to/file/raw"
+    )
+
+
+def test_load_data(mock_gitlab_client):
+    mock_project = mock_gitlab_client.projects.get.return_value
+    mock_project.repository_tree.return_value = [
+        {"type": "blob", "path": "path/to/file1"},
+        {"type": "blob", "path": "path/to/file2"},
+    ]
+
+    reader = GitLabRepositoryReader(gitlab_client=mock_gitlab_client, project_id=12345)
+    reader._load_single_file = mock.Mock(
+        side_effect=[
+            Document(doc_id="1", text="content1", extra_info={}),
+            Document(doc_id="2", text="content2", extra_info={}),
+        ]
+    )
+
+    documents = reader.load_data(ref="main", path="path/to", recursive=True)
+
+    assert len(documents) == 2
+    assert documents[0].doc_id == "1"
+    assert documents[0].text == "content1"
+    assert documents[1].doc_id == "2"
+    assert documents[1].text == "content2"


### PR DESCRIPTION
# Description

Implemented gitlab reader by leveraging [python-gitlab](https://python-gitlab.readthedocs.io/en/stable/index.html) to fetch contents from gitlab projects. The integration mimics the existing GitHub reader. Additional parser capabilities are coming soon.

Two separate readers are provided:

1. Repository Reader
2. Issues Reader

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (new reader)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
