### PR TITLE
fix tool schemas

### DIFF
--- a/llama-index-core/llama_index/core/tools/types.py
+++ b/llama-index-core/llama_index/core/tools/types.py
@@ -38,7 +38,7 @@ class ToolMetadata:
             parameters = {
                 k: v
                 for k, v in parameters.items()
-                if k in ["type", "properties", "required", "definitions"]
+                if k in ["type", "properties", "required", "definitions", "$defs"]
             }
         return parameters
 

--- a/llama-index-core/tests/tools/test_types.py
+++ b/llama-index-core/tests/tools/test_types.py
@@ -1,5 +1,16 @@
 import pytest
+
+from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.program.function_program import _get_function_tool
 from llama_index.core.tools.types import ToolMetadata
+
+
+class Inner(BaseModel):
+    name: str
+
+
+class Outer(BaseModel):
+    inner: Inner
 
 
 def test_toolmetadata_openai_tool_description_max_length() -> None:
@@ -12,3 +23,18 @@ def test_toolmetadata_openai_tool_description_max_length() -> None:
 
     with pytest.raises(ValueError):
         ToolMetadata(invalid_description).to_openai_tool()
+
+
+def test_nested_tool_schema() -> None:
+    tool = _get_function_tool(Outer)
+    schema = tool.metadata.get_parameters_dict()
+
+    assert "$defs" in schema
+    defs = schema["$defs"]
+    assert "Inner" in defs
+    inner = defs["Inner"]
+    assert inner["required"][0] == "name"
+    assert inner["properties"] == {"name": {"title": "Name", "type": "string"}}
+
+    assert schema["required"][0] == "inner"
+    assert schema["properties"] == {"inner": {"$ref": "#/$defs/Inner"}}


### PR DESCRIPTION
Recent changes to pydanticv2 caused our tool json schemas to miss the renamed "definitions" section