### PR TITLE
[Vertex AI] Pass safety_settings to send_message methods to fix settings not being sent to API

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -115,7 +115,7 @@ class Vertex(FunctionCallingLLM):
     ) -> None:
         init_vertexai(project=project, location=location, credentials=credentials)
 
-        safety_settings = safety_settings or {}
+        self._safety_settings = safety_settings or {}
         additional_kwargs = additional_kwargs or {}
         callback_manager = callback_manager or CallbackManager([])
 
@@ -158,7 +158,7 @@ class Vertex(FunctionCallingLLM):
 
             self._client = TextGenerationModel.from_pretrained(model)
         elif is_gemini_model(model):
-            self._client = create_gemini_client(model, safety_settings)
+            self._client = create_gemini_client(model, self._safety_settings)
             self._chat_client = self._client
             self._is_gemini = True
             self._is_chat_model = True
@@ -185,6 +185,7 @@ class Vertex(FunctionCallingLLM):
         base_kwargs = {
             "temperature": self.temperature,
             "max_output_tokens": self.max_tokens,
+            "safety_settings": self._safety_settings
         }
         return {
             **base_kwargs,

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -185,7 +185,7 @@ class Vertex(FunctionCallingLLM):
         base_kwargs = {
             "temperature": self.temperature,
             "max_output_tokens": self.max_tokens,
-            "safety_settings": self._safety_settings
+            "safety_settings": self._safety_settings,
         }
         return {
             **base_kwargs,

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
@@ -93,14 +93,22 @@ def completion_with_retry(
             generation_config = kwargs if kwargs else {}
 
             return generation.send_message(
-                prompt, stream=stream, tools=tools, generation_config=generation_config
+                prompt,
+                stream=stream,
+                tools=tools,
+                generation_config=generation_config,
+                safety_settings=client._safety_settings,
             )
         elif chat:
             generation = client.start_chat(**params)
             if stream:
-                return generation.send_message_streaming(prompt, **kwargs)
+                return generation.send_message_streaming(
+                    prompt, safety_settings=client._safety_settings, **kwargs
+                )
             else:
-                return generation.send_message(prompt, **kwargs)
+                return generation.send_message(
+                    prompt, safety_settings=client._safety_settings, **kwargs
+                )
         else:
             if stream:
                 return client.predict_streaming(prompt, **kwargs)
@@ -132,11 +140,16 @@ async def acompletion_with_retry(
             tools = to_gemini_tools(tools) if tools else []
             generation_config = kwargs if kwargs else {}
             return await generation.send_message_async(
-                prompt, tools=tools, generation_config=generation_config
+                prompt,
+                tools=tools,
+                generation_config=generation_config,
+                safety_settings=client._safety_settings,
             )
         elif chat:
             generation = client.start_chat(**params)
-            return await generation.send_message_async(prompt, **kwargs)
+            return await generation.send_message_async(
+                prompt, safety_settings=client._safety_settings, **kwargs
+            )
         else:
             return await client.predict_async(prompt, **kwargs)
 

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
@@ -97,17 +97,17 @@ def completion_with_retry(
                 stream=stream,
                 tools=tools,
                 generation_config=generation_config,
-                safety_settings=client._safety_settings,
+               
             )
         elif chat:
             generation = client.start_chat(**params)
             if stream:
                 return generation.send_message_streaming(
-                    prompt, safety_settings=client._safety_settings, **kwargs
+                    prompt, **kwargs
                 )
             else:
                 return generation.send_message(
-                    prompt, safety_settings=client._safety_settings, **kwargs
+                    prompt, **kwargs
                 )
         else:
             if stream:
@@ -143,12 +143,12 @@ async def acompletion_with_retry(
                 prompt,
                 tools=tools,
                 generation_config=generation_config,
-                safety_settings=client._safety_settings,
+               
             )
         elif chat:
             generation = client.start_chat(**params)
             return await generation.send_message_async(
-                prompt, safety_settings=client._safety_settings, **kwargs
+                prompt, **kwargs
             )
         else:
             return await client.predict_async(prompt, **kwargs)

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
@@ -97,18 +97,13 @@ def completion_with_retry(
                 stream=stream,
                 tools=tools,
                 generation_config=generation_config,
-               
             )
         elif chat:
             generation = client.start_chat(**params)
             if stream:
-                return generation.send_message_streaming(
-                    prompt, **kwargs
-                )
+                return generation.send_message_streaming(prompt, **kwargs)
             else:
-                return generation.send_message(
-                    prompt, **kwargs
-                )
+                return generation.send_message(prompt, **kwargs)
         else:
             if stream:
                 return client.predict_streaming(prompt, **kwargs)
@@ -143,13 +138,10 @@ async def acompletion_with_retry(
                 prompt,
                 tools=tools,
                 generation_config=generation_config,
-               
             )
         elif chat:
             generation = client.start_chat(**params)
-            return await generation.send_message_async(
-                prompt, **kwargs
-            )
+            return await generation.send_message_async(prompt, **kwargs)
         else:
             return await client.predict_async(prompt, **kwargs)
 

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vertex"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Currently when the Vertex class is initialized with safety_settings these settings aren't actually being sent to the API when using Gemini. This resolves this issue.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ X ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ X ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ X ] I ran `make format; make lint` to appease the lint gods
