### PR TITLE
Add Managed Identity authentication support for Azure storage components

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-azure/llama_index/storage/chat_store/azure/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-azure/llama_index/storage/chat_store/azure/base.py
@@ -118,13 +118,13 @@ class AzureChatStore(BaseChatStore):
 
     @classmethod
     def from_account_and_id(
-            cls,
-            account_name: str,
-            endpoint: Optional[str] = None,
-            chat_table_name: str = DEFAULT_CHAT_TABLE,
-            metadata_table_name: str = DEFAULT_METADATA_TABLE,
-            metadata_partition_key: str = None,
-            service_mode: ServiceMode = ServiceMode.STORAGE,
+        cls,
+        account_name: str,
+        endpoint: Optional[str] = None,
+        chat_table_name: str = DEFAULT_CHAT_TABLE,
+        metadata_table_name: str = DEFAULT_METADATA_TABLE,
+        metadata_partition_key: str = None,
+        service_mode: ServiceMode = ServiceMode.STORAGE,
     ) -> "AzureChatStore":
         """Initializes AzureChatStore from an account name and managed ID."""
         from azure.identity import DefaultAzureCredential

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-azure/llama_index/storage/chat_store/azure/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-azure/llama_index/storage/chat_store/azure/base.py
@@ -117,6 +117,31 @@ class AzureChatStore(BaseChatStore):
         )
 
     @classmethod
+    def from_account_and_id(
+            cls,
+            account_name: str,
+            endpoint: Optional[str] = None,
+            chat_table_name: str = DEFAULT_CHAT_TABLE,
+            metadata_table_name: str = DEFAULT_METADATA_TABLE,
+            metadata_partition_key: str = None,
+            service_mode: ServiceMode = ServiceMode.STORAGE,
+    ) -> "AzureChatStore":
+        """Initializes AzureChatStore from an account name and managed ID."""
+        from azure.identity import DefaultAzureCredential
+
+        if endpoint is None:
+            endpoint = f"https://{account_name}.table.core.windows.net"
+        credential = DefaultAzureCredential()
+        return cls._from_clients(
+            endpoint,
+            credential,
+            chat_table_name,
+            metadata_table_name,
+            metadata_partition_key,
+            service_mode,
+        )
+
+    @classmethod
     def from_sas_token(
         cls,
         endpoint: str,

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-azure/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-azure/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-chat-store-azure"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/llama_index/storage/docstore/azure/base.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/llama_index/storage/docstore/azure/base.py
@@ -108,6 +108,33 @@ class AzureDocumentStore(KVDocumentStore):
         )
 
     @classmethod
+    def from_account_and_id(
+            cls,
+            account_name: str,
+            namespace: Optional[str] = None,
+            node_collection_suffix: Optional[str] = None,
+            ref_doc_collection_suffix: Optional[str] = None,
+            metadata_collection_suffix: Optional[str] = None,
+            service_mode: ServiceMode = ServiceMode.STORAGE,
+            partition_key: Optional[str] = None,
+            **kwargs,
+    ) -> "AzureDocumentStore":
+        """Initialize an AzureDocumentStore from an account name and managed ID."""
+        azure_kvstore = AzureKVStore.from_account_and_id(
+            account_name,
+            service_mode=service_mode,
+            partition_key=partition_key,
+        )
+        return cls(
+            azure_kvstore,
+            namespace,
+            node_collection_suffix,
+            ref_doc_collection_suffix,
+            metadata_collection_suffix,
+            **kwargs,
+        )
+
+    @classmethod
     def from_sas_token(
         cls,
         endpoint: str,

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/llama_index/storage/docstore/azure/base.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/llama_index/storage/docstore/azure/base.py
@@ -109,15 +109,15 @@ class AzureDocumentStore(KVDocumentStore):
 
     @classmethod
     def from_account_and_id(
-            cls,
-            account_name: str,
-            namespace: Optional[str] = None,
-            node_collection_suffix: Optional[str] = None,
-            ref_doc_collection_suffix: Optional[str] = None,
-            metadata_collection_suffix: Optional[str] = None,
-            service_mode: ServiceMode = ServiceMode.STORAGE,
-            partition_key: Optional[str] = None,
-            **kwargs,
+        cls,
+        account_name: str,
+        namespace: Optional[str] = None,
+        node_collection_suffix: Optional[str] = None,
+        ref_doc_collection_suffix: Optional[str] = None,
+        metadata_collection_suffix: Optional[str] = None,
+        service_mode: ServiceMode = ServiceMode.STORAGE,
+        partition_key: Optional[str] = None,
+        **kwargs,
     ) -> "AzureDocumentStore":
         """Initialize an AzureDocumentStore from an account name and managed ID."""
         azure_kvstore = AzureKVStore.from_account_and_id(

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/pyproject.toml
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-azure/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-docstore-azure"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-azure/llama_index/storage/index_store/azure/base.py
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-azure/llama_index/storage/index_store/azure/base.py
@@ -68,6 +68,28 @@ class AzureIndexStore(KVIndexStore):
         return cls(azure_kvstore, namespace, collection_suffix)
 
     @classmethod
+    def from_account_and_id(
+            cls,
+            account_name: str,
+            namespace: Optional[str] = None,
+            endpoint: Optional[str] = None,
+            service_mode: ServiceMode = ServiceMode.STORAGE,
+            partition_key: Optional[str] = None,
+            collection_suffix: Optional[str] = None,
+    ) -> "AzureIndexStore":
+        """Load an AzureIndexStore from an account name and managed ID.
+
+        Args:
+            account_name (str): Azure Storage Account Name
+            namespace (Optional[str]): namespace for the AzureIndexStore
+            service_mode (ServiceMode): CosmosDB or Azure Table service mode
+        """
+        azure_kvstore = AzureKVStore.from_account_and_id(
+            account_name, endpoint, service_mode, partition_key
+        )
+        return cls(azure_kvstore, namespace, collection_suffix)
+
+    @classmethod
     def from_sas_token(
         cls,
         endpoint: str,

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-azure/llama_index/storage/index_store/azure/base.py
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-azure/llama_index/storage/index_store/azure/base.py
@@ -69,13 +69,13 @@ class AzureIndexStore(KVIndexStore):
 
     @classmethod
     def from_account_and_id(
-            cls,
-            account_name: str,
-            namespace: Optional[str] = None,
-            endpoint: Optional[str] = None,
-            service_mode: ServiceMode = ServiceMode.STORAGE,
-            partition_key: Optional[str] = None,
-            collection_suffix: Optional[str] = None,
+        cls,
+        account_name: str,
+        namespace: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        service_mode: ServiceMode = ServiceMode.STORAGE,
+        partition_key: Optional[str] = None,
+        collection_suffix: Optional[str] = None,
     ) -> "AzureIndexStore":
         """Load an AzureIndexStore from an account name and managed ID.
 

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-azure/pyproject.toml
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-azure/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-index-store-azure"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-azure/llama_index/storage/kvstore/azure/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-azure/llama_index/storage/kvstore/azure/base.py
@@ -127,6 +127,29 @@ class AzureKVStore(BaseKVStore):
         )
 
     @classmethod
+    def from_account_and_id(
+            cls,
+            account_name: str,
+            endpoint: Optional[str] = None,
+            service_mode: ServiceMode = ServiceMode.STORAGE,
+            partition_key: Optional[str] = None,
+            *args: Any,
+            **kwargs: Any,
+    ) -> "AzureKVStore":
+        """Creates an instance of AzureKVStore from an account name and managed ID."""
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ImportError:
+            raise ImportError(IMPORT_ERROR_MSG)
+
+        if endpoint is None:
+            endpoint = f"https://{account_name}.table.core.windows.net"
+        credential = DefaultAzureCredential()
+        return cls._from_clients(
+            endpoint, credential, service_mode, partition_key, *args, **kwargs
+        )
+
+    @classmethod
     def from_sas_token(
         cls,
         endpoint: str,

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-azure/llama_index/storage/kvstore/azure/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-azure/llama_index/storage/kvstore/azure/base.py
@@ -128,13 +128,13 @@ class AzureKVStore(BaseKVStore):
 
     @classmethod
     def from_account_and_id(
-            cls,
-            account_name: str,
-            endpoint: Optional[str] = None,
-            service_mode: ServiceMode = ServiceMode.STORAGE,
-            partition_key: Optional[str] = None,
-            *args: Any,
-            **kwargs: Any,
+        cls,
+        account_name: str,
+        endpoint: Optional[str] = None,
+        service_mode: ServiceMode = ServiceMode.STORAGE,
+        partition_key: Optional[str] = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> "AzureKVStore":
         """Creates an instance of AzureKVStore from an account name and managed ID."""
         try:

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-azure/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-azure/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-kvstore-azure"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

This PR adds support for Azure Managed Identity authentication across storage components for Azure. The changes include:

- Implemented `from_account_and_id()` class method in:
  - storage/chat_store/azure/base.py
  - storage/docstore/azure/base.py
  - storage/index_store/azure/base.py
  - storage/kvstore/azure/base.py
- Uses DefaultAzureCredential for authentication

This addition enables authentication using Azure Managed Identities instead of connection strings or access keys.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed [README.md](http://readme.md/) for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods