### PR TITLE
feat[elasticsearch]: Add Support for Custom Metadata Keyword Suffix in Elasticsearch Integration

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -42,7 +42,9 @@ DISTANCE_STRATEGIES = Literal[
 ]
 
 
-def _to_elasticsearch_filter(standard_filters: MetadataFilters) -> Dict[str, Any]:
+def _to_elasticsearch_filter(
+    standard_filters: MetadataFilters, metadata_keyword_suffix: str = ".keyword"
+) -> Dict[str, Any]:
     """
     Convert standard filters to Elasticsearch filter.
 
@@ -56,7 +58,7 @@ def _to_elasticsearch_filter(standard_filters: MetadataFilters) -> Dict[str, Any
         filter = standard_filters.legacy_filters()[0]
         return {
             "term": {
-                f"metadata.{filter.key}.keyword": {
+                f"metadata.{filter.key}{metadata_keyword_suffix}": {
                     "value": filter.value,
                 }
             }
@@ -67,7 +69,7 @@ def _to_elasticsearch_filter(standard_filters: MetadataFilters) -> Dict[str, Any
             operands.append(
                 {
                     "term": {
-                        f"metadata.{filter.key}.keyword": {
+                        f"metadata.{filter.key}{metadata_keyword_suffix}": {
                             "value": filter.value,
                         }
                     }
@@ -407,6 +409,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             Callable[[Dict, Union[VectorStoreQuery, None]], Dict]
         ] = None,
         es_filter: Optional[List[Dict]] = None,
+        metadata_keyword_suffix: str = ".keyword",
         **kwargs: Any,
     ) -> VectorStoreQueryResult:
         """
@@ -421,6 +424,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             es_filter: Optional. Elasticsearch filter to apply to the
                         query. If filter is provided in the query,
                         this filter will be ignored.
+            metadata_keyword_suffix (str): The suffix to append to the metadata field of the keyword type.
 
         Returns:
             VectorStoreQueryResult: Result of the query.
@@ -440,6 +444,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             Callable[[Dict, Union[VectorStoreQuery, None]], Dict]
         ] = None,
         es_filter: Optional[List[Dict]] = None,
+        metadata_keyword_suffix: str = ".keyword",
         **kwargs: Any,
     ) -> VectorStoreQueryResult:
         """
@@ -454,6 +459,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             es_filter: Optional. AsyncElasticsearch filter to apply to the
                         query. If filter is provided in the query,
                         this filter will be ignored.
+            metadata_keyword_suffix (str): The suffix to append to the metadata field of the keyword type.
 
         Returns:
             VectorStoreQueryResult: Result of the query.
@@ -465,7 +471,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
         _mode_must_match_retrieval_strategy(query.mode, self.retrieval_strategy)
 
         if query.filters is not None and len(query.filters.legacy_filters()) > 0:
-            filter = [_to_elasticsearch_filter(query.filters)]
+            filter = [_to_elasticsearch_filter(query.filters, metadata_keyword_suffix)]
         else:
             filter = es_filter or []
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR enhances the Elasticsearch integration within LlamaIndex by allowing a custom suffix to be appended to metadata fields in Elasticsearch queries. By default, the `.keyword` suffix is used, but with this update, users can pass a different suffix or remove it entirely, depending on their needs.

Fixes # (issue)
#16518 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [*] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [*] No

## Type of Change
- [*] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [*] I added new unit tests to cover this change

## Suggested Checklist:

- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [*] I have added Google Colab support for the newly added notebooks.
- [*] My changes generate no new warnings
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] New and existing unit tests pass locally with my changes
- [*] I ran `make format; make lint` to appease the lint gods

### Changes Made:
1. Modified `_to_elasticsearch_filter` function to accept an optional parameter metadata_keyword_suffix (defaulting to `.keyword`).
2. Updated the logic in `_to_elasticsearch_filter` to append the custom suffix to metadata field names.
3. Modified the `query` methods in `ElasticsearchStore` to pass the `metadata_keyword_suffix` parameter when constructing filters.
4. Added test cases in `test_vector_stores_elasticsearch.py` to validate:
    - Default behavior with `.keyword` suffix.
    - Custom suffix support (e.g., `.enum`).
    - Handling of empty suffixes.

### Testing:
- A new unit test `test_metadata_filter_to_es_filter` has been added to verify the correct functionality with both default and custom suffixes.
- Tests ensure that Elasticsearch queries correctly use the provided suffix or default to `.keyword`.

Here is the testing result
```
pytest test_vector_stores_elasticsearch.py::test_metadata_filter_to_es_filter -s -v
/home/data/git/WalkerWang731/llama_index/venv/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
================================================= test session starts ==================================================
platform linux -- Python 3.10.14, pytest-8.3.3, pluggy-1.5.0 -- /home/data/git/WalkerWang731/llama_index/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/data/git/WalkerWang731/llama_index/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch
configfile: pyproject.toml
plugins: asyncio-0.24.0, anyio-4.5.0, mock-3.14.0
asyncio: mode=strict, default_loop_scope=None
collected 1 item

test_vector_stores_elasticsearch.py::test_metadata_filter_to_es_filter PASSED
```

### Why This Change Is Needed:
This change addresses a limitation where users are restricted to using the `.keyword` suffix for metadata fields in Elasticsearch queries. By introducing flexibility to define custom suffixes, users can adapt the filtering to their specific Elasticsearch index structure, improving compatibility and usability.


### Use in the code
Case 1
```
retriever = index.as_retriever(
    similarity_top_k=5,
    filters=MetadataFilters(filters=[ExactMatchFilter(key="k1", value="v1")]),
    vector_store_kwargs={
        "metadata_keyword_suffix": ".enum"
    }
)
```

Case 2
```
retriever = VectorIndexRetriever(
    index=index,
    similarity_top_k=5,
    filters=MetadataFilters(filters=[ExactMatchFilter(key="k1", value="v1")]),
    vector_store_kwargs={
        "metadata_keyword_suffix": ".enum"
    }
)
```