### PR TITLE
account for tools in prompt helper

### DIFF
--- a/llama-index-core/llama_index/core/indices/common/struct_store/base.py
+++ b/llama-index-core/llama_index/core/indices/common/struct_store/base.py
@@ -98,7 +98,9 @@ class SQLDocumentContextBuilder:
 
         text_splitter = (
             self._text_splitter
-            or self._prompt_helper.get_text_splitter_given_prompt(prompt_with_schema)
+            or self._prompt_helper.get_text_splitter_given_prompt(
+                prompt_with_schema, llm=self._llm
+            )
         )
         # we use the ResponseBuilder to iteratively go through all texts
         response_builder = get_response_synthesizer(

--- a/llama-index-core/llama_index/core/indices/common_tree/base.py
+++ b/llama-index-core/llama_index/core/indices/common_tree/base.py
@@ -99,6 +99,7 @@ class GPTTreeIndexBuilder:
                     node.get_content(metadata_mode=MetadataMode.LLM)
                     for node in cur_nodes_chunk
                 ],
+                llm=self._llm,
             )
             text_chunk = "\n".join(truncated_chunks)
             indices.append(i)

--- a/llama-index-core/llama_index/core/indices/prompt_helper.py
+++ b/llama-index-core/llama_index/core/indices/prompt_helper.py
@@ -229,10 +229,14 @@ class PromptHelper(BaseComponent):
             prompt_str = get_empty_prompt_txt(prompt)
             num_prompt_tokens = self._token_counter.get_string_tokens(prompt_str)
 
-        num_prompt_tokens += self._token_counter.estimate_tokens_in_tools(tools)
-        num_prompt_tokens += self._token_counter.get_string_tokens(
-            llm.system_prompt or ""
+        num_prompt_tokens += self._token_counter.estimate_tokens_in_tools(
+            [x.metadata.to_openai_tool() for x in tools]
         )
+
+        if llm is not None:
+            num_prompt_tokens += self._token_counter.get_string_tokens(
+                llm.system_prompt or ""
+            )
 
         available_context_size = self._get_available_context_size(num_prompt_tokens)
         result = available_context_size // num_chunks - padding

--- a/llama-index-core/llama_index/core/indices/prompt_helper.py
+++ b/llama-index-core/llama_index/core/indices/prompt_helper.py
@@ -225,11 +225,14 @@ class PromptHelper(BaseComponent):
             num_prompt_tokens = self._token_counter.estimate_tokens_in_messages(
                 partial_messages
             )
-            num_prompt_tokens += self._token_counter.estimate_tokens_in_tools(tools)
         else:
             prompt_str = get_empty_prompt_txt(prompt)
             num_prompt_tokens = self._token_counter.get_string_tokens(prompt_str)
-            num_prompt_tokens += self._token_counter.estimate_tokens_in_tools(tools)
+
+        num_prompt_tokens += self._token_counter.estimate_tokens_in_tools(tools)
+        num_prompt_tokens += self._token_counter.get_string_tokens(
+            llm.system_prompt or ""
+        )
 
         available_context_size = self._get_available_context_size(num_prompt_tokens)
         result = available_context_size // num_chunks - padding

--- a/llama-index-core/llama_index/core/indices/prompt_helper.py
+++ b/llama-index-core/llama_index/core/indices/prompt_helper.py
@@ -236,8 +236,12 @@ class PromptHelper(BaseComponent):
             [x.metadata.to_openai_tool() for x in tools]
         )
 
-        # structured llms cannot have system prompts currently
-        if llm is not None and not isinstance(llm, StructuredLLM):
+        # structured llms cannot have system prompts currently -- check the underlying llm
+        if isinstance(llm, StructuredLLM):
+            num_prompt_tokens += self._token_counter.get_string_tokens(
+                llm.llm.system_prompt or ""
+            )
+        else:
             num_prompt_tokens += self._token_counter.get_string_tokens(
                 llm.system_prompt or ""
             )

--- a/llama-index-core/llama_index/core/indices/prompt_helper.py
+++ b/llama-index-core/llama_index/core/indices/prompt_helper.py
@@ -241,7 +241,7 @@ class PromptHelper(BaseComponent):
             num_prompt_tokens += self._token_counter.get_string_tokens(
                 llm.llm.system_prompt or ""
             )
-        else:
+        elif llm is not None:
             num_prompt_tokens += self._token_counter.get_string_tokens(
                 llm.system_prompt or ""
             )

--- a/llama-index-core/llama_index/core/indices/tree/inserter.py
+++ b/llama-index-core/llama_index/core/indices/tree/inserter.py
@@ -77,6 +77,7 @@ class TreeIndexInserter:
                 text_chunks=[
                     node.get_content(metadata_mode=MetadataMode.LLM) for node in half1
                 ],
+                llm=self._llm,
             )
             text_chunk1 = "\n".join(truncated_chunks)
 
@@ -89,6 +90,7 @@ class TreeIndexInserter:
                 text_chunks=[
                     node.get_content(metadata_mode=MetadataMode.LLM) for node in half2
                 ],
+                llm=self._llm,
             )
             text_chunk2 = "\n".join(truncated_chunks)
             summary2 = self._llm.predict(self.summary_prompt, context_str=text_chunk2)
@@ -129,6 +131,7 @@ class TreeIndexInserter:
             text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
                 prompt=self.insert_prompt,
                 num_chunks=len(cur_graph_node_list),
+                llm=self._llm,
             )
             numbered_text = get_numbered_text_from_nodes(
                 cur_graph_node_list, text_splitter=text_splitter
@@ -163,6 +166,7 @@ class TreeIndexInserter:
                     node.get_content(metadata_mode=MetadataMode.LLM)
                     for node in cur_graph_node_list
                 ],
+                llm=self._llm,
             )
             text_chunk = "\n".join(truncated_chunks)
             new_summary = self._llm.predict(self.summary_prompt, context_str=text_chunk)

--- a/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
+++ b/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
@@ -182,6 +182,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
             text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
                 prompt=query_template,
                 num_chunks=len(cur_node_list),
+                llm=self._llm,
             )
             numbered_node_text = get_numbered_text_from_nodes(
                 cur_node_list, text_splitter=text_splitter
@@ -201,6 +202,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
             text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
                 prompt=query_template_multiple,
                 num_chunks=len(cur_node_list),
+                llm=self._llm,
             )
             numbered_node_text = get_numbered_text_from_nodes(
                 cur_node_list, text_splitter=text_splitter
@@ -296,6 +298,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
             text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
                 prompt=query_template,
                 num_chunks=len(cur_node_list),
+                llm=self._llm,
             )
             numbered_node_text = get_numbered_text_from_nodes(
                 cur_node_list, text_splitter=text_splitter
@@ -315,6 +318,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
             text_splitter = self._prompt_helper.get_text_splitter_given_prompt(
                 prompt=query_template_multiple,
                 num_chunks=len(cur_node_list),
+                llm=self._llm,
             )
             numbered_node_text = get_numbered_text_from_nodes(
                 cur_node_list, text_splitter=text_splitter

--- a/llama-index-core/llama_index/core/program/function_program.py
+++ b/llama-index-core/llama_index/core/program/function_program.py
@@ -49,7 +49,7 @@ def _parse_tool_outputs(
         return outputs[0]
 
 
-def _get_function_tool(output_cls: Type[Model]) -> FunctionTool:
+def get_function_tool(output_cls: Type[Model]) -> FunctionTool:
     """Get function tool."""
     schema = output_cls.model_json_schema()
     schema_description = schema.get("description", None)
@@ -194,7 +194,7 @@ class FunctionCallingProgram(BasePydanticProgram[BaseModel]):
         **kwargs: Any,
     ) -> BaseModel:
         llm_kwargs = llm_kwargs or {}
-        tool = _get_function_tool(self._output_cls)
+        tool = get_function_tool(self._output_cls)
 
         messages = self._prompt.format_messages(llm=self._llm, **kwargs)
         messages = self._llm._extend_messages(messages)
@@ -218,7 +218,7 @@ class FunctionCallingProgram(BasePydanticProgram[BaseModel]):
         **kwargs: Any,
     ) -> BaseModel:
         llm_kwargs = llm_kwargs or {}
-        tool = _get_function_tool(self._output_cls)
+        tool = get_function_tool(self._output_cls)
 
         agent_response = await self._llm.apredict_and_call(
             [tool],
@@ -294,7 +294,7 @@ class FunctionCallingProgram(BasePydanticProgram[BaseModel]):
             raise ValueError("stream_call is only supported for LLMs.")
 
         llm_kwargs = llm_kwargs or {}
-        tool = _get_function_tool(self._output_cls)
+        tool = get_function_tool(self._output_cls)
 
         messages = self._prompt.format_messages(llm=self._llm, **kwargs)
         messages = self._llm._extend_messages(messages)
@@ -333,7 +333,7 @@ class FunctionCallingProgram(BasePydanticProgram[BaseModel]):
             if not isinstance(self._llm, FunctionCallingLLM):
                 raise ValueError("stream_call is only supported for LLMs.")
 
-            tool = _get_function_tool(self._output_cls)
+            tool = get_function_tool(self._output_cls)
 
             messages = self._prompt.format_messages(llm=self._llm, **kwargs)
             messages = self._llm._extend_messages(messages)

--- a/llama-index-core/llama_index/core/response_synthesizers/accumulate.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/accumulate.py
@@ -117,7 +117,9 @@ class Accumulate(BaseSynthesizer):
         """Give responses given a query and a corresponding text chunk."""
         text_qa_template = self._text_qa_template.partial_format(query_str=query_str)
 
-        text_chunks = self._prompt_helper.repack(text_qa_template, [text_chunk])
+        text_chunks = self._prompt_helper.repack(
+            text_qa_template, [text_chunk], llm=self._llm
+        )
 
         predictor: Callable
         if self._output_cls is None:

--- a/llama-index-core/llama_index/core/response_synthesizers/compact_and_accumulate.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/compact_and_accumulate.py
@@ -20,7 +20,9 @@ class CompactAndAccumulate(Accumulate):
         text_qa_template = self._text_qa_template.partial_format(query_str=query_str)
 
         with temp_set_attrs(self._prompt_helper):
-            new_texts = self._prompt_helper.repack(text_qa_template, text_chunks)
+            new_texts = self._prompt_helper.repack(
+                text_qa_template, text_chunks, llm=self._llm
+            )
 
             return await super().aget_response(
                 query_str=query_str,
@@ -41,7 +43,9 @@ class CompactAndAccumulate(Accumulate):
         text_qa_template = self._text_qa_template.partial_format(query_str=query_str)
 
         with temp_set_attrs(self._prompt_helper):
-            new_texts = self._prompt_helper.repack(text_qa_template, text_chunks)
+            new_texts = self._prompt_helper.repack(
+                text_qa_template, text_chunks, llm=self._llm
+            )
 
             return super().get_response(
                 query_str=query_str,

--- a/llama-index-core/llama_index/core/response_synthesizers/compact_and_refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/compact_and_refine.py
@@ -54,4 +54,4 @@ class CompactAndRefine(Refine):
         refine_template = self._refine_template.partial_format(query_str=query_str)
 
         max_prompt = get_biggest_prompt([text_qa_template, refine_template])
-        return self._prompt_helper.repack(max_prompt, text_chunks)
+        return self._prompt_helper.repack(max_prompt, text_chunks, llm=self._llm)

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -220,7 +220,9 @@ class Refine(BaseSynthesizer):
     ) -> RESPONSE_TEXT_TYPE:
         """Give response given a query and a corresponding text chunk."""
         text_qa_template = self._text_qa_template.partial_format(query_str=query_str)
-        text_chunks = self._prompt_helper.repack(text_qa_template, [text_chunk])
+        text_chunks = self._prompt_helper.repack(
+            text_qa_template, [text_chunk], llm=self._llm
+        )
 
         response: Optional[RESPONSE_TEXT_TYPE] = None
         program = self._program_factory(text_qa_template)
@@ -301,7 +303,7 @@ class Refine(BaseSynthesizer):
 
         # obtain text chunks to add to the refine template
         text_chunks = self._prompt_helper.repack(
-            refine_template, text_chunks=[text_chunk]
+            refine_template, text_chunks=[text_chunk], llm=self._llm
         )
 
         program = self._program_factory(refine_template)
@@ -410,7 +412,7 @@ class Refine(BaseSynthesizer):
 
         # obtain text chunks to add to the refine template
         text_chunks = self._prompt_helper.repack(
-            refine_template, text_chunks=[text_chunk]
+            refine_template, text_chunks=[text_chunk], llm=self._llm
         )
 
         program = self._program_factory(refine_template)
@@ -467,7 +469,9 @@ class Refine(BaseSynthesizer):
     ) -> RESPONSE_TEXT_TYPE:
         """Give response given a query and a corresponding text chunk."""
         text_qa_template = self._text_qa_template.partial_format(query_str=query_str)
-        text_chunks = self._prompt_helper.repack(text_qa_template, [text_chunk])
+        text_chunks = self._prompt_helper.repack(
+            text_qa_template, [text_chunk], llm=self._llm
+        )
 
         response: Optional[RESPONSE_TEXT_TYPE] = None
         program = self._program_factory(text_qa_template)

--- a/llama-index-core/llama_index/core/response_synthesizers/simple_summarize.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/simple_summarize.py
@@ -49,6 +49,7 @@ class SimpleSummarize(BaseSynthesizer):
         truncated_chunks = self._prompt_helper.truncate(
             prompt=text_qa_template,
             text_chunks=[single_text_chunk],
+            llm=self._llm,
         )
 
         response: RESPONSE_TEXT_TYPE
@@ -83,6 +84,7 @@ class SimpleSummarize(BaseSynthesizer):
         truncated_chunks = self._prompt_helper.truncate(
             prompt=text_qa_template,
             text_chunks=[single_text_chunk],
+            llm=self._llm,
         )
 
         response: RESPONSE_TEXT_TYPE

--- a/llama-index-core/llama_index/core/response_synthesizers/tree_summarize.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/tree_summarize.py
@@ -68,7 +68,7 @@ class TreeSummarize(BaseSynthesizer):
         summary_template = self._summary_template.partial_format(query_str=query_str)
         # repack text_chunks so that each chunk fills the context window
         text_chunks = self._prompt_helper.repack(
-            summary_template, text_chunks=text_chunks
+            summary_template, text_chunks=text_chunks, llm=self._llm
         )
 
         if self._verbose:
@@ -144,7 +144,7 @@ class TreeSummarize(BaseSynthesizer):
         summary_template = self._summary_template.partial_format(query_str=query_str)
         # repack text_chunks so that each chunk fills the context window
         text_chunks = self._prompt_helper.repack(
-            summary_template, text_chunks=text_chunks
+            summary_template, text_chunks=text_chunks, llm=self._llm
         )
 
         if self._verbose:

--- a/llama-index-core/llama_index/core/utilities/token_counting.py
+++ b/llama-index-core/llama_index/core/utilities/token_counting.py
@@ -88,4 +88,7 @@ class TokenCounter:
         Returns:
             int: The estimated token count.
         """
+        if not tools:
+            return 0
+
         return self.get_string_tokens(str(tools))

--- a/llama-index-core/llama_index/core/utilities/token_counting.py
+++ b/llama-index-core/llama_index/core/utilities/token_counting.py
@@ -48,6 +48,7 @@ class TokenCounter:
 
             additional_kwargs = {**message.additional_kwargs}
 
+            # backward compatibility
             if "function_call" in additional_kwargs:
                 function_call = additional_kwargs.pop("function_call")
                 if function_call.get("name", None) is not None:
@@ -58,25 +59,33 @@ class TokenCounter:
 
                 tokens += 3  # Additional tokens for function call
 
+            if "tool_calls" in additional_kwargs:
+                for tool_call in additional_kwargs["tool_calls"]:
+                    if (
+                        hasattr(tool_call, "function")
+                        and tool_call.function is not None
+                    ):
+                        tokens += self.get_string_tokens(tool_call.function.name)
+                        tokens += self.get_string_tokens(tool_call.function.arguments)
+
+                        tokens += 3  # Additional tokens for tool call
+
             tokens += 3  # Add three per message
 
-            if message.role == MessageRole.FUNCTION:
+            if message.role == MessageRole.FUNCTION or message.role == MessageRole.TOOL:
                 tokens -= 2  # Subtract 2 if role is "function"
 
         return tokens
 
-    def estimate_tokens_in_functions(self, functions: List[Dict[str, Any]]) -> int:
-        """Estimate token count for the functions.
+    def estimate_tokens_in_tools(self, tools: List[Dict[str, Any]]) -> int:
+        """Estimate token count for the tools.
 
-        We take here a list of functions created using the `to_openai_spec` function (or similar).
+        We take here a list of tools created using the `to_openai_tool()` function (or similar).
 
         Args:
-            function (list[Dict[str, Any]]): The functions to estimate the token count for.
+            tools (list[Dict[str, Any]]): The tools to estimate the token count for.
 
         Returns:
             int: The estimated token count.
         """
-        prompt_definition = str(functions)
-        tokens = self.get_string_tokens(prompt_definition)
-        tokens += 9  # Additional tokens for function definition
-        return tokens
+        return self.get_string_tokens(str(tools))

--- a/llama-index-core/tests/indices/response/test_tree_summarize.py
+++ b/llama-index-core/tests/indices/response/test_tree_summarize.py
@@ -1,6 +1,6 @@
 """Test tree summarize."""
 
-from typing import Any, List, Sequence
+from typing import Any, List, Sequence, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -15,7 +15,10 @@ from llama_index.core.response_synthesizers import TreeSummarize
 @pytest.fixture()
 def mock_prompt_helper(patch_llm_predictor, patch_token_text_splitter):
     def mock_repack(
-        prompt_template: PromptTemplate, text_chunks: Sequence[str]
+        prompt_template: PromptTemplate,
+        text_chunks: Sequence[str],
+        llm: Optional[Any] = None,
+        tools: Optional[Any] = None,
     ) -> List[str]:
         merged_chunks = []
         for chunks in zip(*[iter(text_chunks)] * 2):

--- a/llama-index-core/tests/tools/test_types.py
+++ b/llama-index-core/tests/tools/test_types.py
@@ -1,7 +1,7 @@
 import pytest
 
 from llama_index.core.bridge.pydantic import BaseModel
-from llama_index.core.program.function_program import _get_function_tool
+from llama_index.core.program.function_program import get_function_tool
 from llama_index.core.tools.types import ToolMetadata
 
 
@@ -26,7 +26,7 @@ def test_toolmetadata_openai_tool_description_max_length() -> None:
 
 
 def test_nested_tool_schema() -> None:
-    tool = _get_function_tool(Outer)
+    tool = get_function_tool(Outer)
     schema = tool.metadata.get_parameters_dict()
 
     assert "$defs" in schema


### PR DESCRIPTION
Currently, if you attach a structured LLM to any response synthesizer, it will not properly count tokens for
- tools
- system prompt attached to LLM

Additionally, our token-counter was terribly out of date, and skipping token counts for any function calls in chat messages.

This PR introduces logic in the prompt helper to grab tools from the StructuredLLM class, as well as the system prompt, and do its best to count those.