### PR TITLE
Fix typo in BasePGRetriever causing graph context to not be added

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/base.py
@@ -93,10 +93,10 @@ class BasePGRetriever(BaseRetriever):
             mapped_node = og_node_map.get(node_with_score.node.ref_doc_id or "", None)
 
             if mapped_node:
-                graph_content = graph_node_map.get(node.node_id, [])
+                graph_content = graph_node_map.get(mapped_node.node_id, [])
                 if len(graph_content) > 0:
                     graph_content_str = "\n".join(graph_content)
-                    cur_content = node.get_content()
+                    cur_content = mapped_node.get_content()
                     preamble_text = (
                         self._include_text_preamble
                         if self._include_text_preamble
@@ -105,7 +105,7 @@ class BasePGRetriever(BaseRetriever):
                     new_content = (
                         preamble_text + graph_content_str + "\n\n" + cur_content
                     )
-                    mapped_node = TextNode(**node.dict())
+                    mapped_node = TextNode(**mapped_node.dict())
                     mapped_node.text = new_content
                 result_nodes.append(
                     NodeWithScore(


### PR DESCRIPTION
# Description

In the `_add_source_text()` method of `BasePGRetriever`, there is a mis-named variable that causes the graph content to never be included when creating the source text for a retrieval. This fixes the variable name.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense
- [x] Tested locally

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `make format; make lint` to appease the lint gods
