### PR TITLE
Fix LangChainDeprecationWarning

### DIFF
--- a/llama-index-core/llama_index/core/bridge/langchain.py
+++ b/llama-index-core/llama_index/core/bridge/langchain.py
@@ -20,10 +20,8 @@ from langchain.chains.prompt_selector import (
 )  # pants: no-infer-dep
 from langchain.chat_models.base import BaseChatModel  # pants: no-infer-dep
 from langchain.docstore.document import Document  # pants: no-infer-dep
-from langchain.memory import (
-    ChatMessageHistory,
-    ConversationBufferMemory,
-)  # pants: no-infer-dep
+from langchain.memory import ConversationBufferMemory  # pants: no-infer-dep
+from langchain_community.chat_message_histories import ChatMessageHistory  # pants: no-infer-dep
 
 # chat and memory
 from langchain.memory.chat_memory import BaseChatMemory  # pants: no-infer-dep

--- a/llama-index-core/llama_index/core/bridge/langchain.py
+++ b/llama-index-core/llama_index/core/bridge/langchain.py
@@ -20,16 +20,7 @@ from langchain.chains.prompt_selector import (
 )  # pants: no-infer-dep
 from langchain.chat_models.base import BaseChatModel  # pants: no-infer-dep
 from langchain.docstore.document import Document  # pants: no-infer-dep
-try:
-    # Attempt to import from langchain 0.2 version module
-    from langchain_community.chat_message_histories import ChatMessageHistory  # pants: no-infer-dep
-    from langchain.memory import ConversationBufferMemory  # pants: no-infer-dep
-except ImportError:
-    # If the import fails, fallback to the langchain 0.1 version import path
-    from langchain.memory import (
-        ChatMessageHistory,
-        ConversationBufferMemory,
-    )  # pants: no-infer-dep
+from langchain.memory import ConversationBufferMemory  # pants: no-infer-dep
 
 # chat and memory
 from langchain.memory.chat_memory import BaseChatMemory  # pants: no-infer-dep
@@ -69,6 +60,7 @@ from langchain.text_splitter import (
     TextSplitter,
 )  # pants: no-infer-dep
 from langchain.tools import BaseTool, StructuredTool, Tool  # pants: no-infer-dep
+from langchain_community.chat_message_histories import ChatMessageHistory  # pants: no-infer-dep
 from langchain_community.chat_models import (
     ChatAnyscale,
     ChatOpenAI,

--- a/llama-index-core/llama_index/core/bridge/langchain.py
+++ b/llama-index-core/llama_index/core/bridge/langchain.py
@@ -20,8 +20,16 @@ from langchain.chains.prompt_selector import (
 )  # pants: no-infer-dep
 from langchain.chat_models.base import BaseChatModel  # pants: no-infer-dep
 from langchain.docstore.document import Document  # pants: no-infer-dep
-from langchain.memory import ConversationBufferMemory  # pants: no-infer-dep
-from langchain_community.chat_message_histories import ChatMessageHistory  # pants: no-infer-dep
+try:
+    # Attempt to import from langchain 0.2 version module
+    from langchain_community.chat_message_histories import ChatMessageHistory  # pants: no-infer-dep
+    from langchain.memory import ConversationBufferMemory  # pants: no-infer-dep
+except ImportError:
+    # If the import fails, fallback to the langchain 0.1 version import path
+    from langchain.memory import (
+        ChatMessageHistory,
+        ConversationBufferMemory,
+    )  # pants: no-infer-dep
 
 # chat and memory
 from langchain.memory.chat_memory import BaseChatMemory  # pants: no-infer-dep

--- a/llama-index-core/llama_index/core/bridge/langchain.py
+++ b/llama-index-core/llama_index/core/bridge/langchain.py
@@ -60,7 +60,9 @@ from langchain.text_splitter import (
     TextSplitter,
 )  # pants: no-infer-dep
 from langchain.tools import BaseTool, StructuredTool, Tool  # pants: no-infer-dep
-from langchain_community.chat_message_histories import ChatMessageHistory  # pants: no-infer-dep
+from langchain_community.chat_message_histories import (
+    ChatMessageHistory,
+)  # pants: no-infer-dep
 from langchain_community.chat_models import (
     ChatAnyscale,
     ChatOpenAI,


### PR DESCRIPTION
# Description

The PR fix an warning issue when using VectorStoreIndex.from_vector_store:

.venv/lib/python3.10/site-packages/langchain/_api/module_import.py:92: LangChainDeprecationWarning: Importing ChatMessageHistory from langchain.memory is deprecated. Please replace deprecated imports:

> from langchain.memory import ChatMessageHistory

with new imports of:

> from langchain_community.chat_message_histories import ChatMessageHistory
You can use the langchain cli to **automatically** upgrade many imports. Please see documentation here <https://python.langchain.com/v0.2/docs/versions/v0_2/>

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
