### PR TITLE
Fix _merge_ref_doc_kv_pairs duped for-loop

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -125,19 +125,18 @@ class KVDocumentStore(BaseDocumentStore):
     def _merge_ref_doc_kv_pairs(self, ref_doc_kv_pairs: dict) -> List[Tuple[str, dict]]:
         merged_ref_doc_kv_pairs: List[Tuple[str, dict]] = []
         for key, kv_pairs in ref_doc_kv_pairs.items():
-            for key, kv_pairs in ref_doc_kv_pairs.items():
-                merged_node_ids: List[str] = []
-                metadata: Dict[str, Any] = {}
-                for kv_pair in kv_pairs:
-                    nodes = kv_pair[1].get("node_ids", [])
-                    new_nodes = set(nodes).difference(set(merged_node_ids))
-                    merged_node_ids.extend(
-                        [node for node in nodes if node in new_nodes]
-                    )
-                    metadata.update(kv_pair[1].get("metadata", {}))
-                merged_ref_doc_kv_pairs.append(
-                    (key, {"node_ids": merged_node_ids, "metadata": metadata})
+            merged_node_ids: List[str] = []
+            metadata: Dict[str, Any] = {}
+            for kv_pair in kv_pairs:
+                nodes = kv_pair[1].get("node_ids", [])
+                new_nodes = set(nodes).difference(set(merged_node_ids))
+                merged_node_ids.extend(
+                    [node for node in nodes if node in new_nodes]
                 )
+                metadata.update(kv_pair[1].get("metadata", {}))
+            merged_ref_doc_kv_pairs.append(
+                (key, {"node_ids": merged_node_ids, "metadata": metadata})
+            )
 
         return merged_ref_doc_kv_pairs
 

--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -130,9 +130,7 @@ class KVDocumentStore(BaseDocumentStore):
             for kv_pair in kv_pairs:
                 nodes = kv_pair[1].get("node_ids", [])
                 new_nodes = set(nodes).difference(set(merged_node_ids))
-                merged_node_ids.extend(
-                    [node for node in nodes if node in new_nodes]
-                )
+                merged_node_ids.extend([node for node in nodes if node in new_nodes])
                 metadata.update(kv_pair[1].get("metadata", {}))
             merged_ref_doc_kv_pairs.append(
                 (key, {"node_ids": merged_node_ids, "metadata": metadata})


### PR DESCRIPTION
The double loop was a long-standing bug, hidden by the usage of a default batch size of 1. The result merged_ref_doc_kv_pairs had n_keys**2 values, instead of n_keys.

# Description

I decided to update the batch_size when calling `_docstore.add_documents` in a custom index implementation. This resulted in a SQL error about repeated rows being added in a batch.

It turns out, the ref_doc_id kv pairs were being repeated by a faulty for-loop in the KVDocumentStore class

Fixes # (issue) None

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
