### PR TITLE
fix: model_name property and pydantic v2 in Azure Inference package

### DIFF
--- a/docs/docs/understanding/workflows/index.md
+++ b/docs/docs/understanding/workflows/index.md
@@ -36,4 +36,8 @@ For simple RAG pipelines and linear demos we do not expect you will need Workflo
 
 ## Next steps
 
-Let's build [a basic workflow](basic_flow.md).
+Let's build [a basic workflow](basic_flow.md). Follow the tutorial sequence step-by-step to learn the core concepts.
+
+Once you're done, check out our [Workflows component guide](../../module_guides/workflow/index.md) as a reference guide + more practical examples on building RAG/agents.
+
+If you're done building and want to deploy your workflow to production, check out [our llama_deploy guide](../../module_guides/workflow/deployment.md) ([repo](https://github.com/run-llama/llama_deploy)).

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/llama_index/embeddings/azure_inference/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/llama_index/embeddings/azure_inference/base.py
@@ -1,5 +1,6 @@
 """Azure AI model inference embeddings client."""
 
+import logging
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
 from llama_index.core.base.embeddings.base import (
@@ -16,6 +17,9 @@ if TYPE_CHECKING:
 from azure.ai.inference import EmbeddingsClient
 from azure.ai.inference.aio import EmbeddingsClient as EmbeddingsClientAsync
 from azure.core.credentials import AzureKeyCredential
+from azure.core.exceptions import HttpResponseError
+
+logger = logging.getLogger(__name__)
 
 
 class AzureAIEmbeddingsModel(BaseEmbedding):
@@ -75,7 +79,7 @@ class AzureAIEmbeddingsModel(BaseEmbedding):
         callback_manager: Optional[CallbackManager] = None,
         num_workers: Optional[int] = None,
         client_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         client_kwargs = client_kwargs or {}
 
@@ -104,6 +108,32 @@ class AzureAIEmbeddingsModel(BaseEmbedding):
                 "Pass the credential as a parameter or set the AZURE_INFERENCE_CREDENTIAL"
             )
 
+        client = EmbeddingsClient(
+            endpoint=endpoint,
+            credential=credential,
+            user_agent="llamaindex",
+            **client_kwargs,
+        )
+
+        async_client = EmbeddingsClientAsync(
+            endpoint=endpoint,
+            credential=credential,
+            user_agent="llamaindex",
+            **client_kwargs,
+        )
+
+        if not model_name:
+            try:
+                # Get model info from the endpoint. This method may not be supported by all
+                # endpoints.
+                model_info = client.get_model_info()
+                model_name = model_info.get("model_name", None)
+            except HttpResponseError:
+                logger.warning(
+                    f"Endpoint '{self._client._config.endpoint}' does not support model metadata retrieval. "
+                    "Unable to populate model attributes."
+                )
+
         super().__init__(
             model_name=model_name or "unknown",
             embed_batch_size=embed_batch_size,
@@ -111,19 +141,9 @@ class AzureAIEmbeddingsModel(BaseEmbedding):
             num_workers=num_workers,
             **kwargs,
         )
-        self._client = EmbeddingsClient(
-            endpoint=endpoint,
-            credential=credential,
-            user_agent="llamaindex",
-            **client_kwargs,
-        )
 
-        self._async_client = EmbeddingsClientAsync(
-            endpoint=endpoint,
-            credential=credential,
-            user_agent="llamaindex",
-            **client_kwargs,
-        )
+        self._client = client
+        self._async_client = async_client
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 name = "llama-index-embeddings-azure-inference"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
@@ -30,6 +30,13 @@ def test_embed():
     assert response[0].embedding
 
 
+@pytest.mark.skipif(
+    not {
+        "AZURE_INFERENCE_ENDPOINT",
+        "AZURE_INFERENCE_CREDENTIAL",
+    }.issubset(set(os.environ)),
+    reason="Azure AI endpoint and/or credential are not set.",
+)
 def test_get_metadata(caplog):
     """Tests if we can get model metadata back from the endpoint. If so,
     model_name should not be 'unknown'. Some endpoints may not support this

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
@@ -28,3 +28,20 @@ def test_embed():
 
     assert len(response) == len(nodes)
     assert response[0].embedding
+
+
+def test_get_metadata(caplog):
+    """Tests if we can get model metadata back from the endpoint. If so,
+    model_name should not be 'unknown'. Some endpoints may not support this
+    and in those cases a warning should be logged.
+    """
+    # In case the endpoint being tested serves more than one model
+    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
+
+    embed_model = AzureAIEmbeddingsModel(model_name=model_name)
+
+    assert (
+        embed_model.model_name != "unknown"
+        or "does not support model metadata retrieval" in caplog.text
+    )
+    assert not model_name or embed_model.model_name == model_name

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 name = "llama-index-llms-azure-inference"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
@@ -146,3 +146,4 @@ def test_get_metadata(caplog):
         response.model_name != "unknown"
         or "does not support model metadata retrieval" in caplog.text
     )
+    assert not model_name or response.model_name == model_name


### PR DESCRIPTION
# Description

This PR includes the following bug fixes:

* It populates the property `model_name` for LLM models even when model metadata retrieval may fail. This is useful when using tracing integrations that read the property `model_name`.
* It populates the property `model_name` for embeddings models using metadata retrieval or a known value if available. Similar behavior than for LLMs. Again, this is useful when using tracing integrations.
* It removes warnings from pydantic V2 migration.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
