### PR TITLE
Check if hnsw index exists

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -377,9 +377,21 @@ class PGVectorStore(BasePydanticVectorStore):
         hnsw_m = self.hnsw_kwargs.pop("hnsw_m")
         hnsw_dist_method = self.hnsw_kwargs.pop("hnsw_dist_method", "vector_cosine_ops")
 
+        index_name = f"{self._table_class.__tablename__}_embedding_idx"
+
         with self._session() as session, session.begin():
+            index_exists = session.execute(
+                sqlalchemy.text(
+                    f"SELECT 1 FROM pg_indexes WHERE tablename = '{self._table_class.__tablename__}' AND indexname = '{index_name}';"
+                )
+            ).fetchone()
+
+            if index_exists:
+                _logger.info(f"Index {index_name} already exists, skipping creation.")
+                return
+
             statement = sqlalchemy.text(
-                f"CREATE INDEX ON {self.schema_name}.{self._table_class.__tablename__} USING hnsw (embedding {hnsw_dist_method}) WITH (m = {hnsw_m}, ef_construction = {hnsw_ef_construction})"
+                f"CREATE INDEX {index_name} ON {self.schema_name}.{self._table_class.__tablename__} USING hnsw (embedding {hnsw_dist_method}) WITH (m = {hnsw_m}, ef_construction = {hnsw_ef_construction})"
             )
             session.execute(statement)
             session.commit()

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -382,12 +382,18 @@ class PGVectorStore(BasePydanticVectorStore):
         with self._session() as session, session.begin():
             index_exists = session.execute(
                 sqlalchemy.text(
-                    f"SELECT 1 FROM pg_indexes WHERE tablename = '{self._table_class.__tablename__}' AND indexname = '{index_name}';"
+                    f"""
+                    SELECT 1
+                    FROM pg_indexes
+                    WHERE schemaname = '{self.schema_name}'
+                      AND tablename = '{self._table_class.__tablename__}'
+                      AND indexname = '{index_name}';
+                    """
                 )
             ).fetchone()
 
             if index_exists:
-                _logger.info(f"Index {index_name} already exists, skipping creation.")
+                _logger.debug(f"Index {index_name} already exists, skipping creation.")
                 return
 
             statement = sqlalchemy.text(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.1.13"
+version = "0.1.14"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -158,7 +158,7 @@ def pg_hnsw_hybrid(db_hnsw: None) -> Any:
 
 
 @pytest.fixture()
-def pg_hnsw_multiple(db_hnsw: None) -> List[PGVectorStore]:
+def pg_hnsw_multiple(db_hnsw: None) -> Generator[List[PGVectorStore], None, None]:
     """
     This creates multiple instances of PGVectorStore.
     """

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -23,6 +23,8 @@ from llama_index.vector_stores.postgres import PGVectorStore
 
 
 PARAMS: Dict[str, Union[str, int]] = {
+    "host": "pgtime",
+    "password": "latte8bubbly737g",
     "host": "localhost",
     "user": "postgres",
     "password": "mark90",
@@ -914,7 +916,7 @@ async def test_hnsw_index_creation(
     # create a connection to the TEST_DB_HNSW database to make sure that one, and only one, index was created
     with psycopg2.connect(**PARAMS, database=TEST_DB_HNSW) as hnsw_conn:
         with hnsw_conn.cursor() as c:
-            index_count = c.execute(
+            c.execute(
                 f"SELECT COUNT(*) FROM pg_indexes WHERE schemaname = '{TEST_SCHEMA_NAME}' AND tablename = '{data_test_table_name}' AND indexname LIKE '{data_test_index_name}%';"
             )
             index_count = c.fetchone()[0]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -23,8 +23,6 @@ from llama_index.vector_stores.postgres import PGVectorStore
 
 
 PARAMS: Dict[str, Union[str, int]] = {
-    "host": "pgtime",
-    "password": "latte8bubbly737g",
     "host": "localhost",
     "user": "postgres",
     "password": "mark90",

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -157,6 +157,33 @@ def pg_hnsw_hybrid(db_hnsw: None) -> Any:
     asyncio.run(pg.close())
 
 
+@pytest.fixture()
+def pg_hnsw_multiple(db_hnsw: None) -> List[PGVectorStore]:
+    """
+    This creates multiple instances of PGVectorStore.
+    """
+    pgs = []
+    for _ in range(2):
+        pg = PGVectorStore.from_params(
+            **PARAMS,  # type: ignore
+            database=TEST_DB_HNSW,
+            table_name=TEST_TABLE_NAME,
+            schema_name=TEST_SCHEMA_NAME,
+            embed_dim=TEST_EMBED_DIM,
+            hnsw_kwargs={
+                "hnsw_m": 16,
+                "hnsw_ef_construction": 64,
+                "hnsw_ef_search": 40,
+            },
+        )
+        pgs.append(pg)
+
+    yield pgs
+
+    for pg in pgs:
+        asyncio.run(pg.close())
+
+
 @pytest.fixture(scope="session")
 def node_embeddings() -> List[TextNode]:
     return [
@@ -860,6 +887,41 @@ async def test_delete_nodes_metadata(
         res = pg.query(q)
     assert all(i not in res.ids for i in ["bbb", "aaa", "ddd"])
     assert "ccc" in res.ids
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_hnsw_index_creation(
+    pg_hnsw_multiple: List[PGVectorStore],
+    node_embeddings: List[TextNode],
+    use_async: bool,
+) -> None:
+    """
+    This test will make sure that creating multiple PGVectorStores handles db initialization properly.
+    """
+    # calling add will make the db initialization run
+    for pg in pg_hnsw_multiple:
+        if use_async:
+            await pg.async_add(node_embeddings)
+        else:
+            pg.add(node_embeddings)
+
+    # these are the actual table and index names that PGVectorStore automatically created
+    data_test_table_name = f"data_{TEST_TABLE_NAME}"
+    data_test_index_name = f"data_{TEST_TABLE_NAME}_embedding_idx"
+
+    # create a connection to the TEST_DB_HNSW database to make sure that one, and only one, index was created
+    with psycopg2.connect(**PARAMS, database=TEST_DB_HNSW) as hnsw_conn:
+        with hnsw_conn.cursor() as c:
+            index_count = c.execute(
+                f"SELECT COUNT(*) FROM pg_indexes WHERE schemaname = '{TEST_SCHEMA_NAME}' AND tablename = '{data_test_table_name}' AND indexname LIKE '{data_test_index_name}%';"
+            )
+            index_count = c.fetchone()[0]
+
+    assert (
+        index_count == 1
+    ), f"Expected exactly one '{data_test_index_name}' index, but found {index_count}."
 
 
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")


### PR DESCRIPTION
# Description

When using  `llama_index.vector_stores.postgres.PGVectorStore` to store embedding in PostgreSQL, the hnsw index gets created multiple times. This happens when passing in `hnsw_kwargs` to create a PGVectorStore() instance.

This PR updates the `_create_hnsw_index` method to check for the existence of the hnsw index before creating it. If it does exist, the index creation will be skipped.  

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x]  I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods