### PR TITLE
bring back support for prompt templates in context chat engines

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/utils.py
+++ b/llama-index-core/llama_index/core/chat_engine/utils.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, Dict, List, Optional
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
@@ -7,20 +7,20 @@ from llama_index.core.base.llms.types import (
     MessageRole,
 )
 from llama_index.core.llms.llm import LLM
-from llama_index.core.prompts import ChatPromptTemplate
+from llama_index.core.prompts import ChatPromptTemplate, PromptTemplate
 from llama_index.core.response_synthesizers import CompactAndRefine
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.types import TokenGen, TokenAsyncGen
 
 
 def get_prefix_messages_with_context(
-    context_template: str,
+    context_template: PromptTemplate,
     system_prompt: str,
     prefix_messages: List[ChatMessage],
     chat_history: List[ChatMessage],
     llm_metadata_system_role: MessageRole,
 ) -> List[ChatMessage]:
-    context_str_w_sys_prompt = context_template + system_prompt.strip()
+    context_str_w_sys_prompt = context_template.template + system_prompt.strip()
     return [
         ChatMessage(content=context_str_w_sys_prompt, role=llm_metadata_system_role),
         *prefix_messages,
@@ -35,12 +35,20 @@ def get_response_synthesizer(
     qa_messages: List[ChatMessage],
     refine_messages: List[ChatMessage],
     streaming: bool = False,
+    qa_function_mappings: Optional[Dict[str, Callable]] = None,
+    refine_function_mappings: Optional[Dict[str, Callable]] = None,
 ) -> CompactAndRefine:
     return CompactAndRefine(
         llm=llm,
         callback_manager=callback_manager,
-        text_qa_template=ChatPromptTemplate.from_messages(qa_messages),
-        refine_template=ChatPromptTemplate.from_messages(refine_messages),
+        text_qa_template=ChatPromptTemplate.from_messages(
+            qa_messages,
+            function_mappings=qa_function_mappings,
+        ),
+        refine_template=ChatPromptTemplate.from_messages(
+            refine_messages,
+            function_mappings=refine_function_mappings,
+        ),
         streaming=streaming,
     )
 


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/16810

By bringing back prompt templates, we can add support back for custom string variables 