### PR TITLE
add retry logic to requests in cases where access token expires

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -145,6 +145,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
 
             if response.status_code == 401:
                 # refresh token
+                logger.debug("Received 401. Refreshing access token.")
                 access_token = self._get_access_token()
                 self._authorization_headers = {
                     "Authorization": f"Bearer {access_token}"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -144,7 +144,8 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
             response = session.send(prepared_request)
 
             if response.status_code == 401:
-                # refresh token
+                # 401 status code indicates that the access token has expired
+                # refresh the token and retry once
                 logger.debug("Received 401. Refreshing access token.")
                 access_token = self._get_access_token()
                 self._authorization_headers = {

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -131,6 +131,39 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
             logger.error("Error retrieving access token: %s", json_response["error"])
             raise ValueError(f"Error retrieving access token: {error_message}")
 
+    def _make_request_with_retry(self, request: requests.Request) -> requests.Response:
+        """
+        Makes a request to the SharePoint API with the provided request object.
+        If the request fails with a 401 status code, the access token is refreshed and the request is retried once.
+        """
+        curr_headers = (request.headers or {}).copy()
+        curr_headers.update(self._authorization_headers)
+        request.headers = curr_headers
+        prepared_request = request.prepare()
+        with requests.Session() as session:
+            response = session.send(prepared_request)
+
+            if response.status_code == 401:
+                # refresh token
+                access_token = self._get_access_token()
+                self._authorization_headers = {
+                    "Authorization": f"Bearer {access_token}"
+                }
+                curr_headers.update(self._authorization_headers)
+                request.headers = curr_headers
+                prepared_request = request.prepare()
+                response = session.send(prepared_request)
+
+            response.raise_for_status()
+            return response
+
+    def _make_get_with_retry(self, url: str) -> requests.Response:
+        request = requests.Request(
+            method="GET",
+            url=url,
+        )
+        return self._make_request_with_retry(request)
+
     def _get_site_id_with_host_name(
         self, access_token, sharepoint_site_name: Optional[str]
     ) -> str:
@@ -160,10 +193,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         site_information_endpoint = f"https://graph.microsoft.com/v1.0/sites"
 
         while site_information_endpoint:
-            response = requests.get(
-                url=site_information_endpoint,
-                headers=self._authorization_headers,
-            )
+            response = self._make_get_with_retry(site_information_endpoint)
 
             json_response = response.json()
             if response.status_code == 200 and "value" in json_response:
@@ -214,10 +244,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
 
         self._drive_id_endpoint = f"https://graph.microsoft.com/v1.0/sites/{self._site_id_with_host_name}/drives"
 
-        response = requests.get(
-            url=self._drive_id_endpoint,
-            headers=self._authorization_headers,
-        )
+        response = self._make_get_with_retry(self._drive_id_endpoint)
         json_response = response.json()
 
         if response.status_code == 200 and "value" in json_response:
@@ -254,10 +281,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
             f"{self._drive_id_endpoint}/{self._drive_id}/root:/{folder_path}"
         )
 
-        response = requests.get(
-            url=folder_id_endpoint,
-            headers=self._authorization_headers,
-        )
+        response = self._make_get_with_retry(folder_id_endpoint)
 
         if response.status_code == 200 and "id" in response.json():
             return response.json()["id"]
@@ -363,10 +387,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         permissions_info_endpoint = (
             f"{self._drive_id_endpoint}/{self._drive_id}/items/{item_id}/permissions"
         )
-        response = requests.get(
-            url=permissions_info_endpoint,
-            headers=self._authorization_headers,
-        )
+        response = self._make_get_with_retry(permissions_info_endpoint)
         permissions = response.json()
 
         identity_sets = []
@@ -612,10 +633,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         folder_contents_endpoint = (
             f"{self._drive_id_endpoint}/{self._drive_id}/items/{folder_id}/children"
         )
-        response = requests.get(
-            url=folder_contents_endpoint,
-            headers=self._authorization_headers,
-        )
+        response = self._make_get_with_retry(folder_contents_endpoint)
         items = response.json().get("value", [])
         file_paths = []
         for item in items:
@@ -643,10 +661,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         drive_contents_endpoint = (
             f"{self._drive_id_endpoint}/{self._drive_id}/root/children"
         )
-        response = requests.get(
-            url=drive_contents_endpoint,
-            headers=self._authorization_headers,
-        )
+        response = self._make_get_with_retry(drive_contents_endpoint)
         items = response.json().get("value", [])
 
         file_paths = []
@@ -749,10 +764,7 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         file_path = "/".join(parts)
         endpoint = f"{self._drive_id_endpoint}/{self._drive_id}/root:/{file_path}"
 
-        response = requests.get(
-            url=endpoint,
-            headers=self._authorization_headers,
-        )
+        response = self._make_get_with_retry(endpoint)
 
         return response.json()
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["arun-soliton"]
 name = "llama-index-readers-microsoft-sharepoint"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -60,7 +60,7 @@ def sharepoint_reader():
     return sharepoint_reader
 
 
-def mock_requests_get(url, headers):
+def mock_send_get_with_retry(url):
     mock_response = MagicMock()
     mock_response.status_code = 200
 
@@ -145,8 +145,8 @@ def mock_sharepoint_api_calls():
         SharePointReader, "_get_sharepoint_folder_id", return_value="dummy_folder_id"
     ), patch.object(
         SharePointReader, "_get_drive_id", return_value="dummy_drive_id"
-    ), patch(
-        "requests.get", side_effect=mock_requests_get
+    ), patch.object(
+        SharePointReader, "_send_get_with_retry", side_effect=mock_send_get_with_retry
     ):
         yield
 


### PR DESCRIPTION
# Description

If sharepoint methods take too long, they run the risk of having their access token expire after 1 hour. This change aims to refresh the token when that happens.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests
- [x] Gonna test rn

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
