### PR TITLE
remove nested progress bars in base element node parser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -202,9 +202,7 @@ class BaseElementNodeParser(NodeParser):
             _get_table_output(table_context, self.summary_query_str)
             for table_context in table_context_list
         ]
-        summary_co = run_jobs(
-            summary_jobs, show_progress=self.show_progress, workers=self.num_workers
-        )
+        summary_co = run_jobs(summary_jobs, workers=self.num_workers)
         summary_outputs = asyncio_run(summary_co)
         for element, summary_output in zip(elements, summary_outputs):
             element.table_output = summary_output
@@ -251,9 +249,7 @@ class BaseElementNodeParser(NodeParser):
             _get_table_output(table_context, self.summary_query_str)
             for table_context in table_context_list
         ]
-        summary_outputs = await run_jobs(
-            summary_jobs, show_progress=self.show_progress, workers=self.num_workers
-        )
+        summary_outputs = await run_jobs(summary_jobs, workers=self.num_workers)
         for element, summary_output in zip(elements, summary_outputs):
             element.table_output = summary_output
 


### PR DESCRIPTION
We are already creating a progress bar for the top-level node iteration in the element node parsers.

No need to create a nested progress bar with `run_jobs()`