### PR TITLE
Fix structured predict type hints

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/cypher_template.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/cypher_template.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Type
 
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.graph_stores.types import PropertyGraphStore
@@ -15,7 +15,7 @@ class CypherTemplateRetriever(BasePGRetriever):
     Args:
         graph_store (PropertyGraphStore):
             The graph store to retrieve data from.
-        output_cls (BaseModel):
+        output_cls (Type[BaseModel]):
             The output class to use for the LLM.
             Should contain the params needed for the cypher query.
         cypher_query (str):
@@ -27,7 +27,7 @@ class CypherTemplateRetriever(BasePGRetriever):
     def __init__(
         self,
         graph_store: PropertyGraphStore,
-        output_cls: BaseModel,
+        output_cls: Type[BaseModel],
         cypher_query: str,
         llm: Optional[LLM] = None,
         **kwargs: Any,
@@ -38,7 +38,9 @@ class CypherTemplateRetriever(BasePGRetriever):
             )
 
         self.llm = llm or Settings.llm
-        self.output_cls = output_cls
+        # Explicit type hint to suppress:
+        #   `Expected type '_SpecialForm[BaseModel]', got 'Type[BaseModel]' instead`
+        self.output_cls: Type[BaseModel] = output_cls
         self.cypher_query = cypher_query
 
         super().__init__(

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -334,6 +334,8 @@ class LLM(BaseLLM):
                 Output class to use for structured prediction.
             prompt (PromptTemplate):
                 Prompt template to use for structured prediction.
+            llm_kwargs (Optional[Dict[str, Any]]):
+                Arguments that are passed down to the LLM invoked by the program.
             prompt_args (Any):
                 Additional arguments to format the prompt with.
 
@@ -378,6 +380,7 @@ class LLM(BaseLLM):
         self,
         output_cls: Type[BaseModel],
         prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
     ) -> BaseModel:
         r"""Async Structured predict.
@@ -387,6 +390,8 @@ class LLM(BaseLLM):
                 Output class to use for structured prediction.
             prompt (PromptTemplate):
                 Prompt template to use for structured prediction.
+            llm_kwargs (Optional[Dict[str, Any]]):
+                Arguments that are passed down to the LLM invoked by the program.
             prompt_args (Any):
                 Additional arguments to format the prompt with.
 
@@ -423,7 +428,7 @@ class LLM(BaseLLM):
             pydantic_program_mode=self.pydantic_program_mode,
         )
 
-        result = await program.acall(**prompt_args)
+        result = await program.acall(llm_kwargs=llm_kwargs, **prompt_args)
         dispatcher.event(LLMStructuredPredictEndEvent(output=result))
         return result
 
@@ -442,6 +447,8 @@ class LLM(BaseLLM):
                 Output class to use for structured prediction.
             prompt (PromptTemplate):
                 Prompt template to use for structured prediction.
+            llm_kwargs (Optional[Dict[str, Any]]):
+                Arguments that are passed down to the LLM invoked by the program.
             prompt_args (Any):
                 Additional arguments to format the prompt with.
 
@@ -501,6 +508,8 @@ class LLM(BaseLLM):
                 Output class to use for structured prediction.
             prompt (PromptTemplate):
                 Prompt template to use for structured prediction.
+            llm_kwargs (Optional[Dict[str, Any]]):
+                Arguments that are passed down to the LLM invoked by the program.
             prompt_args (Any):
                 Additional arguments to format the prompt with.
 

--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -12,6 +12,7 @@ from typing import (
     get_args,
     runtime_checkable,
     TYPE_CHECKING,
+    Type,
 )
 from typing_extensions import Annotated
 
@@ -321,7 +322,7 @@ class LLM(BaseLLM):
     @dispatcher.span
     def structured_predict(
         self,
-        output_cls: BaseModel,
+        output_cls: Type[BaseModel],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
@@ -375,7 +376,7 @@ class LLM(BaseLLM):
     @dispatcher.span
     async def astructured_predict(
         self,
-        output_cls: BaseModel,
+        output_cls: Type[BaseModel],
         prompt: PromptTemplate,
         **prompt_args: Any,
     ) -> BaseModel:
@@ -429,7 +430,7 @@ class LLM(BaseLLM):
     @dispatcher.span
     def stream_structured_predict(
         self,
-        output_cls: BaseModel,
+        output_cls: Type[BaseModel],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
@@ -488,7 +489,7 @@ class LLM(BaseLLM):
     @dispatcher.span
     async def astream_structured_predict(
         self,
-        output_cls: BaseModel,
+        output_cls: Type[BaseModel],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
@@ -864,7 +865,7 @@ class LLM(BaseLLM):
 
     def as_structured_llm(
         self,
-        output_cls: BaseModel,
+        output_cls: Type[BaseModel],
         **kwargs: Any,
     ) -> "StructuredLLM":
         """Return a structured LLM around a given object."""

--- a/llama-index-core/llama_index/core/program/utils.py
+++ b/llama-index-core/llama_index/core/program/utils.py
@@ -32,7 +32,7 @@ def create_list_model(base_cls: Type[BaseModel]) -> Type[BaseModel]:
 
 
 def get_program_for_llm(
-    output_cls: BaseModel,
+    output_cls: Type[BaseModel],
     prompt: BasePromptTemplate,
     llm: LLM,
     pydantic_program_mode: PydanticProgramMode = PydanticProgramMode.DEFAULT,
@@ -44,7 +44,7 @@ def get_program_for_llm(
             from llama_index.core.program.function_program import FunctionCallingProgram
 
             return FunctionCallingProgram.from_defaults(
-                output_cls=output_cls,  # type: ignore
+                output_cls=output_cls,
                 llm=llm,
                 prompt=prompt,
                 **kwargs,
@@ -55,7 +55,7 @@ def get_program_for_llm(
             )
 
             return LLMTextCompletionProgram.from_defaults(
-                output_parser=PydanticOutputParser(output_cls=output_cls),  # type: ignore
+                output_parser=PydanticOutputParser(output_cls=output_cls),
                 llm=llm,
                 prompt=prompt,
                 **kwargs,
@@ -66,7 +66,7 @@ def get_program_for_llm(
         )  # pants: no-infer-dep
 
         return OpenAIPydanticProgram.from_defaults(
-            output_cls=output_cls,  # type: ignore
+            output_cls=output_cls,
             llm=llm,
             prompt=prompt,
             **kwargs,
@@ -75,7 +75,7 @@ def get_program_for_llm(
         from llama_index.core.program.function_program import FunctionCallingProgram
 
         return FunctionCallingProgram.from_defaults(
-            output_cls=output_cls,  # type: ignore
+            output_cls=output_cls,
             llm=llm,
             prompt=prompt,
             **kwargs,
@@ -85,7 +85,7 @@ def get_program_for_llm(
         from llama_index.core.program.llm_program import LLMTextCompletionProgram
 
         return LLMTextCompletionProgram.from_defaults(
-            output_parser=PydanticOutputParser(output_cls=output_cls),  # type: ignore
+            output_parser=PydanticOutputParser(output_cls=output_cls),
             llm=llm,
             prompt=prompt,
             **kwargs,

--- a/llama-index-core/llama_index/core/program/utils.py
+++ b/llama-index-core/llama_index/core/program/utils.py
@@ -68,7 +68,7 @@ def get_program_for_llm(
         return OpenAIPydanticProgram.from_defaults(
             output_cls=output_cls,
             llm=llm,
-            prompt=prompt,
+            prompt=prompt,  # type: ignore
             **kwargs,
         )
     elif pydantic_program_mode == PydanticProgramMode.FUNCTION:

--- a/llama-index-core/llama_index/core/query_engine/retriever_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/retriever_query_engine.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Sequence
+from typing import Any, List, Optional, Sequence, Type
 
 from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.base.base_retriever import BaseRetriever
@@ -71,7 +71,7 @@ class RetrieverQueryEngine(BaseQueryEngine):
         refine_template: Optional[BasePromptTemplate] = None,
         summary_template: Optional[BasePromptTemplate] = None,
         simple_template: Optional[BasePromptTemplate] = None,
-        output_cls: Optional[BaseModel] = None,
+        output_cls: Optional[Type[BaseModel]] = None,
         use_async: bool = False,
         streaming: bool = False,
         **kwargs: Any,
@@ -80,21 +80,22 @@ class RetrieverQueryEngine(BaseQueryEngine):
 
         Args:
             retriever (BaseRetriever): A retriever object.
+            llm (Optional[LLM]): An instance of an LLM.
+            response_synthesizer (Optional[BaseSynthesizer]): An instance of a response
+                synthesizer.
             node_postprocessors (Optional[List[BaseNodePostprocessor]]): A list of
                 node postprocessors.
             callback_manager (Optional[CallbackManager]): A callback manager.
-            verbose (bool): Whether to print out debug info.
             response_mode (ResponseMode): A ResponseMode object.
             text_qa_template (Optional[BasePromptTemplate]): A BasePromptTemplate
                 object.
             refine_template (Optional[BasePromptTemplate]): A BasePromptTemplate object.
+            summary_template (Optional[BasePromptTemplate]): A BasePromptTemplate object.
             simple_template (Optional[BasePromptTemplate]): A BasePromptTemplate object.
-
+            output_cls (Optional[Type[BaseModel]]): The pydantic model to pass to the
+                response synthesizer.
             use_async (bool): Whether to use async.
             streaming (bool): Whether to use streaming.
-            optimizer (Optional[BaseTokenUsageOptimizer]): A BaseTokenUsageOptimizer
-                object.
-
         """
         llm = llm or Settings.llm
 

--- a/llama-index-core/llama_index/core/response_synthesizers/accumulate.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/accumulate.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, Type
 
 from llama_index.core.async_utils import run_async_tasks
 from llama_index.core.bridge.pydantic import BaseModel
@@ -24,7 +24,7 @@ class Accumulate(BaseSynthesizer):
         callback_manager: Optional[CallbackManager] = None,
         prompt_helper: Optional[PromptHelper] = None,
         text_qa_template: Optional[BasePromptTemplate] = None,
-        output_cls: Optional[BaseModel] = None,
+        output_cls: Optional[Type[BaseModel]] = None,
         streaming: bool = False,
         use_async: bool = False,
     ) -> None:
@@ -36,7 +36,7 @@ class Accumulate(BaseSynthesizer):
         )
         self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
         self._use_async = use_async
-        self._output_cls = output_cls  # type: ignore
+        self._output_cls = output_cls
 
     def _get_prompts(self) -> PromptDictType:
         """Get prompts."""
@@ -135,9 +135,9 @@ class Accumulate(BaseSynthesizer):
             ]
         else:
             predictor = (
-                self._llm.astructured_predict  # type: ignore
+                self._llm.astructured_predict
                 if use_async
-                else self._llm.structured_predict  # type: ignore
+                else self._llm.structured_predict
             )
 
             return [

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -10,7 +10,7 @@ Will support different modes, from 1) stuffing chunks into prompt,
 
 import logging
 from abc import abstractmethod
-from typing import Any, Dict, Generator, List, Optional, Sequence, AsyncGenerator
+from typing import Any, Dict, Generator, List, Optional, Sequence, AsyncGenerator, Type
 
 from llama_index.core.base.query_pipeline.query import (
     ChainableMixin,
@@ -73,7 +73,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin, DispatcherSpanMixin):
         callback_manager: Optional[CallbackManager] = None,
         prompt_helper: Optional[PromptHelper] = None,
         streaming: bool = False,
-        output_cls: Optional[BaseModel] = None,
+        output_cls: Optional[Type[BaseModel]] = None,
     ) -> None:
         """Init params."""
         self._llm = llm or Settings.llm
@@ -186,7 +186,7 @@ class BaseSynthesizer(ChainableMixin, PromptMixin, DispatcherSpanMixin):
                 metadata=response_metadata,
             )
 
-        if isinstance(response_str, self._output_cls):  # type: ignore
+        if self._output_cls is not None and isinstance(response_str, self._output_cls):
             return PydanticResponse(
                 response_str, source_nodes=source_nodes, metadata=response_metadata
             )

--- a/llama-index-core/llama_index/core/response_synthesizers/factory.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/factory.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, Type
 
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.callbacks.base import CallbackManager
@@ -42,7 +42,7 @@ def get_response_synthesizer(
     use_async: bool = False,
     streaming: bool = False,
     structured_answer_filtering: bool = False,
-    output_cls: Optional[BaseModel] = None,
+    output_cls: Optional[Type[BaseModel]] = None,
     program_factory: Optional[
         Callable[[BasePromptTemplate], BasePydanticProgram]
     ] = None,

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -133,7 +133,7 @@ class Refine(BaseSynthesizer):
         self._refine_template = refine_template or DEFAULT_REFINE_PROMPT_SEL
         self._verbose = verbose
         self._structured_answer_filtering = structured_answer_filtering
-        self._output_cls = output_cls  # type: ignore
+        self._output_cls = output_cls
 
         if self._streaming and self._structured_answer_filtering:
             raise ValueError(

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -62,7 +62,7 @@ class DefaultRefineProgram(BasePydanticProgram):
         self,
         prompt: BasePromptTemplate,
         llm: LLM,
-        output_cls: Optional[BaseModel] = None,
+        output_cls: Optional[Type[BaseModel]] = None,
     ):
         self._prompt = prompt
         self._llm = llm
@@ -74,7 +74,7 @@ class DefaultRefineProgram(BasePydanticProgram):
 
     def __call__(self, *args: Any, **kwds: Any) -> StructuredRefineResponse:
         if self._output_cls is not None:
-            answer = self._llm.structured_predict(  # type: ignore
+            answer = self._llm.structured_predict(
                 self._output_cls,
                 self._prompt,
                 **kwds,
@@ -115,7 +115,7 @@ class Refine(BaseSynthesizer):
         prompt_helper: Optional[PromptHelper] = None,
         text_qa_template: Optional[BasePromptTemplate] = None,
         refine_template: Optional[BasePromptTemplate] = None,
-        output_cls: Optional[BaseModel] = None,
+        output_cls: Optional[Type[BaseModel]] = None,
         streaming: bool = False,
         verbose: bool = False,
         structured_answer_filtering: bool = False,
@@ -205,15 +205,15 @@ class Refine(BaseSynthesizer):
             from llama_index.core.program.utils import get_program_for_llm
 
             return get_program_for_llm(
-                StructuredRefineResponse,  # type: ignore
+                StructuredRefineResponse,
                 prompt,
-                self._llm,  # type: ignore
+                self._llm,
                 verbose=self._verbose,
             )
         else:
             return DefaultRefineProgram(
                 prompt=prompt,
-                llm=self._llm,  # type: ignore
+                llm=self._llm,
                 output_cls=self._output_cls,
             )
 

--- a/llama-index-core/llama_index/core/response_synthesizers/tree_summarize.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/tree_summarize.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Type
 
 from llama_index.core.async_utils import run_async_tasks
 from llama_index.core.callbacks.base import CallbackManager
@@ -33,7 +33,7 @@ class TreeSummarize(BaseSynthesizer):
         callback_manager: Optional[CallbackManager] = None,
         prompt_helper: Optional[PromptHelper] = None,
         summary_template: Optional[BasePromptTemplate] = None,
-        output_cls: Optional[BaseModel] = None,
+        output_cls: Optional[Type[BaseModel]] = None,
         streaming: bool = False,
         use_async: bool = False,
         verbose: bool = False,
@@ -89,7 +89,7 @@ class TreeSummarize(BaseSynthesizer):
                         **response_kwargs,
                     )
                 else:
-                    response = await self._llm.astructured_predict(  # type: ignore
+                    response = await self._llm.astructured_predict(
                         self._output_cls,
                         summary_template,
                         context_str=text_chunks[0],
@@ -112,7 +112,7 @@ class TreeSummarize(BaseSynthesizer):
                 ]
             else:
                 tasks = [
-                    self._llm.astructured_predict(  # type: ignore
+                    self._llm.astructured_predict(
                         self._output_cls,
                         summary_template,
                         context_str=text_chunk,
@@ -165,7 +165,7 @@ class TreeSummarize(BaseSynthesizer):
                         **response_kwargs,
                     )
                 else:
-                    response = self._llm.structured_predict(  # type: ignore
+                    response = self._llm.structured_predict(
                         self._output_cls,
                         summary_template,
                         context_str=text_chunks[0],
@@ -188,7 +188,7 @@ class TreeSummarize(BaseSynthesizer):
                     ]
                 else:
                     tasks = [
-                        self._llm.astructured_predict(  # type: ignore
+                        self._llm.astructured_predict(
                             self._output_cls,
                             summary_template,
                             context_str=text_chunk,
@@ -217,7 +217,7 @@ class TreeSummarize(BaseSynthesizer):
                     ]
                 else:
                     summaries = [
-                        self._llm.structured_predict(  # type: ignore
+                        self._llm.structured_predict(
                             self._output_cls,
                             summary_template,
                             context_str=text_chunk,


### PR DESCRIPTION
# Description
The methods to perform structured prediction caused my IDE to throw a type warning (see the linked issue). The bug was in fact traced due to the type hints in the program factory. This PR fixes the LLM methods for structured prediction, the program factory and a few issues in other places that I stumbled over.

Fixes #16582

## New Package?
- [ ] Yes
- [x] No

## Version Bump?
Changes to llama-index-core
- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
