### PR TITLE
Update neo4j_property_graph.py

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -427,10 +427,10 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
             WITH e
             MATCH (e)<-[r{':`' + '`|`'.join(relation_names) + '`' if relation_names else ''}]-(t:__Entity__)
             RETURN t.name AS source_id, [l in labels(t) WHERE l <> '__Entity__' | l][0] AS source_type,
-                   e{{.* , embedding: Null, name: Null}} AS source_properties,
+                   t{{.* , embedding: Null, name: Null}} AS source_properties,
                    type(r) AS type,
                    e.name AS target_id, [l in labels(e) WHERE l <> '__Entity__' | l][0] AS target_type,
-                   t{{.* , embedding: Null, name: Null}} AS target_properties
+                   e{{.* , embedding: Null, name: Null}} AS target_properties
         }}
         RETURN source_id, source_type, type, target_id, target_type, source_properties, target_properties"""
         cypher_statement += return_statement


### PR DESCRIPTION
# Description

The properties of target nodes is mistakenly returned as the properties of the source nodes. 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
