### PR TITLE
Use backticks to escape label

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/analytics_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/analytics_property_graph.py
@@ -83,7 +83,7 @@ class NeptuneAnalyticsPropertyGraphStore(NeptuneBasePropertyGraph):
         )
 
         data = self.structured_query(
-            f"""MATCH (e:'{BASE_ENTITY_LABEL}')
+            f"""MATCH (e:`{BASE_ENTITY_LABEL}`)
             WHERE ({filters})
             CALL neptune.algo.vectors.get(e)
             YIELD embedding

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neptune"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR fixes an issue whereby querying a `PropertyGraphIndex` backed by a `NeptuneAnalyticsPropertyGraphStore` would throw the following exception.

```
NeptuneQueryException: {'message': 'An error occurred while executing the query.', 'details': "An error occurred (ValidationException) when calling the ExecuteQuery operation (reached max retries: 0): Invalid input ''': expected whitespace or a label name (line 1, column 10 (offset: 9))"}
```

Fixes # (issue)

The fix was to use backticks to escape the label in the `vector_query` method.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in a Jupyer notebook that was used to build and query a property graph index backed by `NeptuneAnalyticsPropertyGraphStore` .

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
