### PR TITLE
[fix] Gemini LLM pydantic v2 issue

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -140,7 +140,7 @@ class Gemini(CustomLLM):
 
         model_meta = genai.get_model(model)
 
-        model = genai.GenerativeModel(
+        genai_model = genai.GenerativeModel(
             model_name=model,
             generation_config=final_gen_config,
             safety_settings=safety_settings,
@@ -167,7 +167,7 @@ class Gemini(CustomLLM):
         )
 
         self._model_meta = model_meta
-        self._model = model
+        self._model = genai_model
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-gemini"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

`model` was being overridden with the `genai.GenerativeModel` when it was supposed to be the model name (i.e., `str`). As a result Pydantic threw a validation error. This PR resolves this.

Fixes #15618


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

