### PR TITLE
CI: run unit tests on 3.9 through 3.12

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: clear space
         env:


### PR DESCRIPTION
# Description

Change the Python version matrix from 3.8-3.10 to 3.9-3.12.

Many packages we depend on already broke compabiltiy with 3.8 (approaching EOL in october). I would argue it's more reliable to test agains 3.11 and 3.12 and leave 3.8 to its destiny.