### PR TITLE
Fix incorrect variable name in RetrieverTool

### DIFF
--- a/llama-index-core/llama_index/core/tools/retriever_tool.py
+++ b/llama-index-core/llama_index/core/tools/retriever_tool.py
@@ -87,7 +87,7 @@ class RetrieverTool(AsyncBaseTool):
         return ToolOutput(
             content=content,
             tool_name=self.metadata.name,
-            raw_input={"input": input},
+            raw_input={"input": query_str},
             raw_output=docs,
         )
 
@@ -112,7 +112,7 @@ class RetrieverTool(AsyncBaseTool):
         return ToolOutput(
             content=content,
             tool_name=self.metadata.name,
-            raw_input={"input": input},
+            raw_input={"input": query_str},
             raw_output=docs,
         )
 


### PR DESCRIPTION
# Description

This change fixes a pydantic serialization error when using both RetrieverTool and phoenix/llamatrace.

`input` is referencing the python built-in rather than the desired query input.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

To reproduce, setup llamatrace on a project and use the retriever tool.  Note that pydantic serialization exceptions are logged by the openinference handler.
https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-llama-index/src/openinference/instrumentation/llama_index/_handler.py#L249-L254

- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
