### PR TITLE
feat: add quip reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-quip/.gitignore
+++ b/llama-index-integrations/readers/llama-index-readers-quip/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/readers/llama-index-readers-quip/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-quip/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-quip/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-quip/BUILD
@@ -1,1 +1,3 @@
-python_sources()
+poetry_requirements(
+    name="poetry",
+)

--- a/llama-index-integrations/readers/llama-index-readers-quip/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-quip/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/readers/llama-index-readers-quip/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-quip/README.md
@@ -1,0 +1,29 @@
+# LlamaIndex Readers Integration: Quip
+
+## Overview
+
+The Quip Reader enables loading data from Quip documents. It constructs queries to retrieve thread content based on thread IDs.
+
+### Installation
+
+You can install the Quip Reader via pip:
+
+```bash
+pip install llama-index-readers-quip
+```
+
+### Usage
+
+```python
+from llama_index.readers.quip import QuipReader
+
+# Initialize QuipReader
+reader = QuipReader(access_token="<Access Token>")
+
+# Load data from Quip
+documents = reader.load_data(thread_ids=["<Thread ID 1>", "<Thread ID 2>"])
+```
+
+This loader is designed to be used as a way to load data into
+[LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently
+used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent.

--- a/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/__init__.py
@@ -1,0 +1,4 @@
+from llama_index.readers.quip.base import QuipReader
+
+
+__all__ = ["QuipReader"]

--- a/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/base.py
@@ -18,9 +18,20 @@ class QuipReader(BasePydanticReader):
         default=None, description="Headers to be sent with the request"
     )
 
-    def __init__(self, **data) -> None:
-        super().__init__(**data)
-        self.headers = {"Authorization": "Bearer " + self.access_token}
+    def __init__(
+        self,
+        access_token: str,
+        request_timeout: Optional[float] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        headers = headers or {}
+        if "Authorization" not in headers:
+            headers["Authorization"] = "Bearer " + access_token
+        super().__init__(
+            access_token=access_token,
+            request_timeout=request_timeout,
+            headers=headers,
+        )
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-quip/llama_index/readers/quip/base.py
@@ -1,0 +1,82 @@
+"""Quip reader."""
+from llama_index.core.readers.base import BasePydanticReader
+from llama_index.core.schema import Document
+from typing import Any, Dict, List, Optional
+import requests  # type: ignore
+import time
+from pydantic import Field
+
+BASE_URL = "https://platform.quip.com"
+
+
+class QuipReader(BasePydanticReader):
+    access_token: str = Field(description="Quip API access token")
+    request_timeout: Optional[float] = Field(
+        default=None, description="Request timeout in seconds"
+    )
+    headers: Dict[str, str] = Field(
+        default=None, description="Headers to be sent with the request"
+    )
+
+    def __init__(self, **data) -> None:
+        super().__init__(**data)
+        self.headers = {"Authorization": "Bearer " + self.access_token}
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "QuipReader"
+
+    def load_data(self, thread_ids: List[str]) -> List[Document]:
+        """Load data from Quip."""
+        documents = []
+        thread_contents = self._get_threads(thread_ids)
+        for i, content in enumerate(thread_contents):
+            doc = Document(
+                text=content, id_=thread_ids[i], extra_info={"thread_id": thread_ids[i]}
+            )
+            documents.append(doc)
+        return documents
+
+    def _get_threads(self, ids: List[str]) -> List[str]:
+        """Returns a dictionary of threads for the given IDs."""
+        threads = []
+        for id in ids:
+            thread_content = self._get_thread(id)
+            threads.append(thread_content)
+        return threads
+
+    def _get_thread(self, id) -> str:
+        """Returns the thread with the given ID."""
+        url = BASE_URL + "/2/" + "threads/" + id + "/html"
+        return self._request_with_retry("GET", url, headers=self.headers).get(
+            "html", ""
+        )
+
+    def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        headers: Dict[str, str],
+        json: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Make a request with retry and rate limit handling."""
+        max_retries = 5
+        backoff_factor = 1
+
+        for attempt in range(max_retries):
+            try:
+                response = requests.request(method, url, headers=headers, json=json)
+                response.raise_for_status()
+                return response.json()
+            except requests.exceptions.HTTPError:
+                if response.status_code == 429:
+                    # Rate limit exceeded
+                    retry_after = int(response.headers.get("Retry-After", 1))
+                    time.sleep(backoff_factor * (2**attempt) + retry_after)
+                else:
+                    raise requests.exceptions.HTTPError(
+                        f"Request failed: {response.text}"
+                    )
+            except requests.exceptions.RequestException as err:
+                raise requests.exceptions.RequestException(f"Request failed: {err}")
+        raise Exception("Maximum retries exceeded")

--- a/llama-index-integrations/readers/llama-index-readers-quip/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-quip/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+# Feel free to un-skip examples, and experimental, you will just need to
+# work through many typos (--write-changes and --interactive will help)
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.quip"
+
+[tool.llamahub.class_authors]
+QuipReader = "ag-chirag"
+
+[tool.mypy]
+disallow_untyped_defs = true
+# Remove venv skip when integrated with pre-commit
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"
+
+[tool.poetry]
+authors = ["Chirag Agrawal <chirag.agrawal93@gmail.com>"]
+description = "llama-index readers quip integration"
+license = "MIT"
+name = "llama-index-readers-quip"
+packages = [{include = "llama_index/"}]
+readme = "README.md"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = ">=3.8.1,<4.0"
+llama-index-core = "^0.11.0"
+
+[tool.poetry.group.dev.dependencies]
+black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
+codespell = {extras = ["toml"], version = ">=v2.2.6"}
+ipython = "8.10.0"
+jupyter = "^1.0.0"
+mypy = "0.991"
+pre-commit = "3.2.0"
+pylint = "2.15.10"
+pytest = "7.2.1"
+pytest-asyncio = "^0.23.6"
+pytest-mock = "3.11.1"
+ruff = "0.0.292"
+tree-sitter-languages = "^1.8.0"
+types-Deprecated = ">=0.1.0"
+types-PyYAML = "^6.0.12.12"
+types-protobuf = "^4.24.0.4"
+types-redis = "4.5.5.0"
+types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-setuptools = "67.1.0.0"

--- a/llama-index-integrations/readers/llama-index-readers-quip/tests/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-quip/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/llama-index-integrations/readers/llama-index-readers-quip/tests/test_readers_quip.py
+++ b/llama-index-integrations/readers/llama-index-readers-quip/tests/test_readers_quip.py
@@ -1,0 +1,7 @@
+from llama_index.core.readers.base import BaseReader
+from llama_index.readers.quip import QuipReader
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in QuipReader.__mro__]
+    assert BaseReader.__name__ in names_of_base_classes


### PR DESCRIPTION
# Description

Added a Quip Reader that enables loading data from Quip documents. It constructs queries to retrieve thread content based on thread IDs. Quip is a popular collaboration tool used by several large corporations. A quip reader is a valuable addition to LlamaIndex. This change doesn't require any additional dependencies outside of what's already installed for all reader packages. 

Fixes # (issue)

## New Package? Yes

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump? No

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
