### PR TITLE
Remove usage of `ServiceContext` in Colbert integration

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-colbert/llama_index/indices/managed/colbert/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-colbert/llama_index/indices/managed/colbert/base.py
@@ -7,7 +7,6 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.data_structs.data_structs import IndexDict
 from llama_index.core.indices.base import BaseIndex, IndexNode
 from llama_index.core.schema import BaseNode, NodeWithScore
-from llama_index.core.service_context import ServiceContext
 from llama_index.core.storage.docstore.types import RefDocInfo
 from llama_index.core.storage.storage_context import StorageContext
 
@@ -58,8 +57,6 @@ class ColbertIndex(BaseIndex[IndexDict]):
         doc_maxlen: int = 120,
         query_maxlen: int = 60,
         kmeans_niters: int = 4,
-        # deprecated
-        service_context: Optional[ServiceContext] = None,
         **kwargs: Any,
     ) -> None:
         self.model_name = model_name
@@ -83,7 +80,6 @@ class ColbertIndex(BaseIndex[IndexDict]):
             nodes=nodes,
             index_struct=index_struct,
             index_name=index_name,
-            service_context=service_context,
             storage_context=storage_context,
             show_progress=show_progress,
             objects=objects,

--- a/llama-index-integrations/indices/llama-index-indices-managed-colbert/llama_index/indices/managed/colbert/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-colbert/llama_index/indices/managed/colbert/retriever.py
@@ -4,10 +4,7 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.constants import DEFAULT_SIMILARITY_TOP_K
 from llama_index.core.schema import NodeWithScore, QueryBundle
-from llama_index.core.settings import (
-    Settings,
-    callback_manager_from_settings_or_context,
-)
+from llama_index.core.settings import Settings
 from llama_index.core.vector_stores.types import MetadataFilters
 
 from .base import ColbertIndex
@@ -40,7 +37,6 @@ class ColbertRetriever(BaseRetriever):
     ) -> None:
         """Initialize params."""
         self._index = index
-        self._service_context = self._index.service_context
         self._docstore = self._index.docstore
         self._similarity_top_k = similarity_top_k
         self._node_ids = node_ids
@@ -48,10 +44,7 @@ class ColbertRetriever(BaseRetriever):
         self._filters = filters
         self._kwargs: Dict[str, Any] = kwargs.get("colbert_kwargs", {})
         super().__init__(
-            callback_manager=callback_manager
-            or callback_manager_from_settings_or_context(
-                Settings, self._service_context
-            ),
+            callback_manager=callback_manager or Settings.callback_manager,
             object_map=object_map,
             verbose=verbose,
         )

--- a/llama-index-integrations/indices/llama-index-indices-managed-colbert/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-colbert/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-colbert"
 readme = "README.md"
-version = "0.1.2"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Stop using the deprecated `ServiceContext` object, that will be soon removed from llama-index-core 0.11.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
