### PR TITLE
feature: Make SentenceSplitter's secondary_chunking_regex optional

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/sentence.py
+++ b/llama-index-core/llama_index/core/node_parser/text/sentence.py
@@ -55,7 +55,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
     paragraph_separator: str = Field(
         default=DEFAULT_PARAGRAPH_SEP, description="Separator between paragraphs."
     )
-    secondary_chunking_regex: str = Field(
+    secondary_chunking_regex: Optional[str] = Field(
         default=CHUNKING_REGEX, description="Backup regex for splitting into sentences."
     )
 
@@ -72,7 +72,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
         tokenizer: Optional[Callable] = None,
         paragraph_separator: str = DEFAULT_PARAGRAPH_SEP,
         chunking_tokenizer_fn: Optional[Callable[[str], List[str]]] = None,
-        secondary_chunking_regex: str = CHUNKING_REGEX,
+        secondary_chunking_regex: Optional[str] = CHUNKING_REGEX,
         callback_manager: Optional[CallbackManager] = None,
         include_metadata: bool = True,
         include_prev_next_rel: bool = True,
@@ -107,11 +107,17 @@ class SentenceSplitter(MetadataAwareTextSplitter):
             self._chunking_tokenizer_fn,
         ]
 
-        self._sub_sentence_split_fns = [
-            split_by_regex(secondary_chunking_regex),
-            split_by_sep(separator),
-            split_by_char(),
-        ]
+        if secondary_chunking_regex:
+            self._sub_sentence_split_fns = [
+                split_by_regex(secondary_chunking_regex),
+                split_by_sep(separator),
+                split_by_char(),
+            ]
+        else:
+            self._sub_sentence_split_fns = [
+                split_by_sep(separator),
+                split_by_char(),
+            ]
 
     @classmethod
     def from_defaults(


### PR DESCRIPTION
# Description

The `SentenceSplitter`'s `secondary_chunking_regex` is lossy; it can lose punctuation as it splits text. For users who do not want this behavior, and do not want to write their own alternative regex, this PR makes the `secondary_chunking_regex` optional.

## New Package?

N/A - no new package

## Version Bump?

N/A - change in `llama-index-core`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Because of the size of the change (very small), I did not introduce new unit tests or example code. However, I did load `SentenceSplitter`s with and without a `secondary_chunking_regex` to confirm setting `secondary_chunking_regex=None` fixes the issue described above.

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
