### PR TITLE
Fixed issue with default value set as None for get method, which rais…

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -156,7 +156,7 @@ class Context:
         async with self.lock:
             self._globals[key] = value
 
-    async def get(self, key: str, default: Optional[Any] = None) -> Any:
+    async def get(self, key: str, default: Optional[Any] = Ellipsis) -> Any:
         """Get the value corresponding to `key` from the Context.
 
         Args:
@@ -169,7 +169,7 @@ class Context:
         async with self.lock:
             if key in self._globals:
                 return self._globals[key]
-            elif default is not None:
+            elif default is not Ellipsis:
                 return default
 
         msg = f"Key '{key}' not found in Context"


### PR DESCRIPTION
 Fixed issue with default value set as None for `get` method.

### Description:
This pull request addresses a bug in the `get` method where a `ValueError` was raised if the default value was set to `None`. The intended behavior, as documented, should return the default value instead of raising an error. To align with this expected behavior, the `default` parameter now uses the `Ellipsis` approach, allowing `None` to be used as a valid default value.

### Code Changes:
`
#async def get(self, key: str, default: Optional[Any] = None) -> Any:
`
`
async def get(self, key: str, default: Optional[Any] = Ellipsis) -> Any:
`
and
`
#elif default is not None:
`
`
elif default is not Ellipsis:
`

### Motivation
The previous implementation incorrectly raised a ValueError when None was provided as the default value. This change fixes the issue, ensuring that None is treated as a valid default value, consistent with the behavior documented in the "Maintaining State" context for LlamaIndex.

### Testing:

- Verified that the ValueError is no longer raised when None is provided as the default value.
- Ensured that the new implementation returns the default value as expected.

### Related Issues:

1. Resolves #15748 
2. Resolves #16063 

### Additional Notes:
- The change follows coding standards.