### PR TITLE
Use response synthesizer in context chat engines

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -213,9 +213,8 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         self, chat_history: List[ChatMessage]
     ) -> List[ChatMessage]:
         """Get the prefix messages with context."""
-        context_str_w_sys_prompt = (
-            self._context_prompt_template + self._system_prompt.strip()
-        )
+        system_prompt = self._system_prompt or ""
+        context_str_w_sys_prompt = self._context_prompt_template + system_prompt.strip()
         return [
             ChatMessage(
                 content=context_str_w_sys_prompt, role=self._llm.metadata.system_role
@@ -228,9 +227,9 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         self, chat_history: List[ChatMessage]
     ) -> List[ChatMessage]:
         """Get the prefix messages with context."""
-        # ensure we grab the user-configured system prompt
+        system_prompt = self._system_prompt or ""
         context_str_w_sys_prompt = (
-            self._context_refine_prompt_template + self._system_prompt.strip()
+            self._context_refine_prompt_template + system_prompt.strip()
         )
 
         return [

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -1,8 +1,17 @@
-import asyncio
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence
 
 from llama_index.core.base.base_retriever import BaseRetriever
-from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    MessageRole,
+)
+from llama_index.core.base.response.schema import (
+    StreamingResponse,
+    AsyncStreamingResponse,
+)
 from llama_index.core.callbacks import CallbackManager, trace_method
 from llama_index.core.chat_engine.types import (
     AgentChatResponse,
@@ -13,16 +22,26 @@ from llama_index.core.chat_engine.types import (
 from llama_index.core.llms.llm import LLM
 from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.core.prompts import ChatPromptTemplate
+from llama_index.core.response_synthesizers import CompactAndRefine
 from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
-from llama_index.core.settings import (
-    Settings,
-)
-from llama_index.core.types import Thread
+from llama_index.core.settings import Settings
+
 
 DEFAULT_CONTEXT_TEMPLATE = (
-    "Context information is below."
+    "Use the context information below to assist the user."
     "\n--------------------\n"
     "{context_str}"
+    "\n--------------------\n"
+)
+
+DEFAULT_REFINE_TEMPLATE = (
+    "Using the context below, refine the following existing answer using the provided context to assist the user."
+    "\n--------------------\n"
+    "{context_str}"
+    "\n--------------------\n"
+    "Existing Answer:\n"
+    "{existing_answer}"
     "\n--------------------\n"
 )
 
@@ -43,6 +62,7 @@ class ContextChatEngine(BaseChatEngine):
         prefix_messages: List[ChatMessage],
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         context_template: Optional[str] = None,
+        context_refine_template: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
     ) -> None:
         self._retriever = retriever
@@ -51,6 +71,10 @@ class ContextChatEngine(BaseChatEngine):
         self._prefix_messages = prefix_messages
         self._node_postprocessors = node_postprocessors or []
         self._context_template = context_template or DEFAULT_CONTEXT_TEMPLATE
+        self._context_refine_template = (
+            context_refine_template or DEFAULT_REFINE_TEMPLATE
+        )
+        self._synthesizer_cls = CompactAndRefine
 
         self.callback_manager = callback_manager or CallbackManager([])
         for node_postprocessor in self._node_postprocessors:
@@ -66,6 +90,7 @@ class ContextChatEngine(BaseChatEngine):
         prefix_messages: Optional[List[ChatMessage]] = None,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         context_template: Optional[str] = None,
+        context_refine_template: Optional[str] = None,
         llm: Optional[LLM] = None,
         **kwargs: Any,
     ) -> "ContextChatEngine":
@@ -97,9 +122,10 @@ class ContextChatEngine(BaseChatEngine):
             node_postprocessors=node_postprocessors,
             callback_manager=Settings.callback_manager,
             context_template=context_template,
+            context_refine_template=context_refine_template,
         )
 
-    def _generate_context(self, message: str) -> Tuple[str, List[NodeWithScore]]:
+    def _get_nodes(self, message: str) -> List[NodeWithScore]:
         """Generate context information from a message."""
         nodes = self._retriever.retrieve(message)
         for postprocessor in self._node_postprocessors:
@@ -107,26 +133,21 @@ class ContextChatEngine(BaseChatEngine):
                 nodes, query_bundle=QueryBundle(message)
             )
 
-        context_str = "\n\n".join(
-            [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
-        )
+        return nodes
 
-        return self._context_template.format(context_str=context_str), nodes
-
-    async def _agenerate_context(self, message: str) -> Tuple[str, List[NodeWithScore]]:
+    async def _aget_nodes(self, message: str) -> List[NodeWithScore]:
         """Generate context information from a message."""
         nodes = await self._retriever.aretrieve(message)
         for postprocessor in self._node_postprocessors:
             nodes = postprocessor.postprocess_nodes(
                 nodes, query_bundle=QueryBundle(message)
             )
-        context_str = "\n\n".join(
-            [n.node.get_content(metadata_mode=MetadataMode.LLM).strip() for n in nodes]
-        )
 
-        return self._context_template.format(context_str=context_str), nodes
+        return nodes
 
-    def _get_prefix_messages_with_context(self, context_str: str) -> List[ChatMessage]:
+    def _get_prefix_qa_messages_with_context(
+        self, chat_history: List[ChatMessage]
+    ) -> List[ChatMessage]:
         """Get the prefix messages with context."""
         # ensure we grab the user-configured system prompt
         system_prompt = ""
@@ -138,13 +159,74 @@ class ContextChatEngine(BaseChatEngine):
             system_prompt = str(self._prefix_messages[0].content)
             prefix_messages = self._prefix_messages[1:]
 
-        context_str_w_sys_prompt = system_prompt.strip() + "\n" + context_str
+        context_str_w_sys_prompt = self._context_template + system_prompt.strip()
         return [
             ChatMessage(
                 content=context_str_w_sys_prompt, role=self._llm.metadata.system_role
             ),
             *prefix_messages,
+            *chat_history,
+            ChatMessage(content="{query_str}", role=MessageRole.USER),
         ]
+
+    def _get_prefix_refine_messages_with_context(
+        self, chat_history: List[ChatMessage]
+    ) -> List[ChatMessage]:
+        """Get the prefix messages with context."""
+        # ensure we grab the user-configured system prompt
+        system_prompt = ""
+        prefix_messages = self._prefix_messages
+        if (
+            len(self._prefix_messages) != 0
+            and self._prefix_messages[0].role == MessageRole.SYSTEM
+        ):
+            system_prompt = str(self._prefix_messages[0].content)
+            prefix_messages = self._prefix_messages[1:]
+
+        context_str_w_sys_prompt = self._context_refine_template + system_prompt.strip()
+        return [
+            ChatMessage(
+                content=context_str_w_sys_prompt, role=self._llm.metadata.system_role
+            ),
+            *prefix_messages,
+            *chat_history,
+            ChatMessage(content="{query_str}", role=MessageRole.USER),
+        ]
+
+    def _get_response_synthesizer(
+        self, chat_history: List[ChatMessage], streaming: bool = False
+    ) -> CompactAndRefine:
+        qa_messages = self._get_prefix_qa_messages_with_context(chat_history)
+        refine_messages = self._get_prefix_refine_messages_with_context(chat_history)
+        return self._synthesizer_cls(
+            llm=self._llm,
+            callback_manager=self.callback_manager,
+            text_qa_template=ChatPromptTemplate.from_messages(qa_messages),
+            refine_template=ChatPromptTemplate.from_messages(refine_messages),
+            streaming=streaming,
+        )
+
+    def _get_current_chat_history(
+        self, input_msg: str, nodes: List[NodeWithScore]
+    ) -> List[ChatMessage]:
+        # get the current memory buffer safely
+        if hasattr(self._memory, "tokenizer_fn"):
+            prefix_messages_token_count = len(
+                self._memory.tokenizer_fn(
+                    " ".join(
+                        [
+                            (node.get_content(metadata_mode=MetadataMode.LLM))
+                            for node in nodes
+                        ]
+                    )
+                )
+            )
+        else:
+            prefix_messages_token_count = 0
+
+        return self._memory.get(
+            input=input_msg, initial_token_count=prefix_messages_token_count
+        )
 
     @trace_method("chat")
     def chat(
@@ -155,50 +237,31 @@ class ContextChatEngine(BaseChatEngine):
     ) -> AgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
-        self._memory.put(ChatMessage(content=message, role="user"))
 
-        context_str_template, nodes = self._generate_context(message)
-
-        # If the fetched context is completely empty
+        # get nodes and postprocess them
+        nodes = self._get_nodes(message)
         if len(nodes) == 0 and prev_chunks is not None:
-            context_str = "\n\n".join(
-                [
-                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
-                    for n in prev_chunks
-                ]
-            )
+            nodes = prev_chunks
 
-            # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(
-                context_str=context_str
-            )
+        # Get the response synthesizer with dynamic prompts
+        chat_history = self._get_current_chat_history(message, nodes)
+        synthesizer = self._get_response_synthesizer(chat_history)
 
-        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        response = synthesizer.synthesize(message, nodes)
+        user_message = ChatMessage(content=message, role=MessageRole.USER)
+        ai_message = ChatMessage(content=str(response), role=MessageRole.ASSISTANT)
 
-        if hasattr(self._memory, "tokenizer_fn"):
-            prefix_messages_token_count = len(
-                self._memory.tokenizer_fn(
-                    " ".join([(m.content or "") for m in prefix_messages])
-                )
-            )
-        else:
-            prefix_messages_token_count = 0
-
-        all_messages = prefix_messages + self._memory.get(
-            initial_token_count=prefix_messages_token_count
-        )
-        chat_response = self._llm.chat(all_messages)
-        ai_message = chat_response.message
+        self._memory.put(user_message)
         self._memory.put(ai_message)
 
         return AgentChatResponse(
-            response=str(chat_response.message.content),
+            response=str(response),
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(prefix_messages[0]),
+                    content=str(nodes),
                     raw_input={"message": message},
-                    raw_output=prefix_messages[0],
+                    raw_output=nodes,
                 )
             ],
             source_nodes=nodes,
@@ -214,57 +277,47 @@ class ContextChatEngine(BaseChatEngine):
         if chat_history is not None:
             self._memory.set(chat_history)
 
-        self._memory.put(ChatMessage(content=message, role="user"))
-
-        context_str_template, nodes = self._generate_context(message)
-
-        # If the fetched context is completely empty
+        # get nodes and postprocess them
+        nodes = self._get_nodes(message)
         if len(nodes) == 0 and prev_chunks is not None:
-            context_str = "\n\n".join(
-                [
-                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
-                    for n in prev_chunks
-                ]
-            )
+            nodes = prev_chunks
 
-            # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(
-                context_str=context_str
-            )
+        # Get the response synthesizer with dynamic prompts
+        chat_history = self._get_current_chat_history(message, nodes)
+        synthesizer = self._get_response_synthesizer(chat_history, streaming=True)
 
-        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        response = synthesizer.synthesize(message, nodes)
+        assert isinstance(response, StreamingResponse)
 
-        if hasattr(self._memory, "tokenizer_fn"):
-            initial_token_count = len(
-                self._memory.tokenizer_fn(
-                    " ".join([(m.content or "") for m in prefix_messages])
+        def wrapped_gen(response: StreamingResponse) -> ChatResponseGen:
+            full_response = ""
+            for token in response.response_gen:
+                full_response += token
+                yield ChatResponse(
+                    message=ChatMessage(
+                        content=full_response, role=MessageRole.ASSISTANT
+                    ),
+                    delta=token,
                 )
-            )
-        else:
-            initial_token_count = 0
 
-        all_messages = prefix_messages + self._memory.get(
-            initial_token_count=initial_token_count
-        )
+            user_message = ChatMessage(content=message, role=MessageRole.USER)
+            ai_message = ChatMessage(content=full_response, role=MessageRole.ASSISTANT)
+            self._memory.put(user_message)
+            self._memory.put(ai_message)
 
-        chat_response = StreamingAgentChatResponse(
-            chat_stream=self._llm.stream_chat(all_messages),
+        return StreamingAgentChatResponse(
+            chat_stream=wrapped_gen(response),
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(prefix_messages[0]),
+                    content=str(nodes),
                     raw_input={"message": message},
-                    raw_output=prefix_messages[0],
+                    raw_output=nodes,
                 )
             ],
             source_nodes=nodes,
+            is_writing_to_memory=False,
         )
-        thread = Thread(
-            target=chat_response.write_response_to_history, args=(self._memory,)
-        )
-        thread.start()
-
-        return chat_response
 
     @trace_method("chat")
     async def achat(
@@ -275,51 +328,31 @@ class ContextChatEngine(BaseChatEngine):
     ) -> AgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
-        self._memory.put(ChatMessage(content=message, role="user"))
 
-        context_str_template, nodes = await self._agenerate_context(message)
-
-        # If the fetched context is completely empty
+        # get nodes and postprocess them
+        nodes = await self._aget_nodes(message)
         if len(nodes) == 0 and prev_chunks is not None:
-            context_str = "\n\n".join(
-                [
-                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
-                    for n in prev_chunks
-                ]
-            )
+            nodes = prev_chunks
 
-            # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(
-                context_str=context_str
-            )
+        # Get the response synthesizer with dynamic prompts
+        chat_history = self._get_current_chat_history(message, nodes)
+        synthesizer = self._get_response_synthesizer(chat_history)
 
-        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        response = await synthesizer.asynthesize(message, nodes)
+        user_message = ChatMessage(content=message, role=MessageRole.USER)
+        ai_message = ChatMessage(content=str(response), role=MessageRole.ASSISTANT)
 
-        if hasattr(self._memory, "tokenizer_fn"):
-            initial_token_count = len(
-                self._memory.tokenizer_fn(
-                    " ".join([(m.content or "") for m in prefix_messages])
-                )
-            )
-        else:
-            initial_token_count = 0
-
-        all_messages = prefix_messages + self._memory.get(
-            initial_token_count=initial_token_count
-        )
-
-        chat_response = await self._llm.achat(all_messages)
-        ai_message = chat_response.message
+        self._memory.put(user_message)
         self._memory.put(ai_message)
 
         return AgentChatResponse(
-            response=str(chat_response.message.content),
+            response=str(response),
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(prefix_messages[0]),
+                    content=str(nodes),
                     raw_input={"message": message},
-                    raw_output=prefix_messages[0],
+                    raw_output=nodes,
                 )
             ],
             source_nodes=nodes,
@@ -334,54 +367,47 @@ class ContextChatEngine(BaseChatEngine):
     ) -> StreamingAgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
-        self._memory.put(ChatMessage(content=message, role="user"))
-
-        context_str_template, nodes = await self._agenerate_context(message)
-
-        # If the fetched context is completely empty
+        # get nodes and postprocess them
+        nodes = await self._aget_nodes(message)
         if len(nodes) == 0 and prev_chunks is not None:
-            context_str = "\n\n".join(
-                [
-                    n.node.get_content(metadata_mode=MetadataMode.LLM).strip()
-                    for n in prev_chunks
-                ]
-            )
+            nodes = prev_chunks
 
-            # Create a new context string template by using previous nodes
-            context_str_template = self._context_template.format(
-                context_str=context_str
-            )
+        # Get the response synthesizer with dynamic prompts
+        chat_history = self._get_current_chat_history(message, nodes)
+        synthesizer = self._get_response_synthesizer(chat_history, streaming=True)
 
-        prefix_messages = self._get_prefix_messages_with_context(context_str_template)
+        response = await synthesizer.asynthesize(message, nodes)
+        assert isinstance(response, AsyncStreamingResponse)
 
-        if hasattr(self._memory, "tokenizer_fn"):
-            initial_token_count = len(
-                self._memory.tokenizer_fn(
-                    " ".join([(m.content or "") for m in prefix_messages])
+        async def wrapped_gen(response: AsyncStreamingResponse) -> ChatResponseAsyncGen:
+            full_response = ""
+            async for token in response.async_response_gen():
+                full_response += token
+                yield ChatResponse(
+                    message=ChatMessage(
+                        content=full_response, role=MessageRole.ASSISTANT
+                    ),
+                    delta=token,
                 )
-            )
-        else:
-            initial_token_count = 0
 
-        all_messages = prefix_messages + self._memory.get(
-            initial_token_count=initial_token_count
-        )
+            user_message = ChatMessage(content=message, role=MessageRole.USER)
+            ai_message = ChatMessage(content=full_response, role=MessageRole.ASSISTANT)
+            self._memory.put(user_message)
+            self._memory.put(ai_message)
 
-        chat_response = StreamingAgentChatResponse(
-            achat_stream=await self._llm.astream_chat(all_messages),
+        return StreamingAgentChatResponse(
+            achat_stream=wrapped_gen(response),
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(prefix_messages[0]),
+                    content=str(nodes),
                     raw_input={"message": message},
-                    raw_output=prefix_messages[0],
+                    raw_output=nodes,
                 )
             ],
             source_nodes=nodes,
+            is_writing_to_memory=False,
         )
-        asyncio.create_task(chat_response.awrite_response_to_history(self._memory))
-
-        return chat_response
 
     def reset(self) -> None:
         self._memory.reset()

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Sequence
+from typing import Any, List, Optional
 
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import (
@@ -324,7 +324,7 @@ class ContextChatEngine(BaseChatEngine):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        prev_chunks: Optional[Sequence[NodeWithScore]] = None,
+        prev_chunks: Optional[List[NodeWithScore]] = None,
     ) -> AgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
@@ -363,7 +363,7 @@ class ContextChatEngine(BaseChatEngine):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        prev_chunks: Optional[Sequence[NodeWithScore]] = None,
+        prev_chunks: Optional[List[NodeWithScore]] = None,
     ) -> StreamingAgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -279,6 +279,9 @@ class StreamingAgentChatResponse:
                     # Queue is empty, but we're not done yet. Sleep for 0 secs to release the GIL and allow other threads to run.
                     time.sleep(0)
         else:
+            if self.chat_stream is None:
+                raise ValueError("chat_stream is None!")
+
             for chat_response in self.chat_stream:
                 self.unformatted_response += chat_response.delta or ""
                 yield chat_response.delta or ""
@@ -306,6 +309,9 @@ class StreamingAgentChatResponse:
                 else:
                     break
         else:
+            if self.achat_stream is None:
+                raise ValueError("achat_stream is None!")
+
             async for chat_response in self.achat_stream:
                 self.unformatted_response += chat_response.delta or ""
                 yield chat_response.delta or ""

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -116,6 +116,7 @@ class StreamingAgentChatResponse:
     is_function_false_event: Optional[asyncio.Event] = None
     # signal when an OpenAI function is being executed
     is_function_not_none_thread_event: Event = field(default_factory=Event)
+    is_writing_to_memory: bool = True
     # Track if an exception occurred
     exception: Optional[Exception] = None
 
@@ -265,39 +266,49 @@ class StreamingAgentChatResponse:
 
     @property
     def response_gen(self) -> Generator[str, None, None]:
-        while not self.is_done or not self.queue.empty():
-            if self.exception is not None:
-                raise self.exception
+        if self.is_writing_to_memory:
+            while not self.is_done or not self.queue.empty():
+                if self.exception is not None:
+                    raise self.exception
 
-            try:
-                delta = self.queue.get(block=False)
-                self.unformatted_response += delta
-                yield delta
-            except Empty:
-                # Queue is empty, but we're not done yet. Sleep for 0 secs to release the GIL and allow other threads to run.
-                time.sleep(0)
+                try:
+                    delta = self.queue.get(block=False)
+                    self.unformatted_response += delta
+                    yield delta
+                except Empty:
+                    # Queue is empty, but we're not done yet. Sleep for 0 secs to release the GIL and allow other threads to run.
+                    time.sleep(0)
+        else:
+            for chat_response in self.chat_stream:
+                self.unformatted_response += chat_response.delta or ""
+                yield chat_response.delta or ""
         self.response = self.unformatted_response.strip()
 
     async def async_response_gen(self) -> AsyncGenerator[str, None]:
         self._ensure_async_setup()
         assert self.aqueue is not None
 
-        while True:
-            if not self.aqueue.empty() or not self.is_done:
-                if self.exception is not None:
-                    raise self.exception
+        if self.is_writing_to_memory:
+            while True:
+                if not self.aqueue.empty() or not self.is_done:
+                    if self.exception is not None:
+                        raise self.exception
 
-                try:
-                    delta = await asyncio.wait_for(self.aqueue.get(), timeout=0.1)
-                except asyncio.TimeoutError:
-                    if self.is_done:
-                        break
-                    continue
-                if delta is not None:
-                    self.unformatted_response += delta
-                    yield delta
-            else:
-                break
+                    try:
+                        delta = await asyncio.wait_for(self.aqueue.get(), timeout=0.1)
+                    except asyncio.TimeoutError:
+                        if self.is_done:
+                            break
+                        continue
+                    if delta is not None:
+                        self.unformatted_response += delta
+                        yield delta
+                else:
+                    break
+        else:
+            async for chat_response in self.achat_stream:
+                self.unformatted_response += chat_response.delta or ""
+                yield chat_response.delta or ""
         self.response = self.unformatted_response.strip()
 
     def print_response_stream(self) -> None:

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -1,8 +1,8 @@
 import pytest
 
 from llama_index.core import MockEmbedding
-from llama_index.core.chat_engine.condense_plus_context import (
-    CondensePlusContextChatEngine,
+from llama_index.core.chat_engine.context import (
+    ContextChatEngine,
 )
 from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.llms.mock import MockLLM
@@ -12,17 +12,17 @@ SYSTEM_PROMPT = "Talk like a pirate."
 
 
 @pytest.fixture()
-def chat_engine() -> CondensePlusContextChatEngine:
+def chat_engine() -> ContextChatEngine:
     index = VectorStoreIndex.from_documents(
         [Document.example()], embed_model=MockEmbedding(embed_dim=3)
     )
     retriever = index.as_retriever()
-    return CondensePlusContextChatEngine.from_defaults(
+    return ContextChatEngine.from_defaults(
         retriever, llm=MockLLM(), system_prompt=SYSTEM_PROMPT
     )
 
 
-def test_chat(chat_engine: CondensePlusContextChatEngine):
+def test_chat(chat_engine: ContextChatEngine):
     response = chat_engine.chat("Hello World!")
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
@@ -35,7 +35,7 @@ def test_chat(chat_engine: CondensePlusContextChatEngine):
     assert len(chat_engine.chat_history) == 4
 
 
-def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
+def test_chat_stream(chat_engine: ContextChatEngine):
     response = chat_engine.stream_chat("Hello World!")
 
     num_iters = 0
@@ -61,7 +61,7 @@ def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
 
 
 @pytest.mark.asyncio()
-async def test_achat(chat_engine: CondensePlusContextChatEngine):
+async def test_achat(chat_engine: ContextChatEngine):
     response = await chat_engine.achat("Hello World!")
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
@@ -75,7 +75,7 @@ async def test_achat(chat_engine: CondensePlusContextChatEngine):
 
 
 @pytest.mark.asyncio()
-async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
+async def test_chat_astream(chat_engine: ContextChatEngine):
     response = await chat_engine.astream_chat("Hello World!")
 
     num_iters = 0


### PR DESCRIPTION
The context chat engines do not handle token overflows well. It requires the user to
- limit the token limit on their memory
- limit the overall top-k on each retrieval

By using a response synthesizer, we can make this a little more painless.

This needed up being a decent refactor, but I think it simplified a lot too