### PR TITLE
Support token counting for llama-index integration with bedrock

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
@@ -278,11 +278,13 @@ class Bedrock(LLM):
             max_retries=self.max_retries,
             stream=True,
             **all_kwargs,
-        )["body"]
+        )
+        response_body = response["body"]
+        response_headers = response["ResponseMetadata"]["HTTPHeaders"]
 
         def gen() -> CompletionResponseGen:
             content = ""
-            for r in response:
+            for r in response_body:
                 r = json.loads(r["chunk"]["bytes"])
                 content_delta = self._provider.get_text_from_stream_response(r)
                 content += content_delta

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
@@ -255,7 +255,7 @@ class Bedrock(LLM):
         return CompletionResponse(
             text=self._provider.get_text_from_response(response_body),
             raw=response_body,
-            additional_kwargs=self._get_response_token_counts(response_headers)
+            additional_kwargs=self._get_response_token_counts(response_headers),
         )
 
     @llm_completion_callback()
@@ -286,9 +286,12 @@ class Bedrock(LLM):
                 r = json.loads(r["chunk"]["bytes"])
                 content_delta = self._provider.get_text_from_stream_response(r)
                 content += content_delta
-                yield CompletionResponse(text=content, delta=content_delta, raw=r,
-                additional_kwargs = self._get_response_token_counts(
-                    response_headers))
+                yield CompletionResponse(
+                    text=content,
+                    delta=content_delta,
+                    raw=r,
+                    additional_kwargs=self._get_response_token_counts(response_headers),
+                )
 
         return gen()
 
@@ -338,7 +341,4 @@ class Bedrock(LLM):
         if (input_tokens and output_tokens) is None:
             return {}
 
-        return {
-            "prompt_tokens": input_tokens,
-            "completion_tokens": output_tokens
-        }
+        return {"prompt_tokens": input_tokens, "completion_tokens": output_tokens}

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
@@ -248,10 +248,14 @@ class Bedrock(LLM):
             request_body=request_body_str,
             max_retries=self.max_retries,
             **all_kwargs,
-        )["body"].read()
-        response = json.loads(response)
+        )
+        response_body = response["body"].read()
+        response_headers = response["ResponseMetadata"]["HTTPHeaders"]
+        response_body = json.loads(response_body)
         return CompletionResponse(
-            text=self._provider.get_text_from_response(response), raw=response
+            text=self._provider.get_text_from_response(response_body),
+            raw=response_body,
+            additional_kwargs=self._get_response_token_counts(response_headers)
         )
 
     @llm_completion_callback()
@@ -282,7 +286,9 @@ class Bedrock(LLM):
                 r = json.loads(r["chunk"]["bytes"])
                 content_delta = self._provider.get_text_from_stream_response(r)
                 content += content_delta
-                yield CompletionResponse(text=content, delta=content_delta, raw=r)
+                yield CompletionResponse(text=content, delta=content_delta, raw=r,
+                additional_kwargs = self._get_response_token_counts(
+                    response_headers))
 
         return gen()
 
@@ -320,3 +326,19 @@ class Bedrock(LLM):
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponseAsyncGen:
         raise NotImplementedError
+
+    def _get_response_token_counts(self, headers: Any) -> dict:
+        """Get the token usage reported by the response."""
+        if not isinstance(headers, dict):
+            return {}
+
+        input_tokens = headers.get("x-amzn-bedrock-input-token-count", None)
+        output_tokens = headers.get("x-amzn-bedrock-output-token-count", None)
+        # NOTE: other model providers that use the OpenAI client may not report usage
+        if (input_tokens and output_tokens) is None:
+            return {}
+
+        return {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens
+        }

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock"
 readme = "README.md"
-version = "0.1.12"
+version = "0.1.13"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

The counters for prompt and completion tokens for bedrock are being included in the HTTP response headers. This PR includes the support to get the tokens and send it in the additional kwargs.

Fixes # (issue)

Token counter for Bedrock models

## New Package?

No

## Version Bump?

-  Yes. Version - 0.1.13


## Type of Change

-  Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Ran the existing test cases for Bedrock. Unable to add specific tests to cover all flows of the new code as the existing test cases do not provide token information in the response.
