### PR TITLE
Bug fix for KuzuPropertyGraphStore: Allow upserting relations even when chunks are absent

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-kuzu"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR addresses [this issue](https://github.com/kuzudb/kuzu/issues/4208) reported by a user of the `KuzuPropertyGraphStore`. 

Description:
In the prior release, we expected that a `Chunk` is present, but in case the user is working with a pre-existing graph and doesn't have entities and relations extracted by an LLM (but rather, manually creates and inserts them). When chunks are absent, the relations weren't inserted. This PR fixes the logic for upserting relations accordingly.

Fixes external issue in Kùzu GitHub repo: https://github.com/kuzudb/kuzu/issues/4208

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
