### PR TITLE
fix: convert Document id from int to string in DiscordReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-discord/llama_index/readers/discord/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-discord/llama_index/readers/discord/base.py
@@ -73,7 +73,7 @@ async def read_channel(
     return [
         Document(
             text=msg.content,
-            id_=msg.id,
+            id_=str(msg.id),
             metadata={
                 "message_id": msg.id,
                 "username": msg.author.name,

--- a/llama-index-integrations/readers/llama-index-readers-discord/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-discord/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["jerryjliu"]
 name = "llama-index-readers-discord"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR fixes an issue where the DiscordReader would throw an error because the message id was expected to be a string but was an int.

Fixes #15805

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
