### PR TITLE
feat: Depend on AstraPy 1.5 and above for AstraDBVectorStore

### DIFF
--- a/docs/docs/examples/vector_stores/AstraDBIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/AstraDBIndexDemo.ipynb
@@ -26,7 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index-vector-stores-astra-db"
+    "%pip install llama-index-vector-stores-astra-db\n",
+    "%pip install llama-index-embeddings-openai"
    ]
   },
   {
@@ -36,7 +37,7 @@
    "outputs": [],
    "source": [
     "!pip install llama-index\n",
-    "!pip install \"astrapy>=0.6.0\""
+    "!pip install \"astrapy>=1.0\""
    ]
   },
   {
@@ -86,6 +87,7 @@
     "    SimpleDirectoryReader,\n",
     "    StorageContext,\n",
     ")\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
     "from llama_index.vector_stores.astra_db import AstraDBVectorStore"
    ]
   },
@@ -164,10 +166,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "embed_model = OpenAIEmbedding(model_name=\"text-embedding-3-small\")\n",
+    "\n",
     "storage_context = StorageContext.from_defaults(vector_store=astra_db_store)\n",
     "\n",
     "index = VectorStoreIndex.from_documents(\n",
-    "    documents, storage_context=storage_context\n",
+    "    documents, storage_context=storage_context, embed_model=embed_model\n",
     ")"
    ]
   },

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
@@ -62,7 +62,7 @@ class AstraDBVectorStore(BasePydanticVectorStore):
         token (str): The Astra DB Application Token to use.
         api_endpoint (str): The Astra DB JSON API endpoint for your database.
         embedding_dimension (int): length of the embedding vectors in use.
-        namespace (Optional[str]): The namespace to use. If not provided, 'default_keyspace'
+        keyspace (Optional[str]): The keyspace to use. If not provided, 'default_keyspace'
 
     Examples:
         `pip install llama-index-vector-stores-astra`
@@ -95,7 +95,7 @@ class AstraDBVectorStore(BasePydanticVectorStore):
         token: str,
         api_endpoint: str,
         embedding_dimension: int,
-        namespace: Optional[str] = None,
+        keyspace: Optional[str] = None,
         ttl_seconds: Optional[int] = None,
     ) -> None:
         super().__init__()
@@ -122,7 +122,7 @@ class AstraDBVectorStore(BasePydanticVectorStore):
         ).get_database(
             api_endpoint,
             token=token,
-            namespace=namespace,
+            keyspace=keyspace,
         )
 
         from astrapy.exceptions import DataAPIException

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/llama_index/vector_stores/astra_db/base.py
@@ -63,6 +63,7 @@ class AstraDBVectorStore(BasePydanticVectorStore):
         api_endpoint (str): The Astra DB JSON API endpoint for your database.
         embedding_dimension (int): length of the embedding vectors in use.
         keyspace (Optional[str]): The keyspace to use. If not provided, 'default_keyspace'
+        namespace (Optional[str]): [DEPRECATED] The keyspace to use. If not provided, 'default_keyspace'
 
     Examples:
         `pip install llama-index-vector-stores-astra`
@@ -96,6 +97,7 @@ class AstraDBVectorStore(BasePydanticVectorStore):
         api_endpoint: str,
         embedding_dimension: int,
         keyspace: Optional[str] = None,
+        namespace: Optional[str] = None,
         ttl_seconds: Optional[int] = None,
     ) -> None:
         super().__init__()
@@ -115,6 +117,9 @@ class AstraDBVectorStore(BasePydanticVectorStore):
 
         _logger.debug("Creating the Astra DB client and database instances")
 
+        # Choose the keyspace param
+        keyspace_param = keyspace or namespace
+
         # Build the Database object
         self._database = DataAPIClient(
             caller_name=getattr(llama_index, "__name__", "llama_index"),
@@ -122,7 +127,7 @@ class AstraDBVectorStore(BasePydanticVectorStore):
         ).get_database(
             api_endpoint,
             token=token,
-            keyspace=keyspace,
+            keyspace=keyspace_param,
         )
 
         from astrapy.exceptions import DataAPIException

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-astra-db"
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-astrapy = "^1.3"
+astrapy = "^1.5"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/tests/test_astra_db.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-astra-db/tests/test_astra_db.py
@@ -19,7 +19,7 @@ def astra_db_store() -> Iterable[AstraDBVectorStore]:
         token=ASTRA_DB_APPLICATION_TOKEN,
         api_endpoint=ASTRA_DB_API_ENDPOINT,
         collection_name="test_collection",
-        namespace=ASTRA_DB_KEYSPACE,
+        keyspace=ASTRA_DB_KEYSPACE,
         embedding_dimension=2,
     )
     store._collection.delete_many({})


### PR DESCRIPTION
# Description

This pull request updates the Astra DB Vector Store integration to use the latest version of the Python client AstraPy (1.5+), which includes the deprecation of the `namespace` parameter in favor of `keyspace`.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
