### PR TITLE
Bump html2text

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.2.0"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 atlassian-python-api = "^3.41.9"
-html2text = "^2020.1.16"
+html2text = "^2024.2.26"
 pytesseract = "^0.3.10"
 pdf2image = "^1.17.0"
 pillow = "^10.2.0"

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["zywilliamli"]
 name = "llama-index-readers-confluence"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Update `html2text` dep. This resolves conflicts in using both `llama-index-readers-web` and `llama-index-readers-confluence` in the same project (like llama-cloud does).

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
