### PR TITLE
Attempt #3 of context/result refactor

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -22,7 +22,8 @@ class Context:
     Both `set` and `get` operations on global data are governed by a lock, and considered coroutine-safe.
     """
 
-    def __init__(self, workflow: "Workflow") -> None:
+    def __init__(self, workflow: "Workflow", stepwise: bool = False) -> None:
+        self.stepwise = stepwise
         self._workflow = workflow
         # Broker machinery
         self._queues: Dict[str, asyncio.Queue] = {}

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -1,8 +1,8 @@
 import asyncio
-from typing import Any, Optional
+from typing import Any, AsyncGenerator, Optional
 
 from llama_index.core.workflow.context import Context
-from llama_index.core.workflow.events import StopEvent
+from llama_index.core.workflow.events import Event, StopEvent
 from llama_index.core.workflow.errors import WorkflowDone
 
 
@@ -19,7 +19,10 @@ class WorkflowHandler(asyncio.Future):
     def is_done(self) -> bool:
         return self.done()
 
-    async def stream_events(self):
+    async def stream_events(self) -> AsyncGenerator[Event, None]:
+        if not self.ctx:
+            raise ValueError("Context is not set!")
+
         while True:
             ev = await self.ctx.streaming_queue.get()
             if type(ev) is StopEvent:

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -1,0 +1,71 @@
+import asyncio
+from typing import Any, Optional
+
+from llama_index.core.workflow.context import Context
+from llama_index.core.workflow.events import StopEvent
+from llama_index.core.workflow.errors import WorkflowDone
+
+
+class WorkflowHandler(asyncio.Future):
+    def __init__(
+        self, *args: Any, ctx: Optional[Context] = None, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.ctx = ctx
+
+    def __str__(self) -> str:
+        return str(self.result())
+
+    def is_done(self) -> bool:
+        return self.done()
+
+    async def stream_events(self):
+        while True:
+            ev = await self.ctx.streaming_queue.get()
+            if type(ev) is StopEvent:
+                break
+
+            yield ev
+
+    async def run_step(self) -> Optional[Any]:
+        if self.ctx and not self.ctx.stepwise:
+            raise ValueError("Stepwise context is required to run stepwise.")
+
+        if self.ctx:
+            # Unblock all pending steps
+            for flag in self.ctx._step_flags.values():
+                flag.set()
+
+            # Yield back control to the event loop to give an unblocked step
+            # the chance to run (we won't actually sleep here).
+            await asyncio.sleep(0)
+
+            # See if we're done, or if a step raised any error
+            we_done = False
+            exception_raised = None
+            for t in self.ctx._tasks:
+                # Check if we're done
+                if not t.done():
+                    continue
+
+                we_done = True
+                e = t.exception()
+                if type(e) != WorkflowDone:
+                    exception_raised = e
+
+            retval = None
+            if we_done:
+                # Remove any reference to the tasks
+                for t in self.ctx._tasks:
+                    t.cancel()
+                    await asyncio.sleep(0)
+                retval = self.ctx.get_result()
+
+                self.set_result(retval)
+
+            if exception_raised:
+                raise exception_raised
+        else:
+            raise ValueError("Context is not set!")
+
+        return retval

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -290,7 +290,7 @@ class Workflow(metaclass=WorkflowMeta):
 
         result = WorkflowHandler(ctx=ctx)
 
-        async def _run_workflow():
+        async def _run_workflow() -> None:
             try:
                 # Send the first event
                 ctx.send_event(StartEvent(**kwargs))

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -336,6 +336,14 @@ class Workflow(metaclass=WorkflowMeta):
     @dispatcher.span
     async def run_step(self, **kwargs: Any) -> Optional[Any]:
         """Runs the workflow stepwise until completion."""
+        warnings.warn(
+            "run_step() is deprecated, use `workflow.run(stepwise=True)` instead.\n"
+            "handler = workflow.run(stepwise=True)\n"
+            "while not handler.is_done():\n"
+            "    result = await handler.run_step()\n"
+            "    print(result)\n"
+        )
+
         # Check if we need to start a new session
         if self._stepwise_context is None:
             self._validate()

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -16,6 +16,7 @@ from .utils import (
     get_steps_from_instance,
     ServiceDefinition,
 )
+from .handler import WorkflowHandler
 
 
 dispatcher = get_dispatcher(__name__)
@@ -139,17 +140,25 @@ class Workflow(metaclass=WorkflowMeta):
         """Returns all the steps, whether defined as methods or free functions."""
         return {**get_steps_from_instance(self), **self._step_functions}  # type: ignore[attr-defined]
 
-    def _start(self, stepwise: bool = False) -> Context:
+    def _start(self, stepwise: bool = False, ctx: Optional[Context] = None) -> Context:
         """Sets up the queues and tasks for each declared step.
 
         This method also launches each step as an async task.
         """
-        ctx = Context(self)
-        self._contexts.add(ctx)
+        if ctx is None:
+            ctx = Context(self, stepwise=stepwise)
+            self._contexts.add(ctx)
+        else:
+            # clean up the context from the previous run
+            ctx._tasks = set()
+            ctx._queues = {}
+            ctx._step_flags = {}
+            ctx._retval = None
 
         for name, step_func in self._get_steps().items():
             ctx._queues[name] = asyncio.Queue()
             ctx._step_flags[name] = asyncio.Event()
+
             # At this point, step_func is guaranteed to have the `__step_config` attribute
             step_config: StepConfig = getattr(step_func, "__step_config")
 
@@ -249,6 +258,7 @@ class Workflow(metaclass=WorkflowMeta):
                         name=name,
                     )
                 )
+
         return ctx
 
     def send_event(self, message: Event, step: Optional[str] = None) -> None:
@@ -268,73 +278,64 @@ class Workflow(metaclass=WorkflowMeta):
         ctx.send_event(message=message, step=step)
 
     @dispatcher.span
-    async def run(self, **kwargs: Any) -> str:
-        """Runs the workflow until completion.
-
-        Works by
-            1. validating the workflow
-            2. starting the workflow by setting up the queues and tasks
-            3. sending a StartEvent to kick things off
-            4. waiting for all tasks to finish or be cancelled
-        """
+    def run(
+        self, ctx: Optional[Context] = None, stepwise: bool = False, **kwargs: Any
+    ) -> WorkflowHandler:
+        """Runs the workflow until completion."""
         # Validate the workflow if needed
         self._validate()
 
-        # Start the machinery in a new Context
-        ctx = self._start()
+        # Start the machinery in a new Context or use the provided one
+        ctx = self._start(ctx=ctx, stepwise=stepwise)
 
-        # Send the first event
-        ctx.send_event(StartEvent(**kwargs))
+        result = WorkflowHandler(ctx=ctx)
 
-        done, unfinished = await asyncio.wait(
-            ctx._tasks, timeout=self._timeout, return_when=asyncio.FIRST_EXCEPTION
-        )
+        async def _run_workflow():
+            try:
+                # Send the first event
+                ctx.send_event(StartEvent(**kwargs))
 
-        we_done = False
-        exception_raised = None
-        # A task that raised an exception will be returned in the `done` set
-        for task in done:
-            # Check if any exception was raised from a step function
-            e = task.exception()
-            # If the error was of type WorkflowDone, the _done step run successfully
-            if type(e) == WorkflowDone:
-                we_done = True
-            # In any other case, we will re-raise after cleaning up.
-            # Since wait() is called with return_when=asyncio.FIRST_EXCEPTION,
-            # we can assume exception_raised will be only one.
-            elif e is not None:
-                exception_raised = e
-                break
+                done, unfinished = await asyncio.wait(
+                    ctx._tasks,
+                    timeout=self._timeout,
+                    return_when=asyncio.FIRST_EXCEPTION,
+                )
 
-        # Cancel any pending tasks
-        for t in unfinished:
-            t.cancel()
-            await asyncio.sleep(0)
+                we_done = False
+                exception_raised = None
+                for task in done:
+                    e = task.exception()
+                    if type(e) == WorkflowDone:
+                        we_done = True
+                    elif e is not None:
+                        exception_raised = e
+                        break
 
-        # Bubble up the error if any step raised an exception
-        if exception_raised:
-            # Make sure to stop streaming, in case the workflow terminated abnormally
-            ctx.write_event_to_stream(StopEvent())
-            raise exception_raised
+                # Cancel any pending tasks
+                for t in unfinished:
+                    t.cancel()
+                    await asyncio.sleep(0)
 
-        # Raise WorkflowTimeoutError if the workflow timed out
-        if not we_done:
-            msg = f"Operation timed out after {self._timeout} seconds"
-            raise WorkflowTimeoutError(msg)
+                if exception_raised:
+                    ctx.write_event_to_stream(StopEvent())
+                    raise exception_raised
 
-        return ctx._retval
+                if not we_done:
+                    msg = f"Operation timed out after {self._timeout} seconds"
+                    raise WorkflowTimeoutError(msg)
+
+                result.set_result(ctx._retval)
+            except Exception as e:
+                result.set_exception(e)
+            finally:
+                ctx.write_event_to_stream(StopEvent())
+
+        asyncio.create_task(_run_workflow())
+        return result
 
     @dispatcher.span
-    async def run_step(self, **kwargs: Any) -> Optional[str]:
-        """Runs the workflow stepwise until completion.
-
-        Works by
-            1. Validating and setting up the queues and tasks if the first step hasn't been started
-            2. Sending a StartEvent to kick things off
-            3. Sets the flag for all steps to run once (if they can run)
-            4. Waiting for the next step(s) to finish
-            5. Returning the result if the workflow is done
-        """
+    async def run_step(self, **kwargs: Any) -> Optional[Any]:
+        """Runs the workflow stepwise until completion."""
         # Check if we need to start a new session
         if self._stepwise_context is None:
             self._validate()

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -28,9 +28,9 @@ class StreamingWorkflow(Workflow):
 @pytest.mark.asyncio()
 async def test_e2e():
     wf = StreamingWorkflow()
-    r = asyncio.create_task(wf.run())
+    r = wf.run()
 
-    async for ev in wf.stream_events():
+    async for ev in r.stream_events():
         assert "msg" in ev
 
     await r
@@ -58,10 +58,10 @@ async def test_task_raised():
             raise ValueError("The step raised an error!")
 
     wf = DummyWorkflow()
-    r = asyncio.create_task(wf.run())
+    r = wf.run()
 
     # Make sure we don't block indefinitely here because the step raised
-    async for ev in wf.stream_events():
+    async for ev in r.stream_events():
         assert ev.test_param == "foo"
 
     # Make sure the await actually caught the exception
@@ -70,17 +70,56 @@ async def test_task_raised():
 
 
 @pytest.mark.asyncio()
-async def test_multiple_streams():
+async def test_multiple_sequential_streams():
     wf = StreamingWorkflow()
-    r = asyncio.create_task(wf.run())
+    r = wf.run()
 
     # stream 1
-    async for _ in wf.stream_events():
+    async for _ in r.stream_events():
         pass
     await r
 
     # stream 2 -- should not raise an error
-    r = asyncio.create_task(wf.run())
-    async for _ in wf.stream_events():
+    r = wf.run()
+    async for _ in r.stream_events():
         pass
     await r
+
+
+@pytest.mark.asyncio()
+async def test_multiple_ongoing_streams():
+    wf = StreamingWorkflow()
+    stream_1 = wf.run()
+    stream_2 = wf.run()
+
+    async for ev in stream_1.stream_events():
+        assert "msg" in ev
+
+    async for ev in stream_2.stream_events():
+        assert "msg" in ev
+
+
+@pytest.mark.asyncio()
+async def test_resume_streams():
+    class CounterWorkflow(Workflow):
+        @step
+        async def count(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            ctx.write_event_to_stream(Event(msg="hello!"))
+
+            cur_count = await ctx.get("cur_count", default=0)
+            await ctx.set("cur_count", cur_count + 1)
+            return StopEvent(result="done")
+
+    wf = CounterWorkflow()
+    handler_1 = wf.run()
+
+    async for _ in handler_1.stream_events():
+        pass
+    await handler_1
+
+    handler_2 = wf.run(ctx=handler_1.ctx)
+    async for _ in handler_2.stream_events():
+        pass
+    await handler_2
+
+    assert await handler_2.ctx.get("cur_count") == 2


### PR DESCRIPTION
This PR subclasses asyncio.Future in order to enable
- multiple streams at the some time
- using a previous context in a new run
- moving the streaming and stepwise APIs to the context object

```python
# stream
handler = workflow.run()
async for event in handler.stream_events():
  pass

final_result = await handler

# stepwise
handler = workflow.run(stepwise=True)
async for step in handler.run_step():
  if handler.is_done():
    break

final_result = await handler

# re-use context
final_result = await workflow.run(ctx=handler.ctx)
```