### PR TITLE
Hotfix: Fix Citations Text

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
@@ -85,7 +85,7 @@ class VectaraRetriever(BaseRetriever):
                  #citation-format-in-summary) for more details.
             This is a Vectara Scale only feature. Defaults to None.
         citations_text_pattern: The displayed text for citations.
-            Must be specified for html and markdown citations.
+            If not specified, numeric citations are displayed for text.
     """
 
     def __init__(
@@ -250,7 +250,8 @@ class VectaraRetriever(BaseRetriever):
                     data["query"][0]["summary"][0]["citationParams"] = {
                         "style": self._citations_style,
                     }
-                elif self._citations_url_pattern and self._citations_text_pattern:
+
+                elif self._citations_url_pattern:
                     data["query"][0]["summary"][0]["citationParams"] = {
                         "style": self._citations_style,
                         "urlPattern": self._citations_url_pattern,

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
@@ -31,7 +31,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-vectara"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/tests/test_indices_managed_vectara.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/tests/test_indices_managed_vectara.py
@@ -231,3 +231,16 @@ def test_citations(vectara2) -> None:
     res = query_engine.query("Describe Paul's early life and career.")
     summary = res.response
     assert re.search(r"\[\d+\]", summary)
+
+    # test citations with url pattern only (no text pattern)
+    query_engine = vectara2.as_query_engine(
+        similarity_top_k=10,
+        summary_num_results=7,
+        summary_prompt_name="vectara-summary-ext-24-05-med-omni",
+        citations_style="markdown",
+        citations_url_pattern="{doc.url}",
+    )
+    res = query_engine.query("Describe Paul's early life and career.")
+    summary = res.response
+    assert "https://www.paulgraham.com/worked.html" in summary
+    assert re.search(r"\[\d+\]", summary)


### PR DESCRIPTION
# Description

The previous construction of the query body for markdown and html citations required that both parameters `citations_url_pattern` and `citations_text_pattern` be provided by the user. However, we have functionality for this such that if the user only provides `citations_url_pattern` and not `citations_text_pattern`, the text displayed will be the numeric citation by default. This fix changes how the query body is built for Vectara's llama_index `VectaraRetriever` class to support this functionality.

Fixes: Now allows for users to only specify one of two arguments (`citations_url_pattern` is still required) for html and markdown citation styles.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I added a new test to our existing test file that passes in only the `citations_url_pattern` and not the `citations_text_pattern`. I made sure that the markdown citations work as intended, displaying numbers for the text and having the correct specified url pattern.

- [x] Added new unit/integration tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
