### PR TITLE
add type ignore for streaming agents

### DIFF
--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -703,8 +703,7 @@ class AgentRunner(BaseAgentRunner):
             )
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
 
-        assert isinstance(chat_response, StreamingAgentChatResponse)
-        return chat_response
+        return chat_response  # type: ignore
 
     @dispatcher.span
     @trace_method("chat")
@@ -730,8 +729,7 @@ class AgentRunner(BaseAgentRunner):
             )
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
 
-        assert isinstance(chat_response, StreamingAgentChatResponse)
-        return chat_response
+        return chat_response  # type: ignore
 
     def undo_step(self, task_id: str) -> None:
         """Undo previous step."""

--- a/llama-index-core/llama_index/core/agent/runner/parallel.py
+++ b/llama-index-core/llama_index/core/agent/runner/parallel.py
@@ -469,9 +469,9 @@ class ParallelAgentRunner(BaseAgentRunner):
             chat_response = self._chat(
                 message, chat_history, tool_choice, mode=ChatResponseMode.STREAM
             )
-            assert isinstance(chat_response, StreamingAgentChatResponse)
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
-        return chat_response
+
+        return chat_response  # type: ignore
 
     @trace_method("chat")
     async def astream_chat(
@@ -487,9 +487,9 @@ class ParallelAgentRunner(BaseAgentRunner):
             chat_response = await self._achat(
                 message, chat_history, tool_choice, mode=ChatResponseMode.STREAM
             )
-            assert isinstance(chat_response, StreamingAgentChatResponse)
+
             e.on_end(payload={EventPayload.RESPONSE: chat_response})
-        return chat_response
+        return chat_response  # type: ignore
 
     def undo_step(self, task_id: str) -> None:
         """Undo previous step."""


### PR DESCRIPTION
When streaming and you have return_direct=True for a tool, we do a hacky thing and return an AgentResponse that pretends to be a StreamingAgentResponse

Obviously, this makes mypy unhappy, which is why the assert was added.

But instead, to avoid assertion errors, ignoring mypy is a better option

Fixes https://github.com/run-llama/llama_index/issues/15883