### PR TITLE
Fix querying for ID in AzureAISearchVectorStore (fixes delete_nodes by node_ids)

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -279,7 +279,12 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
 
         logger.info(f"Configuring {index_name} fields for Azure AI Search")
         fields = [
-            SimpleField(name=self._field_mapping["id"], type="Edm.String", key=True, filterable=True),
+            SimpleField(
+                name=self._field_mapping["id"],
+                type="Edm.String",
+                key=True,
+                filterable=True,
+            ),
             SearchableField(
                 name=self._field_mapping["chunk"],
                 type="Edm.String",

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -279,7 +279,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
 
         logger.info(f"Configuring {index_name} fields for Azure AI Search")
         fields = [
-            SimpleField(name=self._field_mapping["id"], type="Edm.String", key=True),
+            SimpleField(name=self._field_mapping["id"], type="Edm.String", key=True, filterable=True),
             SearchableField(
                 name=self._field_mapping["chunk"],
                 type="Edm.String",

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-azureaisearch"
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

AzureAISearch indices created by llama-index do not set the ID field to be filterable. However, the internal function `_build_filter_delete_query` used by `delete_nodes` builds a query that requires the ID field to be filterable.

```python
    def _build_filter_delete_query(
        self,
        node_ids: Optional[List[str]] = None,
        filters: Optional[MetadataFilters] = None,
    ) -> str:
        """Build the OData filter query for the deletion process."""
        if node_ids:
            return " or ".join(
                [
                    f'{self._field_mapping["id"]} eq \'{node_id}\''
                    for node_id in node_ids
                ]
            )
```

Hence, we should make the ID field filterable by default. 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
