### PR TITLE
fix return type check on workflows

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -396,7 +396,7 @@ class Workflow(metaclass=WorkflowMeta):
     @step
     async def _done(self, ctx: Context, ev: StopEvent) -> None:
         """Tears down the whole workflow and stop execution."""
-        ctx._retval = ev.result or None
+        ctx._retval = ev.result
         ctx.write_event_to_stream(ev)
 
         # Signal we want to stop the workflow


### PR DESCRIPTION
Somehow, `ev.result or None` can evaluate to `None`, even when `ev.result` is a valid result (like a pydantic object)