### PR TITLE
feat: Support for api_version and Azure AI model inference service

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/README.md
@@ -3,3 +3,10 @@
 The integration package `llama-index-embeddings-azure-inference` brings support for embedding models deployed in Azure AI, including Azure AI studio and Azure Machine Learning, to the `llama_index` ecosystem. Any model endpoint supporting the [Azure AI model inference API](https://aka.ms/azureai/modelinference) can be used with this integration.
 
 For details and examples about how to use this integration, see [Getting starting with LlamaIndex and Azure AI](https://aka.ms/azureai/llamaindex).
+
+## Changelog
+
+- **0.2.4**:
+
+  - Introduce `api_version` parameter in the `AzureAIEmbeddingsModel` class to allow overriding of the default value.
+  - Introduce support for [Azure AI model inference service](https://aka.ms/aiservices/infernece) which requires `azure-ai-inference>=1.0.0b5`.

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/llama_index/embeddings/azure_inference/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/llama_index/embeddings/azure_inference/base.py
@@ -75,6 +75,7 @@ class AzureAIEmbeddingsModel(BaseEmbedding):
         endpoint: str = None,
         credential: Union[str, AzureKeyCredential, "TokenCredential"] = None,
         model_name: str = None,
+        api_version: str = None,
         embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
         callback_manager: Optional[CallbackManager] = None,
         num_workers: Optional[int] = None,
@@ -107,6 +108,9 @@ class AzureAIEmbeddingsModel(BaseEmbedding):
                 "You must provide an credential to use the Azure AI model inference LLM."
                 "Pass the credential as a parameter or set the AZURE_INFERENCE_CREDENTIAL"
             )
+
+        if api_version:
+            client_kwargs["api_version"] = api_version
 
         client = EmbeddingsClient(
             endpoint=endpoint,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-azure-ai-inference = ">=1.0.0b2"
+azure-ai-inference = ">=1.0.0b5"
 azure-identity = "^1.15.0"
 llama-index-core = "^0.11.0"
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
@@ -34,7 +34,7 @@ version = "0.2.4"
 python = ">=3.8.1,<4.0"
 azure-ai-inference = ">=1.0.0b5"
 azure-identity = "^1.15.0"
-aiohttp = "^3.7.4"
+aiohttp = "^3.10.0"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
@@ -34,6 +34,7 @@ version = "0.2.4"
 python = ">=3.8.1,<4.0"
 azure-ai-inference = ">=1.0.0b5"
 azure-identity = "^1.15.0"
+aiohttp = "^3.7.4"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 name = "llama-index-embeddings-azure-inference"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
@@ -1,8 +1,11 @@
 from unittest import mock
+
+# import aiohttp to force Pants to include it in the required dependencies
+import aiohttp  # noqa
 import pytest
-from llama_index.embeddings.azure_inference import AzureAIEmbeddingsModel
+from azure.ai.inference.models import EmbeddingItem, EmbeddingsResult
 from llama_index.core.schema import TextNode
-from azure.ai.inference.models import EmbeddingsResult, EmbeddingItem
+from llama_index.embeddings.azure_inference import AzureAIEmbeddingsModel
 
 
 @pytest.fixture()

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
@@ -1,82 +1,47 @@
-import os
+from unittest import mock
 import pytest
 from llama_index.embeddings.azure_inference import AzureAIEmbeddingsModel
 from llama_index.core.schema import TextNode
+from azure.ai.inference.models import EmbeddingsResult, EmbeddingItem
 
 
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_embed():
+@pytest.fixture()
+def test_embed_model():
+    with mock.patch(
+        "llama_index.embeddings.azure_inference.base.EmbeddingsClient", autospec=True
+    ):
+        embed_model = AzureAIEmbeddingsModel(
+            endpoint="https://my-endpoint.inference.ai.azure.com",
+            credential="my-api-key",
+            model_name="my_model_name",
+        )
+    embed_model._client.embed.return_value = EmbeddingsResult(
+        data=[EmbeddingItem(embedding=[1.0, 2.0, 3.0], index=0)]
+    )
+    return embed_model
+
+
+def test_embed(test_embed_model: AzureAIEmbeddingsModel):
     """Test the basic embedding functionality."""
     # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
-
-    embed_model = AzureAIEmbeddingsModel(model_name=model_name)
-
     nodes = [
         TextNode(
             text="Before college the two main things I worked on, "
             "outside of school, were writing and programming."
         )
     ]
-    response = embed_model(nodes=nodes)
+    response = test_embed_model(nodes=nodes)
 
     assert len(response) == len(nodes)
     assert response[0].embedding
 
 
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_chat_completion_api_version():
-    """Test the basic embedding functionality with API version."""
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
-
-    embed_model = AzureAIEmbeddingsModel(
-        model_name=model_name, api_version="2024-05-01-preview"
-    )
-
-    nodes = [
-        TextNode(
-            text="Before college the two main things I worked on, "
-            "outside of school, were writing and programming."
-        )
-    ]
-    response = embed_model(nodes=nodes)
-
-    assert len(response) == len(nodes)
-    assert response[0].embedding
-
-
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_get_metadata(caplog):
+def test_get_metadata(test_embed_model: AzureAIEmbeddingsModel, caplog):
     """Tests if we can get model metadata back from the endpoint. If so,
     model_name should not be 'unknown'. Some endpoints may not support this
     and in those cases a warning should be logged.
     """
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
-
-    embed_model = AzureAIEmbeddingsModel(model_name=model_name)
-
     assert (
-        embed_model.model_name != "unknown"
+        test_embed_model.model_name != "unknown"
         or "does not support model metadata retrieval" in caplog.text
     )
-    assert not model_name or embed_model.model_name == model_name

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
@@ -37,6 +37,32 @@ def test_embed():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
+def test_embed_api_version():
+    """Test the basic embedding functionality."""
+    # In case the endpoint being tested serves more than one model
+    model_name = os.environ.get("AZURE_INFERENCE_MODEL", "gpt-4o")
+
+    embed_model = AzureAIEmbeddingsModel(model_name=model_name)
+
+    nodes = [
+        TextNode(
+            text="Before college the two main things I worked on, "
+            "outside of school, were writing and programming."
+        )
+    ]
+    response = embed_model(nodes=nodes)
+
+    assert len(response) == len(nodes)
+    assert response[0].embedding
+
+
+@pytest.mark.skipif(
+    not {
+        "AZURE_INFERENCE_ENDPOINT",
+        "AZURE_INFERENCE_CREDENTIAL",
+    }.issubset(set(os.environ)),
+    reason="Azure AI endpoint and/or credential are not set.",
+)
 def test_get_metadata(caplog):
     """Tests if we can get model metadata back from the endpoint. If so,
     model_name should not be 'unknown'. Some endpoints may not support this

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
@@ -37,6 +37,34 @@ def test_embed():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
+def test_chat_completion_api_version():
+    """Test the basic embedding functionality with API version."""
+    # In case the endpoint being tested serves more than one model
+    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
+
+    embed_model = AzureAIEmbeddingsModel(
+        model_name=model_name, api_version="2024-05-01-preview"
+    )
+
+    nodes = [
+        TextNode(
+            text="Before college the two main things I worked on, "
+            "outside of school, were writing and programming."
+        )
+    ]
+    response = embed_model(nodes=nodes)
+
+    assert len(response) == len(nodes)
+    assert response[0].embedding
+
+
+@pytest.mark.skipif(
+    not {
+        "AZURE_INFERENCE_ENDPOINT",
+        "AZURE_INFERENCE_CREDENTIAL",
+    }.issubset(set(os.environ)),
+    reason="Azure AI endpoint and/or credential are not set.",
+)
 def test_get_metadata(caplog):
     """Tests if we can get model metadata back from the endpoint. If so,
     model_name should not be 'unknown'. Some endpoints may not support this

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-inference/tests/test_embeddings_azure_inference.py
@@ -37,32 +37,6 @@ def test_embed():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_embed_api_version():
-    """Test the basic embedding functionality."""
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", "gpt-4o")
-
-    embed_model = AzureAIEmbeddingsModel(model_name=model_name)
-
-    nodes = [
-        TextNode(
-            text="Before college the two main things I worked on, "
-            "outside of school, were writing and programming."
-        )
-    ]
-    response = embed_model(nodes=nodes)
-
-    assert len(response) == len(nodes)
-    assert response[0].embedding
-
-
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
 def test_get_metadata(caplog):
     """Tests if we can get model metadata back from the endpoint. If so,
     model_name should not be 'unknown'. Some endpoints may not support this

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/README.md
@@ -3,3 +3,10 @@
 The integration package `llama-index-llms-azure-inference` brings support for language models deployed in Azure AI, including Azure AI studio and Azure Machine Learning, to the `llama_index` ecosystem. Any model endpoint supporting the [Azure AI model inference API](https://aka.ms/azureai/modelinference) can be used with this integration.
 
 For details and examples about how to use this integration, see [Getting starting with LlamaIndex and Azure AI](https://aka.ms/azureai/llamaindex).
+
+## Changelog
+
+- **0.2.4**:
+
+  - Introduce `api_version` parameter in the `AzureAICompletionsModel` class to allow overriding of the default value.
+  - Introduce support for [Azure AI model inference service](https://aka.ms/aiservices/infernece) which requires `azure-ai-inference>=1.0.0b5`.

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/llama_index/llms/azure_inference/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/llama_index/llms/azure_inference/base.py
@@ -214,6 +214,7 @@ class AzureAICompletionsModel(FunctionCallingLLM):
         temperature: float = DEFAULT_TEMPERATURE,
         max_tokens: Optional[int] = None,
         model_name: Optional[str] = None,
+        api_version: Optional[str] = None,
         callback_manager: Optional[CallbackManager] = None,
         system_prompt: Optional[str] = None,
         messages_to_prompt: Optional[Callable[[Sequence[ChatMessage]], str]] = None,
@@ -250,6 +251,9 @@ class AzureAICompletionsModel(FunctionCallingLLM):
                 "You must provide an credential to use the Azure AI model inference LLM."
                 "Pass the credential as a parameter or set the AZURE_INFERENCE_CREDENTIAL"
             )
+
+        if api_version:
+            client_kwargs["api_version"] = api_version
 
         super().__init__(
             model_name=model_name,

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/llama_index/llms/azure_inference/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/llama_index/llms/azure_inference/base.py
@@ -419,7 +419,7 @@ class AzureAICompletionsModel(FunctionCallingLLM):
         messages = to_inference_message(messages)
         all_kwargs = self._get_all_kwargs(**kwargs)
 
-        response = self._async_client.complete(
+        response = await self._async_client.complete(
             messages=messages, stream=True, **all_kwargs
         )
 

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
@@ -32,7 +32,7 @@ version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-azure-ai-inference = ">=1.0.0b2"
+azure-ai-inference = ">=1.0.0b5"
 azure-identity = "^1.15.0"
 llama-index-core = "^0.11.0"
 

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
@@ -34,7 +34,7 @@ version = "0.2.4"
 python = ">=3.8.1,<4.0"
 azure-ai-inference = ">=1.0.0b5"
 azure-identity = "^1.15.0"
-aiohttp = "^3.7.4"
+aiohttp = "^3.10.0"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 name = "llama-index-llms-azure-inference"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/pyproject.toml
@@ -34,6 +34,7 @@ version = "0.2.4"
 python = ">=3.8.1,<4.0"
 azure-ai-inference = ">=1.0.0b5"
 azure-identity = "^1.15.0"
+aiohttp = "^3.7.4"
 llama-index-core = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
@@ -1,19 +1,21 @@
 import asyncio
+import json
 import logging
 import os
 from unittest import mock
-import pytest
-import json
-from llama_index.llms.azure_inference import AzureAICompletionsModel
-from llama_index.core.llms import ChatMessage, MessageRole
-from llama_index.core.tools import FunctionTool
 
+# import aiohttp to force Pants to include it in the required dependencies
+import aiohttp  # noqa
+import pytest
 from azure.ai.inference.models import (
-    ChatCompletions,
     ChatChoice,
+    ChatCompletions,
     ChatResponseMessage,
     ModelInfo,
 )
+from llama_index.core.llms import ChatMessage, MessageRole
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.azure_inference import AzureAICompletionsModel
 
 logger = logging.getLogger(__name__)
 

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
@@ -1,11 +1,19 @@
 import asyncio
 import logging
 import os
+from unittest import mock
 import pytest
 import json
 from llama_index.llms.azure_inference import AzureAICompletionsModel
 from llama_index.core.llms import ChatMessage, MessageRole
 from llama_index.core.tools import FunctionTool
+
+from azure.ai.inference.models import (
+    ChatCompletions,
+    ChatChoice,
+    ChatResponseMessage,
+    ModelInfo,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +29,7 @@ def loop():
 
 
 @pytest.fixture()
-def this_is_a_test_params() -> dict:
+def test_params() -> dict:
     return {
         "messages": [
             ChatMessage(
@@ -36,45 +44,117 @@ def this_is_a_test_params() -> dict:
     }
 
 
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_chat_completion(this_is_a_test_params: dict):
+@pytest.fixture()
+def test_llm():
+    with mock.patch(
+        "llama_index.llms.azure_inference.base.ChatCompletionsClient", autospec=True
+    ):
+        with mock.patch(
+            "llama_index.llms.azure_inference.base.ChatCompletionsClientAsync",
+            autospec=True,
+        ):
+            llm = AzureAICompletionsModel(
+                endpoint="https://my-endpoint.inference.ai.azure.com",
+                credential="my-api-key",
+            )
+    llm._client.complete.return_value = ChatCompletions(
+        choices=[
+            ChatChoice(
+                message=ChatResponseMessage(
+                    content="Yes, this is a test.", role="assistant"
+                )
+            )
+        ]
+    )
+    llm._client.get_model_info.return_value = ModelInfo(
+        model_name="my_model_name",
+        model_provider_name="my_provider_name",
+        model_type="chat-completions",
+    )
+    llm._async_client.complete = mock.AsyncMock(
+        return_value=ChatCompletions(
+            choices=[
+                ChatChoice(
+                    message=ChatResponseMessage(
+                        content="Yes, this is a test.", role="assistant"
+                    )
+                )
+            ]
+        )
+    )
+    return llm
+
+
+@pytest.fixture()
+def test_llm_json():
+    with mock.patch(
+        "llama_index.llms.azure_inference.base.ChatCompletionsClient", autospec=True
+    ):
+        llm = AzureAICompletionsModel(
+            endpoint="https://my-endpoint.inference.ai.azure.com",
+            credential="my-api-key",
+        )
+    llm._client.complete.return_value = ChatCompletions(
+        choices=[
+            ChatChoice(
+                message=ChatResponseMessage(
+                    content='{ "message": "Yes, this is a test." }', role="assistant"
+                )
+            )
+        ]
+    )
+    return llm
+
+
+@pytest.fixture()
+def test_llm_tools():
+    with mock.patch(
+        "llama_index.llms.azure_inference.base.ChatCompletionsClient", autospec=True
+    ):
+        llm = AzureAICompletionsModel(
+            endpoint="https://my-endpoint.inference.ai.azure.com",
+            credential="my-api-key",
+        )
+    llm._client.complete.return_value = ChatCompletions(
+        choices=[
+            ChatChoice(
+                message=ChatResponseMessage(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "abc0dF1gh",
+                            "type": "function",
+                            "function": {
+                                "name": "echo",
+                                "arguments": None,
+                                "call_id": None,
+                            },
+                        }
+                    ],
+                )
+            )
+        ]
+    )
+    return llm
+
+
+def test_chat_completion(test_llm: AzureAICompletionsModel, test_params: dict):
     """Tests the basic chat completion functionality."""
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
-
-    llm = AzureAICompletionsModel(
-        model_name=model_name,
-    )
-
-    response = llm.chat(**this_is_a_test_params)
+    response = test_llm.chat(**test_params)
 
     assert response.message.role == MessageRole.ASSISTANT
     assert response.message.content.strip() == "Yes, this is a test."
 
 
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_achat_completion(loop: asyncio.AbstractEventLoop, this_is_a_test_params: dict):
+def test_achat_completion(
+    test_llm: AzureAICompletionsModel,
+    loop: asyncio.AbstractEventLoop,
+    test_params: dict,
+):
     """Tests the basic chat completion functionality asynchronously."""
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
+    response = loop.run_until_complete(test_llm.achat(**test_params))
 
-    llm = AzureAICompletionsModel(
-        model_name=model_name,
-    )
-
-    response = loop.run_until_complete(llm.achat(**this_is_a_test_params))
     assert response.message.role == MessageRole.ASSISTANT
     assert response.message.content.strip() == "Yes, this is a test."
 
@@ -86,16 +166,13 @@ def test_achat_completion(loop: asyncio.AbstractEventLoop, this_is_a_test_params
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_stream_chat_completion(this_is_a_test_params: dict):
+def test_stream_chat_completion(test_params: dict):
     """Tests the basic chat completion functionality with streaming."""
-    # In case the endpoint being tested serves more than one model
     model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
 
-    llm = AzureAICompletionsModel(
-        model_name=model_name,
-    )
+    llm = AzureAICompletionsModel(model_name=model_name)
 
-    response_stream = llm.stream_chat(**this_is_a_test_params)
+    response_stream = llm.stream_chat(**test_params)
 
     buffer = ""
     for chunk in response_stream:
@@ -111,19 +188,14 @@ def test_stream_chat_completion(this_is_a_test_params: dict):
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_astream_chat_completion(
-    loop: asyncio.AbstractEventLoop, this_is_a_test_params: dict
-):
+def test_astream_chat_completion(test_params: dict, loop: asyncio.AbstractEventLoop):
     """Tests the basic chat completion functionality with streaming."""
-    # In case the endpoint being tested serves more than one model
     model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
 
-    llm = AzureAICompletionsModel(
-        model_name=model_name,
-    )
+    llm = AzureAICompletionsModel(model_name=model_name)
 
     async def iterate():
-        stream = await llm.astream_chat(**this_is_a_test_params)
+        stream = await llm.astream_chat(**test_params)
         buffer = ""
         async for chunk in stream:
             buffer += chunk.delta
@@ -134,24 +206,12 @@ def test_astream_chat_completion(
     assert response.strip() == "Yes, this is a test."
 
 
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_chat_completion_kwargs():
+def test_chat_completion_kwargs(
+    test_llm_json: AzureAICompletionsModel,
+):
     """Tests chat completions using extra parameters."""
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
-
-    llm = AzureAICompletionsModel(
-        model_name=model_name,
-        model_kwargs={"response_format": {"type": "json_object"}},
-    )
-
-    response = llm.chat(
+    test_llm_json.model_kwargs.update({"response_format": {"type": "json_object"}})
+    response = test_llm_json.chat(
         [
             ChatMessage(
                 role="system",
@@ -172,26 +232,15 @@ def test_chat_completion_kwargs():
     )
 
 
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_chat_completion_with_tools():
+def test_chat_completion_with_tools(test_llm_tools: AzureAICompletionsModel):
     """Tests the chat completion functionality with the help of tools."""
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
-
-    llm = AzureAICompletionsModel(model_name=model_name)
 
     def echo(message: str) -> str:
         """Echoes the user's message."""
         print("Echo: " + message)
         return message
 
-    response = llm.chat_with_tools(
+    response = test_llm_tools.chat_with_tools(
         user_msg="Is this a test?",
         chat_history=[
             ChatMessage(
@@ -224,7 +273,7 @@ def test_chat_completion_with_tools():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_chat_completion_gpt4o_api_version(this_is_a_test_params: dict):
+def test_chat_completion_gpt4o_api_version(test_params: dict):
     """Test chat completions endpoint with api_version indicated for a GPT model."""
     # In case the endpoint being tested serves more than one model
     model_name = os.environ.get("AZURE_INFERENCE_MODEL", "gpt-4o")
@@ -233,33 +282,20 @@ def test_chat_completion_gpt4o_api_version(this_is_a_test_params: dict):
         model_name=model_name, api_version="2024-05-01-preview"
     )
 
-    response = llm.chat(**this_is_a_test_params)
+    response = llm.chat(**test_params)
 
     assert response.message.role == MessageRole.ASSISTANT
     assert response.message.content.strip() == "Yes, this is a test."
 
 
-@pytest.mark.skipif(
-    not {
-        "AZURE_INFERENCE_ENDPOINT",
-        "AZURE_INFERENCE_CREDENTIAL",
-    }.issubset(set(os.environ)),
-    reason="Azure AI endpoint and/or credential are not set.",
-)
-def test_get_metadata(caplog):
+def test_get_metadata(test_llm: AzureAICompletionsModel, caplog):
     """Tests if we can get model metadata back from the endpoint. If so,
     model_name should not be 'unknown'. Some endpoints may not support this
     and in those cases a warning should be logged.
     """
-    # In case the endpoint being tested serves more than one model
-    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
-
-    llm = AzureAICompletionsModel(model_name=model_name)
-
-    response = llm.metadata
+    response = test_llm.metadata
 
     assert (
         response.model_name != "unknown"
         or "does not support model metadata retrieval" in caplog.text
     )
-    assert not model_name or response.model_name == model_name

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
@@ -130,6 +130,39 @@ def test_chat_completion_with_tools():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
+def test_chat_completion_gpt4o_api_version():
+    """Test chat completions endpoint with api_version indicated for a GPT model."""
+    # In case the endpoint being tested serves more than one model
+    model_name = os.environ.get("AZURE_INFERENCE_MODEL", "gpt-4o")
+
+    llm = AzureAICompletionsModel(
+        model_name=model_name, api_version="2024-05-01-preview"
+    )
+
+    response = llm.chat(
+        [
+            ChatMessage(
+                role="system",
+                content="You are a helpful assistant. When you are asked about if this "
+                "is a test, you always reply 'Yes, this is a test.'",
+            ),
+            ChatMessage(role="user", content="Is this a test?"),
+        ],
+        temperature=0.0,
+        top_p=1.0,
+    )
+
+    assert response.message.role == MessageRole.ASSISTANT
+    assert response.message.content.strip() == "Yes, this is a test."
+
+
+@pytest.mark.skipif(
+    not {
+        "AZURE_INFERENCE_ENDPOINT",
+        "AZURE_INFERENCE_CREDENTIAL",
+    }.issubset(set(os.environ)),
+    reason="Azure AI endpoint and/or credential are not set.",
+)
 def test_get_metadata(caplog):
     """Tests if we can get model metadata back from the endpoint. If so,
     model_name should not be 'unknown'. Some endpoints may not support this

--- a/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-inference/tests/test_llms_azure_inference.py
@@ -10,11 +10,30 @@ from llama_index.core.tools import FunctionTool
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def loop():
-    loop = asyncio.new_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
     yield loop
     loop.close()
+
+
+@pytest.fixture()
+def this_is_a_test_params() -> dict:
+    return {
+        "messages": [
+            ChatMessage(
+                role="system",
+                content="You are a helpful assistant. When you are asked about if this "
+                "is a test, you always reply 'Yes, this is a test.'",
+            ),
+            ChatMessage(role="user", content="Is this a test?"),
+        ],
+        "top_p": 1.0,
+        "temperature": 0.0,
+    }
 
 
 @pytest.mark.skipif(
@@ -24,29 +43,17 @@ def loop():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_chat_completion():
+def test_chat_completion(this_is_a_test_params: dict):
     """Tests the basic chat completion functionality."""
     # In case the endpoint being tested serves more than one model
     model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
 
     llm = AzureAICompletionsModel(
         model_name=model_name,
-        temperature=0.0,
     )
 
-    response = llm.chat(
-        [
-            ChatMessage(
-                role="system",
-                content="You are a helpful assistant. When you are asked about if this "
-                "is a test, you always reply 'Yes, this is a test.'",
-            ),
-            ChatMessage(role="user", content="Is this a test?"),
-        ],
-        top_p=1.0,
-    )
+    response = llm.chat(**this_is_a_test_params)
 
-    assert "temperature" in llm._model_kwargs
     assert response.message.role == MessageRole.ASSISTANT
     assert response.message.content.strip() == "Yes, this is a test."
 
@@ -58,7 +65,7 @@ def test_chat_completion():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_achat_completion(loop: asyncio.AbstractEventLoop):
+def test_achat_completion(loop: asyncio.AbstractEventLoop, this_is_a_test_params: dict):
     """Tests the basic chat completion functionality asynchronously."""
     # In case the endpoint being tested serves more than one model
     model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
@@ -67,18 +74,7 @@ def test_achat_completion(loop: asyncio.AbstractEventLoop):
         model_name=model_name,
     )
 
-    response = loop.run_until_complete(
-        llm.achat(
-            [
-                ChatMessage(
-                    role="system",
-                    content="You are a helpful assistant. When you are asked about if this "
-                    "is a test, you always reply 'Yes, this is a test.'",
-                ),
-                ChatMessage(role="user", content="Is this a test?"),
-            ],
-        )
-    )
+    response = loop.run_until_complete(llm.achat(**this_is_a_test_params))
     assert response.message.role == MessageRole.ASSISTANT
     assert response.message.content.strip() == "Yes, this is a test."
 
@@ -90,7 +86,7 @@ def test_achat_completion(loop: asyncio.AbstractEventLoop):
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_stream_chat_completion():
+def test_stream_chat_completion(this_is_a_test_params: dict):
     """Tests the basic chat completion functionality with streaming."""
     # In case the endpoint being tested serves more than one model
     model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
@@ -99,24 +95,43 @@ def test_stream_chat_completion():
         model_name=model_name,
     )
 
-    response_stream = llm.stream_chat(
-        [
-            ChatMessage(
-                role="system",
-                content="You are a helpful assistant. When you are asked about if this "
-                "is a test, you always reply 'Yes, this is a test.'",
-            ),
-            ChatMessage(role="user", content="Is this a test?"),
-        ],
-        temperature=0.0,
-        top_p=1.0,
-    )
+    response_stream = llm.stream_chat(**this_is_a_test_params)
 
     buffer = ""
     for chunk in response_stream:
         buffer += chunk.delta
 
     assert buffer.strip() == "Yes, this is a test."
+
+
+@pytest.mark.skipif(
+    not {
+        "AZURE_INFERENCE_ENDPOINT",
+        "AZURE_INFERENCE_CREDENTIAL",
+    }.issubset(set(os.environ)),
+    reason="Azure AI endpoint and/or credential are not set.",
+)
+def test_astream_chat_completion(
+    loop: asyncio.AbstractEventLoop, this_is_a_test_params: dict
+):
+    """Tests the basic chat completion functionality with streaming."""
+    # In case the endpoint being tested serves more than one model
+    model_name = os.environ.get("AZURE_INFERENCE_MODEL", None)
+
+    llm = AzureAICompletionsModel(
+        model_name=model_name,
+    )
+
+    async def iterate():
+        stream = await llm.astream_chat(**this_is_a_test_params)
+        buffer = ""
+        async for chunk in stream:
+            buffer += chunk.delta
+
+        return buffer
+
+    response = loop.run_until_complete(iterate())
+    assert response.strip() == "Yes, this is a test."
 
 
 @pytest.mark.skipif(
@@ -209,7 +224,7 @@ def test_chat_completion_with_tools():
     }.issubset(set(os.environ)),
     reason="Azure AI endpoint and/or credential are not set.",
 )
-def test_chat_completion_gpt4o_api_version():
+def test_chat_completion_gpt4o_api_version(this_is_a_test_params: dict):
     """Test chat completions endpoint with api_version indicated for a GPT model."""
     # In case the endpoint being tested serves more than one model
     model_name = os.environ.get("AZURE_INFERENCE_MODEL", "gpt-4o")
@@ -218,18 +233,7 @@ def test_chat_completion_gpt4o_api_version():
         model_name=model_name, api_version="2024-05-01-preview"
     )
 
-    response = llm.chat(
-        [
-            ChatMessage(
-                role="system",
-                content="You are a helpful assistant. When you are asked about if this "
-                "is a test, you always reply 'Yes, this is a test.'",
-            ),
-            ChatMessage(role="user", content="Is this a test?"),
-        ],
-        temperature=0.0,
-        top_p=1.0,
-    )
+    response = llm.chat(**this_is_a_test_params)
 
     assert response.message.role == MessageRole.ASSISTANT
     assert response.message.content.strip() == "Yes, this is a test."


### PR DESCRIPTION
# Description

Introducing support for `api_version` parameter in case the user needs to override the default version used in the client. It was possible before by using `client_kwards` but now it's more transparent by indicating it on the constructor. It also introduces support for the [Azure AI model inference service](https://aka.ms/aiservices/inference).

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
