### PR TITLE
fix react agent streaming

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -683,8 +683,8 @@ class ReActAgentWorker(BaseAgentWorker):
                 )
         else:
             # remove "Answer: " from the response, and anything before it
-            start_idx = latest_chunk.message.content.find("Answer:")
-            if start_idx != -1:
+            start_idx = (latest_chunk.message.content or "").find("Answer:")
+            if start_idx != -1 and latest_chunk.message.content:
                 latest_chunk.message.content = latest_chunk.message.content[
                     start_idx + len("Answer:") :
                 ].strip()
@@ -776,8 +776,8 @@ class ReActAgentWorker(BaseAgentWorker):
                 )
         else:
             # remove "Answer: " from the response, and anything before it
-            start_idx = latest_chunk.message.content.find("Answer:")
-            if start_idx != -1:
+            start_idx = (latest_chunk.message.content or "").find("Answer:")
+            if start_idx != -1 and latest_chunk.message.content:
                 latest_chunk.message.content = latest_chunk.message.content[
                     start_idx + len("Answer:") :
                 ].strip()

--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -494,7 +494,7 @@ class ReActAgentWorker(BaseAgentWorker):
                 missed_chunks_storage.append(chunk)
             elif not latest_content.startswith("Thought"):
                 return True
-            elif "Answer: " in latest_content:
+            elif "Answer:" in latest_content:
                 missed_chunks_storage.clear()
                 return True
         return False
@@ -682,11 +682,22 @@ class ReActAgentWorker(BaseAgentWorker):
                     )
                 )
         else:
-            # Get the response in a separate thread so we can yield the response
+            # remove "Answer: " from the response, and anything before it
+            start_idx = latest_chunk.message.content.find("Answer:")
+            if start_idx != -1:
+                latest_chunk.message.content = latest_chunk.message.content[
+                    start_idx + len("Answer:") :
+                ].strip()
+
+            # set delta to the content, minus the "Answer: "
+            latest_chunk.delta = latest_chunk.message.content
+
+            # add back the chunks that were missed
             response_stream = self._add_back_chunk_to_stream(
                 chunks=[*missed_chunks_storage, latest_chunk], chat_stream=chat_stream
             )
 
+            # Get the response in a separate thread so we can yield the response
             agent_response_stream = StreamingAgentChatResponse(
                 chat_stream=response_stream,
                 sources=task.extra_state["sources"],
@@ -764,7 +775,17 @@ class ReActAgentWorker(BaseAgentWorker):
                     )
                 )
         else:
-            # Get the response in a separate thread so we can yield the response
+            # remove "Answer: " from the response, and anything before it
+            start_idx = latest_chunk.message.content.find("Answer:")
+            if start_idx != -1:
+                latest_chunk.message.content = latest_chunk.message.content[
+                    start_idx + len("Answer:") :
+                ].strip()
+
+            # set delta to the content, minus the "Answer: "
+            latest_chunk.delta = latest_chunk.message.content
+
+            # add back the chunks that were missed
             response_stream = self._async_add_back_chunk_to_stream(
                 chunks=[*missed_chunks_storage, latest_chunk], chat_stream=chat_stream
             )

--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -34,7 +34,10 @@ logger.setLevel(logging.WARNING)
 
 def is_function(message: ChatMessage) -> bool:
     """Utility for ChatMessage responses from OpenAI models."""
-    return "tool_calls" in message.additional_kwargs
+    return (
+        "tool_calls" in message.additional_kwargs
+        and len(message.additional_kwargs["tool_calls"]) > 0
+    )
 
 
 class ChatResponseMode(str, Enum):

--- a/llama-index-core/llama_index/core/indices/struct_store/json_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/json_query.py
@@ -65,8 +65,8 @@ def default_output_processor(llm_output: str, json_value: JSONType) -> Dict[str,
     expressions = [expr.strip() for expr in llm_output.split(",")]
 
     try:
-        from jsonpath_ng.ext import parse
-        from jsonpath_ng.jsonpath import DatumInContext
+        from jsonpath_ng.ext import parse  # pants: no-infer-dep
+        from jsonpath_ng.jsonpath import DatumInContext  # pants: no-infer-dep
     except ImportError as exc:
         IMPORT_ERROR_MSG = "You need to install jsonpath-ng to use this function!"
         raise ImportError(IMPORT_ERROR_MSG) from exc

--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/pyproject.toml
@@ -30,12 +30,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-bge-m3"
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
-peft = "^0.12.0"
-flagembedding = "^1.2.11"
+python = ">=3.10,<4.0"
+peft = ">=0.12.0"
+flagembedding = ">=1.2.11"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/tests/BUILD
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/tests/BUILD
@@ -1,1 +1,0 @@
-python_tests()

--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/tests/test_indices_bge_m3.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/tests/test_indices_bge_m3.py
@@ -1,7 +1,0 @@
-from llama_index.core.indices.base import BaseIndex
-from llama_index.indices.managed.bge_m3 import BGEM3Index
-
-
-def test_class():
-    names_of_base_classes = [b.__name__ for b in BGEM3Index.__mro__]
-    assert BaseIndex.__name__ in names_of_base_classes


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/16754

What a doozy

After much debugging, narrowed this down to a few issues:
- LLMs like anthropic stream in packs of like 5 tokens, making the detection for when a react loop is done tricky
- We were not writing to memory because tool_calls was in additional_kwargs for some llms (but it was empty)

Fixes
- Remove anything before `Answer:` from the stream and deltas
- Add additional check for if tool_calls is in additional_kwargs, also check if there are any items in it