### PR TITLE
Fix image document deserialization issue

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -138,9 +138,7 @@ class BaseComponent(BaseModel):
     def from_dict(cls, data: Dict[str, Any], **kwargs: Any) -> Self:  # type: ignore
         # In SimpleKVStore we rely on shallow coping. Hence, the data will be modified in the store directly.
         # And it is the same when the user is passing a dictionary to create a component. We can't modify the passed down dictionary.
-        data = {
-            k: v for k, v in data.items()
-        }
+        data = dict(data)
         if isinstance(kwargs, dict):
             data.update(kwargs)
         data.pop("class_name", None)

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -136,9 +136,13 @@ class BaseComponent(BaseModel):
     # TODO: return type here not supported by current mypy version
     @classmethod
     def from_dict(cls, data: Dict[str, Any], **kwargs: Any) -> Self:  # type: ignore
+        # In SimpleKVStore we rely on shallow coping. Hence, the data will be modified in the store directly.
+        # And it is the same when the user is passing a dictionary to create a component. We can't modify the passed down dictionary.
+        data = {
+            k: v for k, v in data.items()
+        }
         if isinstance(kwargs, dict):
             data.update(kwargs)
-
         data.pop("class_name", None)
         return cls(**data)
 

--- a/llama-index-core/llama_index/core/storage/docstore/utils.py
+++ b/llama-index-core/llama_index/core/storage/docstore/utils.py
@@ -27,9 +27,10 @@ def json_to_doc(doc_dict: dict) -> BaseNode:
         return legacy_json_to_doc(doc_dict)
     else:
         if doc_type == Document.get_type():
-            doc = Document.from_dict(data_dict)
-        elif doc_type == ImageDocument.get_type():
-            doc = ImageDocument.from_dict(data_dict)
+            if data_dict["class_name"] == ImageDocument.class_name():
+                doc = ImageDocument.from_dict(data_dict)
+            else:
+                doc = Document.from_dict(data_dict)
         elif doc_type == TextNode.get_type():
             doc = TextNode.from_dict(data_dict)
         elif doc_type == ImageNode.get_type():

--- a/llama-index-core/llama_index/core/storage/docstore/utils.py
+++ b/llama-index-core/llama_index/core/storage/docstore/utils.py
@@ -13,7 +13,7 @@ from llama_index.core.schema import (
 
 def doc_to_json(doc: BaseNode) -> dict:
     return {
-        DATA_KEY: doc.dict(),
+        DATA_KEY: doc.to_dict(),
         TYPE_KEY: doc.get_type(),
     }
 


### PR DESCRIPTION
# Description

Adjust `json_to_doc` logic to depend on both `__type__` and `class_name` when deserialize `Document` objects.

Fixes #15856

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods