### PR TITLE
Doc-fix at Understanding/Workflows/state.md for "TypeError: 'coroutine' object is not subscriptable"

### DIFF
--- a/docs/docs/understanding/workflows/state.md
+++ b/docs/docs/understanding/workflows/state.md
@@ -56,7 +56,7 @@ async def step_two(self, ctx: Context, ev: StepTwoEvent) -> StopEvent:
     # do something with the data
     print("Data is ", await ctx.get("some_database"))
 
-    return StopEvent(result=await ctx.get("some_database")[1])
+    return StopEvent(result=await ctx.get("some_database"))
 
 
 w = StatefulFlow(timeout=10, verbose=False)


### PR DESCRIPTION
### Title:
Fixes documentation issue in `State.md` under `Understanding/workflows/`, which is causing TypeError due to subscripting on coroutine.
### Description:
This pull request addresses an issue with the documentation for State management of workflows under the "Understanding" section. The issue results in a `TypeError: 'coroutine' object is not subscriptable`.

The error occurs due to subscripting the coroutine object: `await ctx.get("some_database")[1]`.

It has been resolved by removing the subscript on the coroutine object, like this: `await ctx.get("some_database")`. 

This change ensures successful execution and understanding of the "Maintaining State" section of the documentation.
### Code Changes:
```
- return StopEvent(result=await ctx.get("some_database")[1])
+ return StopEvent(result=await ctx.get("some_database"))
```
### Motivation:
This change is necessary to fix the documentation error, which was causing confusion and execution issues when users followed the example code. By correcting the example, users will now be able to successfully understand and implement state management as intended.
### Testing:
- Verified that the `TypeError` no longer occurs with the updated code.
- Ensured that the documentation accurately reflects the correct usage.

### Related Issues:
- NA.
### Additional Notes:
- The change aligns with the project's coding standards.