### PR TITLE
Add get/set API to the Context and make it coroutine-safe

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -8,12 +8,12 @@ from .events import Event
 class Context:
     """A global object representing a context for a given workflow run.
 
-    The Context object can be used to store data that needs to be shared across iterations during a workflow execution.
-    Steps can use data stored in a Context object to keep a state across multiple executions within a workflow run.
-    Any Context instance offers two type of data storage: a global one, that's shared among all the steps within a
+    The Context object can be used to store data that needs to be available across iterations during a workflow
+    execution, and across multiple workflow runs.
+    Every context instance offers two type of data storage: a global one, that's shared among all the steps within a
     workflow, and private one, that's only accessible from a single step.
 
-    Both `set` and `get` operations on global data are governed by a lock, hence to be considered corountine-safe.
+    Both `set` and `get` operations on global data are governed by a lock, and considered coroutine-safe.
     """
 
     def __init__(self, parent: Optional["Context"] = None) -> None:

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -40,14 +40,6 @@ class Context:
         self._events_buffer: Dict[Type[Event], List[Event]] = defaultdict(list)
 
     @property
-    def parent(self) -> Optional["Context"]:
-        """Access this Context's parent object.
-
-        It returns `None` if the current context is root.
-        """
-        return self._parent
-
-    @property
     def globals(self) -> Dict[str, Any]:
         """Returns the local storage."""
         return self._globals
@@ -68,7 +60,7 @@ class Context:
     @property
     def lock(self) -> asyncio.Lock:
         """Returns a mutex to lock the Context."""
-        return self.parent._lock if self.parent else self._lock
+        return self._parent._lock if self._parent else self._lock
 
     async def __aenter__(self) -> "Context":
         await self.lock.acquire()

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -49,9 +49,8 @@ class Context:
             self._locals[key] = value
             return
 
-        await self.lock.acquire()
-        self._globals[key] = value
-        self.lock.release()
+        async with self.lock:
+            self._globals[key] = value
 
     async def get(self, key: str, default: Optional[Any] = None) -> Any:
         """Get the value corresponding to `key` from the Context.
@@ -66,10 +65,8 @@ class Context:
         if key in self._locals:
             return self._locals[key]
         elif key in self._globals:
-            await self.lock.acquire()
-            ret = self._globals[key]
-            self.lock.release()
-            return ret
+            async with self.lock:
+                return self._globals[key]
         elif default is not None:
             return default
 
@@ -80,7 +77,7 @@ class Context:
     def data(self):
         """This property is provided for backward compatibility.
 
-        Use `globals` instead.
+        Use `get` and `set` instead.
         """
         return self._globals
 

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,20 +1,87 @@
 from collections import defaultdict
+import asyncio
 from typing import Dict, Any, Optional, List, Type
+from types import TracebackType
 
 from .events import Event
 
 
 class Context:
+    """A global object representing a context for a given workflow run.
+
+    The Context object can be used to store data that needs to be shared across iterations during a workflow execution.
+    Steps can use data stored in a Context object to keep a state across multiple executions within a workflow run.
+    Any Context instance offers two type of data storage: `ctx.globals`, that's shared among all the steps within a
+    workflow, and `ctx.locals`, that's private to a single step.
+
+    Note that using `ctx.globals` is not coroutine-safe if you `await` for something in-between accessing
+    the global state. In that case, make sure to lock the Context object before accessing `ctx.globals`. You can also
+    use the Context object as an async context manager:
+
+        with ctx:
+            ctx.globals["foo"] = "bar"
+            await some_async_call()
+            ctx.globals["foo"] = "baz"
+    """
+
     def __init__(self, parent: Optional["Context"] = None) -> None:
-        # Global state
+        # Global data storage
         if parent:
-            self.data = parent.data
+            self._globals = parent.data
         else:
-            self.data: Dict[str, Any] = {}
+            self._globals: Dict[str, Any] = {}
+            self._lock = asyncio.Lock()
+
+        # Local data storage
+        self._locals: Dict[str, Any] = {}
 
         # Step-specific instance
-        self.parent = parent
+        self._parent: Optional[Context] = parent
         self._events_buffer: Dict[Type[Event], List[Event]] = defaultdict(list)
+
+    @property
+    def parent(self) -> Optional["Context"]:
+        """Access this Context's parent object.
+
+        It returns `None` if the current context is root.
+        """
+        return self._parent
+
+    @property
+    def globals(self) -> Dict[str, Any]:
+        """Returns the local storage."""
+        return self._globals
+
+    @property
+    def data(self):
+        """This property is provided for backward compatibility.
+
+        Use `globals` instead.
+        """
+        return self._globals
+
+    @property
+    def locals(self) -> Dict[str, Any]:
+        """Returns the local storage."""
+        return self._locals
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        """Returns a mutex to lock the Context."""
+        return self.parent._lock if self.parent else self._lock
+
+    async def __aenter__(self) -> "Context":
+        await self.lock.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self.lock.release()
+        return None
 
     def collect_events(
         self, ev: Event, expected: List[Type[Event]]

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -37,3 +37,46 @@ async def test_collect_events():
     workflow = TestWorkflow()
     result = await workflow.run()
     assert result == [ev1, ev2]
+
+
+@pytest.mark.asyncio()
+async def test_set_global():
+    c1 = Context()
+    await c1.set(key="test_key", value=42)
+
+    c2 = Context(parent=c1)
+    assert await c2.get(key="test_key") == 42
+
+
+@pytest.mark.asyncio()
+async def test_set_private():
+    c1 = Context()
+    await c1.set(key="test_key", value=42, make_private=True)
+    assert await c1.get(key="test_key") == 42
+
+    c2 = Context(parent=c1)
+    with pytest.raises(ValueError):
+        await c2.get(key="test_key")
+
+
+@pytest.mark.asyncio()
+async def test_set_private_duplicate():
+    c1 = Context()
+    await c1.set(key="test_key", value=42)
+
+    c2 = Context(parent=c1)
+    with pytest.raises(ValueError):
+        await c2.set(key="test_key", value=99, make_private=True)
+
+
+@pytest.mark.asyncio()
+async def test_get_default():
+    c1 = Context()
+    assert await c1.get(key="test_key", default=42) == 42
+
+
+@pytest.mark.asyncio()
+async def test_legacy_data():
+    c1 = Context()
+    await c1.set(key="test_key", value=42)
+    assert c1.data["test_key"] == 42


### PR DESCRIPTION
# Description

- Introduce `get` and `set` APIs and make them coroutine-safe
- Hide the actual storage data structures, so that the context can be implemented differently without breaking changes
- Introduce the concept of "private storaging" for data that shouldn't be shared across different steps

Fixes #15276

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
