### PR TITLE
[Feature Request] Ability to cancel workflow execution

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -29,6 +29,7 @@ class Context:
         self._queues: Dict[str, asyncio.Queue] = {}
         self._tasks: Set[asyncio.Task] = set()
         self._broker_log: List[Event] = []
+        self._cancel_flag: asyncio.Event = asyncio.Event()
         self._step_flags: Dict[str, asyncio.Event] = {}
         self._step_event_holding: Optional[Event] = None
         self._step_lock: asyncio.Lock = asyncio.Lock()

--- a/llama-index-core/llama_index/core/workflow/errors.py
+++ b/llama-index-core/llama_index/core/workflow/errors.py
@@ -12,3 +12,7 @@ class WorkflowRuntimeError(Exception):
 
 class WorkflowDone(Exception):
     pass
+
+
+class WorkflowCancelled(Exception):
+    pass

--- a/llama-index-core/llama_index/core/workflow/errors.py
+++ b/llama-index-core/llama_index/core/workflow/errors.py
@@ -14,5 +14,5 @@ class WorkflowDone(Exception):
     pass
 
 
-class WorkflowCancelled(Exception):
+class WorkflowCancelledByUser(Exception):
     pass

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -3,7 +3,7 @@ from typing import Any, AsyncGenerator, Optional
 
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.events import Event, StopEvent
-from llama_index.core.workflow.errors import WorkflowDone, WorkflowCancelled
+from llama_index.core.workflow.errors import WorkflowDone
 
 
 class WorkflowHandler(asyncio.Future):
@@ -107,9 +107,5 @@ class WorkflowHandler(asyncio.Future):
 
     async def cancel_run(self) -> None:
         """Method to cancel a Workflow execution."""
-        for t in self.ctx._tasks:
-            t.cancel()
-            await asyncio.sleep(0)
-
-        err = WorkflowCancelled()
-        self.set_exception(err)
+        self.ctx._cancel_flag.set()
+        await asyncio.sleep(0)

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -107,5 +107,6 @@ class WorkflowHandler(asyncio.Future):
 
     async def cancel_run(self) -> None:
         """Method to cancel a Workflow execution."""
-        self.ctx._cancel_flag.set()
-        await asyncio.sleep(0)
+        if self.ctx:
+            self.ctx._cancel_flag.set()
+            await asyncio.sleep(0)

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -3,7 +3,7 @@ from typing import Any, AsyncGenerator, Optional
 
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.events import Event, StopEvent
-from llama_index.core.workflow.errors import WorkflowDone
+from llama_index.core.workflow.errors import WorkflowDone, WorkflowCancelled
 
 
 class WorkflowHandler(asyncio.Future):
@@ -104,3 +104,12 @@ class WorkflowHandler(asyncio.Future):
             raise ValueError("Context is not set!")
 
         return retval
+
+    async def cancel_run(self) -> None:
+        """Method to cancel a Workflow execution."""
+        for t in self.ctx._tasks:
+            t.cancel()
+            await asyncio.sleep(0)
+
+        err = WorkflowCancelled()
+        self.set_exception(err)

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -285,7 +285,7 @@ class Workflow(metaclass=WorkflowMeta):
             # add dedicated cancel task
             async def _cancel_workflow_task() -> None:
                 await ctx._cancel_flag.wait()
-                raise WorkflowCancelled
+                raise WorkflowCancelledByUser
 
             ctx._tasks.add(
                 asyncio.create_task(

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -75,6 +75,7 @@ async def test_workflow_cancelled_by_user(workflow):
     handler.ctx.send_event(event)
 
     await handler.cancel_run()
+    await asyncio.sleep(0.1)  # let workflow get cancelled
     assert handler.is_done()
     assert type(handler.exception()) == WorkflowCancelled
 

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -19,7 +19,7 @@ from llama_index.core.workflow.workflow import (
     WorkflowTimeoutError,
     WorkflowValidationError,
     WorkflowRuntimeError,
-    WorkflowCancelled,
+    WorkflowCancelledByUser,
 )
 
 from .conftest import AnotherTestEvent, LastEvent, OneTestEvent
@@ -77,7 +77,7 @@ async def test_workflow_cancelled_by_user(workflow):
     await handler.cancel_run()
     await asyncio.sleep(0.1)  # let workflow get cancelled
     assert handler.is_done()
-    assert type(handler.exception()) == WorkflowCancelled
+    assert type(handler.exception()) == WorkflowCancelledByUser
 
 
 @pytest.mark.asyncio()

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -19,6 +19,7 @@ from llama_index.core.workflow.workflow import (
     WorkflowTimeoutError,
     WorkflowValidationError,
     WorkflowRuntimeError,
+    WorkflowCancelled,
 )
 
 from .conftest import AnotherTestEvent, LastEvent, OneTestEvent
@@ -62,6 +63,20 @@ async def test_workflow_run_step(workflow):
     result = await handler
     assert handler.is_done()
     assert result == "Workflow completed"
+
+
+@pytest.mark.asyncio()
+async def test_workflow_cancelled_by_user(workflow):
+    handler = workflow.run(stepwise=True)
+
+    event = await handler.run_step()
+    assert isinstance(event, OneTestEvent)
+    assert not handler.is_done()
+    handler.ctx.send_event(event)
+
+    await handler.cancel_run()
+    assert handler.is_done()
+    assert type(handler.exception()) == WorkflowCancelled
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
# Description

This PR provides the user the ability to cancel a workflow execution.

```python
workflow = ...

# run
handler = workflow.run()

# cancel
await handler.cancel_run()
```

Under the hood, `cancel_run()` sets the `Context._cancel_flag` and there is a dedicated `cancel_workflow_task` that waits for this and raises the newly defined `WorkflowCancelledByUser` exception. Following that the rest of the workflow mechanics take care of the exception being raised and setting the exception on the handler.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense
