### PR TITLE
chore: remove usage of ServiceContext from packs

### DIFF
--- a/llama-index-packs/llama-index-packs-auto-merging-retriever/llama_index/packs/auto_merging_retriever/base.py
+++ b/llama-index-packs/llama-index-packs-auto-merging-retriever/llama_index/packs/auto_merging_retriever/base.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, VectorStoreIndex
+from llama_index.core import VectorStoreIndex
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.node_parser import (
     HierarchicalNodeParser,
@@ -13,7 +13,6 @@ from llama_index.core.retrievers.auto_merging_retriever import AutoMergingRetrie
 from llama_index.core.schema import Document
 from llama_index.core.storage import StorageContext
 from llama_index.core.storage.docstore import SimpleDocumentStore
-from llama_index.llms.openai import OpenAI
 
 
 class AutoMergingRetrieverPack(BaseLlamaPack):
@@ -41,15 +40,7 @@ class AutoMergingRetrieverPack(BaseLlamaPack):
 
         # define storage context (will include vector store by default too)
         storage_context = StorageContext.from_defaults(docstore=docstore)
-
-        service_context = ServiceContext.from_defaults(
-            llm=OpenAI(model="gpt-3.5-turbo")
-        )
-        self.base_index = VectorStoreIndex(
-            leaf_nodes,
-            storage_context=storage_context,
-            service_context=service_context,
-        )
+        self.base_index = VectorStoreIndex(leaf_nodes, storage_context=storage_context)
         base_retriever = self.base_index.as_retriever(similarity_top_k=6)
         self.retriever = AutoMergingRetriever(
             base_retriever, storage_context, verbose=True

--- a/llama-index-packs/llama-index-packs-auto-merging-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-auto-merging-retriever/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-packs-auto-merging-retriever"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-cohere-citation-chat/llama_index/packs/cohere_citation_chat/citations_context_chat_engine.py
+++ b/llama-index-packs/llama-index-packs-cohere-citation-chat/llama_index/packs/cohere_citation_chat/citations_context_chat_engine.py
@@ -250,20 +250,11 @@ class VectorStoreIndexWithCitationsChat(VectorStoreIndex):
         if chat_mode not in [ChatModeCitations.COHERE_CITATIONS_CONTEXT]:
             return super().as_chat_engine(chat_mode=chat_mode, llm=llm, **kwargs)
         else:
-            service_context = kwargs.get("service_context", self.service_context)
-
-            if service_context is not None:
-                llm = (
-                    resolve_llm(llm, callback_manager=self._callback_manager)
-                    if llm
-                    else service_context.llm
-                )
-            else:
-                llm = (
-                    resolve_llm(llm, callback_manager=self._callback_manager)
-                    if llm
-                    else Settings.llm
-                )
+            llm = (
+                resolve_llm(llm, callback_manager=self._callback_manager)
+                if llm
+                else Settings.llm
+            )
 
             return CitationsContextChatEngine.from_defaults(
                 retriever=self.as_retriever(**kwargs),

--- a/llama-index-packs/llama-index-packs-cohere-citation-chat/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-cohere-citation-chat/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["EugeneLightsOn"]
 name = "llama-index-packs-cohere-citation-chat"
 readme = "README.md"
-version = "0.1.7"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-dense-x-retrieval/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-dense-x-retrieval/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["logan-markewich"]
 name = "llama-index-packs-dense-x-retrieval"
 readme = "README.md"
-version = "0.1.4"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-fusion-retriever/llama_index/packs/fusion_retriever/hybrid_fusion/base.py
+++ b/llama-index-packs/llama-index-packs-fusion-retriever/llama_index/packs/fusion_retriever/hybrid_fusion/base.py
@@ -1,8 +1,9 @@
 """Hybrid Fusion Retriever Pack."""
+
 import os
 from typing import Any, Dict, List
 
-from llama_index.core.indices.service_context import ServiceContext
+from llama_index.core import Settings
 from llama_index.core.indices.vector_store import VectorStoreIndex
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.query_engine import RetrieverQueryEngine
@@ -32,7 +33,7 @@ class HybridFusionRetrieverPack(BaseLlamaPack):
         **kwargs: Any,
     ) -> None:
         """Init params."""
-        service_context = ServiceContext.from_defaults(chunk_size=chunk_size)
+        Settings.chunk_size = chunk_size
         if cache_dir is not None and os.path.exists(cache_dir):
             # Load from cache
             from llama_index import StorageContext, load_index_from_storage
@@ -42,11 +43,9 @@ class HybridFusionRetrieverPack(BaseLlamaPack):
             # load index
             index = load_index_from_storage(storage_context)
         elif documents is not None:
-            index = VectorStoreIndex.from_documents(
-                documents=documents, service_context=service_context
-            )
+            index = VectorStoreIndex.from_documents(documents=documents)
         else:
-            index = VectorStoreIndex(nodes, service_context=service_context)
+            index = VectorStoreIndex(nodes)
 
         if cache_dir is not None and not os.path.exists(cache_dir):
             index.storage_context.persist(persist_dir=cache_dir)

--- a/llama-index-packs/llama-index-packs-fusion-retriever/llama_index/packs/fusion_retriever/query_rewrite/base.py
+++ b/llama-index-packs/llama-index-packs-fusion-retriever/llama_index/packs/fusion_retriever/query_rewrite/base.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-from llama_index.core.indices.service_context import ServiceContext
+from llama_index.core import Settings
 from llama_index.core.indices.vector_store import VectorStoreIndex
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.query_engine import RetrieverQueryEngine
@@ -31,8 +31,8 @@ class QueryRewritingRetrieverPack(BaseLlamaPack):
         **kwargs: Any,
     ) -> None:
         """Init params."""
-        service_context = ServiceContext.from_defaults(chunk_size=chunk_size)
-        index = VectorStoreIndex(nodes, service_context=service_context)
+        Settings.chunk_size = chunk_size
+        index = VectorStoreIndex(nodes)
         self.vector_retriever = index.as_retriever(
             similarity_top_k=vector_similarity_top_k
         )

--- a/llama-index-packs/llama-index-packs-fusion-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-fusion-retriever/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-packs-fusion-retriever"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-multi-document-agents/llama_index/packs/multi_document_agents/base.py
+++ b/llama-index-packs/llama-index-packs-multi-document-agents/llama_index/packs/multi_document_agents/base.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from llama_index.agent.openai import OpenAIAgent
 from llama_index.agent.openai_legacy import FnRetrieverOpenAIAgent
-from llama_index.core import ServiceContext, SummaryIndex, VectorStoreIndex
+from llama_index.core import Settings, SummaryIndex, VectorStoreIndex
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.objects import ObjectIndex, SimpleToolNodeMapping
@@ -32,7 +32,7 @@ class MultiDocumentAgentsPack(BaseLlamaPack):
         """Init params."""
         self.node_parser = SentenceSplitter()
         self.llm = OpenAI(temperature=0, model="gpt-3.5-turbo")
-        self.service_context = ServiceContext.from_defaults(llm=self.llm)
+        Settings.llm = self.llm
 
         # Build agents dictionary
         self.agents = {}
@@ -48,10 +48,10 @@ class MultiDocumentAgentsPack(BaseLlamaPack):
             all_nodes.extend(nodes)
 
             # build vector index
-            vector_index = VectorStoreIndex(nodes, service_context=self.service_context)
+            vector_index = VectorStoreIndex(nodes)
 
             # build summary index
-            summary_index = SummaryIndex(nodes, service_context=self.service_context)
+            summary_index = SummaryIndex(nodes)
             # define query engines
             vector_query_engine = vector_index.as_query_engine()
             summary_query_engine = summary_index.as_query_engine()

--- a/llama-index-packs/llama-index-packs-multi-document-agents/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-multi-document-agents/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-packs-multi-document-agents"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-multi-tenancy-rag/llama_index/packs/multi_tenancy_rag/base.py
+++ b/llama-index-packs/llama-index-packs-multi-tenancy-rag/llama_index/packs/multi_tenancy_rag/base.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, VectorStoreIndex, get_response_synthesizer
+from llama_index.core import Settings, VectorStoreIndex, get_response_synthesizer
 from llama_index.core.ingestion import IngestionPipeline
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.query_engine import RetrieverQueryEngine
@@ -14,11 +14,9 @@ from llama_index.llms.openai import OpenAI
 class MultiTenancyRAGPack(BaseLlamaPack):
     def __init__(self) -> None:
         llm = OpenAI(model="gpt-3.5-turbo", temperature=0.1)
-        service_context = ServiceContext.from_defaults(llm=llm)
         self.llm = llm
-        self.index = VectorStoreIndex.from_documents(
-            documents=[], service_context=service_context
-        )
+        Settings.llm = self.llm
+        self.index = VectorStoreIndex.from_documents(documents=[])
 
     def get_modules(self) -> Dict[str, Any]:
         """Get modules."""
@@ -52,7 +50,7 @@ class MultiTenancyRAGPack(BaseLlamaPack):
                     )
                 ]
             ),
-            **kwargs
+            **kwargs,
         )
         # Define response synthesizer
         response_synthesizer = get_response_synthesizer(response_mode="compact")

--- a/llama-index-packs/llama-index-packs-multi-tenancy-rag/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-multi-tenancy-rag/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["ravi03071991"]
 name = "llama-index-packs-multi-tenancy-rag"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-nebulagraph-query-engine/llama_index/packs/nebulagraph_query_engine/base.py
+++ b/llama-index-packs/llama-index-packs-nebulagraph-query-engine/llama_index/packs/nebulagraph_query_engine/base.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 from llama_index.core import (
     KnowledgeGraphIndex,
     QueryBundle,
-    ServiceContext,
+    Settings,
     StorageContext,
     VectorStoreIndex,
     get_response_synthesizer,
@@ -72,13 +72,12 @@ class NebulaGraphQueryEnginePack(BaseLlamaPack):
 
         # define LLM
         self.llm = OpenAI(temperature=0.1, model="gpt-3.5-turbo")
-        self.service_context = ServiceContext.from_defaults(llm=self.llm)
+        Settings.llm = self.llm
 
         nebulagraph_index = KnowledgeGraphIndex.from_documents(
             documents=docs,
             storage_context=nebulagraph_storage_context,
             max_triplets_per_chunk=max_triplets_per_chunk,
-            service_context=self.service_context,
             space_name=space_name,
             edge_types=edge_types,
             rel_prop_names=rel_prop_names,
@@ -126,8 +125,7 @@ class NebulaGraphQueryEnginePack(BaseLlamaPack):
 
             # create response synthesizer
             nebulagraph_response_synthesizer = get_response_synthesizer(
-                service_context=self.service_context,
-                response_mode="tree_summarize",
+                response_mode="tree_summarize"
             )
 
             # Custom combo query engine
@@ -142,7 +140,6 @@ class NebulaGraphQueryEnginePack(BaseLlamaPack):
 
             self.query_engine = KnowledgeGraphQueryEngine(
                 storage_context=nebulagraph_storage_context,
-                service_context=self.service_context,
                 llm=self.llm,
                 verbose=True,
             )
@@ -154,13 +151,12 @@ class NebulaGraphQueryEnginePack(BaseLlamaPack):
 
             nebulagraph_graph_rag_retriever = KnowledgeGraphRAGRetriever(
                 storage_context=nebulagraph_storage_context,
-                service_context=self.service_context,
                 llm=self.llm,
                 verbose=True,
             )
 
             self.query_engine = RetrieverQueryEngine.from_args(
-                nebulagraph_graph_rag_retriever, service_context=self.service_context
+                nebulagraph_graph_rag_retriever
             )
 
         else:
@@ -171,7 +167,6 @@ class NebulaGraphQueryEnginePack(BaseLlamaPack):
         """Get modules."""
         return {
             "llm": self.llm,
-            "service_context": self.service_context,
             "query_engine": self.query_engine,
         }
 

--- a/llama-index-packs/llama-index-packs-nebulagraph-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-nebulagraph-query-engine/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["wenqiglantz"]
 name = "llama-index-packs-nebulagraph-query-engine"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-neo4j-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-neo4j-query-engine/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["wenqiglantz"]
 name = "llama-index-packs-neo4j-query-engine"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-ollama-query-engine/llama_index/packs/ollama_query_engine/base.py
+++ b/llama-index-packs/llama-index-packs-ollama-query-engine/llama_index/packs/ollama_query_engine/base.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, VectorStoreIndex
+from llama_index.core import Settings, VectorStoreIndex
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.llama_pack.base import BaseLlamaPack
@@ -21,17 +21,13 @@ class OllamaQueryEnginePack(BaseLlamaPack):
     ) -> None:
         self._model = model
         self._base_url = base_url
+        self.llm = Ollama(model=self._model, base_url=self._base_url)
 
-        llm = Ollama(model=self._model, base_url=self._base_url)
-
-        embed_model = OllamaEmbedding(model_name=self._model, base_url=self._base_url)
-
-        service_context = ServiceContext.from_defaults(llm=llm, embed_model=embed_model)
-
-        self.llm = llm
-        self.index = VectorStoreIndex.from_documents(
-            documents, service_context=service_context
+        Settings.llm = self.llm
+        Settings.embed_model = OllamaEmbedding(
+            model_name=self._model, base_url=self._base_url
         )
+        self.index = VectorStoreIndex.from_documents(documents)
 
     def get_modules(self) -> Dict[str, Any]:
         """Get modules."""

--- a/llama-index-packs/llama-index-packs-ollama-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-ollama-query-engine/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["chnsagitchen"]
 name = "llama-index-packs-ollama-query-engine"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-rag-cli-local/llama_index/packs/rag_cli_local/base.py
+++ b/llama-index-packs/llama-index-packs-rag-cli-local/llama_index/packs/rag_cli_local/base.py
@@ -9,7 +9,7 @@ from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.llms.ollama import Ollama
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.core.utils import get_cache_dir
-from llama_index.core import ServiceContext, VectorStoreIndex
+from llama_index.core import Settings, VectorStoreIndex
 from llama_index.core.response_synthesizers import CompactAndRefine
 from llama_index.core.query_pipeline import InputComponent
 from llama_index.core.llama_pack.base import BaseLlamaPack
@@ -50,13 +50,12 @@ def init_local_rag_cli(
         cache=IngestionCache(),
     )
 
-    service_context = ServiceContext.from_defaults(llm=llm, embed_model=embed_model)
+    Settings.llm = llm
+    Settings.embed_model = embed_model
     retriever = VectorStoreIndex.from_vector_store(
-        ingestion_pipeline.vector_store, service_context=service_context
+        ingestion_pipeline.vector_store
     ).as_retriever(similarity_top_k=8)
-    response_synthesizer = CompactAndRefine(
-        service_context=service_context, streaming=True, verbose=True
-    )
+    response_synthesizer = CompactAndRefine(streaming=True, verbose=True)
     # define query pipeline
     query_pipeline = QueryPipeline(verbose=verbose)
     query_pipeline.add_modules(

--- a/llama-index-packs/llama-index-packs-rag-cli-local/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-rag-cli-local/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-packs-rag-cli-local"
 readme = "README.md"
-version = "0.1.4"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-ragatouille-retriever/llama_index/packs/ragatouille_retriever/base.py
+++ b/llama-index-packs/llama-index-packs-ragatouille-retriever/llama_index/packs/ragatouille_retriever/base.py
@@ -2,13 +2,13 @@
 
 from typing import Any, Dict, List, Optional
 
+from llama_index.core import Settings
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.indices.query.schema import QueryBundle
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.llms.llm import LLM
 from llama_index.core.query_engine import RetrieverQueryEngine
 from llama_index.core.schema import Document, NodeWithScore, TextNode
-from llama_index.core.service_context import ServiceContext
 from llama_index.llms.openai import OpenAI
 
 
@@ -90,9 +90,8 @@ class RAGatouilleRetrieverPack(BaseLlamaPack):
         self.documents = documents
 
         self.llm = llm or OpenAI(model="gpt-3.5-turbo")
-        self.query_engine = RetrieverQueryEngine.from_args(
-            self.custom_retriever, service_context=ServiceContext.from_defaults(llm=llm)
-        )
+        Settings.llm = self.llm
+        self.query_engine = RetrieverQueryEngine.from_args(self.custom_retriever)
 
     def add_documents(self, documents: List[Document]) -> None:
         """Add documents."""

--- a/llama-index-packs/llama-index-packs-ragatouille-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-ragatouille-retriever/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-packs-ragatouille-retriever"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-recursive-retriever/llama_index/packs/recursive_retriever/small_to_big/base.py
+++ b/llama-index-packs/llama-index-packs-recursive-retriever/llama_index/packs/recursive_retriever/small_to_big/base.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, VectorStoreIndex
+from llama_index.core import Settings, VectorStoreIndex
 from llama_index.core.embeddings.utils import resolve_embed_model
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.node_parser import SentenceSplitter
@@ -35,9 +35,9 @@ class RecursiveRetrieverSmallToBigPack(BaseLlamaPack):
             node.id_ = f"node-{idx}"
         self.embed_model = resolve_embed_model("local:BAAI/bge-small-en")
         self.llm = OpenAI(model="gpt-3.5-turbo")
-        self.service_context = ServiceContext.from_defaults(
-            llm=self.llm, embed_model=self.embed_model
-        )
+        Settings.llm = self.llm
+        Settings.embed_model = self.embed_model
+
         # build graph of smaller chunks pointing to bigger parent chunks
         # make chunk overlap 0
         sub_chunk_sizes = [128, 256, 512]
@@ -60,9 +60,7 @@ class RecursiveRetrieverSmallToBigPack(BaseLlamaPack):
         all_nodes_dict = {n.node_id: n for n in all_nodes}
 
         # define recursive retriever
-        self.vector_index_chunk = VectorStoreIndex(
-            all_nodes, service_context=self.service_context
-        )
+        self.vector_index_chunk = VectorStoreIndex(all_nodes)
         vector_retriever_chunk = self.vector_index_chunk.as_retriever(
             similarity_top_k=2
         )
@@ -72,9 +70,7 @@ class RecursiveRetrieverSmallToBigPack(BaseLlamaPack):
             node_dict=all_nodes_dict,
             verbose=True,
         )
-        self.query_engine = RetrieverQueryEngine.from_args(
-            self.recursive_retriever, service_context=self.service_context
-        )
+        self.query_engine = RetrieverQueryEngine.from_args(self.recursive_retriever)
 
     def get_modules(self) -> Dict[str, Any]:
         """Get modules."""
@@ -83,7 +79,6 @@ class RecursiveRetrieverSmallToBigPack(BaseLlamaPack):
             "recursive_retriever": self.recursive_retriever,
             "llm": self.llm,
             "embed_model": self.embed_model,
-            "service_context": self.service_context,
         }
 
     def run(self, *args: Any, **kwargs: Any) -> Any:

--- a/llama-index-packs/llama-index-packs-recursive-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-recursive-retriever/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-packs-recursive-retriever"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-resume-screener/llama_index/packs/resume_screener/base.py
+++ b/llama-index-packs/llama-index-packs-resume-screener/llama_index/packs/resume_screener/base.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from llama_index.core import ServiceContext
+from llama_index.core import Settings
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.response_synthesizers import TreeSummarize
 from llama_index.core.schema import NodeWithScore
@@ -61,10 +61,8 @@ class ResumeScreenerPack(BaseLlamaPack):
     ) -> None:
         self.reader = PDFReader()
         llm = llm or OpenAI(model="gpt-4")
-        service_context = ServiceContext.from_defaults(llm=llm)
-        self.synthesizer = TreeSummarize(
-            output_cls=ResumeScreenerDecision, service_context=service_context
-        )
+        Settings.llm = llm
+        self.synthesizer = TreeSummarize(output_cls=ResumeScreenerDecision)
         criteria_str = _format_criteria_str(criteria)
         self.query = QUERY_TEMPLATE.format(
             job_description=job_description, criteria_str=criteria_str

--- a/llama-index-packs/llama-index-packs-resume-screener/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-resume-screener/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["Disiok"]
 name = "llama-index-packs-resume-screener"
 readme = "README.md"
-version = "0.1.6"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-sentence-window-retriever/llama_index/packs/sentence_window_retriever/base.py
+++ b/llama-index-packs/llama-index-packs-sentence-window-retriever/llama_index/packs/sentence_window_retriever/base.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, VectorStoreIndex
+from llama_index.core import Settings, VectorStoreIndex
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.node_parser import (
     SentenceWindowNodeParser,
@@ -40,15 +40,12 @@ class SentenceWindowRetrieverPack(BaseLlamaPack):
         self.embed_model = HuggingFaceEmbedding(
             model_name="sentence-transformers/all-mpnet-base-v2", max_length=512
         )
-        self.service_context = ServiceContext.from_defaults(
-            llm=self.llm,
-            embed_model=self.embed_model,
-        )
+        Settings.llm = self.llm
+        Settings.embed_model = self.embed_model
+
         # extract nodes
         nodes = self.node_parser.get_nodes_from_documents(docs)
-        self.sentence_index = VectorStoreIndex(
-            nodes, service_context=self.service_context
-        )
+        self.sentence_index = VectorStoreIndex(nodes)
         self.postprocessor = MetadataReplacementPostProcessor(
             target_metadata_key="window"
         )
@@ -67,7 +64,6 @@ class SentenceWindowRetrieverPack(BaseLlamaPack):
             "llm": self.llm,
             "embed_model": self.embed_model,
             "query_engine": self.query_engine,
-            "service_context": self.service_context,
         }
 
     def run(self, *args: Any, **kwargs: Any) -> Any:

--- a/llama-index-packs/llama-index-packs-sentence-window-retriever/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-sentence-window-retriever/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-packs-sentence-window-retriever"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-snowflake-query-engine/llama_index/packs/snowflake_query_engine/base.py
+++ b/llama-index-packs/llama-index-packs-snowflake-query-engine/llama_index/packs/snowflake_query_engine/base.py
@@ -3,7 +3,7 @@
 import os
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, SQLDatabase
+from llama_index.core import SQLDatabase
 from llama_index.core.indices.struct_store.sql_query import NLSQLTableQueryEngine
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from sqlalchemy import create_engine
@@ -44,18 +44,13 @@ class SnowflakeQueryEnginePack(BaseLlamaPack):
         self._sql_database = SQLDatabase(engine)
         self.tables = tables
 
-        self._service_context = ServiceContext.from_defaults()
-
         self.query_engine = NLSQLTableQueryEngine(
-            sql_database=self._sql_database,
-            tables=self.tables,
-            service_context=self._service_context,
+            sql_database=self._sql_database, tables=self.tables
         )
 
     def get_modules(self) -> Dict[str, Any]:
         """Get modules."""
         return {
-            "service_context": self._service_context,
             "sql_database": self._sql_database,
             "query_engine": self.query_engine,
         }

--- a/llama-index-packs/llama-index-packs-snowflake-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-snowflake-query-engine/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["wenqiglantz"]
 name = "llama-index-packs-snowflake-query-engine"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-stock-market-data-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-stock-market-data-query-engine/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["anoopshrma"]
 name = "llama-index-packs-stock-market-data-query-engine"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-streamlit-chatbot/llama_index/packs/streamlit_chatbot/base.py
+++ b/llama-index-packs/llama-index-packs-streamlit-chatbot/llama_index/packs/streamlit_chatbot/base.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import Any, Dict
 
 from llama_index.core import (
-    ServiceContext,
+    Settings,
     VectorStoreIndex,
 )
 from llama_index.core.llama_pack.base import BaseLlamaPack
@@ -74,12 +74,9 @@ class StreamlitChatPack(BaseLlamaPack):
         def load_index_data():
             loader = WikipediaReader()
             docs = loader.load_data(pages=[self.wikipedia_page])
-            service_context = ServiceContext.from_defaults(
-                llm=OpenAI(model="gpt-3.5-turbo", temperature=0.5)
-            )
-            return VectorStoreIndex.from_documents(
-                docs, service_context=service_context
-            )
+            Settings.llm = OpenAI(model="gpt-3.5-turbo", temperature=0.5)
+
+            return VectorStoreIndex.from_documents(docs)
 
         index = load_index_data()
 

--- a/llama-index-packs/llama-index-packs-streamlit-chatbot/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-streamlit-chatbot/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["carolinedlu"]
 name = "llama-index-packs-streamlit-chatbot"
 readme = "README.md"
-version = "0.1.5"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.9.7 || >3.9.7,<4.0"

--- a/llama-index-packs/llama-index-packs-voyage-query-engine/llama_index/packs/voyage_query_engine/base.py
+++ b/llama-index-packs/llama-index-packs-voyage-query-engine/llama_index/packs/voyage_query_engine/base.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, VectorStoreIndex
+from llama_index.core import Settings, VectorStoreIndex
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.schema import Document
 from llama_index.embeddings.voyageai import VoyageEmbedding
@@ -14,11 +14,11 @@ class VoyageQueryEnginePack(BaseLlamaPack):
         embed_model = VoyageEmbedding(
             model_name="voyage-01", voyage_api_key=os.environ["VOYAGE_API_KEY"]
         )
-        service_context = ServiceContext.from_defaults(llm=llm, embed_model=embed_model)
+
         self.llm = llm
-        self.index = VectorStoreIndex.from_documents(
-            documents, service_context=service_context
-        )
+        Settings.llm = self.llm
+        Settings.embed_model = embed_model
+        self.index = VectorStoreIndex.from_documents(documents)
 
     def get_modules(self) -> Dict[str, Any]:
         """Get modules."""

--- a/llama-index-packs/llama-index-packs-voyage-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-voyage-query-engine/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["Liuhong99"]
 name = "llama-index-packs-voyage-query-engine"
 readme = "README.md"
-version = "0.1.3"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-packs/llama-index-packs-zephyr-query-engine/llama_index/packs/zephyr_query_engine/base.py
+++ b/llama-index-packs/llama-index-packs-zephyr-query-engine/llama_index/packs/zephyr_query_engine/base.py
@@ -1,9 +1,8 @@
 """LlamaPack class."""
 
-
 from typing import Any, Dict, List
 
-from llama_index.core import ServiceContext, VectorStoreIndex, set_global_tokenizer
+from llama_index.core import Settings, VectorStoreIndex, set_global_tokenizer
 from llama_index.core.llama_pack.base import BaseLlamaPack
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.schema import Document
@@ -75,14 +74,11 @@ class ZephyrQueryEnginePack(BaseLlamaPack):
         tokenizer = AutoTokenizer.from_pretrained("HuggingFaceH4/zephyr-7b-beta")
         set_global_tokenizer(tokenizer.encode)
 
-        service_context = ServiceContext.from_defaults(
-            llm=llm, embed_model="local:BAAI/bge-base-en-v1.5"
-        )
+        Settings.llm = llm
+        Settings.embed_model = "local:BAAI/bge-base-en-v1.5"
 
         self.llm = llm
-        self.index = VectorStoreIndex.from_documents(
-            documents, service_context=service_context
-        )
+        self.index = VectorStoreIndex.from_documents(documents)
 
     def get_modules(self) -> Dict[str, Any]:
         """Get modules."""

--- a/llama-index-packs/llama-index-packs-zephyr-query-engine/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-zephyr-query-engine/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["logan-markewich"]
 name = "llama-index-packs-zephyr-query-engine"
 readme = "README.md"
-version = "0.1.2"
+version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Part of the work to remove usage of the deprecated `ServiceContext`

Affected packs:
- llama-index-packs-auto-merging-retriever
- llama-index-packs-cohere-citation-chat
- llama-index-packs-dense-x-retrieval
- llama-index-packs-fusion-retriever
- llama-index-packs-multi-document-agents
- llama-index-packs-multi-tenancy-rag
- llama-index-packs-nebulagraph-query-engine
- llama-index-packs-neo4j-query-engine
- llama-index-packs-o- llama-query-engine
- llama-index-packs-rag-cli-local
- llama-index-packs-ragatouille-retriever
- llama-index-packs-recursive-retriever
- llama-index-packs-resume-screener
- llama-index-packs-sentence-window-retriever
- llama-index-packs-snowflake-query-engine
- llama-index-packs-stock-market-data-query-engine
- llama-index-packs-streamlit-chatbot
- llama-index-packs-voyage-query-engine
- llama-index-packs-zephyr-query-engine

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


