### PR TITLE
Fix generate_qa_embedding_pairs usage in the examples

### DIFF
--- a/docs/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
+++ b/docs/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
@@ -248,14 +248,15 @@
     "\n",
     "\n",
     "train_dataset = generate_qa_embedding_pairs(\n",
-    "    llm=OpenAI(model=\"gpt-3.5-turbo\"), nodes=train_nodes\n",
+    "    llm=OpenAI(model=\"gpt-3.5-turbo\"),\n",
+    "    nodes=train_nodes,\n",
+    "    output_path=\"train_dataset.json\"\n",
     ")\n",
     "val_dataset = generate_qa_embedding_pairs(\n",
-    "    llm=OpenAI(model=\"gpt-3.5-turbo\"), nodes=val_nodes\n",
-    ")\n",
-    "\n",
-    "train_dataset.save_json(\"train_dataset.json\")\n",
-    "val_dataset.save_json(\"val_dataset.json\")"
+    "    llm=OpenAI(model=\"gpt-3.5-turbo\"),\n",
+    "    nodes=val_nodes,\n",
+    "    output_path=\"val_dataset.json\",\n",
+    ")\n"
    ]
   },
   {

--- a/docs/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
+++ b/docs/docs/examples/finetuning/embeddings/finetune_embedding.ipynb
@@ -250,13 +250,13 @@
     "train_dataset = generate_qa_embedding_pairs(\n",
     "    llm=OpenAI(model=\"gpt-3.5-turbo\"),\n",
     "    nodes=train_nodes,\n",
-    "    output_path=\"train_dataset.json\"\n",
+    "    output_path=\"train_dataset.json\",\n",
     ")\n",
     "val_dataset = generate_qa_embedding_pairs(\n",
     "    llm=OpenAI(model=\"gpt-3.5-turbo\"),\n",
     "    nodes=val_nodes,\n",
     "    output_path=\"val_dataset.json\",\n",
-    ")\n"
+    ")"
    ]
   },
   {


### PR DESCRIPTION
# Description

Fix wrong usage of generate_qa_embedding_pairs() in the example

Fixes #16479

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ X] No

## Type of Change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
