### PR TITLE
feat: Allow None metadata filter by using IS_EMPTY operator

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/simple.py
+++ b/llama-index-core/llama_index/core/vector_stores/simple.py
@@ -91,12 +91,19 @@ def _build_metadata_filter_fn(
         filter_matches_list = []
         for filter_ in filter_list:
             filter_matches = True
-
-            filter_matches = _process_filter_match(
-                operator=filter_.operator,
-                value=filter_.value,
-                metadata_value=metadata.get(filter_.key, None),
-            )
+            metadata_value = metadata.get(filter_.key, None)
+            if filter_.operator == FilterOperator.IS_EMPTY:
+                filter_matches = (
+                    metadata_value is None
+                    or metadata_value == ""
+                    or metadata_value == []
+                )
+            else:
+                filter_matches = _process_filter_match(
+                    operator=filter_.operator,
+                    value=filter_.value,
+                    metadata_value=metadata_value,
+                )
 
             filter_matches_list.append(filter_matches)
 

--- a/llama-index-core/llama_index/core/vector_stores/types.py
+++ b/llama-index-core/llama_index/core/vector_stores/types.py
@@ -95,14 +95,15 @@ class MetadataFilter(BaseModel):
     """
 
     key: str
-    value: Union[
-        StrictInt,
-        StrictFloat,
-        StrictStr,
-        List[StrictStr],
-        List[StrictFloat],
-        List[StrictInt],
-        None,
+    value: Optional[
+        Union[
+            StrictInt,
+            StrictFloat,
+            StrictStr,
+            List[StrictStr],
+            List[StrictFloat],
+            List[StrictInt],
+        ]
     ]
     operator: FilterOperator = FilterOperator.EQ
 

--- a/llama-index-core/llama_index/core/vector_stores/types.py
+++ b/llama-index-core/llama_index/core/vector_stores/types.py
@@ -74,6 +74,7 @@ class FilterOperator(str, Enum):
     ALL = "all"  # Contains all (array of strings)
     TEXT_MATCH = "text_match"  # full text match (allows you to search for a specific substring, token or phrase within the text field)
     CONTAINS = "contains"  # metadata array contains value (string or number)
+    IS_EMPTY = "is_empty"  # the field is not exist or empty (null or empty array)
 
 
 class FilterCondition(str, Enum):
@@ -101,6 +102,7 @@ class MetadataFilter(BaseModel):
         List[StrictStr],
         List[StrictFloat],
         List[StrictInt],
+        None,
     ]
     operator: FilterOperator = FilterOperator.EQ
 

--- a/llama-index-core/tests/vector_stores/test_simple.py
+++ b/llama-index-core/tests/vector_stores/test_simple.py
@@ -400,6 +400,23 @@ class SimpleVectorStoreTest(unittest.TestCase):
         assert result.ids is not None
         self.assertEqual(len(result.ids), 2)
 
+    def test_query_with_is_empty_filter_returns_matches(self) -> None:
+        simple_vector_store = SimpleVectorStore()
+        simple_vector_store.add(_node_embeddings_for_test())
+
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="not_existed_key", operator=FilterOperator.IS_EMPTY, value=None
+                )
+            ]
+        )
+        query = VectorStoreQuery(
+            query_embedding=[1.0, 1.0], filters=filters, similarity_top_k=3
+        )
+        result = simple_vector_store.query(query)
+        self.assertEqual(len(result.ids), len(_node_embeddings_for_test()))
+
     def test_clear(self) -> None:
         simple_vector_store = SimpleVectorStore()
         simple_vector_store.add(_node_embeddings_for_test())

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -44,8 +44,10 @@ from qdrant_client.http.models import (
     MatchText,
     MatchValue,
     Payload,
+    PayloadField,
     Range,
     HasIdCondition,
+    IsEmptyCondition,
 )
 
 logger = logging.getLogger(__name__)
@@ -1094,6 +1096,12 @@ class QdrantVectorStore(BasePydanticVectorStore):
                         key=subfilter.key,
                         match=MatchExcept(**{"except": values}),
                     )
+                )
+            elif subfilter.operator == FilterOperator.IS_EMPTY:
+                # This condition will match all records where the field reports either does not exist, or has null or [] value.
+                # https://qdrant.tech/documentation/concepts/filtering/#is-empty
+                conditions.append(
+                    IsEmptyCondition(is_empty=PayloadField(key=subfilter.key))
                 )
 
         filter = Filter()


### PR DESCRIPTION
# Description

From what I know, we currently don't support filtering for fields that don't exist in the metadata or have a null value. In reality, indexed data can come from various streams, and differences in metadata happen quite often. It would be great if we could support filtering with null values or allow fields that aren’t available in the metadata to be filtered as well.

So in this PR, I'd like to propose adding a filter: `is_empty(key)` filter - which would match all records that either don't have a key or have a key that is null or empty. This is similar to the `is_empty` filter from Qdrant: https://qdrant.tech/documentation/concepts/filtering/#is-empty

Let me know if you have any other ideas, and I can put together another PR for that!

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
