### PR TITLE
Fix delete operation for OraLlamaVS

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
@@ -536,7 +536,7 @@ class OraLlamaVS(BasePydanticVectorStore):
     @_handle_exceptions
     def delete(self, doc_id: str, **kwargs: Any) -> None:
         with self._client.cursor() as cursor:
-            ddl = f"DELETE FROM {self.table_name} WHERE id = :doc_id"
+            ddl = f"DELETE FROM {self.table_name} WHERE doc_id = :doc_id"
             cursor.execute(ddl, [doc_id])
             self._client.commit()
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
@@ -536,7 +536,7 @@ class OraLlamaVS(BasePydanticVectorStore):
     @_handle_exceptions
     def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
         with self._client.cursor() as cursor:
-            ddl = f"DELETE FROM {self.table_name} WHERE doc_id = :doc_id"
+            ddl = f"DELETE FROM {self.table_name} WHERE doc_id = :ref_doc_id"
             cursor.execute(ddl, [ref_doc_id])
             self._client.commit()
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
@@ -534,7 +534,7 @@ class OraLlamaVS(BasePydanticVectorStore):
         return [node.node_id for node in nodes]
 
     @_handle_exceptions
-    def delete(self, doc_id: str, **kwargs: Any) -> None:
+    def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
         with self._client.cursor() as cursor:
             ddl = f"DELETE FROM {self.table_name} WHERE doc_id = :doc_id"
             cursor.execute(ddl, [doc_id])

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/llama_index/vector_stores/oracledb/base.py
@@ -537,7 +537,7 @@ class OraLlamaVS(BasePydanticVectorStore):
     def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
         with self._client.cursor() as cursor:
             ddl = f"DELETE FROM {self.table_name} WHERE doc_id = :doc_id"
-            cursor.execute(ddl, [doc_id])
+            cursor.execute(ddl, [ref_doc_id])
             self._client.commit()
 
     @_handle_exceptions

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-oracledb/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-oracledb"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"


### PR DESCRIPTION
# Description

* Fix delete operation in OracleDB implementation for VectorStore.

## Motivation
* `delete` method should implement delete operation using document id, not node id.
```python
class BasePydanticVectorStore(BaseComponent, ABC):
    @abstractmethod
    def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
        """
        Delete nodes using with ref_doc_id."""
```

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I've tested this in my project
- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
