### PR TITLE
Fix BUG where the api_key parameter is not set when calling DashScopeRerank.

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
@@ -38,8 +38,9 @@ class DashScopeRerank(BaseNodePostprocessor):
                 "Must pass in dashscope api key or "
                 "specify via DASHSCOPE_API_KEY environment variable "
             )
-        self._api_key = api_key
+
         super().__init__(top_n=top_n, model=model, return_documents=return_documents)
+        self._api_key = api_key
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
@@ -1,7 +1,7 @@
 import os
 from typing import List, Optional
 
-from llama_index.core.bridge.pydantic import Field
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CBEventType, EventPayload
 from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.instrumentation.events.rerank import (
@@ -22,6 +22,7 @@ except ImportError:
 class DashScopeRerank(BaseNodePostprocessor):
     model: str = Field(description="Dashscope rerank model name.")
     top_n: int = Field(description="Top N nodes to return.")
+    _api_key: Optional[str] = PrivateAttr()
 
     def __init__(
         self,
@@ -37,7 +38,7 @@ class DashScopeRerank(BaseNodePostprocessor):
                 "Must pass in dashscope api key or "
                 "specify via DASHSCOPE_API_KEY environment variable "
             )
-
+        self._api_key = api_key
         super().__init__(top_n=top_n, model=model, return_documents=return_documents)
 
     @classmethod
@@ -81,6 +82,7 @@ class DashScopeRerank(BaseNodePostprocessor):
                 top_n=self.top_n,
                 query=query_bundle.query_str,
                 documents=texts,
+                api_key=self._api_key,
             )
             new_nodes = []
             for result in results.output.results:

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-postprocessor-dashscope-rerank"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Fix BUG where the api_key parameter is not set when calling DashScopeRerank.

# Description

the api_key parameter is not set when calling DashScopeRerank.

Fixes # (issue)

## New Package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

