### PR TITLE
Fix RagCLI

### DIFF
--- a/llama-index-cli/llama_index/cli/rag/base.py
+++ b/llama-index-cli/llama_index/cli/rag/base.py
@@ -90,7 +90,7 @@ class RagCLI(BaseModel):
     )
     chat_engine: Optional[CondenseQuestionChatEngine] = Field(
         description="Chat engine to use for chatting.",
-        default_factory=None,
+        default=None,
     )
     file_extractor: Optional[Dict[str, BaseReader]] = Field(
         description="File extractor to use for extracting text from files.",

--- a/llama-index-cli/pyproject.toml
+++ b/llama-index-cli/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = [
 name = "llama-index-cli"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Minor tweak, `default_factory=None` is invalid (should be `default=None`)

Fixes https://github.com/run-llama/llama_index/issues/15909