### PR TITLE
Jimmy/disable embeddings for sparse strategy

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -341,6 +341,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
         ids: List[str] = []
         for node in nodes:
             ids.append(node.node_id)
+            print("\n\nnode.get_embedding()", node.get_embedding())
             embeddings.append(node.get_embedding())
             texts.append(node.get_content(metadata_mode=MetadataMode.NONE))
             metadatas.append(node_to_metadata_dict(node, remove_text=True))
@@ -349,8 +350,10 @@ class ElasticsearchStore(BasePydanticVectorStore):
             self._store.num_dimensions = len(embeddings[0])
 
         # Omit the vectors argument entirely if embeddings aren't generated.
-        if not any(embeddings):
-            embeddings = None
+        # if not any(embeddings):
+        #     embeddings = None
+
+        embeddings = None
 
         return await self._store.add_texts(
             texts=texts,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -268,6 +268,14 @@ class ElasticsearchStore(BasePydanticVectorStore):
             retrieval_strategy=retrieval_strategy,
         )
 
+        # Check if retrieval_strategy is AsyncSparseVectorStrategy
+        print(
+            "DISABLE is_embedding_query?",
+            isinstance(retrieval_strategy, AsyncSparseVectorStrategy),
+        )
+        if isinstance(retrieval_strategy, AsyncSparseVectorStrategy):
+            self.is_embedding_query = False
+
     @property
     def client(self) -> Any:
         """Get async elasticsearch client."""

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -268,12 +268,9 @@ class ElasticsearchStore(BasePydanticVectorStore):
             retrieval_strategy=retrieval_strategy,
         )
 
-        # Check if retrieval_strategy is AsyncSparseVectorStrategy
-        print(
-            "DISABLE is_embedding_query?",
-            isinstance(retrieval_strategy, AsyncSparseVectorStrategy),
-        )
-        if isinstance(retrieval_strategy, AsyncSparseVectorStrategy):
+        # Disable query embeddings when using Sparse vectors or BM25.
+        # ELSER generates its own embeddings server-side
+        if not isinstance(retrieval_strategy, AsyncDenseVectorStrategy):
             self.is_embedding_query = False
 
     @property
@@ -343,25 +340,24 @@ class ElasticsearchStore(BasePydanticVectorStore):
         if len(nodes) == 0:
             return []
 
-        embeddings: List[List[float]] = []
+        embeddings: Optional[List[List[float]]] = None
         texts: List[str] = []
         metadatas: List[dict] = []
         ids: List[str] = []
         for node in nodes:
             ids.append(node.node_id)
-            print("\n\nnode.get_embedding()", node.get_embedding())
-            embeddings.append(node.get_embedding())
             texts.append(node.get_content(metadata_mode=MetadataMode.NONE))
             metadatas.append(node_to_metadata_dict(node, remove_text=True))
 
-        if not self._store.num_dimensions:
-            self._store.num_dimensions = len(embeddings[0])
+        # Generate embeddings when using dense vectors. They are not needed
+        # for other strategies.
+        if isinstance(self.retrieval_strategy, AsyncDenseVectorStrategy):
+            embeddings = []
+            for node in nodes:
+                embeddings.append(node.get_embedding())
 
-        # Omit the vectors argument entirely if embeddings aren't generated.
-        # if not any(embeddings):
-        #     embeddings = None
-
-        embeddings = None
+            if not self._store.num_dimensions:
+                self._store.num_dimensions = len(embeddings[0])
 
         return await self._store.add_texts(
             texts=texts,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

After integrating the change in https://github.com/run-llama/llama_index/pull/14918, I found that issue #14821 was still affecting my elasticsearch + ELSER-based vector store. This is another iteration that properly disables embedding generation both during indexing and querying.

Fixes #14821

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

I didn't create a notebook, but I've forked both the llamaindex and elasticsearch library and tested this code end-to-end against an ELSER-enabled elasticsearch index.

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
