### PR TITLE
Add workaround for Handling MySQL Protocol Limitations in TiDB Vector with insert_batch_size

### DIFF
--- a/docs/docs/examples/vector_stores/TiDBVector.ipynb
+++ b/docs/docs/examples/vector_stores/TiDBVector.ipynb
@@ -160,6 +160,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note: If you encounter errors during this process due to the MySQL protocol’s packet size limitation, such as when trying to insert a large number of vectors (e.g., 2000 rows) , you can mitigate this issue by splitting the insertion into smaller batches. For example, you can set the `insert_batch_size` parameter to a smaller value (e.g., 1000) to avoid exceeding the packet size limit, ensuring smooth insertion of your data into the TiDB vector store:\n",
+    "\n",
+    "```python\n",
+    "storage_context = StorageContext.from_defaults(vector_store=tidbvec)\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents, storage_context=storage_context, insert_batch_size=1000, show_progress=True\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Semantic similarity search\n",
     "\n",
     "This section focus on vector search basics and refining results using metadata filters. Please note that tidb vector only supports Deafult VectorStoreQueryMode."


### PR DESCRIPTION
# Description

This PR enhances the documentation for creating a query engine based on the TiDB vector store by addressing potential issues related to the MySQL protocol’s packet size limitation.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update



