### PR TITLE
Fixed sql_retriever.py bug

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
@@ -143,7 +143,7 @@ class DefaultSQLParser(BaseSQLParser):
         sql_result_start = response.find("SQLResult:")
         if sql_result_start != -1:
             response = response[:sql_result_start]
-        return response.strip().strip("```sql").strip("```").strip()
+        return response.replace("```sql", "").replace("```", "").strip()
 
 
 class PGVectorSQLParser(BaseSQLParser):


### PR DESCRIPTION
# Description

My sql queries were being truncated if they had an s, a q or an l at the end. Example:

`select * from candidates`

ended up as 

`select * from candidate`

strip gets rid of all the characters you mention in the parameter, not just if they are at the ends.

## Type of Change
- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ x] I believe this change is already covered by existing unit tests
