### PR TITLE
Use port of redirect uri in credential file to run local server in GoogleDocsReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
@@ -103,6 +103,7 @@ class GoogleDocsReader(BasePydanticReader):
             Credentials, the obtained credential.
         """
         creds = None
+        port = 8080
         if os.path.exists("token.json"):
             creds = Credentials.from_authorized_user_file("token.json", SCOPES)
         # If there are no (valid) credentials available, let the user log in.
@@ -114,8 +115,7 @@ class GoogleDocsReader(BasePydanticReader):
                     "credentials.json", SCOPES
                 )
 
-                port = 8080
-                with open("credentials.json", "r") as json_file:
+                with open("credentials.json") as json_file:
                     client_config = json.load(json_file)
                     redirect_uris = client_config["web"].get("redirect_uris", [])
                     if len(redirect_uris) > 0:

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
@@ -1,5 +1,6 @@
 """Google docs reader."""
 
+import json
 import logging
 import os
 import random
@@ -112,7 +113,15 @@ class GoogleDocsReader(BasePydanticReader):
                 flow = InstalledAppFlow.from_client_secrets_file(
                     "credentials.json", SCOPES
                 )
-                creds = flow.run_local_server(port=0)
+
+                port = 8080
+                with open("credentials.json", "r") as json_file:
+                    client_config = json.load(json_file)
+                    redirect_uris = client_config["web"].get("redirect_uris", [])
+                    if len(redirect_uris) > 0:
+                        port = redirect_uris[0].strip("/").split(":")[-1]
+
+                creds = flow.run_local_server(port=port)
             # Save the credentials for the next run
             with open("token.json", "w") as token:
                 token.write(creds.to_json())

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -47,7 +47,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.4.1"
+version = "0.4.2"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Get the port from redirect URI in credential file, and use it to run local server.

Fixes # [16326](https://github.com/run-llama/llama_index/issues/16326)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
