### PR TITLE
fix: Error when parsing output if tool name contains non-English characters

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/output_parser.py
+++ b/llama-index-core/llama_index/core/agent/react/output_parser.py
@@ -15,7 +15,7 @@ from llama_index.core.types import BaseOutputParser
 
 def extract_tool_use(input_text: str) -> Tuple[str, str, str]:
     pattern = (
-        r"\s*Thought: (.*?)\n+Action: ([a-zA-Z0-9_]+).*?\n+Action Input: .*?(\{.*\})"
+        r"\s*Thought: (.*?)\n+Action: ([^\n]+).*?\n+Action Input: .*?(\{.*\})"
     )
 
     match = re.search(pattern, input_text, re.DOTALL)


### PR DESCRIPTION
# Description

I created a tool with a Chinese name, and after the agent invoked it, I encountered the error "Failed to parse output." However, no error occurred during the tool creation process, which made this issue confusing.

```python
llm = OpenAI(model="gpt-4-turbo", temperature=0)

entry_agent = ReActAgent.from_tools(
    [
        weather_tool,
        address_geo_tool,
        web_search_tool,
        gas_knowledge_tool,
        # This tool fails to work because its name is in Chinese
        QueryEngineTool(
            query_engine=kitchen_appliance_agent,
            metadata=ToolMetadata(
                name="厨房电器推荐",
                description="可以根据用户的喜好推荐各种厨房电器",
            ),
        ),
    ],
    llm=llm,
    max_iterations=5,
    verbose=True,
)
```

The root cause lies in the regular expression used in `output_parser.py`, which currently limits tool names to characters in the range `a-zA-Z0-9_`. In my opinion, this restriction is unnecessary.

This PR modifies the regular expression to allow tool names to include any character. The change works as expected in my case.



Fixes # (issue)

Error when parsing output if tool name contains non-English characters.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
