### PR TITLE
Use Replicate streaming API

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-replicate/llama_index/llms/replicate/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-replicate/llama_index/llms/replicate/base.py
@@ -144,11 +144,12 @@ class Replicate(CustomLLM):
         if not formatted:
             prompt = self.completion_to_prompt(prompt)
         input_dict = self._get_input_dict(prompt, **kwargs)
-        response_iter = replicate.run(self.model, input=input_dict)
+        response_iter = replicate.stream(self.model, input=input_dict)
 
         def gen() -> CompletionResponseGen:
             text = ""
-            for delta in response_iter:
+            for server_event in response_iter:
+                delta = str(server_event)
                 text += delta
                 yield CompletionResponse(
                     delta=delta,

--- a/llama-index-integrations/llms/llama-index-llms-replicate/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-replicate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-replicate"
 readme = "README.md"
-version = "0.2.1"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

The Replicate integration did not use streaming text response as the integration predates [v0.21.0](https://github.com/replicate/replicate-python/releases/tag/0.21.0). 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Small breaking change as setups with replicate library < 0.25.2 may not work (and definitively when < 0.21.0).

## How Has This Been Tested?

- [x] I tested the modified integration with versions `0.25.2` (april 2024), `0.34.2` (last version in 0.x), `1.0.2` (newest) and they all stream the text response. Here is the testing code:

```python
import replicate
from llama_index.llms.replicate import Replicate

replicate.default_client._api_token = "<YOUR_API_KEY>"

llm = Replicate(model="meta/meta-llama-3-70b-instruct")
for ev in llm.stream_complete("How are you doing ?"):
    print(ev.delta, end="", flush=True)
```

