### PR TITLE
Add missing openai agent dep

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,12 +29,13 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 openai = "^1.40.0"
 llama-index-core = "^0.11.0"
+llama-index-agent-openai = "^0.3.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
The OpenAI LLM had a hidden import to the openai agent, but was not included in the dependencies of the integration