### PR TITLE
Update base.py

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/maps/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/maps/base.py
@@ -62,7 +62,7 @@ class GoogleMapsTextSearchReader(BaseReader):
                 break
             for place in places:
                 formatted_address = place["formattedAddress"]
-                rating = place["rating"]
+                average_rating = place["rating"]
                 display_name = place["displayName"]
                 if isinstance(display_name, dict):
                     display_name = display_name["text"]
@@ -85,7 +85,7 @@ class GoogleMapsTextSearchReader(BaseReader):
                 place = Place(
                     reviews=reviews,
                     address=formatted_address,
-                    average_rating=rating,
+                    average_rating=average_rating,
                     display_name=display_name,
                     number_of_ratings=number_of_ratings,
                 )

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -47,7 +47,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.2.10"
+version = "0.2.11"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
Fix the average_rating bug

# Description

After merging the PR (https://github.com/run-llama/llama_index/pull/15047), the bug is still not fully fixed. When I print the average rating in the data loader, the data type is now correct but the value seems to be casted from an integer:

Little Hunan Restaurant has rating: 5.0
Hot Wok Bistro has rating: 4.0
Little Shanghai Restaurant has rating: 2.0
Oceanic Restaurant has rating: 3.0
Town of dumpling has rating: 5.0

It is due to another bug that the rating was overwritten by the inner loop (line 75), we can fix it by renaming the variable. Please note that in Google's response, the place.rating field is the average rating.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:
