### PR TITLE
Add llama-index-graph-stores-neo4j dependency in GraphRAG v2

### DIFF
--- a/docs/docs/examples/cookbooks/GraphRAG_v2.ipynb
+++ b/docs/docs/examples/cookbooks/GraphRAG_v2.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install llama-index graspologic numpy==1.24.4 scipy==1.12.0"
+    "!pip install llama-index llama-index-graph-stores-neo4j graspologic numpy==1.24.4 scipy==1.12.0"
    ]
   },
   {


### PR DESCRIPTION
# Description

Add llama-index-graph-stores-neo4j dependency in GraphRAG v2, as we will run into issues for the notebook later if the dependency is missing.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
