### PR TITLE
Resolve stray `__pydantic_var__` Pydantic V2 issues in integrations/packs

### DIFF
--- a/llama-index-integrations/callbacks/llama-index-callbacks-agentops/llama_index/callbacks/agentops/base.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-agentops/llama_index/callbacks/agentops/base.py
@@ -85,10 +85,10 @@ class AgentOpsSpanHandler(SimpleSpanHandler):
     def __init__(
         self, shared_handler_state: AgentOpsHandlerState, ao_client: AOClient
     ) -> None:
+        super().__init__()
         self._shared_handler_state = shared_handler_state
         self._ao_client = ao_client
         self._observed_exceptions = set()
-        super().__init__()
 
     @classmethod
     def class_name(cls) -> str:
@@ -155,9 +155,9 @@ class AgentOpsEventHandler(BaseEventHandler):
     def __init__(
         self, shared_handler_state: AgentOpsHandlerState, ao_client: AOClient
     ) -> None:
+        super().__init__()
         self._shared_handler_state = shared_handler_state
         self._ao_client = ao_client
-        super().__init__()
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/callbacks/llama-index-callbacks-agentops/pyproject.toml
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-agentops/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-callbacks-agentops"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google/llama_index/embeddings/google/univ_sent_encoder.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google/llama_index/embeddings/google/univ_sent_encoder.py
@@ -33,12 +33,12 @@ class GoogleUnivSentEncoderEmbedding(BaseEmbedding):
                 "Please install tensorflow_hub: `pip install tensorflow_hub`"
             )
 
-        self._model = model
         super().__init__(
             embed_batch_size=embed_batch_size,
             callback_manager=callback_manager,
             model_name=handle,
         )
+        self._model = model
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-google"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-palm/llama_index/llms/palm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-palm/llama_index/llms/palm/base.py
@@ -92,10 +92,10 @@ class PaLM(CustomLLM):
             )
 
         model_name = model_name
-        self._model = models_dict[model_name]
+        model = models_dict[model_name]
 
         # get num_output
-        num_output = num_output or self._model.output_token_limit
+        num_output = num_output or model.output_token_limit
 
         generate_kwargs = generate_kwargs or {}
         super().__init__(
@@ -109,6 +109,7 @@ class PaLM(CustomLLM):
             pydantic_program_mode=pydantic_program_mode,
             output_parser=output_parser,
         )
+        self._model = model
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/llms/llama-index-llms-palm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-palm/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-palm"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-elasticsearch/llama_index/readers/elasticsearch/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-elasticsearch/llama_index/readers/elasticsearch/base.py
@@ -35,6 +35,9 @@ class ElasticsearchReader(BasePydanticReader):
         self, endpoint: str, index: str, httpx_client_args: Optional[dict] = None
     ):
         """Initialize with parameters."""
+        super().__init__(
+            endpoint=endpoint, index=index, httpx_client_args=httpx_client_args
+        )
         import_err_msg = """
             `httpx` package not found. Install via `pip install httpx`
         """
@@ -43,10 +46,6 @@ class ElasticsearchReader(BasePydanticReader):
         except ImportError:
             raise ImportError(import_err_msg)
         self._client = httpx.Client(base_url=endpoint, **(httpx_client_args or {}))
-
-        super().__init__(
-            endpoint=endpoint, index=index, httpx_client_args=httpx_client_args
-        )
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/readers/llama-index-readers-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-elasticsearch/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jaylmiller"]
 name = "llama-index-readers-elasticsearch"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-slack/llama_index/readers/slack/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-slack/llama_index/readers/slack/base.py
@@ -61,9 +61,9 @@ class SlackReader(BasePydanticReader):
                 "variable `SLACK_BOT_TOKEN`."
             )
         if ssl is None:
-            self._client = WebClient(token=slack_token)
+            client = WebClient(token=slack_token)
         else:
-            self._client = WebClient(token=slack_token, ssl=ssl)
+            client = WebClient(token=slack_token, ssl=ssl)
         if latest_date is not None and earliest_date is None:
             raise ValueError(
                 "Must specify `earliest_date` if `latest_date` is specified."
@@ -76,7 +76,7 @@ class SlackReader(BasePydanticReader):
             latest_date_timestamp = latest_date.timestamp()
         else:
             latest_date_timestamp = datetime.now().timestamp() or latest_date_timestamp
-        res = self._client.api_test()
+        res = client.api_test()
         if not res["ok"]:
             raise ValueError(f"Error initializing Slack API: {res['error']}")
 
@@ -85,6 +85,7 @@ class SlackReader(BasePydanticReader):
             earliest_date_timestamp=earliest_date_timestamp,
             latest_date_timestamp=latest_date_timestamp,
         )
+        self._client = client
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/readers/llama-index-readers-slack/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-slack/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-slack"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/beautiful_soup_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/beautiful_soup_web/base.py
@@ -148,8 +148,8 @@ class BeautifulSoupWebReader(BasePydanticReader):
     _website_extractor: Dict[str, Callable] = PrivateAttr()
 
     def __init__(self, website_extractor: Optional[Dict[str, Callable]] = None) -> None:
-        self._website_extractor = website_extractor or DEFAULT_WEBSITE_EXTRACTOR
         super().__init__()
+        self._website_extractor = website_extractor or DEFAULT_WEBSITE_EXTRACTOR
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/simple_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/simple_web/base.py
@@ -38,8 +38,8 @@ class SimpleWebPageReader(BasePydanticReader):
             raise ImportError(
                 "`html2text` package not found, please run `pip install html2text`"
             )
-        self._metadata_fn = metadata_fn
         super().__init__(html_to_text=html_to_text)
+        self._metadata_fn = metadata_fn
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -45,7 +45,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
@@ -197,8 +197,8 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
 
         if clickhouse_client is None:
             raise ValueError("Missing ClickHouse client!")
-        self._client = clickhouse_client
-        self._config = ClickHouseSettings(
+        client = clickhouse_client
+        config = ClickHouseSettings(
             table=table,
             database=database,
             engine=engine,
@@ -211,7 +211,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
         )
 
         # schema column name, type, and construct format method
-        self._column_config: Dict = {
+        column_config: Dict = {
             "id": {"type": "String", "extract_func": lambda x: x.node_id},
             "doc_id": {"type": "String", "extract_func": lambda x: x.ref_doc_id},
             "text": {
@@ -233,14 +233,10 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
                 "extract_func": lambda x: json.dumps(x.metadata),
             },
         }
-        self._column_names = list(self._column_config.keys())
-        self._column_type_names = [
-            self._column_config[column_name]["type"]
-            for column_name in self._column_names
+        column_names = list(self._column_config.keys())
+        column_type_names = [
+            column_config[column_name]["type"] for column_name in column_names
         ]
-
-        dimension = len(Settings.embed_model.get_query_embedding("try this out"))
-        self.create_table(dimension)
 
         super().__init__(
             clickhouse_client=clickhouse_client,
@@ -253,6 +249,13 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             index_params=index_params,
             search_params=search_params,
         )
+        self._client = client
+        self._config = config
+        self._column_config = column_config
+        self._column_names = column_names
+        self._column_type_names = column_type_names
+        dimension = len(Settings.embed_model.get_query_embedding("try this out"))
+        self.create_table(dimension)
 
     @property
     def client(self) -> Any:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-clickhouse"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/llama_index/vector_stores/couchbase/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/llama_index/vector_stores/couchbase/base.py
@@ -186,6 +186,7 @@ class CouchbaseVectorStore(BasePydanticVectorStore):
                 f"got {type(cluster)}"
             )
 
+        super().__init__()
         self._cluster = cluster
 
         if not bucket_name:
@@ -241,8 +242,6 @@ class CouchbaseVectorStore(BasePydanticVectorStore):
         self._bucket = self._cluster.bucket(self._bucket_name)
         self._scope = self._bucket.scope(self._scope_name)
         self._collection = self._scope.collection(self._collection_name)
-
-        super().__init__()
 
     def add(self, nodes: List[BaseNode], **kwargs: Any) -> List[str]:
         """

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-vector-stores-couchbase"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
@@ -157,10 +157,6 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
             columns = []
         if "doc_id" not in columns:
             columns = columns[:19] + ["doc_id"]
-        super().__init__(
-            text_column=text_column,
-            columns=columns,
-        )
 
         # initialize the column name for the text column in the delta table
         if self._is_databricks_managed_embeddings():

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/pyproject.toml
@@ -26,7 +26,7 @@ description = "llama-index vector_stores databricks vector search integration"
 license = "MIT"
 name = "llama-index-vector-stores-databricks"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"

--- a/llama-index-packs/llama-index-packs-query-understanding-agent/llama_index/packs/query_understanding_agent/step.py
+++ b/llama-index-packs/llama-index-packs-query-understanding-agent/llama_index/packs/query_understanding_agent/step.py
@@ -142,15 +142,15 @@ class QueryUnderstandingAgentWorker(CustomSimpleAgentWorker):
                 raise ValueError(
                     f"Tool {tool.metadata.name} is not a query engine tool."
                 )
+        super().__init__(
+            tools=tools,
+            **kwargs,
+        )
         self._router_query_engine = RouterQueryEngine.from_defaults(
             llm=kwargs.get("llm"),
             select_multi=False,
             query_engine_tools=tools,
             verbose=kwargs.get("verbose", False),
-        )
-        super().__init__(
-            tools=tools,
-            **kwargs,
         )
 
     def _initialize_state(self, task: Task, **kwargs: Any) -> Dict[str, Any]:

--- a/llama-index-packs/llama-index-packs-query-understanding-agent/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-query-understanding-agent/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-packs-query-understanding-agent"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Some missed integrations and packs were missed when resolving `__pydantic_var__` errors which can be resolved by moving the `super().__init__(...)` call before any private vars are set within a custom `__init__()` function of a `BaseModel` subclass.

Fixes # (issue)

Closes #15609

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
