### PR TITLE
Update docstring in base.py in MilvusVectorStore adding COSINE as available similarity metric

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -112,7 +112,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         doc_id_field (str, optional): The name of the doc_id field for the collection,
             defaults to DEFAULT_DOC_ID_KEY.
         similarity_metric (str, optional): The similarity metric to use,
-            currently supports IP and L2.
+            currently supports IP, COSINE and L2.
         consistency_level (str, optional): Which consistency level to use for a newly
             created collection. Defaults to "Session".
         overwrite (bool, optional): Whether to overwrite existing collection with same


### PR DESCRIPTION






# Description

According to Milvus Documentation, **COSINE** as similarity metric is supported (Both Milvus and Milvus Lite) but in Llama-Index docs was missing.

- [Link to Milvus official docs](https://milvus.io/docs/metric.md?tab=floating#Similarity-Metrics)

Fixes # (issue)

I've checked in the [code](https://github.com/run-llama/llama_index/blob/723c2533ed4b7b43b7d814c89af1838f0f1994c2/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py#L256) , so indeed COSINE is supported, so no more further changes are needed.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

- [X] This change requires a documentation update

## How Has This Been Tested?

I've checked in the [code](https://github.com/run-llama/llama_index/blob/723c2533ed4b7b43b7d814c89af1838f0f1994c2/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py#L256) , so indeed COSINE is supported, so no more further changes are needed.

- [X] I stared at the code and made sure it makes sense


