### PR TITLE
docs: add decorators to the api reference

### DIFF
--- a/docs/docs/api_reference/workflow/decorators.md
+++ b/docs/docs/api_reference/workflow/decorators.md
@@ -1,0 +1,4 @@
+::: llama_index.core.workflow.decorators
+    options:
+      members:
+        - step

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1584,10 +1584,11 @@ nav:
           - ./api_reference/tools/yelp.md
           - ./api_reference/tools/zapier.md
       - Workflow:
+          - ./api_reference/workflow/decorators.md
           - ./api_reference/workflow/context.md
           - ./api_reference/workflow/events.md
-          - ./api_reference/workflow/workflow.md
           - ./api_reference/workflow/retry_policy.md
+          - ./api_reference/workflow/workflow.md
   - Open-Source Community:
       - Integrations: ./community/integrations.md
       - Full Stack Projects: ./community/full_stack_projects.md

--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -31,7 +31,7 @@ def step(
     *args: Any,
     workflow: Optional[Type["Workflow"]] = None,
     pass_context: bool = False,
-    num_workers: int = 1,
+    num_workers: int = 4,
     retry_policy: Optional[RetryPolicy] = None,
 ) -> Callable:
     """Decorator used to mark methods and functions as workflow steps.
@@ -40,6 +40,13 @@ def step(
     starting the communication channels until runtime. For this reason,
     we temporarily store the list of events that will be consumed by this
     step in the function object itself.
+
+    Args:
+        workflow: Workflow class to which the decorated step will be added. Only needed when using the
+            decorator on free functions instead of class methods.
+        num_workers: The number of workers that will process events for the decorated step. The default
+            value works most of the times.
+        retry_policy: The policy used to retry a step that encountered an error while running.
     """
 
     def decorator(func: Callable) -> Callable:

--- a/llama-index-core/llama_index/core/workflow/retry_policy.py
+++ b/llama-index-core/llama_index/core/workflow/retry_policy.py
@@ -6,7 +6,7 @@ class RetryPolicy(Protocol):
     def next(
         self, elapsed_time: float, attempts: int, error: Exception
     ) -> Optional[float]:
-        """Decide if we should make another retry, returning the number of seconds to wait before the next run.
+        """Decides if we should make another retry, returning the number of seconds to wait before the next run.
 
         Args:
             elapsed_time: Time in seconds that passed since the last attempt.
@@ -19,7 +19,15 @@ class RetryPolicy(Protocol):
 
 
 class ConstantDelayRetryPolicy:
+    """A simple policy that retries a step at regular intervals for a number of times."""
+
     def __init__(self, maximum_attempts: int = 3, delay: float = 5) -> None:
+        """Creates a ConstantDelayRetryPolicy instance.
+
+        Args:
+            maximum_attempts: How many consecutive times the workflow should try to run the step in case of an error.
+            delay: how much time in seconds must pass before another attempt.
+        """
         self.maximum_attempts = maximum_attempts
         self.delay = delay
 


### PR DESCRIPTION
# Description

Add the `decorators` module and the `step` decorator function to the API reference docs.

Notes: 
- while fixing the docs I found out the default value for `num_workers` in the code is 1, but it should actually be 4 (as documented, and because we assessed overall it's a safer default value for the param).
- I also added documentation for the retry policy

