### PR TITLE
fix bug when caling llama-index-postprocessor-dashscope-rerank

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
@@ -77,7 +77,7 @@ class DashScopeRerank(BaseNodePostprocessor):
                 for node in nodes
             ]
             results = dashscope.TextReRank.call(
-                model_name=self.model,
+                model=self.model,
                 top_n=self.top_n,
                 query=query_bundle.query_str,
                 documents=texts,

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-postprocessor-dashscope-rerank"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

dashscope.TextRank use model as input parameter rather than "model_name"

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

-  Yes

## Type of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I stared at the code and made sure it makes sense

## Suggested Checklist:

- I have performed a self-review of my own code