### PR TITLE
[Feature] Add optional timeout to a step execution of a Workflow

### DIFF
--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -21,6 +21,7 @@ class StepConfig(BaseModel):
     context_parameter: Optional[str]
     num_workers: int
     requested_services: List[ServiceDefinition]
+    timeout: Optional[float] = None
 
 
 def step(

--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -29,6 +29,7 @@ def step(
     workflow: Optional[Type["Workflow"]] = None,
     pass_context: bool = False,
     num_workers: int = 1,
+    timeout: Optional[float] = None,
 ) -> Callable:
     """Decorator used to mark methods and functions as workflow steps.
 
@@ -57,6 +58,7 @@ def step(
             context_parameter=spec.context_parameter,
             num_workers=num_workers,
             requested_services=spec.requested_services or [],
+            timeout=timeout,
         )
 
         # If this is a free function, call add_step() explicitly.

--- a/llama-index-core/llama_index/core/workflow/errors.py
+++ b/llama-index-core/llama_index/core/workflow/errors.py
@@ -6,6 +6,10 @@ class WorkflowTimeoutError(Exception):
     pass
 
 
+class WorkflowStepTimeoutError(Exception):
+    pass
+
+
 class WorkflowRuntimeError(Exception):
     pass
 

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -158,7 +158,13 @@ class Workflow(metaclass=WorkflowMeta):
                         new_ev_fut = asyncio.get_event_loop().run_in_executor(
                             None, run_task
                         )
-                    new_ev = await asyncio.wait_for(new_ev_fut, timeout=config.timeout)
+                    try:
+                        new_ev = await asyncio.wait_for(
+                            new_ev_fut, timeout=config.timeout
+                        )
+                    except asyncio.TimeoutError as e:
+                        msg = f"Step timed out after {config.timeout} seconds"
+                        raise WorkflowStepTimeoutError(msg) from e
 
                     if self._verbose and name != "_done":
                         if new_ev is not None:

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -70,11 +70,24 @@ async def test_workflow_timeout():
 
 
 @pytest.mark.asyncio()
-async def test_workflow_step_timeout():
+async def test_workflow_async_step_timeout():
     class WorkflowWithSlowStep(Workflow):
         @step(timeout=1)
         async def slow_step(self, ev: StartEvent) -> StopEvent:
             await asyncio.sleep(5.0)
+            return StopEvent(result="Done")
+
+    workflow = WorkflowWithSlowStep()
+    with pytest.raises(WorkflowStepTimeoutError):
+        await workflow.run()
+
+
+@pytest.mark.asyncio()
+async def test_workflow_sync_step_timeout():
+    class WorkflowWithSlowStep(Workflow):
+        @step(timeout=1)
+        def slow_step(self, ev: StartEvent) -> StopEvent:
+            time.sleep(5.0)
             return StopEvent(result="Done")
 
     workflow = WorkflowWithSlowStep()

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -12,6 +12,7 @@ from llama_index.core.workflow.workflow import (
     WorkflowTimeoutError,
     WorkflowValidationError,
     WorkflowRuntimeError,
+    WorkflowStepTimeoutError,
 )
 
 from .conftest import AnotherTestEvent, LastEvent, OneTestEvent
@@ -65,6 +66,19 @@ async def test_workflow_timeout():
 
     workflow = SlowWorkflow(timeout=1)
     with pytest.raises(WorkflowTimeoutError):
+        await workflow.run()
+
+
+@pytest.mark.asyncio()
+async def test_workflow_step_timeout():
+    class WorkflowWithSlowStep(Workflow):
+        @step(timeout=1)
+        async def slow_step(self, ev: StartEvent) -> StopEvent:
+            await asyncio.sleep(5.0)
+            return StopEvent(result="Done")
+
+    workflow = WorkflowWithSlowStep()
+    with pytest.raises(WorkflowStepTimeoutError):
         await workflow.run()
 
 


### PR DESCRIPTION
# Description

Currently, the execution of an entire Workflow (and its comprised steps) are under a single, overall timeout. However, it may be desirable for some use-cases (e.g., human-in-the-loop) for a single step to be executed up to a specified timeout. This PR adds an optional timeout parameter in the `StepConfig` that is used to execute a step under this timeout.

To specify a timeout for a step, we pass in a float value to the `timeout` param when using `step` decorator (defaults to `None` in which case, the standard async execution is performed):

```python
        @step(timeout=1)
        async def my_step(self, ev: StartEvent) -> NextEvent:
            # do step stuff
            return NextEvent(...)

        # works the same for a sync step
        @step(timeout=1)
        def my_sync_step(self, ev: StartEvent) -> NextEvent:
            # do step stuff
            return NextEvent(...)
```

In execution of the step, if a timeout is reached, then we catch the error and raise the newly defined `WorkflowStepTimeoutError`.

Closes #15894

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense
