### PR TITLE
make workflow context able to collect multiples of the same event

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import Dict, Any, Optional, List, Type
 
 from .events import Event
@@ -13,13 +14,11 @@ class Context:
 
         # Step-specific instance
         self.parent = parent
-        self._events_buffer: Dict[Type[Event], List[Event]] = {}
+        self._events_buffer: Dict[Type[Event], List[Event]] = defaultdict(list)
 
     def collect_events(
         self, ev: Event, expected: List[Type[Event]]
     ) -> Optional[List[Event]]:
-        if type(ev) not in self._events_buffer:
-            self._events_buffer[type(ev)] = []
         self._events_buffer[type(ev)].append(ev)
 
         retval: List[Event] = []


### PR DESCRIPTION
Currently, `context.collect_events` assumes one of each event type, but this kind of limits use-cases

What if we trigger and collect multiple of the same event?

This PR enables that