### PR TITLE
Rremoving safety settings from generation config for Vertex AI models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -187,7 +187,6 @@ class Vertex(FunctionCallingLLM):
         base_kwargs = {
             "temperature": self.temperature,
             "max_output_tokens": self.max_tokens,
-            "safety_settings": self._safety_settings,
         }
         return {
             **base_kwargs,

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vertex"
 readme = "README.md"
-version = "0.3.6"
+version = "0.3.7"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Vertex's GenerationConfig does not accept safety_settings, but they were being fed to it, causing errors. I removed the safety_settings from GenerationConfig, as they were already being passed through the client initialization. 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [X] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
