### PR TITLE
Remove deprecated `ServiceContext` from the `objects` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ credentials.json
 token.json
 .python-version
 .DS_Store
+storage/

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ credentials.json
 token.json
 .python-version
 .DS_Store
-storage/
+/storage/

--- a/llama-index-core/tests/objects/test_base.py
+++ b/llama-index-core/tests/objects/test_base.py
@@ -4,12 +4,11 @@ from llama_index.core.indices.list.base import SummaryIndex
 from llama_index.core.objects.base import ObjectIndex
 from llama_index.core.objects.base_node_mapping import SimpleObjectNodeMapping
 from llama_index.core.objects.tool_node_mapping import SimpleToolNodeMapping
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.schema import TextNode
 
 
-def test_object_index(mock_service_context: ServiceContext) -> None:
+def test_object_index() -> None:
     """Test object index."""
     object_mapping = SimpleObjectNodeMapping.from_objects(["a", "b", "c"])
     obj_index = ObjectIndex.from_objects(
@@ -23,7 +22,7 @@ def test_object_index(mock_service_context: ServiceContext) -> None:
     assert obj_index.as_retriever().retrieve("test") == ["a", "b", "c", "d"]
 
 
-def test_object_index_default_mapping(mock_service_context: ServiceContext) -> None:
+def test_object_index_default_mapping() -> None:
     """Test object index."""
     obj_index = ObjectIndex.from_objects(["a", "b", "c"], index_cls=SummaryIndex)
     # should just retrieve everything
@@ -34,7 +33,7 @@ def test_object_index_default_mapping(mock_service_context: ServiceContext) -> N
     assert obj_index.as_retriever().retrieve("test") == ["a", "b", "c", "d"]
 
 
-def test_object_index_fn_mapping(mock_service_context: ServiceContext) -> None:
+def test_object_index_fn_mapping() -> None:
     """Test object index."""
     objects = {obj: obj for obj in ["a", "b", "c", "d"]}
     print(objects)
@@ -60,7 +59,7 @@ def test_object_index_fn_mapping(mock_service_context: ServiceContext) -> None:
     assert obj_index.as_retriever().retrieve("test") == ["a", "b", "c", "d"]
 
 
-def test_object_index_persist(mock_service_context: ServiceContext) -> None:
+def test_object_index_persist() -> None:
     """Test object index persist/load."""
     object_mapping = SimpleObjectNodeMapping.from_objects(["a", "b", "c"])
     obj_index = ObjectIndex.from_objects(
@@ -88,7 +87,7 @@ def test_object_index_persist(mock_service_context: ServiceContext) -> None:
     )
 
 
-def test_object_index_with_tools(mock_service_context: ServiceContext) -> None:
+def test_object_index_with_tools() -> None:
     """Test object index with tools."""
     tool1 = FunctionTool.from_defaults(fn=lambda x: x, name="test_tool")
     tool2 = FunctionTool.from_defaults(fn=lambda x, y: x + y, name="test_tool2")

--- a/llama-index-core/tests/objects/test_node_mapping.py
+++ b/llama-index-core/tests/objects/test_node_mapping.py
@@ -12,7 +12,7 @@ from llama_index.core.tools.function_tool import FunctionTool
 from pytest_mock import MockerFixture
 
 
-class TestObject(BaseModel):
+class _TestObject(BaseModel):
     """Test object for node mapping."""
 
     __test__ = False
@@ -23,10 +23,10 @@ class TestObject(BaseModel):
         return hash(self.name)
 
     def __str__(self) -> str:
-        return f"TestObject(name='{self.name}')"
+        return f"_TestObject(name='{self.name}')"
 
 
-class TestSQLDatabase(SQLDatabase):
+class _TestSQLDatabase(SQLDatabase):
     """Test object for SQL Table Schema Node Mapping."""
 
     def __init__(self) -> None:
@@ -40,9 +40,9 @@ def test_simple_object_node_mapping() -> None:
     assert node_mapping.to_node("a").text == "a"
     assert node_mapping.from_node(node_mapping.to_node("a")) == "a"
 
-    objects = [TestObject(name="a"), TestObject(name="b"), TestObject(name="c")]
+    objects = [_TestObject(name="a"), _TestObject(name="b"), _TestObject(name="c")]
     node_mapping = SimpleObjectNodeMapping.from_objects(objects)
-    assert node_mapping.to_node(objects[0]).text == "TestObject(name='a')"
+    assert node_mapping.to_node(objects[0]).text == "_TestObject(name='a')"
     assert node_mapping.from_node(node_mapping.to_node(objects[0])) == objects[0]
 
 
@@ -102,7 +102,7 @@ def test_sql_table_node_mapping_to_node(mocker: MockerFixture) -> None:
     tables = [table1, table2]
 
     # Create the mapping
-    sql_database = TestSQLDatabase()
+    sql_database = _TestSQLDatabase()
     mapping = SQLTableNodeMapping(sql_database)
 
     # Create the nodes


### PR DESCRIPTION
# Description

Remove deprecated feature to prepare for the next minor release

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
