### PR TITLE
Client compatible model validation

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/llama_index/embeddings/nvidia/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/llama_index/embeddings/nvidia/base.py
@@ -144,8 +144,13 @@ class NVIDIAEmbedding(BaseEmbedding):
         )
         self._aclient._custom_headers = {"User-Agent": "llama-index-embeddings-nvidia"}
 
-        if not model:
+        self.model = model
+        if self._is_hosted and not self.model:
+            self.model = DEFAULT_MODEL
+        elif not self._is_hosted and not self.model:
             self.__get_default_model()
+
+        self._validate_model(self.model)  ## validate model
 
     def __get_default_model(self) -> None:
         """Set default model."""
@@ -182,6 +187,26 @@ class NVIDIAEmbedding(BaseEmbedding):
         if base_url.endswith("embeddings"):
             warnings.warn(f"{expected_format} Rest is ignored")
         return base_url.strip("/")
+
+    def _validate_model(self, model_name: str) -> None:
+        """
+        Validates compatibility of the hosted model with the client.
+
+        Args:
+            model_name (str): The name of the model.
+
+        Raises:
+            ValueError: If the model is incompatible with the client.
+        """
+        if self._is_hosted:
+            if model_name not in MODEL_ENDPOINT_MAP:
+                raise ValueError(
+                    f"Model {model_name} is incompatible with client {self.class_name()}. "
+                    f"Please check `{self.class_name()}.available_models()`."
+                )
+        else:
+            if model_name not in [model.id for model in self.available_models]:
+                raise ValueError(f"No locally hosted {model_name} was found.")
 
     @property
     def available_models(self) -> List[Model]:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/test_embeddings_nvidia.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/test_embeddings_nvidia.py
@@ -32,14 +32,14 @@ def test_embedding_class():
 def test_nvidia_embedding_param_setting():
     emb = NVIDIAEmbedding(
         api_key="BOGUS",
-        model="test-model",
+        model="NV-Embed-QA",
         truncate="END",
         timeout=20,
         max_retries=10,
         embed_batch_size=15,
     )
 
-    assert emb.model == "test-model"
+    assert emb.model == "NV-Embed-QA"
     assert emb.truncate == "END"
     assert emb._client.timeout == 20
     assert emb._client.max_retries == 10
@@ -90,3 +90,19 @@ def test_nvidia_embedding_callback(mock_integration_api):
 def test_nvidia_embedding_throws_with_invalid_key(mock_integration_api):
     emb = NVIDIAEmbedding(api_key="invalid")
     emb.get_text_embedding("hi")
+
+
+# @pytest.mark.parametrize("model", list(MODEL_ENDPOINT_MAP.keys()))
+# def test_model_compatible_client_model(model: str) -> None:
+#     NVIDIAEmbedding(api_key="BOGUS", model=model)
+
+
+def test_model_incompatible_client_model() -> None:
+    model_name = "x"
+    err_msg = (
+        f"Model {model_name} is incompatible with client NVIDIAEmbedding. "
+        f"Please check `NVIDIAEmbedding.available_models()`."
+    )
+    with pytest.raises(ValueError) as msg:
+        NVIDIAEmbedding(api_key="BOGUS", model=model_name)
+    assert err_msg == str(msg.value)

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/utils.py
@@ -42,6 +42,10 @@ NVIDIA_FUNTION_CALLING_MODELS = (
 
 COMPLETION_MODELS = ("bigcode/starcoder2-7b", "bigcode/starcoder2-15b")
 
+ALL_MODELS = (
+    tuple(API_CATALOG_MODELS.keys()) + NVIDIA_FUNTION_CALLING_MODELS + COMPLETION_MODELS
+)
+
 
 def is_chat_model(modelname: str):
     return modelname not in COMPLETION_MODELS

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_mode_switch.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_mode_switch.py
@@ -17,7 +17,7 @@ def mock_unknown_urls(httpx_mock: HTTPXMock, base_url: str):
     mock_response = {
         "data": [
             {
-                "id": "dummy",
+                "id": "meta/llama3-8b-instruct",
                 "object": "model",
                 "created": 1234567890,
                 "owned_by": "OWNER",
@@ -63,16 +63,18 @@ def test_mode_switch_nim_with_url_deprecated():
 
 @pytest.mark.parametrize("base_url", ["https://test_url/v1/"])
 def test_mode_switch_param_setting_deprecated(base_url):
-    instance = Interface(model="dummy")
+    instance = Interface(model="meta/llama3-8b-instruct")
 
     with pytest.warns(DeprecationWarning):
         instance1 = instance.mode("nim", base_url=base_url)
-    assert instance1.model == "dummy"
+    assert instance1.model == "meta/llama3-8b-instruct"
     assert str(instance1.api_base) == base_url
 
     with pytest.warns(DeprecationWarning):
-        instance2 = instance1.mode("nvidia", api_key="test", model="dummy-2")
-    assert instance2.model == "dummy-2"
+        instance2 = instance1.mode(
+            "nvidia", api_key="test", model="meta/llama3-15b-instruct"
+        )
+    assert instance2.model == "meta/llama3-15b-instruct"
     assert str(instance2.api_base) == BASE_URL
     assert instance2.api_key == "test"
 

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_nvidia.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_nvidia.py
@@ -1,7 +1,6 @@
 import os
 from typing import Any, AsyncGenerator, Generator, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
 from llama_index.core.base.llms.types import ChatMessage, LLMMetadata
 from llama_index.llms.nvidia import NVIDIA
@@ -16,6 +15,11 @@ from openai.types.chat.chat_completion_chunk import ChatCompletionChunk, ChoiceD
 from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 from openai.types.completion import Completion, CompletionUsage
 from pytest_httpx import HTTPXMock
+from llama_index.llms.nvidia.utils import (
+    NVIDIA_FUNTION_CALLING_MODELS,
+    API_CATALOG_MODELS,
+    COMPLETION_MODELS,
+)
 
 
 class CachedNVIDIApiKeys:
@@ -260,7 +264,7 @@ def test_metadata() -> None:
     assert isinstance(NVIDIA().metadata, LLMMetadata)
 
 
-def test_default_known(mock_local_models, known_unknown: str) -> None:
+def test_default_local_known(mock_local_models, known_unknown: str) -> None:
     """
     Test that a model in the model table will be accepted.
     """
@@ -270,10 +274,59 @@ def test_default_known(mock_local_models, known_unknown: str) -> None:
         assert x.model == known_unknown
 
 
-def test_default_lora() -> None:
+def test_default_local_lora(mock_local_models) -> None:
     """
     Test that a model in the model table will be accepted.
     """
     # find a model that matches the public_class under test
     x = NVIDIA(base_url="http://localhost:8000/v1", model="lora1")
     assert x.model == "lora1"
+
+
+def test_local_model_not_found(mock_local_models) -> None:
+    """
+    Test that a model in the model table will be accepted.
+    """
+    err_msg = f"No locally hosted lora3 was found."
+    with pytest.raises(ValueError) as msg:
+        x = NVIDIA(base_url="http://localhost:8000/v1", model="lora3")
+    assert err_msg == str(msg.value)
+
+
+@patch("llama_index.llms.openai.base.SyncOpenAI")
+def test_model_compatible_client_default_model(MockSyncOpenAI: MagicMock) -> None:
+    with CachedNVIDIApiKeys(set_fake_key=True):
+        mock_instance = MockSyncOpenAI.return_value
+        mock_instance.chat.completions.create.return_value = mock_chat_completion_v1()
+
+        llm = NVIDIA()
+        message = ChatMessage(role="user", content="test message")
+        llm.chat([message])
+
+
+@patch("llama_index.llms.openai.base.SyncOpenAI")
+@pytest.mark.parametrize(
+    "model",
+    (
+        NVIDIA_FUNTION_CALLING_MODELS[0],
+        next(iter(API_CATALOG_MODELS.keys())),
+        COMPLETION_MODELS[0],
+    ),
+)
+def test_model_compatible_client_model(MockSyncOpenAI: MagicMock, model: str) -> None:
+    with CachedNVIDIApiKeys(set_fake_key=True):
+        mock_instance = MockSyncOpenAI.return_value
+        mock_instance.chat.completions.create.return_value = mock_chat_completion_v1()
+
+        NVIDIA(api_key="BOGUS", model=model)
+
+
+def test_model_incompatible_client_model() -> None:
+    model_name = "x"
+    err_msg = (
+        f"Model {model_name} is incompatible with client NVIDIA. "
+        f"Please check `NVIDIA.available_models()`."
+    )
+    with pytest.raises(ValueError) as msg:
+        NVIDIA(model=model_name)
+    assert err_msg == str(msg.value)

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_postprocessor_nvidia_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_postprocessor_nvidia_rerank.py
@@ -203,10 +203,22 @@ def test_default_known(mock_local_models, known_unknown: str) -> None:
         assert x.model == known_unknown
 
 
-def test_default_lora() -> None:
+def test_local_model_not_found(mock_local_models) -> None:
     """
     Test that a model in the model table will be accepted.
     """
-    # find a model that matches the public_class under test
-    x = NVIDIARerank(base_url="http://localhost:8000/v1", model="lora1")
-    assert x.model == "lora1"
+    err_msg = f"No locally hosted lora3 was found."
+    with pytest.raises(ValueError) as msg:
+        x = NVIDIARerank(base_url="http://localhost:8000/v1", model="lora3")
+    assert err_msg == str(msg.value)
+
+
+def test_model_incompatible_client() -> None:
+    model_name = "x"
+    err_msg = (
+        f"Model {model_name} is incompatible with client NVIDIARerank. "
+        f"Please check `NVIDIARerank.available_models()`."
+    )
+    with pytest.raises(ValueError) as msg:
+        NVIDIARerank(api_key="BOGUS", model=model_name)
+    assert err_msg == str(msg.value)


### PR DESCRIPTION
# Client compatible model validation

As a user of the connectors, I can select from many modals and want to be alerted early if a model is not compatible with my use case.

Example test, w/ public_class of NVIDIA, NVIDIAEmbedding, NVIDIARerank -
invalid = select known model that does not work with public_class, e.g. NV-Embed-QA and NVIDIA

## Type of Change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

cc: @sumitkbh @mattf @dglogo 