### PR TITLE
adding async concurrency into VectorStoreIndex

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -7,7 +7,7 @@ An index that is built on top of an existing vector store.
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Generator, Coroutine
 
 from llama_index.core.async_utils import run_async_tasks
 from llama_index.core.base.base_retriever import BaseRetriever
@@ -60,6 +60,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         callback_manager: Optional[CallbackManager] = None,
         transformations: Optional[List[TransformComponent]] = None,
         show_progress: bool = False,
+        async_concurrency: int = 2,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -72,6 +73,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         )
 
         self._insert_batch_size = insert_batch_size
+        self._async_concurrency = async_concurrency
         super().__init__(
             nodes=nodes,
             index_struct=index_struct,
@@ -173,23 +175,24 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
             results.append(result)
         return results
 
-    async def _async_add_nodes_to_index(
+    def _async_add_nodes_to_index(
         self,
         index_struct: IndexDict,
         nodes: Sequence[BaseNode],
         show_progress: bool = False,
         **insert_kwargs: Any,
-    ) -> None:
+    ) -> Generator[Coroutine[Any, None, None], None, None]:
         """Asynchronously add nodes to index."""
         if not nodes:
             return
 
-        for nodes_batch in iter_batch(nodes, self._insert_batch_size):
+        async def process_batch(
+            index_struct, insert_kwargs, nodes_batch, show_progress
+        ):
             nodes_batch = await self._aget_node_with_embedding(
                 nodes_batch, show_progress
             )
             new_ids = await self._vector_store.async_add(nodes_batch, **insert_kwargs)
-
             # if the vector store doesn't store text, we need to add the nodes to the
             # index struct and document store
             if not self._vector_store.stores_text or self._store_nodes_override:
@@ -199,7 +202,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
                     node_without_embedding.embedding = None
 
                     index_struct.add_node(node_without_embedding, text_id=new_id)
-                    self._docstore.add_documents(
+                    await self._docstore.async_add_documents(
                         [node_without_embedding], allow_update=True
                     )
             else:
@@ -212,9 +215,12 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
                         node_without_embedding.embedding = None
 
                         index_struct.add_node(node_without_embedding, text_id=new_id)
-                        self._docstore.add_documents(
+                        await self._docstore.async_add_documents(
                             [node_without_embedding], allow_update=True
                         )
+
+        for nodes_batch in iter_batch(nodes, self._insert_batch_size):
+            yield process_batch(index_struct, insert_kwargs, nodes_batch, show_progress)
 
     def _add_nodes_to_index(
         self,
@@ -265,15 +271,17 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         """Build index from nodes."""
         index_struct = self.index_struct_cls()
         if self._use_async:
-            tasks = [
+            for tasks in iter_batch(
                 self._async_add_nodes_to_index(
                     index_struct,
                     nodes,
                     show_progress=self._show_progress,
                     **insert_kwargs,
-                )
-            ]
-            run_async_tasks(tasks)
+                ),
+                self._async_concurrency,
+            ):
+                run_async_tasks(tasks)
+
         else:
             self._add_nodes_to_index(
                 index_struct,

--- a/llama-index-core/tests/indices/multi_modal/BUILD
+++ b/llama-index-core/tests/indices/multi_modal/BUILD
@@ -1,0 +1,16 @@
+python_sources()
+
+python_test_utils(
+    name="test_utils",
+    dependencies=[
+        "llama-index-core/tests/indices/multi_modal/mock_services.py",
+        "llama-index-core/tests/mock_utils/mock_predict.py",
+        "llama-index-core/tests/mock_utils/mock_text_splitter.py",
+        "llama-index-core/tests/mock_utils/mock_utils.py",
+        "llama-index-core/tests/mock_utils/mock_prompts.py",
+    ],
+)
+
+python_tests(
+    name="tests",
+)

--- a/llama-index-core/tests/indices/multi_modal/test_multi_modal.py
+++ b/llama-index-core/tests/indices/multi_modal/test_multi_modal.py
@@ -1,0 +1,22 @@
+import unittest
+
+from llama_index.core import Document
+from llama_index.core.indices import MultiModalVectorStoreIndex
+from llama_index.core.schema import ImageDocument
+from unittest.mock import patch
+import os
+
+
+@unittest.skip("It seems there are no multimodel embeddings mock so yet. TBC")
+@patch.dict(os.environ, {"IS_TESTING": "True"}, clear=True)
+def test_async_multi_from_documents(mock_embed_model):
+    documents = [Document(text=hex(i)[2:]) for i in range(16)] + [ImageDocument()]
+    index = MultiModalVectorStoreIndex.from_documents(
+        documents=documents,
+        use_async=True,
+        embed_model=mock_embed_model,
+        image_embed_model="default",
+        insert_batch_size=2,
+        async_concurrency=2,
+    )
+    assert len(index.index_struct.nodes_dict) == 16

--- a/llama-index-core/tests/indices/vector_store/test_simple.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple.py
@@ -176,6 +176,19 @@ def test_simple_async(
         assert (node.get_content(), embedding) in actual_node_tups
 
 
+def test_async_from_documents(mock_embed_model):
+    documents = [Document(text=hex(i)[2:]) for i in range(16)]
+    index = VectorStoreIndex.from_documents(
+        documents=documents,
+        use_async=True,
+        embed_model=mock_embed_model,
+        insert_batch_size=2,
+        async_concurrency=2,
+    )
+    assert len(index.index_struct.nodes_dict) == 16
+    # TODO assert embeds, check concurrency
+
+
 def test_simple_insert_save(
     documents: List[Document],
     patch_llm_predictor,


### PR DESCRIPTION
# implementing `VectorStoreIndex.use_async=True` for concurrent asyncio execution

Now there's no concurrency even if use_async=True. This PR introduces concurrent execution via asyncio.

## Type of Change

Please delete options that are not relevant.

- [v] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I keep it draft because I want to test it thoroughly. Before I write many tests, could you please confirm if it's a right direction toward.  

- [v] I added new unit tests to cover this change

## Suggested Checklist:

- [v] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [v] New and existing unit tests pass locally with my changes
- [v] I ran `make format; make lint` to appease the lint gods
