### PR TITLE
Sql markdown response

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -379,22 +379,22 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
     def _format_result_markdown(self, retrieved_nodes):
         """Format the result in markdown."""
         all_data = [eval(node.node.text) for node in retrieved_nodes]
-        
+
         if not all_data:
             return "| | |\n|---|---|\n| No data available | |"
-        
-        columns = retrieved_nodes[0].node.metadata.get('col_keys', [])
-        
+
+        columns = retrieved_nodes[0].node.metadata.get("col_keys", [])
+
         data = [item for sublist in all_data for item in sublist]
-        
+
         markdown = "| " + " | ".join(columns) + " |\n"
         markdown += "|" + "|".join(["---" for _ in columns]) + "|\n"
-        
+
         for row in data:
             markdown += "| " + " | ".join(str(item) for item in row) + " |\n"
-            
+
         return markdown
-    
+
     def _query(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
         """Answer a query."""
         retrieved_nodes, metadata = self.sql_retriever.retrieve_with_metadata(
@@ -481,6 +481,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
         text_to_sql_prompt: Optional[BasePromptTemplate] = None,
         context_query_kwargs: Optional[dict] = None,
         synthesize_response: bool = True,
+        markdown_response: bool = False,
         response_synthesis_prompt: Optional[BasePromptTemplate] = None,
         refine_synthesis_prompt: Optional[BasePromptTemplate] = None,
         tables: Optional[Union[List[str], List[Table]]] = None,
@@ -507,6 +508,7 @@ class NLSQLTableQueryEngine(BaseSQLTableQueryEngine):
         )
         super().__init__(
             synthesize_response=synthesize_response,
+            markdown_response=markdown_response,
             response_synthesis_prompt=response_synthesis_prompt,
             refine_synthesis_prompt=refine_synthesis_prompt,
             llm=llm,

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -383,8 +383,8 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
             node = node_with_score.node
             metadata = node.metadata
 
-            col_keys = metadata.get('col_keys', [])
-            results = metadata.get('result', [])
+            col_keys = metadata.get("col_keys", [])
+            results = metadata.get("result", [])
             table_header = "| " + " | ".join(col_keys) + " |\n"
             table_separator = "|" + "|".join(["---"] * len(col_keys)) + "|\n"
 
@@ -394,8 +394,7 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
 
             markdown_table = table_header + table_separator + table_rows
             tables.append(markdown_table)
-            print(markdown_table)
-        
+
         return "\n\n".join(tables).strip()
 
     def _query(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -35,7 +35,7 @@ from llama_index.core.prompts.prompt_type import PromptType
 from llama_index.core.response_synthesizers import (
     get_response_synthesizer,
 )
-from llama_index.core.schema import QueryBundle
+from llama_index.core.schema import NodeWithScore, QueryBundle
 from llama_index.core.settings import Settings
 from llama_index.core.utilities.sql_wrapper import SQLDatabase
 from sqlalchemy import Table
@@ -376,7 +376,7 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
     def sql_retriever(self) -> NLSQLRetriever:
         """Get SQL retriever."""
 
-    def _format_result_markdown(self, retrieved_nodes):
+    def _format_result_markdown(self, retrieved_nodes: List[NodeWithScore]) -> str:
         """Format the result in markdown."""
         tables = []
         for node_with_score in retrieved_nodes:

--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -378,22 +378,25 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
 
     def _format_result_markdown(self, retrieved_nodes):
         """Format the result in markdown."""
-        all_data = [eval(node.node.text) for node in retrieved_nodes]
+        tables = []
+        for node_with_score in retrieved_nodes:
+            node = node_with_score.node
+            metadata = node.metadata
 
-        if not all_data:
-            return "| | |\n|---|---|\n| No data available | |"
+            col_keys = metadata.get('col_keys', [])
+            results = metadata.get('result', [])
+            table_header = "| " + " | ".join(col_keys) + " |\n"
+            table_separator = "|" + "|".join(["---"] * len(col_keys)) + "|\n"
 
-        columns = retrieved_nodes[0].node.metadata.get("col_keys", [])
+            table_rows = ""
+            for row in results:
+                table_rows += "| " + " | ".join(str(item) for item in row) + " |\n"
 
-        data = [item for sublist in all_data for item in sublist]
-
-        markdown = "| " + " | ".join(columns) + " |\n"
-        markdown += "|" + "|".join(["---" for _ in columns]) + "|\n"
-
-        for row in data:
-            markdown += "| " + " | ".join(str(item) for item in row) + " |\n"
-
-        return markdown
+            markdown_table = table_header + table_separator + table_rows
+            tables.append(markdown_table)
+            print(markdown_table)
+        
+        return "\n\n".join(tables).strip()
 
     def _query(self, query_bundle: QueryBundle) -> RESPONSE_TYPE:
         """Answer a query."""

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -83,7 +83,7 @@ def test_sql_index_query(
     assert str(response) == """| user_id | foo |
 |---|---|
 | 2 | bar |
-| 8 | hello |\n"""
+| 8 | hello |"""
 
 def test_sql_index_async_query(
     allow_networking: Any,

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -48,7 +48,7 @@ def test_sql_index_query(
     sql_query_engine = SQLStructStoreQueryEngine(index, **query_kwargs)
     response = sql_query_engine.query(sql_to_test)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
-
+        
     # query the index with natural language
     nl_query_engine = NLStructStoreQueryEngine(index, **query_kwargs)
     response = nl_query_engine.query("test_table:user_id,foo")
@@ -77,6 +77,13 @@ def test_sql_index_query(
     response = nl_table_engine.query("test_table:user_id,foo")
     assert str(response) == sql_to_test
 
+    # query with markdown return
+    nl_table_engine = NLSQLTableQueryEngine(index.sql_database, synthesize_response=False, markdown_response=True)
+    response = nl_table_engine.query("test_table:user_id,foo")
+    assert str(response) == """| user_id | foo |
+|---|---|
+| 2 | bar |
+| 8 | hello |\n"""
 
 def test_sql_index_async_query(
     allow_networking: Any,

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -48,7 +48,7 @@ def test_sql_index_query(
     sql_query_engine = SQLStructStoreQueryEngine(index, **query_kwargs)
     response = sql_query_engine.query(sql_to_test)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
-        
+
     # query the index with natural language
     nl_query_engine = NLStructStoreQueryEngine(index, **query_kwargs)
     response = nl_query_engine.query("test_table:user_id,foo")
@@ -78,12 +78,18 @@ def test_sql_index_query(
     assert str(response) == sql_to_test
 
     # query with markdown return
-    nl_table_engine = NLSQLTableQueryEngine(index.sql_database, synthesize_response=False, markdown_response=True)
+    nl_table_engine = NLSQLTableQueryEngine(
+        index.sql_database, synthesize_response=False, markdown_response=True
+    )
     response = nl_table_engine.query("test_table:user_id,foo")
-    assert str(response) == """| user_id | foo |
+    assert (
+        str(response)
+        == """| user_id | foo |
 |---|---|
 | 2 | bar |
 | 8 | hello |"""
+    )
+
 
 def test_sql_index_async_query(
     allow_networking: Any,


### PR DESCRIPTION
# Description

A flag has been implemented to provide functionality where, when this flag is set to True alongside the synthesise_response set to False, instead of returning the data in an array format, it returns the data as a markdown table structure. This is useful for direct responses and aids in processing and understanding the model, as it also provides column names, unlike the previous model's return format.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

We used this class with this implementation within product implementations we have. Since this is a core modification, we decided to push it forward. It has been extensively tested in our application calls.

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
