### PR TITLE
Fix serde issue for huggingface inference API embedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/llama_index/embeddings/huggingface_api/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/llama_index/embeddings/huggingface_api/base.py
@@ -61,7 +61,7 @@ class HuggingFaceInferenceAPIEmbedding(BaseEmbedding):  # type: ignore[misc]
             " Defaults to None, meaning it will loop until the server is available."
         ),
     )
-    headers: Dict[str, str] = Field(
+    headers: Optional[Dict[str, str]] = Field(
         default=None,
         description=(
             "Additional headers to send to the server. By default only the"
@@ -69,7 +69,7 @@ class HuggingFaceInferenceAPIEmbedding(BaseEmbedding):  # type: ignore[misc]
             " will override the default values."
         ),
     )
-    cookies: Dict[str, str] = Field(
+    cookies: Optional[Dict[str, str]] = Field(
         default=None, description="Additional cookies to send to the server."
     )
     task: Optional[str] = Field(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-huggingface-api"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/tests/test_hf_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/tests/test_hf_inference.py
@@ -106,3 +106,10 @@ class TestHuggingFaceInferenceAPIEmbeddings:
         assert serialized["model_name"] == STUB_MODEL_NAME
         # Check Hugging Face Inference API Embeddings derived class specifics
         assert serialized["pooling"] == Pooling.CLS
+
+    def test_serde(
+        self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
+    ) -> None:
+        serialized = hf_inference_api_embedding.model_dump()
+        deserialized = HuggingFaceInferenceAPIEmbedding.model_validate(serialized)
+        assert deserialized.headers == hf_inference_api_embedding.headers


### PR DESCRIPTION
# Description

bad type hinting is breaking serde in pydantic V2 (now more strict). This properly put optional as type hint. 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
