### PR TITLE
start trace for llm callbacks

### DIFF
--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -52,7 +52,9 @@ def llm_chat_callback() -> Callable:
         async def wrapped_async_llm_chat(
             _self: Any, messages: Sequence[ChatMessage], **kwargs: Any
         ) -> Any:
-            with wrapper_logic(_self) as callback_manager:
+            with wrapper_logic(_self) as callback_manager, callback_manager.as_trace(
+                "chat"
+            ):
                 span_id = active_span_id.get()
                 model_dict = _self.to_dict()
                 model_dict.pop("api_key", None)
@@ -409,7 +411,9 @@ def llm_completion_callback() -> Callable:
 
         def wrapped_llm_predict(_self: Any, *args: Any, **kwargs: Any) -> Any:
             prompt = extract_prompt(*args, **kwargs)
-            with wrapper_logic(_self) as callback_manager:
+            with wrapper_logic(_self) as callback_manager, callback_manager.as_trace(
+                "completion"
+            ):
                 span_id = active_span_id.get()
                 model_dict = _self.to_dict()
                 model_dict.pop("api_key", None)

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -148,7 +148,9 @@ def llm_chat_callback() -> Callable:
         def wrapped_llm_chat(
             _self: Any, messages: Sequence[ChatMessage], **kwargs: Any
         ) -> Any:
-            with wrapper_logic(_self) as callback_manager:
+            with wrapper_logic(_self) as callback_manager, callback_manager.as_trace(
+                "chat"
+            ):
                 span_id = active_span_id.get()
                 model_dict = _self.to_dict()
                 model_dict.pop("api_key", None)
@@ -309,7 +311,9 @@ def llm_completion_callback() -> Callable:
             _self: Any, *args: Any, **kwargs: Any
         ) -> Any:
             prompt = extract_prompt(*args, **kwargs)
-            with wrapper_logic(_self) as callback_manager:
+            with wrapper_logic(_self) as callback_manager, callback_manager.as_trace(
+                "completion"
+            ):
                 span_id = active_span_id.get()
                 model_dict = _self.to_dict()
                 model_dict.pop("api_key", None)


### PR DESCRIPTION
# Description

Fix issue callbacks could not trace CBEventType.LLM.
When using CallbackManager, some handler requires a trace to start like langfuse.
In my case, when I test my RAG code, I could not find the trace of CBEventType.LLM with langfuse.
Langfuse only creates an observation after starting a trace.

my issue：https://github.com/run-llama/llama_index/issues/15537#issue-2477322274

Fixes # (issue)

## Version Bump?

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
