### PR TITLE
Remove deprecated `ServiceContext` from the `postprocessor` package

### DIFF
--- a/llama-index-core/tests/postprocessor/test_base.py
+++ b/llama-index-core/tests/postprocessor/test_base.py
@@ -22,7 +22,6 @@ from llama_index.core.schema import (
     RelatedNodeInfo,
     TextNode,
 )
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.storage.docstore.simple_docstore import SimpleDocumentStore
 
 spacy_installed = bool(find_spec("spacy"))
@@ -70,7 +69,10 @@ def test_forward_back_processor(tmp_path: Path) -> None:
         docstore=docstore, num_nodes=1, mode="next"
     )
     processed_nodes = node_postprocessor.postprocess_nodes(
-        [nodes_with_scores[1], nodes_with_scores[2]]
+        [
+            nodes_with_scores[1],
+            nodes_with_scores[2],
+        ]
     )
     assert len(processed_nodes) == 3
     assert processed_nodes[0].node.node_id == "2"
@@ -82,7 +84,10 @@ def test_forward_back_processor(tmp_path: Path) -> None:
         docstore=docstore, num_nodes=1, mode="previous"
     )
     processed_nodes = node_postprocessor.postprocess_nodes(
-        [nodes_with_scores[1], nodes_with_scores[2]]
+        [
+            nodes_with_scores[1],
+            nodes_with_scores[2],
+        ]
     )
     assert len(processed_nodes) == 3
     assert processed_nodes[0].node.node_id == "3"
@@ -118,7 +123,10 @@ def test_forward_back_processor(tmp_path: Path) -> None:
         docstore=docstore, num_nodes=1, mode="both"
     )
     processed_nodes = node_postprocessor.postprocess_nodes(
-        [nodes_with_scores[0], nodes_with_scores[4]]
+        [
+            nodes_with_scores[0],
+            nodes_with_scores[4],
+        ]
     )
     assert len(processed_nodes) == 4
     # nodes are sorted
@@ -132,7 +140,10 @@ def test_forward_back_processor(tmp_path: Path) -> None:
         docstore=docstore, num_nodes=0, mode="both"
     )
     processed_nodes = node_postprocessor.postprocess_nodes(
-        [nodes_with_scores[0], nodes_with_scores[4]]
+        [
+            nodes_with_scores[0],
+            nodes_with_scores[4],
+        ]
     )
     assert len(processed_nodes) == 2
     # nodes are sorted
@@ -144,9 +155,7 @@ def test_forward_back_processor(tmp_path: Path) -> None:
         PrevNextNodePostprocessor(docstore=docstore, num_nodes=4, mode="asdfasdf")
 
 
-def test_fixed_recency_postprocessor(
-    mock_service_context: ServiceContext,
-) -> None:
+def test_fixed_recency_postprocessor() -> None:
     """Test fixed recency processor."""
     # try in metadata
     nodes = [
@@ -177,9 +186,7 @@ def test_fixed_recency_postprocessor(
     ]
     node_with_scores = [NodeWithScore(node=node) for node in nodes]
 
-    postprocessor = FixedRecencyPostprocessor(
-        top_k=1, service_context=mock_service_context
-    )
+    postprocessor = FixedRecencyPostprocessor(top_k=1)
     query_bundle: QueryBundle = QueryBundle(query_str="What is?")
     result_nodes = postprocessor.postprocess_nodes(
         node_with_scores, query_bundle=query_bundle
@@ -191,9 +198,7 @@ def test_fixed_recency_postprocessor(
     )
 
 
-def test_embedding_recency_postprocessor(
-    mock_service_context: ServiceContext,
-) -> None:
+def test_embedding_recency_postprocessor() -> None:
     """Test fixed recency processor."""
     # try in node info
     nodes = [
@@ -232,7 +237,6 @@ def test_embedding_recency_postprocessor(
 
     postprocessor = EmbeddingRecencyPostprocessor(
         top_k=1,
-        embed_model=mock_service_context.embed_model,
         in_metadata=False,
         query_embedding_tmpl="{context_str}",
     )

--- a/llama-index-core/tests/postprocessor/test_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_llm_rerank.py
@@ -7,7 +7,6 @@ from llama_index.core.llms.mock import MockLLM
 from llama_index.core.postprocessor.llm_rerank import LLMRerank
 from llama_index.core.prompts import BasePromptTemplate
 from llama_index.core.schema import BaseNode, NodeWithScore, QueryBundle, TextNode
-from llama_index.core.service_context import ServiceContext
 
 
 def mock_llmpredictor_predict(
@@ -46,7 +45,7 @@ def mock_format_node_batch_fn(nodes: List[BaseNode]) -> str:
     "predict",
     mock_llmpredictor_predict,
 )
-def test_llm_rerank(mock_service_context: ServiceContext) -> None:
+def test_llm_rerank() -> None:
     """Test LLM rerank."""
     nodes = [
         TextNode(text="Test"),
@@ -63,10 +62,7 @@ def test_llm_rerank(mock_service_context: ServiceContext) -> None:
     # choice batch size 4 (so two batches)
     # take top-3 across all data
     llm_rerank = LLMRerank(
-        format_node_batch_fn=mock_format_node_batch_fn,
-        choice_batch_size=4,
-        top_n=3,
-        service_context=mock_service_context,
+        format_node_batch_fn=mock_format_node_batch_fn, choice_batch_size=4, top_n=3
     )
     query_str = "What is?"
     result_nodes = llm_rerank.postprocess_nodes(


### PR DESCRIPTION
# Description

Remove deprecated feature to prepare for the next minor release

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
