### PR TITLE
Add native vector index support for neo4j lpg and fix vector filters

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -165,7 +165,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
         )
         # Verify version to check if we can use vector index
         self.verify_version()
-        if self._vector_index:
+        if self._supports_vector_index:
             self.structured_query(
                 f"CREATE VECTOR INDEX {VECTOR_INDEX_NAME} IF NOT EXISTS "
                 "FOR (m:__Entity__) ON m.embedding"
@@ -593,7 +593,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
             if conditions is not None
             else "1 = 1"
         )
-        if not query.filters and self._vector_index:
+        if not query.filters and self._supports_vector_index:
             data = self.structured_query(
                 f"""CALL db.index.vector.queryNodes('{VECTOR_INDEX_NAME}', $limit, $embedding)
                 YIELD node, score RETURN node.id AS name,
@@ -971,9 +971,9 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
         target_version = (5, 23, 0)
 
         if version_tuple >= target_version:
-            self._vector_index = True
+            self._supports_vector_index = True
         else:
-            self._vector_index = False
+            self._supports_vector_index = False
 
 
 Neo4jPGStore = Neo4jPropertyGraphStore

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neo4j"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
new neo4j supports vector indexes without prespecifying embedding dimension, which means we can use it in the LPG abstraction.

Also fixed vector filters