### PR TITLE
Fix the ElasticsearchStore key error

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -483,7 +483,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
         top_k_scores = []
         for hit in hits:
             source = hit["_source"]
-            metadata = source.get("metadata", None)
+            metadata = source.get("metadata", {})
             text = source.get(self.text_field, None)
             node_id = hit["_id"]
 
@@ -493,7 +493,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             except Exception:
                 # Legacy support for old metadata format
                 logger.warning(
-                    f"Could not parse metadata from hit {hit['_source']['metadata']}"
+                    f"Could not parse metadata from hit {hit['_source'].get('metadata')}"
                 )
                 node_info = source.get("node_info")
                 relationships = source.get("relationships", {})

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Change None to empty dict and add get metadata using function get to avoid key error.

# Description

When there is no metadata in the Elasticsearch index, a `KeyError: 'metadata'` occurs during retrieval. If you try to use the `get` function to avoid this key error, a new error arises from Pydantic. `ValidationError: 1 validation error for TextNode`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
