### PR TITLE
[Fix] `_example_type` class var being read as private attr with Pydantic V2

### DIFF
--- a/llama-index-core/llama_index/core/llama_dataset/base.py
+++ b/llama-index-core/llama_index/core/llama_dataset/base.py
@@ -3,7 +3,17 @@
 import json
 from abc import abstractmethod
 from enum import Enum
-from typing import Any, Generator, Generic, List, Optional, Type, TypeVar, Union
+from typing import (
+    Any,
+    ClassVar,
+    Generator,
+    Generic,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import tqdm
 from llama_index.core.async_utils import asyncio_module
@@ -62,7 +72,7 @@ class BaseLlamaDataExample(BaseModel):
 
 
 class BaseLlamaPredictionDataset(BaseModel):
-    _prediction_type: Type[BaseLlamaExamplePrediction] = BaseLlamaExamplePrediction  # type: ignore[misc]
+    _prediction_type: ClassVar[Type[BaseLlamaExamplePrediction]]
     predictions: List[BaseLlamaExamplePrediction] = Field(
         default=list, description="Predictions on train_examples."
     )
@@ -114,7 +124,7 @@ class BaseLlamaPredictionDataset(BaseModel):
 
 
 class BaseLlamaDataset(BaseModel, Generic[P]):
-    _example_type: Type[BaseLlamaDataExample] = BaseLlamaDataExample  # type: ignore[misc]
+    _example_type: ClassVar[Type[BaseLlamaDataExample]]  # type: ignore[misc]
     examples: List[BaseLlamaDataExample] = Field(
         default=[], description="Data examples of this dataset."
     )

--- a/llama-index-core/llama_index/core/llama_dataset/base.py
+++ b/llama-index-core/llama_index/core/llama_dataset/base.py
@@ -124,7 +124,7 @@ class BaseLlamaPredictionDataset(BaseModel):
 
 
 class BaseLlamaDataset(BaseModel, Generic[P]):
-    _example_type: ClassVar[Type[BaseLlamaDataExample]]  # type: ignore[misc]
+    _example_type: ClassVar[Type[BaseLlamaDataExample]]
     examples: List[BaseLlamaDataExample] = Field(
         default=[], description="Data examples of this dataset."
     )


### PR DESCRIPTION
# Description

In Pydantic V2, fields starting with "_" are generally treated as PrivateAttr. However, if they are annotated with `ClassVar` then these won't be converted to pydantic PrivateAttr but rather is properly treated as a class variable. Adding this notation to the `_example_type` and `_prediction_type` of `BaseLlamaDataset` and `BaseLlamaPredictionDataset`, respectively makes these two variables properly treated as class vars as required.

Fixes #15746 

## New Package?


## Version Bump?

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested the users code and it is able to download and create llama-datasets
- [x] I stared at the code and made sure it makes sense

