### PR TITLE
update typing for workflow timeouts

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -30,7 +30,7 @@ class _WorkflowMeta(type):
 class Workflow(metaclass=_WorkflowMeta):
     def __init__(
         self,
-        timeout: int = 10,
+        timeout: Optional[float] = 10.0,
         disable_validation: bool = False,
         verbose: bool = False,
     ) -> None:


### PR DESCRIPTION
Technically it should be a float. It can also be optional (which disables the timeout)