### PR TITLE
add ollama response usage

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -184,6 +184,20 @@ class Ollama(FunctionCallingLLM):
             for message in messages
         ]
 
+    def _get_response_token_counts(self, raw_response: dict) -> dict:
+        """Get the token usage reported by the response."""
+        try:
+            prompt_tokens = raw_response["prompt_eval_count"]
+            completion_tokens = raw_response["eval_count"]
+            total_tokens = prompt_tokens + completion_tokens
+        except KeyError:
+            return {}
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        }
+
     def _prepare_chat_with_tools(
         self,
         tools: List["BaseTool"],
@@ -268,6 +282,9 @@ class Ollama(FunctionCallingLLM):
         )
 
         tool_calls = response["message"].get("tool_calls", [])
+        token_counts = self._get_response_token_counts(response)
+        if token_counts:
+            response["usage"] = token_counts
 
         return ChatResponse(
             message=ChatMessage(
@@ -305,6 +322,9 @@ class Ollama(FunctionCallingLLM):
                 response_txt += r["message"]["content"]
 
                 tool_calls = r["message"].get("tool_calls", [])
+                token_counts = self._get_response_token_counts(r)
+                if token_counts:
+                    response["usage"] = token_counts
 
                 yield ChatResponse(
                     message=ChatMessage(
@@ -345,6 +365,9 @@ class Ollama(FunctionCallingLLM):
                 response_txt += r["message"]["content"]
 
                 tool_calls = r["message"].get("tool_calls", [])
+                token_counts = self._get_response_token_counts(r)
+                if token_counts:
+                    response["usage"] = token_counts
 
                 yield ChatResponse(
                     message=ChatMessage(
@@ -376,6 +399,9 @@ class Ollama(FunctionCallingLLM):
         )
 
         tool_calls = response["message"].get("tool_calls", [])
+        token_counts = self._get_response_token_counts(response)
+        if token_counts:
+            response["usage"] = token_counts
 
         return ChatResponse(
             message=ChatMessage(

--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -324,7 +324,7 @@ class Ollama(FunctionCallingLLM):
                 tool_calls = r["message"].get("tool_calls", [])
                 token_counts = self._get_response_token_counts(r)
                 if token_counts:
-                    response["usage"] = token_counts
+                    r["usage"] = token_counts
 
                 yield ChatResponse(
                     message=ChatMessage(
@@ -367,7 +367,7 @@ class Ollama(FunctionCallingLLM):
                 tool_calls = r["message"].get("tool_calls", [])
                 token_counts = self._get_response_token_counts(r)
                 if token_counts:
-                    response["usage"] = token_counts
+                    r["usage"] = token_counts
 
                 yield ChatResponse(
                     message=ChatMessage(

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ollama"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

When using the ollama chat model, I noticed that the return format is slightly different from the general ones. It returns like this: 
```
{
    "model": "qwen2:72b",
    "created_at": "2024-09-02T03:27:36.526752985Z",
    "message": {"role": "assistant", "content": ""},
    "done_reason": "stop",
    "done": True,
    "total_duration": 2128547675,
    "load_duration": 25776264,
    "prompt_eval_count": 189,
    "prompt_eval_duration": 402063000,
    "eval_count": 37,
    "eval_duration": 1659622000,
}
```
Some methods that count tokens through 'usage' do not work effectively. I tried modifying the return format to store the token counts in 'usage'. I am not sure if this is a good solution.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
