### PR TITLE
[WIP] Expose workflow contexts as reusable objects

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,5 +1,6 @@
 import asyncio
 import warnings
+import uuid
 from collections import defaultdict
 from typing import Dict, Any, Optional, List, Type, TYPE_CHECKING, Set, Tuple
 
@@ -22,7 +23,9 @@ class Context:
     Both `set` and `get` operations on global data are governed by a lock, and considered coroutine-safe.
     """
 
-    def __init__(self, workflow: "Workflow") -> None:
+    def __init__(self, workflow: "Workflow", session_id: Optional[str] = None) -> None:
+        self.session_id = session_id or str(uuid.uuid4())
+
         self._workflow = workflow
         # Broker machinery
         self._queues: Dict[str, asyncio.Queue] = {}

--- a/llama-index-core/llama_index/core/workflow/drawing.py
+++ b/llama-index-core/llama_index/core/workflow/drawing.py
@@ -85,7 +85,7 @@ def draw_most_recent_execution(
     net = Network(directed=True, height="750px", width="100%")
 
     # Add nodes and edges based on execution history
-    existing_context = next(iter(workflow._contexts), None)
+    existing_context = next(iter(workflow._contexts.values()), None)
     if existing_context is None:
         raise ValueError("No runs found in workflow")
 

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -84,3 +84,16 @@ async def test_multiple_streams():
     async for _ in wf.stream_events():
         pass
     await r
+
+
+@pytest.mark.asyncio()
+async def test_multiple_streams_at_the_same_time():
+    wf = StreamingWorkflow()
+
+    session_context_1 = wf.init_session_context()
+    session_context_2 = wf.init_session_context()
+
+    # running multiple streams should work, since they are separated by context
+    async for _ in wf.run_with_streaming_session_context(session_context_1):
+        async for _ in wf.run_with_streaming_session_context(session_context_2):
+            pass

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -381,3 +381,19 @@ def test_workflow_disable_validation():
     w._get_steps = mock.MagicMock()
     w._validate()
     w._get_steps.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_session_context_api():
+    class DummyWorkflow(Workflow):
+        @step
+        async def step(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result=ev.number * 2)
+
+    w = DummyWorkflow()
+
+    context = w.init_session_context("test_id")
+    assert context.session_id == "test_id"
+
+    result = await w.run_with_session_context(context, number=2)
+    assert result == 4


### PR DESCRIPTION
This PR aims to expose contexts to the user a way to 
- persist data across runs
- allow multiple runs to stream at the same time
- separate data between users

So far, I think this is a little experimental. But very open to feedback

Example Usage:

```python
w = Workflow()

context = w.init_session_context(session_id="test")
result = await w.run_with_session_context(context, arg1="hello world")

# resume with a context
context = w.init_session_context(context=context)
result = await w.run_with_session_context(context, arg1="hello world again")
```

Still TODO (assuming we like this approach):
- [ ] Do stepwise properly
- [ ] Probably rethink how streaming works (should it be attached to the context?)
- [ ] Name functions better
- [ ] Docs