### PR TITLE
Correct Import Statement in 'Using as a Retriever' Section

### DIFF
--- a/docs/docs/module_guides/querying/router/index.md
+++ b/docs/docs/module_guides/querying/router/index.md
@@ -122,7 +122,7 @@ query_engine.query("<query>")
 Similarly, a `RouterRetriever` is composed on top of other retrievers as tools. An example is given below:
 
 ```python
-from llama_index.core.query_engine import RouterQueryEngine
+from llama_index.core.query_engine import RouterRetriever
 from llama_index.core.selectors import PydanticSingleSelector
 from llama_index.core.tools import RetrieverTool
 

--- a/docs/docs/module_guides/querying/router/index.md
+++ b/docs/docs/module_guides/querying/router/index.md
@@ -122,7 +122,7 @@ query_engine.query("<query>")
 Similarly, a `RouterRetriever` is composed on top of other retrievers as tools. An example is given below:
 
 ```python
-from llama_index.core.query_engine import RouterRetriever
+from llama_index.core.retrievers import RouterRetriever
 from llama_index.core.selectors import PydanticSingleSelector
 from llama_index.core.tools import RetrieverTool
 


### PR DESCRIPTION
# Description

This pull request fixes an incorrect import statement in the **Using as a Retriever** section of the Routing guide. The current documentation shows:

```
from llama_index.core.query_engine import RouterQueryEngine
from llama_index.core.selectors import PydanticSingleSelector
from llama_index.core.tools import RetrieverTool
```
However, the correct import statement should be:

```
from llama_index.core.retrievers import RouterRetriever
```
This correction is necessary because the current import statement is incorrect and can lead to confusion for users trying to implement the retriever functionality.


Fixes #15255 
check
## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
