### PR TITLE
add `dimensions` param to `LiteLLMEmbedding`, fix a bug that prevents reading vars from env

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -5,7 +5,9 @@ from llama_index.core.bridge.pydantic import Field
 from llama_index.core.embeddings import BaseEmbedding
 
 
-def get_embeddings(api_key: str, api_base: str, model_name: str, input: List[str], **kwargs: Any,):
+def get_embeddings(
+    api_key: str, api_base: str, model_name: str, input: List[str], **kwargs: Any
+):
     if not api_key:
         # If key is not provided, we assume the consumer has configured
         # their LiteLLM proxy server with their API key.

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -32,9 +32,7 @@ def get_embeddings(
 
 
 class LiteLLMEmbedding(BaseEmbedding):
-    model_name: str = Field(
-        description="The name of the embedding model."
-    )
+    model_name: str = Field(description="The name of the embedding model.")
     api_key: Optional[str] = Field(
         default=None,
         description="OpenAI key. If not provided, the proxy server must be configured with the key.",

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -7,12 +7,20 @@ from llama_index.core.embeddings import BaseEmbedding
 
 def get_embeddings(
     api_key: str, api_base: str, model_name: str, input: List[str], **kwargs: Any
-):
-    if not api_key:
-        # If key is not provided, we assume the consumer has configured
-        # their LiteLLM proxy server with their API key.
-        api_key = "some key"
+) -> List[List[float]]:
+    """
+    Retrieve embeddings for a given list of input strings using the specified model.
 
+    Args:
+        api_key (str): The API key for authentication.
+        api_base (str): The base URL of the LiteLLM proxy server.
+        model_name (str): The name of the model to use for generating embeddings.
+        input (List[str]): A list of input strings for which embeddings are to be generated.
+        **kwargs (Any): Additional keyword arguments to be passed to the embedding function.
+
+    Returns:
+        List[List[float]]: A list of embeddings, where each embedding corresponds to an input string.
+    """
     response = embedding(
         api_key=api_key,
         api_base=api_base,
@@ -25,14 +33,14 @@ def get_embeddings(
 
 class LiteLLMEmbedding(BaseEmbedding):
     model_name: str = Field(
-        default="unknown", description="The name of the embedding model."
+        default=None, description="The name of the embedding model."
     )
     api_key: str = Field(
-        default="unknown",
+        default=None,
         description="OpenAI key. If not provided, the proxy server must be configured with the key.",
     )
     api_base: str = Field(
-        default="unknown", description="The base URL of the LiteLLM proxy."
+        default=None, description="The base URL of the LiteLLM proxy."
     )
     dimensions: Optional[int] = Field(
         default=None,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -5,7 +5,7 @@ from llama_index.core.bridge.pydantic import Field
 from llama_index.core.embeddings import BaseEmbedding
 
 
-def get_embeddings(api_key: str, api_base: str, model_name: str, input: List[str]):
+def get_embeddings(api_key: str, api_base: str, model_name: str, input: List[str], **kwargs: Any,):
     if not api_key:
         # If key is not provided, we assume the consumer has configured
         # their LiteLLM proxy server with their API key.
@@ -16,6 +16,7 @@ def get_embeddings(api_key: str, api_base: str, model_name: str, input: List[str
         api_base=api_base,
         model=model_name,
         input=input,
+        **kwargs,
     )
     return [result["embedding"] for result in response.data]
 
@@ -30,6 +31,13 @@ class LiteLLMEmbedding(BaseEmbedding):
     )
     api_base: str = Field(
         default="unknown", description="The base URL of the LiteLLM proxy."
+    )
+    dimensions: Optional[int] = Field(
+        default=None,
+        description=(
+            "The number of dimensions the resulting output embeddings should have. "
+            "Only supported in text-embedding-3 and later models."
+        ),
     )
 
     @classmethod
@@ -47,6 +55,7 @@ class LiteLLMEmbedding(BaseEmbedding):
             api_key=self.api_key,
             api_base=self.api_base,
             model_name=self.model_name,
+            dimensions=self.dimensions,
             input=[query],
         )
         return embeddings[0]
@@ -56,6 +65,7 @@ class LiteLLMEmbedding(BaseEmbedding):
             api_key=self.api_key,
             api_base=self.api_base,
             model_name=self.model_name,
+            dimensions=self.dimensions,
             input=[text],
         )
         return embeddings[0]
@@ -65,5 +75,6 @@ class LiteLLMEmbedding(BaseEmbedding):
             api_key=self.api_key,
             api_base=self.api_base,
             model_name=self.model_name,
+            dimensions=self.dimensions,
             input=texts,
         )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -32,14 +32,14 @@ def get_embeddings(
 
 
 class LiteLLMEmbedding(BaseEmbedding):
-    model_name: str = Field(
+    model_name: Optional[str] = Field(
         default=None, description="The name of the embedding model."
     )
-    api_key: str = Field(
+    api_key: Optional[str] = Field(
         default=None,
         description="OpenAI key. If not provided, the proxy server must be configured with the key.",
     )
-    api_base: str = Field(
+    api_base: Optional[str] = Field(
         default=None, description="The base URL of the LiteLLM proxy."
     )
     dimensions: Optional[int] = Field(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import List, Any, Optional
 from litellm import embedding
 
 from llama_index.core.bridge.pydantic import Field

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -32,8 +32,8 @@ def get_embeddings(
 
 
 class LiteLLMEmbedding(BaseEmbedding):
-    model_name: Optional[str] = Field(
-        default=None, description="The name of the embedding model."
+    model_name: str = Field(
+        description="The name of the embedding model."
     )
     api_key: Optional[str] = Field(
         default=None,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Optional
+from typing import Any, List, Optional
 from litellm import embedding
 
 from llama_index.core.bridge.pydantic import Field

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/llama_index/embeddings/litellm/base.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 from litellm import embedding
 
 from llama_index.core.bridge.pydantic import Field

--- a/llama-index-integrations/embeddings/llama-index-embeddings-litellm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-litellm/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-litellm"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
This is a minor update.

Adds `dimensions` param to `LiteLLMEmbedding`.
Remove invalid default values so that class can read variables from environment as expected: https://docs.litellm.ai/docs/embedding/supported_embedding#api-keys

Fixes https://github.com/run-llama/llama_index/issues/15771 
Fixes https://github.com/run-llama/llama_index/issues/15772

cc: @isaac-chung @logan-markewich @shashvatsinha @ishaan-jaff
