### PR TITLE
fix: use parent source node to node relationships if possible

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -70,6 +70,12 @@ class NodeParser(TransformComponent, ABC):
             parent_doc = parent_doc_map.get(node.ref_doc_id, None)
 
             if parent_doc is not None:
+                if parent_doc.source_node is not None:
+                    node.relationships.update(
+                        {
+                            NodeRelationship.SOURCE: parent_doc.source_node,
+                        }
+                    )
                 start_char_idx = parent_doc.text.find(
                     node.get_content(metadata_mode=MetadataMode.NONE)
                 )

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -4,7 +4,7 @@ from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.extractors import KeywordExtractor
 from llama_index.core.ingestion.pipeline import IngestionPipeline
 from llama_index.core.llms.mock import MockLLM
-from llama_index.core.node_parser import SentenceSplitter
+from llama_index.core.node_parser import SentenceSplitter, MarkdownElementNodeParser
 from llama_index.core.readers import ReaderConfig, StringIterableReader
 from llama_index.core.schema import Document
 from llama_index.core.storage.docstore import SimpleDocumentStore
@@ -55,6 +55,25 @@ def test_run_pipeline() -> None:
 
     assert len(nodes) == 2
     assert len(nodes[0].metadata) > 0
+
+
+def test_run_pipeline_with_parent_node():
+    documents = [
+        Document(text="one", doc_id="1"),
+    ]
+    pipeline = IngestionPipeline(
+        documents=documents,
+        transformations=[
+            MarkdownElementNodeParser(),
+            SentenceSplitter(),
+            MockEmbedding(embed_dim=8),
+        ],
+    )
+
+    nodes = pipeline.run()
+
+    assert len(nodes) == 1
+    assert nodes[0].ref_doc_id == "1"
 
 
 def test_save_load_pipeline() -> None:

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -57,7 +57,7 @@ def test_run_pipeline() -> None:
     assert len(nodes[0].metadata) > 0
 
 
-def test_run_pipeline_with_parent_node():
+def test_run_pipeline_with_ref_doc_id():
     documents = [
         Document(text="one", doc_id="1"),
     ]


### PR DESCRIPTION
# Description

Previously, in the e2e test, there was only one node parser so that the node relationship would be correctly linked to the original documents. But in the new code, it will have more than two node parsers, and then the node relationship will use the returns nodes from the first node parser, which has randomly node IDs, so this causes the node relationship to be inconstant so that it cannot link to the original doc.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
