### PR TITLE
disable failing zenguard test

### DIFF
--- a/llama-index-packs/llama-index-packs-zenguard/tests/test_packs_zenguard.py
+++ b/llama-index-packs/llama-index-packs-zenguard/tests/test_packs_zenguard.py
@@ -65,11 +65,12 @@ def test_secrets(zenguard_pack):
     assert response["is_detected"] is False
 
 
-def test_toxicity(zenguard_pack):
-    prompt = "Simple toxicity test"
-    detectors = [Detector.TOXICITY]
-    response = zenguard_pack.run(detectors=detectors, prompt=prompt)
-    assert response["is_detected"] is False
+# TODO: toxcity endpoint is down
+# def test_toxicity(zenguard_pack):
+#     prompt = "Simple toxicity test"
+#     detectors = [Detector.TOXICITY]
+#     response = zenguard_pack.run(detectors=detectors, prompt=prompt)
+#     assert response["is_detected"] is False
 
 
 def test_get_modules(zenguard_pack):


### PR DESCRIPTION
Seems like their toxicity endpoint is down -- disabling for now because its failing other PRs