### PR TITLE
Remove deprecated `ServiceContext` from the `selectors` package

### DIFF
--- a/llama-index-core/llama_index/core/selectors/llm_selectors.py
+++ b/llama-index-core/llama_index/core/selectors/llm_selectors.py
@@ -16,11 +16,10 @@ from llama_index.core.selectors.prompts import (
     MultiSelectPrompt,
     SingleSelectPrompt,
 )
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.service_context_elements.llm_predictor import (
     LLMPredictorType,
 )
-from llama_index.core.settings import Settings, llm_from_settings_or_context
+from llama_index.core.settings import Settings
 from llama_index.core.tools.types import ToolMetadata
 from llama_index.core.types import BaseOutputParser
 
@@ -73,12 +72,11 @@ class LLMSingleSelector(BaseSelector):
     def from_defaults(
         cls,
         llm: Optional[LLMPredictorType] = None,
-        service_context: Optional[ServiceContext] = None,
         prompt_template_str: Optional[str] = None,
         output_parser: Optional[BaseOutputParser] = None,
     ) -> "LLMSingleSelector":
         # optionally initialize defaults
-        llm = llm or llm_from_settings_or_context(Settings, service_context)
+        llm = llm or Settings.llm
         prompt_template_str = prompt_template_str or DEFAULT_SINGLE_SELECT_PROMPT_TMPL
         output_parser = output_parser or SelectionOutputParser()
 
@@ -169,10 +167,8 @@ class LLMMultiSelector(BaseSelector):
         prompt_template_str: Optional[str] = None,
         output_parser: Optional[BaseOutputParser] = None,
         max_outputs: Optional[int] = None,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
     ) -> "LLMMultiSelector":
-        llm = llm or llm_from_settings_or_context(Settings, service_context)
+        llm = llm or Settings.llm
         prompt_template_str = prompt_template_str or DEFAULT_MULTI_SELECT_PROMPT_TMPL
         output_parser = output_parser or SelectionOutputParser()
 


### PR DESCRIPTION
# Description

Remove deprecated feature to prepare for the next minor release

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
