### PR TITLE
More Pydantic V2 Migration (core)

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -6,7 +6,11 @@ from enum import Enum
 from typing import Any, Callable, Coroutine, List, Optional, Tuple
 
 import numpy as np
-from llama_index.core.bridge.pydantic import Field, ConfigDict
+from llama_index.core.bridge.pydantic import (
+    Field,
+    ConfigDict,
+    field_validator,
+)
 from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.callbacks.schema import CBEventType, EventPayload
 from llama_index.core.constants import (
@@ -82,6 +86,13 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
         default=None,
         description="The number of workers to use for async embedding calls.",
     )
+
+    @field_validator("callback_manager")
+    @classmethod
+    def check_callback_manager(cls, v: CallbackManager) -> CallbackManager:
+        if v is None:
+            return CallbackManager([])
+        return v
 
     @abstractmethod
     def _get_query_embedding(self, query: str) -> Embedding:

--- a/llama-index-core/llama_index/core/bridge/pydantic.py
+++ b/llama-index-core/llama_index/core/bridge/pydantic.py
@@ -22,6 +22,7 @@ from pydantic import (
     WrapSerializer,
     field_serializer,
     Secret,
+    SecretStr,
     model_serializer,
 )
 from pydantic.fields import FieldInfo
@@ -55,5 +56,6 @@ __all__ = [
     "WrapSerializer",
     "field_serializer",
     "Secret",
+    "SecretStr",
     "model_serializer",
 ]


### PR DESCRIPTION
# Description

Adds a few items that were missed in core that were discovered in testing integrations...

- SecretStr
- add validator for callback_manager to `BaseEmbeddings` so if None is inputted then its filled with `CallbackManager([])`
