### PR TITLE
ensure callback manager is set on llms

### DIFF
--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -288,12 +288,9 @@ def llm_completion_callback() -> Callable:
         def wrapper_logic(_self: Any) -> Generator[CallbackManager, None, None]:
             callback_manager = getattr(_self, "callback_manager", None)
             if not isinstance(callback_manager, CallbackManager):
-                raise ValueError(
-                    "Cannot use llm_completion_callback on an instance "
-                    "without a callback_manager attribute."
-                )
+                _self.callback_manager = CallbackManager()
 
-            yield callback_manager
+            yield _self.callback_manager
 
         def extract_prompt(*args: Any, **kwargs: Any) -> str:
             if len(args) > 0:


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/15597

Ensures we always have a callback manager set, rather than raising an error