### PR TITLE
add truncate support

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/README.md
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/README.md
@@ -103,3 +103,9 @@ nodes = parser.get_nodes_from_documents(documents)
 # rerank
 rerank.postprocess_nodes(nodes, query_str=query)
 ```
+
+## Truncation
+
+Ranking models have a maximum input size. It is likely that input documents will
+exceed these limits. To let the server-side shorten input so that it stays within
+the limits, pass `truncate="END"` when constructing an NVIDIARerank instance.

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
@@ -92,9 +92,9 @@ class NVIDIARerank(BaseNodePostprocessor):
         super().__init__(model=model, **kwargs)
 
         if base_url is None or base_url in MODEL_ENDPOINT_MAP.values():
-            base_url = MODEL_ENDPOINT_MAP.get(model, BASE_URL)
+            self._base_url = MODEL_ENDPOINT_MAP.get(model, BASE_URL)
         else:
-            base_url = self._validate_url(base_url)
+            self._base_url = self._validate_url(base_url)
 
         self._api_key = get_from_param_or_env(
             "api_key",

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
@@ -53,6 +53,13 @@ class NVIDIARerank(BaseNodePostprocessor):
         ge=1,
         description="The maximum batch size supported by the inference server.",
     )
+    truncate: Optional[Literal["NONE", "END"]] = Field(
+        description=(
+            "Truncate input text if it exceeds the model's maximum token length. "
+            "Default is model dependent and is likely to raise error if an "
+            "input is too long."
+        ),
+    )
     _api_key: str = PrivateAttr("NO_API_KEY_PROVIDED")  # TODO: should be SecretStr
     _mode: str = PrivateAttr("nvidia")
     _is_hosted: bool = PrivateAttr(True)
@@ -84,6 +91,9 @@ class NVIDIARerank(BaseNodePostprocessor):
             nvidia_api_key (str, optional): The NVIDIA API key. Defaults to None.
             api_key (str, optional): The API key. Defaults to None.
             base_url (str, optional): The base URL of the on-premises NIM. Defaults to None.
+            truncate (str): "NONE", "END", truncate input text if it exceeds
+                            the model's context length. Default is model dependent and
+                            is likely to raise an error if an input is too long.
             **kwargs: Additional keyword arguments.
 
         API Key:
@@ -243,6 +253,7 @@ class NVIDIARerank(BaseNodePostprocessor):
             for batch in batched(nodes, self.max_batch_size):
                 payloads = {
                     "model": self.model,
+                    **({"truncate": self.truncate} if self.truncate else {}),
                     "query": {"text": query_bundle.query_str},
                     "passages": [
                         {"text": n.get_content(metadata_mode=MetadataMode.EMBED)}

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-postprocessor-nvidia-rerank"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-postprocessor-nvidia-rerank"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_truncate.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_truncate.py
@@ -1,0 +1,118 @@
+from typing import Any, Literal, Optional
+
+import pytest
+import re
+from requests_mock import Mocker
+from llama_index.postprocessor.nvidia_rerank import NVIDIARerank
+from llama_index.core.schema import NodeWithScore, Document
+
+
+@pytest.fixture()
+def mock_v1_models(requests_mock: Mocker) -> None:
+    requests_mock.get(
+        "https://integrate.api.nvidia.com/v1/models",
+        json={
+            "data": [
+                {
+                    "id": "mock-model",
+                    "object": "model",
+                    "created": 1234567890,
+                    "owned_by": "OWNER",
+                }
+            ]
+        },
+    )
+
+
+@pytest.fixture()
+def mock_v1_ranking(requests_mock: Mocker) -> None:
+    requests_mock.post(
+        re.compile(r"https://ai.api.nvidia.com/v1/.*/reranking"),
+        json={
+            "rankings": [
+                {"index": 0, "logit": 4.2},
+            ]
+        },
+    )
+
+
+@pytest.fixture()
+def mock(mock_v1_models: None, mock_v1_ranking: None) -> None:
+    pass
+
+
+@pytest.mark.parametrize(
+    "truncate",
+    [
+        None,
+        "END",
+        "NONE",
+    ],
+)
+def test_truncate_passed(
+    mock: None,
+    requests_mock: Mocker,
+    truncate: Optional[Literal["END", "NONE"]],
+) -> None:
+    client = NVIDIARerank(
+        api_key="BOGUS",
+        model="mock-model",
+        **({"truncate": truncate} if truncate else {}),
+    )
+    response = client.postprocess_nodes(
+        [NodeWithScore(node=Document(text="Nothing really."))],
+        query_str="What is it?",
+    )
+
+    assert len(response) == 1
+
+    assert requests_mock.last_request is not None
+    request_payload = requests_mock.last_request.json()
+    if truncate is None:
+        assert "truncate" not in request_payload
+    else:
+        assert "truncate" in request_payload
+        assert request_payload["truncate"] == truncate
+
+
+@pytest.mark.parametrize("truncate", [True, False, 1, 0, 1.0, "START", "BOGUS"])
+def test_truncate_invalid(truncate: Any) -> None:
+    with pytest.raises(ValueError):
+        NVIDIARerank(truncate=truncate)
+
+
+@pytest.mark.integration()
+@pytest.mark.parametrize("truncate", ["END"])
+def test_truncate_positive(model: str, mode: dict, truncate: str) -> None:
+    query = "What is acceleration?"
+    nodes = [
+        NodeWithScore(node=Document(text="NVIDIA " * length))
+        for length in [32, 1024, 64, 128, 2048, 256, 512]
+    ]
+    client = NVIDIARerank(model=model, top_n=len(nodes), truncate=truncate, **mode)
+    response = client.postprocess_nodes(nodes, query_str=query)
+    print(response)
+    assert len(response) == len(nodes)
+
+
+@pytest.mark.integration()
+@pytest.mark.parametrize("truncate", [None, "NONE"])
+def test_truncate_negative(model: str, mode: dict, truncate: str) -> None:
+    if model == "nv-rerank-qa-mistral-4b:1":
+        pytest.skip(
+            "truncation is inconsistent across models, "
+            "nv-rerank-qa-mistral-4b:1 truncates by default "
+            "while others do not"
+        )
+    query = "What is acceleration?"
+    nodes = [
+        NodeWithScore(node=Document(text="NVIDIA " * length))
+        for length in [32, 1024, 64, 128, 2048, 256, 512]
+    ]
+    client = NVIDIARerank(
+        model=model, **mode, **({"truncate": truncate} if truncate else {})
+    )
+    with pytest.raises(Exception) as e:
+        client.postprocess_nodes(nodes, query_str=query)
+    assert "400" in str(e.value)
+    # assert "exceeds maximum allowed" in str(e.value)

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_truncate.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_truncate.py
@@ -27,7 +27,7 @@ def mock_v1_models(requests_mock: Mocker) -> None:
 @pytest.fixture()
 def mock_v1_ranking(requests_mock: Mocker) -> None:
     requests_mock.post(
-        re.compile(r"https://ai.api.nvidia.com/v1/.*/reranking"),
+        re.compile(r"https://ai\.api\.nvidia\.com/v1/.*/reranking"),
         json={
             "rankings": [
                 {"index": 0, "logit": 4.2},


### PR DESCRIPTION
# Description

some reranking models accept a `truncate` param to shorten inputs server-side, this exposes that feature to developers

Depends on: https://github.com/run-llama/llama_index/pull/15485

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
