### PR TITLE
Fix workflow timeout streaming

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -372,10 +372,15 @@ class Workflow(metaclass=WorkflowMeta):
                 ctx.is_running = False
 
                 if exception_raised:
+                    # cancel the stream
                     ctx.write_event_to_stream(StopEvent())
+
                     raise exception_raised
 
                 if not we_done:
+                    # cancel the stream
+                    ctx.write_event_to_stream(StopEvent())
+
                     msg = f"Operation timed out after {self._timeout} seconds"
                     raise WorkflowTimeoutError(msg)
 

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -1,12 +1,11 @@
 import asyncio
-
 import pytest
 
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.core.workflow.workflow import Workflow
-from llama_index.core.workflow.errors import WorkflowRuntimeError
+from llama_index.core.workflow.errors import WorkflowRuntimeError, WorkflowTimeoutError
 
 from .conftest import OneTestEvent
 
@@ -68,6 +67,28 @@ async def test_task_raised():
 
     # Make sure the await actually caught the exception
     with pytest.raises(ValueError, match="The step raised an error!"):
+        await r
+
+
+@pytest.mark.asyncio()
+async def test_task_timeout():
+    class DummyWorkflow(Workflow):
+        @step
+        async def step(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            ctx.write_event_to_stream(OneTestEvent(test_param="foo"))
+            await asyncio.sleep(10000)
+            return StopEvent()
+
+    wf = DummyWorkflow(timeout=1)
+    r = wf.run()
+
+    # Make sure we don't block indefinitely here because the step raised
+    async for ev in r.stream_events():
+        if not isinstance(ev, StopEvent):
+            assert ev.test_param == "foo"
+
+    # Make sure the await actually caught the exception
+    with pytest.raises(WorkflowTimeoutError, match="Operation timed out"):
         await r
 
 

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -76,7 +76,7 @@ async def test_task_timeout():
         @step
         async def step(self, ctx: Context, ev: StartEvent) -> StopEvent:
             ctx.write_event_to_stream(OneTestEvent(test_param="foo"))
-            await asyncio.sleep(10000)
+            await asyncio.sleep(2)
             return StopEvent()
 
     wf = DummyWorkflow(timeout=1)


### PR DESCRIPTION
During a timeout, the workflow is not canceling the stream, causing user code to hang in an async for loop when using `stream_events()`

This fix writes the StopEvent to the stream to cancel properly, and also adds a unit test.