### PR TITLE
Modify the validate function in ReflectionWorkflow example notebook to use pydantic model_validate_json method

### DIFF
--- a/docs/docs/examples/workflow/reflection.ipynb
+++ b/docs/docs/examples/workflow/reflection.ipynb
@@ -198,7 +198,7 @@
     "        self, ev: ExtractionDone\n",
     "    ) -> StopEvent | ValidationErrorEvent:\n",
     "        try:\n",
-    "            json.loads(ev.output)\n",
+    "            CarCollection.model_validate_json(ev.output)\n",
     "        except Exception as e:\n",
     "            print(\"Validation failed, retrying...\")\n",
     "            return ValidationErrorEvent(\n",
@@ -295,7 +295,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/docs/docs/examples/workflow/reflection.ipynb
+++ b/docs/docs/examples/workflow/reflection.ipynb
@@ -295,8 +295,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

I updated the sample notebook for `Reflection Workflow for Structured Outputs`.
The workflow in this notebook did not check an output using pydantic.
It causes that a non-compliant output passes the validation process of the workflow.
I modified the validate function  to use pydantic model's model_validate_json method.

Fixes #15549

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
