### PR TITLE
Fix link to llama_deploy docs

### DIFF
--- a/docs/docs/module_guides/workflow/index.md
+++ b/docs/docs/module_guides/workflow/index.md
@@ -506,7 +506,7 @@ result = await handler
 
 ## Deploying a Workflow
 
-You can deploy a workflow as a multi-agent service with [llama_deploy](../../module_guides/workflow/deployment.md) ([repo](https://github.com/run-llama/llama_deploy)). Each agent service is orchestrated via a control plane and communicates via a message queue. Deploy locally or on Kubernetes.
+You can deploy a workflow as a multi-agent service with [llama_deploy](../../module_guides/workflow/llama_deploy) ([repo](https://github.com/run-llama/llama_deploy)). Each agent service is orchestrated via a control plane and communicates via a message queue. Deploy locally or on Kubernetes.
 
 ## Examples
 


### PR DESCRIPTION
# Description

Fixes a broken link, currently pointing to https://docs.llamaindex.ai/en/stable/module_guides/workflow/deployment.md, so that it points to https://docs.llamaindex.ai/en/stable/module_guides/llama_deploy/

Fixes # (issue)


## Type of Change

Please delete options that are not relevant.

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [N/A] I added new unit tests to cover this change
- [X ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [N/A] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
- [N/A] I ran `make format; make lint` to appease the lint gods
