### PR TITLE
Fix typo in Property Graph Index docs (lpg_index_guide.md) and update args

### DIFF
--- a/docs/docs/module_guides/indexing/lpg_index_guide.md
+++ b/docs/docs/module_guides/indexing/lpg_index_guide.md
@@ -163,10 +163,9 @@ kg_extractor = SchemaLLMPathExtractor(
     possible_entities=entities,
     possible_relations=relations,
     kg_validation_schema=schema,
-    strict=True,  # if false, will allow triples outside of the schema
+    strict=True,  # if false, will allow triplets outside of the schema
     num_workers=4,
-    max_paths_per_chunk=10,
-    show_progres=False,
+    max_triplets_per_chunk=10
 )
 ```
 

--- a/docs/docs/module_guides/indexing/lpg_index_guide.md
+++ b/docs/docs/module_guides/indexing/lpg_index_guide.md
@@ -165,7 +165,7 @@ kg_extractor = SchemaLLMPathExtractor(
     kg_validation_schema=schema,
     strict=True,  # if false, will allow triplets outside of the schema
     num_workers=4,
-    max_triplets_per_chunk=10
+    max_triplets_per_chunk=10,
 )
 ```
 


### PR DESCRIPTION
# Description

Fixed the args for `SchemaLLMPathExtractor` in the `Property Graph Index` docs to match what's expected from the current class.

The tutorial page contains outdated/incorrect parameters supplied to `SchemaLLMPathExtractor`. This PR fixes this so users can follow along with the correct parameters. For reference, this is the current definition for `SchemaLLMPathExtractor`.


```python
class SchemaLLMPathExtractor(
    llm: LLM,
    extract_prompt: PromptTemplate | str | None = None,
    possible_entities: TypeAlias | None = None,
    possible_entity_props: List[str] | List[Tuple[str, str]] | None = None,
    possible_relations: TypeAlias | None = None,
    possible_relation_props: List[str] | List[Tuple[str, str]] | None = None,
    strict: bool = True,
    kg_schema_cls: Any = None,
    kg_validation_schema: Dict[str, str] | List[Triple] | None = None,
    max_triplets_per_chunk: int = 10,
    num_workers: int = 4
)
```

The documentation had `show_progres` (and even without the typo this is not present in the class), and `max_paths_per_chunk`.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No
- [x] N/A

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No
- [x] N/A

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

