### PR TITLE
Wordpress - allow options to set custom post types

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
@@ -27,9 +27,21 @@ documents = loader.load_data()
 This loader is designed to be used as a way to load data into
 [LlamaIndex](https://github.com/run-llama/llama_index/).
 
-## Pages and Posts
+## Pages, Posts and Custom Post types
 
 Be default, the loader retrieves both Wordpress _pages_ (static content) and
 _posts_ (blog entries) from the target site. This behavior can be configured
-by setting `get_pages=False` or `get_posts=False` when initializing the
+by setting `post_types=posts,pages`, a comma separated list of post types, when initializing the
 `WordpressReader` object.
+
+```python
+from llama_index.readers.wordpress import WordpressReader
+
+loader = WordpressReader(
+    url="https://www.mysite.com",
+    username="my_username",
+    password="my_password",
+    post_types="posts,pages,my-custom-post1,my-custom-post-2"
+)
+documents = loader.load_data()
+```

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/README.md
@@ -27,12 +27,16 @@ documents = loader.load_data()
 This loader is designed to be used as a way to load data into
 [LlamaIndex](https://github.com/run-llama/llama_index/).
 
-## Pages, Posts and Custom Post types
+## Pages and Posts
 
 Be default, the loader retrieves both Wordpress _pages_ (static content) and
 _posts_ (blog entries) from the target site. This behavior can be configured
-by setting `post_types=posts,pages`, a comma separated list of post types, when initializing the
+by setting `get_pages=False` or `get_posts=False` when initializing the
 `WordpressReader` object.
+
+## Additional Custom Post types
+
+To scrape additional custom endpoints beside _posts_ and _pages_, you can specify `additional_post_types` as a comma-separated list (e.g., `additional_post_types="custom-pages,custom-posts"`) when initializing the `WordpressReader` object.
 
 ```python
 from llama_index.readers.wordpress import WordpressReader
@@ -41,7 +45,7 @@ loader = WordpressReader(
     url="https://www.mysite.com",
     username="my_username",
     password="my_password",
-    post_types="posts,pages,my-custom-post1,my-custom-post-2"
+    additional_post_types="webiners,podcasts",
 )
 documents = loader.load_data()
 ```

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/llama_index/readers/wordpress/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/llama_index/readers/wordpress/base.py
@@ -1,7 +1,6 @@
 """Wordpress reader."""
 import json
 import warnings
-
 from typing import List, Optional
 
 from llama_index.core.readers.base import BaseReader
@@ -12,28 +11,29 @@ class WordpressReader(BaseReader):
     """Wordpress reader. Reads data from a Wordpress workspace.
 
     Args:
-        wordpress_subdomain (str): Wordpress subdomain
-        get_pages (bool): Retrieve static Wordpress 'pages'.  Default True.
-        get_posts (bool): Retrieve Wordpress 'posts' (blog entries).  Default True.
+        url (str): Base URL of the WordPress site.
+        username (Optional[str]): WordPress username for authentication.
+        password (Optional[str]): WordPress password for authentication.
+        post_types (Optional[str]): Comma-separated list of post types to retrieve (e.g., 'pages,posts,my-custom-page').
+                                    Default is "pages,posts".
     """
 
     def __init__(
         self,
         url: str,
-        password: Optional[str] = None,
         username: Optional[str] = None,
-        get_pages: bool = True,
-        get_posts: bool = True,
+        password: Optional[str] = None,
+        post_types: Optional[str] = "pages,posts",
     ) -> None:
         """Initialize Wordpress reader."""
         self.url = url
         self.username = username
         self.password = password
-        self.get_pages = get_pages
-        self.get_posts = get_posts
+        # Split the post_types string into a list
+        self.post_types = [post_type.strip() for post_type in post_types.split(",")]
 
     def load_data(self) -> List[Document]:
-        """Load data from the workspace.
+        """Load data from the specified post types.
 
         Returns:
             List[Document]: List of documents.
@@ -48,12 +48,11 @@ class WordpressReader(BaseReader):
         results = []
         articles = []
 
-        if self.get_pages:
-            articles.extend(self.get_all_posts("pages"))
+        # Fetch articles for each specified post type
+        for post_type in self.post_types:
+            articles.extend(self.get_all_posts(post_type))
 
-        if self.get_posts:
-            articles.extend(self.get_all_posts("posts"))
-
+        # Process each article to extract content and metadata
         for article in articles:
             body = article.get("content", {}).get("rendered", None)
             if body is None:
@@ -62,9 +61,7 @@ class WordpressReader(BaseReader):
             soup = BeautifulSoup(body)
             body = soup.get_text()
 
-            title = article.get("title", {}).get("rendered", None)
-            if not title:
-                title = article.get("title")
+            title = article.get("title", {}).get("rendered", None) or article.get("title")
 
             extra_info = {
                 "id": article["id"],
@@ -81,7 +78,8 @@ class WordpressReader(BaseReader):
             )
         return results
 
-    def get_all_posts(self, post_type: str):
+    def get_all_posts(self, post_type: str) -> List[dict]:
+        """Retrieve all posts of a specific type, handling pagination."""
         posts = []
         next_page = 1
 
@@ -95,26 +93,20 @@ class WordpressReader(BaseReader):
 
         return posts
 
-    def get_posts_page(self, post_type: str, current_page: int = 1):
+    def get_posts_page(self, post_type: str, current_page: int = 1) -> dict:
+        """Retrieve a single page of posts for a given post type."""
         import requests
 
         url = f"{self.url}/wp-json/wp/v2/{post_type}?per_page=100&page={current_page}"
 
-        response = requests.get(url)
+        # Handle authentication if username and password are provided
+        auth = (self.username, self.password) if self.username and self.password else None
+        response = requests.get(url, auth=auth)
+        response.raise_for_status()  # Raise an error for bad responses
+
         headers = response.headers
+        num_pages = int(headers.get("X-WP-TotalPages", 1))
+        next_page = current_page + 1 if num_pages > current_page else None
 
-        if "X-WP-TotalPages" in headers:
-            num_pages = int(headers["X-WP-TotalPages"])
-        else:
-            num_pages = 1
-
-        if num_pages > current_page:
-            next_page = current_page + 1
-        else:
-            next_page = None
-
-        response_json = json.loads(response.text)
-
-        articles = response_json
-
+        articles = response.json()
         return {"articles": articles, "next_page": next_page}

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["bbornsztein"]
 name = "llama-index-readers-wordpress"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
@@ -66,7 +66,7 @@ def test_retreive_pages(mocked_responses) -> None:
                 }]
             """,
     )
-    wordpress_reader = WordpressReader("http://test.wordpress.org", get_posts=False)
+    wordpress_reader = WordpressReader("http://test.wordpress.org", post_types="pages")
     documents = wordpress_reader.load_data()
 
 
@@ -83,5 +83,5 @@ def test_retreive_posts(mocked_responses) -> None:
                 }]
             """,
     )
-    wordpress_reader = WordpressReader("http://test.wordpress.org", get_pages=False)
+    wordpress_reader = WordpressReader("http://test.wordpress.org", post_types="posts")
     documents = wordpress_reader.load_data()

--- a/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
+++ b/llama-index-integrations/readers/llama-index-readers-wordpress/tests/test_readers_wordpress.py
@@ -66,7 +66,7 @@ def test_retreive_pages(mocked_responses) -> None:
                 }]
             """,
     )
-    wordpress_reader = WordpressReader("http://test.wordpress.org", post_types="pages")
+    wordpress_reader = WordpressReader("http://test.wordpress.org", get_posts=False)
     documents = wordpress_reader.load_data()
 
 
@@ -83,5 +83,37 @@ def test_retreive_posts(mocked_responses) -> None:
                 }]
             """,
     )
-    wordpress_reader = WordpressReader("http://test.wordpress.org", post_types="posts")
+    wordpress_reader = WordpressReader("http://test.wordpress.org", get_pages=False)
+    documents = wordpress_reader.load_data()
+
+
+def test_retreive_pages_with_additional_post_types(mocked_responses) -> None:
+    mocked_responses.get(
+        "http://test.wordpress.org/wp-json/wp/v2/pages",
+        content_type="application/json",
+        body="""
+                [{"id": 1,
+                    "title": { "rendered": "foo" },
+                    "link": "http://test.wordpress.org/posts/1",
+                    "modified": "Never",
+                    "content": { "rendered": "Lorem ipsum" }
+                }]
+            """,
+    )
+    mocked_responses.get(
+        "http://test.wordpress.org/wp-json/wp/v2/greetings",
+        content_type="application/json",
+        body="""
+                [{"id": 1,
+                    "title": { "msg": "greet" },
+                    "link": "http://test.wordpress.org/greetings/1",
+                    "modified": "Never",
+                    "content": { "rendered": "Namaste everyone!!" }
+                }]
+            """,
+    )
+
+    wordpress_reader = WordpressReader(
+        "http://test.wordpress.org", additional_post_types="greetings", get_posts=False
+    )
     documents = wordpress_reader.load_data()


### PR DESCRIPTION
# Description

Wordpress allows to define custom post types, this enables to fetch any custom defined post types with a comma separate list, hence scarping is not just limited to posts and pages.

Fixes # (issue)
N/A

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Extending the option to scrape custom post types via wordpress api
- [x] Breaking change (If you are using boolean options like get_posts=False, get_pages=False)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.
- [x] I have updated the test to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
