### PR TITLE
[Fix] Colbert Rerank pydantic v2 issue

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/llama_index/postprocessor/colbert_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/llama_index/postprocessor/colbert_rerank/base.py
@@ -46,6 +46,7 @@ class ColbertRerank(BaseNodePostprocessor):
             top_n=top_n,
             device=device,
             keep_retrieval_score=keep_retrieval_score,
+            model=model,
         )
         self._tokenizer = AutoTokenizer.from_pretrained(tokenizer)
         self._model = AutoModel.from_pretrained(model)

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/tests/test_postprocessor_colbert_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-colbert-rerank/tests/test_postprocessor_colbert_rerank.py
@@ -1,0 +1,14 @@
+from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.postprocessor.colbert_rerank import ColbertRerank
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in ColbertRerank.__mro__]
+    assert BaseNodePostprocessor.__name__ in names_of_base_classes
+
+
+def test_init():
+    m = ColbertRerank(top_n=10)
+
+    assert m.model == "colbert-ir/colbertv2.0"
+    assert m.top_n == 10


### PR DESCRIPTION
# Description

The `model` param was not being set by default in the `ColbertRerank` class. As a result Pydantic V2 throws a validation error. This PR resolves this issue.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense