### PR TITLE
fix deeplake (again)

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-deeplake/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-deeplake/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-deeplake"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-deeplake = ">=3.9.12"
+deeplake = ">=3.9.12,<4.0"
 llama-index-core = "^0.11.0"
 pyjwt = "*"
 


### PR DESCRIPTION
Deeplake released 4.0 which appears to be breaking imports. I'm not sure what else it broke, since their docs aren't updated, so limiting the version for now