### PR TITLE
Vertex LLM: Remove manual setting of message content to `Function Calling`

### DIFF
--- a/llama-index-core/llama_index/core/utilities/gemini_utils.py
+++ b/llama-index-core/llama_index/core/utilities/gemini_utils.py
@@ -53,13 +53,6 @@ def merge_neighboring_same_role_messages(
             content="\n".join([str(msg_content) for msg_content in merged_content]),
             additional_kwargs=current_message.additional_kwargs,
         )
-        # When making function calling, 'assistant->model' response does not contain text.
-        # Gemini chat takes 'user', 'model' message alternately.
-        # https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/getting-started/intro_gemini_chat.ipynb
-        # It cannot skip empty 'model' content.
-        # It will cause "empty text parameter" issue, the following code can avoid it.
-        if merged_message.content == "" and merged_message.role == MessageRole.MODEL:
-            merged_message.content = "Function Calling"
 
         merged_messages.append(merged_message)
         i += 1

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/gemini_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/gemini_utils.py
@@ -46,7 +46,7 @@ def convert_chat_message_to_gemini_content(
             raise ValueError("Only text and image_url types are supported!")
         return Part.from_image(image)
 
-    if message.content == "Function Calling":
+    if message.content == "" and "tool_calls" in message.additional_kwargs:
         tool_calls = message.additional_kwargs["tool_calls"]
         parts = [
             Part._from_gapic(raw_part=gapic_content_types.Part(function_call=tool_call))

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vertex"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Remove manual setting of message content to `Function Calling`

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
