### PR TITLE
fix var name in pinecone vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
@@ -433,7 +433,7 @@ class PineconeVectorStore(BasePydanticVectorStore):
             similarity_top_k (int): top k most similar nodes
 
         """
-        sparse_vector = None
+        pinecone_sparse_vector = None
         if (
             query.mode in (VectorStoreQueryMode.SPARSE, VectorStoreQueryMode.HYBRID)
             and self._sparse_embedding_model is not None

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-pinecone"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"


### PR DESCRIPTION
Make sure the sparse vector is defined before trying to use it