### PR TITLE
build: fix Docling reader package build

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-docling/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-docling/pyproject.toml
@@ -33,7 +33,7 @@ readme = "README.md"
 version = "0.2.0"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10,<3.13"  # 3.13 disabled until llama-index-core supports a 3.13-capable numpy version
 llama-index-core = "^0.11.19"
 docling-core = "^2.2.0"
 docling = "^2.2.0"

--- a/llama-index-integrations/readers/llama-index-readers-docling/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-docling/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-readers-docling"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"  # 3.13 disabled until llama-index-core supports a 3.13-capable numpy version


### PR DESCRIPTION
# Description

The latest Docling integration update (https://github.com/run-llama/llama_index/commit/8c7dd3d0c01cca4872337dbd9aa2a1a7065e2c60) failed during the reader package build ([GH Action log](https://github.com/run-llama/llama_index/actions/runs/11527964490/job/32094460352)) due to a conflict on dependency versions for Python 3.13 (namely llama-index-core currently does not support any 3.13-capable numpy version).

This change therefore disables Python 3.13 for now, in order to allow the Docling Reader package to build.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
