### PR TITLE
fix: add num_workers in decorator to resolve step parallelism issue

### DIFF
--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -1,12 +1,11 @@
-from typing import Any, Callable, List, Optional, TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type
+
+from pydantic import Field
 
 from llama_index.core.bridge.pydantic import BaseModel
-from .utils import (
-    validate_step_signature,
-    is_free_function,
-)
-from .errors import WorkflowValidationError
 
+from .errors import WorkflowValidationError
+from .utils import is_free_function, validate_step_signature
 
 if TYPE_CHECKING:
     from .workflow import Workflow
@@ -17,9 +16,14 @@ class StepConfig(BaseModel):
     event_name: str
     return_types: List[Any]
     pass_context: bool
+    num_workers: int = Field(default=1, gt=0)
 
 
-def step(workflow: Optional[Type["Workflow"]] = None, pass_context: bool = False):
+def step(
+    workflow: Optional[Type["Workflow"]] = None,
+    pass_context: bool = False,
+    num_workers: int = 1,
+):
     """Decorator used to mark methods and functions as workflow steps.
 
     Decorators are evaluated at import time, but we need to wait for
@@ -45,6 +49,7 @@ def step(workflow: Optional[Type["Workflow"]] = None, pass_context: bool = False
             event_name=event_name,
             return_types=return_types,
             pass_context=pass_context,
+            num_workers=num_workers,
         )
 
         return func

--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type
 
-from pydantic import Field
-
 from llama_index.core.bridge.pydantic import BaseModel
 
 from .errors import WorkflowValidationError
@@ -16,7 +14,7 @@ class StepConfig(BaseModel):
     event_name: str
     return_types: List[Any]
     pass_context: bool
-    num_workers: int = Field(default=1, gt=0)
+    num_workers: int
 
 
 def step(
@@ -39,6 +37,11 @@ def step(
                 msg = f"To decorate {func.__name__} please pass a workflow instance to the @step() decorator."
                 raise WorkflowValidationError(msg)
             workflow.add_step(func)
+
+        if not isinstance(num_workers, int) or num_workers <= 0:
+            raise WorkflowValidationError(
+                "num_workers must be an integer greater than 0"
+            )
 
         # This will raise providing a message with the specific validation failure
         event_name, event_types, return_types = validate_step_signature(func)

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -1,10 +1,11 @@
 import re
 
 import pytest
+from pydantic import ValidationError
 
 from llama_index.core.workflow.decorators import step
-from llama_index.core.workflow.events import Event
 from llama_index.core.workflow.errors import WorkflowValidationError
+from llama_index.core.workflow.events import Event
 from llama_index.core.workflow.workflow import Workflow
 
 
@@ -48,4 +49,22 @@ def test_decorate_free_function_wrong_decorator():
 
         @step()
         def f(ev: Event) -> Event:
+            return Event()
+
+
+def test_decorate_free_function_wrong_num_workers():
+    # num_workers must be greater than 0
+    class TestWorkflow(Workflow):
+        pass
+
+    with pytest.raises(ValidationError):
+
+        @step(workflow=TestWorkflow, num_workers=0)
+        def f1(ev: Event) -> Event:
+            return Event()
+
+    with pytest.raises(ValidationError):
+
+        @step(workflow=TestWorkflow, num_workers=-1)
+        def f2(ev: Event) -> Event:
             return Event()

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-from pydantic import ValidationError
 
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.errors import WorkflowValidationError
@@ -53,18 +52,21 @@ def test_decorate_free_function_wrong_decorator():
 
 
 def test_decorate_free_function_wrong_num_workers():
-    # num_workers must be greater than 0
     class TestWorkflow(Workflow):
         pass
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(
+        WorkflowValidationError, match="num_workers must be an integer greater than 0"
+    ):
 
         @step(workflow=TestWorkflow, num_workers=0)
         def f1(ev: Event) -> Event:
             return Event()
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(
+        WorkflowValidationError, match="num_workers must be an integer greater than 0"
+    ):
 
-        @step(workflow=TestWorkflow, num_workers=-1)
+        @step(workflow=TestWorkflow, num_workers=0.5)
         def f2(ev: Event) -> Event:
             return Event()

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -1,16 +1,19 @@
-import pytest
 import asyncio
+import time
 
-from llama_index.core.workflow.workflow import (
-    Workflow,
-    WorkflowValidationError,
-    WorkflowTimeoutError,
-)
+import pytest
+from pydantic import ValidationError
+
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import StartEvent, StopEvent
+from llama_index.core.workflow.workflow import (
+    Context,
+    Workflow,
+    WorkflowTimeoutError,
+    WorkflowValidationError,
+)
 
-
-from .conftest import OneTestEvent
+from .conftest import AnotherTestEvent, LastEvent, OneTestEvent
 
 
 @pytest.mark.asyncio()
@@ -110,3 +113,67 @@ async def test_sync_async_steps():
     workflow = SyncAsyncWorkflow()
     await workflow.run()
     assert workflow.is_done()
+
+
+@pytest.mark.asyncio()
+async def test_workflow_num_workers():
+    class NumWorkersWorkflow(Workflow):
+        @step(pass_context=True)
+        async def original_step(
+            self, ctx: Context, ev: StartEvent
+        ) -> OneTestEvent | LastEvent:
+            ctx.data["num_to_collect"] = 3
+            self.send_event(OneTestEvent(test_param="test1"))
+            self.send_event(OneTestEvent(test_param="test2"))
+            self.send_event(OneTestEvent(test_param="test3"))
+
+            return LastEvent()
+
+        @step(num_workers=3)
+        async def test_step(self, ev: OneTestEvent) -> AnotherTestEvent:
+            await asyncio.sleep(1.0)
+            return AnotherTestEvent(another_test_param=ev.test_param)
+
+        @step(pass_context=True)
+        async def final_step(
+            self, ctx: Context, ev: AnotherTestEvent | LastEvent
+        ) -> StopEvent:
+            events = ctx.collect_events(
+                ev, [AnotherTestEvent] * ctx.data["num_to_collect"]
+            )
+            if events is None:
+                return None
+            return StopEvent(result=[ev.another_test_param for ev in events])
+
+    workflow = NumWorkersWorkflow()
+
+    start_time = time.time()
+    result = await workflow.run()
+    end_time = time.time()
+
+    assert workflow.is_done()
+    assert set(result) == {"test1", "test2", "test3"}
+
+    # Check if the execution time is close to 1 second (with some tolerance)
+    execution_time = end_time - start_time
+    assert (
+        1.0 <= execution_time < 1.1
+    ), f"Execution time was {execution_time:.2f} seconds"
+
+
+@pytest.mark.asyncio()
+async def test_workflow_num_workers_error():
+    # num_workers must be greater than 0
+    with pytest.raises(ValidationError):
+
+        class NumWorkersErrorWorkflow(Workflow):
+            @step(num_workers=0)
+            async def step1(self, ev: StartEvent) -> StopEvent:
+                return StopEvent(result="Done")
+
+    with pytest.raises(ValidationError):
+
+        class NumWorkersErrorWorkflow(Workflow):
+            @step(num_workers=-1)
+            async def step1(self, ev: StartEvent) -> StopEvent:
+                return StopEvent(result="Done")

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 
 import pytest
-from pydantic import ValidationError
 
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import StartEvent, StopEvent
@@ -159,21 +158,3 @@ async def test_workflow_num_workers():
     assert (
         1.0 <= execution_time < 1.1
     ), f"Execution time was {execution_time:.2f} seconds"
-
-
-@pytest.mark.asyncio()
-async def test_workflow_num_workers_error():
-    # num_workers must be greater than 0
-    with pytest.raises(ValidationError):
-
-        class NumWorkersErrorWorkflow(Workflow):
-            @step(num_workers=0)
-            async def step1(self, ev: StartEvent) -> StopEvent:
-                return StopEvent(result="Done")
-
-    with pytest.raises(ValidationError):
-
-        class NumWorkersErrorWorkflow(Workflow):
-            @step(num_workers=-1)
-            async def step1(self, ev: StartEvent) -> StopEvent:
-                return StopEvent(result="Done")


### PR DESCRIPTION
# Description

- Add `num_workers` param in `@step` decorator and `StepConfig` to make self._tasks add asyncio task `num_workers` times.
- Add unittests to check the value of  num_workers and whether async steps are work well.

Fixes #15204 

### Limitations
- `add_step` method currently doesn't support num_workers parameter, maybe need to fix it.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
