### PR TITLE
CI: disable fail-fast in job matrix

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -13,8 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest-unit-tester
     strategy:
-      # You can use PyPy versions in python-version.
-      # For example, pypy-2.7 and pypy-3.8
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     steps:


### PR DESCRIPTION
# Description

With `fail-fast: true` (the default value), if a job of the matrix fails, all the others are cancelled. This might be annoying at times:
- if a successful job is responsible for caching something, the operation might be interrupted by another job failing for unrelated reasons
- it's hard to tell if a failure depends on the Python version used in the matrix
