### PR TITLE
FunctionCallingAgent sources bug + light wrapper to create agent

### DIFF
--- a/docs/docs/examples/agent/agentic_rag_using_vertex_ai.ipynb
+++ b/docs/docs/examples/agent/agentic_rag_using_vertex_ai.ipynb
@@ -439,8 +439,7 @@
     "from llama_index.core.vector_stores import MetadataFilters\n",
     "from pathlib import Path\n",
     "\n",
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
-    "from llama_index.core.agent import AgentRunner"
+    "from llama_index.core.agent import FunctionCallingAgent"
    ]
   },
   {
@@ -936,11 +935,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create Agent Runner\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "# Create Agent\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [vector_query_tool, summary_tool], llm=vertex_gemini, verbose=True\n",
-    ")\n",
-    "agent = AgentRunner(agent_worker)"
+    ")"
    ]
   },
   {
@@ -1035,7 +1033,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    tool_retriever=obj_retriever,\n",
     "    llm=vertex_gemini,\n",
     "    system_prompt=\"\"\" \\\n",
@@ -1044,8 +1042,7 @@
     "\n",
     "\"\"\",\n",
     "    verbose=True,\n",
-    ")\n",
-    "agent = AgentRunner(agent_worker)"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/agent/agentic_rag_with_llamaindex_and_vertexai_managed_index.ipynb
+++ b/docs/docs/examples/agent/agentic_rag_with_llamaindex_and_vertexai_managed_index.ipynb
@@ -157,8 +157,7 @@
     "from llama_index.core.vector_stores import MetadataFilters\n",
     "from pathlib import Path\n",
     "\n",
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
-    "from llama_index.core.agent import AgentRunner"
+    "from llama_index.core.agent import FunctionCallingAgent"
    ]
   },
   {
@@ -829,11 +828,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create Agent Runner\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "# Create Agent\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [vector_query_tool, summary_tool], llm=vertex_gemini, verbose=True\n",
-    ")\n",
-    "agent = AgentRunner(agent_worker)"
+    ")"
    ]
   },
   {
@@ -927,7 +925,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    tool_retriever=obj_retriever,\n",
     "    llm=vertex_gemini,\n",
     "    system_prompt=\"\"\" \\\n",
@@ -936,8 +934,7 @@
     "\n",
     "\"\"\",\n",
     "    verbose=True,\n",
-    ")\n",
-    "agent = AgentRunner(agent_worker)"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/agent/anthropic_agent.ipynb
+++ b/docs/docs/examples/agent/anthropic_agent.ipynb
@@ -170,15 +170,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    allow_parallel_tool_calls=False,\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {
@@ -265,13 +264,12 @@
    ],
    "source": [
     "# enable parallel function calling\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    allow_parallel_tool_calls=True,\n",
     ")\n",
-    "agent = agent_worker.as_agent()\n",
     "response = await agent.achat(\"What is (121 * 3) + (5 * 8)?\")\n",
     "print(str(response))"
    ]
@@ -358,12 +356,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [query_engine_tool], llm=llm, verbose=True\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/agent/bedrock_converse_agent.ipynb
+++ b/docs/docs/examples/agent/bedrock_converse_agent.ipynb
@@ -175,15 +175,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    allow_parallel_tool_calls=False,\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {
@@ -287,12 +286,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [query_engine_tool], llm=llm, verbose=True\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/agent/memory/composable_memory.ipynb
+++ b/docs/docs/examples/agent/memory/composable_memory.ipynb
@@ -510,7 +510,7 @@
    "source": [
     "from llama_index.llms.openai import OpenAI\n",
     "from llama_index.core.tools import FunctionTool\n",
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
     "import nest_asyncio\n",
     "\n",
@@ -583,10 +583,12 @@
    "outputs": [],
    "source": [
     "llm = OpenAI(model=\"gpt-3.5-turbo-0613\")\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
-    "    [multiply_tool, mystery_tool], llm=llm, verbose=True\n",
-    ")\n",
-    "agent = agent_worker.as_agent(memory=composable_memory)"
+    "agent = FunctionCallingAgent.from_tools(\n",
+    "    [multiply_tool, mystery_tool],\n",
+    "    llm=llm,\n",
+    "    memory=composable_memory,\n",
+    "    verbose=True,\n",
+    ")"
    ]
   },
   {
@@ -685,10 +687,9 @@
    "outputs": [],
    "source": [
     "llm = OpenAI(model=\"gpt-3.5-turbo-0613\")\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent_without_memory = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, mystery_tool], llm=llm, verbose=True\n",
-    ")\n",
-    "agent_without_memory = agent_worker.as_agent()"
+    ")"
    ]
   },
   {
@@ -737,9 +738,7 @@
    "outputs": [],
    "source": [
     "llm = OpenAI(model=\"gpt-3.5-turbo-0613\")\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
-    "    [multiply_tool, mystery_tool], llm=llm, verbose=True\n",
-    ")\n",
+    "\n",
     "composable_memory = SimpleComposableMemory.from_defaults(\n",
     "    primary_memory=ChatMemoryBuffer.from_defaults(),\n",
     "    secondary_memory_sources=[\n",
@@ -749,7 +748,13 @@
     "        # later will use original vector_memory again\n",
     "    ],\n",
     ")\n",
-    "agent_with_memory = agent_worker.as_agent(memory=composable_memory)"
+    "\n",
+    "agent_with_memory = FunctionCallingAgent.from_tools(\n",
+    "    [multiply_tool, mystery_tool],\n",
+    "    llm=llm,\n",
+    "    memory=composable_memory,\n",
+    "    verbose=True,\n",
+    ")"
    ]
   },
   {
@@ -937,9 +942,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llama-index-core",
+   "display_name": "llama-index-caVs7DDe-py3.11",
    "language": "python",
-   "name": "llama-index-core"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/docs/examples/agent/mistral_agent.ipynb
+++ b/docs/docs/examples/agent/mistral_agent.ipynb
@@ -172,15 +172,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    allow_parallel_tool_calls=False,\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {
@@ -267,13 +266,13 @@
    ],
    "source": [
     "# enable parallel function calling\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    allow_parallel_tool_calls=True,\n",
     ")\n",
-    "agent = agent_worker.as_agent()\n",
+    "\n",
     "response = await agent.achat(\"What is (121 * 3) + (5 * 8)?\")\n",
     "print(str(response))"
    ]
@@ -360,12 +359,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [query_engine_tool], llm=llm, verbose=True\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/agent/nvidia_agent.ipynb
+++ b/docs/docs/examples/agent/nvidia_agent.ipynb
@@ -150,14 +150,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {
@@ -275,12 +274,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    system_prompt=SHAKESPEARE_WRITING_ASSISTANT,\n",
-    ").as_agent()"
+    ")"
    ]
   },
   {
@@ -367,10 +366,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [query_engine_tool], llm=llm, verbose=True\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/agent/return_direct_agent.ipynb
+++ b/docs/docs/examples/agent/return_direct_agent.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "from llama_index.llms.anthropic import Anthropic\n",
     "from llama_index.core.llms import ChatMessage\n",
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
     "llm = Anthropic(model=\"claude-3-sonnet-20240229\", temperature=0.1)\n",
     "\n",
@@ -154,7 +154,7 @@
     "    )\n",
     "]\n",
     "\n",
-    "worker = FunctionCallingAgentWorker(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    tools=[\n",
     "        get_booking_state_tool,\n",
     "        update_booking_tool,\n",
@@ -166,9 +166,7 @@
     "    max_function_calls=10,\n",
     "    allow_parallel_tool_calls=False,\n",
     "    verbose=True,\n",
-    ")\n",
-    "\n",
-    "agent = worker.as_agent()"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/cookbooks/mistralai.ipynb
+++ b/docs/docs/examples/cookbooks/mistralai.ipynb
@@ -218,7 +218,7 @@
    "outputs": [],
    "source": [
     "from llama_index.core.tools import QueryEngineTool, ToolMetadata\n",
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgent\n",
     "\n",
     "query_engine_tools = [\n",
     "    QueryEngineTool(\n",
@@ -237,13 +237,12 @@
     "    ),\n",
     "]\n",
     "\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    query_engine_tools,\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    allow_parallel_tool_calls=False,\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {
@@ -378,7 +377,7 @@
    "source": [
     "from llama_index.core.tools import FunctionTool\n",
     "from llama_index.core.agent import (\n",
-    "    FunctionCallingAgentWorker,\n",
+    "    FunctionCallingAgent,\n",
     "    ReActAgent,\n",
     ")"
    ]
@@ -423,13 +422,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, add_tool, subtract_tool],\n",
     "    llm=llm,\n",
     "    verbose=True,\n",
     "    allow_parallel_tool_calls=False,\n",
-    ")\n",
-    "agent = agent_worker.as_agent()"
+    ")"
    ]
   },
   {

--- a/docs/docs/examples/property_graph/agentic_graph_rag_vertex.ipynb
+++ b/docs/docs/examples/property_graph/agentic_graph_rag_vertex.ipynb
@@ -212,8 +212,7 @@
     "from llama_index.core.vector_stores import MetadataFilters\n",
     "from pathlib import Path\n",
     "\n",
-    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
-    "from llama_index.core.agent import AgentRunner"
+    "from llama_index.core.agent import FunctionCallingAgent"
    ]
   },
   {
@@ -1085,10 +1084,9 @@
    "outputs": [],
    "source": [
     "# Create Agent Runner\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent = FunctionCallingAgent.from_tools(\n",
     "    [summary_tool, vector_query_tool], llm=vertex_gemini, verbose=True\n",
-    ")\n",
-    "agent = AgentRunner(agent_worker)"
+    ")"
    ]
   },
   {

--- a/docs/docs/presentations/materials/2024-06-13-vector-ess-oss-tools.ipynb
+++ b/docs/docs/presentations/materials/2024-06-13-vector-ess-oss-tools.ipynb
@@ -932,7 +932,7 @@
     "    SimpleComposableMemory,\n",
     "    ChatMemoryBuffer,\n",
     ")\n",
-    "from llama_index.core.agent import FunctionCallingAgentWorker"
+    "from llama_index.core.agent import FunctionCallingAgent"
    ]
   },
   {
@@ -984,10 +984,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
-    "    [multiply_tool, mystery_tool], llm=openai_llm, verbose=True\n",
-    ")\n",
-    "agent = agent_worker.as_agent(memory=composable_memory)"
+    "agent = FunctionCallingAgent.from_tools(\n",
+    "    [multiply_tool, mystery_tool],\n",
+    "    llm=openai_llm,\n",
+    "    memory=composable_memory,\n",
+    "    verbose=True,\n",
+    ")"
    ]
   },
   {
@@ -1069,10 +1071,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
+    "agent_without_memory = FunctionCallingAgent.from_tools(\n",
     "    [multiply_tool, mystery_tool], llm=openai_llm, verbose=True\n",
-    ")\n",
-    "agent_without_memory = agent_worker.as_agent()"
+    ")"
    ]
   },
   {
@@ -1113,9 +1114,7 @@
    "outputs": [],
    "source": [
     "llm = OpenAI(model=\"gpt-3.5-turbo-0613\")\n",
-    "agent_worker = FunctionCallingAgentWorker.from_tools(\n",
-    "    [multiply_tool, mystery_tool], llm=openai_llm, verbose=True\n",
-    ")\n",
+    "\n",
     "composable_memory = SimpleComposableMemory.from_defaults(\n",
     "    primary_memory=ChatMemoryBuffer.from_defaults(),\n",
     "    secondary_memory_sources=[\n",
@@ -1125,7 +1124,13 @@
     "        # later will use original vector_memory again\n",
     "    ],\n",
     ")\n",
-    "agent_with_memory = agent_worker.as_agent(memory=composable_memory)"
+    "\n",
+    "agent_with_memory = FunctionCallingAgent.from_tools(\n",
+    "    [multiply_tool, mystery_tool],\n",
+    "    llm=openai_llm,\n",
+    "    memory=composable_memory,\n",
+    "    verbose=True,\n",
+    ")"
    ]
   },
   {
@@ -1418,6 +1423,7 @@
     "    ToolInteractiveReflectionAgentWorker,\n",
     ")\n",
     "from llama_index.agent.openai import OpenAIAgentWorker\n",
+    "from llama_index.core.agent import FunctionCallingAgentWorker\n",
     "from llama_index.core.llms import ChatMessage, MessageRole"
    ]
   },

--- a/llama-index-core/llama_index/core/agent/__init__.py
+++ b/llama-index-core/llama_index/core/agent/__init__.py
@@ -12,6 +12,7 @@ from llama_index.core.agent.runner.planner import StructuredPlannerAgent
 from llama_index.core.agent.runner.parallel import ParallelAgentRunner
 from llama_index.core.agent.types import Task
 from llama_index.core.chat_engine.types import AgentChatResponse
+from llama_index.core.agent.function_calling.base import FunctionCallingAgent
 from llama_index.core.agent.function_calling.step import FunctionCallingAgentWorker
 
 __all__ = [
@@ -26,6 +27,7 @@ __all__ = [
     "ReActChatFormatter",
     "FunctionCallingAgentWorker",
     "FnAgentWorker",
+    "FunctionCallingAgent",
     # beta
     "MultimodalReActAgentWorker",
     # schema-related

--- a/llama-index-core/llama_index/core/agent/function_calling/base.py
+++ b/llama-index-core/llama_index/core/agent/function_calling/base.py
@@ -1,23 +1,81 @@
 """Function calling agent."""
 
+from typing import Any, List, Optional
 
-from llama_index.core.agent.runner.base import AgentRunner
+from llama_index.core.agent.runner.base import AgentRunner, AgentState
+from llama_index.core.agent.function_calling.step import (
+    FunctionCallingAgentWorker,
+    DEFAULT_MAX_FUNCTION_CALLS,
+)
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core.llms.function_calling import FunctionCallingLLM
+from llama_index.core.memory.types import BaseMemory
+from llama_index.core.objects.base import ObjectRetriever
+from llama_index.core.settings import Settings
+from llama_index.core.tools.types import BaseTool
 
 
 class FunctionCallingAgent(AgentRunner):
     """Function calling agent.
 
-    Calls any LLM that supports function calling in a while loop until the task is complete.
-
+    Light wrapper around AgentRunner.
     """
 
-    # def __init__(
-    #     self,
-    #     tools: List[BaseTool],
-    #     llm: OpenAI,
-    #     memory: BaseMemory,
-    #     prefix_messages: List[ChatMessage],
-    #     verbose: bool = False,
-    #     max_function_calls: int = 5,
-    #     default_tool_choice: str = "auto",
-    # )
+    @classmethod
+    def from_tools(
+        cls,
+        tools: Optional[List[BaseTool]] = None,
+        tool_retriever: Optional[ObjectRetriever[BaseTool]] = None,
+        llm: Optional[FunctionCallingLLM] = None,
+        verbose: bool = False,
+        max_function_calls: int = DEFAULT_MAX_FUNCTION_CALLS,
+        callback_manager: Optional[CallbackManager] = None,
+        system_prompt: Optional[str] = None,
+        prefix_messages: Optional[List[ChatMessage]] = None,
+        memory: Optional[BaseMemory] = None,
+        chat_history: Optional[List[ChatMessage]] = None,
+        state: Optional[AgentState] = None,
+        **kwargs: Any,
+    ) -> "FunctionCallingAgent":
+        """Create a FunctionCallingAgent from a list of tools."""
+        tools = tools or []
+
+        llm = llm or Settings.llm  # type: ignore
+        assert isinstance(
+            llm, FunctionCallingLLM
+        ), "llm must be an instance of FunctionCallingLLM"
+
+        if callback_manager is not None:
+            llm.callback_manager = callback_manager
+
+        if system_prompt is not None:
+            if prefix_messages is not None:
+                raise ValueError(
+                    "Cannot specify both system_prompt and prefix_messages"
+                )
+            prefix_messages = [ChatMessage(content=system_prompt, role="system")]
+
+        prefix_messages = prefix_messages or []
+
+        agent_worker = FunctionCallingAgentWorker.from_tools(
+            tools,
+            tool_retriever=tool_retriever,
+            llm=llm,
+            verbose=verbose,
+            max_function_calls=max_function_calls,
+            callback_manager=callback_manager,
+            system_prompt=system_prompt,
+            prefix_messages=prefix_messages,
+        )
+
+        return cls(
+            agent_worker=agent_worker,
+            memory=memory,
+            chat_history=chat_history,
+            state=state,
+            llm=llm,
+            callback_manager=callback_manager,
+            verbose=verbose,
+            **kwargs,
+        )

--- a/llama-index-core/llama_index/core/agent/function_calling/base.py
+++ b/llama-index-core/llama_index/core/agent/function_calling/base.py
@@ -36,6 +36,7 @@ class FunctionCallingAgent(AgentRunner):
         memory: Optional[BaseMemory] = None,
         chat_history: Optional[List[ChatMessage]] = None,
         state: Optional[AgentState] = None,
+        allow_parallel_tool_calls: bool = True,
         **kwargs: Any,
     ) -> "FunctionCallingAgent":
         """Create a FunctionCallingAgent from a list of tools."""
@@ -67,6 +68,7 @@ class FunctionCallingAgent(AgentRunner):
             callback_manager=callback_manager,
             system_prompt=system_prompt,
             prefix_messages=prefix_messages,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
         )
 
         return cls(

--- a/llama-index-core/llama_index/core/agent/function_calling/step.py
+++ b/llama-index-core/llama_index/core/agent/function_calling/step.py
@@ -128,6 +128,7 @@ class FunctionCallingAgentWorker(BaseAgentWorker):
         llm: Optional[FunctionCallingLLM] = None,
         verbose: bool = False,
         max_function_calls: int = DEFAULT_MAX_FUNCTION_CALLS,
+        allow_parallel_tool_calls: bool = True,
         callback_manager: Optional[CallbackManager] = None,
         system_prompt: Optional[str] = None,
         prefix_messages: Optional[List[ChatMessage]] = None,
@@ -167,6 +168,7 @@ class FunctionCallingAgentWorker(BaseAgentWorker):
             verbose=verbose,
             max_function_calls=max_function_calls,
             callback_manager=callback_manager,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
             **kwargs,
         )
 

--- a/llama-index-core/llama_index/core/agent/function_calling/step.py
+++ b/llama-index-core/llama_index/core/agent/function_calling/step.py
@@ -373,7 +373,9 @@ class FunctionCallingAgentWorker(BaseAgentWorker):
         except AttributeError:
             response_str = str(response)
 
-        agent_response = AgentChatResponse(response=response_str, sources=tool_outputs)
+        agent_response = AgentChatResponse(
+            response=response_str, sources=task.extra_state["sources"]
+        )
 
         return TaskStepOutput(
             output=agent_response,
@@ -466,7 +468,9 @@ class FunctionCallingAgentWorker(BaseAgentWorker):
         except AttributeError:
             response_str = str(response)
 
-        agent_response = AgentChatResponse(response=response_str, sources=tool_outputs)
+        agent_response = AgentChatResponse(
+            response=response_str, sources=task.extra_state["sources"]
+        )
 
         return TaskStepOutput(
             output=agent_response,


### PR DESCRIPTION
This PR
- fixes a bug where sources across all steps weren't being propagated properly in the FunctionCallingAgentWorker
- Adds a light FunctionCallingAgent wrapper, so users can directly do `agent = FunctionCallingAgent.from_tools()`
- Updates docs and imports