### PR TITLE
fix: strip '''sql (Markdown SQL code snippet) in SQL Retriever

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
@@ -149,7 +149,7 @@ class DefaultSQLParser(BaseSQLParser):
         sql_result_start = response.find("SQLResult:")
         if sql_result_start != -1:
             response = response[:sql_result_start]
-        return response.strip().strip("```").strip()
+        return response.strip().strip("```sql").strip("```").strip()
 
 
 class PGVectorSQLParser(BaseSQLParser):
@@ -175,7 +175,7 @@ class PGVectorSQLParser(BaseSQLParser):
             response = response[:sql_result_start]
 
         # this gets you the sql string with [query_vector] placeholders
-        raw_sql_str = response.strip().strip("```").strip()
+        raw_sql_str = response.strip().strip("```sql").strip("```").strip()
         query_embedding = self._embed_model.get_query_embedding(query_bundle.query_str)
         query_embedding_str = str(query_embedding)
         return raw_sql_str.replace("[query_vector]", query_embedding_str)


### PR DESCRIPTION
# Description

Improve generated SQL query stripping by stripping ``` with the "SQL" text. There are cases when the AI model generates a SQL query wrapped with a Markdown SQL code snippet which is currently not being handled correctly resulting in the generated incorrect SQL query that fails to retrieve data from the database.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
