### PR TITLE
feat: Allow using step without parentheses

### DIFF
--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -19,6 +19,7 @@ class StepConfig(BaseModel):
 
 
 def step(
+    *args,
     workflow: Optional[Type["Workflow"]] = None,
     pass_context: bool = False,
     num_workers: int = 1,
@@ -61,4 +62,9 @@ def step(
 
         return func
 
+    if len(args):
+        # The decorator was used without parentheses, like `@step`
+        func = args[0]
+        decorator(func)
+        return func
     return decorator

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -19,6 +19,21 @@ def test_decorated_config(workflow):
     assert config.return_types == [Event]
 
 
+def test_decorate_method():
+    class TestWorkflow(Workflow):
+        @step
+        def f1(self, ev: Event) -> Event:
+            return ev
+
+        @step()
+        def f2(self, ev: Event) -> Event:
+            return ev
+
+    wf = TestWorkflow()
+    assert getattr(wf.f1, "__step_config")
+    assert getattr(wf.f2, "__step_config")
+
+
 def test_decorate_wrong_signature():
     def f():
         pass


### PR DESCRIPTION
# Description

When there's no need to pass parameters to the `step` decorator, allow using it without parentheses to avoid problems like #15444.

Fixes #15444 and part of the docs improvement after we removed the need for `pass_context` in #15325 (we now have a lot of instances where you wuold just have `@step()` that's ugly and prone to errors)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
