### PR TITLE
[chore] fix incorrect `handler.context` for `handler.ctx` in docs

### DIFF
--- a/docs/docs/module_guides/workflow/index.md
+++ b/docs/docs/module_guides/workflow/index.md
@@ -365,7 +365,7 @@ handler = w.run(topic="Pirates")
 # Iterate until done
 async for _ in handler:
     # inspect context
-    # val = await handler.context.get("key")
+    # val = await handler.ctx.get("key")
     continue
 
 # Get the final result
@@ -429,7 +429,7 @@ handler = w.run()
 result = await handler
 
 # continue with next run
-handler = w.run(context=handler.context)
+handler = w.run(ctx=handler.ctx)
 result = await handler
 ```
 

--- a/docs/docs/understanding/workflows/observability.md
+++ b/docs/docs/understanding/workflows/observability.md
@@ -109,7 +109,7 @@ handler = w.run()
 
 async for _ in handler.run_step():
     # inspect context
-    # val = await handler.context.get("key")
+    # val = await handler.ctx.get("key")
     continue
 
 # get the result


### PR DESCRIPTION
# Description

There's an error in the docs where we use `handler.context` instead of `handler.ctx` and also `Workflow.run(context=...)` instead of `Workflow.run(ctx=...)`


## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


- [x] I stared at the code and made sure it makes sense
