### PR TITLE
Fixed issue #14728 for similarity score from Weaviate

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -333,7 +333,7 @@ class WeaviateVectorStore(BasePydanticVectorStore):
         elif query.mode == VectorStoreQueryMode.HYBRID:
             _logger.debug(f"Using hybrid search with alpha {query.alpha}")
             if vector is not None and query.query_str:
-                alpha = query.alpha
+                alpha = query.alpha or 0.5
 
         if query.filters is not None:
             filters = _to_weaviate_filter(query.filters)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -325,14 +325,13 @@ class WeaviateVectorStore(BasePydanticVectorStore):
         return_metatada = wvc.query.MetadataQuery(distance=True, score=True)
 
         vector = query.query_embedding
-        similarity_key = "distance"
+        similarity_key = "score"
         if query.mode == VectorStoreQueryMode.DEFAULT:
             _logger.debug("Using vector search")
             if vector is not None:
                 alpha = 1
         elif query.mode == VectorStoreQueryMode.HYBRID:
             _logger.debug(f"Using hybrid search with alpha {query.alpha}")
-            similarity_key = "score"
             if vector is not None and query.query_str:
                 alpha = query.alpha
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/utils.py
@@ -97,15 +97,15 @@ def get_all_properties(client: Any, class_name: str) -> List[str]:
     return [p.name for p in properties]
 
 
-def get_node_similarity(entry: Dict, similarity_key: str = "distance") -> float:
+def get_node_similarity(entry: Dict, similarity_key: str = "score") -> float:
     """Get converted node similarity from distance."""
-    distance = getattr(entry["metadata"], similarity_key)
+    score = getattr(entry["metadata"], similarity_key)
 
-    if distance is None:
-        return 1.0
+    if score is None:
+        return 0.0
 
-    # convert distance https://forum.weaviate.io/t/distance-vs-certainty-scores/258
-    return 1.0 - float(distance)
+    # The hybrid search in Weaviate returns similarity score: https://weaviate.io/developers/weaviate/search/hybrid#explain-the-search-results
+    return float(score)
 
 
 def to_node(entry: Dict, text_key: str = DEFAULT_TEXT_KEY) -> TextNode:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
 readme = "README.md"
-version = "1.1.1"
+version = "1.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -1,7 +1,63 @@
+import weaviate
+import pytest
+
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
+from llama_index.core.schema import TextNode
+from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode
 from llama_index.vector_stores.weaviate import WeaviateVectorStore
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in WeaviateVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+@pytest.fixture(scope="module")
+def vector_store():
+    client = weaviate.connect_to_embedded()
+
+    vector_store = WeaviateVectorStore(weaviate_client=client)
+
+    nodes = [
+        TextNode(text="Hello world.", embedding=[0.0, 0.0, 0.3]),
+        TextNode(text="This is a test.", embedding=[0.3, 0.0, 0.0]),
+    ]
+
+    vector_store.add(nodes)
+
+    yield vector_store
+
+    client.close()
+
+
+def test_basic_flow(vector_store):
+    query = VectorStoreQuery(
+        query_embedding=[0.3, 0.0, 0.0],
+        similarity_top_k=2,
+        query_str="world",
+        mode=VectorStoreQueryMode.DEFAULT,
+    )
+
+    results = vector_store.query(query)
+
+    assert len(results.nodes) == 2
+    assert results.nodes[0].text == "This is a test."
+    assert results.similarities[0] == 1.0
+
+    assert results.similarities[0] > results.similarities[1]
+
+
+def test_hybrid_search(vector_store):
+    query = VectorStoreQuery(
+        query_embedding=[0.0, 0.3, 0.0],
+        similarity_top_k=2,
+        query_str="world",
+        mode=VectorStoreQueryMode.HYBRID,
+    )
+
+    results = vector_store.query(query)
+    assert len(results.nodes) == 2
+    assert results.nodes[0].text == "Hello world."
+    assert results.nodes[1].text == "This is a test."
+
+    assert results.similarities[0] > results.similarities[1]


### PR DESCRIPTION
# Description

The Weaviate score returned during hybrid search is a similarity score, not a distance score. You can refer to this [page](https://weaviate.io/developers/weaviate/search/hybrid#explain-the-search-results) in the Weaviate documentation for more details. The distance score is used when performing vector searches, as detailed on this [page](https://weaviate.io/developers/weaviate/search/similarity#search-with-a-vector).

From my understanding, the current implementation in `llama_index.vector_stores.weaviate` always uses hybrid search (if the user wants to perform vector search it is just sets `a=1`). Therefore, we should not subtract the score from 1 to convert a distance score into a similarity score, as it is already a similarity score.
Fixes #14728 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
