### PR TITLE
chore: fix parent node metadata

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -95,12 +95,8 @@ class NodeParser(TransformComponent, ABC):
 
             if parent_node is not None:
                 if self.include_metadata:
-                    parent_metadata = parent_node.metadata
-
-                    combined_metadata = {**parent_metadata, **node.metadata}
-
                     # Merge parent_node.metadata into nodes.metadata, giving preference to node's values
-                    node.metadata.update(combined_metadata)
+                    node.metadata.update(parent_node.metadata)
 
             if self.include_prev_next_rel:
                 # establish prev/next relationships if nodes share the same source_node


### PR DESCRIPTION
in the previous [PR](https://github.com/run-llama/llama_index/pull/15254) accidentally added                     `combined_metadata = {**parent_metadata, **node.metadata}` where node.metadata will overwrite the parent node metadata always with the parent doc metadata and we don't want that