### PR TITLE
fix: remove context after running workflow

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -245,6 +245,9 @@ class Workflow(metaclass=_WorkflowMeta):
             t.cancel()
             await asyncio.sleep(0)
 
+        # remove context
+        self._contexts.remove(ctx)
+
         # Bubble up the error if any step raised an exception
         if exception_raised:
             # Make sure to stop streaming, in case the workflow terminated abnormally

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -67,6 +67,9 @@ class Workflow(metaclass=_WorkflowMeta):
 
             yield ev
 
+        # remove context to free up room for the next stream_events call
+        self._contexts.remove(ctx)
+
     @classmethod
     def add_step(cls, func: Callable) -> None:
         """Adds a free function as step for this workflow instance.
@@ -244,9 +247,6 @@ class Workflow(metaclass=_WorkflowMeta):
         for t in unfinished:
             t.cancel()
             await asyncio.sleep(0)
-
-        # remove context
-        self._contexts.remove(ctx)
 
         # Bubble up the error if any step raised an exception
         if exception_raised:

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -67,3 +67,20 @@ async def test_task_raised():
     # Make sure the await actually caught the exception
     with pytest.raises(ValueError, match="The step raised an error!"):
         await r
+
+
+@pytest.mark.asyncio()
+async def test_multiple_streams():
+    wf = StreamingWorkflow()
+    r = asyncio.create_task(wf.run())
+
+    # stream 1
+    async for _ in wf.stream_events():
+        pass
+    await r
+
+    # stream 2 -- should not raise an error
+    r = asyncio.create_task(wf.run())
+    async for _ in wf.stream_events():
+        pass
+    await r


### PR DESCRIPTION
# Description

Calling `workflow.run` doesn't clean up the context of the run from the `_contexts` set

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
