### PR TITLE
bug: Semantic double merging splitter creates chunks larger thank chunk size

### DIFF
--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -21,7 +21,10 @@ doc = Document(
 
 try:
     splitter = SemanticDoubleMergingSplitterNodeParser(
-        initial_threshold=0.7, appending_threshold=0.8, merging_threshold=0.7
+        initial_threshold=0.7,
+        appending_threshold=0.8,
+        merging_threshold=0.7,
+        max_chunk_size=1000,
     )
     splitter.language_config.load_model()
     spacy_available = True
@@ -30,7 +33,7 @@ except Exception:
 
 
 @pytest.mark.skipif(not spacy_available, reason="Spacy model not available")
-def test_number_of_returned_nides() -> None:
+def test_number_of_returned_nodes() -> None:
     nodes = splitter.get_nodes_from_documents([doc])
 
     assert len(nodes) == 3
@@ -60,3 +63,41 @@ def test_config_models() -> None:
         LanguageConfig(language="empty", spacy_model="empty")
 
     LanguageConfig(language="english", spacy_model="en_core_web_md")
+
+
+@pytest.mark.skipif(not spacy_available, reason="Spacy model not available")
+def test_chunk_size_1() -> None:
+    splitter.max_chunk_size = 0
+    nodes = splitter.get_nodes_from_documents([doc])
+
+    # length of each sentence
+    assert len(nodes) == 13
+    assert len(nodes[0].get_content()) == 111
+    assert len(nodes[1].get_content()) == 72
+    assert len(nodes[2].get_content()) == 91
+    assert len(nodes[3].get_content()) == 99
+    assert len(nodes[4].get_content()) == 100
+    assert len(nodes[5].get_content()) == 66
+    assert len(nodes[6].get_content()) == 94
+    assert len(nodes[7].get_content()) == 100
+    assert len(nodes[8].get_content()) == 69
+    assert len(nodes[9].get_content()) == 95
+    assert len(nodes[10].get_content()) == 77
+    assert len(nodes[11].get_content()) == 114
+    assert len(nodes[12].get_content()) == 65
+
+
+@pytest.mark.skipif(not spacy_available, reason="Spacy model not available")
+def test_chunk_size_2() -> None:
+    splitter.max_chunk_size = 200
+    nodes = splitter.get_nodes_from_documents([doc])
+    assert len(nodes) == 9
+    assert len(nodes[0].get_content()) < 200
+    assert len(nodes[1].get_content()) < 200
+    assert len(nodes[2].get_content()) < 200
+    assert len(nodes[3].get_content()) < 200
+    assert len(nodes[4].get_content()) < 200
+    assert len(nodes[5].get_content()) < 200
+    assert len(nodes[6].get_content()) < 200
+    assert len(nodes[7].get_content()) < 200
+    assert len(nodes[8].get_content()) < 200


### PR DESCRIPTION
# Description
Fixed bug by adding proper conditions, checked the solution with tests.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
