### PR TITLE
fix: show `Workflow`'s constructor documentation

### DIFF
--- a/docs/docs/api_reference/workflow/workflow.md
+++ b/docs/docs/api_reference/workflow/workflow.md
@@ -2,3 +2,4 @@
     options:
       members:
         - Workflow
+      filters: []

--- a/docs/docs/api_reference/workflow/workflow.md
+++ b/docs/docs/api_reference/workflow/workflow.md
@@ -2,4 +2,4 @@
     options:
       members:
         - Workflow
-      filters: []
+      filters: ["!^_", "^__init__$"]


### PR DESCRIPTION
# Description

Docstrings from `__init__` methods are globally excluded but it's particularly important we document `Workflow`'s constructor as it contains several key options.

Let's make an exception and show the `__init__` doc for the `workflow` module.

Fixes: constructor not documented in https://docs.llamaindex.ai/en/stable/api_reference/workflow/workflow/