### PR TITLE
markdown element node parser reliability

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -1,5 +1,5 @@
 from typing import Any, List, Optional
-from llama_index.core.bridge.pydantic import BaseModel, SerializeAsAny, ConfigDict
+from llama_index.core.bridge.pydantic import SerializeAsAny, ConfigDict
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
@@ -69,7 +69,7 @@ class LLMStructuredPredictEndEvent(BaseEvent):
         output (BaseModel): Predicted output class.
     """
 
-    output: SerializeAsAny[BaseModel]
+    output: SerializeAsAny[Any]
 
     @classmethod
     def class_name(cls) -> str:
@@ -84,7 +84,7 @@ class LLMStructuredPredictInProgressEvent(BaseEvent):
         output (BaseModel): Predicted output class.
     """
 
-    output: SerializeAsAny[BaseModel]
+    output: SerializeAsAny[Any]
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -14,7 +14,13 @@ from llama_index.core.bridge.pydantic import (
 from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.llms.llm import LLM
 from llama_index.core.node_parser.interface import NodeParser
-from llama_index.core.schema import BaseNode, Document, IndexNode, TextNode
+from llama_index.core.schema import (
+    BaseNode,
+    Document,
+    IndexNode,
+    MetadataMode,
+    TextNode,
+)
 from llama_index.core.utils import get_tqdm_iterable
 
 DEFAULT_SUMMARY_QUERY_STR = """\
@@ -328,7 +334,7 @@ class BaseElementNodeParser(NodeParser):
 
         node_parser = self.nested_node_parser or SentenceSplitter()
 
-        nodes = []
+        nodes: List[BaseNode] = []
         cur_text_el_buffer: List[str] = []
         for element in elements:
             if element.type == "table" or element.type == "table_text":
@@ -384,11 +390,11 @@ class BaseElementNodeParser(NodeParser):
                     if start_char_idx >= 0:
                         end_char_idx = start_char_idx + len(str(element.element))
                     else:
-                        start_char_idx = None
-                        end_char_idx = None
+                        start_char_idx = None  # type: ignore
+                        end_char_idx = None  # type: ignore
                 else:
-                    start_char_idx = None
-                    end_char_idx = None
+                    start_char_idx = None  # type: ignore
+                    end_char_idx = None  # type: ignore
 
                 # shared index_id and node_id
                 node_id = str(uuid.uuid4())
@@ -445,14 +451,18 @@ class BaseElementNodeParser(NodeParser):
                 node.excluded_llm_metadata_keys = (
                     node_inherited.excluded_llm_metadata_keys
                 )
-        return [node for node in nodes if len(node.text) > 0]
+        return [
+            node
+            for node in nodes
+            if len(node.get_content(metadata_mode=MetadataMode.NONE)) > 0
+        ]
 
-    def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
-        nodes = self.get_nodes_from_documents(nodes, **kwargs)
+    def __call__(self, nodes: Sequence[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        nodes = self.get_nodes_from_documents(nodes, **kwargs)  # type: ignore
         nodes, objects = self.get_nodes_and_objects(nodes)
-        return nodes + objects
+        return nodes + objects  # type: ignore
 
-    async def acall(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
-        nodes = await self.aget_nodes_from_documents(nodes, **kwargs)
+    async def acall(self, nodes: Sequence[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        nodes = await self.aget_nodes_from_documents(nodes, **kwargs)  # type: ignore
         nodes, objects = self.get_nodes_and_objects(nodes)
-        return nodes + objects
+        return nodes + objects  # type: ignore

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -188,7 +188,8 @@ class BaseElementNodeParser(NodeParser):
             index = SummaryIndex.from_documents(
                 [Document(text=table_context)],
             )
-            query_engine = index.as_query_engine(llm=llm, output_cls=TableOutput)
+            sllm = llm.as_structured_llm(TableOutput)
+            query_engine = index.as_query_engine(llm=sllm)
             try:
                 response = await query_engine.aquery(summary_query_str)
                 return cast(PydanticResponse, response).response

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -79,7 +79,8 @@ class DefaultRefineProgram(BasePydanticProgram):
                 self._prompt,
                 **kwds,
             )
-            answer = answer.model_dump_json()
+            if isinstance(answer, BaseModel):
+                answer = answer.model_dump_json()
         else:
             answer = self._llm.predict(
                 self._prompt,
@@ -94,7 +95,8 @@ class DefaultRefineProgram(BasePydanticProgram):
                 self._prompt,
                 **kwds,
             )
-            answer = answer.model_dump_json()
+            if isinstance(answer, BaseModel):
+                answer = answer.model_dump_json()
         else:
             answer = await self._llm.apredict(
                 self._prompt,
@@ -185,7 +187,10 @@ class Refine(BaseSynthesizer):
             prev_response = response
         if isinstance(response, str):
             if self._output_cls is not None:
-                response = self._output_cls.model_validate_json(response)
+                try:
+                    response = self._output_cls.model_validate_json(response)
+                except ValidationError:
+                    pass
             else:
                 response = response or "Empty Response"
         else:


### PR DESCRIPTION
Our structured outputs are a little flakey
- when the LLM decides not to output the output class, we throw errors
- specifically in the markdown element node parser, these errors interrupt execution

This PR updates synthesizers to be more robust to these errors, as well as letting the markdown element node parser handle non-base model outputs