### PR TITLE
Set Limit 1 in CALL apoc.meta.subGraph({}) for schema_counts in refresh_schema in neo4j_property_graph

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -254,7 +254,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
             "CALL apoc.meta.subGraph({}) YIELD nodes, relationships "
             "RETURN nodes, [rel in relationships | {name:apoc.any.property"
             "(rel, 'type'), count: apoc.any.property(rel, 'count')}]"
-            " AS relationships"
+            " AS relationships LIMIT 1"
         )
         # Update node info
         for node in schema_counts[0].get("nodes", []):


### PR DESCRIPTION
# Description

This pull request addresses a performance bottleneck in the Neo4j integration for the Llama Index package, where loading large graphs with over half a million nodes and more than a million relationships results in unacceptable start-up delays. The core issue is caused by the apoc.meta.subGraph process. 
https://github.com/nightosong/llama_index/blob/900f830c7a90ce3208471fd89aa1a52d59ab1221/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py#L254

This fix aims to improve the responsiveness of applications using Neo4jPropertyGraphStore by adjusting the graph loading process for substantial datasets, optimizing the initialization phase, and minimizing potential load times that previously blocked the application start-up.

Fixes # (issue)
[16812](https://github.com/run-llama/llama_index/issues/16812)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
