### PR TITLE
add the upper bound of python version 4.0

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-fireworks/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-fireworks/pyproject.toml
@@ -27,10 +27,10 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-fireworks"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1"
+python = ">=3.8.1,<4.0"
 llama-index-llms-openai = "^0.2.0"
 llama-index-core = "^0.11.0"
 


### PR DESCRIPTION
# Description

My last PR removed the upper bound of python version which caused a (publish error)[
Publish Sub-Package to PyPI if Needed]. This PR adds the version upper bound as per the error message.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
