### PR TITLE
escape json in structured llm

### DIFF
--- a/llama-index-core/llama_index/core/llms/structured_llm.py
+++ b/llama-index-core/llama_index/core/llms/structured_llm.py
@@ -48,7 +48,7 @@ def _escape_braces(text: str) -> str:
             return match.group(0)  # Already escaped, return as is
         return "{{" + match.group(1) + "}}"
 
-    pattern = r"\{+([^{}]+?)\}+"
+    pattern = r"(?<!\{)\{([^{}]+?)\}(?!\})"
     return re.sub(pattern, replace, text)
 
 

--- a/llama-index-core/llama_index/core/llms/structured_llm.py
+++ b/llama-index-core/llama_index/core/llms/structured_llm.py
@@ -36,6 +36,22 @@ from llama_index.core.base.query_pipeline.query import (
 )
 
 
+def _escape_json(messages: Sequence[ChatMessage]) -> Sequence[ChatMessage]:
+    """Escape JSON in messages."""
+    new_messages = []
+    for message in messages:
+        if isinstance(message.content, str):
+            new_messages.append(
+                ChatMessage(
+                    role=message.role,
+                    content=message.content.replace("{", "{{").replace("}", "}}"),
+                )
+            )
+        else:
+            new_messages.append(message)
+    return new_messages
+
+
 class StructuredLLM(LLM):
     """
     A structured LLM takes in an inner LLM along with a designated output class,
@@ -65,7 +81,7 @@ class StructuredLLM(LLM):
         # make this work with our FunctionCallingProgram, even though
         # the messages don't technically have any variables (they are already formatted)
 
-        chat_prompt = ChatPromptTemplate(message_templates=messages)
+        chat_prompt = ChatPromptTemplate(message_templates=_escape_json(messages))
 
         output = self.llm.structured_predict(
             output_cls=self.output_cls, prompt=chat_prompt
@@ -79,7 +95,7 @@ class StructuredLLM(LLM):
     def stream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
-        chat_prompt = ChatPromptTemplate(message_templates=messages)
+        chat_prompt = ChatPromptTemplate(message_templates=_escape_json(messages))
 
         stream_output = self.llm.stream_structured_predict(
             output_cls=self.output_cls, prompt=chat_prompt, **kwargs
@@ -117,7 +133,7 @@ class StructuredLLM(LLM):
         # make this work with our FunctionCallingProgram, even though
         # the messages don't technically have any variables (they are already formatted)
 
-        chat_prompt = ChatPromptTemplate(message_templates=messages)
+        chat_prompt = ChatPromptTemplate(message_templates=_escape_json(messages))
 
         output = await self.llm.astructured_predict(
             output_cls=self.output_cls, prompt=chat_prompt
@@ -136,7 +152,7 @@ class StructuredLLM(LLM):
         """Async stream chat endpoint for LLM."""
 
         async def gen() -> ChatResponseAsyncGen:
-            chat_prompt = ChatPromptTemplate(message_templates=messages)
+            chat_prompt = ChatPromptTemplate(message_templates=_escape_json(messages))
 
             stream_output = await self.llm.astream_structured_predict(
                 output_cls=self.output_cls, prompt=chat_prompt, **kwargs

--- a/llama-index-core/tests/llms/test_structured_llm.py
+++ b/llama-index-core/tests/llms/test_structured_llm.py
@@ -46,3 +46,12 @@ def test_escape_json() -> None:
             additional_kwargs={"test": "test"},
         )
     ]
+
+    # shouldn't escape already escaped brackets with 4 brackets
+    test_case_5 = _escape_json(
+        [ChatMessage(role="user", content="test {{{{message}}}} {test}")]
+    )
+    assert test_case_5 == [
+        ChatMessage(role="user", content="test {{{{message}}}} {{test}}")
+    ]
+

--- a/llama-index-core/tests/llms/test_structured_llm.py
+++ b/llama-index-core/tests/llms/test_structured_llm.py
@@ -54,4 +54,3 @@ def test_escape_json() -> None:
     assert test_case_5 == [
         ChatMessage(role="user", content="test {{{{message}}}} {{test}}")
     ]
-

--- a/llama-index-core/tests/llms/test_structured_llm.py
+++ b/llama-index-core/tests/llms/test_structured_llm.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from llama_index.core.llms.structured_llm import _escape_json
+from llama_index.core.base.llms.types import ChatMessage
+
+
+def test_escape_json() -> None:
+    """Test escape JSON.
+
+    If there's curly brackets, escape it.
+    
+    """
+    
+    # create dumb test case
+    test_case_1 = _escape_json([ChatMessage(role="user", content="test message")])
+    assert test_case_1 == [ChatMessage(role="user", content="test message")]
+
+    # create test case with two brackets
+    test_case_2 = _escape_json([ChatMessage(role="user", content="test {message} {test}")])
+    assert test_case_2 == [ChatMessage(role="user", content="test {{message}} {{test}}")]
+
+    # create test case with a bracket that's already escaped - shouldn't change!
+    test_case_3 = _escape_json([ChatMessage(role="user", content="test {{message}} {test}")])
+    print(test_case_3[0].content)
+    assert test_case_3 == [ChatMessage(role="user", content="test {{message}} {{test}}")]
+
+    # test with additional kwargs
+    test_case_4 = _escape_json([ChatMessage(role="user", content="test {{message}} {test}", additional_kwargs={"test": "test"})])
+    assert test_case_4 == [ChatMessage(role="user", content="test {{message}} {{test}}", additional_kwargs={"test": "test"})]

--- a/llama-index-core/tests/llms/test_structured_llm.py
+++ b/llama-index-core/tests/llms/test_structured_llm.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from llama_index.core.llms.structured_llm import _escape_json
 from llama_index.core.base.llms.types import ChatMessage
 
@@ -8,22 +6,43 @@ def test_escape_json() -> None:
     """Test escape JSON.
 
     If there's curly brackets, escape it.
-    
+
     """
-    
     # create dumb test case
     test_case_1 = _escape_json([ChatMessage(role="user", content="test message")])
     assert test_case_1 == [ChatMessage(role="user", content="test message")]
 
     # create test case with two brackets
-    test_case_2 = _escape_json([ChatMessage(role="user", content="test {message} {test}")])
-    assert test_case_2 == [ChatMessage(role="user", content="test {{message}} {{test}}")]
+    test_case_2 = _escape_json(
+        [ChatMessage(role="user", content="test {message} {test}")]
+    )
+    assert test_case_2 == [
+        ChatMessage(role="user", content="test {{message}} {{test}}")
+    ]
 
     # create test case with a bracket that's already escaped - shouldn't change!
-    test_case_3 = _escape_json([ChatMessage(role="user", content="test {{message}} {test}")])
+    test_case_3 = _escape_json(
+        [ChatMessage(role="user", content="test {{message}} {test}")]
+    )
     print(test_case_3[0].content)
-    assert test_case_3 == [ChatMessage(role="user", content="test {{message}} {{test}}")]
+    assert test_case_3 == [
+        ChatMessage(role="user", content="test {{message}} {{test}}")
+    ]
 
     # test with additional kwargs
-    test_case_4 = _escape_json([ChatMessage(role="user", content="test {{message}} {test}", additional_kwargs={"test": "test"})])
-    assert test_case_4 == [ChatMessage(role="user", content="test {{message}} {{test}}", additional_kwargs={"test": "test"})]
+    test_case_4 = _escape_json(
+        [
+            ChatMessage(
+                role="user",
+                content="test {{message}} {test}",
+                additional_kwargs={"test": "test"},
+            )
+        ]
+    )
+    assert test_case_4 == [
+        ChatMessage(
+            role="user",
+            content="test {{message}} {{test}}",
+            additional_kwargs={"test": "test"},
+        )
+    ]


### PR DESCRIPTION
if there was text in brackets {, } then it would get mistakenly treated as a template variable

@logan-markewich is there a centralized utils method to escape json? seems like a genreally helpful function 