### PR TITLE
Fix pydantic errors in upstash_chat_store

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/llama_index/storage/chat_store/upstash/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/llama_index/storage/chat_store/upstash/base.py
@@ -61,7 +61,7 @@ class UpstashChatStore(BaseChatStore):
         """
         if redis_url == "" or redis_token == "":
             raise ValueError("Please provide a valid URL and token")
-
+        super().__init__(ttl=ttl)
         try:
             self._sync_redis_client = SyncRedis(url=redis_url, token=redis_token)
             self._async_redis_client = AsyncRedis(url=redis_url, token=redis_token)
@@ -69,7 +69,6 @@ class UpstashChatStore(BaseChatStore):
             logger.error(f"Upstash Redis client could not be initiated: {error}")
 
         # self.ttl = ttl
-        super().__init__(ttl=ttl)
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-chat-store-upstash"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description
Currently you get an error message AttributeError: 'UpstashChatStore' object has no attribute '_sync_redis_client'

Fixes # (issue)
In pydantic v2, you have to put super init before you assign self variables. 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
