### PR TITLE
[WIP] Fixing instrumentation for workflows

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -1,3 +1,5 @@
+import asyncio
+from functools import partial
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from typing import Any, Callable, Generator, List, Optional, Dict, Protocol
@@ -261,20 +263,53 @@ class Dispatcher(BaseModel):
                 parent_id=parent_id,
                 tags=tags,
             )
+
+            def handle_future_result(future, span_id, bound_args, instance):
+                try:
+                    result = future.result()
+                    self.span_exit(
+                        id_=span_id,
+                        bound_args=bound_args,
+                        instance=instance,
+                        result=result,
+                    )
+                    return result
+                except BaseException as e:
+                    self.event(SpanDropEvent(span_id=span_id, err_str=str(e)))
+                    self.span_drop(
+                        id_=span_id, bound_args=bound_args, instance=instance, err=e
+                    )
+                    raise
+                finally:
+                    active_span_id.reset(token)
+
             try:
                 result = func(*args, **kwargs)
+                if isinstance(result, asyncio.Future):
+                    # If the result is a Future, wrap it
+                    new_future = asyncio.ensure_future(result)
+                    new_future.add_done_callback(
+                        partial(
+                            handle_future_result,
+                            span_id=id_,
+                            bound_args=bound_args,
+                            instance=instance,
+                        )
+                    )
+                    return new_future
+                else:
+                    # For non-Future results, proceed as before
+                    self.span_exit(
+                        id_=id_, bound_args=bound_args, instance=instance, result=result
+                    )
+                    return result
             except BaseException as e:
                 self.event(SpanDropEvent(span_id=id_, err_str=str(e)))
                 self.span_drop(id_=id_, bound_args=bound_args, instance=instance, err=e)
                 raise
-            else:
-                self.span_exit(
-                    id_=id_, bound_args=bound_args, instance=instance, result=result
-                )
-                return result
             finally:
-                # clean up
-                active_span_id.reset(token)
+                if not isinstance(result, asyncio.Future):
+                    active_span_id.reset(token)
 
         @wrapt.decorator
         async def async_wrapper(

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -264,7 +264,12 @@ class Dispatcher(BaseModel):
                 tags=tags,
             )
 
-            def handle_future_result(future, span_id, bound_args, instance):
+            def handle_future_result(
+                future: asyncio.Future,
+                span_id: str,
+                bound_args: inspect.BoundArguments,
+                instance: Any,
+            ) -> None:
                 try:
                     result = future.result()
                     self.span_exit(

--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -253,6 +253,7 @@ class Dispatcher(BaseModel):
             bound_args = inspect.signature(func).bind(*args, **kwargs)
             id_ = f"{func.__qualname__}-{uuid.uuid4()}"
             tags = active_instrument_tags.get()
+            result = None
 
             token = active_span_id.set(id_)
             parent_id = None if token.old_value is Token.MISSING else token.old_value

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-retrievers-bm25"
 readme = "README.md"
-version = "0.3.1"
+version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-bm25s = "^0.1.7"
+bm25s = "^0.2.0"
 pystemmer = "^2.2.0.1"
 llama-index-core = "^0.11.0"
 


### PR DESCRIPTION
Since workflows return a Future directly now, instrumentation will log the future instead of the actual result

So, to remedy this, we need to handle returning futures in our span decorators

This fix seems to work, but seeing the "error" below when using arize (note that this seems benign? since things are still logged to arize properly?)

```python
ERROR [opentelemetry.context] Failed to detach context
Traceback (most recent call last):
  File "/Users/loganmarkewich/Library/Caches/pypoetry/virtualenvs/llama-index-caVs7DDe-py3.11/lib/python3.11/site-packages/opentelemetry/context/__init__.py", line 154, in detach
    _RUNTIME_CONTEXT.detach(token)
  File "/Users/loganmarkewich/Library/Caches/pypoetry/virtualenvs/llama-index-caVs7DDe-py3.11/lib/python3.11/site-packages/opentelemetry/context/contextvars_context.py", line 50, in detach
    self._current_context.reset(token)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: <Token var=<ContextVar name='current_context' default={} at 0x2acb049f0> at 0x2cb890500> was created in a different Context
```

I bit more validation is needed

Fixes https://github.com/run-llama/llama_index/issues/16283