### PR TITLE
allow passing in openai clients directly

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -239,6 +239,8 @@ class OpenAI(FunctionCallingLLM):
         default_headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.Client] = None,
         async_http_client: Optional[httpx.AsyncClient] = None,
+        openai_client: Optional[SyncOpenAI] = None,
+        async_openai_client: Optional[AsyncOpenAI] = None,
         # base class
         system_prompt: Optional[str] = None,
         messages_to_prompt: Optional[Callable[[Sequence[ChatMessage]], str]] = None,
@@ -282,8 +284,8 @@ class OpenAI(FunctionCallingLLM):
             **kwargs,
         )
 
-        self._client = None
-        self._aclient = None
+        self._client = openai_client
+        self._aclient = async_openai_client
         self._http_client = http_client
         self._async_http_client = async_http_client
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.2.13"
+version = "0.2.14"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Quick change to the openai constructor to allow passing in clients directly

This is useful for libraries that need to wrap the openai client for observability 