### PR TITLE
[FIX] broken workflow unit test

### DIFF
--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -390,7 +390,7 @@ async def test_workflow_task_raises_step():
 
     workflow = DummyWorkflow()
     with pytest.raises(ValueError, match="The step raised an error!"):
-        await workflow.run_step()
+        await workflow.run()
 
 
 def test_workflow_disable_validation():

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -390,7 +390,8 @@ async def test_workflow_task_raises_step():
 
     workflow = DummyWorkflow()
     with pytest.raises(ValueError, match="The step raised an error!"):
-        await workflow.run()
+        handler = workflow.run(stepwise=True)
+        await handler.run_step()
 
 
 def test_workflow_disable_validation():


### PR DESCRIPTION
# Description

For some reason this test didn't fail after deleting `Workflow.run_step`. Fixing this test now.

## Type of Change

Please delete options that are not relevant.

- [x] Fix broken unit test

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Fixed unit/integration tests
- [x] I stared at the code and made sure it makes sense
