### PR TITLE
docs: document retry policy

### DIFF
--- a/docs/docs/api_reference/workflow/retry_policy.md
+++ b/docs/docs/api_reference/workflow/retry_policy.md
@@ -1,0 +1,5 @@
+::: llama_index.core.workflow.retry_policy
+    options:
+      members:
+        - RetryPolicy
+        - ConstantDelayRetryPolicy

--- a/docs/docs/module_guides/workflow/index.md
+++ b/docs/docs/module_guides/workflow/index.md
@@ -280,6 +280,63 @@ class MyWorkflow(Workflow):
         return StopEvent(result=events)
 ```
 
+## Retry steps execution in case of failures
+
+A step that fails its execution might result in the failure of the entire workflow, but oftentimes errors are
+expected and the execution can be safely retried. Think of a HTTP request that times out because of a transient
+congestion of the network, or an external API call that hits a rate limiter.
+
+For all those situation where you want the step to try again, you can use a "Retry Policy". A retry policy is an object
+that instructs the workflow to execute a step multiple times, dictating how much time has to pass before a new attempt.
+Policies take into consideration how much time passed since the first failure, how many consecutive failures happened
+and which was the last error occurred.
+
+To set a policy for a specific step, all you have to do is passing a policy object to the `@step` decorator:
+
+
+```python
+from llama_index.core.workflow.retry_policy import ConstantDelayRetryPolicy
+
+
+class MyWorkflow(Workflow):
+    # ...more workflow definition...
+
+    # This policy will retry this step on failure every 5 seconds for at most 10 times
+    @step(retry_policy=ConstantDelayRetryPolicy(delay=5, maximum_attempts=10))
+    async def flaky_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
+        result = flaky_call()  # this might raise
+        return StopEvent(result=result)
+```
+
+You can see the [API docs](../../api_reference/workflow/retry_policy/) for a detailed description of the policies
+available in the framework. If you can't find a policy that's suitable for your use case, you can easily write a
+custom one. The only requirement for custom policies is to write a Python class that respects the `RetryPolicy`
+protocol. In other words, your custom policy class must have a method with the following signature:
+
+```python
+def next(
+    self, elapsed_time: float, attempts: int, error: Exception
+) -> Optional[float]:
+    ...
+```
+
+For example, this is a retry policy that's excited about the weekend and only retries a step if it's Friday:
+
+```python
+from datetime import datetime
+
+
+class RetryOnFridayPolicy:
+    def next(
+        self, elapsed_time: float, attempts: int, error: Exception
+    ) -> Optional[float]:
+        if datetime.today().strftime("%A") == "Friday":
+            # retry in 5 seconds
+            return 5
+        # tell the workflow we don't want to retry
+        return None
+```
+
 ## Stepwise Execution
 
 Workflows have built-in utilities for stepwise execution, allowing you to control execution and debug state as things progress.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -788,6 +788,7 @@ nav:
           - ./module_guides/observability/index.md
           - ./module_guides/observability/instrumentation.md
       - Settings: ./module_guides/supporting_modules/settings.md
+      - Workflows: ./module_guides/workflow/index.md
   - Advanced Topics:
       - ./optimizing/production_rag.md
       - ./optimizing/basic_strategies/basic_strategies.md
@@ -1571,6 +1572,7 @@ nav:
           - ./api_reference/workflow/context.md
           - ./api_reference/workflow/events.md
           - ./api_reference/workflow/workflow.md
+          - ./api_reference/workflow/retry_policy.md
   - Open-Source Community:
       - Integrations: ./community/integrations.md
       - Full Stack Projects: ./community/full_stack_projects.md


### PR DESCRIPTION
# Description

Add documentation and API reference for the newly added Retry Policy:

- Added API reference
- Added a paragraph under "Component Guides / Workflow"
- Made "Workflow" prominent in the TOC of the "Component Guides" page (left the inner link there, to avoid broken links for SEO hygiene) 