### PR TITLE
Docs: Update Dependencies and Fix Typo in Pairwise Comparison Evaluator

### DIFF
--- a/docs/docs/examples/finetuning/llm_judge/pairwise/finetune_llm_judge.ipynb
+++ b/docs/docs/examples/finetuning/llm_judge/pairwise/finetune_llm_judge.ipynb
@@ -153,7 +153,7 @@
     "train_cities = [\n",
     "    \"San Francisco\",\n",
     "    \"Toronto\",\n",
-    "    \"New York\",\n",
+    "    \"New York City\",\n",
     "    \"Vancouver\",\n",
     "    \"Montreal\",\n",
     "    \"Boston\",\n",

--- a/docs/docs/examples/finetuning/llm_judge/pairwise/finetune_llm_judge.ipynb
+++ b/docs/docs/examples/finetuning/llm_judge/pairwise/finetune_llm_judge.ipynb
@@ -27,7 +27,7 @@
     "%pip install llama-index-readers-wikipedia\n",
     "%pip install llama-index-finetuning\n",
     "%pip install llama-index-llms-openai\n",
-    "%pip install llama-index-finetuning-callbacks\n",
+    "%pip install llama-index-llms-mistralai\n",
     "%pip install llama-index-llms-huggingface-api"
    ]
   },

--- a/docs/docs/examples/finetuning/llm_judge/pairwise/finetune_llm_judge.ipynb
+++ b/docs/docs/examples/finetuning/llm_judge/pairwise/finetune_llm_judge.ipynb
@@ -544,7 +544,7 @@
     "\n",
     "llm_4 = OpenAI(temperature=0, model=\"gpt-4\", callback_manager=callback_manager)\n",
     "\n",
-    "gpt4_judge = PairwiseComparisonEvaluator(llm=llm)"
+    "gpt4_judge = PairwiseComparisonEvaluator(llm=llm_4)"
    ]
   },
   {


### PR DESCRIPTION
# Description

This pull request addresses three primary issues in the `finetune_llm_judge` Jupyter notebook within the pairwise examples.

Changes:  
1. Removed the installation line for the non-existent package `llama-index-finetuning-callbacks`.  
2. Added the installation command for `llama-index-llms-mistralai` to match the required dependency for `OpenAIFineTuningHandler`.  
3. Corrected the typo in the `PairwiseComparisonEvaluator` from `llm` to `llm_4` to reference the correctly initialized LLM instance.  
4. Changed the ambiguous reference from "New York" to "New York City" in the list of training cities to resolve the `DisambiguationError`.