### PR TITLE
fix: `resolve_tool_choice` import error

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/__init__.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/__init__.py
@@ -1,3 +1,4 @@
 from llama_index.llms.openai.base import AsyncOpenAI, OpenAI, SyncOpenAI, Tokenizer
+from llama_index.llms.openai.utils import resolve_tool_choice
 
-__all__ = ["OpenAI", "Tokenizer", "SyncOpenAI", "AsyncOpenAI"]
+__all__ = ["OpenAI", "Tokenizer", "SyncOpenAI", "AsyncOpenAI", "resolve_tool_choice"]


### PR DESCRIPTION
# Description

this PR is to fix this error I've been getting:
```
E   ImportError: cannot import name 'resolve_tool_choice' from 'llama_index.llms.openai.utils' (/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/llama_index/llms/openai/utils.py)
```

Fixes # (issue)



## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
