### PR TITLE
support sparse embedding models, fix delete for serverless for pinecone

### DIFF
--- a/docs/docs/examples/vector_stores/PineconeIndexDemo-Hybrid.ipynb
+++ b/docs/docs/examples/vector_stores/PineconeIndexDemo-Hybrid.ipynb
@@ -31,17 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index-vector-stores-pinecone"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8604a171",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install llama-index>=0.9.31 pinecone-client>=3.0.0 \"transformers[torch]\""
+    "%pip install llama-index-vector-stores-pinecone \"transformers[torch]\""
    ]
   },
   {
@@ -50,20 +40,6 @@
    "metadata": {},
    "source": [
     "#### Creating a Pinecone Index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d48af8e1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "import sys\n",
-    "\n",
-    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
-    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))"
    ]
   },
   {
@@ -85,12 +61,8 @@
    "source": [
     "import os\n",
     "\n",
-    "os.environ[\n",
-    "    \"PINECONE_API_KEY\"\n",
-    "] = #\"<Your Pinecone API key, from app.pinecone.io>\"\n",
-    "os.environ[\n",
-    "    \"OPENAI_API_KEY\"\n",
-    "] = \"sk-...\"\n",
+    "os.environ[\"PINECONE_API_KEY\"] = \"...\"\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"\n",
     "\n",
     "api_key = os.environ[\"PINECONE_API_KEY\"]\n",
     "\n",
@@ -105,7 +77,7 @@
    "outputs": [],
    "source": [
     "# delete if needed\n",
-    "# pc.delete_index(\"quickstart\")"
+    "pc.delete_index(\"quickstart\")"
    ]
   },
   {
@@ -122,7 +94,7 @@
     "    name=\"quickstart\",\n",
     "    dimension=1536,\n",
     "    metric=\"dotproduct\",\n",
-    "    spec=ServerlessSpec(cloud=\"aws\", region=\"us-west-2\"),\n",
+    "    spec=ServerlessSpec(cloud=\"aws\", region=\"us-east-1\"),\n",
     ")\n",
     "\n",
     "# If you need to create a PodBased Pinecone index, you could alternatively do this:\n",
@@ -178,7 +150,11 @@
    "id": "8ee4473a-094f-4d0a-a825-e1213db07240",
    "metadata": {},
    "source": [
-    "#### Load documents, build the PineconeVectorStore"
+    "#### Load documents, build the PineconeVectorStore\n",
+    "\n",
+    "When `add_sparse_vector=True`, the `PineconeVectorStore` will compute sparse vectors for each document.\n",
+    "\n",
+    "By default, it is using simple token frequency for the sparse vectors. But, you can also specify a custom sparse embedding model.\n"
    ]
   },
   {
@@ -211,17 +187,19 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e6a2a5579ce45e7953eed31c4c24e14",
+       "model_id": "bb2c43f2d48e4293b9df39ad3615080b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -265,18 +243,7 @@
    "execution_count": null,
    "id": "35369eda",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# set Logging to DEBUG for more detailed outputs\n",
     "query_engine = index.as_query_engine(vector_store_query_mode=\"hybrid\")\n",
@@ -292,7 +259,7 @@
     {
      "data": {
       "text/markdown": [
-       "<b>At Viaweb, Lisp was used as a programming language. The speaker gave a talk at a Lisp conference about how Lisp was used at Viaweb, and afterward, the talk gained a lot of attention when it was posted online. This led to a realization that publishing essays online could reach a wider audience than traditional print media. The speaker also wrote a collection of essays, which was later published as a book called \"Hackers & Painters.\"</b>"
+       "<b>Paul Graham started Viaweb because he needed money. As the company grew, he realized he didn't want to run a big company and decided to build a subset of the vision as an open source project. Eventually, Viaweb was bought by Yahoo in the summer of 1998, which was a huge relief for Paul Graham.</b>"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -303,6 +270,129 @@
     }
    ],
    "source": [
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35ee5bcb",
+   "metadata": {},
+   "source": [
+    "## Changing the sparse embedding model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46320213",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-sparse-embeddings-fastembed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d99347cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clear the vector store\n",
+    "vector_store.clear()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4249825",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "185bdaff9cce4fd38cf3291a37df559d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching 5 files:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from llama_index.sparse_embeddings.fastembed import FastEmbedSparseEmbedding\n",
+    "\n",
+    "sparse_embedding_model = FastEmbedSparseEmbedding(\n",
+    "    model_name=\"prithivida/Splade_PP_en_v1\"\n",
+    ")\n",
+    "\n",
+    "vector_store = PineconeVectorStore(\n",
+    "    pinecone_index=pinecone_index,\n",
+    "    add_sparse_vector=True,\n",
+    "    sparse_embedding_model=sparse_embedding_model,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb539f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "282f48ba565744c1a498725dbdec481f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Upserted vectors:   0%|          | 0/22 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents, storage_context=storage_context\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ab6250c",
+   "metadata": {},
+   "source": [
+    "Wait a mininute for things to upload.."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70e127f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "<b>Paul Graham started Viaweb because he needed money. He recruited a team to work on building software and services, with a focus on creating an application builder and network infrastructure. However, halfway through the summer, Paul realized he didn't want to run a big company and decided to shift his focus to building a subset of the project as an open source project. This led to the development of a new dialect of Lisp called Arc. Ultimately, Viaweb was sold to Yahoo in the summer of 1998, providing relief to Paul Graham and allowing him to transition to a new phase in his life.</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "response = query_engine.query(\"What happened at Viaweb?\")\n",
     "display(Markdown(f\"<b>{response}</b>\"))"
    ]
   }

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/BUILD
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/BUILD
@@ -1,3 +1,4 @@
 poetry_requirements(
     name="poetry",
+    module_mapping={"pinecone-client": ["pinecone"]},
 )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
@@ -6,10 +6,9 @@ An index that is built on top of an existing vector store.
 """
 
 import logging
-from collections import Counter
-from functools import partial
 from typing import Any, Callable, Dict, List, Optional, cast
 
+from llama_index.core.base.embeddings.base_sparse import BaseSparseEmbedding
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode, TextNode
 from llama_index.core.vector_stores.types import (
@@ -25,9 +24,11 @@ from llama_index.core.vector_stores.utils import (
     metadata_dict_to_node,
     node_to_metadata_dict,
 )
+import pinecone
 from llama_index.vector_stores.pinecone.utils import (
     _import_pinecone,
     _is_pinecone_v3,
+    DefaultPineconeSparseEmbedding,
 )
 
 ID_KEY = "id"
@@ -70,63 +71,6 @@ def _transform_pinecone_filter_operator(operator: str) -> str:
         return "$nin"
     else:
         raise ValueError(f"Filter operator {operator} not supported")
-
-
-def build_dict(input_batch: List[List[int]]) -> List[Dict[str, Any]]:
-    """
-    Build a list of sparse dictionaries from a batch of input_ids.
-
-    NOTE: taken from https://www.pinecone.io/learn/hybrid-search-intro/.
-
-    """
-    # store a batch of sparse embeddings
-    sparse_emb = []
-    # iterate through input batch
-    for token_ids in input_batch:
-        indices = []
-        values = []
-        # convert the input_ids list to a dictionary of key to frequency values
-        d = dict(Counter(token_ids))
-        for idx in d:
-            indices.append(idx)
-            values.append(float(d[idx]))
-        sparse_emb.append({"indices": indices, "values": values})
-    # return sparse_emb list
-    return sparse_emb
-
-
-def generate_sparse_vectors(
-    context_batch: List[str], tokenizer: Callable
-) -> List[Dict[str, Any]]:
-    """
-    Generate sparse vectors from a batch of contexts.
-
-    NOTE: taken from https://www.pinecone.io/learn/hybrid-search-intro/.
-
-    """
-    # create batch of input_ids
-    inputs = tokenizer(context_batch)["input_ids"]
-    # create sparse dictionaries
-    return build_dict(inputs)
-
-
-def get_default_tokenizer() -> Callable:
-    """
-    Get default tokenizer.
-
-    NOTE: taken from https://www.pinecone.io/learn/hybrid-search-intro/.
-
-    """
-    from transformers import BertTokenizerFast
-
-    orig_tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
-    # set some default arguments, so input is just a list of strings
-    return partial(
-        orig_tokenizer,
-        padding=True,
-        truncation=True,
-        max_length=512,
-    )
 
 
 def _to_pinecone_filter(standard_filters: MetadataFilters) -> dict:
@@ -230,8 +174,8 @@ class PineconeVectorStore(BasePydanticVectorStore):
     batch_size: int
     remove_text_from_metadata: bool
 
-    _pinecone_index: Any = PrivateAttr()
-    _tokenizer: Optional[Callable] = PrivateAttr()
+    _pinecone_index: pinecone.Index = PrivateAttr()
+    _sparse_embedding_model: Optional[BaseSparseEmbedding] = PrivateAttr()
 
     def __init__(
         self,
@@ -249,12 +193,22 @@ class PineconeVectorStore(BasePydanticVectorStore):
         batch_size: int = DEFAULT_BATCH_SIZE,
         remove_text_from_metadata: bool = False,
         default_empty_query_vector: Optional[List[float]] = None,
+        sparse_embedding_model: Optional[BaseSparseEmbedding] = None,
         **kwargs: Any,
     ) -> None:
         insert_kwargs = insert_kwargs or {}
 
-        if tokenizer is None and add_sparse_vector:
-            tokenizer = get_default_tokenizer()
+        if add_sparse_vector:
+            if sparse_embedding_model is not None:
+                sparse_embedding_model = sparse_embedding_model
+            elif tokenizer is not None:
+                sparse_embedding_model = DefaultPineconeSparseEmbedding(
+                    tokenizer=tokenizer
+                )
+            else:
+                sparse_embedding_model = DefaultPineconeSparseEmbedding()
+        else:
+            sparse_embedding_model = None
 
         super().__init__(
             index_name=index_name,
@@ -268,7 +222,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             remove_text_from_metadata=remove_text_from_metadata,
         )
 
-        self._tokenizer = tokenizer
+        self._sparse_embedding_model = sparse_embedding_model
 
         # TODO: Make following instance check stronger -- check if pinecone_index is not pinecone.Index, else raise
         #  ValueError
@@ -368,6 +322,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
         """
         ids = []
         entries = []
+        sparse_inputs = []
         for node in nodes:
             node_id = node.node_id
 
@@ -377,20 +332,32 @@ class PineconeVectorStore(BasePydanticVectorStore):
                 flat_metadata=self.flat_metadata,
             )
 
+            if self.add_sparse_vector and self._sparse_embedding_model is not None:
+                sparse_inputs.append(node.get_content(metadata_mode=MetadataMode.EMBED))
+
+            if node.ref_doc_id is not None:
+                node_id = f"{node.ref_doc_id}#{node_id}"
+
+            ids.append(node_id)
+
             entry = {
                 ID_KEY: node_id,
                 VECTOR_KEY: node.get_embedding(),
                 METADATA_KEY: metadata,
             }
-            if self.add_sparse_vector and self._tokenizer is not None:
-                sparse_vector = generate_sparse_vectors(
-                    [node.get_content(metadata_mode=MetadataMode.EMBED)],
-                    self._tokenizer,
-                )[0]
-                entry[SPARSE_VECTOR_KEY] = sparse_vector
-
-            ids.append(node_id)
             entries.append(entry)
+
+        # batch sparse embedding generation
+        if sparse_inputs:
+            sparse_vectors = self._sparse_embedding_model.get_text_embedding_batch(
+                sparse_inputs
+            )
+            for i, sparse_vector in enumerate(sparse_vectors):
+                entries[i][SPARSE_VECTOR_KEY] = {
+                    "indices": list(sparse_vector.keys()),
+                    "values": list(sparse_vector.values()),
+                }
+
         self._pinecone_index.upsert(
             entries,
             namespace=self.namespace,
@@ -407,12 +374,23 @@ class PineconeVectorStore(BasePydanticVectorStore):
             ref_doc_id (str): The doc_id of the document to delete.
 
         """
-        # delete by filtering on the doc_id metadata
-        self._pinecone_index.delete(
-            filter={"doc_id": {"$eq": ref_doc_id}},
-            namespace=self.namespace,
-            **delete_kwargs,
-        )
+        try:
+            # delete by filtering on the doc_id metadata
+            self._pinecone_index.delete(
+                filter={"doc_id": {"$eq": ref_doc_id}},
+                namespace=self.namespace,
+                **delete_kwargs,
+            )
+        except Exception:
+            # fallback to deleting by prefix for serverless
+            # TODO: this is a bit of a hack, we should find a better way to handle this
+            id_gen = self._pinecone_index.list(
+                prefix=ref_doc_id, namespace=self.namespace
+            )
+            ids_to_delete = list(id_gen)
+            self._pinecone_index.delete(
+                ids=ids_to_delete, namespace=self.namespace, **delete_kwargs
+            )
 
     def delete_nodes(
         self,
@@ -439,7 +417,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
     def clear(self) -> None:
         """Clears the index."""
-        self._pinecone_index.delete(namespace=self.namespace, deleteAll=True)
+        self._pinecone_index.delete(namespace=self.namespace, delete_all=True)
 
     @property
     def client(self) -> Any:
@@ -458,19 +436,24 @@ class PineconeVectorStore(BasePydanticVectorStore):
         sparse_vector = None
         if (
             query.mode in (VectorStoreQueryMode.SPARSE, VectorStoreQueryMode.HYBRID)
-            and self._tokenizer is not None
+            and self._sparse_embedding_model is not None
         ):
             if query.query_str is None:
                 raise ValueError(
                     "query_str must be specified if mode is SPARSE or HYBRID."
                 )
-            sparse_vector = generate_sparse_vectors([query.query_str], self._tokenizer)[
-                0
-            ]
+            sparse_vector = self._sparse_embedding_model.get_query_embedding(
+                query.query_str
+            )
             if query.alpha is not None:
-                sparse_vector = {
-                    "indices": sparse_vector["indices"],
-                    "values": [v * (1 - query.alpha) for v in sparse_vector["values"]],
+                pinecone_sparse_vector = {
+                    "indices": list(sparse_vector.keys()),
+                    "values": [v * (1 - query.alpha) for v in sparse_vector.values()],
+                }
+            else:
+                pinecone_sparse_vector = {
+                    "indices": list(sparse_vector.keys()),
+                    "values": list(sparse_vector.values()),
                 }
 
         # pinecone requires a query embedding, so default to 0s if not provided
@@ -500,7 +483,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
 
         response = self._pinecone_index.query(
             vector=query_embedding,
-            sparse_vector=sparse_vector,
+            sparse_vector=pinecone_sparse_vector,
             top_k=query.similarity_top_k,
             include_values=kwargs.pop("include_values", True),
             include_metadata=kwargs.pop("include_metadata", True),

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/utils.py
@@ -1,6 +1,79 @@
-from typing import Any
-
+from collections import Counter
 from packaging import version
+from typing import Any, Callable, List
+
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.base.embeddings.base_sparse import (
+    BaseSparseEmbedding,
+    SparseEmbedding,
+)
+
+
+def get_default_tokenizer() -> Callable:
+    """
+    Get default tokenizer.
+
+    NOTE: taken from https://www.pinecone.io/learn/hybrid-search-intro/.
+
+    """
+    from transformers import BertTokenizerFast
+
+    orig_tokenizer = BertTokenizerFast.from_pretrained("bert-base-uncased")
+
+    def _tokenizer(texts: List[str]) -> List[List[int]]:
+        return orig_tokenizer(texts, padding=True, truncation=True, max_length=512)[
+            "input_ids"
+        ]
+
+    return _tokenizer
+
+
+class DefaultPineconeSparseEmbedding(BaseSparseEmbedding):
+    """Default Pinecone sparse embedding."""
+
+    tokenizer: Callable = Field(
+        default_factory=get_default_tokenizer,
+        description="A callable that returns token input ids.",
+    )
+
+    def build_sparse_embeddings(
+        self, input_batch: List[List[int]]
+    ) -> List[SparseEmbedding]:
+        """
+        Build a list of sparse dictionaries from a batch of input_ids.
+
+        NOTE: taken from https://www.pinecone.io/learn/hybrid-search-intro/.
+
+        """
+        # store a batch of sparse embeddings
+        sparse_emb_list = []
+        # iterate through input batch
+        for token_ids in input_batch:
+            sparse_emb = {}
+            # convert the input_ids list to a dictionary of key to frequency values
+            d = dict(Counter(token_ids))
+            for idx in d:
+                sparse_emb[idx] = float(d[idx])
+            sparse_emb_list.append(sparse_emb)
+        # return sparse_emb list
+        return sparse_emb_list
+
+    def _get_query_embedding(self, query: str) -> SparseEmbedding:
+        """Embed the input query synchronously."""
+        token_ids = self.tokenizer([query])[0]
+        return self.build_sparse_embeddings([token_ids])[0]
+
+    async def _aget_query_embedding(self, query: str) -> SparseEmbedding:
+        """Embed the input query asynchronously."""
+        return self._get_query_embedding(query)
+
+    def _get_text_embedding(self, text: str) -> SparseEmbedding:
+        """Embed the input text synchronously."""
+        return self._get_query_embedding(text)
+
+    async def _aget_text_embedding(self, text: str) -> SparseEmbedding:
+        """Embed the input text asynchronously."""
+        return self._get_query_embedding(text)
 
 
 def _import_pinecone() -> Any:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
@@ -27,12 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-pinecone"
 readme = "README.md"
-version = "0.2.1"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
 pinecone-client = ">=3.2.2,<6.0.0"
-llama-index-core = "^0.11.0"
+llama-index-core = "^0.11.10"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/16738
Fixes https://github.com/run-llama/llama_index/issues/13451
Fixes https://github.com/run-llama/llama_index/issues/16049

Implements several improvements
- use the new sparse embedding class for generating sparse embeddings
- fixes delete for severless indexes by using prefixes to delete

TODO: would be nice to not try/except when deleting, but pinecone doesn't offer a way to detect sever less 