### PR TITLE
fix attribute error in PGVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -148,6 +148,7 @@ class PGVectorStore(BasePydanticVectorStore):
     perform_setup: bool
     debug: bool
     use_jsonb: bool
+    create_engine_kwargs: Dict
 
     hnsw_kwargs: Optional[Dict[str, Any]]
 
@@ -218,6 +219,7 @@ class PGVectorStore(BasePydanticVectorStore):
             debug=debug,
             use_jsonb=use_jsonb,
             hnsw_kwargs=hnsw_kwargs,
+            create_engine_kwargs=create_engine_kwargs or {},
         )
 
         # sqlalchemy model
@@ -232,8 +234,6 @@ class PGVectorStore(BasePydanticVectorStore):
             embed_dim=embed_dim,
             use_jsonb=use_jsonb,
         )
-
-        self.create_engine_kwargs = create_engine_kwargs or {}
 
     async def close(self) -> None:
         if not self._is_initialized:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Some versions of pydantic didn't like using `self` to set an attribute that was defined on the class