### PR TITLE
[Feature Request] Support max concurrent `workflow_instance.run()` executions.

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -346,7 +346,7 @@ class Workflow(metaclass=WorkflowMeta):
                 result.set_exception(e)
             finally:
                 if self._sem:
-                    await self._sem.release()
+                    self._sem.release()
 
         asyncio.create_task(_run_workflow())
         return result


### PR DESCRIPTION
# Description

Currently, a `Workflow.run()` call starts the contained `_run_workflow()` coro. As such, we can't use `llama_index.core.async_utils` in order to control the number of `workflow_instance.run()` calls to be made simultaneously. 
You would need to do this for example if your Workflow makes an api call and has chance of getting rate limit errors.

Proposed design:

```python
w = Workflow(num_concurrent_runs=5)

tasks = []
for _ in range(1000):
  tasks.append(w.run())
  
results = asyncio.gather(*tasks)
```

This PR makes use of `asyncio.Semaphore` to limit the number of workflow instance runs occurring simultaneously.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense