### PR TITLE
chore: only show errors from pants during unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pants
-	pants --no-local-cache --changed-since=origin/main --changed-dependents=transitive test
+	pants --level=error --no-local-cache --changed-since=origin/main --changed-dependents=transitive test
 
 test-core:	## Run tests via pants
 	pants --no-local-cache test llama-index-core/::


### PR DESCRIPTION
# Description

Pants outputs a huge amount of warnings while collecting unit tests in CI, see [this example](https://github.com/run-llama/llama_index/actions/runs/10321421443/job/28574282624?pr=15259#step:9:1). This not only pegs web browsers when opening that page, but it also hides the real test failures that sit at the bottom of that endless stream of warnings.

This PR silences warnings to make the testing logs useful.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
