### PR TITLE
Hotfix: Chain Query Configuration

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
@@ -259,17 +259,23 @@ class VectaraRetriever(BaseRetriever):
             reranking_config = current_config = {}
 
             for i, rerank_info in enumerate(self._rerank_chain):
-                current_config["reranker_name"] = CHAIN_RERANKER_NAMES[
-                    rerank_info["type"]
-                ]
+                rerank_type = rerank_info.get("type", None)
+                if rerank_type is None:
+                    print("Missing argument 'type' in chain reranker")
+                else:
+                    current_config["reranker_name"] = CHAIN_RERANKER_NAMES[rerank_type]
 
-                rerank_info.pop("type")
-                for param, value in rerank_info.items():
-                    current_config[param] = value
+                    current_config.update(
+                        {
+                            param: value
+                            for param, value in rerank_info.items()
+                            if param != "type"
+                        }
+                    )
 
-                if i < len(self._rerank_chain) - 1:
-                    current_config["next_reranking_config"] = {}
-                    current_config = current_config["next_reranking_config"]
+                    if i < len(self._rerank_chain) - 1:
+                        current_config["next_reranking_config"] = {}
+                        current_config = current_config["next_reranking_config"]
 
             data["query"][0]["rerankingConfig"] = reranking_config
 

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
@@ -31,7 +31,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-vectara"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/tests/test_indices_managed_vectara.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/tests/test_indices_managed_vectara.py
@@ -207,6 +207,12 @@ def test_chain_rerank_retrieval(vectara1) -> None:
     assert len(res) == 1
     assert res[0].node.get_content() == docs[0].text
 
+    # Second query with same retriever to ensure rerank chain configuration remains the same
+    res = qe.retrieve("How will I look when I'm older?")
+    assert qe._rerank_chain[0].get("type") == "slingshot"
+    assert qe._rerank_chain[1].get("type") == "mmr"
+    assert res[0].node.get_content() == docs[2].text
+
 
 @pytest.fixture()
 def vectara2():


### PR DESCRIPTION
# Description

This change fixed issues related to the VectaraRetriever.

Fixes:
In my previous PR for chain reranking, there was a bug related to how the Vectara query body was built using the `_rerank_chain` member of the `VectaraRetriever` class. In the previous implementation, the `.pop()` method was used to extract the "type" key from each dictionary, but this removed the "type" parameter for each reranker in the chain for future queries. As a result, the retriever fails when performing more than one query. I have fixed this issue in this PR.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

In my previous tests of chain reranking, I created a new retriever for each test, which means that I only called each retriever once (which is why I initially missed the issue). I have now added a test that calls an existing retriever twice and ensures that the type parameters were preserved in subsequent queries.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
