### PR TITLE
15275 feature request make all events accessible like mappings

### DIFF
--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -105,10 +105,4 @@ class StopEvent(DictLikeEvent):
         super().__init__(result=result)
 
 
-class CustomEvent(DictLikeEvent):
-    """StartEvent is implicitly sent when a workflow runs."""
-
-    _param1: str = PrivateAttr()
-
-
 EventType = Type[Union[Event, DictLikeEvent]]

--- a/llama-index-core/tests/workflow/test_event.py
+++ b/llama-index-core/tests/workflow/test_event.py
@@ -3,13 +3,13 @@ from llama_index.core.bridge.pydantic import PrivateAttr
 from typing import Any
 
 
-class TestEvent(Event):
+class _TestEvent(Event):
     param: str
     _private_param_1: str = PrivateAttr()
     _private_param_2: str = PrivateAttr(default_factory=str)
 
 
-class TestEvent2(Event):
+class _TestEvent2(Event):
     """Custom Test Event.
 
     Private Attrs:
@@ -38,7 +38,7 @@ def test_event_init_basic():
 
 
 def test_custom_event_with_fields_and_private_params():
-    evt = TestEvent(a=1, param="test_param", _private_param_1="test_private_param_1")
+    evt = _TestEvent(a=1, param="test_param", _private_param_1="test_private_param_1")
 
     assert evt.a == 1
     assert evt["a"] == evt.a
@@ -49,7 +49,7 @@ def test_custom_event_with_fields_and_private_params():
 
 
 def test_custom_event_override_init():
-    evt = TestEvent2(a=1, b=2, _private_param=2, _modified_private_param=2)
+    evt = _TestEvent2(a=1, b=2, _private_param=2, _modified_private_param=2)
 
     assert evt.a == 1
     assert evt.b == 2

--- a/llama-index-core/tests/workflow/test_event.py
+++ b/llama-index-core/tests/workflow/test_event.py
@@ -1,0 +1,58 @@
+from llama_index.core.workflow.events import Event
+from llama_index.core.bridge.pydantic import PrivateAttr
+from typing import Any
+
+
+class TestEvent(Event):
+    param: str
+    _private_param_1: str = PrivateAttr()
+    _private_param_2: str = PrivateAttr(default_factory=str)
+
+
+class TestEvent2(Event):
+    """Custom Test Event.
+
+    Private Attrs:
+        _private_param: doesn't get modified during construction
+        _modified_private_param: gets processed before being set
+    """
+
+    _private_param: int = PrivateAttr()
+    _modified_private_param: int = PrivateAttr()
+
+    def __init__(self, _modified_private_param: int, **params: Any):
+        super().__init__(**params)
+        self._modified_private_param = _modified_private_param * 2
+
+
+def test_event_init_basic():
+    evt = Event(a=1, b=2, c="c")
+
+    assert evt.a == 1
+    assert evt.b == 2
+    assert evt.c == "c"
+    assert evt["a"] == evt.a
+    assert evt["b"] == evt.b
+    assert evt["c"] == evt.c
+    assert evt.keys() == {"a": 1, "b": 2, "c": "c"}.keys()
+
+
+def test_custom_event_with_fields_and_private_params():
+    evt = TestEvent(a=1, param="test_param", _private_param_1="test_private_param_1")
+
+    assert evt.a == 1
+    assert evt["a"] == evt.a
+    assert evt.param == "test_param"
+    assert evt._data == {"a": 1}
+    assert evt._private_param_1 == "test_private_param_1"
+    assert evt._private_param_2 == ""
+
+
+def test_custom_event_override_init():
+    evt = TestEvent2(a=1, b=2, _private_param=2, _modified_private_param=2)
+
+    assert evt.a == 1
+    assert evt.b == 2
+    assert evt._data == {"a": 1, "b": 2}
+    assert evt._private_param == 2
+    assert evt._modified_private_param == 4


### PR DESCRIPTION
# Description

- Fixing dict interface for `StartEvent` (maximum recursion error with  `__getattr__` and `__setattr__`).
- Updates `Event` type to take on the dict-like interface that was priorly only set for `StartEvent` -- `StartEvent` is now a light subclass of `Event`.
- ~~Also, adds `DictLikeEvent` (naming?) as an event type that can be used generally with a dict-like interface.~~

Closes #15275 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] NA

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

