### PR TITLE
fix async client init

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/llama_index/storage/chat_store/redis/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/llama_index/storage/chat_store/redis/base.py
@@ -370,8 +370,12 @@ class RedisChatStore(BaseChatStore):
             redis_client = self._aredis_sentinel_client(redis_url, **kwargs)
         else:
             # connect to redis server from url, reconnect with cluster client if needed
-            redis_client = redis.asyncio.from_url(redis_url, **kwargs)
-            if self._check_for_cluster(redis_client):
-                redis_client.close()
-                redis_client = self._aredis_cluster_client(redis_url, **kwargs)
-        return redis_client
+            aredis_client = redis.asyncio.from_url(redis_url, **kwargs)
+            redis_client = redis.from_url(redis_url, **kwargs)
+            is_cluster = self._check_for_cluster(redis_client)
+            redis_client.close()
+
+            if is_cluster:
+                aredis_client.close()
+                aredis_client = self._aredis_cluster_client(redis_url, **kwargs)
+        return aredis_client

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-chat-store-redis"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
`client.info` returns a coroutine for the async client

Since we are just needing to check cluster info, and since this needs to run in the constructor, lets keep this specific part sync