### PR TITLE
Wordpress: Allow control of whether Pages and/or Posts are retrieved

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
@@ -24,4 +24,12 @@ loader = WordpressReader(
 documents = loader.load_data()
 ```
 
-This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/).
+This loader is designed to be used as a way to load data into
+[LlamaIndex](https://github.com/run-llama/llama_index/).
+
+## Pages and Posts
+
+Be default, the loader retrieves both Wordpress _pages_ (static content) and
+_posts_ (blog entries) from the target site. This behavior can be configured
+by setting `get_pages=False` or `get_posts=False` when initializing the
+`WordpressReader` object.

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
@@ -18,7 +18,7 @@ WordpressReader = "bbornsztein"
 disallow_untyped_defs = true
 exclude = ["_static", "build", "examples", "notebooks", "venv"]
 ignore_missing_imports = true
-python_version = "3.8"
+python_version = "3.9"
 
 [tool.poetry]
 authors = ["Your Name <you@example.com>"]
@@ -29,10 +29,10 @@ license = "MIT"
 maintainers = ["bbornsztein"]
 name = "llama-index-readers-wordpress"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.9,<4.0"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -43,6 +43,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+responses = "^0.25.3"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
@@ -1,5 +1,14 @@
+import pytest
+import responses
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.wordpress import WordpressReader
+
+
+@pytest.fixture()
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
 
 
 def test_class() -> None:
@@ -13,3 +22,66 @@ def test_allow_with_username_and_password() -> None:
 
 def test_allow_without_username_and_password() -> None:
     wordpress_reader = WordpressReader("http://example.com")
+
+
+def test_retreive_pages_and_posts(mocked_responses) -> None:
+    mocked_responses.get(
+        "http://test.wordpress.org/wp-json/wp/v2/posts",
+        content_type="application/json",
+        body="""
+                [{"id": 1,
+                    "title": { "rendered": "foo" },
+                    "link": "http://test.wordpress.org/posts/1",
+                    "modified": "Never",
+                    "content": { "rendered": "Lorem ipsum" }
+                }]
+            """,
+    )
+    mocked_responses.get(
+        "http://test.wordpress.org/wp-json/wp/v2/pages",
+        content_type="application/json",
+        body="""
+                [{"id": 1,
+                    "title": { "rendered": "foo" },
+                    "link": "http://test.wordpress.org/pages/1",
+                    "modified": "Never",
+                    "content": { "rendered": "Lorem ipsum" }
+                }]
+            """,
+    )
+    wordpress_reader = WordpressReader("http://test.wordpress.org")
+    documents = wordpress_reader.load_data()
+
+
+def test_retreive_pages(mocked_responses) -> None:
+    mocked_responses.get(
+        "http://test.wordpress.org/wp-json/wp/v2/pages",
+        content_type="application/json",
+        body="""
+                [{"id": 1,
+                    "title": { "rendered": "foo" },
+                    "link": "http://test.wordpress.org/pages/1",
+                    "modified": "Never",
+                    "content": { "rendered": "Lorem ipsum" }
+                }]
+            """,
+    )
+    wordpress_reader = WordpressReader("http://test.wordpress.org", get_posts=False)
+    documents = wordpress_reader.load_data()
+
+
+def test_retreive_posts(mocked_responses) -> None:
+    mocked_responses.get(
+        "http://test.wordpress.org/wp-json/wp/v2/posts",
+        content_type="application/json",
+        body="""
+                [{"id": 1,
+                    "title": { "rendered": "foo" },
+                    "link": "http://test.wordpress.org/posts/1",
+                    "modified": "Never",
+                    "content": { "rendered": "Lorem ipsum" }
+                }]
+            """,
+    )
+    wordpress_reader = WordpressReader("http://test.wordpress.org", get_pages=False)
+    documents = wordpress_reader.load_data()


### PR DESCRIPTION
# Description

Wordpress supports two distinct types of content static Pages and blog Posts.  This PR supports retrieving both (or either) varieties of content and provides reasonable discount to support backward-compatibility of code.

Fixes #16065

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update (Done)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (just the README...)
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
