### PR TITLE
Re-factor `WorkflowHandler.run_step()` so user manually emits Event to start next step in worfklow

### DIFF
--- a/docs/docs/understanding/workflows/observability.md
+++ b/docs/docs/understanding/workflows/observability.md
@@ -107,13 +107,19 @@ In a notebook environment it can be helpful to run a workflow step by step. You 
 w = ConcurrentFlow(timeout=10, verbose=True)
 handler = w.run()
 
-async for _ in handler.run_step():
-    # inspect context
+while not handler.is_done():
+    # run_step returns the step's output event
+    ev = await handler.run_step()
+    # can make modifications to the results before dispatching the event
+    # val = ev.get("some_key")
+    # ev.set("some_key", new_val)
+    # can also inspect context
     # val = await handler.ctx.get("key")
+    handler.ctx.send_event(ev)
     continue
 
 # get the result
-result = await handler
+result = handler.result()
 ```
 
 You can call `run_step` multiple times to step through the workflow one step at a time.

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -30,13 +30,13 @@ class Context:
         self._tasks: Set[asyncio.Task] = set()
         self._broker_log: List[Event] = []
         self._step_flags: Dict[str, asyncio.Event] = {}
-        self._event_holding: Optional[Event] = None
-        self._event_lock: asyncio.Lock = asyncio.Lock()
-        self._event_condition: asyncio.Condition = asyncio.Condition(
-            lock=self._event_lock
+        self._step_event_holding: Optional[Event] = None
+        self._step_lock: asyncio.Lock = asyncio.Lock()
+        self._step_condition: asyncio.Condition = asyncio.Condition(
+            lock=self._step_lock
         )
-        self._event_written_condition: asyncio.Condition = asyncio.Condition(
-            lock=self._event_lock
+        self._step_event_written: asyncio.Condition = asyncio.Condition(
+            lock=self._step_lock
         )
         self._accepted_events: List[Tuple[str, str]] = []
         self._retval: Any = None

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -30,6 +30,14 @@ class Context:
         self._tasks: Set[asyncio.Task] = set()
         self._broker_log: List[Event] = []
         self._step_flags: Dict[str, asyncio.Event] = {}
+        self._event_holding: Optional[Event] = None
+        self._event_lock: asyncio.Lock = asyncio.Lock()
+        self._event_condition: asyncio.Condition = asyncio.Condition(
+            lock=self._event_lock
+        )
+        self._event_written_condition: asyncio.Condition = asyncio.Condition(
+            lock=self._event_lock
+        )
         self._accepted_events: List[Tuple[str, str]] = []
         self._retval: Any = None
         # Streaming machinery

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -99,7 +99,7 @@ class WorkflowHandler(asyncio.Future):
             except Exception as e:
                 if not self.is_done():  # Avoid InvalidStateError edge case
                     self.set_exception(e)
-                raise self.exception() or e
+                raise
         else:
             raise ValueError("Context is not set!")
 

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -39,63 +39,67 @@ class WorkflowHandler(asyncio.Future):
         Examples:
             ```python
             handler = workflow.run(stepwise=True)
-            while True:
+            while not handler.is_done():
                 ev = await handler.run_step()
-                if ev is None:
-                    break
                 handler.ctx.send_event(ev)
 
-            result = await handler
+            result = handler.result()
             print(result)
             ```
         """
+        # since event is sent before calling this method, we need to unblock the event loop
+        await asyncio.sleep(0)
+
         if self.ctx and not self.ctx.stepwise:
             raise ValueError("Stepwise context is required to run stepwise.")
 
         if self.ctx:
-            # Unblock all pending steps
-            for flag in self.ctx._step_flags.values():
-                flag.set()
+            try:
+                # Unblock all pending steps
+                for flag in self.ctx._step_flags.values():
+                    flag.set()
 
-            # Yield back control to the event loop to give an unblocked step
-            # the chance to run (we won't actually sleep here).
-            await asyncio.sleep(0)
+                # Yield back control to the event loop to give an unblocked step
+                # the chance to run (we won't actually sleep here).
+                await asyncio.sleep(0)
 
-            # check if we're done, or if a step raised error
-            we_done = False
-            exception_raised = None
-            retval = None
-            for t in self.ctx._tasks:
-                # Check if we're done
-                if not t.done():
-                    continue
-
-                we_done = True
-                e = t.exception()
-                if type(e) != WorkflowDone:
-                    exception_raised = e
-
-            if we_done:
-                # Remove any reference to the tasks
+                # check if we're done, or if a step raised error
+                we_done = False
+                exception_raised = None
+                retval = None
                 for t in self.ctx._tasks:
-                    t.cancel()
-                    await asyncio.sleep(0)
+                    # Check if we're done
+                    if not t.done():
+                        continue
 
-                if exception_raised:
-                    self.set_exception(exception_raised)  # Mark as done
-                    raise exception_raised
+                    we_done = True
+                    e = t.exception()
+                    if type(e) != WorkflowDone:
+                        exception_raised = e
 
-                res = self.ctx.get_result()
-                self.set_result(res)
-            else:  # continue with running next step
-                # notify unblocked task that we're ready to accept next event
-                async with self.ctx._step_condition:
-                    self.ctx._step_condition.notify()
+                if we_done:
+                    # Remove any reference to the tasks
+                    for t in self.ctx._tasks:
+                        t.cancel()
+                        await asyncio.sleep(0)
 
-                # Wait to be notified that the new_ev has been written
-                async with self.ctx._step_event_written:
-                    await self.ctx._step_event_written.wait()
-                    retval = self.ctx._step_event_holding
+                    if exception_raised:
+                        raise exception_raised
+
+                    self.set_result(self.ctx.get_result())
+                else:  # continue with running next step
+                    # notify unblocked task that we're ready to accept next event
+                    async with self.ctx._step_condition:
+                        self.ctx._step_condition.notify()
+
+                    # Wait to be notified that the new_ev has been written
+                    async with self.ctx._step_event_written:
+                        await self.ctx._step_event_written.wait()
+                        retval = self.ctx._step_event_holding
+            except Exception as e:
+                if not self.is_done():  # Avoid InvalidStateError edge case
+                    self.set_exception(e)
+                raise self.exception() or e
         else:
             raise ValueError("Context is not set!")
 

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -44,7 +44,7 @@ class WorkflowHandler(asyncio.Future):
             # the chance to run (we won't actually sleep here).
             await asyncio.sleep(0)
 
-            # check if StopEvent was sent
+            # check if StopEvent is in holding
             if isinstance(self.ctx._event_holding, StopEvent):
                 # See if we're done, or if a step raised any error
                 retval = None
@@ -73,10 +73,11 @@ class WorkflowHandler(asyncio.Future):
                     raise exception_raised
 
             else:
-                # Wait to be notified that the new_ev has been written
+                # notify unblocked task that we're ready to accept next event
                 async with self.ctx._event_condition:
                     self.ctx._event_condition.notify()
 
+                # Wait to be notified that the new_ev has been written
                 async with self.ctx._event_written_condition:
                     await self.ctx._event_written_condition.wait()
                     retval = self.ctx._event_holding

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -45,7 +45,7 @@ class WorkflowHandler(asyncio.Future):
             await asyncio.sleep(0)
 
             # check if StopEvent is in holding
-            if isinstance(self.ctx._event_holding, StopEvent):
+            if isinstance(self.ctx._step_event_holding, StopEvent):
                 # See if we're done, or if a step raised any error
                 retval = None
                 we_done = False
@@ -74,13 +74,13 @@ class WorkflowHandler(asyncio.Future):
 
             else:
                 # notify unblocked task that we're ready to accept next event
-                async with self.ctx._event_condition:
-                    self.ctx._event_condition.notify()
+                async with self.ctx._step_condition:
+                    self.ctx._step_condition.notify()
 
                 # Wait to be notified that the new_ev has been written
-                async with self.ctx._event_written_condition:
-                    await self.ctx._event_written_condition.wait()
-                    retval = self.ctx._event_holding
+                async with self.ctx._step_event_written:
+                    await self.ctx._step_event_written.wait()
+                    retval = self.ctx._step_event_holding
 
         else:
             raise ValueError("Context is not set!")

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -32,6 +32,23 @@ class WorkflowHandler(asyncio.Future):
                 break
 
     async def run_step(self) -> Optional[Event]:
+        """Runs the next workflow step and returns the output Event.
+
+        If return is None, then the workflow is considered done.
+
+        Examples:
+            ```python
+            handler = workflow.run(stepwise=True)
+            while True:
+                ev = await handler.run_step()
+                if ev is None:
+                    break
+                handler.ctx.send_event(ev)
+
+            result = await handler
+            print(result)
+            ```
+        """
         if self.ctx and not self.ctx.stepwise:
             raise ValueError("Stepwise context is required to run stepwise.")
 

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -161,6 +161,7 @@ class Workflow(metaclass=WorkflowMeta):
             ctx._queues = {}
             ctx._step_flags = {}
             ctx._retval = None
+            ctx._event_holding = None
 
         for name, step_func in self._get_steps().items():
             ctx._queues[name] = asyncio.Queue()
@@ -262,8 +263,7 @@ class Workflow(metaclass=WorkflowMeta):
                             async with ctx._event_condition:
                                 await ctx._event_condition.wait()
                                 ctx._event_holding = new_ev
-                                ctx._event_written_condition.notify()
-                                print(f"...notified", flush=True)
+                                ctx._event_written_condition.notify()  # shares same lock
                         else:
                             ctx.send_event(new_ev)
 

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -358,59 +358,6 @@ class Workflow(metaclass=WorkflowMeta):
         asyncio.create_task(_run_workflow())
         return result
 
-    @dispatcher.span
-    async def run_step(self, **kwargs: Any) -> Optional[Any]:
-        """Runs the workflow stepwise until completion."""
-        warnings.warn(
-            "run_step() is deprecated, use `workflow.run(stepwise=True)` instead.\n"
-            "handler = workflow.run(stepwise=True)\n"
-            "while not handler.is_done():\n"
-            "    result = await handler.run_step()\n"
-            "    print(result)\n"
-        )
-
-        # Check if we need to start a new session
-        if self._stepwise_context is None:
-            self._validate()
-            self._stepwise_context = self._start(stepwise=True)
-            # Run the first step
-            self._stepwise_context.send_event(StartEvent(**kwargs))
-
-        # Unblock all pending steps
-        for flag in self._stepwise_context._step_flags.values():
-            flag.set()
-
-        # Yield back control to the event loop to give an unblocked step
-        # the chance to run (we won't actually sleep here).
-        await asyncio.sleep(0)
-
-        # See if we're done, or if a step raised any error
-        we_done = False
-        exception_raised = None
-        for t in self._stepwise_context._tasks:
-            # Check if we're done
-            if not t.done():
-                continue
-
-            we_done = True
-            e = t.exception()
-            if type(e) != WorkflowDone:
-                exception_raised = e
-
-        retval = None
-        if we_done:
-            # Remove any reference to the tasks
-            for t in self._stepwise_context._tasks:
-                t.cancel()
-                await asyncio.sleep(0)
-            retval = self._stepwise_context._retval
-            self._stepwise_context = None
-
-        if exception_raised:
-            raise exception_raised
-
-        return retval
-
     def is_done(self) -> bool:
         """Checks if the workflow is done."""
         return self._stepwise_context is None

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -37,31 +37,6 @@ async def test_workflow_run(workflow):
     assert result == "Workflow completed"
 
 
-# @pytest.mark.asyncio()
-# async def test_deprecated_workflow_run_step(workflow):
-#     workflow._verbose = True
-
-#     # First step
-#     result = await workflow.run_step()
-#     assert result is None
-#     assert not workflow.is_done()
-
-#     # Second step
-#     result = await workflow.run_step()
-#     assert result is None
-#     assert not workflow.is_done()
-
-#     # Final step
-#     result = await workflow.run_step()
-#     assert not workflow.is_done()
-#     assert result is None
-
-#     # Cleanup step
-#     result = await workflow.run_step()
-#     assert result == "Workflow completed"
-#     assert workflow.is_done()
-
-
 @pytest.mark.asyncio()
 async def test_workflow_run_step(workflow):
     handler = workflow.run(stepwise=True)

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -67,7 +67,6 @@ async def test_workflow_run_step(workflow):
     handler = workflow.run(stepwise=True)
     await asyncio.sleep(0)
 
-    print("here", flush=True)
     event = await handler.run_step()
     assert isinstance(event, OneTestEvent)
     assert not handler.is_done()

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -65,7 +65,6 @@ async def test_workflow_run(workflow):
 @pytest.mark.asyncio()
 async def test_workflow_run_step(workflow):
     handler = workflow.run(stepwise=True)
-    await asyncio.sleep(0)
 
     event = await handler.run_step()
     assert isinstance(event, OneTestEvent)

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -37,54 +37,58 @@ async def test_workflow_run(workflow):
     assert result == "Workflow completed"
 
 
-@pytest.mark.asyncio()
-async def test_deprecated_workflow_run_step(workflow):
-    workflow._verbose = True
+# @pytest.mark.asyncio()
+# async def test_deprecated_workflow_run_step(workflow):
+#     workflow._verbose = True
 
-    # First step
-    result = await workflow.run_step()
-    assert result is None
-    assert not workflow.is_done()
+#     # First step
+#     result = await workflow.run_step()
+#     assert result is None
+#     assert not workflow.is_done()
 
-    # Second step
-    result = await workflow.run_step()
-    assert result is None
-    assert not workflow.is_done()
+#     # Second step
+#     result = await workflow.run_step()
+#     assert result is None
+#     assert not workflow.is_done()
 
-    # Final step
-    result = await workflow.run_step()
-    assert not workflow.is_done()
-    assert result is None
+#     # Final step
+#     result = await workflow.run_step()
+#     assert not workflow.is_done()
+#     assert result is None
 
-    # Cleanup step
-    result = await workflow.run_step()
-    assert result == "Workflow completed"
-    assert workflow.is_done()
+#     # Cleanup step
+#     result = await workflow.run_step()
+#     assert result == "Workflow completed"
+#     assert workflow.is_done()
 
 
 @pytest.mark.asyncio()
 async def test_workflow_run_step(workflow):
     handler = workflow.run(stepwise=True)
+    await asyncio.sleep(0)
 
-    result = await handler.run_step()
-    assert result is None
+    print("here", flush=True)
+    event = await handler.run_step()
+    assert isinstance(event, OneTestEvent)
     assert not handler.is_done()
+    handler.ctx.send_event(event)
 
-    result = await handler.run_step()
-    assert result is None
+    event = await handler.run_step()
+    assert isinstance(event, LastEvent)
     assert not handler.is_done()
+    handler.ctx.send_event(event)
 
-    result = await handler.run_step()
-    assert result is None
+    event = await handler.run_step()
+    assert isinstance(event, StopEvent)
     assert not handler.is_done()
+    handler.ctx.send_event(event)
 
-    result = await handler.run_step()
-    assert result is None
-    assert not handler.is_done()
+    event = await handler.run_step()
+    assert event is None
 
-    result = await handler.run_step()
-    assert result == "Workflow completed"
+    result = await handler
     assert handler.is_done()
+    assert result == "Workflow completed"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
# Description

Currently run_step() is able to run a Workflow steps one at a time, however, it doesn't really provide the user the ability to control the step-by-step execution. In other words, the user isn't able to control when a step ends and thus when to trigger to the next event.

Acceptance Criteria:

The user is able to end the current step by emitting the appropriate event, which then kicks off the next step.

Current Design:

```python
handler = workflow.run(stepwise=True)
while not handler.is_done():
    ev = await handler.run_step()
    handler.ctx.send_event(ev)

result = await handler
print(result)
```

NOTE:
- Currently this breaks the already deprecated `Workflow.run_step` since this invokes `_start(stepwise=True)` which has been modified in this re-factor.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated relevant unit/integration tests
- [x] I stared at the code and made sure it makes sense
