### PR TITLE
Allow for images in Anthropic messages

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -2,7 +2,7 @@ from typing import Dict, Sequence, Tuple
 
 from llama_index.core.base.llms.types import ChatMessage, ChatResponse, MessageRole
 
-from anthropic.types import MessageParam, TextBlockParam
+from anthropic.types import MessageParam, TextBlockParam, ImageBlockParam
 from anthropic.types.tool_result_block_param import ToolResultBlockParam
 from anthropic.types.tool_use_block_param import ToolUseBlockParam
 
@@ -83,7 +83,16 @@ def messages_to_anthropic_messages(
             anthropic_messages.append(anth_message)
         else:
             content = []
-            if message.content:
+            if message.content and isinstance(message.content, list):
+                for item in message.content:
+                    if item and isinstance(item, dict) and item.get("type", None):
+                        if item["type"] == "image":
+                            content.append(ImageBlockParam(**item))
+                        else:
+                            content.append(TextBlockParam(**item))
+                    else:
+                        content.append(TextBlockParam(text=item, type="text"))
+            elif message.content:
                 content.append(TextBlockParam(text=message.content, type="text"))
 
             tool_calls = message.additional_kwargs.get("tool_calls", [])

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-anthropic"
 readme = "README.md"
-version = "0.1.16"
+version = "0.1.17"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

If the content of an Anthropic message is a List of Dicts I check for "image" type and append the ImageBlockParams object instead of the TextBlockParams object. Other LI LLMs support passing in image types into a message list so i figure adding this support to Anthropic was legitimate. In our case we do image processing outside Llama Index but still want to perform multimodal queries using Llama Index libs.

Fixes # (issue)
Contributes to #14568

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
