### PR TITLE
Fix Issue 15504 - Remove requirement to specify "allowed_query_fields"  parameter when using "cypher_validator" in TextToCypher retriever

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/text_to_cypher.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/text_to_cypher.py
@@ -61,7 +61,7 @@ class TextToCypherRetriever(BasePGRetriever):
         self.allowed_output_fields = allowed_output_fields
         super().__init__(graph_store=graph_store, include_text=False)
 
-    def _parse_generated_cyher(self, cypher_query: str) -> str:
+    def _parse_generated_cypher(self, cypher_query: str) -> str:
         if self.cypher_validator is not None:
             return self.cypher_validator(cypher_query)
         return cypher_query
@@ -101,9 +101,7 @@ class TextToCypherRetriever(BasePGRetriever):
             question=question,
         )
 
-        parsed_cypher_query = response
-        if self.allowed_output_fields is not None:
-            parsed_cypher_query = self._parse_generated_cyher(response)
+        parsed_cypher_query = self._parse_generated_cypher(response)
 
         query_output = self._graph_store.structured_query(parsed_cypher_query)
 
@@ -135,9 +133,7 @@ class TextToCypherRetriever(BasePGRetriever):
             question=question,
         )
 
-        parsed_cypher_query = response
-        if self.allowed_output_fields is not None:
-            parsed_cypher_query = self._parse_generated_cyher(response)
+        parsed_cypher_query = self._parse_generated_cypher(response)
 
         query_output = await self._graph_store.astructured_query(parsed_cypher_query)
 


### PR DESCRIPTION
Fixed issue 15504 where the `allowed_query_fields` parameter was required when running `cypher_validator` but was not needed.

I also fixed a typo of the procedure in the retriever to be "cypher"

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X ] No - this is in the core package

## Type of Change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X ] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
- [X ] I ran `make format; make lint` to appease the lint gods
