### PR TITLE
Update RankLLM with new rerankers

### DIFF
--- a/docs/docs/examples/node_postprocessor/rankLLM.ipynb
+++ b/docs/docs/examples/node_postprocessor/rankLLM.ipynb
@@ -329,7 +329,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.20it/s]\n"
+      "Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.11it/s]\n"
      ]
     },
     {
@@ -343,7 +343,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 1/1 [00:11<00:00, 11.05s/it]\n"
+      "100%|██████████| 1/1 [00:11<00:00, 11.38s/it]\n"
      ]
     },
     {
@@ -435,7 +435,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Other models. Use `model=`\n",
+    "#### For other models, use `model=`\n",
     "- `monot5` for MonoT5 pointwise reranker\n",
     "- `castorini/LiT5-Distill-base` for LiT5 distill reranker\n",
     "- `castorini/LiT5-Score-base` for LiT5 score reranker"

--- a/docs/docs/examples/node_postprocessor/rankLLM.ipynb
+++ b/docs/docs/examples/node_postprocessor/rankLLM.ipynb
@@ -6,23 +6,23 @@
    "source": [
     "# RankLLM Reranker Demonstration (Van Gogh Wiki)\n",
     "\n",
-    "This demo showcases how to use RankLLM (https://github.com/castorini/rank_llm) to rerank passages. RankLLM offers a suite of listwise rerankers, albeit with focus on open source LLMs finetuned for the task - RankVicuna and RankZephyr being two of them.\n",
+    "This demo showcases how to use [RankLLM](https://github.com/castorini/rank_llm) to rerank passages. \n",
     "\n",
-    "It compares query search results from Van Gogh’s wikipedia with just retrieval (using VectorIndexRetriever from llama-index) and retrieval+reranking with RankLLM. It demonstrates two models from RankLLM:\n",
+    "RankLLM offers a suite of listwise rerankers, albeit with focus on open source LLMs finetuned for the task - RankVicuna and RankZephyr being two of them.\n",
     "\n",
-    "- ```RankVicuna 7B V1```\n",
-    "- ```RankZephyr 7B V1 - Full - BF16```\n",
+    "It compares query search results from Van Gogh’s wikipedia with just retrieval (using VectorIndexRetriever from llama-index) and retrieval+reranking with RankLLM. We show an example of reranking 50 candidates using the RankZephyr reranker, which uses a listwise sliding window algorithm.\n",
     "\n",
+    "\n",
+    "_______________________________\n",
     "Dependencies:\n",
     "\n",
-    "- Currently, RankLLM's rerankers require requires `CUDA`\n",
+    "- **CUDA**\n",
     "- The built-in retriever, which uses [Pyserini](https://github.com/castorini/pyserini), requires `JDK11`, `PyTorch`, and `Faiss`\n",
     "\n",
     "\n",
     "### castorini/rank_llm\n",
-    "Repository for prompt-decoding using LLMs (```GPT3.5```, ```GPT4```, ```Vicuna```, and ```Zephyr```)\\\n",
-    "Website: [http://rankllm.ai](http://rankllm.ai)\\\n",
-    "Stars: 193"
+    "Suite of LLM-based reranking models (e.g, `RankZephyr`, `LiT5`, `RankVicuna`)\n",
+    "Website: [http://rankllm.ai](http://rankllm.ai)\\"
    ]
   },
   {
@@ -165,12 +165,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Retrieval + RankLLM Reranking\n",
+    "### Retrieval + RankLLM Reranking (sliding window)\n",
     "\n",
     "1. Set up retriever and reranker\n",
     "2. Retrieve results given search query without reranking\n",
-    "3. Retrieve results given search query with RankZephyr reranking\n",
-    "4. Retrieve results given search query with RankVicuna reranking"
+    "3. Retrieve results given search query with RankZephyr reranking"
    ]
   },
   {
@@ -181,9 +180,10 @@
    "source": [
     "from llama_index.core.retrievers import VectorIndexRetriever\n",
     "from llama_index.core import QueryBundle\n",
-    "from llama_index.postprocessor.rankLLM_rerank import RankLLMRerank\n",
+    "from llama_index.postprocessor.rankllm_rerank import RankLLMRerank\n",
     "\n",
     "import pandas as pd\n",
+    "import torch\n",
     "from IPython.display import display, HTML\n",
     "\n",
     "\n",
@@ -192,9 +192,8 @@
     "    vector_top_k=10,\n",
     "    reranker_top_n=3,\n",
     "    with_reranker=False,\n",
-    "    with_retrieval=False,\n",
-    "    model=\"zephyr\",\n",
-    "    gpt_model=\"gpt-3.5-turbo\",\n",
+    "    model=\"rank_zephyr\",\n",
+    "    window_size=None,\n",
     "):\n",
     "    query_bundle = QueryBundle(query_str)\n",
     "    # configure retriever\n",
@@ -203,18 +202,20 @@
     "        similarity_top_k=vector_top_k,\n",
     "    )\n",
     "    retrieved_nodes = retriever.retrieve(query_bundle)\n",
+    "    retrieved_nodes.reverse()\n",
     "\n",
     "    if with_reranker:\n",
     "        # configure reranker\n",
     "        reranker = RankLLMRerank(\n",
-    "            top_n=reranker_top_n,\n",
-    "            model=model,\n",
-    "            with_retrieval=with_retrieval,\n",
-    "            gpt_model=gpt_model,\n",
+    "            model=model, top_n=reranker_top_n, window_size=window_size\n",
     "        )\n",
     "        retrieved_nodes = reranker.postprocess_nodes(\n",
     "            retrieved_nodes, query_bundle\n",
     "        )\n",
+    "\n",
+    "        # clear cache, rank_zephyr uses 16GB of GPU VRAM\n",
+    "        del reranker\n",
+    "        torch.cuda.empty_cache()\n",
     "\n",
     "    return retrieved_nodes\n",
     "\n",
@@ -236,9 +237,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Retrieval top 3 results without reranking\n",
+    "### Without `RankZephyr` reranking, the correct result is ranked `47`th/50.\n",
     "\n",
-    "## Expected result:\n",
+    "#### Expected result:\n",
     "```After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers;```"
    ]
   },
@@ -269,18 +270,18 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.851540</td>\n",
-       "      <td>Gauguin fled Arles, never to see Van Gogh again. They continued to correspond, and in 1890, Gauguin proposed they form a studio in Antwerp. Meanwhile, other visitors to the hospital included Marie Ginoux and Roulin.Despite a pessimistic diagnosis, Van Gogh recovered and returned to the Yellow House on 7 January 1889. He spent the following month between hospital and home, suffering from hallucinations and delusions of poisoning. In March, the police closed his house after a petition by 30 townspeople (including the Ginoux family) who described him as le fou roux \"the redheaded madman\"; Van Gogh returned to hospital. Paul Signac visited him twice in March; in April, Van Gogh moved into rooms owned by Dr Rey after floods damaged paintings in his own home. Two months later, he left Arles and voluntarily entered an asylum in Saint-Rémy-de-Provence. Around this time, he wrote, \"Sometimes moods of indescribable anguish, sometimes moments when the veil of time and fatality of circumstances seemed to be torn apart for an instant.\"Van Gogh gave his 1889 Portrait of Doctor Félix Rey to Dr Rey. The physician was not fond of the painting and used it to repair a chicken coop, then gave it away. In 2016, the portrait was housed at the Pushkin Museum of Fine Arts and estimated to be worth over $50 million.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Saint-Rémy (May 1889 – May 1890) ====<br><br>Van Gogh entered the Saint-Paul-de-Mausole asylum on 8 May 1889, accompanied by his caregiver, Frédéric Salles, a Protestant clergyman. Saint-Paul was a former monastery in Saint-Rémy, located less than 30 kilometres (19 mi) from Arles, and it was run by a former naval doctor, Théophile Peyron. Van Gogh had two cells with barred windows, one of which he used as a studio. The clinic and its garden became the main subjects of his paintings.</td>\n",
+       "      <td>0.766322</td>\n",
+       "      <td>Yellow meant the most to him, because it symbolised emotional truth. He used yellow as a symbol for sunlight, life, and God.<br>Van Gogh strove to be a painter of rural life and nature; during his first summer in Arles he used his new palette to paint landscapes and traditional rural life. His belief that a power existed behind the natural led him to try to capture a sense of that power, or the essence of nature in his art, sometimes through the use of symbols. His renditions of the sower, at first copied from Jean-François Millet, reflect the influence of Thomas Carlyle and Friedrich Nietzsche's thoughts on the heroism of physical labour, as well as van Gogh's religious beliefs: the sower as Christ sowing life beneath the hot sun. These were themes and motifs he returned to often to rework and develop. His paintings of flowers are filled with symbolism, but rather than use traditional Christian iconography he made up his own, where life is lived under the sun and work is an allegory of life. In Arles, having gained confidence after painting spring blossoms and learning to capture bright sunlight, he was ready to paint The Sower.<br><br>Van Gogh stayed within what he called the \"guise of reality\" and was critical of overly stylised works. He wrote afterwards that the abstraction of Starry Night had gone too far and that reality had \"receded too far in the background\". Hughes describes it as a moment of extreme visionary ecstasy: the stars are in a great whirl, reminiscent of Hokusai's Great Wave, the movement in the heaven above is reflected by the movement of the cypress on the earth below, and the painter's vision is \"translated into a thick, emphatic plasma of paint\".<br>Between 1885 and his death in 1890, van Gogh appears to have been building an oeuvre, a collection that reflected his personal vision and could be commercially successful. He was influenced by Blanc's definition of style, that a true painting required optimal use of colour, perspective and brushstrokes. Van Gogh applied the word \"purposeful\" to paintings he thought he had mastered, as opposed to those he thought of as studies.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.849399</td>\n",
-       "      <td>On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps. The single painting Gauguin completed during his visit was his portrait of Van Gogh.Van Gogh and Gauguin visited Montpellier in December 1888, where they saw works by Courbet and Delacroix in the Musée Fabre. Their relationship began to deteriorate; Van Gogh admired Gauguin and wanted to be treated as his equal, but Gauguin was arrogant and domineering, which frustrated Van Gogh. They often quarrelled; Van Gogh increasingly feared that Gauguin was going to desert him, and the situation, which Van Gogh described as one of \"excessive tension\", rapidly headed towards crisis point.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Hospital in Arles (December 1888) ====<br><br>The exact sequence that led to the mutilation of van Gogh's ear is not known. Gauguin said, fifteen years later, that the night followed several instances of physically threatening behaviour. Their relationship was complex and Theo may have owed money to Gauguin, who suspected the brothers were exploiting him financially. It seems likely that Vincent realised that Gauguin was planning to leave. The following days saw heavy rain, leading to the two men being shut in the Yellow House. Gauguin recalled that Van Gogh followed him after he left for a walk and \"rushed towards me, an open razor in his hand.\"</td>\n",
+       "      <td>0.768032</td>\n",
+       "      <td>==== Self-portraits ====<br><br>Van Gogh created more than 43 self-portraits between 1885 and 1889. They were usually completed in series, such as those painted in Paris in mid-1887, and continued until shortly before his death. Generally the portraits were studies, created during periods when he was reluctant to mix with others or when he lacked models and painted himself.<br>Van Gogh's self-portraits reflect a high degree of self-scrutiny. Often they were intended to mark important periods in his life; for example, the mid-1887 Paris series were painted at the point where he became aware of Claude Monet, Paul Cézanne and Signac. In Self-Portrait with Grey Felt Hat, heavy strains of paint spread outwards across the canvas. It is one of his most renowned self-portraits of that period, \"with its highly organized rhythmic brushstrokes, and the novel halo derived from the Neo-impressionist repertoire was what van Gogh himself called a 'purposeful' canvas\".<br>They contain a wide array of physiognomical representations. Van Gogh's mental and physical condition is usually apparent; he may appear unkempt, unshaven or with a neglected beard, with deeply sunken eyes, a weak jaw, or having lost teeth. Some show him with full lips, a long face or prominent skull, or sharpened, alert features. His hair is sometimes depicted in a vibrant reddish hue and at other times ash colored.<br>Van Gogh's self-portraits vary stylistically. In those painted after December 1888, the strong contrast of vivid colors highlight the haggard pallor of his skin. Some depict the artist with a beard, others without. He can be seen with bandages in portraits executed just after he mutilated his ear. In only a few does he depict himself as a painter. Those painted in Saint-Rémy show the head from the right, the side opposite his damaged ear, as he painted himself reflected in his mirror.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.848984</td>\n",
-       "      <td>When he visited Saintes-Maries-de-la-Mer in June, he gave lessons to a Zouave second lieutenant – Paul-Eugène Milliet – and painted boats on the sea and the village. MacKnight introduced Van Gogh to Eugène Boch, a Belgian painter who sometimes stayed in Fontvieille, and the two exchanged visits in July.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Gauguin's visit (1888) ====<br> <br>When Gauguin agreed to visit Arles in 1888, Van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.\"When Boch visited again, Van Gogh painted a portrait of him, as well as the study The Poet Against a Starry Sky.In preparation for Gauguin's visit, Van Gogh bought two beds on advice from the station's postal supervisor Joseph Roulin, whose portrait he painted. On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps.</td>\n",
+       "      <td>0.769051</td>\n",
+       "      <td>With their broad brushstrokes, inventive perspectives, colours, contours and designs, these paintings represent the style he sought.<br><br><br>=== Major series ===<br><br>Van Gogh's stylistic developments are usually linked to the periods he spent living in different places across Europe. He was inclined to immerse himself in local cultures and lighting conditions, although he maintained a highly individual visual outlook throughout. His evolution as an artist was slow and he was aware of his painterly limitations. Van Gogh moved home often, perhaps to expose himself to new visual stimuli, and through exposure develop his technical skill. Art historian Melissa McQuillan believes the moves also reflect later stylistic changes and that van Gogh used the moves to avoid conflict, and as a coping mechanism for when the idealistic artist was faced with the realities of his then current situation.<br><br><br>==== Portraits ====<br><br>Van Gogh said portraiture was his greatest interest. \"What I'm most passionate about, much much more than all the rest in my profession\", he wrote in 1890, \"is the portrait, the modern portrait.\" It is \"the only thing in painting that moves me deeply and that gives me a sense of the infinite.\" He wrote to his sister that he wished to paint portraits that would endure, and that he would use colour to capture their emotions and character rather than aiming for photographic realism. Those closest to van Gogh are mostly absent from his portraits; he rarely painted Theo, van Rappard or Bernard. The portraits of his mother were from photographs.<br>Van Gogh painted Arles' postmaster Joseph Roulin and his family repeatedly. In five versions of La Berceuse (The Lullaby), van Gogh painted Augustine Roulin quietly holding a rope that rocks the unseen cradle of her infant daughter. Van Gogh had planned for it to be the central image of a triptych, flanked by paintings of sunflowers.</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -296,26 +297,18 @@
    "source": [
     "new_nodes = get_retrieved_nodes(\n",
     "    \"Which date did Paul Gauguin arrive in Arles?\",\n",
-    "    vector_top_k=3,\n",
+    "    vector_top_k=50,\n",
     "    with_reranker=False,\n",
-    "    model=\"zephyr\",\n",
     ")\n",
     "\n",
-    "visualize_retrieved_nodes(new_nodes)"
+    "visualize_retrieved_nodes(new_nodes[:3])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### The correct result is ranked 3rd."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Retrieve and Rerank top 10 results using RankZephyr and return top 3"
+    "### With `RankZephyr` reranking, the correct result is ranked `1`st/50"
    ]
   },
   {
@@ -328,28 +321,29 @@
      "output_type": "stream",
      "text": [
       "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
+      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "Loading rank_zephyr ...\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1ad13a552896432ba5b8fdcef814aab0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.80s/it]\n"
+      "Loading checkpoint shards: 100%|██████████| 3/3 [00:02<00:00,  1.20it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Completed loading rank_zephyr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [00:11<00:00, 11.05s/it]\n"
      ]
     },
     {
@@ -366,18 +360,18 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.848984</td>\n",
-       "      <td>When he visited Saintes-Maries-de-la-Mer in June, he gave lessons to a Zouave second lieutenant – Paul-Eugène Milliet – and painted boats on the sea and the village. MacKnight introduced Van Gogh to Eugène Boch, a Belgian painter who sometimes stayed in Fontvieille, and the two exchanged visits in July.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Gauguin's visit (1888) ====<br> <br>When Gauguin agreed to visit Arles in 1888, Van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.\"When Boch visited again, Van Gogh painted a portrait of him, as well as the study The Poet Against a Starry Sky.In preparation for Gauguin's visit, Van Gogh bought two beds on advice from the station's postal supervisor Joseph Roulin, whose portrait he painted. On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps.</td>\n",
+       "      <td>0.857234</td>\n",
+       "      <td>After much pleading from van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted van Gogh in his The Painter of Sunflowers; van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps. The single painting Gauguin completed during his visit was his portrait of van Gogh.<br>Van Gogh and Gauguin visited Montpellier in December 1888, where they saw works by Courbet and Delacroix in the Musée Fabre. Their relationship began to deteriorate; van Gogh admired Gauguin and wanted to be treated as his equal, but Gauguin was arrogant and domineering, which frustrated van Gogh. They often quarreled; van Gogh increasingly feared that Gauguin was going to desert him, and the situation, which van Gogh described as one of \"excessive tension\", rapidly headed towards crisis point.<br><br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Hospital in Arles (December 1888) ====<br><br>The exact sequence that led to the mutilation of van Gogh's ear is not known. Gauguin said, fifteen years later, that the night followed several instances of physically threatening behaviour. Their relationship was complex and Theo may have owed money to Gauguin, who suspected the brothers were exploiting him financially. It seems likely that Vincent realised that Gauguin was planning to leave. The following days saw heavy rain, leading to the two men being shut in the Yellow House. Gauguin recalled that van Gogh followed him after he left for a walk and \"rushed towards me, an open razor in his hand.\" This account is uncorroborated; Gauguin was almost certainly absent from the Yellow House that night, most likely staying in a hotel.<br>After an altercation on the evening of 23 December 1888, van Gogh returned to his room where he seemingly heard voices and either wholly or in part severed his left ear with a razor causing severe bleeding.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.849399</td>\n",
-       "      <td>On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps. The single painting Gauguin completed during his visit was his portrait of Van Gogh.Van Gogh and Gauguin visited Montpellier in December 1888, where they saw works by Courbet and Delacroix in the Musée Fabre. Their relationship began to deteriorate; Van Gogh admired Gauguin and wanted to be treated as his equal, but Gauguin was arrogant and domineering, which frustrated Van Gogh. They often quarrelled; Van Gogh increasingly feared that Gauguin was going to desert him, and the situation, which Van Gogh described as one of \"excessive tension\", rapidly headed towards crisis point.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Hospital in Arles (December 1888) ====<br><br>The exact sequence that led to the mutilation of van Gogh's ear is not known. Gauguin said, fifteen years later, that the night followed several instances of physically threatening behaviour. Their relationship was complex and Theo may have owed money to Gauguin, who suspected the brothers were exploiting him financially. It seems likely that Vincent realised that Gauguin was planning to leave. The following days saw heavy rain, leading to the two men being shut in the Yellow House. Gauguin recalled that Van Gogh followed him after he left for a walk and \"rushed towards me, an open razor in his hand.\"</td>\n",
+       "      <td>0.861649</td>\n",
+       "      <td>==== Gauguin's visit (1888) ====<br> <br><br>When Gauguin agreed to visit Arles in 1888, van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.\" <br>When Boch visited again, van Gogh painted a portrait of him, as well as the study The Poet Against a Starry Sky.<br>In preparation for Gauguin's visit, van Gogh bought two beds on advice from the station's postal supervisor Joseph Roulin, whose portrait he painted. On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.<br>After much pleading from van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted van Gogh in his The Painter of Sunflowers; van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps. The single painting Gauguin completed during his visit was his portrait of van Gogh.<br>Van Gogh and Gauguin visited Montpellier in December 1888, where they saw works by Courbet and Delacroix in the Musée Fabre. Their relationship began to deteriorate; van Gogh admired Gauguin and wanted to be treated as his equal, but Gauguin was arrogant and domineering, which frustrated van Gogh.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.819207</td>\n",
-       "      <td>The ear was brought to the hospital, but Rey did not attempt to reattach it as too much time had passed. Van Gogh researcher and art historian Bernadette Murphy discovered the true identity of the woman named Gabrielle, who died in Arles at the age of 80 in 1952, and whose descendants still lived (as of 2020) just outside Arles. Gabrielle, known in her youth as \"Gaby,\" was a 17-year-old cleaning girl at the brothel and other local establishments at the time Van Gogh presented her with his ear.Van Gogh had no recollection of the event, suggesting that he may have suffered an acute mental breakdown. The hospital diagnosis was \"acute mania with generalised delirium\", and within a few days, the local police ordered that he be placed in hospital care. Gauguin immediately notified Theo, who, on 24 December, had proposed marriage to his old friend Andries Bonger's sister Johanna. That evening, Theo rushed to the station to board a night train to Arles. He arrived on Christmas Day and comforted Vincent, who seemed to be semi-lucid. That evening, he left Arles for the return trip to Paris.During the first days of his treatment, Van Gogh repeatedly and unsuccessfully asked for Gauguin, who asked a policeman attending the case to \"be kind enough, Monsieur, to awaken this man with great care, and if he asks for me tell him I have left for Paris; the sight of me might prove fatal for him.\" Gauguin fled Arles, never to see Van Gogh again. They continued to correspond, and in 1890, Gauguin proposed they form a studio in Antwerp. Meanwhile, other visitors to the hospital included Marie Ginoux and Roulin.Despite a pessimistic diagnosis, Van Gogh recovered and returned to the Yellow House on 7 January 1889. He spent the following month between hospital and home, suffering from hallucinations and delusions of poisoning. In March, the police closed his house after a petition by 30 townspeople (including the Ginoux family) who described him as le fou roux \"the redheaded madman\"; Van Gogh returned to hospital.</td>\n",
+       "      <td>0.852035</td>\n",
+       "      <td>Gauguin fled Arles, never to see van Gogh again. They continued to correspond, and in 1890, Gauguin proposed they form a studio in Antwerp. Meanwhile, other visitors to the hospital included Marie Ginoux and Roulin.<br>Despite a pessimistic diagnosis, van Gogh recovered and returned to the Yellow House on 7 January 1889. He spent the following month between hospital and home, suffering from hallucinations and delusions of poisoning. In March, the police closed his house after a petition by 30 townspeople (including the Ginoux family) who described him as le fou roux \"the redheaded madman\"; Van Gogh returned to hospital. Paul Signac visited him twice in March; in April, van Gogh moved into rooms owned by Dr Rey after floods damaged paintings in his own home. Two months later, he left Arles and voluntarily entered an asylum in Saint-Rémy-de-Provence. Around this time, he wrote, \"Sometimes moods of indescribable anguish, sometimes moments when the veil of time and fatality of circumstances seemed to be torn apart for an instant.\"<br>Van Gogh gave his 1889 Portrait of Doctor Félix Rey to Dr Rey. The physician was not fond of the painting and used it to repair a chicken coop, then gave it away. In 2016, the portrait was housed at the Pushkin Museum of Fine Arts and estimated to be worth over $50 million.<br><br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Saint-Rémy (May 1889 – May 1890) ====<br><br>Van Gogh entered the Saint-Paul-de-Mausole asylum on 8 May 1889, accompanied by his caregiver, Frédéric Salles, a Protestant clergyman. Saint-Paul was a former monastery in Saint-Rémy, located less than 30 kilometres (19 mi) from Arles, and it was run by a former naval doctor, Théophile Peyron. Van Gogh had two cells with barred windows, one of which he used as a studio. The clinic and its garden became the main subjects of his paintings.</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
@@ -393,11 +387,11 @@
    "source": [
     "new_nodes = get_retrieved_nodes(\n",
     "    \"Which date did Paul Gauguin arrive in Arles?\",\n",
-    "    vector_top_k=10,\n",
+    "    vector_top_k=50,\n",
     "    reranker_top_n=3,\n",
     "    with_reranker=True,\n",
-    "    with_retrieval=False,\n",
-    "    model=\"zephyr\",\n",
+    "    model=\"rank_zephyr\",\n",
+    "    window_size=15,\n",
     ")\n",
     "\n",
     "visualize_retrieved_nodes(new_nodes)"
@@ -407,14 +401,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### The correct result is ranked 1st after RankZephyr rerank."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Retrieve and Rerank top 10 results using RankVicuna and return top 3."
+    "## Retrieve and Rerank top 10 results using RankVicuna, RankGPT"
    ]
   },
   {
@@ -423,116 +410,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# RankVicuna\n",
     "new_nodes = get_retrieved_nodes(\n",
     "    \"Which date did Paul Gauguin arrive in Arles?\",\n",
     "    vector_top_k=10,\n",
     "    reranker_top_n=3,\n",
     "    with_reranker=True,\n",
-    "    with_retrieval=False,\n",
-    "    model=\"vicuna\",\n",
+    "    model=\"rank_vicuna\",\n",
     ")\n",
     "\n",
-    "visualize_retrieved_nodes(new_nodes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### The correct result is ranked 1st after RankVicuna rerank."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Retrieve and Rerank top 10 results using RankGPT and return top 3\n",
-    "\n",
-    "RankGPT is built into RankLLM and can be used as shown below. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  0%|                                                                                                                                                                  | 0/1 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.57s/it]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Score</th>\n",
-       "      <th>Text</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0.849399</td>\n",
-       "      <td>On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps. The single painting Gauguin completed during his visit was his portrait of Van Gogh.Van Gogh and Gauguin visited Montpellier in December 1888, where they saw works by Courbet and Delacroix in the Musée Fabre. Their relationship began to deteriorate; Van Gogh admired Gauguin and wanted to be treated as his equal, but Gauguin was arrogant and domineering, which frustrated Van Gogh. They often quarrelled; Van Gogh increasingly feared that Gauguin was going to desert him, and the situation, which Van Gogh described as one of \"excessive tension\", rapidly headed towards crisis point.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Hospital in Arles (December 1888) ====<br><br>The exact sequence that led to the mutilation of van Gogh's ear is not known. Gauguin said, fifteen years later, that the night followed several instances of physically threatening behaviour. Their relationship was complex and Theo may have owed money to Gauguin, who suspected the brothers were exploiting him financially. It seems likely that Vincent realised that Gauguin was planning to leave. The following days saw heavy rain, leading to the two men being shut in the Yellow House. Gauguin recalled that Van Gogh followed him after he left for a walk and \"rushed towards me, an open razor in his hand.\"</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.848972</td>\n",
-       "      <td>When he visited Saintes-Maries-de-la-Mer in June, he gave lessons to a Zouave second lieutenant – Paul-Eugène Milliet – and painted boats on the sea and the village. MacKnight introduced Van Gogh to Eugène Boch, a Belgian painter who sometimes stayed in Fontvieille, and the two exchanged visits in July.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Gauguin's visit (1888) ====<br> <br>When Gauguin agreed to visit Arles in 1888, Van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.\"When Boch visited again, Van Gogh painted a portrait of him, as well as the study The Poet Against a Starry Sky.In preparation for Gauguin's visit, Van Gogh bought two beds on advice from the station's postal supervisor Joseph Roulin, whose portrait he painted. On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.828397</td>\n",
-       "      <td>In April, he was visited by the American artist Dodge MacKnight, who was living nearby at Fontvieille.On 1 May 1888,  Van Gogh signed a lease for four rooms in  the Yellow House.  The house at 2 place Lamartine cost 15 francs per month. The rooms were unfurnished and had been uninhabited for months. Because the Yellow House had to be furnished before he could fully move in, Van Gogh moved from the Hôtel Carrel to the Café de la Gare on 7 May 1888. He had befriended the Yellow House's proprietors, Joseph and Marie Ginoux, and was able to use it as a studio. Van Gogh wanted a gallery to display his work and started a series of paintings that eventually included Van Gogh's Chair (1888), Bedroom in Arles (1888), The Night Café (1888), Café Terrace at Night (September 1888), Starry Night Over the Rhone (1888), and Still Life: Vase with Twelve Sunflowers (1888), all intended for the decoration for the Yellow House.Van Gogh wrote that with The Night Café he tried \"to express the idea that the café is a place where one can ruin oneself, go mad, or commit a crime\". When he visited Saintes-Maries-de-la-Mer in June, he gave lessons to a Zouave second lieutenant – Paul-Eugène Milliet – and painted boats on the sea and the village. MacKnight introduced Van Gogh to Eugène Boch, a Belgian painter who sometimes stayed in Fontvieille, and the two exchanged visits in July.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Gauguin's visit (1888) ====<br> <br>When Gauguin agreed to visit Arles in 1888, Van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
+    "# Using RankGPT\n",
     "new_nodes = get_retrieved_nodes(\n",
     "    \"Which date did Paul Gauguin arrive in Arles?\",\n",
     "    vector_top_k=10,\n",
     "    reranker_top_n=3,\n",
     "    with_reranker=True,\n",
-    "    with_retrieval=False,\n",
-    "    model=\"gpt\",\n",
-    "    gpt_model=\"gpt-3.5-turbo\",\n",
+    "    model=\"gpt-3.5-turbo\",\n",
     ")\n",
     "\n",
     "visualize_retrieved_nodes(new_nodes)"
@@ -542,479 +435,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### The correct result is ranked 1st after RankGPT rerank."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Sliding window example with RankZephyr."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index.core.retrievers import VectorIndexRetriever\n",
-    "from llama_index.core import QueryBundle\n",
-    "from llama_index.postprocessor.rankLLM_rerank import RankLLMRerank\n",
-    "\n",
-    "import pandas as pd\n",
-    "from IPython.display import display, HTML\n",
-    "\n",
-    "\n",
-    "def get_retrieved_nodes_mixed(\n",
-    "    query_str,\n",
-    "    vector_top_k=10,\n",
-    "    reranker_top_n=3,\n",
-    "    with_reranker=False,\n",
-    "    with_retrieval=False,\n",
-    "    step_size=10,\n",
-    "    model=\"zephyr\",\n",
-    "    gpt_model=\"gpt-3.5-turbo\",\n",
-    "):\n",
-    "    query_bundle = QueryBundle(query_str)\n",
-    "    # configure retriever\n",
-    "    retriever = VectorIndexRetriever(\n",
-    "        index=index,\n",
-    "        similarity_top_k=vector_top_k,\n",
-    "    )\n",
-    "    retrieved_nodes = retriever.retrieve(query_bundle)\n",
-    "\n",
-    "    retrieved_nodes.reverse()\n",
-    "\n",
-    "    if with_reranker:\n",
-    "        # configure reranker\n",
-    "        reranker = RankLLMRerank(\n",
-    "            top_n=reranker_top_n,\n",
-    "            model=model,\n",
-    "            with_retrieval=with_retrieval,\n",
-    "            gpt_model=gpt_model,\n",
-    "        )\n",
-    "        retrieved_nodes = reranker.postprocess_nodes(\n",
-    "            retrieved_nodes, query_bundle\n",
-    "        )\n",
-    "\n",
-    "    return retrieved_nodes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### After retrieving the top 50 results and reversing the order, the correct result is ranked 47th/50.\n",
-    "\n",
-    "### Expected result:\n",
-    "```After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers;```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Score</th>\n",
-       "      <th>Text</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0.752651</td>\n",
-       "      <td>== Nazi-looted art ==<br><br>During the Nazi period (1933–1945) a great number of artworks by Van Gogh changed hands, many of them looted from Jewish collectors who were forced into exile or murdered. Some of these works have disappeared into private collections. Others have since resurfaced in museums, or at auction, or have been reclaimed, often in high-profile lawsuits, by their former owners. The German Lost Art Foundation still lists dozens of missing van Goghs and the American Alliance of Museums lists 73 van Goghs on the Nazi Era Provenance Internet Portal.<br><br><br>== References ==<br><br><br>=== Explanatory footnotes ===<br><br><br>=== Citations ===<br><br><br>=== General and cited sources ===<br><br><br>== External links ==<br><br>The Vincent van Gogh Gallery, the complete works and letters of Van Gogh<br>Vincent van Gogh The letters, the complete letters of Van Gogh (translated into English and annotated)<br>Vincent van Gogh, teaching resource on Van Gogh<br>Works by Vincent van Gogh at Project Gutenberg<br>Works by or about Vincent van Gogh at Internet Archive<br>Works by Vincent van Gogh at LibriVox (public domain audiobooks) <br>Vincent van Gogh at IMDb</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.765492</td>\n",
-       "      <td>Yellow meant the most to him, because it symbolised emotional truth. He used yellow as a symbol for sunlight, life, and God.Van Gogh strove to be a painter of rural life and nature; during his first summer in Arles he used his new palette to paint landscapes and traditional rural life. His belief that a power existed behind the natural led him to try to capture a sense of that power, or the essence of nature in his art, sometimes through the use of symbols. His renditions of the sower, at first copied from Jean-François Millet, reflect the influence of Thomas Carlyle and Friedrich Nietzsche's thoughts on the heroism of physical labour, as well as Van Gogh's religious beliefs: the sower as Christ sowing life beneath the hot sun. These were themes and motifs he returned to often to rework and develop. His paintings of flowers are filled with symbolism, but rather than use traditional Christian iconography he made up his own, where life is lived under the sun and work is an allegory of life. In Arles, having gained confidence after painting spring blossoms and learning to capture bright sunlight, he was ready to paint The Sower.<br>Van Gogh stayed within what he called the \"guise of reality\" and was critical of overly stylised works. He wrote afterwards that the abstraction of Starry Night had gone too far and that reality had \"receded too far in the background\". Hughes describes it as a moment of extreme visionary ecstasy: the stars are in a great whirl, reminiscent of Hokusai's Great Wave, the movement in the heaven above is reflected by the movement of the cypress on the earth below, and the painter's vision is \"translated into a thick, emphatic plasma of paint\".Between 1885 and his death in 1890, Van Gogh appears to have been building an oeuvre, a collection that reflected his personal vision and could be commercially successful. He was influenced by Blanc's definition of style, that a true painting required optimal use of colour, perspective and brushstrokes. Van Gogh applied the word \"purposeful\" to paintings he thought he had mastered, as opposed to those he thought of as studies.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.768011</td>\n",
-       "      <td>His legacy is honored and celebrated by the Van Gogh Museum in Amsterdam, which holds the world's largest collection of his paintings and drawings.<br><br><br>== Letters ==<br><br>The most comprehensive primary source on Van Gogh is his correspondence with his younger brother, Theo. Their lifelong friendship, and most of what is known of Vincent's thoughts and theories of art, are recorded in the hundreds of letters they exchanged from 1872 until 1890. Theo van Gogh was an art dealer and provided his brother with financial and emotional support as well as access to influential people on the contemporary art scene.Theo kept all of Vincent's letters to him; but Vincent kept only a few of the letters he received. After both had died, Theo's widow Jo Bonger-van Gogh arranged for the publication of some of their letters. A few appeared in 1906 and 1913; the majority were published in 1914. Vincent's letters are eloquent and expressive, have been described as having a \"diary-like intimacy\", and read in parts like autobiography. Translator Arnold Pomerans wrote that their publication adds a \"fresh dimension to the understanding of Van Gogh's artistic achievement, an understanding granted to us by virtually no other painter\".<br><br>There are more than 600 letters from Vincent to Theo and around 40 from Theo to Vincent. There are 22 to his sister Wil, 58 to the painter Anthon van Rappard, 22 to Émile Bernard as well as individual letters to Paul Signac, Paul Gauguin, and the critic Albert Aurier. Some are illustrated with sketches. Many are undated, but art historians have been able to place most in chronological order. Problems in transcription and dating remain, mainly with those posted from Arles. While there, Vincent wrote around 200 letters in Dutch, French, and English. There is a gap in the record when he lived in Paris as the brothers lived together and had no need to correspond.The highly paid contemporary artist Jules Breton was frequently mentioned in Vincent's letters. In 1875 letters to Theo, Vincent mentions he saw Breton, discusses the Breton paintings he saw at a Salon, and discusses sending one of Breton's books but only on the condition that it be returned.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0.769008</td>\n",
-       "      <td>==== Self-portraits ====<br><br>Van Gogh created more than 43 self-portraits between 1885 and 1889. They were usually completed in series, such as those painted in Paris in mid-1887, and continued until shortly before his death. Generally the portraits were studies, created during periods when he was reluctant to mix with others or when he lacked models and painted himself.Van Gogh's self-portraits reflect a high degree of self-scrutiny. Often they were intended to mark important periods in his life; for example, the mid-1887 Paris series were painted at the point where he became aware of Claude Monet, Paul Cézanne and Signac. In Self-Portrait with Grey Felt Hat, heavy strains of paint spread outwards across the canvas. It is one of his most renowned self-portraits of that period, \"with its highly organized rhythmic brushstrokes, and the novel halo derived from the Neo-impressionist repertoire was what Van Gogh himself called a 'purposeful' canvas\".They contain a wide array of physiognomical representations. Van Gogh's mental and physical condition is usually apparent; he may appear unkempt, unshaven or with a neglected beard, with deeply sunken eyes, a weak jaw, or having lost teeth. Some show him with full lips, a long face or prominent skull, or sharpened, alert features. His hair is sometimes depicted in a vibrant reddish hue and at other times ash colored.Van Gogh's self-portraits vary stylistically. In those painted after December 1888, the strong contrast of vivid colors highlight the haggard pallor of his skin. Some depict the artist with a beard, others without. He can be seen with bandages in portraits executed just after he mutilated his ear. In only a few does he depict himself as a painter. Those painted in Saint-Rémy show the head from the right, the side opposite his damaged ear, as he painted himself reflected in his mirror.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0.769796</td>\n",
-       "      <td>Sien gave her daughter to her mother and baby Willem to her brother. Willem remembered visiting Rotterdam when he was about 12, when an uncle tried to persuade Sien to marry to legitimise the child. He believed Van Gogh was his father, but the timing of his birth makes this unlikely. Sien drowned herself in the River Scheldt in 1904.In September 1883, Van Gogh moved to Drenthe in the northern Netherlands. In December driven by loneliness, he went to live with his parents, then in Nuenen, North Brabant.<br><br><br>=== Emerging artist ===<br><br><br>==== Nuenen and Antwerp (1883–1886) ====<br><br>In Nuenen, Van Gogh focused on painting and drawing. Working outside and very quickly, he completed sketches and paintings of weavers and their cottages. Van Gogh also completed The Parsonage Garden at Nuenen, which was stolen from the Singer Laren in March 2020. From August 1884, Margot Begemann, a neighbour's daughter ten years his senior, joined him on his forays; she fell in love and he reciprocated, though less enthusiastically. They wanted to marry, but neither side of their families were in favor. Margot was distraught and took an overdose of strychnine, but survived after Van Gogh rushed her to a nearby hospital. On 26 March 1885, his father died of a heart attack.Van Gogh painted several groups of still lifes in 1885. During his two-year stay in Nuenen, he completed numerous drawings and watercolours and nearly 200 oil paintings. His palette consisted mainly of sombre earth tones, particularly dark brown, and showed no sign of the vivid colours that distinguished his later work.There was interest from a dealer in Paris early in 1885. Theo asked Vincent if he had paintings ready to exhibit. In May, Van Gogh responded with his first major work, The Potato Eaters, and a series of \"peasant character studies\" which were the culmination of several years of work.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>0.770298</td>\n",
-       "      <td>==== Cypresses and olives ====<br><br>Fifteen canvases depict cypresses, a tree he became fascinated with in Arles. He brought life to the trees, which were traditionally seen as emblematic of death. The series of cypresses he began in Arles featured the trees in the distance, as windbreaks in fields; when he was at Saint-Rémy he brought them to the foreground. Vincent wrote to Theo in May 1889: \"Cypresses still preoccupy me, I should like to do something with them like my canvases of sunflowers\"; he went on to say, \"They are beautiful in line and proportion like an Egyptian obelisk.\"In mid-1889, and at his sister Wil's request, Van Gogh painted several smaller versions of Wheat Field with Cypresses. The works are characterised by swirls and densely painted impasto, and include The Starry Night, in which cypresses dominate the foreground. In addition to this, other notable works on cypresses include Cypresses (1889), Cypresses with Two Figures (1889–90), and Road with Cypress and Star (1890).During the last six or seven months of the year 1889, he had also created at least fifteen paintings of olive trees, a subject which he considered as demanding and compelling. Among these works are Olive Trees with the Alpilles in the Background (1889), about which in a letter to his brother Van Gogh wrote, \"At last I have a landscape with olives\". While in Saint-Rémy, Van Gogh spent time outside the asylum, where he painted trees in the olive groves. In these works, natural life is rendered as gnarled and arthritic as if a personification of the natural world, which are, according to Hughes, filled with \"a continuous field of energy of which nature is a manifestation\".</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>0.771924</td>\n",
-       "      <td>He wrote afterwards that the abstraction of Starry Night had gone too far and that reality had \"receded too far in the background\". Hughes describes it as a moment of extreme visionary ecstasy: the stars are in a great whirl, reminiscent of Hokusai's Great Wave, the movement in the heaven above is reflected by the movement of the cypress on the earth below, and the painter's vision is \"translated into a thick, emphatic plasma of paint\".Between 1885 and his death in 1890, Van Gogh appears to have been building an oeuvre, a collection that reflected his personal vision and could be commercially successful. He was influenced by Blanc's definition of style, that a true painting required optimal use of colour, perspective and brushstrokes. Van Gogh applied the word \"purposeful\" to paintings he thought he had mastered, as opposed to those he thought of as studies. He painted many series of studies; most of which were still lifes, many executed as colour experiments or as gifts to friends. The work in Arles contributed considerably to his oeuvre: those he thought the most important from that time were The Sower, Night Cafe, Memory of the Garden in Etten and Starry Night. With their broad brushstrokes, inventive perspectives, colours, contours and designs, these paintings represent the style he sought.<br><br><br>=== Major series ===<br><br>Van Gogh's stylistic developments are usually linked to the periods he spent living in different places across Europe. He was inclined to immerse himself in local cultures and lighting conditions, although he maintained a highly individual visual outlook throughout. His evolution as an artist was slow and he was aware of his painterly limitations. Van Gogh moved home often, perhaps to expose himself to new visual stimuli, and through exposure develop his technical skill. Art historian Melissa McQuillan believes the moves also reflect later stylistic changes and that Van Gogh used the moves to avoid conflict, and as a coping mechanism for when the idealistic artist was faced with the realities of his then current situation.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>0.772942</td>\n",
-       "      <td>Among these was Two Peasant Women Digging in a Snow-Covered Field at Sunset. Hulsker believes that this small group of paintings formed the nucleus of many drawings and study sheets depicting landscapes and figures that Van Gogh worked on during this time. He comments that this short period was the only time that Van Gogh's illness had a significant effect on his work. Van Gogh asked his mother and his brother to send him drawings and rough work he had done in the early 1880s so he could work on new paintings from his old sketches. Belonging to this period is Sorrowing Old Man (\"At Eternity's Gate\"), a colour study Hulsker describes as \"another unmistakable remembrance of times long past\". His late paintings show an artist at the height of his abilities, according to the art critic Robert Hughes, \"longing for concision and grace\".After the birth of his nephew, Van Gogh wrote, \"I started right away to make a picture for him, to hang in their bedroom, branches of white almond blossom against a blue sky.\"</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>0.774411</td>\n",
-       "      <td>He moved to Nuenen after a short period of time in Drenthe and began work on several large paintings but destroyed most of them. The Potato Eaters and its companion pieces are the only ones to have survived. Following a visit to the Rijksmuseum Van Gogh wrote of his admiration for the quick, economical brushwork of the Dutch Masters, especially Rembrandt and Frans Hals. He was aware many of his faults were due to lack of experience and technical expertise, so in November 1885 he travelled to Antwerp and later Paris to learn and develop his skills.<br>Theo criticised The Potato Eaters for its dark palette, which he thought unsuitable for a modern style. During Van Gogh's stay in Paris between 1886 and 1887, he tried to master a new, lighter palette. His Portrait of Père Tanguy (1887) shows his success with the brighter palette and is evidence of an evolving personal style. Charles Blanc's treatise on colour interested him greatly and led him to work with complementary colours. Van Gogh came to believe that the effect of colour went beyond the descriptive; he said that \"colour expresses something in itself\". According to Hughes, Van Gogh perceived colour as having a \"psychological and moral weight\", as exemplified in the garish reds and greens of The Night Café, a work he wanted to \"express the terrible passions of humanity\". Yellow meant the most to him, because it symbolised emotional truth. He used yellow as a symbol for sunlight, life, and God.Van Gogh strove to be a painter of rural life and nature; during his first summer in Arles he used his new palette to paint landscapes and traditional rural life. His belief that a power existed behind the natural led him to try to capture a sense of that power, or the essence of nature in his art, sometimes through the use of symbols. His renditions of the sower, at first copied from Jean-François Millet, reflect the influence of Thomas Carlyle and Friedrich Nietzsche's thoughts on the heroism of physical labour, as well as Van Gogh's religious beliefs: the sower as Christ sowing life beneath the hot sun. These were themes and motifs he returned to often to rework and develop.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>0.774471</td>\n",
-       "      <td>With their broad brushstrokes, inventive perspectives, colours, contours and designs, these paintings represent the style he sought.<br><br><br>=== Major series ===<br><br>Van Gogh's stylistic developments are usually linked to the periods he spent living in different places across Europe. He was inclined to immerse himself in local cultures and lighting conditions, although he maintained a highly individual visual outlook throughout. His evolution as an artist was slow and he was aware of his painterly limitations. Van Gogh moved home often, perhaps to expose himself to new visual stimuli, and through exposure develop his technical skill. Art historian Melissa McQuillan believes the moves also reflect later stylistic changes and that Van Gogh used the moves to avoid conflict, and as a coping mechanism for when the idealistic artist was faced with the realities of his then current situation.<br><br><br>==== Portraits ====<br><br>Van Gogh said portraiture was his greatest interest. \"What I'm most passionate about, much much more than all the rest in my profession\", he wrote in 1890, \"is the portrait, the modern portrait.\" It is \"the only thing in painting that moves me deeply and that gives me a sense of the infinite.\" He wrote to his sister that he wished to paint portraits that would endure, and that he would use colour to capture their emotions and character rather than aiming for photographic realism. Those closest to Van Gogh are mostly absent from his portraits; he rarely painted Theo, Van Rappard or Bernard. The portraits of his mother were from photographs.Van Gogh painted Arles' postmaster Joseph Roulin and his family repeatedly. In five versions of La Berceuse (The Lullaby), Van Gogh painted Augustine Roulin quietly holding a rope that rocks the unseen cradle of her infant daughter. Van Gogh had planned for it to be the central image of a triptych, flanked by paintings of sunflowers.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>0.776510</td>\n",
-       "      <td>These began a compelling mythology of Van Gogh as an intense and dedicated painter who suffered for his art and died young. In 1934, the novelist Irving Stone wrote a biographical novel of Van Gogh's life titled Lust for Life, based on Van Gogh's letters to Theo. This novel and the 1956 film further enhanced his fame, especially in the United States where Stone surmised only a few hundred people had heard of Van Gogh prior to his surprise best-selling book.In 1957, Francis Bacon based a series of paintings on reproductions of Van Gogh's The Painter on the Road to Tarascon, the original of which was destroyed during the Second World War. Bacon was inspired by an image he described as \"haunting\", and regarded Van Gogh as an alienated outsider, a position which resonated with him. Bacon identified with Van Gogh's theories of art and quoted lines written to Theo: \"[R]eal painters do not paint things as they are ... [T]hey paint them as they themselves feel them to be.\"Van Gogh's works are among the world's most expensive paintings. Those sold for over US$100 million (today's equivalent) include Portrait of Dr Gachet, Portrait of Joseph Roulin and Irises. The Metropolitan Museum of Art acquired a copy of Wheat Field with Cypresses in 1993 for US$57 million by using funds donated by publisher, diplomat and philanthropist Walter Annenberg. In 2015, L'Allée des Alyscamps sold for US$66.3 million at Sotheby's, New York, exceeding its reserve of US$40 million.Minor planet 4457 van Gogh is named in his honour.In October 2022, two activists protesting the effects of the fossil fuel industry on climate change threw a can of tomato soup on Van Gogh's Sunflowers in the National Gallery, London, and then glued their hands to the gallery wall. As the painting was covered by glass it was not damaged.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>0.776510</td>\n",
-       "      <td>==== Flowers ====<br><br>Van Gogh painted several landscapes with flowers, including roses, lilacs, irises, and sunflowers. Some reflect his interests in the language of colour, and also in Japanese ukiyo-e. There are two series of dying sunflowers. The first was painted in Paris in 1887 and shows flowers lying on the ground. The second set was completed a year later in Arles and is of bouquets in a vase positioned in early morning light. Both are built from thickly layered paintwork, which, according to the London National Gallery, evoke the \"texture of the seed-heads\".In these series, Van Gogh was not preoccupied by his usual interest in filling his paintings with subjectivity and emotion; rather, the two series are intended to display his technical skill and working methods to Gauguin, who was about to visit. The 1888 paintings were created during a rare period of optimism for the artist. Vincent wrote to Theo in August 1888:<br><br>I'm painting with the gusto of a Marseillais eating bouillabaisse, which won't surprise you when it's a question of painting large sunflowers ... If I carry out this plan there'll be a dozen or so panels. The whole thing will therefore be a symphony in blue and yellow. I work on it all these mornings, from sunrise. Because the flowers wilt quickly and it's a matter of doing the whole thing in one go.<br>The sunflowers were painted to decorate the walls in anticipation of Gauguin's visit, and Van Gogh placed individual works around the Yellow House's guest room in Arles. Gauguin was deeply impressed and later acquired two of the Paris versions. After Gauguin's departure, Van Gogh imagined the two major versions of the sunflowers as wings of the Berceuse Triptych, and included them in his Les XX in Brussels exhibit. Today the major pieces of the series are among his best known, celebrated for the sickly connotations of the colour yellow and its tie-in with the Yellow House, the expressionism of the brush strokes, and their contrast against often dark backgrounds.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>0.778443</td>\n",
-       "      <td>His father was the youngest son of a minister. The two met when Anna's younger sister, Cornelia, married Theodorus's older brother Vincent (Cent). Van Gogh's parents married in May 1851 and moved to Zundert. His brother Theo was born on 1 May 1857. There was another brother, Cor, and three sisters: Elisabeth, Anna, and Willemina (known as \"Wil\"). In later life, Van Gogh remained in touch only with Willemina and Theo. Theodorus's salary as a minister was modest, but the Church also supplied the family with a house, a maid, two cooks, a gardener, a carriage and horse; his mother Anna instilled in the children a duty to uphold the family's high social position.Van Gogh was a serious and thoughtful child. He was taught at home by his mother and a governess, and in 1860, was sent to the village school. In 1864, he was placed in a boarding school at Zevenbergen, where he felt abandoned, and he campaigned to come home. Instead, in 1866, his parents sent him to the middle school in Tilburg, where he was also deeply unhappy. His interest in art began at a young age. He was encouraged to draw as a child by his mother, and his early drawings are expressive, but do not approach the intensity of his later work. Constant Cornelis Huijsmans, who had been a successful artist in Paris, taught the students at Tilburg. His philosophy was to reject technique in favour of capturing the impressions of things, particularly nature or common objects. Van Gogh's profound unhappiness seems to have overshadowed the lessons, which had little effect. In March 1868, he abruptly returned home. He later wrote that his youth was \"austere and cold, and sterile\".In July 1869, Van Gogh's uncle Cent obtained a position for him at the art dealers Goupil &amp; Cie in The Hague. After completing his training in 1873, he was transferred to Goupil's London branch on Southampton Street, and took lodgings at 87 Hackford Road, Stockwell.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>0.778511</td>\n",
-       "      <td>=== Death ===<br><br>On 27 July 1890, aged 37, Van Gogh shot himself in the chest with a revolver. The shooting may have taken place in the wheat field in which he had been painting, or in a local barn. The bullet was deflected by a rib and passed through his chest without doing apparent damage to internal organs – possibly stopped by his spine. He was able to walk back to the Auberge Ravoux, where he was attended to by two doctors. One of them, Dr Gachet, served as a war surgeon in 1870 and had extensive knowledge of gunshots. Vincent was possibly attended to during the night by Dr Gachet's son Paul Louis Gachet and the innkeeper, Arthur Ravoux. The following morning, Theo rushed to his brother's side, finding him in good spirits. But within hours Vincent's health began to fail, suffering from an infection resulting from the wound. He died in the early hours of 29 July. According to Theo, Vincent's last words were: \"The sadness will last forever\".<br>Van Gogh was buried on 30 July, in the municipal cemetery of Auvers-sur-Oise. The funeral was attended by Theo van Gogh, Andries Bonger, Charles Laval, Lucien Pissarro, Émile Bernard, Julien Tanguy and Paul Gachet, among twenty family members, friends and locals. Theo suffered from syphilis, and his health began to decline further after his brother's death. Weak and unable to come to terms with Vincent's absence, he died on 25 January 1891 at Den Dolder and was buried in Utrecht. In 1914, Johanna van Gogh-Bonger had Theo's body exhumed and moved from Utrecht to be re-buried alongside Vincent's at Auvers-sur-Oise.There have been numerous debates as to the nature of Van Gogh's illness and its effect on his work, and many retrospective diagnoses have been proposed. The consensus is that Van Gogh had an episodic condition with periods of normal functioning. Perry was the first to suggest bipolar disorder in 1947, and this has been supported by the psychiatrists Hemphill and Blumer.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>0.780200</td>\n",
-       "      <td>He was encouraged to draw as a child by his mother, and his early drawings are expressive, but do not approach the intensity of his later work. Constant Cornelis Huijsmans, who had been a successful artist in Paris, taught the students at Tilburg. His philosophy was to reject technique in favour of capturing the impressions of things, particularly nature or common objects. Van Gogh's profound unhappiness seems to have overshadowed the lessons, which had little effect. In March 1868, he abruptly returned home. He later wrote that his youth was \"austere and cold, and sterile\".In July 1869, Van Gogh's uncle Cent obtained a position for him at the art dealers Goupil &amp; Cie in The Hague. After completing his training in 1873, he was transferred to Goupil's London branch on Southampton Street, and took lodgings at 87 Hackford Road, Stockwell. This was a happy time for Van Gogh; he was successful at work and, at 20, was earning more than his father. Theo's wife, Jo Van Gogh-Bonger, later remarked that this was the best year of Vincent's life. He became infatuated with his landlady's daughter, Eugénie Loyer, but she rejected him after he confessed his feelings; she was secretly engaged to a former lodger. He grew more isolated and religiously fervent. His father and uncle arranged a transfer to Paris in 1875, where he became resentful of issues such as the degree to which the art dealers commodified art, and he was dismissed a year later.<br>In April 1876, he returned to England to take unpaid work as a supply teacher in a small boarding school in Ramsgate. When the proprietor moved to Isleworth in Middlesex, Van Gogh went with him. The arrangement was not successful; he left to become a Methodist minister's assistant. His parents had meanwhile moved to Etten; in 1876 he returned home at Christmas for six months and took work at a bookshop in Dordrecht. He was unhappy in the position, and spent his time doodling or translating passages from the Bible into English, French, and German.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>0.780329</td>\n",
-       "      <td>Influenced by Van Gogh, Matisse abandoned his earth-coloured palette for bright colours.In Paris in 1901, a large Van Gogh retrospective was held at the Bernheim-Jeune Gallery, which excited André Derain and Maurice de Vlaminck, and contributed to the emergence of Fauvism. Important group exhibitions took place with the Sonderbund artists in Cologne in 1912, the Armory Show, New York in 1913, and Berlin in 1914. Henk Bremmer was instrumental in teaching and talking about Van Gogh, and introduced Helene Kröller-Müller to Van Gogh's art; she became an avid collector of his work. The early figures in German Expressionism such as Emil Nolde acknowledged a debt to Van Gogh's work. Bremmer assisted Jacob Baart de la Faille, whose catalogue raisonné L'Oeuvre de Vincent van Gogh appeared in 1928.<br>Van Gogh's fame reached its first peak in Austria and Germany before World War I, helped by the publication of his letters in three volumes in 1914. His letters are expressive and literate, and have been described as among the foremost 19th-century writings of their kind. These began a compelling mythology of Van Gogh as an intense and dedicated painter who suffered for his art and died young. In 1934, the novelist Irving Stone wrote a biographical novel of Van Gogh's life titled Lust for Life, based on Van Gogh's letters to Theo. This novel and the 1956 film further enhanced his fame, especially in the United States where Stone surmised only a few hundred people had heard of Van Gogh prior to his surprise best-selling book.In 1957, Francis Bacon based a series of paintings on reproductions of Van Gogh's The Painter on the Road to Tarascon, the original of which was destroyed during the Second World War. Bacon was inspired by an image he described as \"haunting\", and regarded Van Gogh as an alienated outsider, a position which resonated with him.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>0.780921</td>\n",
-       "      <td>Theo suffered from syphilis, and his health began to decline further after his brother's death. Weak and unable to come to terms with Vincent's absence, he died on 25 January 1891 at Den Dolder and was buried in Utrecht. In 1914, Johanna van Gogh-Bonger had Theo's body exhumed and moved from Utrecht to be re-buried alongside Vincent's at Auvers-sur-Oise.There have been numerous debates as to the nature of Van Gogh's illness and its effect on his work, and many retrospective diagnoses have been proposed. The consensus is that Van Gogh had an episodic condition with periods of normal functioning. Perry was the first to suggest bipolar disorder in 1947, and this has been supported by the psychiatrists Hemphill and Blumer. Biochemist Wilfred Arnold has countered that the symptoms are more consistent with acute intermittent porphyria, noting that the popular link between bipolar disorder and creativity might be spurious. Temporal lobe epilepsy with bouts of depression has also been suggested. Whatever the diagnosis, his condition was likely worsened by malnutrition, overwork, insomnia and alcohol.<br><br><br>== Style and works ==<br><br><br>=== Artistic development ===<br>Van Gogh drew and painted with watercolours while at school, but only a few examples survive and the authorship of some has been challenged. When he took up art as an adult, he began at an elementary level. In early 1882, his uncle, Cornelis Marinus, owner of a well-known gallery of contemporary art in Amsterdam, asked for drawings of The Hague. Van Gogh's work did not live up to expectations. Marinus offered a second commission, specifying the subject matter in detail, but was again disappointed with the result. Van Gogh persevered; he experimented with lighting in his studio using variable shutters and different drawing materials. For more than a year he worked on single figures – highly elaborate studies in black and white, which at the time gained him only criticism. Later, they were recognised as early masterpieces.In August 1882, Theo gave Vincent money to buy materials for working en plein air. Vincent wrote that he could now \"go on painting with new vigour\".</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>0.784223</td>\n",
-       "      <td>Those sold for over US$100 million (today's equivalent) include Portrait of Dr Gachet, Portrait of Joseph Roulin and Irises. The Metropolitan Museum of Art acquired a copy of Wheat Field with Cypresses in 1993 for US$57 million by using funds donated by publisher, diplomat and philanthropist Walter Annenberg. In 2015, L'Allée des Alyscamps sold for US$66.3 million at Sotheby's, New York, exceeding its reserve of US$40 million.Minor planet 4457 van Gogh is named in his honour.In October 2022, two activists protesting the effects of the fossil fuel industry on climate change threw a can of tomato soup on Van Gogh's Sunflowers in the National Gallery, London, and then glued their hands to the gallery wall. As the painting was covered by glass it was not damaged.<br><br><br>=== Van Gogh Museum ===<br><br>Van Gogh's nephew and namesake, Vincent Willem van Gogh (1890–1978), inherited the estate after his mother's death in 1925. During the early 1950s he arranged for the publication of a complete edition of the letters presented in four volumes and several languages. He then began negotiations with the Dutch government to subsidise a foundation to purchase and house the entire collection. Theo's son participated in planning the project in the hope that the works would be exhibited under the best possible conditions. The project began in 1963; architect Gerrit Rietveld was commissioned to design it, and after his death in 1964 Kisho Kurokawa took charge. Work progressed throughout the 1960s, with 1972 as the target for its grand opening.The Van Gogh Museum opened in the Museumplein in Amsterdam in 1973. It became the second most popular museum in the Netherlands, after the Rijksmuseum, regularly receiving more than 1.5 million visitors a year. In 2015 it had a record 1.9 million. Eighty-five percent of the visitors come from other countries.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>0.786045</td>\n",
-       "      <td>They wanted to marry, but neither side of their families were in favor. Margot was distraught and took an overdose of strychnine, but survived after Van Gogh rushed her to a nearby hospital. On 26 March 1885, his father died of a heart attack.Van Gogh painted several groups of still lifes in 1885. During his two-year stay in Nuenen, he completed numerous drawings and watercolours and nearly 200 oil paintings. His palette consisted mainly of sombre earth tones, particularly dark brown, and showed no sign of the vivid colours that distinguished his later work.There was interest from a dealer in Paris early in 1885. Theo asked Vincent if he had paintings ready to exhibit. In May, Van Gogh responded with his first major work, The Potato Eaters, and a series of \"peasant character studies\" which were the culmination of several years of work. When he complained that Theo was not making enough effort to sell his paintings in Paris, his brother responded that they were too dark and not in keeping with the bright style of Impressionism. In August his work was publicly exhibited for the first time, in the shop windows of the dealer Leurs in The Hague. One of his young peasant sitters became pregnant in September 1885; Van Gogh was accused of forcing himself upon her, and the village priest forbade parishioners to model for him.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>He moved to Antwerp that November and rented a room above a paint dealer's shop in the rue des Images (Lange Beeldekensstraat). He lived in poverty and ate poorly, preferring to spend the money Theo sent on painting materials and models. Bread, coffee and tobacco became his staple diet. In February 1886, he wrote to Theo that he could only remember eating six hot meals since the previous May. His teeth became loose and painful. In Antwerp he applied himself to the study of colour theory and spent time in museums—particularly studying the work of Peter Paul Rubens—and broadened his palette to include carmine, cobalt blue and emerald green.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>0.786288</td>\n",
-       "      <td>Vincent Willem van Gogh (Dutch: [ˈvɪnsɛnt ˈʋɪləɱ‿vɑŋ‿ˈɣɔx] ; 30 March 1853 – 29 July 1890) was a Dutch Post-Impressionist painter who is among the most famous and influential figures in the history of Western art. In just over a decade, he created approximately 2100 artworks, including around 860 oil paintings, most of them in the last two years of his life. His oeuvre includes landscapes, still lifes, portraits, and self-portraits, most of which are characterized by bold colors and dramatic brushwork that contributed to the rise of expressionism in modern art. Van Gogh's work was beginning to gain critical attention before he died at age 37, by what was suspected at the time to be a suicide. During his lifetime, only one of Van Gogh's paintings, The Red Vineyard, was sold. <br>Born into an upper-middle-class family, Van Gogh drew as a child and was serious, quiet and thoughtful, but showed signs of mental instability. As a young man, he worked as an art dealer, often travelling, but became depressed after he was transferred to London. He turned to religion and spent time as a missionary in southern Belgium. Later he drifted into ill-health and solitude. He was keenly aware of modernist trends in art and, while back with his parents, took up painting in 1881. His younger brother, Theo, supported him financially, and the two of them maintained a long correspondence.<br>Van Gogh's early works consist of mostly still lifes and depictions of peasant laborers. In 1886, he moved to Paris, where he met members of the artistic avant-garde, including Émile Bernard and Paul Gauguin, who were seeking new paths beyond Impressionism. Frustrated in Paris and inspired by a growing spirit of artistic change and collaboration, in February 1888, Van Gogh moved to Arles in southern France to establish an artistic retreat and commune. Once there, Van Gogh's art changed.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>0.788811</td>\n",
-       "      <td>==== Wheat fields ====<br><br>Van Gogh made several painting excursions during visits to the landscape around Arles. He made paintings of harvests, wheat fields and other rural landmarks of the area, including The Old Mill (1888); a good example of a picturesque structure bordering the wheat fields beyond. At various points, Van Gogh painted the view from his window – at The Hague, Antwerp, and Paris. These works culminated in The Wheat Field series, which depicted the view from his cells in the asylum at Saint-Rémy.Many of the late paintings are sombre but essentially optimistic and, right up to the time of Van Gogh's death, reflect his desire to return to lucid mental health. Yet some of his final works reflect his deepening concerns. Writing in July 1890, from Auvers, Van Gogh said that he had become absorbed \"in the immense plain against the hills, boundless as the sea, delicate yellow\".Van Gogh was captivated by the fields in May when the wheat was young and green. His Wheatfields at Auvers with White House shows a more subdued palette of yellows and blues, which creates a sense of idyllic harmony.About 10 July 1890, Van Gogh wrote to Theo of \"vast fields of wheat under troubled skies\". Wheatfield with Crows shows the artist's state of mind in his final days; Hulsker describes the work as a \"doom-filled painting with threatening skies and ill-omened crows\". Its dark palette and heavy brushstrokes convey a sense of menace.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>== Reputation and legacy ==<br><br>After Van Gogh's first exhibitions in the late 1880s, his reputation grew steadily among artists, art critics, dealers and collectors. In 1887, André Antoine hung Van Gogh's alongside works of Georges Seurat and Paul Signac, at the Théâtre Libre in Paris; some were acquired by Julien Tanguy. In 1889, his work was described in the journal Le Moderniste Illustré by Albert Aurier as characterised by \"fire, intensity, sunshine\". Ten paintings were shown at the Société des Artistes Indépendants, in Brussels in January 1890.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>0.789036</td>\n",
-       "      <td>== Reputation and legacy ==<br><br>After Van Gogh's first exhibitions in the late 1880s, his reputation grew steadily among artists, art critics, dealers and collectors. In 1887, André Antoine hung Van Gogh's alongside works of Georges Seurat and Paul Signac, at the Théâtre Libre in Paris; some were acquired by Julien Tanguy. In 1889, his work was described in the journal Le Moderniste Illustré by Albert Aurier as characterised by \"fire, intensity, sunshine\". Ten paintings were shown at the Société des Artistes Indépendants, in Brussels in January 1890. French president Marie François Sadi Carnot was said to have been impressed by Van Gogh's work.After Van Gogh's death, memorial exhibitions were held in Brussels, Paris, The Hague and Antwerp. His work was shown in several high-profile exhibitions, including six works at Les XX; in 1891 there was a retrospective exhibition in Brussels. In 1892, Octave Mirbeau wrote that Van Gogh's suicide was an \"infinitely sadder loss for art ... even though the populace has not crowded to a magnificent funeral, and poor Vincent van Gogh, whose demise means the extinction of a beautiful flame of genius, has gone to his death as obscure and neglected as he lived.\"Theo died in January 1891, removing Vincent's most vocal and well-connected champion. Theo's widow Johanna van Gogh-Bonger was a Dutchwoman in her twenties who had not known either her husband or her brother-in-law very long and who suddenly had to take care of several hundreds of paintings, letters and drawings, as well as her infant son, Vincent Willem van Gogh. Gauguin was not inclined to offer assistance in promoting Van Gogh's reputation, and Johanna's brother Andries Bonger also seemed lukewarm about his work. Aurier, one of Van Gogh's earliest supporters among the critics, died of typhoid fever in 1892 at the age of 27.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>0.790108</td>\n",
-       "      <td>When he took up art as an adult, he began at an elementary level. In early 1882, his uncle, Cornelis Marinus, owner of a well-known gallery of contemporary art in Amsterdam, asked for drawings of The Hague. Van Gogh's work did not live up to expectations. Marinus offered a second commission, specifying the subject matter in detail, but was again disappointed with the result. Van Gogh persevered; he experimented with lighting in his studio using variable shutters and different drawing materials. For more than a year he worked on single figures – highly elaborate studies in black and white, which at the time gained him only criticism. Later, they were recognised as early masterpieces.In August 1882, Theo gave Vincent money to buy materials for working en plein air. Vincent wrote that he could now \"go on painting with new vigour\". From early 1883, he worked on multi-figure compositions. He had some of them photographed, but when his brother remarked that they lacked liveliness and freshness, he destroyed them and turned to oil painting. Van Gogh turned to well-known Hague School artists like Weissenbruch and Blommers, and he received technical advice from them as well as from painters like De Bock and Van der Weele, both of the Hague School's second generation. He moved to Nuenen after a short period of time in Drenthe and began work on several large paintings but destroyed most of them. The Potato Eaters and its companion pieces are the only ones to have survived. Following a visit to the Rijksmuseum Van Gogh wrote of his admiration for the quick, economical brushwork of the Dutch Masters, especially Rembrandt and Frans Hals. He was aware many of his faults were due to lack of experience and technical expertise, so in November 1885 he travelled to Antwerp and later Paris to learn and develop his skills.<br>Theo criticised The Potato Eaters for its dark palette, which he thought unsuitable for a modern style. During Van Gogh's stay in Paris between 1886 and 1887, he tried to master a new, lighter palette.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>0.790171</td>\n",
-       "      <td>Soon after, he first painted in oils, bought with money borrowed from Theo. He liked the medium, and he spread the paint liberally, scraping from the canvas and working back with the brush. He wrote that he was surprised at how good the results were.<br>By March 1882, Mauve appeared to have gone cold towards Van Gogh, and he stopped replying to his letters. He had learned of Van Gogh's new domestic arrangement with an alcoholic prostitute, Clasina Maria \"Sien\" Hoornik (1850–1904), and her young daughter. Van Gogh had met Sien towards the end of January 1882, when she had a five-year-old daughter and was pregnant. She had previously borne two children who died, but Van Gogh was unaware of this. On 2 July, she gave birth to a baby boy, Willem. When Van Gogh's father discovered the details of their relationship, he put pressure on his son to abandon Sien and her two children. Vincent at first defied him, and considered moving the family out of the city, but in late 1883, he left Sien and the children.Poverty may have pushed Sien back into prostitution; the home became less happy and Van Gogh may have felt family life was irreconcilable with his artistic development. Sien gave her daughter to her mother and baby Willem to her brother. Willem remembered visiting Rotterdam when he was about 12, when an uncle tried to persuade Sien to marry to legitimise the child. He believed Van Gogh was his father, but the timing of his birth makes this unlikely. Sien drowned herself in the River Scheldt in 1904.In September 1883, Van Gogh moved to Drenthe in the northern Netherlands. In December driven by loneliness, he went to live with his parents, then in Nuenen, North Brabant.<br><br><br>=== Emerging artist ===<br><br><br>==== Nuenen and Antwerp (1883–1886) ====<br><br>In Nuenen, Van Gogh focused on painting and drawing. Working outside and very quickly, he completed sketches and paintings of weavers and their cottages.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>0.791175</td>\n",
-       "      <td>His friendship with Gauguin ended after a confrontation with a razor when, in a rage, he severed his left ear. Van Gogh spent time in psychiatric hospitals, including a period at Saint-Rémy. After he discharged himself and moved to the Auberge Ravoux in Auvers-sur-Oise near Paris, he came under the care of the homeopathic doctor Paul Gachet. His depression persisted, and on 27 July 1890, Van Gogh is believed to have shot himself in the chest with a revolver, dying from his injuries two days later.<br>Van Gogh's work began to attract critical artistic attention in the last year of his life. After his death, Van Gogh's art and life story captured public imagination as an emblem of misunderstood genius, due in large part to the efforts of his widowed sister-in-law Johanna van Gogh-Bonger. His bold use of color, expressive line and thick application of paint inspired avant-garde artistic groups like the Fauves and German Expressionists in the early 20th century. Van Gogh's work gained widespread critical and commercial success in the following decades, and he has become a lasting icon of the romantic ideal of the tortured artist. Today, Van Gogh's works are among the world's most expensive paintings ever sold. His legacy is honored and celebrated by the Van Gogh Museum in Amsterdam, which holds the world's largest collection of his paintings and drawings.<br><br><br>== Letters ==<br><br>The most comprehensive primary source on Van Gogh is his correspondence with his younger brother, Theo. Their lifelong friendship, and most of what is known of Vincent's thoughts and theories of art, are recorded in the hundreds of letters they exchanged from 1872 until 1890. Theo van Gogh was an art dealer and provided his brother with financial and emotional support as well as access to influential people on the contemporary art scene.Theo kept all of Vincent's letters to him; but Vincent kept only a few of the letters he received. After both had died, Theo's widow Jo Bonger-van Gogh arranged for the publication of some of their letters. A few appeared in 1906 and 1913; the majority were published in 1914.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>0.792039</td>\n",
-       "      <td>He turned around and returned without making his presence known. It appears Breton was unaware of Van Gogh or his attempted visit. There are no known letters between the two artists and Van Gogh is not one of the contemporary artists discussed by Breton in his 1891 autobiography Life of an Artist.<br><br><br>== Life ==<br><br><br>=== Early years ===<br><br>Vincent Willem van Gogh was born on 30 March 1853 in Groot-Zundert, in the predominantly Catholic province of North Brabant in the Netherlands. He was the oldest surviving child of Theodorus van Gogh (1822–1885), a minister of the Dutch Reformed Church, and his wife, Anna Cornelia Carbentus (1819–1907). Van Gogh was given the name of his grandfather and of a brother stillborn exactly a year before his birth. Vincent was a common name in the Van Gogh family. The name had been borne by his grandfather, the prominent art dealer Vincent (1789–1874), and a theology graduate at the University of Leiden in 1811. This Vincent had six sons, three of whom became art dealers, and may have been named after his great-uncle, a sculptor (1729–1802).Van Gogh's mother came from a prosperous family in The Hague. His father was the youngest son of a minister. The two met when Anna's younger sister, Cornelia, married Theodorus's older brother Vincent (Cent). Van Gogh's parents married in May 1851 and moved to Zundert. His brother Theo was born on 1 May 1857. There was another brother, Cor, and three sisters: Elisabeth, Anna, and Willemina (known as \"Wil\"). In later life, Van Gogh remained in touch only with Willemina and Theo. Theodorus's salary as a minister was modest, but the Church also supplied the family with a house, a maid, two cooks, a gardener, a carriage and horse; his mother Anna instilled in the children a duty to uphold the family's high social position.Van Gogh was a serious and thoughtful child.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>0.792563</td>\n",
-       "      <td>The physician was not fond of the painting and used it to repair a chicken coop, then gave it away. In 2016, the portrait was housed at the Pushkin Museum of Fine Arts and estimated to be worth over $50 million.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Saint-Rémy (May 1889 – May 1890) ====<br><br>Van Gogh entered the Saint-Paul-de-Mausole asylum on 8 May 1889, accompanied by his caregiver, Frédéric Salles, a Protestant clergyman. Saint-Paul was a former monastery in Saint-Rémy, located less than 30 kilometres (19 mi) from Arles, and it was run by a former naval doctor, Théophile Peyron. Van Gogh had two cells with barred windows, one of which he used as a studio. The clinic and its garden became the main subjects of his paintings. He made several studies of the hospital's interiors, such as Vestibule of the Asylum and Saint-Rémy (September 1889), and its gardens, such as Lilacs (May 1889). Some of his works from this time are characterised by swirls, such as The Starry Night. He was allowed short supervised walks, during which time he painted cypresses and olive trees, including Valley with Ploughman Seen from Above, Olive Trees with the Alpilles in the Background 1889, Cypresses 1889, Cornfield with Cypresses (1889), Country road in Provence by Night (1890). In September 1889, he produced two further versions of Bedroom in Arles and The Gardener.Limited access to life outside the clinic resulted in a shortage of subject matter. Van Gogh instead worked on interpretations of other artist's paintings, such as Millet's The Sower and Noonday Rest, and variations on his own earlier work. Van Gogh was an admirer of the Realism of Jules Breton, Gustave Courbet and Millet, and he compared his copies to a musician's interpreting Beethoven.His Prisoners' Round (after Gustave Doré) (1890) was painted after an engraving by Gustave Doré (1832–1883).</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>0.792953</td>\n",
-       "      <td>One of his young peasant sitters became pregnant in September 1885; Van Gogh was accused of forcing himself upon her, and the village priest forbade parishioners to model for him.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>He moved to Antwerp that November and rented a room above a paint dealer's shop in the rue des Images (Lange Beeldekensstraat). He lived in poverty and ate poorly, preferring to spend the money Theo sent on painting materials and models. Bread, coffee and tobacco became his staple diet. In February 1886, he wrote to Theo that he could only remember eating six hot meals since the previous May. His teeth became loose and painful. In Antwerp he applied himself to the study of colour theory and spent time in museums—particularly studying the work of Peter Paul Rubens—and broadened his palette to include carmine, cobalt blue and emerald green. Van Gogh bought Japanese ukiyo-e woodcuts in the docklands, later incorporating elements of their style into the background of some of his paintings. He was drinking heavily again, and was hospitalised between February and March 1886, when he was possibly also treated for syphilis.<br><br>After his recovery, despite his antipathy towards academic teaching, he took the higher-level admission exams at the Academy of Fine Arts in Antwerp and, in January 1886, matriculated in painting and drawing. He became ill and run down by overwork, poor diet and excessive smoking. He started to attend drawing classes after plaster models at the Antwerp Academy on 18 January 1886. He quickly got into trouble with Charles Verlat, the director of the academy and teacher of a painting class, because of his unconventional painting style. Van Gogh had also clashed with the instructor of the drawing class Franz Vinck. Van Gogh finally started to attend the drawing classes after antique plaster models given by Eugène Siberdt. Soon Siberdt and Van Gogh came into conflict when the latter did not comply with Siberdt's requirement that drawings express the contour and concentrate on the line. When Van Gogh was required to draw the Venus de Milo during a drawing class, he produced the limbless, naked torso of a Flemish peasant woman.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>0.793931</td>\n",
-       "      <td>In September 1889, he produced two further versions of Bedroom in Arles and The Gardener.Limited access to life outside the clinic resulted in a shortage of subject matter. Van Gogh instead worked on interpretations of other artist's paintings, such as Millet's The Sower and Noonday Rest, and variations on his own earlier work. Van Gogh was an admirer of the Realism of Jules Breton, Gustave Courbet and Millet, and he compared his copies to a musician's interpreting Beethoven.His Prisoners' Round (after Gustave Doré) (1890) was painted after an engraving by Gustave Doré (1832–1883). Tralbaut suggests that the face of the prisoner in the centre of the painting looking towards the viewer is Van Gogh himself; Jan Hulsker discounts this.Between February and April 1890, Van Gogh suffered a severe relapse. Depressed and unable to bring himself to write, he was still able to paint and draw a little during this time, and he later wrote to Theo that he had made a few small canvases \"from memory ... reminisces of the North\". Among these was Two Peasant Women Digging in a Snow-Covered Field at Sunset. Hulsker believes that this small group of paintings formed the nucleus of many drawings and study sheets depicting landscapes and figures that Van Gogh worked on during this time. He comments that this short period was the only time that Van Gogh's illness had a significant effect on his work. Van Gogh asked his mother and his brother to send him drawings and rough work he had done in the early 1880s so he could work on new paintings from his old sketches. Belonging to this period is Sorrowing Old Man (\"At Eternity's Gate\"), a colour study Hulsker describes as \"another unmistakable remembrance of times long past\".</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>0.798987</td>\n",
-       "      <td>He grew more isolated and religiously fervent. His father and uncle arranged a transfer to Paris in 1875, where he became resentful of issues such as the degree to which the art dealers commodified art, and he was dismissed a year later.<br>In April 1876, he returned to England to take unpaid work as a supply teacher in a small boarding school in Ramsgate. When the proprietor moved to Isleworth in Middlesex, Van Gogh went with him. The arrangement was not successful; he left to become a Methodist minister's assistant. His parents had meanwhile moved to Etten; in 1876 he returned home at Christmas for six months and took work at a bookshop in Dordrecht. He was unhappy in the position, and spent his time doodling or translating passages from the Bible into English, French, and German. He immersed himself in Christianity and became increasingly pious and monastic. According to his flatmate of the time, Paulus van Görlitz, Van Gogh ate frugally, avoiding meat.To support his religious conviction and his desire to become a pastor, in 1877, the family sent him to live with his uncle Johannes Stricker, a respected theologian, in Amsterdam.  Van Gogh prepared for the University of Amsterdam theology entrance examination; he failed the exam and left his uncle's house in July 1878. He undertook, but also failed, a three-month course at a Protestant missionary school in Laken, near Brussels. In January 1879, he took up a post as a missionary at Petit-Wasmes in the working class, coal-mining district of Borinage in Belgium. To show support for his impoverished congregation, he gave up his comfortable lodgings at a bakery to a homeless person and moved to a small hut, where he slept on straw. His humble living conditions did not endear him to church authorities, who dismissed him for \"undermining the dignity of the priesthood\". He then walked the 75 kilometres (47 mi) to Brussels, returned briefly to Cuesmes in the Borinage, but he gave in to pressure from his parents to return home to Etten. He stayed there until around March 1880, which caused concern and frustration for his parents.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>0.800982</td>\n",
-       "      <td>\"Theo died in January 1891, removing Vincent's most vocal and well-connected champion. Theo's widow Johanna van Gogh-Bonger was a Dutchwoman in her twenties who had not known either her husband or her brother-in-law very long and who suddenly had to take care of several hundreds of paintings, letters and drawings, as well as her infant son, Vincent Willem van Gogh. Gauguin was not inclined to offer assistance in promoting Van Gogh's reputation, and Johanna's brother Andries Bonger also seemed lukewarm about his work. Aurier, one of Van Gogh's earliest supporters among the critics, died of typhoid fever in 1892 at the age of 27.<br>In 1892, Émile Bernard organised a small solo show of Van Gogh's paintings in Paris, and Julien Tanguy exhibited his Van Gogh paintings with several consigned from Johanna van Gogh-Bonger. In April 1894, the Durand-Ruel Gallery in Paris agreed to take 10 paintings on consignment from Van Gogh's estate. In 1896, the Fauvist painter Henri Matisse, then an unknown art student, visited John Russell on Belle Île off Brittany. Russell had been a close friend of Van Gogh; he introduced Matisse to the Dutchman's work, and gave him a Van Gogh drawing. Influenced by Van Gogh, Matisse abandoned his earth-coloured palette for bright colours.In Paris in 1901, a large Van Gogh retrospective was held at the Bernheim-Jeune Gallery, which excited André Derain and Maurice de Vlaminck, and contributed to the emergence of Fauvism. Important group exhibitions took place with the Sonderbund artists in Cologne in 1912, the Armory Show, New York in 1913, and Berlin in 1914. Henk Bremmer was instrumental in teaching and talking about Van Gogh, and introduced Helene Kröller-Müller to Van Gogh's art; she became an avid collector of his work. The early figures in German Expressionism such as Emil Nolde acknowledged a debt to Van Gogh's work.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31</th>\n",
-       "      <td>0.801200</td>\n",
-       "      <td>==== Orchards ====<br><br>The Flowering Orchards (also the Orchards in Blossom) are among the first groups of work completed after Van Gogh's arrival in Arles in February 1888. The 14 paintings are optimistic, joyous and visually expressive of the burgeoning spring. They are delicately sensitive and unpopulated. He painted swiftly, and although he brought to this series a version of Impressionism, a strong sense of personal style began to emerge during this period. The transience of the blossoming trees, and the passing of the season, seemed to align with his sense of impermanence and belief in a new beginning in Arles. During the blossoming of the trees that spring, he found \"a world of motifs that could not have been more Japanese\". Vincent wrote to Theo on 21 April 1888 that he had 10 orchards and \"one big [painting] of a cherry tree, which I've spoiled\".During this period Van Gogh mastered the use of light by subjugating shadows and painting the trees as if they are the source of light – almost in a sacred manner. Early the following year he painted another smaller group of orchards, including View of Arles, Flowering Orchards. Van Gogh was enthralled by the landscape and vegetation of the south of France, and often visited the farm gardens near Arles. In the vivid light of the Mediterranean climate his palette significantly brightened.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>32</th>\n",
-       "      <td>0.801701</td>\n",
-       "      <td>Within days he left for Amsterdam. Kee would not meet him, and her parents wrote that his \"persistence is disgusting\". In despair, he held his left hand in the flame of a lamp, with the words: \"Let me see her for as long as I can keep my hand in the flame.\" He did not recall the event well, but later assumed that his uncle had blown out the flame. Kee's father made it clear that her refusal should be heeded and that the two would not marry, largely because of Van Gogh's inability to support himself.Mauve took Van Gogh on as a student and introduced him to watercolour, which he worked on for the next month before returning home for Christmas. He quarrelled with his father, refusing to attend church, and left for The Hague. In January 1882, Mauve introduced him to painting in oil and lent him money to set up a studio. Within a month Van Gogh and Mauve fell out, possibly over the viability of drawing from plaster casts. Van Gogh could afford to hire only people from the street as models, a practice of which Mauve seems to have disapproved. In June, Van Gogh suffered a bout of gonorrhoea and spent three weeks in hospital. Soon after, he first painted in oils, bought with money borrowed from Theo. He liked the medium, and he spread the paint liberally, scraping from the canvas and working back with the brush. He wrote that he was surprised at how good the results were.<br>By March 1882, Mauve appeared to have gone cold towards Van Gogh, and he stopped replying to his letters. He had learned of Van Gogh's new domestic arrangement with an alcoholic prostitute, Clasina Maria \"Sien\" Hoornik (1850–1904), and her young daughter. Van Gogh had met Sien towards the end of January 1882, when she had a five-year-old daughter and was pregnant. She had previously borne two children who died, but Van Gogh was unaware of this. On 2 July, she gave birth to a baby boy, Willem.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>33</th>\n",
-       "      <td>0.803687</td>\n",
-       "      <td>He comments that this short period was the only time that Van Gogh's illness had a significant effect on his work. Van Gogh asked his mother and his brother to send him drawings and rough work he had done in the early 1880s so he could work on new paintings from his old sketches. Belonging to this period is Sorrowing Old Man (\"At Eternity's Gate\"), a colour study Hulsker describes as \"another unmistakable remembrance of times long past\". His late paintings show an artist at the height of his abilities, according to the art critic Robert Hughes, \"longing for concision and grace\".After the birth of his nephew, Van Gogh wrote, \"I started right away to make a picture for him, to hang in their bedroom, branches of white almond blossom against a blue sky.\"<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== 1890 Exhibitions and recognition ====<br>See also Vincent van Gogh's display at Les XX, 1890<br>Albert Aurier praised his work in the Mercure de France in January 1890 and described him as \"a genius\". In February, Van Gogh painted five versions of L'Arlésienne (Madame Ginoux), based on a charcoal sketch Gauguin had produced when she sat for both artists in November 1888. Also in February, Van Gogh was invited by Les XX, a society of avant-garde painters in Brussels, to participate in their annual exhibition. At the opening dinner a Les XX member, Henry de Groux, insulted Van Gogh's work. Toulouse-Lautrec demanded satisfaction, and Signac declared he would continue to fight for Van Gogh's honour if Lautrec surrendered. De Groux apologised for the slight and left the group.From 20 March to 27 April 1890, Van Gogh was included in the sixth exhibition of the Société des Artistes Indépendants in the Pavillon de la Ville de Paris on the Champs-Elysées. Van Gogh exhibited ten paintings. While the exhibition was on display with the Artistes Indépendants in Paris, Claude Monet said that Van Gogh's work was the best in the show.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>34</th>\n",
-       "      <td>0.804031</td>\n",
-       "      <td>He registered at the Académie in November 1880, where he studied anatomy and the standard rules of modelling and perspective.<br><br><br>=== Etten, Drenthe and The Hague ===<br><br>Van Gogh returned to Etten in April 1881 for an extended stay with his parents. He continued to draw, often using his neighbours as subjects. In August 1881, his recently widowed cousin, Cornelia \"Kee\" Vos-Stricker, daughter of his mother's older sister Willemina and Johannes Stricker, arrived for a visit. He was thrilled and took long walks with her. Kee was seven years older than he was and had an eight-year-old son. Van Gogh surprised everyone by declaring his love to her and proposing marriage. She refused with the words \"No, nay, never\" (\"nooit, neen, nimmer\"). After Kee returned to Amsterdam, Van Gogh went to The Hague to try to sell paintings and to meet with his second cousin, Anton Mauve. Mauve was the successful artist Van Gogh longed to be. Mauve invited him to return in a few months and suggested he spend the intervening time working in charcoal and pastels; Van Gogh returned to Etten and followed this advice.Late in November 1881, Van Gogh wrote a letter to Johannes Stricker, one which he described to Theo as an attack. Within days he left for Amsterdam. Kee would not meet him, and her parents wrote that his \"persistence is disgusting\". In despair, he held his left hand in the flame of a lamp, with the words: \"Let me see her for as long as I can keep my hand in the flame.\" He did not recall the event well, but later assumed that his uncle had blown out the flame. Kee's father made it clear that her refusal should be heeded and that the two would not marry, largely because of Van Gogh's inability to support himself.Mauve took Van Gogh on as a student and introduced him to watercolour, which he worked on for the next month before returning home for Christmas. He quarrelled with his father, refusing to attend church, and left for The Hague.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>35</th>\n",
-       "      <td>0.804749</td>\n",
-       "      <td>He turned to religion and spent time as a missionary in southern Belgium. Later he drifted into ill-health and solitude. He was keenly aware of modernist trends in art and, while back with his parents, took up painting in 1881. His younger brother, Theo, supported him financially, and the two of them maintained a long correspondence.<br>Van Gogh's early works consist of mostly still lifes and depictions of peasant laborers. In 1886, he moved to Paris, where he met members of the artistic avant-garde, including Émile Bernard and Paul Gauguin, who were seeking new paths beyond Impressionism. Frustrated in Paris and inspired by a growing spirit of artistic change and collaboration, in February 1888, Van Gogh moved to Arles in southern France to establish an artistic retreat and commune. Once there, Van Gogh's art changed. His paintings grew brighter and he turned his attention to the natural world, depicting local olive groves, wheat fields and sunflowers. Van Gogh invited Gauguin to join him in Arles and eagerly anticipated Gauguin's arrival in the fall of 1888.<br>Van Gogh suffered from psychotic episodes and delusions. Though he worried about his mental stability, he often neglected his physical health, did not eat properly and drank heavily. His friendship with Gauguin ended after a confrontation with a razor when, in a rage, he severed his left ear. Van Gogh spent time in psychiatric hospitals, including a period at Saint-Rémy. After he discharged himself and moved to the Auberge Ravoux in Auvers-sur-Oise near Paris, he came under the care of the homeopathic doctor Paul Gachet. His depression persisted, and on 27 July 1890, Van Gogh is believed to have shot himself in the chest with a revolver, dying from his injuries two days later.<br>Van Gogh's work began to attract critical artistic attention in the last year of his life. After his death, Van Gogh's art and life story captured public imagination as an emblem of misunderstood genius, due in large part to the efforts of his widowed sister-in-law Johanna van Gogh-Bonger.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36</th>\n",
-       "      <td>0.805063</td>\n",
-       "      <td>There are 22 to his sister Wil, 58 to the painter Anthon van Rappard, 22 to Émile Bernard as well as individual letters to Paul Signac, Paul Gauguin, and the critic Albert Aurier. Some are illustrated with sketches. Many are undated, but art historians have been able to place most in chronological order. Problems in transcription and dating remain, mainly with those posted from Arles. While there, Vincent wrote around 200 letters in Dutch, French, and English. There is a gap in the record when he lived in Paris as the brothers lived together and had no need to correspond.The highly paid contemporary artist Jules Breton was frequently mentioned in Vincent's letters. In 1875 letters to Theo, Vincent mentions he saw Breton, discusses the Breton paintings he saw at a Salon, and discusses sending one of Breton's books but only on the condition that it be returned. In a March 1884 letter to Rappard he discusses one of Breton's poems that had inspired one of his paintings. In 1885 he describes Breton's famous work The Song of the Lark as being \"fine\". In March 1880, roughly midway between these letters, Van Gogh set out on an 80-kilometre trip on foot to meet with Breton in the village of Courrières; however, he was intimidated by Breton's success and/or the high wall around his estate. He turned around and returned without making his presence known. It appears Breton was unaware of Van Gogh or his attempted visit. There are no known letters between the two artists and Van Gogh is not one of the contemporary artists discussed by Breton in his 1891 autobiography Life of an Artist.<br><br><br>== Life ==<br><br><br>=== Early years ===<br><br>Vincent Willem van Gogh was born on 30 March 1853 in Groot-Zundert, in the predominantly Catholic province of North Brabant in the Netherlands. He was the oldest surviving child of Theodorus van Gogh (1822–1885), a minister of the Dutch Reformed Church, and his wife, Anna Cornelia Carbentus (1819–1907).</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>37</th>\n",
-       "      <td>0.806510</td>\n",
-       "      <td>He became ill and run down by overwork, poor diet and excessive smoking. He started to attend drawing classes after plaster models at the Antwerp Academy on 18 January 1886. He quickly got into trouble with Charles Verlat, the director of the academy and teacher of a painting class, because of his unconventional painting style. Van Gogh had also clashed with the instructor of the drawing class Franz Vinck. Van Gogh finally started to attend the drawing classes after antique plaster models given by Eugène Siberdt. Soon Siberdt and Van Gogh came into conflict when the latter did not comply with Siberdt's requirement that drawings express the contour and concentrate on the line. When Van Gogh was required to draw the Venus de Milo during a drawing class, he produced the limbless, naked torso of a Flemish peasant woman. Siberdt regarded this as defiance against his artistic guidance and made corrections to Van Gogh's drawing with his crayon so vigorously that he tore the paper. Van Gogh then flew into a violent rage and shouted at Siberdt: 'You clearly do not know what a young woman is like, God damn it! A woman must have hips, buttocks, a pelvis in which she can carry a baby!' According to some accounts, this was the last time Van Gogh attended classes at the academy and he left later for Paris. On 31 March 1886, which was about a month after the confrontation with Siberdt, the teachers of the academy decided that 17 students, including Van Gogh, had to repeat a year. The story that Van Gogh was expelled from the academy by Siberdt is therefore unfounded.<br><br><br>==== Paris (1886–1888) ====<br><br>Van Gogh moved to Paris in March 1886 where he shared Theo's rue Laval apartment in Montmartre and studied at Fernand Cormon's studio. In June the brothers took a larger flat at 54 rue Lepic. In Paris, Vincent painted portraits of friends and acquaintances, still life paintings, views of Le Moulin de la Galette, scenes in Montmartre, Asnières and along the Seine.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38</th>\n",
-       "      <td>0.807259</td>\n",
-       "      <td>He undertook, but also failed, a three-month course at a Protestant missionary school in Laken, near Brussels. In January 1879, he took up a post as a missionary at Petit-Wasmes in the working class, coal-mining district of Borinage in Belgium. To show support for his impoverished congregation, he gave up his comfortable lodgings at a bakery to a homeless person and moved to a small hut, where he slept on straw. His humble living conditions did not endear him to church authorities, who dismissed him for \"undermining the dignity of the priesthood\". He then walked the 75 kilometres (47 mi) to Brussels, returned briefly to Cuesmes in the Borinage, but he gave in to pressure from his parents to return home to Etten. He stayed there until around March 1880, which caused concern and frustration for his parents. His father was especially frustrated and advised that his son be committed to the lunatic asylum in Geel.Van Gogh returned to Cuesmes in August 1880, where he lodged with a miner until October. He became interested in the people and scenes around him, and he recorded them in drawings after Theo's suggestion that he take up art in earnest. He traveled to Brussels later in the year, to follow Theo's recommendation that he study with the Dutch artist Willem Roelofs, who persuaded him – in spite of his dislike of formal schools of art – to attend the Académie Royale des Beaux-Arts. He registered at the Académie in November 1880, where he studied anatomy and the standard rules of modelling and perspective.<br><br><br>=== Etten, Drenthe and The Hague ===<br><br>Van Gogh returned to Etten in April 1881 for an extended stay with his parents. He continued to draw, often using his neighbours as subjects. In August 1881, his recently widowed cousin, Cornelia \"Kee\" Vos-Stricker, daughter of his mother's older sister Willemina and Johannes Stricker, arrived for a visit. He was thrilled and took long walks with her. Kee was seven years older than he was and had an eight-year-old son. Van Gogh surprised everyone by declaring his love to her and proposing marriage.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>39</th>\n",
-       "      <td>0.816479</td>\n",
-       "      <td>==== Hospital in Arles (December 1888) ====<br><br>The exact sequence that led to the mutilation of van Gogh's ear is not known. Gauguin said, fifteen years later, that the night followed several instances of physically threatening behaviour. Their relationship was complex and Theo may have owed money to Gauguin, who suspected the brothers were exploiting him financially. It seems likely that Vincent realised that Gauguin was planning to leave. The following days saw heavy rain, leading to the two men being shut in the Yellow House. Gauguin recalled that Van Gogh followed him after he left for a walk and \"rushed towards me, an open razor in his hand.\" This account is uncorroborated; Gauguin was almost certainly absent from the Yellow House that night, most likely staying in a hotel.After an altercation on the evening of 23 December 1888, Van Gogh returned to his room where he seemingly heard voices and either wholly or in part severed his left ear with a razor causing severe bleeding. He bandaged the wound, wrapped the ear in paper and delivered the package to a woman at a brothel Van Gogh and Gauguin both frequented. Van Gogh was found unconscious the next morning by a policeman and taken to hospital, where he was treated by Félix Rey, a young doctor still in training. The ear was brought to the hospital, but Rey did not attempt to reattach it as too much time had passed. Van Gogh researcher and art historian Bernadette Murphy discovered the true identity of the woman named Gabrielle, who died in Arles at the age of 80 in 1952, and whose descendants still lived (as of 2020) just outside Arles. Gabrielle, known in her youth as \"Gaby,\" was a 17-year-old cleaning girl at the brothel and other local establishments at the time Van Gogh presented her with his ear.Van Gogh had no recollection of the event, suggesting that he may have suffered an acute mental breakdown. The hospital diagnosis was \"acute mania with generalised delirium\", and within a few days, the local police ordered that he be placed in hospital care.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>40</th>\n",
-       "      <td>0.819207</td>\n",
-       "      <td>The ear was brought to the hospital, but Rey did not attempt to reattach it as too much time had passed. Van Gogh researcher and art historian Bernadette Murphy discovered the true identity of the woman named Gabrielle, who died in Arles at the age of 80 in 1952, and whose descendants still lived (as of 2020) just outside Arles. Gabrielle, known in her youth as \"Gaby,\" was a 17-year-old cleaning girl at the brothel and other local establishments at the time Van Gogh presented her with his ear.Van Gogh had no recollection of the event, suggesting that he may have suffered an acute mental breakdown. The hospital diagnosis was \"acute mania with generalised delirium\", and within a few days, the local police ordered that he be placed in hospital care. Gauguin immediately notified Theo, who, on 24 December, had proposed marriage to his old friend Andries Bonger's sister Johanna. That evening, Theo rushed to the station to board a night train to Arles. He arrived on Christmas Day and comforted Vincent, who seemed to be semi-lucid. That evening, he left Arles for the return trip to Paris.During the first days of his treatment, Van Gogh repeatedly and unsuccessfully asked for Gauguin, who asked a policeman attending the case to \"be kind enough, Monsieur, to awaken this man with great care, and if he asks for me tell him I have left for Paris; the sight of me might prove fatal for him.\" Gauguin fled Arles, never to see Van Gogh again. They continued to correspond, and in 1890, Gauguin proposed they form a studio in Antwerp. Meanwhile, other visitors to the hospital included Marie Ginoux and Roulin.Despite a pessimistic diagnosis, Van Gogh recovered and returned to the Yellow House on 7 January 1889. He spent the following month between hospital and home, suffering from hallucinations and delusions of poisoning. In March, the police closed his house after a petition by 30 townspeople (including the Ginoux family) who described him as le fou roux \"the redheaded madman\"; Van Gogh returned to hospital.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>41</th>\n",
-       "      <td>0.820484</td>\n",
-       "      <td>Two years later, Vincent and Theo paid for the publication of a book on Monticelli paintings, and Vincent bought some of Monticelli's works to add to his collection.Van Gogh learned about Fernand Cormon's atelier from Theo. He worked at the studio in April and May 1886, where he frequented the circle of the Australian artist John Russell, who painted his portrait in 1886. Van Gogh also met fellow students Émile Bernard, Louis Anquetin and Henri de Toulouse-Lautrec – who painted a portrait of him in pastel. They met at Julien \"Père\" Tanguy's paint shop, (which was, at that time, the only place where Paul Cézanne's paintings were displayed). In 1886, two large exhibitions were staged there, showing Pointillism and Neo-impressionism for the first time and bringing attention to Georges Seurat and Paul Signac. Theo kept a stock of Impressionist paintings in his gallery on boulevard Montmartre, but Van Gogh was slow to acknowledge the new developments in art.Conflicts arose between the brothers. At the end of 1886 Theo found living with Vincent to be \"almost unbearable\". By early 1887, they were again at peace, and Vincent had moved to Asnières, a northwestern suburb of Paris, where he got to know Signac. He adopted elements of Pointillism, a technique in which a multitude of small coloured dots are applied to the canvas so that when seen from a distance they create an optical blend of hues. The style stresses the ability of complementary colours – including blue and orange – to form vibrant contrasts.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>While in Asnières Van Gogh painted parks, restaurants and the Seine, including Bridges across the Seine at Asnières. In November 1887, Theo and Vincent befriended Paul Gauguin who had just arrived in Paris. Towards the end of the year, Vincent arranged an exhibition alongside Bernard, Anquetin, and probably Toulouse-Lautrec, at the Grand-Bouillon Restaurant du Chalet, 43 avenue de Clichy, Montmartre. In a contemporary account, Bernard wrote that the exhibition was ahead of anything else in Paris.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>42</th>\n",
-       "      <td>0.820913</td>\n",
-       "      <td>According to some accounts, this was the last time Van Gogh attended classes at the academy and he left later for Paris. On 31 March 1886, which was about a month after the confrontation with Siberdt, the teachers of the academy decided that 17 students, including Van Gogh, had to repeat a year. The story that Van Gogh was expelled from the academy by Siberdt is therefore unfounded.<br><br><br>==== Paris (1886–1888) ====<br><br>Van Gogh moved to Paris in March 1886 where he shared Theo's rue Laval apartment in Montmartre and studied at Fernand Cormon's studio. In June the brothers took a larger flat at 54 rue Lepic. In Paris, Vincent painted portraits of friends and acquaintances, still life paintings, views of Le Moulin de la Galette, scenes in Montmartre, Asnières and along the Seine. In 1885 in Antwerp he had become interested in Japanese ukiyo-e woodblock prints and had used them to decorate the walls of his studio; while in Paris he collected hundreds of them. He tried his hand at Japonaiserie, tracing a figure from a reproduction on the cover of the magazine Paris Illustre, The Courtesan or Oiran (1887), after Keisai Eisen, which he then graphically enlarged in a painting.After seeing the portrait of Adolphe Monticelli at the Galerie Delareybarette, Van Gogh adopted a brighter palette and a bolder attack, particularly in paintings such as his Seascape at Saintes-Maries (1888). Two years later, Vincent and Theo paid for the publication of a book on Monticelli paintings, and Vincent bought some of Monticelli's works to add to his collection.Van Gogh learned about Fernand Cormon's atelier from Theo. He worked at the studio in April and May 1886, where he frequented the circle of the Australian artist John Russell, who painted his portrait in 1886. Van Gogh also met fellow students Émile Bernard, Louis Anquetin and Henri de Toulouse-Lautrec – who painted a portrait of him in pastel.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>43</th>\n",
-       "      <td>0.823414</td>\n",
-       "      <td>==== Auvers-sur-Oise (May–July 1890) ====<br><br>In May 1890, Van Gogh left the clinic in Saint-Rémy to move nearer to both Dr Paul Gachet in the Paris suburb of Auvers-sur-Oise and to Theo. Gachet was an amateur painter and had treated several other artists – Camille Pissarro had recommended him. Van Gogh's first impression was that Gachet was \"iller than I am, it seemed to me, or let's say just as much.\"The painter Charles Daubigny moved to Auvers in 1861 and in turn drew other artists there, including Camille Corot and Honoré Daumier. In July 1890, Van Gogh completed two paintings of Daubigny's Garden, one of which is likely his final work.<br>During his last weeks at Saint-Rémy, his thoughts returned to \"memories of the North\", and several of the approximately 70 oils, painted during as many days in Auvers-sur-Oise, are reminiscent of northern scenes. In June 1890, he painted several portraits of his doctor, including Portrait of Dr Gachet, and his only etching. In each the emphasis is on Gachet's melancholic disposition. There are other paintings which are probably unfinished, including Thatched Cottages by a Hill.In July, Van Gogh wrote that he had become absorbed \"in the immense plain against the hills, boundless as the sea, delicate yellow\". He had first become captivated by the fields in May, when the wheat was young and green. In July, he described to Theo \"vast fields of wheat under turbulent skies\".He wrote that they represented his \"sadness and extreme loneliness\" and that the \"canvases will tell you what I cannot say in words, that is, how healthy and invigorating I find the countryside\". Wheatfield with Crows, although not his last oil work, is from July 1890 and Hulsker discusses it as being associated with \"melancholy and extreme loneliness\". Hulsker identifies seven oil paintings from Auvers that follow the completion of Wheatfield with Crows. Hulsker also expressed concern about the number of paintings attributed to Van Gogh from the period.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>44</th>\n",
-       "      <td>0.823965</td>\n",
-       "      <td>He adopted elements of Pointillism, a technique in which a multitude of small coloured dots are applied to the canvas so that when seen from a distance they create an optical blend of hues. The style stresses the ability of complementary colours – including blue and orange – to form vibrant contrasts.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>While in Asnières Van Gogh painted parks, restaurants and the Seine, including Bridges across the Seine at Asnières. In November 1887, Theo and Vincent befriended Paul Gauguin who had just arrived in Paris. Towards the end of the year, Vincent arranged an exhibition alongside Bernard, Anquetin, and probably Toulouse-Lautrec, at the Grand-Bouillon Restaurant du Chalet, 43 avenue de Clichy, Montmartre. In a contemporary account, Bernard wrote that the exhibition was ahead of anything else in Paris. There, Bernard and Anquetin sold their first paintings, and Van Gogh exchanged work with Gauguin. Discussions on art, artists, and their social situations started during this exhibition, continued and expanded to include visitors to the show, like Camille Pissarro and his son Lucien, Signac and Seurat. In February 1888, feeling worn out from life in Paris, Van Gogh left, having painted more than 200 paintings during his two years there. Hours before his departure, accompanied by Theo, he paid his first and only visit to Seurat in his studio.<br><br><br>=== Artistic breakthrough ===<br><br><br>==== Arles (1888–89) ====<br><br>Ill from drink and suffering from smoker's cough, in February 1888, Van Gogh sought refuge in Arles. He seems to have moved with thoughts of founding an art colony. The Danish artist Christian Mourier-Petersen was his companion for two months and at first, Arles appeared exotic to Van Gogh. In a letter, he described it as a foreign country: \"The Zouaves, the brothels, the adorable little Arlésienne going to her First Communion, the priest in his surplice, who looks like a dangerous rhinoceros, the people drinking absinthe, all seem to me creatures from another world.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>45</th>\n",
-       "      <td>0.828397</td>\n",
-       "      <td>In April, he was visited by the American artist Dodge MacKnight, who was living nearby at Fontvieille.On 1 May 1888,  Van Gogh signed a lease for four rooms in  the Yellow House.  The house at 2 place Lamartine cost 15 francs per month. The rooms were unfurnished and had been uninhabited for months. Because the Yellow House had to be furnished before he could fully move in, Van Gogh moved from the Hôtel Carrel to the Café de la Gare on 7 May 1888. He had befriended the Yellow House's proprietors, Joseph and Marie Ginoux, and was able to use it as a studio. Van Gogh wanted a gallery to display his work and started a series of paintings that eventually included Van Gogh's Chair (1888), Bedroom in Arles (1888), The Night Café (1888), Café Terrace at Night (September 1888), Starry Night Over the Rhone (1888), and Still Life: Vase with Twelve Sunflowers (1888), all intended for the decoration for the Yellow House.Van Gogh wrote that with The Night Café he tried \"to express the idea that the café is a place where one can ruin oneself, go mad, or commit a crime\". When he visited Saintes-Maries-de-la-Mer in June, he gave lessons to a Zouave second lieutenant – Paul-Eugène Milliet – and painted boats on the sea and the village. MacKnight introduced Van Gogh to Eugène Boch, a Belgian painter who sometimes stayed in Fontvieille, and the two exchanged visits in July.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Gauguin's visit (1888) ====<br> <br>When Gauguin agreed to visit Arles in 1888, Van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>46</th>\n",
-       "      <td>0.838895</td>\n",
-       "      <td>Hours before his departure, accompanied by Theo, he paid his first and only visit to Seurat in his studio.<br><br><br>=== Artistic breakthrough ===<br><br><br>==== Arles (1888–89) ====<br><br>Ill from drink and suffering from smoker's cough, in February 1888, Van Gogh sought refuge in Arles. He seems to have moved with thoughts of founding an art colony. The Danish artist Christian Mourier-Petersen was his companion for two months and at first, Arles appeared exotic to Van Gogh. In a letter, he described it as a foreign country: \"The Zouaves, the brothels, the adorable little Arlésienne going to her First Communion, the priest in his surplice, who looks like a dangerous rhinoceros, the people drinking absinthe, all seem to me creatures from another world.\"The time in Arles was one of Van Gogh's more prolific periods: he completed 200 paintings and more than 100 drawings and watercolors. He was energized by the local countryside and light; his works from this period are rich in yellow, ultramarine and mauve. They include harvests, wheat fields and general rural landmarks from the area, including The Old Mill (1888), one of seven canvases sent to Pont-Aven on 4 October 1888 in an exchange of works with Paul Gauguin, Émile Bernard, Charles Laval and others.In March 1888, Van Gogh created landscapes using a gridded \"perspective frame\"and three of those works were shown at the annual exhibition of the Société des Artistes Indépendants. In April, he was visited by the American artist Dodge MacKnight, who was living nearby at Fontvieille.On 1 May 1888,  Van Gogh signed a lease for four rooms in  the Yellow House.  The house at 2 place Lamartine cost 15 francs per month. The rooms were unfurnished and had been uninhabited for months. Because the Yellow House had to be furnished before he could fully move in, Van Gogh moved from the Hôtel Carrel to the Café de la Gare on 7 May 1888.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>47</th>\n",
-       "      <td>0.848972</td>\n",
-       "      <td>When he visited Saintes-Maries-de-la-Mer in June, he gave lessons to a Zouave second lieutenant – Paul-Eugène Milliet – and painted boats on the sea and the village. MacKnight introduced Van Gogh to Eugène Boch, a Belgian painter who sometimes stayed in Fontvieille, and the two exchanged visits in July.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Gauguin's visit (1888) ====<br> <br>When Gauguin agreed to visit Arles in 1888, Van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.\"When Boch visited again, Van Gogh painted a portrait of him, as well as the study The Poet Against a Starry Sky.In preparation for Gauguin's visit, Van Gogh bought two beds on advice from the station's postal supervisor Joseph Roulin, whose portrait he painted. On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>48</th>\n",
-       "      <td>0.849399</td>\n",
-       "      <td>On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps. The single painting Gauguin completed during his visit was his portrait of Van Gogh.Van Gogh and Gauguin visited Montpellier in December 1888, where they saw works by Courbet and Delacroix in the Musée Fabre. Their relationship began to deteriorate; Van Gogh admired Gauguin and wanted to be treated as his equal, but Gauguin was arrogant and domineering, which frustrated Van Gogh. They often quarrelled; Van Gogh increasingly feared that Gauguin was going to desert him, and the situation, which Van Gogh described as one of \"excessive tension\", rapidly headed towards crisis point.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Hospital in Arles (December 1888) ====<br><br>The exact sequence that led to the mutilation of van Gogh's ear is not known. Gauguin said, fifteen years later, that the night followed several instances of physically threatening behaviour. Their relationship was complex and Theo may have owed money to Gauguin, who suspected the brothers were exploiting him financially. It seems likely that Vincent realised that Gauguin was planning to leave. The following days saw heavy rain, leading to the two men being shut in the Yellow House. Gauguin recalled that Van Gogh followed him after he left for a walk and \"rushed towards me, an open razor in his hand.\"</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>49</th>\n",
-       "      <td>0.851540</td>\n",
-       "      <td>Gauguin fled Arles, never to see Van Gogh again. They continued to correspond, and in 1890, Gauguin proposed they form a studio in Antwerp. Meanwhile, other visitors to the hospital included Marie Ginoux and Roulin.Despite a pessimistic diagnosis, Van Gogh recovered and returned to the Yellow House on 7 January 1889. He spent the following month between hospital and home, suffering from hallucinations and delusions of poisoning. In March, the police closed his house after a petition by 30 townspeople (including the Ginoux family) who described him as le fou roux \"the redheaded madman\"; Van Gogh returned to hospital. Paul Signac visited him twice in March; in April, Van Gogh moved into rooms owned by Dr Rey after floods damaged paintings in his own home. Two months later, he left Arles and voluntarily entered an asylum in Saint-Rémy-de-Provence. Around this time, he wrote, \"Sometimes moods of indescribable anguish, sometimes moments when the veil of time and fatality of circumstances seemed to be torn apart for an instant.\"Van Gogh gave his 1889 Portrait of Doctor Félix Rey to Dr Rey. The physician was not fond of the painting and used it to repair a chicken coop, then gave it away. In 2016, the portrait was housed at the Pushkin Museum of Fine Arts and estimated to be worth over $50 million.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Saint-Rémy (May 1889 – May 1890) ====<br><br>Van Gogh entered the Saint-Paul-de-Mausole asylum on 8 May 1889, accompanied by his caregiver, Frédéric Salles, a Protestant clergyman. Saint-Paul was a former monastery in Saint-Rémy, located less than 30 kilometres (19 mi) from Arles, and it was run by a former naval doctor, Théophile Peyron. Van Gogh had two cells with barred windows, one of which he used as a studio. The clinic and its garden became the main subjects of his paintings.</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "new_nodes = get_retrieved_nodes_mixed(\n",
-    "    \"Which date did Paul Gauguin arrive in Arles?\",\n",
-    "    vector_top_k=50,\n",
-    "    with_reranker=False,\n",
-    ")\n",
-    "\n",
-    "visualize_retrieved_nodes(new_nodes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Retrieve and Rerank reversed top 50 results using RankZephyr and return top 3\n",
-    "\n",
-    "The sliding window size is 20, with a step size of 10."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2c4dcb9f943a4895a338039e11e85b04",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Loading checkpoint shards:   0%|          | 0/3 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:14<00:00, 14.69s/it]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Score</th>\n",
-       "      <th>Text</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0.849399</td>\n",
-       "      <td>On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps. The single painting Gauguin completed during his visit was his portrait of Van Gogh.Van Gogh and Gauguin visited Montpellier in December 1888, where they saw works by Courbet and Delacroix in the Musée Fabre. Their relationship began to deteriorate; Van Gogh admired Gauguin and wanted to be treated as his equal, but Gauguin was arrogant and domineering, which frustrated Van Gogh. They often quarrelled; Van Gogh increasingly feared that Gauguin was going to desert him, and the situation, which Van Gogh described as one of \"excessive tension\", rapidly headed towards crisis point.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Hospital in Arles (December 1888) ====<br><br>The exact sequence that led to the mutilation of van Gogh's ear is not known. Gauguin said, fifteen years later, that the night followed several instances of physically threatening behaviour. Their relationship was complex and Theo may have owed money to Gauguin, who suspected the brothers were exploiting him financially. It seems likely that Vincent realised that Gauguin was planning to leave. The following days saw heavy rain, leading to the two men being shut in the Yellow House. Gauguin recalled that Van Gogh followed him after he left for a walk and \"rushed towards me, an open razor in his hand.\"</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.848972</td>\n",
-       "      <td>When he visited Saintes-Maries-de-la-Mer in June, he gave lessons to a Zouave second lieutenant – Paul-Eugène Milliet – and painted boats on the sea and the village. MacKnight introduced Van Gogh to Eugène Boch, a Belgian painter who sometimes stayed in Fontvieille, and the two exchanged visits in July.<br><br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br>\\t\\t<br>\\t\\t\\t<br>\\t\\t\\t<br>\\t\\t<br><br><br>==== Gauguin's visit (1888) ====<br> <br>When Gauguin agreed to visit Arles in 1888, Van Gogh hoped for friendship and to realize his idea of an artists' collective. Van Gogh prepared for Gauguin's arrival by painting four versions of Sunflowers in one week. \"In the hope of living in a studio of our own with Gauguin,\" he wrote in a letter to Theo, \"I'd like to do a decoration for the studio. Nothing but large Sunflowers.\"When Boch visited again, Van Gogh painted a portrait of him, as well as the study The Poet Against a Starry Sky.In preparation for Gauguin's visit, Van Gogh bought two beds on advice from the station's postal supervisor Joseph Roulin, whose portrait he painted. On 17 September, he spent his first night in the still sparsely furnished Yellow House. When Gauguin consented to work and live in Arles with him, Van Gogh started to work on the Décoration for the Yellow House, probably the most ambitious effort he ever undertook. He completed two chair paintings: Van Gogh's Chair and Gauguin's Chair.After much pleading from Van Gogh, Gauguin arrived in Arles on 23 October and, in November, the two painted together. Gauguin depicted Van Gogh in his The Painter of Sunflowers; Van Gogh painted pictures from memory, following Gauguin's suggestion. Among these \"imaginative\" paintings is Memory of the Garden at Etten. Their first joint outdoor venture was at the Alyscamps, when they produced the pendants Les Alyscamps.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.804749</td>\n",
-       "      <td>He turned to religion and spent time as a missionary in southern Belgium. Later he drifted into ill-health and solitude. He was keenly aware of modernist trends in art and, while back with his parents, took up painting in 1881. His younger brother, Theo, supported him financially, and the two of them maintained a long correspondence.<br>Van Gogh's early works consist of mostly still lifes and depictions of peasant laborers. In 1886, he moved to Paris, where he met members of the artistic avant-garde, including Émile Bernard and Paul Gauguin, who were seeking new paths beyond Impressionism. Frustrated in Paris and inspired by a growing spirit of artistic change and collaboration, in February 1888, Van Gogh moved to Arles in southern France to establish an artistic retreat and commune. Once there, Van Gogh's art changed. His paintings grew brighter and he turned his attention to the natural world, depicting local olive groves, wheat fields and sunflowers. Van Gogh invited Gauguin to join him in Arles and eagerly anticipated Gauguin's arrival in the fall of 1888.<br>Van Gogh suffered from psychotic episodes and delusions. Though he worried about his mental stability, he often neglected his physical health, did not eat properly and drank heavily. His friendship with Gauguin ended after a confrontation with a razor when, in a rage, he severed his left ear. Van Gogh spent time in psychiatric hospitals, including a period at Saint-Rémy. After he discharged himself and moved to the Auberge Ravoux in Auvers-sur-Oise near Paris, he came under the care of the homeopathic doctor Paul Gachet. His depression persisted, and on 27 July 1890, Van Gogh is believed to have shot himself in the chest with a revolver, dying from his injuries two days later.<br>Van Gogh's work began to attract critical artistic attention in the last year of his life. After his death, Van Gogh's art and life story captured public imagination as an emblem of misunderstood genius, due in large part to the efforts of his widowed sister-in-law Johanna van Gogh-Bonger.</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "new_nodes = get_retrieved_nodes_mixed(\n",
-    "    \"Which date did Paul Gauguin arrive in Arles?\",\n",
-    "    vector_top_k=50,\n",
-    "    reranker_top_n=3,\n",
-    "    with_reranker=True,\n",
-    "    with_retrieval=False,\n",
-    "    model=\"zephyr\",\n",
-    "    step_size=10,\n",
-    ")\n",
-    "\n",
-    "visualize_retrieved_nodes(new_nodes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### The correct result is ranked 1st/50 after RankZephyr rerank. "
+    "#### Other models. Use `model=`\n",
+    "- `monot5` for MonoT5 pointwise reranker\n",
+    "- `castorini/LiT5-Distill-base` for LiT5 distill reranker\n",
+    "- `castorini/LiT5-Score-base` for LiT5 score reranker"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "rankllm",
+   "display_name": "main",
    "language": "python",
-   "name": "rankllm"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/docs/module_guides/querying/node_postprocessors/node_postprocessors.md
+++ b/docs/docs/module_guides/querying/node_postprocessors/node_postprocessors.md
@@ -300,10 +300,11 @@ Full notebook guide is available [here](../../../examples/node_postprocessor/Col
 Uses models from [rankLLM](https://github.com/castorini/rank_llm) to rerank documents. Returns the top N ranked nodes.
 
 ```python
-from llama_index.postprocessor import RankLLMRerank
+from llama_index.postprocessor.rankllm_rerank import RankLLMRerank
 
-postprocessor = RankLLMRerank(top_n=5, model="zephyr")
-postprocessor.postprocess_nodes(nodes)
+# RankZephyr reranker, return top 5 candidates
+reranker = RankLLMRerank(model="rank_zephyr", top_n=5)
+reranker.postprocess_nodes(nodes)
 ```
 
 A full [notebook example is available](../../../examples/node_postprocessor/rankLLM.ipynb).

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/README.md
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/README.md
@@ -1,23 +1,40 @@
 # LlamaIndex Postprocessor Integration: Rankllm-Rerank
 
-RankLLM offers a suite of listwise rerankers, albeit with focus on open source LLMs finetuned for the task. Currently, RankLLM supports 2 of these models: RankZephyr (`model="zephyr"`) and RankVicuna (`model="vicuna"`). RankLLM also support RankGPT usage (`model="gpt"`, `gpt_model="VALID_OPENAI_MODEL_NAME"`).
+RankLLM offers a suite of rerankers, albeit with focus on open source LLMs finetuned for the task. To use a model offered by the RankLLM suite, pass the desired model's **Hugging Face model path**, found at [Castorini's Hugging Face](https://huggingface.co/castorini).
 
-Please `pip install llama-index-postprocessor-rankllm-rerank` to install RankLLM rerank package.
+e.g., to access `LiT5-Distill-base`, pass [`castorini/LiT5-Distill-base`](https://huggingface.co/castorini/LiT5-Distill-base) as the model name.
 
-Parameters:
+For more information about RankLLM and the models supported, visit **[rankllm.ai](http://rankllm.ai)**. Please `pip install llama-index-postprocessor-rankllm-rerank` to install RankLLM rerank package.
 
-- top_n: Top N nodes to return from reranking.
-- model: Reranker model name/class (`zephyr`, `vicuna`, or `gpt`).
-- with_retrieval[Optional]: Perform retrieval before reranking with `Pyserini`.
-- step_size[Optional]: Step size of sliding window for reranking large corpuses.
-- gpt_model[Optional]: OpenAI model to use (e.g., `gpt-3.5-turbo`) if `model="gpt"`
+#### Parameters:
+
+- `model`: Reranker model name
+- `top_n`: Top N nodes to return from reranking
+- `window_size`: Reranking window size. Applicable only for listwise and pairwise models.
+- `batch_size`: Reranking batch size. Applicable only for pointwise models.
+
+#### Model Coverage
+
+Below are all the rerankers supported with the model name to be passed as an argument to the constructor. Some model have convenience names for ease of use:
+
+**Listwise**:
+
+- **RankZephyr**. model=`rank_zephyr` or `castorini/rank_zephyr_7b_v1_full`
+- **RankVicuna**. model=`rank_zephyr` or `castorini/rank_vicuna_7b_v1`
+- **RankGPT**. Takes in a _valid_ gpt model. e.g., `gpt-3.5-turbo`, `gpt-4`,`gpt-3`
+- **LiT5 Distill**. model=`castorini/LiT5-Distill-base`
+- **LiT5 Score**. model=`castorini/LiT5-Score-base`
+
+**Pointwise**:
+
+- MonoT5. model='monot5'
 
 ### 💻 Example Usage
 
 ```
 pip install llama-index-core
 pip install llama-index-llms-openai
-pip install llama-index-postprocessor-rankllm-rerank
+from llama_index.postprocessor.rankllm_rerank import RankLLMRerank
 ```
 
 First, build a vector store index with [llama-index](https://pypi.org/project/llama-index/).
@@ -28,7 +45,7 @@ index = VectorStoreIndex.from_documents(
 )
 ```
 
-To set up the retriever and reranker:
+To set up the _retriever_ and _reranker_:
 
 ```
 query_bundle = QueryBundle(query_str)
@@ -41,15 +58,12 @@ retriever = VectorIndexRetriever(
 
 # configure reranker
 reranker = RankLLMRerank(
+    model=model_name
     top_n=reranker_top_n,
-    model=model,
-    with_retrieval=with_retrieval,
-    step_size=step_size,
-    gpt_model=gpt_model,
 )
 ```
 
-To run retrieval+reranking:
+To run _retrieval+reranking_:
 
 ```
 # retrieve nodes
@@ -65,8 +79,6 @@ reranked_nodes = reranker.postprocess_nodes(
 
 Currently, RankLLM rerankers require `CUDA` and for `rank-llm` to be installed (`pip install rank-llm`). The built-in retriever, which uses [Pyserini](https://github.com/castorini/pyserini), requires `JDK11`, `PyTorch`, and `Faiss`.
 
-### castorini/rank_llm
+### `castorini/rank_llm`
 
-Repository for prompt-decoding using LLMs (`GPT3.5`, `GPT4`, `Vicuna`, and `Zephyr`)\
-Website: [http://rankllm.ai](http://rankllm.ai)\
-Stars: 193
+Repository for prompt-decoding using LLMs: **[http://rankllm.ai](http://rankllm.ai)**

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
@@ -12,7 +12,7 @@ from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
 dispatcher = get_dispatcher(__name__)
 
 try:
-    from rank_llm.rerank import Reranker
+    from rank_llm.rerank.reranker import Reranker
     from rank_llm.data import Request, Query, Candidate
 except ImportError:
     raise ImportError("RankLLM requires `pip install rank-llm`")

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
@@ -12,76 +12,64 @@ from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
 
 dispatcher = get_dispatcher(__name__)
 
+try:
+    from rank_llm.rerank import Reranker
+    from rank_llm.data import Request, Query, Candidate
+except ImportError:
+    raise ImportError("RankLLM requires `pip install rank-llm`")
+
 
 class RankLLMRerank(BaseNodePostprocessor):
-    """RankLLM-based reranker."""
+    """
+    RankLLM reranking suite. This class allows access to several reranking models supported by RankLLM. To use a model offered by the RankLLM suite, pass the desired model's hugging face path, found at https://huggingface.co/castorini. e.g., to access LiT5-Distill-base, pass 'castorini/LiT5-Distill-base' as the model name (https://huggingface.co/castorini/LiT5-Distill-base).
 
-    top_n: int = Field(default=5, description="Top N nodes to return from reranking.")
-    model: str = Field(default="zephyr", description="Reranker model name.")
-    with_retrieval: bool = Field(
-        default=False, description="Perform retrieval before reranking."
+    Below are all the rerankers supported with the model name to be passed as an argument to the constructor. Some model have convenience names for ease of use:
+        Listwise:
+            - RankZephyr. model='rank_zephyr' or 'castorini/rank_zephyr_7b_v1_full'
+            - RankVicuna. model='rank_zephyr' or 'castorini/rank_vicuna_7b_v1'
+            - RankGPT. Takes in a valid gpt model. e.g., 'gpt-3.5-turbo', 'gpt-4','gpt-3'
+            - LiT5 Distill. model='castorini/LiT5-Distill-base'
+            - LiT5 Score. model='castorini/LiT5-Score-base'
+        Pointwise:
+            - MonoT5. model='monot5'
+
+    """
+
+    model: str = Field(description="Model name.")
+    top_n: Optional[int] = Field(
+        description="Number of nodes to return sorted by reranking score."
     )
-    step_size: int = Field(
-        default=10, description="Step size for moving sliding window."
+    window_size: Optional[int] = Field(
+        description="Reranking window size. Applicable only for listwise and pairwise models."
     )
-    gpt_model: str = Field(default="gpt-3.5-turbo", description="OpenAI model name.")
+    batch_size: Optional[int] = Field(
+        description="Reranking batch size. Applicable only for pointwise models."
+    )
+
     _model: Any = PrivateAttr()
-    _result: Any = PrivateAttr()
-    _retriever: Any = PrivateAttr()
 
     def __init__(
         self,
-        model,
-        top_n: int = 10,
-        with_retrieval: Optional[bool] = False,
-        step_size: Optional[int] = 10,
-        gpt_model: Optional[str] = "gpt-3.5-turbo",
+        model: str,
+        top_n: Optional[int] = None,
+        window_size: Optional[int] = None,
+        batch_size: Optional[int] = None,
     ):
-        try:
-            model_enum = ModelType(model.lower())
-        except ValueError:
-            raise ValueError(
-                "Unsupported model type. Please use 'vicuna', 'zephyr', or 'gpt'."
-            )
-
-        from rank_llm.result import Result
-
         super().__init__(
             model=model,
             top_n=top_n,
-            with_retrieval=with_retrieval,
-            step_size=step_size,
-            gpt_model=gpt_model,
+            window_size=window_size,
+            batch_size=batch_size,
+            window_size=window_size,
         )
 
-        self._result = Result
-
-        if model_enum == ModelType.VICUNA:
-            from rank_llm.rerank.vicuna_reranker import VicunaReranker
-
-            self._model = VicunaReranker()
-        elif model_enum == ModelType.ZEPHYR:
-            from rank_llm.rerank.zephyr_reranker import ZephyrReranker
-
-            self._model = ZephyrReranker()
-        elif model_enum == ModelType.GPT:
-            from rank_llm.rerank.rank_gpt import SafeOpenai
-            from rank_llm.rerank.reranker import Reranker
-            from llama_index.llms.openai import OpenAI
-
-            llm = OpenAI(
-                model=gpt_model,
-                temperature=0.0,
-            )
-
-            llm.metadata
-
-            agent = SafeOpenai(model=gpt_model, context_size=4096, keys=llm.api_key)
-            self._model = Reranker(agent)
-        if with_retrieval:
-            from rank_llm.retrieve.retriever import Retriever
-
-            self._retriever = Retriever
+        self._model = Reranker.create_agent(
+            model.lower(),
+            default_agent=None,
+            interactive=False,
+            window_size=window_size,
+            batch_size=batch_size,
+        )
 
     @classmethod
     def class_name(cls) -> str:
@@ -106,56 +94,46 @@ class RankLLMRerank(BaseNodePostprocessor):
             for node in nodes
         ]
 
-        if self.with_retrieval:
-            hits = [
-                {
-                    "content": doc[0],
-                    "qid": 1,
-                    "docid": str(index),
-                    "rank": index,
-                    "score": doc[1],
-                }
-                for index, doc in enumerate(docs)
-            ]
-            retrieved_results = self._retriever.from_inline_hits(
-                query=query_bundle.query_str, hits=hits
+        request: List[Request] = [
+            Request(
+                query=Query(
+                    text=query_bundle.query_str,
+                    qid=1,
+                ),
+                candidates=[
+                    Candidate(
+                        docid=index,
+                        score=doc[1],
+                        doc={
+                            "body": doc[0],
+                            "headings": "",
+                            "title": "",
+                            "url": "",
+                        },
+                    )
+                    for index, doc in enumerate(docs)
+                ],
             )
-        else:
-            retrieved_results = [
-                self._result(
-                    query=query_bundle.query_str,
-                    hits=[
-                        {
-                            "content": doc[0],
-                            "qid": 1,
-                            "docid": str(index),
-                            "rank": index,
-                            "score": doc[1],
-                        }
-                        for index, doc in enumerate(docs)
-                    ],
-                )
-            ]
+        ]
 
-        permutation = self._model.rerank(
-            retrieved_results=retrieved_results,
-            rank_end=len(docs),
-            window_size=min(20, len(docs)),
-            step=self.step_size,
+        # scores are maintained the same as generated from the retriever
+        permutation = self._model.rerank_batch(
+            request,
+            rank_end=len(request[0].candidates),
+            rank_start=0,
+            shuffle_candidates=False,
+            logging=False,
+            top_k_retrieve=len(request[0].candidates),
         )
 
         new_nodes: List[NodeWithScore] = []
-        for hit in permutation[0].hits:
-            idx: int = int(hit["docid"])
-            new_nodes.append(
-                NodeWithScore(node=nodes[idx].node, score=nodes[idx].score)
-            )
+        for candidate in permutation[0].candidates:
+            id: int = int(candidate.docid)
+            new_nodes.append(NodeWithScore(node=nodes[id].node, score=nodes[id].score))
 
-        dispatcher.event(ReRankEndEvent(nodes=new_nodes[: self.top_n]))
-        return new_nodes[: self.top_n]
-
-
-class ModelType(Enum):
-    VICUNA = "vicuna"
-    ZEPHYR = "zephyr"
-    GPT = "gpt"
+        if self.top_n is None:
+            dispatcher.event(ReRankEndEvent(nodes=new_nodes))
+            return new_nodes
+        else:
+            dispatcher.event(ReRankEndEvent(nodes=new_nodes[: self.top_n]))
+            return new_nodes[: self.top_n]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
@@ -1,5 +1,4 @@
 from typing import Any, List, Optional
-from enum import Enum
 
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.instrumentation import get_dispatcher
@@ -60,7 +59,6 @@ class RankLLMRerank(BaseNodePostprocessor):
             top_n=top_n,
             window_size=window_size,
             batch_size=batch_size,
-            window_size=window_size,
         )
 
         self._model = Reranker.create_agent(

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/test.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/test.py
@@ -1,0 +1,5 @@
+from rank_llm.rerank.reranker import Reranker
+
+Reranker.create_agent(
+    model_path="rank_zephyr", default_agent=None, interactive=False, vllm_batched=True
+)

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -24,7 +24,7 @@ ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = ["Ryan Nguyen ryan.nguyen@uwaterloo.ca"]
 description = "llama-index postprocessor rankllm-rerank integration"
 exclude = ["**/BUILD"]
 license = "MIT"
@@ -35,6 +35,7 @@ version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
+rank-llm = ">=0.20.1"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -35,7 +35,7 @@ version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-rank-llm = ">=0.20.1"
+rank_llm = ">=0.20.1"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-postprocessor-rankllm-rerank"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -35,7 +35,7 @@ version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-rank_llm = ">=0.20.1"
+rank_llm = ">=0.20.2"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 version = "0.3.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.10,<4.0"
 rank_llm = ">=0.20.1"
 llama-index-core = "^0.11.0"
 

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/tests/BUILD
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    interpreter_constraints=["==3.10.*"]
+)


### PR DESCRIPTION
# Description

Fixes issues in `llama-index-postprocessor-rankllm-rerank` due to refactoring changes within `RankLLM`. 

Adds new availability for new rerankers!

- `LiT5 Distill`
- `LiT5 Score` 
- `MonoT5` (pointwise reranker)
- `RankZephyr` and `RankVicuna` variants
- `window_size` and `batch_size` tuning parameters for listwise and pointwise reranking, respectively

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] 
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
