### PR TITLE
Mistral AI LLM Integration fixes

### DIFF
--- a/docs/docs/examples/llm/mistralai.ipynb
+++ b/docs/docs/examples/llm/mistralai.ipynb
@@ -65,7 +65,7 @@
     "# otherwise it will lookup MISTRAL_API_KEY from your env variable\n",
     "# llm = MistralAI(api_key=\"<api_key>\")\n",
     "\n",
-    "llm = MistralAI(api_key=\"d3BWjjKovVOfREc9AICivX0m9JMSzZc6\")\n",
+    "llm = MistralAI(api_key=\"<replace-with-your-key>\")\n",
     "\n",
     "resp = llm.complete(\"Paul Graham is \")"
    ]

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Laurie Voss <github@seldo.com>"]
 description = ""
 name = "new-docs"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.0"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Laurie Voss <github@seldo.com>"]
 description = ""
 name = "new-docs"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
@@ -48,7 +48,7 @@ from mistralai.models import (
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
 
-DEFAULT_MISTRALAI_MODEL = "mistral-tiny"
+DEFAULT_MISTRALAI_MODEL = "mistral-large-latest"
 DEFAULT_MISTRALAI_ENDPOINT = "https://api.mistral.ai"
 DEFAULT_MISTRALAI_MAX_TOKENS = 512
 

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-mistralai"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

The Mistral API key is revoked in the documentation and in the colab notebook. While working on the use case I could use the same key. I believe it needs to be revoked. Further change of the DEFAULT model for Mistral AI making it suitable for function calling. 

Fixes # (issue)

- API key of Mistral to be revoked

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
