### PR TITLE
[Feature] Include `_data` in `Event` serialization by default.

### DIFF
--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -1,7 +1,13 @@
 from typing import Any, Dict, Type
 from _collections_abc import dict_keys, dict_items, dict_values
 
-from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr, ConfigDict
+from llama_index.core.bridge.pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    ConfigDict,
+    model_serializer,
+)
 
 
 class Event(BaseModel):
@@ -41,7 +47,7 @@ class Event(BaseModel):
         print(evt.field_1)
         print(evt._private_attr_1)
 
-        # `a` and `b` get set in the underliying dict, namely `evt._data`
+        # `a` and `b` get set in the underlying dict, namely `evt._data`
         print((evt.a, evt.b))
         ```
     """
@@ -68,7 +74,8 @@ class Event(BaseModel):
         super().__init__(**fields)
         for private_attr, value in private_attrs.items():
             super().__setattr__(private_attr, value)
-        self._data = data
+        if data:
+            self._data.update(data)
 
     def __getattr__(self, __name: str) -> Any:
         if __name in self.__private_attributes__ or __name in self.model_fields:
@@ -116,6 +123,14 @@ class Event(BaseModel):
 
     def dict(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
         return self._data
+
+    @model_serializer(mode="wrap")
+    def custom_model_dump(self, handler: Any) -> Dict[str, Any]:
+        data = handler(self)
+        # include _data in serialization
+        if self._data:
+            data["_data"] = self._data
+        return data
 
 
 class StartEvent(Event):

--- a/llama-index-core/tests/workflow/test_event.py
+++ b/llama-index-core/tests/workflow/test_event.py
@@ -3,7 +3,7 @@ import pytest
 from llama_index.core.workflow.events import Event
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.workflow.context_serializers import JsonSerializer
-from typing import Any
+from typing import Any, cast
 
 
 class _TestEvent(Event):
@@ -97,5 +97,9 @@ def test_event_serialization():
     deseriazlied_ev = serializer.deserialize(serialized_ev)
 
     assert type(deseriazlied_ev).__name__ == type(ev).__name__
+    deseriazlied_ev = cast(
+        _TestEvent,
+        deseriazlied_ev,
+    )
     assert ev.param == deseriazlied_ev.param
     assert ev._data == deseriazlied_ev._data

--- a/llama-index-core/tests/workflow/test_event.py
+++ b/llama-index-core/tests/workflow/test_event.py
@@ -2,6 +2,7 @@ import pytest
 
 from llama_index.core.workflow.events import Event
 from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.workflow.context_serializers import JsonSerializer
 from typing import Any
 
 
@@ -87,3 +88,14 @@ def test_event_dict_api():
     assert v == "bar"
     assert next(iter(ev)) == "a_new_key"
     assert ev.dict() == {"a_new_key": "bar"}
+
+
+def test_event_serialization():
+    ev = _TestEvent(param="foo", not_a_field="bar")
+    serializer = JsonSerializer()
+    serialized_ev = serializer.serialize(ev)
+    deseriazlied_ev = serializer.deserialize(serialized_ev)
+
+    assert type(deseriazlied_ev).__name__ == type(ev).__name__
+    assert ev.param == deseriazlied_ev.param
+    assert ev._data == deseriazlied_ev._data


### PR DESCRIPTION
# Description

With our `Event` abstraction, we can store data in `Fields`, `PrivateAttr` as well as `_data`. Specifically, a user can subclass `Event` to define their own custom `Fields`, and `PrivateAttr`. And, `_data` acts like an underlying `dict` as well:

- Any fields passed at init that are not a `Field` or `PrivateAttr` of the `Event` gets added to `_data`.
- We can set/get variables from `_data` via a dictionary-like interface as well as via dot notation

```python
ev = MyCustomEvent(field_1=..., not_a_field=...)
ev.get("not_a_field") = ev.not_a_field
```

This is kind of is against Pydantic `BaseModel` convention in that `PrivateAttr`'s start with an underscore "_" and are known to not be included in the model serialization. So, should we include `_data` by defaul in model serialization?


## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change