### PR TITLE
Fix import path and query engine call

### DIFF
--- a/docs/docs/examples/property_graph/property_graph_kuzu.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_kuzu.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install llama-index llama-index-graph-stores-kuzu"
+    "# %pip install llama-index llama-index-embeddings-openai llama-index-graph-stores-kuzu"
    ]
   },
   {
@@ -121,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kuzu_property_graph import KuzuPropertyGraphStore\n",
+    "from llama_index.graph_stores.kuzu import KuzuPropertyGraphStore\n",
     "\n",
     "graph_store = KuzuPropertyGraphStore(db)"
    ]
@@ -238,7 +238,7 @@
     "# Switch to the generate LLM during retrieval\n",
     "Settings.llm = generate_llm\n",
     "\n",
-    "query_engine = index.as_query_engine(include_text=True)\n",
+    "query_engine = index.as_query_engine(include_text=False)\n",
     "\n",
     "response = query_engine.query(\"Tell me more about Interleaf and Viaweb\")\n",
     "\n",
@@ -375,7 +375,7 @@
     "# Switch to the generate LLM during retrieval\n",
     "Settings.llm = generate_llm\n",
     "\n",
-    "query_engine = index.as_query_engine(include_text=True)\n",
+    "query_engine = index.as_query_engine(include_text=False)\n",
     "\n",
     "response2 = query_engine.query(\"Tell me more about Interleaf and Viaweb\")\n",
     "print(str(response2))"
@@ -413,7 +413,7 @@
     "    property_graph_store=graph_store,\n",
     ")\n",
     "\n",
-    "query_engine = index.as_query_engine(include_text=True)\n",
+    "query_engine = index.as_query_engine(include_text=False)\n",
     "\n",
     "response3 = query_engine.query(\"When was Viaweb founded, and by whom?\")\n",
     "print(str(response3))"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-kuzu"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Minor fixes to Kuzu Property Graph Index:
- Fix import path for `kuzu_property_graph`
- Add comments
- Set `incude_text=False` for query engine
- Bump version in `pyproject.toml`

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
