### PR TITLE
[WIP] Attempt #2 for resuming workflows with existing context

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -39,20 +39,6 @@ class Context:
         # Step-specific instance
         self._events_buffer: Dict[Type[Event], List[Event]] = defaultdict(list)
 
-    def soft_reset(self) -> None:
-        self._queues: Dict[str, asyncio.Queue] = {}
-        self._tasks: Set[asyncio.Task] = set()
-        self._broker_log: List[Event] = []
-        self._step_flags: Dict[str, asyncio.Event] = {}
-        self._accepted_events: List[Tuple[str, str]] = []
-        self._retval: Any = None
-        # Streaming machinery
-        self._streaming_queue: asyncio.Queue = asyncio.Queue()
-        # Global data storage
-        self._lock = asyncio.Lock()
-        # Step-specific instance
-        self._events_buffer: Dict[Type[Event], List[Event]] = defaultdict(list)
-
     async def set(self, key: str, value: Any, make_private: bool = False) -> None:
         """Store `value` into the Context under `key`.
 

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -39,6 +39,20 @@ class Context:
         # Step-specific instance
         self._events_buffer: Dict[Type[Event], List[Event]] = defaultdict(list)
 
+    def soft_reset(self) -> None:
+        self._queues: Dict[str, asyncio.Queue] = {}
+        self._tasks: Set[asyncio.Task] = set()
+        self._broker_log: List[Event] = []
+        self._step_flags: Dict[str, asyncio.Event] = {}
+        self._accepted_events: List[Tuple[str, str]] = []
+        self._retval: Any = None
+        # Streaming machinery
+        self._streaming_queue: asyncio.Queue = asyncio.Queue()
+        # Global data storage
+        self._lock = asyncio.Lock()
+        # Step-specific instance
+        self._events_buffer: Dict[Type[Event], List[Event]] = defaultdict(list)
+
     async def set(self, key: str, value: Any, make_private: bool = False) -> None:
         """Store `value` into the Context under `key`.
 

--- a/llama-index-core/llama_index/core/workflow/result.py
+++ b/llama-index-core/llama_index/core/workflow/result.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from llama_index.core.workflow.context import Context
+
+
+class WorkflowResult:
+    def __init__(self, ctx: Context, result: Any, is_done: bool = True) -> None:
+        self.ctx = ctx
+        self.result = result
+        self.is_done = is_done
+
+    def __str__(self) -> str:
+        return str(self.result)

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -148,8 +148,6 @@ class Workflow(metaclass=WorkflowMeta):
         if ctx is None:
             ctx = Context(self)
             self._contexts.add(ctx)
-        else:
-            ctx.soft_reset()
 
         for name, step_func in self._get_steps().items():
             ctx._queues[name] = asyncio.Queue()
@@ -386,7 +384,7 @@ class Workflow(metaclass=WorkflowMeta):
             stepwise_context.send_event(StartEvent(**kwargs))
         elif ctx is not None:
             stepwise_context = ctx
-        else:
+        elif self._stepwise_context is not None:
             stepwise_context = self._stepwise_context
 
         # Unblock all pending steps

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -38,8 +38,8 @@ async def test_collect_events():
             return StopEvent(result=events)
 
     workflow = TestWorkflow()
-    result = await workflow.run()
-    assert result == [ev1, ev2]
+    workflow_result = await workflow.run()
+    assert workflow_result.result == [ev1, ev2]
 
 
 @pytest.mark.asyncio()

--- a/llama-index-core/tests/workflow/test_retry_policy.py
+++ b/llama-index-core/tests/workflow/test_retry_policy.py
@@ -28,7 +28,7 @@ async def test_retry_e2e():
             await ctx.set("counter", count + 1)
 
     workflow = DummyWorkflow(disable_validation=True)
-    assert await workflow.run() == "All good!"
+    assert str(await workflow.run()) == "All good!"
 
 
 def test_ConstantDelayRetryPolicy_init():

--- a/llama-index-core/tests/workflow/test_service.py
+++ b/llama-index-core/tests/workflow/test_service.py
@@ -41,8 +41,8 @@ class DummyWorkflow(Workflow):
         ctx: Context,
         service_workflow: ServiceWorkflow = ServiceWorkflow(),
     ) -> NumGenerated:
-        res = await service_workflow.run()
-        return NumGenerated(num=int(res))
+        workflow_result = await service_workflow.run()
+        return NumGenerated(num=int(workflow_result.result))
 
     @step
     async def multiply(self, ev: NumGenerated) -> StopEvent:
@@ -55,16 +55,16 @@ async def test_e2e():
     # We are responsible for passing the ServiceWorkflow instances to the dummy workflow
     # and give it a name, in this case "service_workflow"
     wf.add_workflows(service_workflow=ServiceWorkflow(the_answer=1337))
-    res = await wf.run()
-    assert res == 2674
+    workflow_result = await wf.run()
+    assert workflow_result.result == 2674
 
 
 @pytest.mark.asyncio()
 async def test_default_value_for_service():
     wf = DummyWorkflow()
     # We don't add any workflow to leverage the default value defined by the user
-    res = await wf.run()
-    assert res == 84
+    workflow_result = await wf.run()
+    assert workflow_result.result == 84
 
 
 def test_service_manager_add():


### PR DESCRIPTION
This is a breaking change, which modifies the return type of a workflow to be a `WorkflowResult` object

Through this, we can return the context and the result, along with anything else.

This PR also enables multiple streams to happen at the same time, which was previously not possible. Although currently, I'm not totally happy with how streaming works.

Lastly, this PR also allows for multiple runs to be running in stepwise mode. But again, the API for this feels a little awkward.

I think what would clean this up, is if streaming and stepwise were all features on the `WorkflowResult` object? But even then, I'm not totally sure, so feedback welcome!

Some current code samples

Streaming:
```python
class CounterWorkflow(Workflow):
    @step
    async def count(self, ctx: Context, ev: StartEvent) -> StopEvent:
        ctx.write_event_to_stream(Event(msg="hello!"))
  
        cur_count = await ctx.get("cur_count", default=0)
        await ctx.set("cur_count", cur_count + 1)
        return StopEvent(result="done")
  
wf = CounterWorkflow()
stream_1 = wf.stream_run()

async for item in stream_1:
pass

stream_2 = wf.stream_run(ctx=item.ctx)
async for item in stream_2:
pass

assert await item.ctx.get("cur_count") == 2
```

Not Streaming:
```python
class DummyWorkflow(Workflow):
    @step
    async def step(self, ctx: Context, ev: StartEvent) -> StopEvent:
        cur_count = await ctx.get("counter", default=0)
        await ctx.set("counter", cur_count + 1)

        return StopEvent(result="Done")

w = DummyWorkflow()

workflow_result = await w.run()
count = await workflow_result.ctx.get("counter")
assert count == 1

workflow_result = await w.run(ctx=workflow_result.ctx)
count = await workflow_result.ctx.get("counter")
assert count == 2
```
