### PR TITLE
fix: children nodes not carrying metadata from source nodes

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -90,13 +90,17 @@ class NodeParser(TransformComponent, ABC):
 
                 # update metadata
                 if self.include_metadata:
-                    # Update parent_doc.metadata with node.metadata, giving preference to node's values
+                    # Merge parent_doc.metadata with node.metadata, giving preference to node's values
                     node.metadata = {**parent_doc.metadata, **node.metadata}
 
             if parent_node is not None:
                 if self.include_metadata:
-                    # Update parent_node.metadata with node.metadata, giving preference to node's values
-                    node.metadata.update(parent_node.metadata)
+                    parent_metadata = parent_node.metadata
+
+                    combined_metadata = {**parent_metadata, **node.metadata}
+
+                    # Merge parent_node.metadata with node.metadata, giving preference to node's values
+                    node.metadata.update(combined_metadata)
 
             if self.include_prev_next_rel:
                 # establish prev/next relationships if nodes share the same source_node

--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -68,6 +68,7 @@ class NodeParser(TransformComponent, ABC):
     ) -> List[BaseNode]:
         for i, node in enumerate(nodes):
             parent_doc = parent_doc_map.get(node.ref_doc_id, None)
+            parent_node = node.relationships.get(NodeRelationship.SOURCE, None)
 
             if parent_doc is not None:
                 if parent_doc.source_node is not None:
@@ -89,7 +90,13 @@ class NodeParser(TransformComponent, ABC):
 
                 # update metadata
                 if self.include_metadata:
-                    node.metadata.update(parent_doc.metadata)
+                    # Update parent_doc.metadata with node.metadata, giving preference to node's values
+                    node.metadata = {**parent_doc.metadata, **node.metadata}
+
+            if parent_node is not None:
+                if self.include_metadata:
+                    # Update parent_node.metadata with node.metadata, giving preference to node's values
+                    node.metadata.update(parent_node.metadata)
 
             if self.include_prev_next_rel:
                 # establish prev/next relationships if nodes share the same source_node

--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -90,7 +90,7 @@ class NodeParser(TransformComponent, ABC):
 
                 # update metadata
                 if self.include_metadata:
-                    # Merge parent_doc.metadata with node.metadata, giving preference to node's values
+                    # Merge parent_doc.metadata into nodes.metadata, giving preference to node's values
                     node.metadata = {**parent_doc.metadata, **node.metadata}
 
             if parent_node is not None:
@@ -99,7 +99,7 @@ class NodeParser(TransformComponent, ABC):
 
                     combined_metadata = {**parent_metadata, **node.metadata}
 
-                    # Merge parent_node.metadata with node.metadata, giving preference to node's values
+                    # Merge parent_node.metadata into nodes.metadata, giving preference to node's values
                     node.metadata.update(combined_metadata)
 
             if self.include_prev_next_rel:

--- a/llama-index-core/tests/node_parser/test_node_parser.py
+++ b/llama-index-core/tests/node_parser/test_node_parser.py
@@ -1,0 +1,41 @@
+from typing import Any, List, Sequence
+from llama_index.core.node_parser import NodeParser
+from llama_index.core.schema import BaseNode, TextNode, Document, NodeRelationship
+
+
+class _TestNodeParser(NodeParser):
+    def _parse_nodes(
+        self, nodes: Sequence[BaseNode], show_progress: bool = False, **kwargs: Any
+    ) -> List[BaseNode]:
+        return super()._parse_nodes(nodes, show_progress, **kwargs)
+
+
+def test__postprocess_parsed_nodes_include_metadata():
+    np = _TestNodeParser()
+
+    nodes = []
+    for i in range(3):
+        node = TextNode(text=f"I am Node number {i}")
+        node.metadata = {"node_number": i}
+        nodes.append(node)
+
+    ret = np._postprocess_parsed_nodes(nodes, {})
+    for i, node in enumerate(ret):
+        assert node.metadata == {"node_number": i}
+
+
+def test__postprocess_parsed_nodes_include_metadata_parent_doc():
+    np = _TestNodeParser()
+    doc = Document(text="I am root")
+    doc.metadata = {"document_type": "root"}
+
+    nodes = []
+    for i in range(3):
+        node = TextNode(text=f"I am Node number {i}")
+        node.metadata = {"node_number": i}
+        node.relationships = {NodeRelationship.SOURCE: doc.as_related_node_info()}
+        nodes.append(node)
+
+    ret = np._postprocess_parsed_nodes(nodes, {})
+    for i, node in enumerate(ret):
+        assert node.metadata == {"node_number": i, "document_type": "root"}


### PR DESCRIPTION
when running 2 node parsers the metadata is being lost

reproducible example:

```py
from os import path

from llama_index.core.ingestion import IngestionPipeline
from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
from llama_index.core.schema import Document

current_dir = path.dirname(path.realpath(__file__))

sample_pdf_path = path.join(current_dir, "apple_2023.txt")

with open(sample_pdf_path, "r") as f:
    documents = [Document(text=f.read())]

pipeline = IngestionPipeline(
    documents=documents,
    transformations=[
        MarkdownNodeParser(),
        SentenceSplitter(),
    ],
)

nodes = pipeline.run()

with open("output.txt", "w") as f:
    for node in nodes:
        f.write(node.get_content(metadata_mode="all"))
        f.write("\n---\n")
```