### PR TITLE
Workflows: fix the validation error in the decorator

### DIFF
--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -34,7 +34,7 @@ def step(
         # If this is a free function, call add_step() explicitly.
         if is_free_function(func.__qualname__):
             if workflow is None:
-                msg = f"To decorate {func.__name__} please pass a workflow instance to the @step() decorator."
+                msg = f"To decorate {func.__name__} please pass a workflow class to the @step() decorator."
                 raise WorkflowValidationError(msg)
             workflow.add_step(func)
 

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -42,7 +42,7 @@ def test_decorate_free_function_wrong_decorator():
     with pytest.raises(
         WorkflowValidationError,
         match=re.escape(
-            "To decorate f please pass a workflow instance to the @step() decorator."
+            "To decorate f please pass a workflow class to the @step() decorator."
         ),
     ):
 


### PR DESCRIPTION
# Description

Fix the misleading validation error in the decorator, the `workflow` must be a class, not instance.

Fixes # no issue, reported offline

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
