### PR TITLE
fix auto-retriever indent error

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/retrievers/auto_retriever/auto_retriever.py
@@ -159,7 +159,7 @@ class VectorIndexAutoRetriever(BaseAutoRetriever):
     ) -> BaseModel:
         # prepare input
         info_str = self._vector_store_info.model_dump_json(indent=4)
-        schema_str = VectorStoreQuerySpec.model_json_schema(indent=4)
+        schema_str = VectorStoreQuerySpec.model_json_schema()
 
         # call LLM
         output = self._llm.predict(
@@ -177,7 +177,7 @@ class VectorIndexAutoRetriever(BaseAutoRetriever):
     ) -> BaseModel:
         # prepare input
         info_str = self._vector_store_info.model_dump_json(indent=4)
-        schema_str = VectorStoreQuerySpec.model_json_schema(indent=4)
+        schema_str = VectorStoreQuerySpec.model_json_schema()
 
         # call LLM
         output = await self._llm.apredict(

--- a/llama-index-integrations/program/llama-index-program-guidance/pyproject.toml
+++ b/llama-index-integrations/program/llama-index-program-guidance/pyproject.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 version = "0.2.1"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 guidance = "^0.1.16"
 llama-index-core = "^0.11.0"
 

--- a/llama-index-integrations/program/llama-index-program-guidance/pyproject.toml
+++ b/llama-index-integrations/program/llama-index-program-guidance/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-program-guidance"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-guidance = "^0.1.10"
+guidance = "^0.1.16"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/program/llama-index-program-guidance/tests/BUILD
+++ b/llama-index-integrations/program/llama-index-program-guidance/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints = ["==3.9.*", "==3.10.*"],
+)

--- a/llama-index-integrations/question_gen/llama-index-question-gen-guidance/tests/BUILD
+++ b/llama-index-integrations/question_gen/llama-index-question-gen-guidance/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints = ["==3.9.*", "==3.10.*"],
+)


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/15647

Pydantic removed the indent argument from this method