### PR TITLE
bump pinecone client version

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
@@ -27,12 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-pinecone"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
 llama-index-core = "^0.10.11.post1"
-pinecone-client = "^3.0.2"
+pinecone-client = ">=3.0.2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/15120

4.0 is not a breaking change for llama-index. We can leave the version req a little loose for now.