### PR TITLE
Ollama Multimodal request timeout 

### DIFF
--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-ollama/llama_index/multi_modal_llms/ollama/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-ollama/llama_index/multi_modal_llms/ollama/base.py
@@ -67,6 +67,7 @@ class OllamaMultiModal(MultiModalLLM):
         gt=0,
     )
     request_timeout: Optional[float] = Field(
+        default=60.0,
         description="The timeout for making http request to Ollama API server",
     )
     additional_kwargs: Dict[str, Any] = Field(

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-multi-modal-llms-ollama"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

`request_timeout` field did not have a default value and thus it was causing pydantic error while creating an instance of Ollama multi-modal as Ollama client requires timeout value in the declaration.

Fixes # (issue)



## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

