### PR TITLE
DOCS: Remove extra dot from the import line in the docstring

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/base.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/base.py
@@ -40,7 +40,7 @@ class OpenAIAgent(AgentRunner):
 
     For the legacy implementation see:
     ```python
-    from llama_index..agent.legacy.openai.base import OpenAIAgent
+    from llama_index.agent.legacy.openai.base import OpenAIAgent
     ```
 
     """


### PR DESCRIPTION
# Description

This is a very minute thing, I was going through the docs for OpenAI agent and saw that the docs include an extra . (dot) and it bugged me.

Fixes # (issue)

A simple deletion of the dot. 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ x ] Minor fix in the documentation.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense
- [ x ] No tests are required as the changes are related to documentation

## Suggested Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
