### PR TITLE
rm extra print statements & replace create tmpfile function

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
@@ -98,7 +98,7 @@ class MinioReader(BaseReader):
         with tempfile.TemporaryDirectory() as temp_dir:
             if self.key:
                 suffix = Path(self.key).suffix
-                filepath = f"{temp_dir}/{next(tempfile._get_candidate_names())}{suffix}"
+                _, filepath = tempfile.mkstemp(dir=temp_dir, suffix=suffix)
                 minio_client.fget_object(
                     bucket_name=self.bucket, object_name=self.key, file_path=filepath
                 )
@@ -108,7 +108,6 @@ class MinioReader(BaseReader):
                 )
                 for i, obj in enumerate(objects):
                     file_name = obj.object_name.split("/")[-1]
-                    print(file_name)
                     if self.num_files_limit is not None and i > self.num_files_limit:
                         break
 
@@ -124,7 +123,6 @@ class MinioReader(BaseReader):
                         continue
 
                     filepath = f"{temp_dir}/{file_name}"
-                    print(filepath)
                     minio_client.fget_object(self.bucket, obj.object_name, filepath)
 
             loader = SimpleDirectoryReader(

--- a/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-readers-minio"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

1. `_get_candidate_names` function is an internal implementation detail of the tempfile module and `mkstemp` is a better choice.
2. in the branch where `key` is empty, there are unnecessary and redundant print statements that need to be removed.


Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
