### PR TITLE
Adding support in FireworksAI for Meta 3.2 Models: 1b-instruct; 3b-instruct; 11b-vision; 90b-vision

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-fireworks/llama_index/llms/fireworks/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-fireworks/llama_index/llms/fireworks/utils.py
@@ -17,6 +17,10 @@ LLAMA_MODELS = {
     "accounts/fireworks/models/llama-v3p1-8b-instruct": 131072,
     "accounts/fireworks/models/llama-v3p1-70b-instruct": 131072,
     "accounts/fireworks/models/llama-v3p1-405b-instruct": 131072,
+    "accounts/fireworks/models/llama-v3p2-1b-instruct": 131072,
+    "accounts/fireworks/models/llama-v3p2-3b-instruct": 131072,
+    "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": 131072,
+    "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": 131072,
 }
 
 MISTRAL_MODELS = {

--- a/llama-index-integrations/llms/llama-index-llms-fireworks/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-fireworks/pyproject.toml
@@ -26,7 +26,7 @@ description = "llama-index llms fireworks integration"
 license = "MIT"
 name = "llama-index-llms-fireworks"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR updates the LLAMA_MODELS dictionary in utils.py for the FireworksAI integration. It includes new models for the Llama v3p2 series, adding configurations for vision-instruct models. This update enhances the support for these new models, extending functionality for the llama-v3p2-1b-instruct, llama-v3p2-3b-instruct, llama-v3p2-11b-vision-instruct, and llama-v3p2-90b-vision-instruct models.

No additional dependencies are required for this change.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x ] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] I ran `make format; make lint` to appease the lint gods
