### PR TITLE
Fixed the JSON Format of Generated Sub-Question (double curly brackets)

### DIFF
--- a/llama-index-core/llama_index/core/question_gen/prompts.py
+++ b/llama-index-core/llama_index/core/question_gen/prompts.py
@@ -67,11 +67,7 @@ EXAMPLES = f"""\
 {example_output_str}
 ```
 
-""".replace(
-    "{", "{{"
-).replace(
-    "}", "}}"
-)
+"""
 
 SUFFIX = """\
 # Example 2


### PR DESCRIPTION
This PR changes the default template for the question_gen LLM so that generated sub-questions are in correct JSON format. 
# Description 
 I am using the default template and default parser with an open-source LLM to generate sub-questions. Here is an example of the generated sub-questions in json format:
LLMQuestionGenerator.generate(), prediction = 
{{
    "items": [
        {{
            "sub_question": "What is the summary of the article about Paul Graham?",
            "tool_name": "summary"
        }},
        {{
            "sub_question": "What are some specific facts about Paul Graham mentioned in the article?",
            "tool_name": "vector_search"
        }}
    ]
}}


As you can see above, "{{" and "}}" is in the json and causing the default json parser to fail. I noticed the default prompt below is instructing the LLM to replace "{" with "{{" and "}" with "}}": https://github.com/run-llama/llama_index/blob/369973f4e8c1d6928149f0904b25473faeadb116/llama-index-core/llama_index/core/question_gen/prompts.py#L68C1-L72C2

I tried removing the "replace" lines above and the sub-questions generated are in correct json format.

In a Discord conversation with @logan-markewich, Logan mentioned: 
"Previously double brackets were needed to escape the python string formatter Changes in other parts of the library made that not needed anymore, so indeed, a PR removing that replace would be the correct thing to do"

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
