### PR TITLE
Propagate default_headers in AnthropicMultiModal

### DIFF
--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-anthropic/llama_index/multi_modal_llms/anthropic/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-anthropic/llama_index/multi_modal_llms/anthropic/base.py
@@ -144,7 +144,7 @@ class AnthropicMultiModal(MultiModalLLM):
             "timeout": self.timeout,
             **kwargs,
         }
-       
+
         if self.default_headers:
             credential_kwargs["default_headers"] = self.default_headers
 

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-anthropic/llama_index/multi_modal_llms/anthropic/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-anthropic/llama_index/multi_modal_llms/anthropic/base.py
@@ -137,13 +137,18 @@ class AnthropicMultiModal(MultiModalLLM):
         )
 
     def _get_credential_kwargs(self, **kwargs: Any) -> Dict[str, Any]:
-        return {
+        credential_kwargs = {
             "api_key": self.api_key,
             "base_url": self.api_base,
             "max_retries": self.max_retries,
             "timeout": self.timeout,
             **kwargs,
         }
+       
+        if self.default_headers:
+            credential_kwargs["default_headers"] = self.default_headers
+
+        return credential_kwargs
 
     def _get_multi_modal_chat_messages(
         self,

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-multi-modal-llms-anthropic"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

AnthropicMultiModal class takes in default_headers, but it does not propagate it. This change fixes that and allows you to set default_headers that get sent to the client. This is a requirement to add features with Helicone.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
