### PR TITLE
Removal of '%' in README for consistency.md

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/README.md
@@ -5,7 +5,7 @@
 To install the required package, run:
 
 ```bash
-%pip install llama-index-llms-ollama
+pip install llama-index-llms-ollama
 ```
 
 ## Setup


### PR DESCRIPTION
Removal of '%' in bash command to make it consistent with other documentation

# Description

Removal of '%' in bash package install command to make it consistent with other documentation

Fixes # (issue)


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

