### PR TITLE
Remove deprecated `ServiceContext` from the response synths

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/retriever_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/retriever_query_engine.py
@@ -16,12 +16,7 @@ from llama_index.core.response_synthesizers import (
     get_response_synthesizer,
 )
 from llama_index.core.schema import NodeWithScore, QueryBundle
-from llama_index.core.service_context import ServiceContext
-from llama_index.core.settings import (
-    Settings,
-    callback_manager_from_settings_or_context,
-    llm_from_settings_or_context,
-)
+from llama_index.core.settings import Settings
 import llama_index.core.instrumentation as instrument
 
 dispatcher = instrument.get_dispatcher(__name__)
@@ -46,11 +41,8 @@ class RetrieverQueryEngine(BaseQueryEngine):
     ) -> None:
         self._retriever = retriever
         self._response_synthesizer = response_synthesizer or get_response_synthesizer(
-            llm=llm_from_settings_or_context(Settings, retriever.get_service_context()),
-            callback_manager=callback_manager
-            or callback_manager_from_settings_or_context(
-                Settings, retriever.get_service_context()
-            ),
+            llm=Settings.llm,
+            callback_manager=callback_manager or Settings.callback_manager,
         )
 
         self._node_postprocessors = node_postprocessors or []
@@ -81,15 +73,12 @@ class RetrieverQueryEngine(BaseQueryEngine):
         output_cls: Optional[BaseModel] = None,
         use_async: bool = False,
         streaming: bool = False,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
         **kwargs: Any,
     ) -> "RetrieverQueryEngine":
         """Initialize a RetrieverQueryEngine object.".
 
         Args:
             retriever (BaseRetriever): A retriever object.
-            service_context (Optional[ServiceContext]): A ServiceContext object.
             node_postprocessors (Optional[List[BaseNodePostprocessor]]): A list of
                 node postprocessors.
             verbose (bool): Whether to print out debug info.
@@ -105,11 +94,10 @@ class RetrieverQueryEngine(BaseQueryEngine):
                 object.
 
         """
-        llm = llm or llm_from_settings_or_context(Settings, service_context)
+        llm = llm or Settings.llm
 
         response_synthesizer = response_synthesizer or get_response_synthesizer(
             llm=llm,
-            service_context=service_context,
             text_qa_template=text_qa_template,
             refine_template=refine_template,
             summary_template=summary_template,
@@ -120,9 +108,7 @@ class RetrieverQueryEngine(BaseQueryEngine):
             streaming=streaming,
         )
 
-        callback_manager = callback_manager_from_settings_or_context(
-            Settings, service_context
-        )
+        callback_manager = Settings.callback_manager
 
         return cls(
             retriever=retriever,

--- a/llama-index-core/llama_index/core/response_synthesizers/accumulate.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/accumulate.py
@@ -10,7 +10,6 @@ from llama_index.core.prompts.default_prompt_selectors import (
 )
 from llama_index.core.prompts.mixin import PromptDictType
 from llama_index.core.response_synthesizers.base import BaseSynthesizer
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 from llama_index.core.types import RESPONSE_TEXT_TYPE
 
@@ -27,14 +26,11 @@ class Accumulate(BaseSynthesizer):
         output_cls: Optional[Any] = None,
         streaming: bool = False,
         use_async: bool = False,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
     ) -> None:
         super().__init__(
             llm=llm,
             callback_manager=callback_manager,
             prompt_helper=prompt_helper,
-            service_context=service_context,
             streaming=streaming,
         )
         self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -38,13 +38,8 @@ from llama_index.core.schema import (
     QueryBundle,
     QueryType,
 )
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
-from llama_index.core.settings import (
-    Settings,
-    callback_manager_from_settings_or_context,
-    llm_from_settings_or_context,
-)
+from llama_index.core.settings import Settings
 from llama_index.core.types import RESPONSE_TEXT_TYPE
 from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.instrumentation.events.synthesis import (
@@ -78,20 +73,15 @@ class BaseSynthesizer(ChainableMixin, PromptMixin, DispatcherSpanMixin):
         callback_manager: Optional[CallbackManager] = None,
         prompt_helper: Optional[PromptHelper] = None,
         streaming: bool = False,
-        output_cls: BaseModel = None,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
+        output_cls: Optional[BaseModel] = None,
     ) -> None:
         """Init params."""
-        self._llm = llm or llm_from_settings_or_context(Settings, service_context)
+        self._llm = llm or Settings.llm
 
         if callback_manager:
             self._llm.callback_manager = callback_manager
 
-        self._callback_manager = (
-            callback_manager
-            or callback_manager_from_settings_or_context(Settings, service_context)
-        )
+        self._callback_manager = callback_manager or Settings.callback_manager
 
         self._prompt_helper = (
             prompt_helper

--- a/llama-index-core/llama_index/core/response_synthesizers/factory.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/factory.py
@@ -26,20 +26,14 @@ from llama_index.core.response_synthesizers.refine import Refine
 from llama_index.core.response_synthesizers.simple_summarize import SimpleSummarize
 from llama_index.core.response_synthesizers.tree_summarize import TreeSummarize
 from llama_index.core.response_synthesizers.type import ResponseMode
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
-from llama_index.core.settings import (
-    Settings,
-    callback_manager_from_settings_or_context,
-    llm_from_settings_or_context,
-)
+from llama_index.core.settings import Settings
 from llama_index.core.types import BasePydanticProgram
 
 
 def get_response_synthesizer(
     llm: Optional[LLMPredictorType] = None,
     prompt_helper: Optional[PromptHelper] = None,
-    service_context: Optional[ServiceContext] = None,
     text_qa_template: Optional[BasePromptTemplate] = None,
     refine_template: Optional[BasePromptTemplate] = None,
     summary_template: Optional[BasePromptTemplate] = None,
@@ -59,21 +53,15 @@ def get_response_synthesizer(
     simple_template = simple_template or DEFAULT_SIMPLE_INPUT_PROMPT
     summary_template = summary_template or DEFAULT_TREE_SUMMARIZE_PROMPT_SEL
 
-    callback_manager = callback_manager or callback_manager_from_settings_or_context(
-        Settings, service_context
-    )
-    llm = llm or llm_from_settings_or_context(Settings, service_context)
-
-    if service_context is not None:
-        prompt_helper = service_context.prompt_helper
-    else:
-        prompt_helper = (
-            prompt_helper
-            or Settings._prompt_helper
-            or PromptHelper.from_llm_metadata(
-                llm.metadata,
-            )
+    callback_manager = callback_manager or Settings.callback_manager
+    llm = llm or Settings.llm
+    prompt_helper = (
+        prompt_helper
+        or Settings._prompt_helper
+        or PromptHelper.from_llm_metadata(
+            llm.metadata,
         )
+    )
 
     if response_mode == ResponseMode.REFINE:
         return Refine(
@@ -87,8 +75,6 @@ def get_response_synthesizer(
             structured_answer_filtering=structured_answer_filtering,
             program_factory=program_factory,
             verbose=verbose,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.COMPACT:
         return CompactAndRefine(
@@ -102,8 +88,6 @@ def get_response_synthesizer(
             structured_answer_filtering=structured_answer_filtering,
             program_factory=program_factory,
             verbose=verbose,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.TREE_SUMMARIZE:
         return TreeSummarize(
@@ -115,8 +99,6 @@ def get_response_synthesizer(
             streaming=streaming,
             use_async=use_async,
             verbose=verbose,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.SIMPLE_SUMMARIZE:
         return SimpleSummarize(
@@ -125,8 +107,6 @@ def get_response_synthesizer(
             prompt_helper=prompt_helper,
             text_qa_template=text_qa_template,
             streaming=streaming,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.GENERATION:
         return Generation(
@@ -135,8 +115,6 @@ def get_response_synthesizer(
             prompt_helper=prompt_helper,
             simple_template=simple_template,
             streaming=streaming,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.ACCUMULATE:
         return Accumulate(
@@ -147,8 +125,6 @@ def get_response_synthesizer(
             output_cls=output_cls,
             streaming=streaming,
             use_async=use_async,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.COMPACT_ACCUMULATE:
         return CompactAndAccumulate(
@@ -159,22 +135,16 @@ def get_response_synthesizer(
             output_cls=output_cls,
             streaming=streaming,
             use_async=use_async,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.NO_TEXT:
         return NoText(
             callback_manager=callback_manager,
             streaming=streaming,
-            # deprecated
-            service_context=service_context,
         )
     elif response_mode == ResponseMode.CONTEXT_ONLY:
         return ContextOnly(
             callback_manager=callback_manager,
             streaming=streaming,
-            # deprecated
-            service_context=service_context,
         )
     else:
         raise ValueError(f"Unknown mode: {response_mode}")

--- a/llama-index-core/llama_index/core/response_synthesizers/generation.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/generation.py
@@ -6,7 +6,6 @@ from llama_index.core.prompts import BasePromptTemplate
 from llama_index.core.prompts.default_prompts import DEFAULT_SIMPLE_INPUT_PROMPT
 from llama_index.core.prompts.mixin import PromptDictType
 from llama_index.core.response_synthesizers.base import BaseSynthesizer
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 from llama_index.core.types import RESPONSE_TEXT_TYPE
 
@@ -19,17 +18,11 @@ class Generation(BaseSynthesizer):
         prompt_helper: Optional[PromptHelper] = None,
         simple_template: Optional[BasePromptTemplate] = None,
         streaming: bool = False,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
     ) -> None:
-        if service_context is not None:
-            prompt_helper = service_context.prompt_helper
-
         super().__init__(
             llm=llm,
             callback_manager=callback_manager,
             prompt_helper=prompt_helper,
-            service_context=service_context,
             streaming=streaming,
         )
         self._input_prompt = simple_template or DEFAULT_SIMPLE_INPUT_PROMPT

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -22,7 +22,6 @@ from llama_index.core.prompts.default_prompt_selectors import (
 from llama_index.core.prompts.mixin import PromptDictType
 from llama_index.core.response.utils import get_response_text, aget_response_text
 from llama_index.core.response_synthesizers.base import BaseSynthesizer
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import (
     LLMPredictorType,
 )
@@ -120,17 +119,11 @@ class Refine(BaseSynthesizer):
         program_factory: Optional[
             Callable[[BasePromptTemplate], BasePydanticProgram]
         ] = None,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
     ) -> None:
-        if service_context is not None:
-            prompt_helper = service_context.prompt_helper
-
         super().__init__(
             llm=llm,
             callback_manager=callback_manager,
             prompt_helper=prompt_helper,
-            service_context=service_context,
             streaming=streaming,
         )
         self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL

--- a/llama-index-core/llama_index/core/response_synthesizers/simple_summarize.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/simple_summarize.py
@@ -8,7 +8,6 @@ from llama_index.core.prompts.default_prompt_selectors import (
 )
 from llama_index.core.prompts.mixin import PromptDictType
 from llama_index.core.response_synthesizers.base import BaseSynthesizer
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 from llama_index.core.types import RESPONSE_TEXT_TYPE
 
@@ -21,17 +20,11 @@ class SimpleSummarize(BaseSynthesizer):
         prompt_helper: Optional[PromptHelper] = None,
         text_qa_template: Optional[BasePromptTemplate] = None,
         streaming: bool = False,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
     ) -> None:
-        if service_context is not None:
-            prompt_helper = service_context.prompt_helper
-
         super().__init__(
             llm=llm,
             callback_manager=callback_manager,
             prompt_helper=prompt_helper,
-            service_context=service_context,
             streaming=streaming,
         )
         self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL

--- a/llama-index-core/llama_index/core/response_synthesizers/tree_summarize.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/tree_summarize.py
@@ -10,7 +10,6 @@ from llama_index.core.prompts.default_prompt_selectors import (
 )
 from llama_index.core.prompts.mixin import PromptDictType
 from llama_index.core.response_synthesizers.base import BaseSynthesizer
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import LLMPredictorType
 from llama_index.core.types import RESPONSE_TEXT_TYPE, BaseModel
 
@@ -38,17 +37,11 @@ class TreeSummarize(BaseSynthesizer):
         streaming: bool = False,
         use_async: bool = False,
         verbose: bool = False,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
     ) -> None:
-        if service_context is not None:
-            prompt_helper = service_context.prompt_helper
-
         super().__init__(
             llm=llm,
             callback_manager=callback_manager,
             prompt_helper=prompt_helper,
-            service_context=service_context,
             streaming=streaming,
             output_cls=output_cls,
         )

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -3,10 +3,8 @@ from typing import Any, Dict, Optional, Type, cast
 
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel
-from llama_index.core.callbacks import CallbackManager
 from llama_index.core.response_synthesizers import Refine
 from llama_index.core.response_synthesizers.refine import StructuredRefineResponse
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.types import BasePydanticProgram
 
 
@@ -28,7 +26,7 @@ class MockRefineProgram(BasePydanticProgram):
         *args: Any,
         context_str: Optional[str] = None,
         context_msg: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> StructuredRefineResponse:
         input_str = context_str or context_msg
         input_str = cast(str, input_str)
@@ -42,7 +40,7 @@ class MockRefineProgram(BasePydanticProgram):
         *args: Any,
         context_str: Optional[str] = None,
         context_msg: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> StructuredRefineResponse:
         input_str = context_str or context_msg
         input_str = cast(str, input_str)
@@ -53,45 +51,31 @@ class MockRefineProgram(BasePydanticProgram):
 
 
 @pytest.fixture()
-def mock_refine_service_context(patch_llm_predictor: Any) -> ServiceContext:
-    cb_manager = CallbackManager([])
-    return ServiceContext.from_defaults(
-        llm_predictor=patch_llm_predictor,
-        callback_manager=cb_manager,
-    )
-
-
-@pytest.fixture()
-def refine_instance(mock_refine_service_context: ServiceContext) -> Refine:
+def refine_instance() -> Refine:
     return Refine(
-        service_context=mock_refine_service_context,
         streaming=False,
         verbose=True,
         structured_answer_filtering=True,
     )
 
 
-def test_constructor_args(mock_refine_service_context: ServiceContext) -> None:
+def test_constructor_args() -> None:
     with pytest.raises(ValueError):
         # can't construct refine with both streaming and answer filtering
         Refine(
-            service_context=mock_refine_service_context,
             streaming=True,
             structured_answer_filtering=True,
         )
     with pytest.raises(ValueError):
         # can't construct refine with a program factory but not answer filtering
         Refine(
-            service_context=mock_refine_service_context,
             program_factory=lambda _: MockRefineProgram({}),
             structured_answer_filtering=False,
         )
 
 
 @pytest.mark.asyncio()
-async def test_answer_filtering_one_answer(
-    mock_refine_service_context: ServiceContext,
-) -> None:
+async def test_answer_filtering_one_answer() -> None:
     input_to_query_satisfied = OrderedDict(
         [
             ("input1", False),
@@ -104,7 +88,6 @@ async def test_answer_filtering_one_answer(
         return MockRefineProgram(input_to_query_satisfied)
 
     refine_instance = Refine(
-        service_context=mock_refine_service_context,
         structured_answer_filtering=True,
         program_factory=program_factory,
     )
@@ -115,9 +98,7 @@ async def test_answer_filtering_one_answer(
 
 
 @pytest.mark.asyncio()
-async def test_answer_filtering_no_answers(
-    mock_refine_service_context: ServiceContext,
-) -> None:
+async def test_answer_filtering_no_answers() -> None:
     input_to_query_satisfied = OrderedDict(
         [
             ("input1", False),
@@ -130,7 +111,6 @@ async def test_answer_filtering_no_answers(
         return MockRefineProgram(input_to_query_satisfied)
 
     refine_instance = Refine(
-        service_context=mock_refine_service_context,
         structured_answer_filtering=True,
         program_factory=program_factory,
     )


### PR DESCRIPTION
# Description

Remove deprecated feature to prepare for the next minor release

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
