### PR TITLE
Ensures ChatMemoryBuffer's chat history never begins with a TOOL message

### DIFF
--- a/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
@@ -123,7 +123,10 @@ class ChatMemoryBuffer(BaseChatStoreMemory):
 
         while token_count > self.token_limit and message_count > 1:
             message_count -= 1
-            while chat_history[-message_count].role in (MessageRole.TOOL, MessageRole.ASSISTANT):
+            while chat_history[-message_count].role in (
+                MessageRole.TOOL,
+                MessageRole.ASSISTANT,
+            ):
                 # we cannot have an assistant message at the start of the chat history
                 # if after removal of the first, we have an assistant message,
                 # we need to remove the assistant message too

--- a/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
@@ -123,15 +123,13 @@ class ChatMemoryBuffer(BaseChatStoreMemory):
 
         while token_count > self.token_limit and message_count > 1:
             message_count -= 1
-            if chat_history[-message_count].role == MessageRole.TOOL:
-                # all tool messages should be preceded by an assistant message
-                # if we remove a tool message, we need to remove the assistant message too
-                message_count -= 1
-
-            if chat_history[-message_count].role == MessageRole.ASSISTANT:
+            while chat_history[-message_count].role in (MessageRole.TOOL, MessageRole.ASSISTANT):
                 # we cannot have an assistant message at the start of the chat history
                 # if after removal of the first, we have an assistant message,
                 # we need to remove the assistant message too
+                #
+                # all tool messages should be preceded by an assistant message
+                # if we remove a tool message, we need to remove the assistant message too
                 message_count -= 1
 
             cur_messages = chat_history[-message_count:]


### PR DESCRIPTION
# Description

Updated the `get(...)` function of core/memory/chat_memory_buffer.py to ensure the chat history never begins with a message using the TOOL role. In the previous implementation, when reducing the size of the chat history to fit within the token limit there were instances where an ASSISTANT message was removed without also removing its associated TOOL message. This led to a bad request error from OpenAI

`BadRequestError: Error code: 400 - {'error': {'message': "Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'.", 'type': 'invalid_request_error', 'param': 'messages.[1].role', 'code': None}}`

Fixes #13715

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ X] No

## Type of Change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X ] I stared at the code and made sure it makes sense

