### PR TITLE
Add default to optional args for BedrockEmbedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -41,21 +41,29 @@ PROVIDER_SPECIFIC_IDENTIFIERS = {
 class BedrockEmbedding(BaseEmbedding):
     model_name: str = Field(description="The modelId of the Bedrock model to use.")
     profile_name: Optional[str] = Field(
+        default=None,
         description="The name of aws profile to use. If not given, then the default profile is used.",
     )
-    aws_access_key_id: Optional[str] = Field(description="AWS Access Key ID to use")
-    aws_secret_access_key: Optional[str] = Field(
-        description="AWS Secret Access Key to use"
+    aws_access_key_id: Optional[str] = Field(
+        default=None, description="AWS Access Key ID to use"
     )
-    aws_session_token: Optional[str] = Field(description="AWS Session Token to use")
+    aws_secret_access_key: Optional[str] = Field(
+        default=None, description="AWS Secret Access Key to use"
+    )
+    aws_session_token: Optional[str] = Field(
+        default=None, description="AWS Session Token to use"
+    )
     region_name: Optional[str] = Field(
+        default=None,
         description="AWS region name to use. Uses region configured in AWS CLI if not passed",
     )
     botocore_session: Optional[Any] = Field(
+        default=None,
         description="Use this Botocore session instead of creating a new default one.",
         exclude=True,
     )
     botocore_config: Optional[Any] = Field(
+        default=None,
         description="Custom configuration object to use instead of the default generated one.",
         exclude=True,
     )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-bedrock"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -190,3 +190,9 @@ class TestBedrockEmbedding(TestCase):
         )
 
         assert bedrock_embedding.list_supported_models() == exp_dict
+
+    def test_optional_args_in_json_schema(self) -> None:
+        json_schema = BedrockEmbedding.model_json_schema()
+        assert "botocore_session" in json_schema["properties"]
+        assert json_schema["properties"]["botocore_session"].get("default") is None
+        assert "botocore_session" not in json_schema.get("required", [])


### PR DESCRIPTION
# Description

Add default to optional args for BedrockEmbedding. Fixes issue where the generated json schema expects e.g. botocore_session to be filled. 

Fixes # (issue)


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
