### PR TITLE
Fixed up test_vectorstore. 

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-mongodb"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/conftest.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/conftest.py
@@ -23,7 +23,7 @@ def documents() -> List[Document]:
     text = Document.example().text
     metadata = Document.example().metadata
     texts = text.split("\n")
-    return [Document(text=text, metadata=metadata) for text in texts]
+    return [Document(text=text, metadata={"text": text}) for text in texts]
 
 
 @pytest.fixture(scope="session")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/test_vectorstore.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mongodb/tests/test_vectorstore.py
@@ -107,7 +107,7 @@ def test_vectorstore(
             "How do we best augment LLMs with our own private data?",
             "easily used with LLMs.",
         ]
-        filters_compoound = MetadataFilters(
+        filters_compound = MetadataFilters(
             condition=FilterCondition.AND,
             filters=[
                 MetadataFilter(
@@ -122,7 +122,7 @@ def test_vectorstore(
             query_str=query_str,
             query_embedding=query_embedding,
             similarity_top_k=n_similar,
-            filters=filters_compoound,
+            filters=filters_compound,
         )
         responses_with_filter_compound = vector_store.query(query=query)
         assert len(responses_with_filter_compound.ids) == n_similar
@@ -158,7 +158,7 @@ def test_vectorstore(
         query = VectorStoreQuery(
             query_str="llamaindex",
             query_embedding=query_embedding,  # "What are LLMs useful for?"
-            hybrid_top_k=n_similar,
+            similarity_top_k=n_similar,
             mode=VectorStoreQueryMode.HYBRID,
             alpha=0.5,
         )


### PR DESCRIPTION


# Description

Fixes small failures introduced in (97ac7e8cc) when me…tadata filtering was refactored, and (26205a0e9) when hybrid_top_k introduced.

## New Package?

- [X] No

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?



- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes

## Type of Change


- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tests have been run against Atlas. It's easy to miss this test as it currently is skipped if one doesn't have MONGODB_URI and OPENAI_API_KEY defined.
