### PR TITLE
Enhance `insert` Method in `BaseIndex` to Support Customizable Transformations

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -203,17 +203,17 @@ class BaseIndex(Generic[IS], ABC):
             self._insert(nodes, **insert_kwargs)
             self._storage_context.index_store.add_index_struct(self._index_struct)
 
-    def insert(self, document: Document, **kwargs: Any) -> None:
+    def insert(self, document: Document, **insert_kwargs: Any) -> None:
         """Insert a document."""
         with self._callback_manager.as_trace("insert"):
             nodes = run_transformations(
                 [document],
                 self._transformations,
                 show_progress=self._show_progress,
-                **kwargs,
+                **insert_kwargs,
             )
 
-            self.insert_nodes(nodes, **kwargs)
+            self.insert_nodes(nodes, **insert_kwargs)
             self.docstore.set_document_hash(document.get_doc_id(), document.hash)
 
     @abstractmethod

--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -355,7 +355,8 @@ class BaseIndex(Generic[IS], ABC):
         ...
 
     @abstractmethod
-    def as_retriever(self, **kwargs: Any) -> BaseRetriever: ...
+    def as_retriever(self, **kwargs: Any) -> BaseRetriever:
+        ...
 
     def as_query_engine(
         self, llm: Optional[LLMType] = None, **kwargs: Any

--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -203,16 +203,17 @@ class BaseIndex(Generic[IS], ABC):
             self._insert(nodes, **insert_kwargs)
             self._storage_context.index_store.add_index_struct(self._index_struct)
 
-    def insert(self, document: Document, **insert_kwargs: Any) -> None:
+    def insert(self, document: Document, **kwargs: Any) -> None:
         """Insert a document."""
         with self._callback_manager.as_trace("insert"):
             nodes = run_transformations(
                 [document],
                 self._transformations,
                 show_progress=self._show_progress,
+                **kwargs,
             )
 
-            self.insert_nodes(nodes, **insert_kwargs)
+            self.insert_nodes(nodes, **kwargs)
             self.docstore.set_document_hash(document.get_doc_id(), document.hash)
 
     @abstractmethod
@@ -354,8 +355,7 @@ class BaseIndex(Generic[IS], ABC):
         ...
 
     @abstractmethod
-    def as_retriever(self, **kwargs: Any) -> BaseRetriever:
-        ...
+    def as_retriever(self, **kwargs: Any) -> BaseRetriever: ...
 
     def as_query_engine(
         self, llm: Optional[LLMType] = None, **kwargs: Any


### PR DESCRIPTION
# Description

This PR updates the `insert` method in the `BaseIndex` class to allow the `kwargs` parameter to be passed to the `run_transformations` function. This enhancement provides greater flexibility for customizing transformation behaviors during document insertion.

Fixes # (issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [ ] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [ ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods