### PR TITLE
fix: stop streaming events when a step raises

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -248,7 +248,7 @@ class Workflow(metaclass=_WorkflowMeta):
         # Bubble up the error if any step raised an exception
         if exception_raised:
             # Make sure to stop streaming, in case the workflow terminated abnormally
-            session.write_event_to_stream(StopEvent())
+            ctx.write_event_to_stream(StopEvent())
             raise exception_raised
 
         # Raise WorkflowTimeoutError if the workflow timed out

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -247,6 +247,8 @@ class Workflow(metaclass=_WorkflowMeta):
 
         # Bubble up the error if any step raised an exception
         if exception_raised:
+            # Make sure to stop streaming, in case the workflow terminated abnormally
+            session.write_event_to_stream(StopEvent())
             raise exception_raised
 
         # Raise WorkflowTimeoutError if the workflow timed out

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -8,6 +8,8 @@ from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.core.workflow.workflow import Workflow
 from llama_index.core.workflow.errors import WorkflowRuntimeError
 
+from .conftest import OneTestEvent
+
 
 class StreamingWorkflow(Workflow):
     @step
@@ -45,3 +47,23 @@ async def test_too_many_runs():
         async for ev in wf.stream_events():
             pass
     await r
+
+
+@pytest.mark.asyncio()
+async def test_task_raised():
+    class DummyWorkflow(Workflow):
+        @step
+        async def step(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            ctx.session.write_event_to_stream(OneTestEvent(test_param="foo"))
+            raise ValueError("The step raised an error!")
+
+    wf = DummyWorkflow()
+    r = asyncio.create_task(wf.run())
+
+    # Make sure we don't block indefinitely here because the step raised
+    async for ev in wf.stream_events():
+        assert ev.test_param == "foo"
+
+    # Make sure the await actually caught the exception
+    with pytest.raises(ValueError, match="The step raised an error!"):
+        await r

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -54,7 +54,7 @@ async def test_task_raised():
     class DummyWorkflow(Workflow):
         @step
         async def step(self, ctx: Context, ev: StartEvent) -> StopEvent:
-            ctx.session.write_event_to_stream(OneTestEvent(test_param="foo"))
+            ctx.write_event_to_stream(OneTestEvent(test_param="foo"))
             raise ValueError("The step raised an error!")
 
     wf = DummyWorkflow()


### PR DESCRIPTION
# Description

In the typical scenario when you want to stream events from a workflow run:

```py
async def main():
    w = MyWorkflow(timeout=10, verbose=True)
    task = asyncio.create_task(w.run(first_input="Start the workflow."))

    async for ev in w.stream_events():
        print(ev.msg)

    final_result = await task
```

If a step raises an exception for whatever reason, that won't bubble up until the execution path gets to `await task`. Before this PR, the streaming queue was not flushed properly in case an exception occurred, and the code would get stuck in the `async for` forever. Now we properly end streaming in case of error.

Issue reported internally.