### PR TITLE
Implement `get_nodes` on `PGVectorStore`

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
@@ -70,9 +70,5 @@ include = "llama_index/"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-filterwarnings = [
-    "ignore::DeprecationWarning:",
-]
-markers = [
-    "asyncio",
-]
+filterwarnings = ["ignore::DeprecationWarning:"]
+markers = ["asyncio"]


### PR DESCRIPTION
# Description

Implemented the function `get_nodes` on `PGVectorStore` inherited from `BasePydanticVectorStore`. Previously, this raised a `NotImplementedError`.

This allows the user to use a `PGVectorStore` to fetch nodes directly from the database without doing a similarity search. 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ x ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ x ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I ran `make format; make lint` to appease the lint gods
