### PR TITLE
[fix] handler.stream_events() doesn't yield `StopEvent`

### DIFF
--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -25,10 +25,11 @@ class WorkflowHandler(asyncio.Future):
 
         while True:
             ev = await self.ctx.streaming_queue.get()
-            if type(ev) is StopEvent:
-                break
 
             yield ev
+
+            if type(ev) is StopEvent:
+                break
 
     async def run_step(self) -> Optional[Any]:
         if self.ctx and not self.ctx.stepwise:

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -327,8 +327,6 @@ class Workflow(metaclass=WorkflowMeta):
                 result.set_result(ctx._retval)
             except Exception as e:
                 result.set_exception(e)
-            finally:
-                ctx.write_event_to_stream(StopEvent())
 
         asyncio.create_task(_run_workflow())
         return result
@@ -394,6 +392,7 @@ class Workflow(metaclass=WorkflowMeta):
     async def _done(self, ctx: Context, ev: StopEvent) -> None:
         """Tears down the whole workflow and stop execution."""
         ctx._retval = ev.result or None
+        ctx.write_event_to_stream(ev)
 
         # Signal we want to stop the workflow
         raise WorkflowDone

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -394,7 +394,6 @@ class Workflow(metaclass=WorkflowMeta):
     async def _done(self, ctx: Context, ev: StopEvent) -> None:
         """Tears down the whole workflow and stop execution."""
         ctx._retval = ev.result or None
-        ctx.write_event_to_stream(ev)
 
         # Signal we want to stop the workflow
         raise WorkflowDone

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -31,7 +31,8 @@ async def test_e2e():
     r = wf.run()
 
     async for ev in r.stream_events():
-        assert "msg" in ev
+        if not isinstance(ev, StopEvent):
+            assert "msg" in ev
 
     await r
 
@@ -62,7 +63,8 @@ async def test_task_raised():
 
     # Make sure we don't block indefinitely here because the step raised
     async for ev in r.stream_events():
-        assert ev.test_param == "foo"
+        if not isinstance(ev, StopEvent):
+            assert ev.test_param == "foo"
 
     # Make sure the await actually caught the exception
     with pytest.raises(ValueError, match="The step raised an error!"):
@@ -93,10 +95,12 @@ async def test_multiple_ongoing_streams():
     stream_2 = wf.run()
 
     async for ev in stream_1.stream_events():
-        assert "msg" in ev
+        if not isinstance(ev, StopEvent):
+            assert "msg" in ev
 
     async for ev in stream_2.stream_events():
-        assert "msg" in ev
+        if not isinstance(ev, StopEvent):
+            assert "msg" in ev
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
# Description

This PR addresses two issues with `StopEvent` and streaming:

1. `StopEvent` is being put to the `ctx.streaming_queue` two times in a single workflow run.
2. `StopEvent` doesn't get yielded when invoking `handler.stream_events()`.

**Details**
For 1.

We put `StopEvent` to the stream under `Workflow._done()`: 
https://github.com/run-llama/llama_index/blob/a18b94699ac4e49b17f3f49879adf29dfc7c3ed3/llama-index-core/llama_index/core/workflow/workflow.py#L397

We also put another `StopEvent` to the stream under `_run_workflow()` within `Workflow.run()`:
https://github.com/run-llama/llama_index/blob/a18b94699ac4e49b17f3f49879adf29dfc7c3ed3/llama-index-core/llama_index/core/workflow/workflow.py#L331

For 2.

`StopEvent` never gets yielded to the user when calling `handler.stream_events()` since we `break` when we run into a `StopEvent` without yielding it first:
https://github.com/run-llama/llama_index/blob/a18b94699ac4e49b17f3f49879adf29dfc7c3ed3/llama-index-core/llama_index/core/workflow/handler.py#L28.


This PR address both issues 1. and 2. Tests were also modified to account for `StopEvent` being streamed.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated relevant unit/integration tests
- [x] I stared at the code and made sure it makes sense

