### PR TITLE
MilvusVectorStore: Add support for nested MetadataFilters and FilterOperator.IS_EMPTY

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
@@ -110,7 +110,7 @@ def parse_standard_filters(standard_filters: MetadataFilters = None):
             filters.append(f'({parse_standard_filters(filter)[1]})')
             continue
         filter_value = parse_filter_value(filter.value)
-        if filter_value is None:
+        if filter_value is None and filter.operator != FilterOperator.IS_EMPTY:
             continue
 
         if filter.operator == FilterOperator.NIN:
@@ -125,6 +125,8 @@ def parse_standard_filters(standard_filters: MetadataFilters = None):
             filters.append(
                 f"{filter.key!s} like {parse_filter_value(filter.value, True)}"
             )
+        elif filter.operator == FilterOperator.IS_EMPTY:
+            filters.append(f'array_length({filter.key!s}) == 0')
         elif filter.operator in [
             FilterOperator.EQ,
             FilterOperator.GT,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
@@ -106,6 +106,9 @@ def parse_standard_filters(standard_filters: MetadataFilters = None):
         return filters, ""
 
     for filter in standard_filters.filters:
+        if isinstance(filter, MetadataFilters):
+            filters.append(f'({parse_standard_filters(filter)[1]})')
+            continue
         filter_value = parse_filter_value(filter.value)
         if filter_value is None:
             continue

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
@@ -126,6 +126,7 @@ def parse_standard_filters(standard_filters: MetadataFilters = None):
                 f"{filter.key!s} like {parse_filter_value(filter.value, True)}"
             )
         elif filter.operator == FilterOperator.IS_EMPTY:
+            # in Milvus, array_length(field_name) returns 0 if the field does not exist or is not an array
             filters.append(f'array_length({filter.key!s}) == 0')
         elif filter.operator in [
             FilterOperator.EQ,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
@@ -107,7 +107,7 @@ def parse_standard_filters(standard_filters: MetadataFilters = None):
 
     for filter in standard_filters.filters:
         if isinstance(filter, MetadataFilters):
-            filters.append(f'({parse_standard_filters(filter)[1]})')
+            filters.append(f"({parse_standard_filters(filter)[1]})")
             continue
         filter_value = parse_filter_value(filter.value)
         if filter_value is None and filter.operator != FilterOperator.IS_EMPTY:
@@ -127,7 +127,7 @@ def parse_standard_filters(standard_filters: MetadataFilters = None):
             )
         elif filter.operator == FilterOperator.IS_EMPTY:
             # in Milvus, array_length(field_name) returns 0 if the field does not exist or is not an array
-            filters.append(f'array_length({filter.key!s}) == 0')
+            filters.append(f"array_length({filter.key!s}) == 0")
         elif filter.operator in [
             FilterOperator.EQ,
             FilterOperator.GT,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.2.6"
+version = "0.2.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/test_vector_stores_milvus.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/test_vector_stores_milvus.py
@@ -128,6 +128,12 @@ def test_to_milvus_filter_with_various_operators():
     expr = _to_milvus_filter(filters)
     assert expr == "array_contains_all(a, [1, 2])"
 
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="a", value=None, operator=FilterOperator.IS_EMPTY)]
+    )
+    expr = _to_milvus_filter(filters)
+    assert expr == "array_length(a) == 0"
+
 
 def test_to_milvus_filter_with_string_value():
     filters = MetadataFilters(filters=[MetadataFilter(key="a", value="hello")])
@@ -179,6 +185,24 @@ def test_to_milvus_filter_with_multiple_filters():
     )
     expr = _to_milvus_filter(filters)
     assert expr == "(a < 1 or a > 10)"
+
+
+def test_milvus_filter_with_nested_filters():
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="a", value=1, operator=FilterOperator.EQ),
+            MetadataFilters(
+                filters=[
+                    MetadataFilter(key="b", value=2, operator=FilterOperator.EQ),
+                    MetadataFilter(key="c", value=3, operator=FilterOperator.EQ)
+                ],
+                condition=FilterCondition.OR
+            )
+        ],
+        condition=FilterCondition.AND
+    )
+    expr = _to_milvus_filter(filters)
+    assert expr == "(a == 1 and (b == 2 or c == 3))"
 
 
 def test_milvus_vector_store():

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/test_vector_stores_milvus.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/test_vector_stores_milvus.py
@@ -194,12 +194,12 @@ def test_milvus_filter_with_nested_filters():
             MetadataFilters(
                 filters=[
                     MetadataFilter(key="b", value=2, operator=FilterOperator.EQ),
-                    MetadataFilter(key="c", value=3, operator=FilterOperator.EQ)
+                    MetadataFilter(key="c", value=3, operator=FilterOperator.EQ),
                 ],
-                condition=FilterCondition.OR
-            )
+                condition=FilterCondition.OR,
+            ),
         ],
-        condition=FilterCondition.AND
+        condition=FilterCondition.AND,
     )
     expr = _to_milvus_filter(filters)
     assert expr == "(a == 1 and (b == 2 or c == 3))"


### PR DESCRIPTION
# Description

Allows nested MetadataFilters by recursively evaluating them and wrapping the result in parentheses.

For example:

```python
filters = MetadataFilters(
    filters=[
        MetadataFilter(key="a", value=1, operator=FilterOperator.EQ),
        MetadataFilters(
            filters=[
                MetadataFilter(key="b", value=2, operator=FilterOperator.EQ),
                MetadataFilter(key="c", value=3, operator=FilterOperator.EQ)
            ],
            condition=FilterCondition.OR
        )
    ],
    condition=FilterCondition.AND
)
expr = _to_milvus_filter(filters)
assert expr == "(a == 1 and (b == 2 or c == 3))"
```

Also allows using `FilterOperator.IS_EMPTY`, which is translated to `array_length(key) == 0`.

Fixes #16310

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
