### PR TITLE
docs: rewrite the examples summary

### DIFF
--- a/docs/docs/examples/workflow/corrective_rag_pack.ipynb
+++ b/docs/docs/examples/workflow/corrective_rag_pack.ipynb
@@ -11,7 +11,7 @@
     "A brief understanding of the paper:\n",
     "\n",
     "\n",
-    "Corrective Retrieval Augmented Generation (CRAG) is a method designed to enhance the robustness of language model generation by evaluating and augmenting the relevance of retrieved documents through a an evaluator and large-scale web searches, ensuring more accurate and reliable information is used in generation.\n",
+    "Corrective Retrieval Augmented Generation (CRAG) is a method designed to enhance the robustness of language model generation by evaluating and augmenting the relevance of retrieved documents through an evaluator and large-scale web searches, ensuring more accurate and reliable information is used in generation.\n",
     "\n",
     "We use `GPT-4` as a relevancy evaluator and `Tavily AI` for web searches. So, we recommend getting `OPENAI_API_KEY` and `tavily_ai_api_key` before proceeding further."
    ]

--- a/docs/docs/module_guides/workflow/index.md
+++ b/docs/docs/module_guides/workflow/index.md
@@ -176,6 +176,7 @@ await w.run(topic="Pirates")
 draw_most_recent_execution(w, filename="joke_flow_recent.html")
 ```
 
+<div id="working-with-global-context-state"></div>
 ## Working with Global Context/State
 
 Optionally, you can choose to use global context between steps. For example, maybe multiple steps access the original `query` input from the user. You can store this in global context so that every step has access.
@@ -492,22 +493,42 @@ You can deploy a workflow as a multi-agent service with [llama_deploy](../../mod
 
 ## Examples
 
-You can find many useful examples of using workflows in the notebooks below:
+To help you become more familiar with the workflow concept and its features, LlamaIndex documentation offers example
+notebooks that you can run for hands-on learning:
+
+- [Common Workflow Patterns](../../examples/workflow/workflows_cookbook.ipynb) walks you through common usage patterns
+like looping and state management using simple workflows. It's usually a great place to start.
+- [RAG + Reranking](../../examples/workflow/rag.ipynb) shows how to implement a real-world use case with a fairly
+simple workflow that performs both ingestion and querying.
+- [Citation Query Engine](../../examples/workflow/citation_query_engine.ipynb) similar to RAG + Reranking, the
+notebook focuses on how to implement intermediate steps in between retrieval and generation. A good example of how to
+use the [`Context`](#working-with-global-context-state) object in a workflow.
+- [Corrective RAG](../../examples/workflow/corrective_rag_pack.ipynb) adds some more complexity on top of a RAG
+workflow, showcasing how to query a web search engine after an evaluation step.
+- [Utilizing Concurrency](../../examples/workflow/parallel_execution.ipynb) explains how to manage the parallel
+execution of steps in a workflow, something that's important to know as your workflows grow in complexity.
+
+RAG applications are well known and relatively simple, a great opportunity to learn the basics, but agents is where
+workflows excel, as you can learn from the following examples:
+
+- [ReAct Agent](../../examples/workflow/react_agent.ipynb) is obviously the perfect example to show how to implement
+tools in a workflow.
+- [Function Calling Agent](../../examples/workflow/function_calling_agent.ipynb) is a great example of how to use the
+LlamaIndex framework primitives in a workflow, keeping it small and tidy even in complex scenarios like function
+calling.
+- [Human In The Loop: Story Crafting](../../examples/workflow/human_in_the_loop_story_crafting.ipynb) is a powerful
+example showing how workflow runs can be interactive and stateful. In this case, to collect input from a human.
+- [Reliable Structured Generation](../../examples/workflow/reflection.ipynb) shows how to implement loops in a
+workflow, in this case to improve structured output through reflection.
+
+Last but not least, a few more advanced use cases that demonstrate how workflows can be extremely handy if you need
+to quickly implement prototypes, for example from literature:
 
 - [Advanced Text-to-SQL](../../examples/workflow/advanced_text_to_sql.ipynb)
-- [Citation Query Engine](../../examples/workflow/citation_query_engine.ipynb)
-- [Common Workflow Patterns](../../examples/workflow/workflows_cookbook.ipynb)
-- [Corrective RAG](../../examples/workflow/corrective_rag_pack.ipynb)
-- [Function Calling Agent](../../examples/workflow/function_calling_agent.ipynb)
-- [Human In The Loop: Story Crafting](../../examples/workflow/human_in_the_loop_story_crafting.ipynb)
 - [JSON Query Engine](../../examples/workflow/JSONalyze_query_engine.ipynb)
 - [Long RAG](../../examples/workflow/long_rag_pack.ipynb)
 - [Multi-Step Query Engine](../../examples/workflow/multi_step_query_engine.ipynb)
 - [Multi-Strategy Workflow](../../examples/workflow/multi_strategy_workflow.ipynb)
-- [RAG + Reranking](../../examples/workflow/rag.ipynb)
-- [ReAct Agent](../../examples/workflow/react_agent.ipynb)
-- [Reliable Structured Generation](../../examples/workflow/reflection.ipynb)
 - [Router Query Engine](../../examples/workflow/router_query_engine.ipynb)
 - [Self Discover Workflow](../../examples/workflow/self_discover_workflow.ipynb)
 - [Sub-Question Query Engine](../../examples/workflow/sub_question_query_engine.ipynb)
-- [Utilizing Concurrency](../../examples/workflow/parallel_execution.ipynb)


### PR DESCRIPTION
# Description

Workflow examples are listed in alphabetical order without context and we suspect this makes the whole section of the page not very user friendly.

This is an attempt to:
- Sort the examples from simpler to harder, taking users by the hand as we show more and more complex features
- Add a brief explanation of what each example is supposed to show to make it more appealing

To ease maintenance and convey the right message, I split the examples in three groups:
- Introductory, using RAG that should be the most widespread concept as of today
- Agentic
- Others - this group is a "catch all" where we can add more advanced examples, assuming they'll be more useful to more advanced users
