### PR TITLE
Update base.py to use @atexit for cleanup

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -26,6 +26,7 @@ from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.llms.vllm.utils import get_response, post_http_request
 import atexit
 
+
 class Vllm(LLM):
     r"""Vllm LLM.
 
@@ -251,6 +252,7 @@ class Vllm(LLM):
     def close():
         import torch
         import gc
+
         if torch.cuda.is_available():
             gc.collect()
             torch.cuda.empty_cache()

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -252,7 +252,6 @@ class Vllm(LLM):
         import torch
         import gc
         if torch.cuda.is_available():
-            _client = None
             gc.collect()
             torch.cuda.empty_cache()
             torch.cuda.synchronize()

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -248,7 +248,7 @@ class Vllm(LLM):
         return {**base_kwargs}
 
     @atexit.register
-    def close():    
+    def close():
         import torch
         import gc
         if torch.cuda.is_available():

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -24,7 +24,7 @@ from llama_index.core.base.llms.generic_utils import (
 from llama_index.core.llms.llm import LLM
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.llms.vllm.utils import get_response, post_http_request
-
+import atexit
 
 class Vllm(LLM):
     r"""Vllm LLM.
@@ -247,12 +247,12 @@ class Vllm(LLM):
         }
         return {**base_kwargs}
 
-    def __del__(self) -> None:
+    @atexit.register
+    def close():    
         import torch
         import gc
-
         if torch.cuda.is_available():
-            del self._client
+            _client = None
             gc.collect()
             torch.cuda.empty_cache()
             torch.cuda.synchronize()

--- a/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vllm"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Change clean up to use @atexit to avoid crashes.

# Description

When using llama_index with vllm (based on github.com/ROCm/vllm) the system will crash during cleanup. This was reported by others at https://github.com/run-llama/llama_index/issues/13925

Fixes # 13925

## New Package 

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This was tested using a Docker container that built the ROCm/vllm code. The test program is:
```
from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, Settings
from llama_index.embeddings.huggingface import HuggingFaceEmbedding
from llama_index.llms.vllm import Vllm
documents = SimpleDirectoryReader("./files").load_data()
# bge-base embedding model
Settings.embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-base-en-v1.5")
# LLM
Settings.llm = Vllm(model="/data/llama-2-7b-chat-hf")
index = VectorStoreIndex.from_documents(
                                        documents,
                                       )
query_engine = index.as_query_engine()
response = query_engine.query("What did the author do growing up?")
print(response)
```
Tested the code with 1000 runs and it worked. The code failed each run without the fix.
No memory was observed and the output was correct.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
