### PR TITLE
rename method for nested workflows to add_workflows

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -60,13 +60,13 @@ class Workflow(metaclass=_WorkflowMeta):
 
         cls._step_functions[func.__name__] = func
 
-    def add_services(self, **services: "Workflow") -> None:
-        """Adds one or more services to this workflow.
+    def add_workflows(self, **workflows: "Workflow") -> None:
+        """Adds one or more nested workflows to this workflow.
 
         This method only accepts keyword arguments, and the name of the parameter
-        will be used as the name of the service.
+        will be used as the name of the workflow.
         """
-        for name, wf in services.items():
+        for name, wf in workflows.items():
             self._service_manager.add(name, wf)
 
     def _get_steps(self) -> Dict[str, Callable]:

--- a/llama-index-core/tests/workflow/test_service.py
+++ b/llama-index-core/tests/workflow/test_service.py
@@ -47,7 +47,7 @@ async def test_e2e():
     wf = DummyWorkflow()
     # We are responsible for passing the ServiceWorkflow instances to the dummy workflow
     # and give it a name, in this case "service_workflow"
-    wf.add_services(service_workflow=ServiceWorkflow())
+    wf.add_workflows(service_workflow=ServiceWorkflow())
     res = await wf.run()
     assert res == 84
 


### PR DESCRIPTION
Renames `add_services()` to `add_workflows()` since for now, this only works for workflows

Keeps the underlying service manager and related code since it is generally useful 