### PR TITLE
fix: `required_exts` for one drive reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -53,6 +53,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
     :param file_paths (List[str], optional): List of specific file paths to download. Will be used if the parameter is not provided when calling load_data().
     :param file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file extension to a BaseReader class that specifies how to convert that file to text.
                                                              See `SimpleDirectoryReader` for more details.
+    :param required_exts (Optional[List[str]]): List of required extensions. Default is None.
 
 
     For interactive authentication to work, a browser is used to authenticate, hence the registered application should have a redirect URI set to 'https://localhost'
@@ -67,6 +68,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
     file_ids: Optional[List[str]] = None
     folder_path: Optional[str] = None
     file_paths: Optional[List[str]] = None
+    required_exts: Optional[List[str]] = None
     file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = Field(
         default=None, exclude=True
     )
@@ -87,6 +89,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         file_paths: Optional[List[str]] = None,
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         attach_permission_metadata: bool = False,
+        required_exts: Optional[List[str]] = None,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -100,6 +103,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
             file_paths=file_paths,
             file_extractor=file_extractor,
             attach_permission_metadata=attach_permission_metadata,
+            required_exts=required_exts,
             **kwargs,
         )
         self._is_interactive_auth = not client_secret
@@ -559,6 +563,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         simple_loader = SimpleDirectoryReader(
             directory,
             file_extractor=self.file_extractor,
+            required_exts=self.required_exts,
             file_metadata=get_metadata,
             recursive=recursive,
         )

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["godwin3737"]
 name = "llama-index-readers-microsoft-onedrive"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -15,18 +15,22 @@ def test_serialize():
     reader = OneDriveReader(
         client_id=test_client_id,
         tenant_id=test_tenant_id,
+        required_exts=[".txt", ".csv"],
     )
 
     schema = reader.schema()
     assert schema is not None
     assert len(schema) > 0
     assert "client_id" in schema["properties"]
+    assert "tenant_id" in schema["properties"]
+    assert "required_exts" in schema["properties"]
 
     json = reader.json(exclude_unset=True)
 
     new_reader = OneDriveReader.parse_raw(json)
     assert new_reader.client_id == reader.client_id
     assert new_reader.tenant_id == reader.tenant_id
+    assert new_reader.required_exts == reader.required_exts
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
