### PR TITLE
Add DiskANN for Azure Cosmos DB Mongo vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/llama_index/vector_stores/azurecosmosmongo/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/llama_index/vector_stores/azurecosmosmongo/base.py
@@ -136,6 +136,8 @@ class AzureCosmosDBMongoDBVectorSearch(BasePydanticVectorStore):
             create_index_commands = self._get_vector_index_ivf(kind)
         elif kind == "vector-hnsw":
             create_index_commands = self._get_vector_index_hnsw(kind)
+        elif kind == "vector-diskann":
+            create_index_commands = self._get_vector_index_diskann(kind)
         db.command(create_index_commands)
 
     def _get_vector_index_ivf(
@@ -178,6 +180,31 @@ class AzureCosmosDBMongoDBVectorSearch(BasePydanticVectorStore):
                         "efConstruction": self._cosmos_search_kwargs.get(
                             "efConstruction", 64
                         ),
+                        "similarity": self._cosmos_search_kwargs.get(
+                            "similarity", "COS"
+                        ),
+                        "dimensions": self._cosmos_search_kwargs.get(
+                            "dimensions", 1536
+                        ),
+                    },
+                }
+            ],
+        }
+
+    def _get_vector_index_diskann(
+        self,
+        kind: str,
+    ) -> Dict[str, Any]:
+        return {
+            "createIndexes": self._collection_name,
+            "indexes": [
+                {
+                    "name": self._index_name,
+                    "key": {self._embedding_key: "cosmosSearch"},
+                    "cosmosSearchOptions": {
+                        "kind": kind,
+                        "maxDegree": self._cosmos_search_kwargs.get("maxDegree", 32),
+                        "lBuild": self._cosmos_search_kwargs.get("lBuild", 50),
                         "similarity": self._cosmos_search_kwargs.get(
                             "similarity", "COS"
                         ),
@@ -274,6 +301,10 @@ class AzureCosmosDBMongoDBVectorSearch(BasePydanticVectorStore):
             pipeline = self._get_pipeline_vector_hnsw(
                 query, kwargs.get("ef_search", 40), kwargs.get("pre_filter", {})
             )
+        elif kind == "vector-diskann":
+            pipeline = self._get_pipeline_vector_diskann(
+                query, kwargs.get("lSearch", 40), kwargs.get("pre_filter", {})
+            )
 
         logger.debug("Running query pipeline: %s", pipeline)
         cursor = self._collection.aggregate(pipeline)  # type: ignore
@@ -348,6 +379,33 @@ class AzureCosmosDBMongoDBVectorSearch(BasePydanticVectorStore):
             "path": self._embedding_key,
             "k": query.similarity_top_k,
             "efSearch": ef_search,
+        }
+        if pre_filter:
+            params["filter"] = pre_filter
+
+        pipeline: List[dict[str, Any]] = [
+            {
+                "$search": {
+                    "cosmosSearch": params,
+                }
+            },
+            {
+                "$project": {
+                    "similarityScore": {"$meta": "searchScore"},
+                    "document": "$$ROOT",
+                }
+            },
+        ]
+        return pipeline
+
+    def _get_pipeline_vector_diskann(
+        self, query: VectorStoreQuery, l_search: int, pre_filter: Optional[Dict]
+    ) -> List[dict[str, Any]]:
+        params = {
+            "vector": query.query_embedding,
+            "path": self._embedding_key,
+            "k": query.similarity_top_k,
+            "lSearch": l_search,
         }
         if pre_filter:
             params["filter"] = pre_filter

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-azurecosmosmongo"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

Add a new vector index type `diskann` to Azure Cosmos DB Mongo vCore vector store. Paper of DiskANN can be found here [DiskANN: Fast Accurate Billion-point Nearest Neighbor Search on a Single Node](https://proceedings.neurips.cc/paper_files/paper/2019/file/09853c7fb1d3f8ee67a61b6bf4a7f8e6-Paper.pdf).

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
