### PR TITLE
fix ollama's complete api to utilize generate endpoint

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -106,7 +106,7 @@ class Ollama(FunctionCallingLLM):
         request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
         prompt_key: str = "prompt",
         json_mode: bool = False,
-        additional_kwargs: Optional[Dict[str, Any]] = None,
+        additional_kwargs: Dict[str, Any] = {},
         client: Optional[Client] = None,
         async_client: Optional[AsyncClient] = None,
         is_function_calling_model: bool = True,
@@ -125,7 +125,6 @@ class Ollama(FunctionCallingLLM):
             **kwargs,
         )
 
-        self.additional_kwargs = additional_kwargs or {}
         self._client = client
         self._async_client = async_client
 

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ollama"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

When using the `llm.complete` interface of Ollama, I found that it actually calls `/api/chat` instead of `/api/generate`. I'm not sure what the initial considerations were for this design. I tried changing it to `/api/generate`, but since Ollama's `is_chat_model` is set to true by default, it may still default to using the `llm.chat` interface in other contexts

Fixes # (issue)


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
