### PR TITLE
Added optional name of text field in Qdrant vector database.

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -88,6 +88,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         sparse_query_fn (Optional[SparseEncoderCallable]): function to encode sparse queries
         hybrid_fusion_fn (Optional[HybridFusionCallable]): function to fuse hybrid search results
         index_doc_id (bool): whether to create a payload index for the document ID. Defaults to True
+        text_key (str): Name of the field holding the text information, Defaults to 'text'
 
     Examples:
         `pip install llama-index-vector-stores-qdrant`
@@ -117,6 +118,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
     enable_hybrid: bool
     index_doc_id: bool
     fastembed_sparse_model: Optional[str]
+    text_key: Optional[str]
 
     _client: qdrant_client.QdrantClient = PrivateAttr()
     _aclient: qdrant_client.AsyncQdrantClient = PrivateAttr()
@@ -148,6 +150,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         sparse_query_fn: Optional[SparseEncoderCallable] = None,
         hybrid_fusion_fn: Optional[HybridFusionCallable] = None,
         index_doc_id: bool = True,
+        text_key: Optional[str] = "text",
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -162,6 +165,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
             enable_hybrid=enable_hybrid,
             index_doc_id=index_doc_id,
             fastembed_sparse_model=fastembed_sparse_model,
+            text_key=text_key,
         )
 
         if (
@@ -996,7 +1000,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
 
                 node = TextNode(
                     id_=str(point.id),
-                    text=payload.get("text"),
+                    text=payload.get(self.text_key),
                     metadata=metadata,
                     start_char_idx=node_info.get("start", None),
                     end_char_idx=node_info.get("end", None),


### PR DESCRIPTION

# Description
Added optional name of text field in Qdrant vector database. Necessary when using other frameworks such as LangChain as they populate the database with text field name that differs from the default "text".


Fixes # (issue)

https://github.com/run-llama/llama_index/issues/16574

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ X] No

## Type of Change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
