### PR TITLE
feat: implement get_nodes for MilvusVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -437,9 +437,21 @@ class MilvusVectorStore(BasePydanticVectorStore):
 
     def get_nodes(
         self,
-        node_ids: list[str] | None = None,
-        filters: MetadataFilters | None = None,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
     ) -> list[BaseNode]:
+        """Get nodes by node ids or metadata filters.
+
+        Args:
+            node_ids (Optional[List[str]], optional): IDs of nodes to retrieve. Defaults to None.
+            filters (Optional[MetadataFilters], optional): Metadata filters. Defaults to None.
+
+        Raises:
+            ValueError: Neither or both of node_ids and filters are provided.
+
+        Returns:
+            List[BaseNode]:
+        """
         if node_ids is None and filters is None:
             raise ValueError("Either node_ids or filters must be provided.")
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

`MilvusVectorStore` is currently missing the implementation of the `get_nodes` method.

Refer to the Milvus Python SDK, it provides the ability to get entities based on either a list of primary keys or filter conditions, without doing a vector search.

https://milvus.io/api-reference/pymilvus/v2.4.x/MilvusClient/Vector/query.md
https://github.com/milvus-io/pymilvus/blob/4a65d03524d571bc5fe206819eba9685e659dc8c/pymilvus/milvus_client/milvus_client.py#L347-L411

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
