### PR TITLE
Issue 16071: wordpress requires username, password

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
@@ -8,7 +8,8 @@ This loader fetches the text from Wordpress blog posts using the Wordpress API. 
 
 ## Usage
 
-To use this loader, you need to pass base url of the Wordpress installation (e.g. `https://www.mysite.com`), a username, and an application password for the user (more about application passwords [here](https://www.paidmembershipspro.com/create-application-password-wordpress/))
+To use this loader, you need to pass base url of the Wordpress installation (e.g. `https://www.mysite.com`) and optionally
+a username, and an application password for the user (more about application passwords [here](https://www.paidmembershipspro.com/create-application-password-wordpress/))
 
 ```python
 from llama_index.readers.wordpress import WordpressReader

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
@@ -8,8 +8,10 @@ This loader fetches the text from Wordpress blog posts using the Wordpress API. 
 
 ## Usage
 
-To use this loader, you need to pass base url of the Wordpress installation (e.g. `https://www.mysite.com`) and optionally
-a username, and an application password for the user (more about application passwords [here](https://www.paidmembershipspro.com/create-application-password-wordpress/))
+To use this loader, you need to pass base url of the Wordpress installation
+(e.g. `https://www.mysite.com`) and optionally a username, and an application
+password for the user (more about application passwords
+[here](https://www.paidmembershipspro.com/create-application-password-wordpress/))
 
 ```python
 from llama_index.readers.wordpress import WordpressReader

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/llama_index/readers/wordpress/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/llama_index/readers/wordpress/base.py
@@ -13,7 +13,7 @@ class WordpressReader(BaseReader):
         wordpress_subdomain (str): Wordpress subdomain
     """
 
-    def __init__(self, url: str, password: str, username: str) -> None:
+    def __init__(self, url: str, password: str = None, username: str = None) -> None:
         """Initialize Wordpress reader."""
         self.url = url
         self.username = username

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/llama_index/readers/wordpress/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/llama_index/readers/wordpress/base.py
@@ -1,6 +1,6 @@
 """Wordpress reader."""
 import json
-from typing import List
+from typing import List, Optional
 
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
@@ -13,7 +13,9 @@ class WordpressReader(BaseReader):
         wordpress_subdomain (str): Wordpress subdomain
     """
 
-    def __init__(self, url: str, password: str = None, username: str = None) -> None:
+    def __init__(
+        self, url: str, password: Optional[str] = None, username: Optional[str] = None
+    ) -> None:
         """Initialize Wordpress reader."""
         self.url = url
         self.username = username

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["bbornsztein"]
 name = "llama-index-readers-wordpress"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
@@ -2,6 +2,14 @@ from llama_index.core.readers.base import BaseReader
 from llama_index.readers.wordpress import WordpressReader
 
 
-def test_class():
+def test_class() -> None:
     names_of_base_classes = [b.__name__ for b in WordpressReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_allow_with_username_and_password() -> None:
+    wordpress_reader = WordpressReader("http://example.com", "user", "pass")
+
+
+def test_allow_without_username_and_password() -> None:
+    wordpress_reader = WordpressReader("http://example.com")


### PR DESCRIPTION
# Description

Fix Issue #16071 - wordpress reader plugin requires username and password when it doesn't have to.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
