### PR TITLE
Fix random_seed type in mistral llm

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
@@ -123,7 +123,7 @@ class MistralAI(FunctionCallingLLM):
     max_retries: int = Field(
         default=5, description="The maximum number of API retries.", gte=0
     )
-    random_seed: str = Field(
+    random_seed: Optional[int] = Field(
         default=None, description="The random seed to use for sampling."
     )
     additional_kwargs: Dict[str, Any] = Field(

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-mistralai"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/15687

Pydantic v2 no longer coerces the type by default, exposing this bug