### PR TITLE
chore: remove leftover occurences of `GradientFinetuneEngine`

### DIFF
--- a/llama-index-cli/llama_index/cli/upgrade/mappings.json
+++ b/llama-index-cli/llama_index/cli/upgrade/mappings.json
@@ -397,7 +397,6 @@
   "generate_qa_embedding_pairs": "llama_index.finetuning",
   "SentenceTransformersFinetuneEngine": "llama_index.finetuning",
   "EmbeddingAdapterFinetuneEngine": "llama_index.finetuning",
-  "GradientFinetuneEngine": "llama_index.finetuning",
   "generate_cohere_reranker_finetuning_dataset": "llama_index.finetuning",
   "CohereRerankerFinetuneEngine": "llama_index.finetuning",
   "MistralAIFinetuneEngine": "llama_index.finetuning",

--- a/llama-index-core/llama_index/core/command_line/mappings.json
+++ b/llama-index-core/llama_index/core/command_line/mappings.json
@@ -397,7 +397,6 @@
   "generate_qa_embedding_pairs": "llama_index.finetuning",
   "SentenceTransformersFinetuneEngine": "llama_index.finetuning",
   "EmbeddingAdapterFinetuneEngine": "llama_index.finetuning",
-  "GradientFinetuneEngine": "llama_index.finetuning",
   "generate_cohere_reranker_finetuning_dataset": "llama_index.finetuning",
   "CohereRerankerFinetuneEngine": "llama_index.finetuning",
   "MistralAIFinetuneEngine": "llama_index.finetuning",

--- a/llama-index-legacy/llama_index/legacy/finetuning/__init__.py
+++ b/llama-index-legacy/llama_index/legacy/finetuning/__init__.py
@@ -10,7 +10,6 @@ from llama_index.legacy.finetuning.embeddings.common import (
 from llama_index.legacy.finetuning.embeddings.sentence_transformer import (
     SentenceTransformersFinetuneEngine,
 )
-from llama_index.legacy.finetuning.gradient.base import GradientFinetuneEngine
 from llama_index.legacy.finetuning.openai.base import OpenAIFinetuneEngine
 from llama_index.legacy.finetuning.rerankers.cohere_reranker import (
     CohereRerankerFinetuneEngine,
@@ -25,7 +24,6 @@ __all__ = [
     "EmbeddingQAFinetuneDataset",
     "SentenceTransformersFinetuneEngine",
     "EmbeddingAdapterFinetuneEngine",
-    "GradientFinetuneEngine",
     "generate_cohere_reranker_finetuning_dataset",
     "CohereRerankerFinetuneEngine",
 ]

--- a/llama-index-legacy/pyproject.toml
+++ b/llama-index-legacy/pyproject.toml
@@ -42,7 +42,7 @@ name = "llama-index-legacy"
 packages = [{include = "llama_index"}]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
-version = "0.9.48post2"
+version = "0.9.48post3"
 
 [tool.poetry.dependencies]
 SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}


### PR DESCRIPTION
# Description

Leftovers from https://github.com/run-llama/llama_index/pull/15022

Fixes issue reported in https://github.com/run-llama/llama_index/pull/15022#issuecomment-2289445604

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
