### PR TITLE
Bugfix upstage embedding when initializing the UpstageEmbedding class

### DIFF
--- a/docs/docs/examples/embeddings/upstage.ipynb
+++ b/docs/docs/examples/embeddings/upstage.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index-embeddings-upstage==0.1.0"
+    "%pip install llama-index-embeddings-upstage==0.2.1"
    ]
   },
   {

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/llama_index/embeddings/upstage/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/llama_index/embeddings/upstage/base.py
@@ -127,14 +127,14 @@ class UpstageEmbedding(OpenAIEmbedding):
     def class_name(cls) -> str:
         return "UpstageEmbedding"
 
-    def _get_credential_kwargs(self) -> Dict[str, Any]:
+    def _get_credential_kwargs(self, is_async: bool = False) -> Dict[str, Any]:
         return {
             "api_key": self.api_key,
             "base_url": self.api_base,
             "max_retries": self.max_retries,
             "timeout": self.timeout,
             "default_headers": self.default_headers,
-            "http_client": self._http_client,
+            "http_client": self._async_http_client if is_async else self._http_client,
         }
 
     def _get_query_embedding(self, query: str) -> List[float]:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/llama_index/embeddings/upstage/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/llama_index/embeddings/upstage/base.py
@@ -51,7 +51,7 @@ class UpstageEmbedding(OpenAIEmbedding):
         default_factory=dict, description="Additional kwargs for the Upstage API."
     )
 
-    api_key: str = Field(alias="upstage_api_key", description="The Upstage API key.")
+    api_key: str = Field(description="The Upstage API key.")
     api_base: Optional[str] = Field(
         default=DEFAULT_UPSTAGE_API_BASE, description="The base URL for Upstage API."
     )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-embeddings-upstage"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/integration_tests/test_integrations.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/integration_tests/test_integrations.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from pytest_mock import MockerFixture
 
 MOCK_EMBEDDING_DATA = [1.0, 2.0, 3.0]
 UPSTAGE_TEST_API_KEY = "UPSTAGE_TEST_API_KEY"
@@ -23,7 +24,7 @@ def upstage_embedding():
 
 
 def test_upstage_embedding_query_embedding(
-    mocker, setup_environment, upstage_embedding
+    mocker: MockerFixture, setup_environment, upstage_embedding
 ):
     query = "hello"
     mock_openai_client = mocker.patch(
@@ -35,9 +36,8 @@ def test_upstage_embedding_query_embedding(
     assert isinstance(embedding, list)
 
 
-@pytest.mark.asyncio()
 async def test_upstage_embedding_async_query_embedding(
-    mocker, setup_environment, upstage_embedding
+    mocker: MockerFixture, setup_environment, upstage_embedding
 ):
     query = "hello"
     mock_openai_client = mocker.patch(
@@ -49,7 +49,9 @@ async def test_upstage_embedding_async_query_embedding(
     assert isinstance(embedding, list)
 
 
-def test_upstage_embedding_text_embedding(mocker, setup_environment, upstage_embedding):
+def test_upstage_embedding_text_embedding(
+    mocker: MockerFixture, setup_environment, upstage_embedding
+):
     text = "hello"
     mock_openai_client = mocker.patch(
         "llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embedding"
@@ -61,7 +63,7 @@ def test_upstage_embedding_text_embedding(mocker, setup_environment, upstage_emb
 
 
 async def test_upstage_embedding_async_text_embedding(
-    mocker, setup_environment, upstage_embedding
+    mocker: MockerFixture, setup_environment, upstage_embedding
 ):
     text = "hello"
     mock_openai_client = mocker.patch(
@@ -74,7 +76,7 @@ async def test_upstage_embedding_async_text_embedding(
 
 
 def test_upstage_embedding_text_embeddings(
-    mocker, setup_environment, upstage_embedding
+    mocker: MockerFixture, setup_environment, upstage_embedding
 ):
     texts = ["hello", "world"]
     mock_openai_client = mocker.patch(
@@ -88,7 +90,9 @@ def test_upstage_embedding_text_embeddings(
     assert all(isinstance(embedding, list) for embedding in embeddings)
 
 
-def test_upstage_embedding_text_embeddings_fail_large_batch(mocker, setup_environment):
+def test_upstage_embedding_text_embeddings_fail_large_batch(
+    mocker: MockerFixture, setup_environment
+):
     large_batch_size = 2049
     UpstageEmbedding = pytest.importorskip(
         "llama_index.embeddings.upstage", reason="Cannot import UpstageEmbedding"
@@ -106,7 +110,7 @@ def test_upstage_embedding_text_embeddings_fail_large_batch(mocker, setup_enviro
 
 
 async def test_upstage_embedding_async_text_embeddings(
-    mocker, setup_environment, upstage_embedding
+    mocker: MockerFixture, setup_environment, upstage_embedding
 ):
     texts = ["hello", "world"]
     mock_openai_client = mocker.patch(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/integration_tests/test_integrations.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/integration_tests/test_integrations.py
@@ -2,15 +2,13 @@ import os
 
 import pytest
 
-pytest_plugins = ('pytest_asyncio',)
-
 MOCK_EMBEDDING_DATA = [1.0, 2.0, 3.0]
 UPSTAGE_TEST_API_KEY = "UPSTAGE_TEST_API_KEY"
 
 
 @pytest.fixture()
 def setup_environment(monkeypatch):
-    monkeypatch.setenv('UPSTAGE_API_KEY', UPSTAGE_TEST_API_KEY)
+    monkeypatch.setenv("UPSTAGE_API_KEY", UPSTAGE_TEST_API_KEY)
 
 
 @pytest.fixture()
@@ -24,19 +22,27 @@ def upstage_embedding():
     return UpstageEmbedding()
 
 
-def test_upstage_embedding_query_embedding(mocker, setup_environment, upstage_embedding):
+def test_upstage_embedding_query_embedding(
+    mocker, setup_environment, upstage_embedding
+):
     query = "hello"
-    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_query_embedding")
+    mock_openai_client = mocker.patch(
+        "llama_index.embeddings.upstage.base.UpstageEmbedding._get_query_embedding"
+    )
     mock_openai_client.return_value = MOCK_EMBEDDING_DATA
 
     embedding = upstage_embedding.get_query_embedding(query)
     assert isinstance(embedding, list)
 
 
-@pytest.mark.asyncio
-async def test_upstage_embedding_async_query_embedding(mocker, setup_environment, upstage_embedding):
+@pytest.mark.asyncio()
+async def test_upstage_embedding_async_query_embedding(
+    mocker, setup_environment, upstage_embedding
+):
     query = "hello"
-    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._aget_query_embedding")
+    mock_openai_client = mocker.patch(
+        "llama_index.embeddings.upstage.base.UpstageEmbedding._aget_query_embedding"
+    )
     mock_openai_client.return_value = MOCK_EMBEDDING_DATA
 
     embedding = await upstage_embedding.aget_query_embedding(query)
@@ -45,25 +51,35 @@ async def test_upstage_embedding_async_query_embedding(mocker, setup_environment
 
 def test_upstage_embedding_text_embedding(mocker, setup_environment, upstage_embedding):
     text = "hello"
-    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embedding")
+    mock_openai_client = mocker.patch(
+        "llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embedding"
+    )
     mock_openai_client.return_value = MOCK_EMBEDDING_DATA
 
     embedding = upstage_embedding.get_text_embedding(text)
     assert isinstance(embedding, list)
 
 
-async def test_upstage_embedding_async_text_embedding(mocker, setup_environment, upstage_embedding):
+async def test_upstage_embedding_async_text_embedding(
+    mocker, setup_environment, upstage_embedding
+):
     text = "hello"
-    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._aget_text_embedding")
+    mock_openai_client = mocker.patch(
+        "llama_index.embeddings.upstage.base.UpstageEmbedding._aget_text_embedding"
+    )
     mock_openai_client.return_value = MOCK_EMBEDDING_DATA
 
     embedding = await upstage_embedding.aget_text_embedding(text)
     assert isinstance(embedding, list)
 
 
-def test_upstage_embedding_text_embeddings(mocker, setup_environment, upstage_embedding):
+def test_upstage_embedding_text_embeddings(
+    mocker, setup_environment, upstage_embedding
+):
     texts = ["hello", "world"]
-    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embeddings")
+    mock_openai_client = mocker.patch(
+        "llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embeddings"
+    )
     mock_openai_client.return_value = [MOCK_EMBEDDING_DATA] * len(texts)
 
     embeddings = upstage_embedding.get_text_embedding_batch(texts)
@@ -78,7 +94,9 @@ def test_upstage_embedding_text_embeddings_fail_large_batch(mocker, setup_enviro
         "llama_index.embeddings.upstage", reason="Cannot import UpstageEmbedding"
     ).UpstageEmbedding
 
-    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embeddings")
+    mock_openai_client = mocker.patch(
+        "llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embeddings"
+    )
     mock_openai_client.return_value = [MOCK_EMBEDDING_DATA] * large_batch_size
 
     texts = ["hello"] * large_batch_size
@@ -87,9 +105,13 @@ def test_upstage_embedding_text_embeddings_fail_large_batch(mocker, setup_enviro
         upstage_embedding.get_text_embedding_batch(texts)
 
 
-async def test_upstage_embedding_async_text_embeddings(mocker, setup_environment, upstage_embedding):
+async def test_upstage_embedding_async_text_embeddings(
+    mocker, setup_environment, upstage_embedding
+):
     texts = ["hello", "world"]
-    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._aget_text_embeddings")
+    mock_openai_client = mocker.patch(
+        "llama_index.embeddings.upstage.base.UpstageEmbedding._aget_text_embeddings"
+    )
     mock_openai_client.return_value = [MOCK_EMBEDDING_DATA] * len(texts)
 
     embeddings = await upstage_embedding.aget_text_embedding_batch(texts)

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/integration_tests/test_integrations.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/integration_tests/test_integrations.py
@@ -2,6 +2,16 @@ import os
 
 import pytest
 
+pytest_plugins = ('pytest_asyncio',)
+
+MOCK_EMBEDDING_DATA = [1.0, 2.0, 3.0]
+UPSTAGE_TEST_API_KEY = "UPSTAGE_TEST_API_KEY"
+
+
+@pytest.fixture()
+def setup_environment(monkeypatch):
+    monkeypatch.setenv('UPSTAGE_API_KEY', UPSTAGE_TEST_API_KEY)
+
 
 @pytest.fixture()
 def upstage_embedding():
@@ -14,50 +24,74 @@ def upstage_embedding():
     return UpstageEmbedding()
 
 
-def test_upstage_embedding_query_embedding(upstage_embedding):
+def test_upstage_embedding_query_embedding(mocker, setup_environment, upstage_embedding):
     query = "hello"
+    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_query_embedding")
+    mock_openai_client.return_value = MOCK_EMBEDDING_DATA
+
     embedding = upstage_embedding.get_query_embedding(query)
     assert isinstance(embedding, list)
 
 
-async def test_upstage_embedding_async_query_embedding(upstage_embedding):
+@pytest.mark.asyncio
+async def test_upstage_embedding_async_query_embedding(mocker, setup_environment, upstage_embedding):
     query = "hello"
+    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._aget_query_embedding")
+    mock_openai_client.return_value = MOCK_EMBEDDING_DATA
+
     embedding = await upstage_embedding.aget_query_embedding(query)
     assert isinstance(embedding, list)
 
 
-def test_upstage_embedding_text_embedding(upstage_embedding):
+def test_upstage_embedding_text_embedding(mocker, setup_environment, upstage_embedding):
     text = "hello"
+    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embedding")
+    mock_openai_client.return_value = MOCK_EMBEDDING_DATA
+
     embedding = upstage_embedding.get_text_embedding(text)
     assert isinstance(embedding, list)
 
 
-async def test_upstage_embedding_async_text_embedding(upstage_embedding):
+async def test_upstage_embedding_async_text_embedding(mocker, setup_environment, upstage_embedding):
     text = "hello"
+    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._aget_text_embedding")
+    mock_openai_client.return_value = MOCK_EMBEDDING_DATA
+
     embedding = await upstage_embedding.aget_text_embedding(text)
     assert isinstance(embedding, list)
 
 
-def test_upstage_embedding_text_embeddings(upstage_embedding):
+def test_upstage_embedding_text_embeddings(mocker, setup_environment, upstage_embedding):
     texts = ["hello", "world"]
+    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embeddings")
+    mock_openai_client.return_value = [MOCK_EMBEDDING_DATA] * len(texts)
+
     embeddings = upstage_embedding.get_text_embedding_batch(texts)
     assert isinstance(embeddings, list)
     assert len(embeddings) == len(texts)
     assert all(isinstance(embedding, list) for embedding in embeddings)
 
 
-def test_upstage_embedding_text_embeddings_fail_large_batch():
+def test_upstage_embedding_text_embeddings_fail_large_batch(mocker, setup_environment):
+    large_batch_size = 2049
     UpstageEmbedding = pytest.importorskip(
         "llama_index.embeddings.upstage", reason="Cannot import UpstageEmbedding"
     ).UpstageEmbedding
-    texts = ["hello"] * 2049
+
+    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._get_text_embeddings")
+    mock_openai_client.return_value = [MOCK_EMBEDDING_DATA] * large_batch_size
+
+    texts = ["hello"] * large_batch_size
     with pytest.raises(ValueError):
         upstage_embedding = UpstageEmbedding(embed_batch_size=2049)
         upstage_embedding.get_text_embedding_batch(texts)
 
 
-async def test_upstage_embedding_async_text_embeddings(upstage_embedding):
+async def test_upstage_embedding_async_text_embeddings(mocker, setup_environment, upstage_embedding):
     texts = ["hello", "world"]
+    mock_openai_client = mocker.patch("llama_index.embeddings.upstage.base.UpstageEmbedding._aget_text_embeddings")
+    mock_openai_client.return_value = [MOCK_EMBEDDING_DATA] * len(texts)
+
     embeddings = await upstage_embedding.aget_text_embedding_batch(texts)
     assert isinstance(embeddings, list)
     assert len(embeddings) == len(texts)

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
@@ -13,7 +13,7 @@ def upstage_embedding():
 
 @pytest.fixture()
 def setup_environment(monkeypatch):
-    monkeypatch.setenv('UPSTAGE_API_KEY', UPSTAGE_TEST_API_KEY)
+    monkeypatch.setenv("UPSTAGE_API_KEY", UPSTAGE_TEST_API_KEY)
 
 
 def test_upstage_embedding_class(upstage_embedding):

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
@@ -1,7 +1,6 @@
 import pytest
 from llama_index.core.base.embeddings.base import BaseEmbedding
 
-
 UPSTAGE_TEST_API_KEY = "upstage_test_key"
 
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
@@ -12,6 +12,11 @@ def upstage_embedding():
     ).UpstageEmbedding
 
 
+@pytest.fixture()
+def setup_environment(monkeypatch):
+    monkeypatch.setenv('UPSTAGE_API_KEY', UPSTAGE_TEST_API_KEY)
+
+
 def test_upstage_embedding_class(upstage_embedding):
     names_of_base_classes = [b.__name__ for b in upstage_embedding.__mro__]
     assert BaseEmbedding.__name__ in names_of_base_classes
@@ -30,3 +35,8 @@ def test_upstage_embedding_api_key_alias(upstage_embedding):
     assert embedding1.api_key == UPSTAGE_TEST_API_KEY
     assert embedding2.api_key == UPSTAGE_TEST_API_KEY
     assert embedding3.api_key == ""
+
+
+def test_upstage_embedding_api_key_with_env(setup_environment, upstage_embedding):
+    embedding = upstage_embedding()
+    assert embedding.api_key == UPSTAGE_TEST_API_KEY

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/tests/unit_tests/test_embeddings_upstage.py
@@ -2,6 +2,9 @@ import pytest
 from llama_index.core.base.embeddings.base import BaseEmbedding
 
 
+UPSTAGE_TEST_API_KEY = "upstage_test_key"
+
+
 @pytest.fixture()
 def upstage_embedding():
     return pytest.importorskip(
@@ -20,11 +23,10 @@ def test_upstage_embedding_fail_wrong_model(upstage_embedding):
 
 
 def test_upstage_embedding_api_key_alias(upstage_embedding):
-    api_key = "test_key"
-    embedding1 = upstage_embedding(api_key=api_key)
-    embedding2 = upstage_embedding(upstage_api_key=api_key)
-    embedding3 = upstage_embedding(error_api_key=api_key)
+    embedding1 = upstage_embedding(api_key=UPSTAGE_TEST_API_KEY)
+    embedding2 = upstage_embedding(upstage_api_key=UPSTAGE_TEST_API_KEY)
+    embedding3 = upstage_embedding(error_api_key=UPSTAGE_TEST_API_KEY)
 
-    assert embedding1.api_key == api_key
-    assert embedding2.api_key == api_key
+    assert embedding1.api_key == UPSTAGE_TEST_API_KEY
+    assert embedding2.api_key == UPSTAGE_TEST_API_KEY
     assert embedding3.api_key == ""


### PR DESCRIPTION
# Description
When following the official documentation to use the `UpstageEmbeddings` class, pydantic validation error occurs when initializing the `UpstageEmbedding` class. I have fixed this bug and updated the failing tests.

Fixes #15766 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?
Test instruction: `pytest llama-index-integrations/embeddings/llama-index-embeddings-upstage`

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
