### PR TITLE
Update base.py

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/maps/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/maps/base.py
@@ -26,7 +26,7 @@ class Review(BaseModel):
 class Place(BaseModel):
     reviews: List[Review]
     address: str
-    average_rating: int
+    average_rating: float
     display_name: str
     number_of_ratings: int
 

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -47,7 +47,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.2.9"
+version = "0.2.10"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
Fix the average_rating bug in google maps

# Description

The average rating in the places data should be float instead of int, e.g. "rating" : 4.4, otherwise, when you queried about the  highest rated restaurant, there will be a lot of ties.

Fixes # (issue)

## New Package?

- [ ] No

## Version Bump?

- [ ] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:
