### PR TITLE
fixes LLMRerank default_parse_choice_select_answer_fn parsing isssue

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -101,7 +101,17 @@ def default_parse_choice_select_answer_fn(
                     "Answer line must be of the form: "
                     "answer_num: <int>, answer_relevance: <float>"
                 )
-        answer_num = int(line_tokens[0].split(":")[1].strip())
+        try:
+            answer_num = int(line_tokens[0].split(":")[1].strip())
+        except (IndexError, ValueError) as e:
+            if not raise_error:
+                continue
+            else:
+                raise ValueError(
+                    f"Invalid answer line: {answer_line}. "
+                    "Answer line must be of the form: "
+                    "answer_num: <int>, answer_relevance: <float>"
+                )
         if answer_num > num_choices:
             continue
         answer_nums.append(answer_num)


### PR DESCRIPTION
# Fixes LLMRerank output parsing bug

Sometimes the LLM does not follow the strict answer format expected by reranker: `"answer_num: <int>, answer_relevance: <float>"`. 
In my case GPT 4.o included additional lines explaining the reason for it's answer. 
This leads to unhandled Index and Value errors which lead to unexpected failure - even when `raise_error` is set to False.
I wrapped the Exceptions to avoid this.

Fixes #11092 

A fix was attempted in #11094 but abandoned.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
