### PR TITLE
Vertexai embedding enhancement

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/CHANGELOG.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/CHANGELOG.md
@@ -1,0 +1,25 @@
+---
+
+### CHANGELOG
+
+**Version:** 0.1.1
+
+#### Added
+- **Credential Processing Enhancements:**
+  - Introduced `_process_credentials` function to handle credentials provided as strings, dictionaries, or `service_account.Credentials` objects. This allows for flexible credential input formats.
+
+- **Model Name Handling in Embedding Requests:**
+  - Updated `_get_embedding_request` to accept `model_name` as a parameter, enabling the function to handle models that either support or do not support the `task_type` parameter, such as `textembedding-gecko@001`.
+
+#### Changed
+- **VertexTextEmbedding Initialization:**
+  - Updated `VertexTextEmbedding` class constructor to use `_process_credentials` for handling credentials, streamlining initialization with different credential formats.
+
+- **Removed Redundant Imports:**
+  - Removed redundant imports and streamlined the import statements.
+
+#### Fixed
+- **Compatibility with Older Models:**
+  - Fixed issues with models that do not support the `task_type` parameter by introducing `_UNSUPPORTED_TASK_TYPE_MODEL` set, ensuring compatibility with models like `textembedding-gecko@001`.
+
+---

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/CHANGELOG.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/CHANGELOG.md
@@ -5,18 +5,14 @@
 **Version:** 0.1.1
 
 #### Added
-- **Credential Processing Enhancements:**
-  - Introduced `_process_credentials` function to handle credentials provided as strings, dictionaries, or `service_account.Credentials` objects. This allows for flexible credential input formats.
 
 - **Model Name Handling in Embedding Requests:**
   - Updated `_get_embedding_request` to accept `model_name` as a parameter, enabling the function to handle models that either support or do not support the `task_type` parameter, such as `textembedding-gecko@001`.
 
 #### Changed
-- **VertexTextEmbedding Initialization:**
-  - Updated `VertexTextEmbedding` class constructor to use `_process_credentials` for handling credentials, streamlining initialization with different credential formats.
 
 - **Removed Redundant Imports:**
-  - Removed redundant imports and streamlined the import statements.
+  - Credential Management: Supports both direct credentials and service account info for secure API access.
 
 #### Fixed
 - **Compatibility with Older Models:**

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
@@ -19,12 +19,7 @@ Otherwise, `VertexTextEmbedding` supports async interface.
 
 - **Flexible Credential Handling:**
 
-  - The `_process_credentials` function now supports credentials provided as:
-    - **JSON String**: `credentials = '{"type": "service_account", ...}'`
-    - **Dictionary**: `credentials = {"type": "service_account", ...}`
-    - **`service_account.Credentials` object**: Directly pass the credentials object.
-
-  This ensures that credentials are correctly processed, regardless of the input format, and are used to initialize Vertex AI.
+  - Credential Management: Supports both direct credentials and service account info for secure API access.
 
 - **Model Name Handling in Embedding Requests:**
   - The `_get_embedding_request` function now accepts the `model_name` parameter, allowing it to manage models that do not support the `task_type` parameter, like `textembedding-gecko@001`.
@@ -32,22 +27,33 @@ Otherwise, `VertexTextEmbedding` supports async interface.
 ### Example Usage
 
 ```python
-from llama_index.embeddings.vertex import (
-    VertexTextEmbedding,
-    VertexEmbeddingMode,
+from google.oauth2 import service_account
+from llama_index.embeddings.vertex import VertexTextEmbedding
+
+credentials = service_account.Credentials.from_service_account_file(
+    "path/to/your/service-account.json"
 )
 
-# Example using a JSON string for credentials
-json_credentials = (
-    '{"type": "service_account", "project_id": "your-project", ...}'
-)
-text_embedder = VertexTextEmbedding(
+embedding = VertexTextEmbedding(
     model_name="textembedding-gecko@003",
-    project="your-gcp-project",
-    location="your-gcp-location",
-    credentials=json_credentials,
-    embed_mode=VertexEmbeddingMode.RETRIEVAL_MODE,
+    project="your-project-id",
+    location="your-region",
+    credentials=credentials,
 )
+```
 
-embeddings = text_embedder.get_text_embedding("Hello World!")
+Alternatively, you can directly pass the required service account parameters:
+
+```python
+from llama_index.embeddings.vertex import VertexTextEmbedding
+
+embedding = VertexTextEmbedding(
+    model_name="textembedding-gecko@003",
+    project="your-project-id",
+    location="your-region",
+    client_email="your-service-account-email",
+    token_uri="your-token-uri",
+    private_key_id="your-private-key-id",
+    private_key="your-private-key",
+)
 ```

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
@@ -12,3 +12,24 @@ Implements Vertex AI Embeddings Models:
 
 **Note**: Currently Vertex AI does not support async on `multimodalembedding`.
 Otherwise, `VertexTextEmbedding` supports async interface.
+
+---
+
+## **Version: [0.1.1]**
+
+### **Key Enhancements**
+
+1. **Flexible Credential Handling**:
+
+   - Added `_process_credentials` to support credentials as JSON strings, dictionaries, or `service_account.Credentials` instances.
+
+2. **Task Type Compatibility**:
+
+   - Improved `_get_embedding_request` to automatically omit the `task_type` parameter for models like `textembedding-gecko@001`.
+
+3. **Additional Configuration Options**:
+
+   - Introduced support for `num_workers`, `callback_manager`, and `additional_kwargs` in `VertexTextEmbedding` for better customization.
+
+4. **Improved Initialization**:
+   - Updated `init_vertexai` to utilize the new credential processing for seamless setup.

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
@@ -15,21 +15,39 @@ Otherwise, `VertexTextEmbedding` supports async interface.
 
 ---
 
-## **Version: [0.1.1]**
+### New Features
 
-### **Key Enhancements**
+- **Flexible Credential Handling:**
 
-1. **Flexible Credential Handling**:
+  - The `_process_credentials` function now supports credentials provided as:
+    - **JSON String**: `credentials = '{"type": "service_account", ...}'`
+    - **Dictionary**: `credentials = {"type": "service_account", ...}`
+    - **`service_account.Credentials` object**: Directly pass the credentials object.
 
-   - Added `_process_credentials` to support credentials as JSON strings, dictionaries, or `service_account.Credentials` instances.
+  This ensures that credentials are correctly processed, regardless of the input format, and are used to initialize Vertex AI.
 
-2. **Task Type Compatibility**:
+- **Model Name Handling in Embedding Requests:**
+  - The `_get_embedding_request` function now accepts the `model_name` parameter, allowing it to manage models that do not support the `task_type` parameter, like `textembedding-gecko@001`.
 
-   - Improved `_get_embedding_request` to automatically omit the `task_type` parameter for models like `textembedding-gecko@001`.
+### Example Usage
 
-3. **Additional Configuration Options**:
+```python
+from llama_index.embeddings.vertex import (
+    VertexTextEmbedding,
+    VertexEmbeddingMode,
+)
 
-   - Introduced support for `num_workers` in `VertexTextEmbedding` for better customization.
+# Example using a JSON string for credentials
+json_credentials = (
+    '{"type": "service_account", "project_id": "your-project", ...}'
+)
+text_embedder = VertexTextEmbedding(
+    model_name="textembedding-gecko@003",
+    project="your-gcp-project",
+    location="your-gcp-location",
+    credentials=json_credentials,
+    embed_mode=VertexEmbeddingMode.RETRIEVAL_MODE,
+)
 
-4. **Improved Initialization**:
-   - Updated `init_vertexai` to utilize the new credential processing for seamless setup.
+embeddings = text_embedder.get_text_embedding("Hello World!")
+```

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/README.md
@@ -29,7 +29,7 @@ Otherwise, `VertexTextEmbedding` supports async interface.
 
 3. **Additional Configuration Options**:
 
-   - Introduced support for `num_workers`, `callback_manager`, and `additional_kwargs` in `VertexTextEmbedding` for better customization.
+   - Introduced support for `num_workers` in `VertexTextEmbedding` for better customization.
 
 4. **Improved Initialization**:
    - Updated `init_vertexai` to utilize the new credential processing for seamless setup.

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/llama_index/embeddings/vertex/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/llama_index/embeddings/vertex/base.py
@@ -96,6 +96,18 @@ class VertexTextEmbedding(BaseEmbedding):
     additional_kwargs: Dict[str, Any] = Field(
         default_factory=dict, description="Additional kwargs for the Vertex."
     )
+    client_email: Optional[str] = Field(
+        description="The client email for the VertexAI credentials."
+    )
+    token_uri: Optional[str] = Field(
+        description="The token URI for the VertexAI credentials."
+    )
+    private_key_id: Optional[str] = Field(
+        description="The private key ID for the VertexAI credentials."
+    )
+    private_key: Optional[str] = Field(
+        description="The private key for the VertexAI credentials."
+    )
 
     _model: TextEmbeddingModel = PrivateAttr()
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-embeddings-vertex"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/tests/test_embeddings_vertex.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/tests/test_embeddings_vertex.py
@@ -2,7 +2,6 @@ import io
 import unittest
 from unittest.mock import patch, Mock, MagicMock, AsyncMock
 
-from google.oauth2 import service_account
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.embeddings import MultiModalEmbedding
 from vertexai.language_models import TextEmbedding, TextEmbeddingInput
@@ -25,7 +24,7 @@ class VertexTextEmbeddingTest(unittest.TestCase):
     @patch("vertexai.init")
     @patch("vertexai.language_models.TextEmbeddingModel.from_pretrained")
     def test_init(self, model_mock: Mock, mock_init: Mock):
-        mock_cred = Mock(spec=service_account.Credentials)
+        mock_cred = Mock(return_value="mock_credentials_instance")
         embedding = VertexTextEmbedding(
             model_name="textembedding-gecko@001",
             project="test-project",
@@ -54,10 +53,11 @@ class VertexTextEmbeddingTest(unittest.TestCase):
     def test_get_embedding_retrieval(self, model_mock: Mock, init_mock: Mock):
         model = MagicMock()
         model_mock.return_value = model
-
+        mock_cred = Mock(return_value="mock_credentials_instance")
         embedding = VertexTextEmbedding(
             project="test-project",
             location="us-test-location",
+            credentials=mock_cred,
             embed_mode=VertexEmbeddingMode.RETRIEVAL_MODE,
             additional_kwargs={"auto_truncate": True},
         )
@@ -121,12 +121,14 @@ class VertexTextEmbeddingTestAsync(unittest.IsolatedAsyncioTestCase):
             AsyncMock()
         )  # Ensure get_embeddings is an AsyncMock for async calls
         model_mock.return_value = model
+        mock_cred = Mock(return_value="mock_credentials_instance")
 
         embedding = VertexTextEmbedding(
             project="test-project",
             location="us-test-location",
             embed_mode=VertexEmbeddingMode.RETRIEVAL_MODE,
             additional_kwargs={"auto_truncate": True},
+            credentials=mock_cred,
         )
 
         model.get_embeddings_async.return_value = [


### PR DESCRIPTION
# Description

1. Added _process_credentials to support credentials as JSON strings, dictionaries, or service_account.Credentials instances.
2. Improved _get_embedding_request to automatically omit the task_type parameter for models like `textembedding-gecko@001`.
3. Introduced support for num_workers, callback_manager, and additional_kwargs in `VertexTextEmbedding` for better customization.
4. Updated init_vertexai to utilize the new credential processing for seamless setup.