### PR TITLE
feature: allow concurrent runs of the same workflow instance

### DIFF
--- a/llama-index-core/llama_index/core/workflow/session.py
+++ b/llama-index-core/llama_index/core/workflow/session.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any, TYPE_CHECKING, Dict, Set, List, Tuple, Optional
 
 
+from .context import Context
 from .decorators import StepConfig
 from .events import Event
 from .errors import WorkflowRuntimeError
@@ -20,6 +21,9 @@ class WorkflowSession:
         self._step_flags: Dict[str, asyncio.Event] = {}
         self._accepted_events: List[Tuple[str, str]] = []
         self._retval: Any = None
+        self._root_context = Context(self)
+        # Context management
+        self._step_to_context: Dict[str, Context] = {}
 
     def send_event(self, message: Event, step: Optional[str] = None) -> None:
         """Sends an event to a specific step in the workflow.
@@ -47,6 +51,17 @@ class WorkflowSession:
                 )
 
         self._broker_log.append(message)
+
+    def get_context(self, step_name: str) -> Context:
+        """Get the global context for this workflow.
+
+        The Workflow instance is ultimately responsible for managing the lifecycle
+        of the global context object and for passing it to the steps functions that
+        require it.
+        """
+        if step_name not in self._step_to_context:
+            self._step_to_context[step_name] = Context(parent=self._root_context)
+        return self._step_to_context[step_name]
 
     def get_result(self) -> Any:
         """Returns the result of the workflow."""

--- a/llama-index-core/llama_index/core/workflow/session.py
+++ b/llama-index-core/llama_index/core/workflow/session.py
@@ -1,0 +1,53 @@
+import asyncio
+from typing import Any, TYPE_CHECKING, Dict, Set, List, Tuple, Optional
+
+
+from .decorators import StepConfig
+from .events import Event
+from .errors import WorkflowRuntimeError
+
+if TYPE_CHECKING:
+    from .workflow import Workflow
+
+
+class WorkflowSession:
+    def __init__(self, workflow: "Workflow") -> None:
+        self._workflow = workflow
+        # Broker machinery
+        self._queues: Dict[str, asyncio.Queue] = {}
+        self._tasks: Set[asyncio.Task] = set()
+        self._broker_log: List[Event] = []
+        self._step_flags: Dict[str, asyncio.Event] = {}
+        self._accepted_events: List[Tuple[str, str]] = []
+        self._retval: Any = None
+
+    def send_event(self, message: Event, step: Optional[str] = None) -> None:
+        """Sends an event to a specific step in the workflow.
+
+        If step is None, the event is sent to all the receivers and we let
+        them discard events they don't want.
+        """
+        if step is None:
+            for queue in self._queues.values():
+                queue.put_nowait(message)
+        else:
+            if step not in self._workflow._get_steps():
+                raise WorkflowRuntimeError(f"Step {step} does not exist")
+
+            step_func = self._workflow._get_steps()[step]
+            step_config: Optional[StepConfig] = getattr(
+                step_func, "__step_config", None
+            )
+
+            if step_config and type(message) in step_config.accepted_events:
+                self._queues[step].put_nowait(message)
+            else:
+                raise WorkflowRuntimeError(
+                    f"Step {step} does not accept event of type {type(message)}"
+                )
+
+        self._broker_log.append(message)
+
+    def get_result(self) -> Any:
+        """Returns the result of the workflow."""
+        return self._retval

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -1,7 +1,7 @@
 import asyncio
 import functools
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Optional, Set
 
 from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.workflow.decorators import StepConfig, step
@@ -14,11 +14,11 @@ from llama_index.core.workflow.utils import (
 from .context import Context
 from .errors import (
     WorkflowDone,
-    WorkflowRuntimeError,
     WorkflowTimeoutError,
     WorkflowValidationError,
 )
 from .service import ServiceManager
+from .session import WorkflowSession
 
 dispatcher = get_dispatcher(__name__)
 
@@ -42,14 +42,9 @@ class Workflow(metaclass=_WorkflowMeta):
         self._verbose = verbose
         self._disable_validation = disable_validation
         # Broker machinery
-        self._queues: Dict[str, asyncio.Queue] = {}
-        self._tasks: Set[asyncio.Task] = set()
-        self._broker_log: List[Event] = []
-        self._step_flags: Dict[str, asyncio.Event] = {}
-        self._accepted_events: List[Tuple[str, str]] = []
-        self._retval: Any = None
+        self._sessions: Set[WorkflowSession] = set()
+        self._step_session: Optional[WorkflowSession] = None
         # Context management
-        self._root_context: Context = Context()
         self._step_to_context: Dict[str, Context] = {}
         # Services management
         self._service_manager = service_manager
@@ -75,7 +70,7 @@ class Workflow(metaclass=_WorkflowMeta):
         for name, wf in services.items():
             self._service_manager.add(name, wf)
 
-    def get_context(self, step_name: str) -> Context:
+    def get_context(self, step_name: str, root_context: Context) -> Context:
         """Get the global context for this workflow.
 
         The Workflow instance is ultimately responsible for managing the lifecycle
@@ -83,21 +78,25 @@ class Workflow(metaclass=_WorkflowMeta):
         require it.
         """
         if step_name not in self._step_to_context:
-            self._step_to_context[step_name] = Context(parent=self._root_context)
+            self._step_to_context[step_name] = Context(parent=root_context)
         return self._step_to_context[step_name]
 
     def _get_steps(self) -> Dict[str, Callable]:
         """Returns all the steps, whether defined as methods or free functions."""
         return {**get_steps_from_instance(self), **self._step_functions}
 
-    def _start(self, stepwise: bool = False) -> None:
+    def _start(self, stepwise: bool = False) -> WorkflowSession:
         """Sets up the queues and tasks for each declared step.
 
         This method also launches each step as an async task.
         """
+        session = WorkflowSession(self)
+        self._sessions.add(session)
+        root_context = Context(session=session)
+
         for name, step_func in self._get_steps().items():
-            self._queues[name] = asyncio.Queue()
-            self._step_flags[name] = asyncio.Event()
+            session._queues[name] = asyncio.Queue()
+            session._step_flags[name] = asyncio.Event()
             step_config: Optional[StepConfig] = getattr(
                 step_func, "__step_config", None
             )
@@ -117,10 +116,10 @@ class Workflow(metaclass=_WorkflowMeta):
 
                     # do we need to wait for the step flag?
                     if stepwise:
-                        await self._step_flags[name].wait()
+                        await session._step_flags[name].wait()
 
                         # clear all flags so that we only run one step
-                        for flag in self._step_flags.values():
+                        for flag in session._step_flags.values():
                             flag.clear()
 
                     if self._verbose and name != "_done":
@@ -129,7 +128,9 @@ class Workflow(metaclass=_WorkflowMeta):
                     # run step
                     kwargs = {}
                     if config.context_parameter:
-                        kwargs[config.context_parameter] = self.get_context(name)
+                        kwargs[config.context_parameter] = self.get_context(
+                            name, root_context
+                        )
                     for service_name in config.services:
                         kwargs[service_name] = self._service_manager.get(service_name)
                     kwargs[config.event_name] = ev
@@ -157,49 +158,23 @@ class Workflow(metaclass=_WorkflowMeta):
                         continue
 
                     # Store the accepted event for the drawing operations
-                    self._accepted_events.append((name, type(ev).__name__))
+                    session._accepted_events.append((name, type(ev).__name__))
 
                     if not isinstance(new_ev, Event):
                         warnings.warn(
                             f"Step function {name} returned {type(new_ev).__name__} instead of an Event instance."
                         )
                     else:
-                        self.send_event(new_ev)
+                        session.send_event(new_ev)
 
             for _ in range(step_config.num_workers):
-                self._tasks.add(
+                session._tasks.add(
                     asyncio.create_task(
-                        _task(name, self._queues[name], step_func, step_config),
+                        _task(name, session._queues[name], step_func, step_config),
                         name=name,
                     )
                 )
-
-    def send_event(self, message: Event, step: Optional[str] = None) -> None:
-        """Sends an event to a specific step in the workflow.
-
-        If step is None, the event is sent to all the receivers and we let
-        them discard events they don't want.
-        """
-        if step is None:
-            for queue in self._queues.values():
-                queue.put_nowait(message)
-        else:
-            if step not in self._get_steps():
-                raise WorkflowRuntimeError(f"Step {step} does not exist")
-
-            step_func = self._get_steps()[step]
-            step_config: Optional[StepConfig] = getattr(
-                step_func, "__step_config", None
-            )
-
-            if step_config and type(message) in step_config.accepted_events:
-                self._queues[step].put_nowait(message)
-            else:
-                raise WorkflowRuntimeError(
-                    f"Step {step} does not accept event of type {type(message)}"
-                )
-
-        self._broker_log.append(message)
+        return session
 
     @dispatcher.span
     async def run(self, **kwargs: Any) -> str:
@@ -211,21 +186,17 @@ class Workflow(metaclass=_WorkflowMeta):
         3. sending a StartEvent to kick things off
         4. waiting for all tasks to finish or be cancelled
         """
-        if self._tasks:
-            msg = "Workflow is already running, wait for it to finish before running again."
-            raise WorkflowRuntimeError(msg)
-
-        # Reset the events log
-        self._accepted_events = []
         # Validate the workflow if needed
         self._validate()
-        # Start the machinery
-        self._start()
+
+        # Start the machinery in a new session
+        session = self._start()
+
         # Send the first event
-        self.send_event(StartEvent(**kwargs))
+        session.send_event(StartEvent(**kwargs))
 
         done, unfinished = await asyncio.wait(
-            self._tasks, timeout=self._timeout, return_when=asyncio.FIRST_EXCEPTION
+            session._tasks, timeout=self._timeout, return_when=asyncio.FIRST_EXCEPTION
         )
 
         we_done = False
@@ -261,7 +232,7 @@ class Workflow(metaclass=_WorkflowMeta):
             msg = f"Operation timed out after {self._timeout} seconds"
             raise WorkflowTimeoutError(msg)
 
-        return self._retval
+        return session._retval
 
     @dispatcher.span
     async def run_step(self, **kwargs: Any) -> Optional[str]:
@@ -274,16 +245,15 @@ class Workflow(metaclass=_WorkflowMeta):
         4. Waiting for the next step(s) to finish
         5. Returning the result if the workflow is done
         """
-        # Check if we need to start
-        if not self._tasks:
-            self._accepted_events = []
+        # Check if we need to start a new session
+        if self._step_session is None:
             self._validate()
-            self._start(stepwise=True)
+            self._step_session = self._start(stepwise=True)
             # Run the first step
-            self.send_event(StartEvent(**kwargs))
+            self._step_session.send_event(StartEvent(**kwargs))
 
         # Unblock all pending steps
-        for flag in self._step_flags.values():
+        for flag in self._step_session._step_flags.values():
             flag.set()
 
         # Yield back control to the event loop to give an unblocked step
@@ -293,7 +263,7 @@ class Workflow(metaclass=_WorkflowMeta):
         # See if we're done, or if a step raised any error
         we_done = False
         exception_raised = None
-        for t in self._tasks:
+        for t in self._step_session._tasks:
             if not t.done():
                 continue
 
@@ -309,30 +279,28 @@ class Workflow(metaclass=_WorkflowMeta):
             # In any other case, bubble up the exception
             exception_raised = e
 
+        retval = None
         if we_done:
             # Remove any reference to the tasks
-            for t in self._tasks:
+            for t in self._step_session._tasks:
                 t.cancel()
                 await asyncio.sleep(0)
-            self._tasks = set()
+            retval = self._step_session._retval
+            self._step_session = None
 
         if exception_raised:
             raise exception_raised
 
-        return self._retval
+        return retval
 
     def is_done(self) -> bool:
         """Checks if the workflow is done."""
-        return len(self._tasks) == 0
-
-    def get_result(self) -> Any:
-        """Returns the result of the workflow."""
-        return self._retval
+        return self._step_session is None
 
     @step()
-    async def _done(self, ev: StopEvent) -> None:
+    async def _done(self, ctx: Context, ev: StopEvent) -> None:
         """Tears down the whole workflow and stop execution."""
-        self._retval = ev.result or None
+        ctx.session._retval = ev.result or None
         # Signal we want to stop the workflow
         raise WorkflowDone
 

--- a/llama-index-core/tests/workflow/conftest.py
+++ b/llama-index-core/tests/workflow/conftest.py
@@ -1,8 +1,9 @@
 import pytest
 
-from llama_index.core.workflow.workflow import Workflow
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import StartEvent, StopEvent, Event
+from llama_index.core.workflow.session import WorkflowSession
+from llama_index.core.workflow.workflow import Workflow
 from llama_index.core.bridge.pydantic import Field
 
 
@@ -40,3 +41,8 @@ def workflow():
 @pytest.fixture()
 def events():
     return [OneTestEvent, AnotherTestEvent]
+
+
+@pytest.fixture()
+def session():
+    return WorkflowSession(workflow=Workflow())

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -7,15 +7,14 @@ from llama_index.core.workflow.workflow import (
 )
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import StartEvent, StopEvent
-from llama_index.core.workflow.session import WorkflowSession
 from llama_index.core.workflow.workflow import Workflow
 
 from .conftest import OneTestEvent, AnotherTestEvent
 
 
-@pytest.fixture()
-def session():
-    return WorkflowSession(workflow=Workflow())
+def test_context_ctor():
+    with pytest.raises(ValueError):
+        ctx = Context()
 
 
 @pytest.mark.asyncio()

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -7,8 +7,15 @@ from llama_index.core.workflow.workflow import (
 )
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import StartEvent, StopEvent
+from llama_index.core.workflow.session import WorkflowSession
+from llama_index.core.workflow.workflow import Workflow
 
 from .conftest import OneTestEvent, AnotherTestEvent
+
+
+@pytest.fixture()
+def session():
+    return WorkflowSession(workflow=Workflow())
 
 
 @pytest.mark.asyncio()
@@ -40,8 +47,8 @@ async def test_collect_events():
 
 
 @pytest.mark.asyncio()
-async def test_set_global():
-    c1 = Context()
+async def test_set_global(session):
+    c1 = Context(session=session)
     await c1.set(key="test_key", value=42)
 
     c2 = Context(parent=c1)
@@ -49,8 +56,8 @@ async def test_set_global():
 
 
 @pytest.mark.asyncio()
-async def test_set_private():
-    c1 = Context()
+async def test_set_private(session):
+    c1 = Context(session=session)
     await c1.set(key="test_key", value=42, make_private=True)
     assert await c1.get(key="test_key") == 42
 
@@ -60,8 +67,8 @@ async def test_set_private():
 
 
 @pytest.mark.asyncio()
-async def test_set_private_duplicate():
-    c1 = Context()
+async def test_set_private_duplicate(session):
+    c1 = Context(session=session)
     await c1.set(key="test_key", value=42)
 
     c2 = Context(parent=c1)
@@ -70,13 +77,13 @@ async def test_set_private_duplicate():
 
 
 @pytest.mark.asyncio()
-async def test_get_default():
-    c1 = Context()
+async def test_get_default(session):
+    c1 = Context(session=session)
     assert await c1.get(key="test_key", default=42) == 42
 
 
 @pytest.mark.asyncio()
-async def test_legacy_data():
-    c1 = Context()
+async def test_legacy_data(session):
+    c1 = Context(session=session)
     await c1.set(key="test_key", value=42)
     assert c1.data["test_key"] == 42

--- a/llama-index-core/tests/workflow/test_session.py
+++ b/llama-index-core/tests/workflow/test_session.py
@@ -53,3 +53,9 @@ def test_send_event_to_step(session):
 def test_get_result(session):
     session._retval = 42
     assert session.get_result() == 42
+
+
+def test_get_context(session):
+    ctx = session.get_context("step")
+    assert session._step_to_context["step"] == ctx
+    assert ctx._parent == session._root_context

--- a/llama-index-core/tests/workflow/test_session.py
+++ b/llama-index-core/tests/workflow/test_session.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+import pytest
+
+from llama_index.core.workflow.errors import WorkflowRuntimeError
+from llama_index.core.workflow.events import Event
+
+
+def test_send_event_step_is_none(session):
+    session._queues = {"step1": mock.MagicMock(), "step2": mock.MagicMock()}
+    ev = Event(foo="bar")
+    session.send_event(ev)
+    for q in session._queues.values():
+        q.put_nowait.assert_called_with(ev)
+    assert session._broker_log == [ev]
+
+
+def test_send_event_to_non_existent_step(session):
+    with pytest.raises(
+        WorkflowRuntimeError, match="Step does_not_exist does not exist"
+    ):
+        session.send_event(Event(), "does_not_exist")
+
+
+def test_send_event_to_wrong_step(session):
+    session._workflow._get_steps = mock.MagicMock(
+        return_value={"step": mock.MagicMock()}
+    )
+
+    with pytest.raises(
+        WorkflowRuntimeError,
+        match="Step step does not accept event of type <class 'llama_index.core.workflow.events.Event'>",
+    ):
+        session.send_event(Event(), "step")
+
+
+def test_send_event_to_step(session):
+    step2 = mock.MagicMock()
+    step2.__step_config.accepted_events = [Event]
+
+    session._workflow._get_steps = mock.MagicMock(
+        return_value={"step1": mock.MagicMock(), "step2": step2}
+    )
+    session._queues = {"step1": mock.MagicMock(), "step2": mock.MagicMock()}
+
+    ev = Event(foo="bar")
+    session.send_event(ev, "step2")
+
+    session._queues["step1"].put_nowait.assert_not_called()
+    session._queues["step2"].put_nowait.assert_called_with(ev)
+
+
+def test_get_result(session):
+    session._retval = 42
+    assert session.get_result() == 42

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -217,3 +217,17 @@ async def test_workflow_missing_service():
         match="The following services are not available: my_service",
     ):
         await workflow.run()
+
+
+@pytest.mark.asyncio()
+async def test_workflow_multiple_runs():
+    class DummyWorkflow(Workflow):
+        @step()
+        async def step(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result=ev.number * 2)
+
+    workflow = DummyWorkflow()
+    results = await asyncio.gather(
+        workflow.run(number=3), workflow.run(number=42), workflow.run(number=-99)
+    )
+    assert set(results) == {6, 84, -198}


### PR DESCRIPTION
# Description

Move the data structures used to implement the workflow runtime into a new object `WorkflowSession`, decoupling it from `Workflow` and allowing mulitple instance of the runtime (read: concurrent `run()`s).

Example:
```py
class DummyWorkflow(Workflow):
    @step()
    async def step(self, ev: StartEvent) -> StopEvent:
        return StopEvent(result=ev.number * 2)

workflow = DummyWorkflow()
results = await asyncio.gather(
    workflow.run(number=3), workflow.run(number=42), workflow.run(number=-99)
)
```

Fixes https://github.com/run-llama/llama_index/issues/15455

Note this moves `self.send_event()` to `ctx.session.send_event()` and I couldn't find a way to keep the old one, so the PR is to be considered breaking.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

