### PR TITLE
Fix: get all documents from Elasticsearch KVStore

### DIFF
--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-kvstore-elasticsearch"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
When creating a pipeline with Elasticsearch + `DocstoreStrategy.UPSERTS_AND_DELETE` the kvstore only retrieves the first 10 results, as it is not handling pagination (or scroll). This PR leverages on `async_scan` from Elasticsearch Client to retrieve all results from the kvstore, allowing the pipeline to compare incoming documents with already stored ones, and identifying which ones need an upsert/delete.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
