### PR TITLE
fix incorrect parameters in VertexAIIndex

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-vertexai/llama_index/indices/managed/vertexai/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vertexai/llama_index/indices/managed/vertexai/base.py
@@ -104,8 +104,8 @@ class VertexAIIndex(BaseManagedIndex):
 
         with telemetry.tool_context_manager(self._user_agent):
             return rag.import_files(
-                corpus=self.corpus_name,
-                uris=uris,
+                corpus_name=self.corpus_name,
+                paths=uris,
                 chunk_size=chunk_size,
                 chunk_overlap=chunk_overlap,
                 timeout=timeout,

--- a/llama-index-integrations/indices/llama-index-indices-managed-vertexai/llama_index/indices/managed/vertexai/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vertexai/llama_index/indices/managed/vertexai/base.py
@@ -104,7 +104,7 @@ class VertexAIIndex(BaseManagedIndex):
 
         with telemetry.tool_context_manager(self._user_agent):
             return rag.import_files(
-                corpus_name=self.corpus_name,
+                self.corpus_name,
                 paths=uris,
                 chunk_size=chunk_size,
                 chunk_overlap=chunk_overlap,

--- a/llama-index-integrations/indices/llama-index-indices-managed-vertexai/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vertexai/pyproject.toml
@@ -30,12 +30,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-vertexai"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llamaindex-py-client = "^0.1.19"
-google-cloud-aiplatform = "^1.53.0"
+google-cloud-aiplatform = ">=1.53.0"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

```rag.import_files``` use some incorrect parameters in VertexAIIndex. This PR will fix it.

Fixes # ([16074](https://github.com/run-llama/llama_index/issues/16074))

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
