### PR TITLE
Bugfix: Remove warnings during data insertion for Hybrid Search due to duplicated columns in the schema

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-kdbai/llama_index/vector_stores/kdbai/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-kdbai/llama_index/vector_stores/kdbai/base.py
@@ -137,6 +137,13 @@ class KDBAIVectorStore(BasePydanticVectorStore):
             elif isinstance(self._table, kdbai.TablePyKx):
                 schema = [item for item in schema if item != "sparseVectors"]
 
+            # For handling the double columns issue from backend (occurs only when schema has sparseVectors).
+            updated_schema = {}
+            for column in schema:
+                if column["name"] not in updated_schema:
+                    updated_schema[column["name"]] = column
+            schema = list(updated_schema.values())
+
         try:
             for node in nodes:
                 doc = {

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-kdbai/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-kdbai/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-kdbai"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Made changes to the source code to remove warnings during data insertion into the table for the hybrid search task. The warnings were caused by the schema received from the backend. Specifically, the issue occurs when the schema contains a sparseVectors column, and the backend duplicates the columns in the schema before returning it.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [x] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
