### PR TITLE
bugfixes for attribute check when retrieving site and correct parsing of file_path

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -157,7 +157,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
                     # find the site with the specified name
                     for site in json_response["value"]:
                         if (
-                            "name" in site 
+                            "name" in site
                             and site["name"].lower() == sharepoint_site_name.lower()
                         ):
                             return site["id"]

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -156,7 +156,10 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
                 ):
                     # find the site with the specified name
                     for site in json_response["value"]:
-                        if "name" in site and site["name"].lower() == sharepoint_site_name.lower():
+                        if (
+                            "name" in site
+                            and site["name"].lower() == sharepoint_site_name.lower()
+                        ):
                             return site["id"]
                     site_information_endpoint = json_response.get(
                         "@odata.nextLink", None
@@ -709,7 +712,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         # Get the file ID
         # remove the site_name prefix
         parts = [part for part in input_file.parts if part != self.sharepoint_site_name]
-        file_path = '/'.join(parts)
+        file_path = "/".join(parts)
         endpoint = f"{self._drive_id_endpoint}/{self._drive_id}/root:/{file_path}"
 
         response = requests.get(

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -156,7 +156,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
                 ):
                     # find the site with the specified name
                     for site in json_response["value"]:
-                        if site["name"].lower() == sharepoint_site_name.lower():
+                        if "name" in site and site["name"].lower() == sharepoint_site_name.lower():
                             return site["id"]
                     site_information_endpoint = json_response.get(
                         "@odata.nextLink", None
@@ -708,9 +708,8 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         """
         # Get the file ID
         # remove the site_name prefix
-        file_path = (
-            str(input_file).lstrip("/").replace(f"{self.sharepoint_site_name}/", "", 1)
-        )
+        parts = [part for part in input_file.parts if part != self.sharepoint_site_name]
+        file_path = '/'.join(parts)
         endpoint = f"{self._drive_id_endpoint}/{self._drive_id}/root:/{file_path}"
 
         response = requests.get(

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["arun-soliton"]
 name = "llama-index-readers-microsoft-sharepoint"
 readme = "README.md"
-version = "0.2.6"
+version = "0.2.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
1. When retrieving site perform neccessary check whether "name" is actually given
2. assembling filepath doesnt work with windows style paths ( // seperator), fixed

Fixes # (issue)
1. When retrieving site perform neccessary check whether "name" is actually given
2. assembling filepath doesnt work with windows style paths ( // seperator), fixed
## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x ] I stared at the code and made sure it makes sense
