### PR TITLE
Fix: Handle Empty Nodes List in Retrieval while adding text

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/base.py
@@ -140,13 +140,13 @@ class BasePGRetriever(BaseRetriever):
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         nodes = self.retrieve_from_graph(query_bundle)
-        if self.include_text:
+        if self.include_text and nodes:
             nodes = self.add_source_text(nodes)
         return nodes
 
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         nodes = await self.aretrieve_from_graph(query_bundle)
-        if self.include_text:
+        if self.include_text and nodes:
             nodes = await self.async_add_source_text(nodes)
         return nodes
 


### PR DESCRIPTION
Empty nodes list trying to fetch all nodes from get_llama_nodes method

# Description

This PR addresses an issue where an empty nodes list was returned when attempting to fetch nodes using the get_llama_nodes method. The fix ensures that when the include_text flag is set, it only attempts to add source text if the retrieved nodes list is not empty. This prevents unnecessary processing and errors when the nodes list is empty.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
