### PR TITLE
Improve Bedrock Tool Calling

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -530,6 +530,7 @@ class BedrockConverse(FunctionCallingLLM):
         chat_history: Optional[List[ChatMessage]] = None,
         verbose: bool = False,
         allow_parallel_tool_calls: bool = False,
+        tool_choice: Optional[dict] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Prepare the arguments needed to let the LLM chat with tools."""
@@ -540,11 +541,15 @@ class BedrockConverse(FunctionCallingLLM):
             chat_history.append(user_msg)
 
         # convert Llama Index tools to AWS Bedrock Converse tools
-        tool_dicts = tools_to_converse_tools(tools)
+        tool_config = tools_to_converse_tools(tools)
+        if tool_choice:
+          # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
+          # e.g. { "auto": {} }
+          tool_config["toolChoice"] = tool_choice
 
         return {
             "messages": chat_history,
-            "tools": tool_dicts or None,
+            "tools": tool_config,
             **kwargs,
         }
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -543,9 +543,9 @@ class BedrockConverse(FunctionCallingLLM):
         # convert Llama Index tools to AWS Bedrock Converse tools
         tool_config = tools_to_converse_tools(tools)
         if tool_choice:
-          # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
-          # e.g. { "auto": {} }
-          tool_config["toolChoice"] = tool_choice
+            # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
+            # e.g. { "auto": {} }
+            tool_config["toolChoice"] = tool_choice
 
         return {
             "messages": chat_history,

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -174,21 +174,10 @@ def tools_to_converse_tools(tools: List["BaseTool"]) -> Dict[str, Any]:
     """
     converse_tools = []
     for tool in tools:
-        tool_name, tool_description = getattr(tool, "name", None), getattr(
-            tool, "description", None
-        )
-        if not tool_name or not tool_description:
-            # get the tool's name and description from the metadata if they aren't defined
-            tool_name = getattr(tool.metadata, "name", None)
-            if tool_fn := getattr(tool, "fn", None):
-                # get the tool's description from the function's docstring
-                tool_description = tool_fn.__doc__
-                if not tool_name:
-                    tool_name = tool_fn.__name__
-            else:
-                tool_description = getattr(tool.metadata, "description", None)
-            if not tool_name or not tool_description:
-                raise ValueError(f"Tool {tool} does not have a name or description.")
+        tool_name, tool_description = tool.metadata.name, tool.metadata.description
+        if not tool_name:
+            raise ValueError(f"Tool {tool} does not have a name.")
+
         tool_dict = {
             "name": tool_name,
             "description": tool_description,

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock-converse"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Fixes an error when a FunctionTool docstring is None (even though ToolMetadata description is populated).  In the current implementation, ToolMetadata should always exist and always contain a description.  Use that directly, rather than reparsing.

Implements tool choice.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This module does not currently support unit testing.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
