### PR TITLE
Remove deprecated `ServiceContext` from the `tools` package

### DIFF
--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -1,4 +1,5 @@
 """Test tools."""
+
 import json
 from typing import List, Optional
 
@@ -150,11 +151,7 @@ async def test_function_tool_async_defaults_langchain() -> None:
     assert result == "1"
 
 
-from llama_index.core import (
-    ServiceContext,
-    VectorStoreIndex,
-)
-from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core import VectorStoreIndex
 from llama_index.core.schema import Document
 from llama_index.core.tools import RetrieverTool, ToolMetadata
 
@@ -169,12 +166,7 @@ def test_retreiver_tool() -> None:
         text=("# title2:This is another test.\n" "This is a test v2."),
         metadata={"file_path": "/data/personal/essay.md"},
     )
-    service_context = ServiceContext.from_defaults(
-        llm=None, embed_model=MockEmbedding(embed_dim=1)
-    )
-    vs_index = VectorStoreIndex.from_documents(
-        [doc1, doc2], service_context=service_context
-    )
+    vs_index = VectorStoreIndex.from_documents([doc1, doc2])
     vs_retriever = vs_index.as_retriever()
     vs_ret_tool = RetrieverTool(
         retriever=vs_retriever,

--- a/llama-index-core/tests/tools/test_ondemand_loader.py
+++ b/llama-index-core/tests/tools/test_ondemand_loader.py
@@ -12,11 +12,10 @@ except ImportError:
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.indices.vector_store.base import VectorStoreIndex
 from llama_index.core.readers.string_iterable import StringIterableReader
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.tools.ondemand_loader_tool import OnDemandLoaderTool
 
 
-class TestSchemaSpec(BaseModel):
+class _TestSchemaSpec(BaseModel):
     """Test schema spec."""
 
     texts: List[str]
@@ -24,16 +23,15 @@ class TestSchemaSpec(BaseModel):
 
 
 @pytest.fixture()
-def tool(mock_service_context: ServiceContext) -> OnDemandLoaderTool:
+def tool(patch_llm_predictor) -> OnDemandLoaderTool:
     # import most basic string reader
     reader = StringIterableReader()
     return OnDemandLoaderTool.from_defaults(
         reader=reader,
         index_cls=VectorStoreIndex,
-        index_kwargs={"service_context": mock_service_context},
         name="ondemand_loader_tool",
         description="ondemand_loader_tool_desc",
-        fn_schema=TestSchemaSpec,
+        fn_schema=_TestSchemaSpec,
     )
 
 
@@ -51,6 +49,6 @@ def test_ondemand_loader_tool_langchain(
 ) -> None:
     # convert tool to structured langchain tool
     lc_tool = tool.to_langchain_structured_tool()
-    assert lc_tool.args_schema == TestSchemaSpec
+    assert lc_tool.args_schema == _TestSchemaSpec
     response = lc_tool.run({"texts": ["Hello world."], "query_str": "What is?"})
     assert str(response) == "What is?:Hello world."


### PR DESCRIPTION
# Description

Remove deprecated feature to prepare for the next minor release

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
