### PR TITLE
allow streaming token counts for openai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.1.30"
+version = "0.1.31"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
OpenAI needs opt-in arguments to enable streaming token counts

```
llm = OpenAI(
    model="gpt-4o-mini", 
    additional_kwargs={"stream_options": {"include_usage": True}}
)
```

The above code sample works, but it will raise in error if you use a non-streaming endpoint like .chat() or .complete()

This PR fixes this by removing stream options from kwargs if streaming isn't enabled. So now you can set it on the LLM, and use streaming or non-streaming ,methods, and not run into errors