### PR TITLE
bump deps for bm25

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-retrievers-bm25"
 readme = "README.md"
-version = "0.3.1"
+version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-bm25s = "^0.1.7"
+bm25s = "^0.2.0"
 pystemmer = "^2.2.0.1"
 llama-index-core = "^0.11.0"
 


### PR DESCRIPTION
BM25s added more features, like better language support

For example, Italian is possible

```
import Stemmer
from llama_index.retrievers.bm25 import BM25Retriever

retriever = BM25Retriever(nodes=nodes, language="it", stemmer=Stemmer.Stemmer("Italian"), ...)
```

Fixes https://github.com/run-llama/llama_index/issues/16333