### PR TITLE
feat: make send_event assign the target step

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -157,15 +157,29 @@ class Workflow(metaclass=_WorkflowMeta):
                     )
                 )
 
-    def send_event(self, message: Event) -> None:
+    def send_event(self, message: Event, step: Optional[str] = None) -> None:
         """Sends an event to a specific step in the workflow.
 
-        Currently we send all the events to all the receivers and we let
-        them discard events they don't want. This should be optimized so
-        that we efficiently send events where we know won't be discarded.
+        If step is None, the event is sent to all the receivers and we let
+        them discard events they don't want.
         """
-        for queue in self._queues.values():
-            queue.put_nowait(message)
+        if step is None:
+            for queue in self._queues.values():
+                queue.put_nowait(message)
+
+        if step not in self._get_steps():
+            raise WorkflowValidationError(f"Step {step} does not exist")
+
+        step_func = self._get_steps()[step]
+        step_config: Optional[StepConfig] = getattr(step_func, "__step_config", None)
+
+        if step_config and type(message) in step_config.accepted_events:
+            self._queues[step].put_nowait(message)
+        else:
+            raise WorkflowValidationError(
+                f"Step {step} does not accept event of type {type(message)}"
+            )
+
         self._broker_log.append(message)
 
     @dispatcher.span

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -182,3 +182,21 @@ async def test_workflow_step_send_event():
     assert workflow.is_done()
     assert ("step2", "OneTestEvent") in workflow._accepted_events
     assert ("step3", "OneTestEvent") not in workflow._accepted_events
+
+
+@pytest.mark.asyncio()
+async def test_workflow_step_send_event_to_None():
+    class StepSendEventToNoneWorkflow(Workflow):
+        @step()
+        async def step1(self, ev: StartEvent) -> OneTestEvent:
+            self.send_event(OneTestEvent(), step=None)
+            return None
+
+        @step()
+        async def step2(self, ev: OneTestEvent) -> StopEvent:
+            return StopEvent(result="step2")
+
+    workflow = StepSendEventToNoneWorkflow()
+    await workflow.run()
+    assert workflow.is_done()
+    assert ("step2", "OneTestEvent") in workflow._accepted_events

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -158,3 +158,27 @@ async def test_workflow_num_workers():
     assert (
         1.0 <= execution_time < 1.1
     ), f"Execution time was {execution_time:.2f} seconds"
+
+
+@pytest.mark.asyncio()
+async def test_workflow_step_send_event():
+    class StepSendEventWorkflow(Workflow):
+        @step()
+        async def step1(self, ev: StartEvent) -> OneTestEvent:
+            self.send_event(OneTestEvent(), step="step2")
+            return None
+
+        @step()
+        async def step2(self, ev: OneTestEvent) -> StopEvent:
+            return StopEvent(result="step2")
+
+        @step()
+        async def step3(self, ev: OneTestEvent) -> StopEvent:
+            return StopEvent(result="step3")
+
+    workflow = StepSendEventWorkflow()
+    result = await workflow.run()
+    assert result == "step2"
+    assert workflow.is_done()
+    assert ("step2", "OneTestEvent") in workflow._accepted_events
+    assert ("step3", "OneTestEvent") not in workflow._accepted_events


### PR DESCRIPTION
# Description

Add step parameter to let step_event method can assign the target step.
If step is None, it will run like the origin one.
If the target step is not existed or the step does not accept this event type, it will raise WorkflowValidationError.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
