### PR TITLE
Workflows + Human In The Loop Support

### DIFF
--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -132,4 +132,18 @@ class StopEvent(Event):
         super().__init__(result=result)
 
 
+class InputRequiredEvent(Event):
+    """InputRequiredEvent is sent when an input is required for a step."""
+
+    prefix: str = Field(
+        description="The prefix and description of the input that is required."
+    )
+
+
+class HumanResponseEvent(Event):
+    """HumanResponseEvent is sent when a human response is required for a step."""
+
+    response: str = Field(description="The response from the human.")
+
+
 EventType = Type[Event]

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -8,7 +8,7 @@ from llama_index.core.instrumentation import get_dispatcher
 
 from .decorators import StepConfig, step
 from .context import Context
-from .events import Event, StartEvent, StopEvent
+from .events import InputRequiredEvent, HumanResponseEvent, Event, StartEvent, StopEvent
 from .errors import *
 from .service import ServiceManager
 from .utils import (
@@ -248,6 +248,8 @@ class Workflow(metaclass=WorkflowMeta):
                         warnings.warn(
                             f"Step function {name} returned {type(new_ev).__name__} instead of an Event instance."
                         )
+                    elif isinstance(new_ev, InputRequiredEvent):
+                        ctx.write_event_to_stream(new_ev)
                     else:
                         ctx.send_event(new_ev)
 
@@ -283,7 +285,11 @@ class Workflow(metaclass=WorkflowMeta):
     ) -> WorkflowHandler:
         """Runs the workflow until completion."""
         # Validate the workflow if needed
-        self._validate()
+        uses_hitl = self._validate()
+        if uses_hitl and stepwise:
+            raise WorkflowRuntimeError(
+                "Human-in-the-loop is not supported with stepwise execution"
+            )
 
         # Start the machinery in a new Context or use the provided one
         ctx = self._start(ctx=ctx, stepwise=stepwise)
@@ -402,7 +408,7 @@ class Workflow(metaclass=WorkflowMeta):
     def _validate(self) -> None:
         """Validate the workflow to ensure it's well-formed."""
         if self._disable_validation:
-            return
+            return None
 
         produced_events: Set[type] = {StartEvent}
         consumed_events: Set[type] = set()
@@ -425,16 +431,22 @@ class Workflow(metaclass=WorkflowMeta):
 
             requested_services.update(step_config.requested_services)
 
-        # Check if all consumed events are produced
-        unconsumed_events = consumed_events - produced_events
+        # Check if all consumed events are produced (except specific built-in events)
+        unconsumed_events = (
+            consumed_events - produced_events - {InputRequiredEvent, HumanResponseEvent}
+        )
         if unconsumed_events:
             names = ", ".join(ev.__name__ for ev in unconsumed_events)
             raise WorkflowValidationError(
                 f"The following events are consumed but never produced: {names}"
             )
 
-        # Check if there are any unused produced events (except StopEvent)
-        unused_events = produced_events - consumed_events - {StopEvent}
+        # Check if there are any unused produced events (except specific built-in events)
+        unused_events = (
+            produced_events
+            - consumed_events
+            - {StopEvent, InputRequiredEvent, HumanResponseEvent}
+        )
         if unused_events:
             names = ", ".join(ev.__name__ for ev in unused_events)
             raise WorkflowValidationError(
@@ -451,3 +463,9 @@ class Workflow(metaclass=WorkflowMeta):
             if missing:
                 msg = f"The following services are not available: {', '.join(str(m) for m in missing)}"
                 raise WorkflowValidationError(msg)
+
+        # Check if the workflow uses human-in-the-loop
+        return (
+            InputRequiredEvent in consumed_events
+            or HumanResponseEvent in consumed_events
+        )

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -405,10 +405,13 @@ class Workflow(metaclass=WorkflowMeta):
         # Signal we want to stop the workflow
         raise WorkflowDone
 
-    def _validate(self) -> None:
-        """Validate the workflow to ensure it's well-formed."""
+    def _validate(self) -> bool:
+        """Validate the workflow to ensure it's well-formed.
+
+        Returns True if the workflow uses human-in-the-loop, False otherwise.
+        """
         if self._disable_validation:
-            return None
+            return False
 
         produced_events: Set[type] = {StartEvent}
         consumed_events: Set[type] = set()
@@ -433,7 +436,7 @@ class Workflow(metaclass=WorkflowMeta):
 
         # Check if all consumed events are produced (except specific built-in events)
         unconsumed_events = (
-            consumed_events - produced_events - {InputRequiredEvent, HumanResponseEvent}
+            consumed_events - produced_events - {InputRequiredEvent, HumanResponseEvent}  # type: ignore
         )
         if unconsumed_events:
             names = ", ".join(ev.__name__ for ev in unconsumed_events)
@@ -466,6 +469,6 @@ class Workflow(metaclass=WorkflowMeta):
 
         # Check if the workflow uses human-in-the-loop
         return (
-            InputRequiredEvent in consumed_events
+            InputRequiredEvent in produced_events
             or HumanResponseEvent in consumed_events
         )

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -435,9 +435,12 @@ class Workflow(metaclass=WorkflowMeta):
             requested_services.update(step_config.requested_services)
 
         # Check if all consumed events are produced (except specific built-in events)
-        unconsumed_events = (
-            consumed_events - produced_events - {InputRequiredEvent, HumanResponseEvent}  # type: ignore
-        )
+        unconsumed_events = consumed_events - produced_events
+        unconsumed_events = {
+            x
+            for x in unconsumed_events
+            if not issubclass(x, (InputRequiredEvent, HumanResponseEvent))
+        }
         if unconsumed_events:
             names = ", ".join(ev.__name__ for ev in unconsumed_events)
             raise WorkflowValidationError(
@@ -445,11 +448,12 @@ class Workflow(metaclass=WorkflowMeta):
             )
 
         # Check if there are any unused produced events (except specific built-in events)
-        unused_events = (
-            produced_events
-            - consumed_events
-            - {StopEvent, InputRequiredEvent, HumanResponseEvent}
-        )
+        unused_events = produced_events - consumed_events
+        unused_events = {
+            x
+            for x in unused_events
+            if not issubclass(x, (InputRequiredEvent, HumanResponseEvent))
+        }
         if unused_events:
             names = ", ".join(ev.__name__ for ev in unused_events)
             raise WorkflowValidationError(


### PR DESCRIPTION
This PR adds some built-in support for human-in-the-loop

Currently, only streaming is supported. I don't think it's possible to support in `run()` since we don't know ahead of time if the user is streaming or not 🤔 Plus, this way, how the user responds to input is completely customizable (using `input()`, using APIs, using another LLM, etc.)

In the future, stepwise can be supported, but we need to refactor how stepwise works first.

Usage:

```python
class HumanInTheLoopWorkflow(Workflow):
    @step
    async def step1(self, ev: StartEvent) -> InputRequiredEvent:
        return InputRequiredEvent(prefix="Enter a number: ")
    
    @step
    async def step2(self, ev: HumanResponseEvent) -> StopEvent:
        return StopEvent(result=ev.response)

# workflow should work with streaming
workflow = HumanInTheLoopWorkflow()

handler: WorkflowHandler = workflow.run()
async for event in handler.stream_events():
    if isinstance(event, InputRequiredEvent):
        assert event.prefix == "Enter a number: "
        handler.ctx.send_event(HumanResponseEvent(response="42"))

final_result = await handler
assert final_result == "42"
```