### PR TITLE
feat: Add a retry policy to steps

### DIFF
--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type
 
-from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.bridge.pydantic import BaseModel, ConfigDict
 
 from .errors import WorkflowValidationError
 from .utils import (
@@ -12,15 +12,19 @@ from .utils import (
 
 if TYPE_CHECKING:  # pragma: no cover
     from .workflow import Workflow
+from .retry_policy import RetryPolicy
 
 
 class StepConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     accepted_events: List[Any]
     event_name: str
     return_types: List[Any]
     context_parameter: Optional[str]
     num_workers: int
     requested_services: List[ServiceDefinition]
+    retry_policy: Optional[RetryPolicy]
 
 
 def step(
@@ -28,6 +32,7 @@ def step(
     workflow: Optional[Type["Workflow"]] = None,
     pass_context: bool = False,
     num_workers: int = 1,
+    retry_policy: Optional[RetryPolicy] = None,
 ):
     """Decorator used to mark methods and functions as workflow steps.
 
@@ -56,6 +61,7 @@ def step(
             context_parameter=spec.context_parameter,
             num_workers=num_workers,
             requested_services=spec.requested_services or [],
+            retry_policy=retry_policy,
         )
 
         # If this is a free function, call add_step() explicitly.

--- a/llama-index-core/llama_index/core/workflow/retry_policy.py
+++ b/llama-index-core/llama_index/core/workflow/retry_policy.py
@@ -1,0 +1,32 @@
+from typing import Protocol, Optional, runtime_checkable
+
+
+@runtime_checkable
+class RetryPolicy(Protocol):
+    def next(
+        self, elapsed_time: float, attempts: int, error: Exception
+    ) -> Optional[float]:
+        """Decide if we should make another retry, returning the number of seconds to wait before the next run.
+
+        Args:
+            elapsed_time: Time in seconds that passed since the last attempt.
+            attempts: The number of attempts done so far.
+            error: The last error occurred.
+
+        Returns:
+            The amount of seconds to wait before the next attempt, or None if we stop retrying.
+        """
+
+
+class ConstantDelayRetryPolicy:
+    def __init__(self, maximum_attempts: int = 3, delay: float = 5) -> None:
+        self.maximum_attempts = maximum_attempts
+        self.delay = delay
+
+    def next(
+        self, elapsed_time: float, attempts: int, error: Exception
+    ) -> Optional[float]:
+        if attempts == self.maximum_attempts:
+            return None
+
+        return self.delay

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import time
 import warnings
 from typing import Any, Callable, Dict, Optional, AsyncGenerator, Set
 
@@ -144,12 +145,35 @@ class Workflow(metaclass=_WorkflowMeta):
                         kwargs[service_definition.name] = service
                     kwargs[config.event_name] = ev
 
-                    # - check if its async or not
-                    # - if not async, run it in an executor
+                    # wrap the step with instrumentation
                     instrumented_step = dispatcher.span(step)
 
+                    # - check if its async or not
+                    # - if not async, run it in an executor
                     if asyncio.iscoroutinefunction(step):
-                        new_ev = await instrumented_step(**kwargs)
+                        retry_start_at = time.time()
+                        attempts = 0
+                        while True:
+                            try:
+                                new_ev = await instrumented_step(**kwargs)
+                                break  # exit the retrying loop
+                            except Exception as e:
+                                if config.retry_policy is None:
+                                    raise e from None
+
+                                delay = config.retry_policy.next(
+                                    retry_start_at + time.time(), attempts, e
+                                )
+                                if delay is None:
+                                    # We're done retrying
+                                    raise e from None
+
+                                attempts += 1
+                                print(
+                                    f"Step {name} produced an error, retry in {delay} seconds"
+                                )
+                                await asyncio.sleep(delay)
+
                     else:
                         run_task = functools.partial(instrumented_step, **kwargs)
                         new_ev = await asyncio.get_event_loop().run_in_executor(

--- a/llama-index-core/tests/workflow/test_retry.py
+++ b/llama-index-core/tests/workflow/test_retry.py
@@ -1,0 +1,30 @@
+import pytest
+
+from llama_index.core.workflow.context import Context
+from llama_index.core.workflow.decorators import step
+from llama_index.core.workflow.events import Event, StartEvent, StopEvent
+from llama_index.core.workflow.retry_policy import ConstantDelayRetryPolicy
+from llama_index.core.workflow.workflow import Workflow
+
+
+@pytest.mark.asyncio()
+async def test_retry_e2e():
+    class CountEvent(Event):
+        """Empty event to signal a step to increment a counter in the Context."""
+
+    class DummyWorkflow(Workflow):
+        @step(retry_policy=ConstantDelayRetryPolicy(delay=1))
+        async def flaky_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            count = await ctx.get("counter", default=0)
+            ctx.send_event(CountEvent())
+            if count < 3:
+                raise ValueError("Something bad happened!")
+            return StopEvent(result="All good!")
+
+        @step
+        async def counter(self, ctx: Context, ev: CountEvent) -> None:
+            count = await ctx.get("counter", default=0)
+            await ctx.set("counter", count + 1)
+
+    workflow = DummyWorkflow(disable_validation=True)
+    await workflow.run()


### PR DESCRIPTION
# Description

Steps can likely fail for transient problems like network errors and rate limiting. Currently users have to implement their own retrying logic inside each step that might require one. This PR introduces a built-in retry logic provided by the worklfow directly. LlamaIndex will provide a set of pre-defined and configurable retry policies that are commonly used, but users will be able to implement their custom ones.

Example.
```python

    class CountEvent(Event):
        """Empty event to signal a step to increment a counter in the Context."""

    class DummyWorkflow(Workflow):
        # ConstantDelayRetryPolicy will retry at fixed intervals of 1 second, for a maximum of 3 attempts (configurable)
        @step(retry_policy=ConstantDelayRetryPolicy(delay=1))
        async def flaky_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
            count = await ctx.get("counter", default=0)
            ctx.send_event(CountEvent())
            if count < 3:
                raise ValueError("Something bad happened!")
            return StopEvent(result="All good!")

        @step
        async def counter(self, ctx: Context, ev: CountEvent) -> None:
            count = await ctx.get("counter", default=0)
            await ctx.set("counter", count + 1)

    workflow = DummyWorkflow(disable_validation=True)
    await workflow.run()

# Step flaky_step produced an error, retry in 1 seconds
# Step flaky_step produced an error, retry in 1 seconds
# Step flaky_step produced an error, retry in 1 seconds
# Workflow run successfully!
```

To use a custom retry policy, all it's needed is providing a class with one method called `next()` having the follow signature:
```python
class UnreliableRetryPolicy:
    def next(
        self, elapsed_time: float, attempts: int, error: Exception
    ) -> Optional[float]:
        """Retry in a random number of seconds between 1 and 10, stop if the number of attempts is more than 10."""
        if attempts == 10:
            return None
        return float(random.randint(1, 10))
```
and then passing it to the step
```python
        ...
        @step(retry_policy=UnreliableRetryPolicy())
        async def flaky_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
        ...
```

Todo before considering this PR ready:
- Implement the retry logic for sync steps and stepwise execution
- Add proper testing
- Provide at least an exponential backoff built-in policy