### PR TITLE
Fix modelscope 'pipeline' referenced before assignment.

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-modelscope/llama_index/llms/modelscope/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/llama_index/llms/modelscope/base.py
@@ -28,7 +28,9 @@ from llama_index.llms.modelscope.utils import (
     modelscope_message_to_chat_response,
 )
 
-DEFAULT_MODELSCOPE_MODEL = "qwen/Qwen-7B-Chat"
+from modelscope.pipelines import pipeline as pipeline_builder
+
+DEFAULT_MODELSCOPE_MODEL = "Qwen/Qwen2-0.5B-Instruct"
 DEFAULT_MODELSCOPE_MODEL_REVISION = "master"
 DEFAULT_MODELSCOPE_TASK = "chat"
 DEFAULT_MODELSCOPE_DTYPE = "float16"
@@ -128,7 +130,7 @@ class ModelScopeLLM(CustomLLM):
         if model:
             pipeline = model
         else:
-            pipeline = pipeline(
+            pipeline = pipeline_builder(
                 task=task_name,
                 model=model_name,
                 model_revision=model_revision,

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/llama_index/llms/modelscope/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/llama_index/llms/modelscope/utils.py
@@ -9,7 +9,7 @@ from llama_index.core.base.llms.types import (
 
 def chat_message_to_modelscope_messages(
     chat_messages: Sequence[ChatMessage],
-) -> List[Dict]:
+) -> Dict:
     messages = []
     for msg in chat_messages:
         messages.append({"role": msg.role.value, "content": msg.content})

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/llama_index/llms/modelscope/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/llama_index/llms/modelscope/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Sequence
+from typing import Dict, Sequence
 
 from llama_index.core.base.llms.types import (
     ChatResponse,

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/pyproject.toml
@@ -34,6 +34,8 @@ python = ">=3.8.1,<3.12"
 modelscope = ">=1.12.0"
 torch = "^2.1.2"
 llama-index-core = "^0.11.0"
+ms-swift = "^2.5.2"
+SentencePiece = "^0.2.0"
 
 [tool.poetry.dependencies.transformers]
 extras = ["torch"]

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/pyproject.toml
@@ -31,11 +31,11 @@ version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"
-modelscope = ">=1.12.0"
+modelscope = {extras = ["framework"], version = ">=1.12.0"}
 torch = "^2.1.2"
 llama-index-core = "^0.11.0"
-ms-swift = "^2.5.2"
-SentencePiece = "^0.2.0"
+sentencepiece = "*"
+ms-swift = "*"
 
 [tool.poetry.dependencies.transformers]
 extras = ["torch"]

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-modelscope"
 readme = "README.md"
-version = "0.2.2"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.12"

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/tests/BUILD
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/tests/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/tests/BUILD
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/tests/BUILD
@@ -1,1 +1,6 @@
-python_tests()
+python_tests(
+    dependencies=[
+        'llama-index-integrations/llms/llama-index-llms-modelscope:poetry#sentencepiece',
+        'llama-index-integrations/llms/llama-index-llms-modelscope:poetry#ms-swift',
+    ],
+)

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/tests/test_modelscope.py
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/tests/test_modelscope.py
@@ -1,0 +1,69 @@
+import pytest
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    MessageRole,
+)
+from llama_index.llms.modelscope.base import ModelScopeLLM
+
+
+@pytest.fixture(scope='function')
+def modelscope_llm():
+    return ModelScopeLLM()
+
+
+@pytest.fixture(scope='function')
+def prompt():
+    return "Hi, my name is"
+
+
+@pytest.fixture(scope='function')
+def messages():
+    return [
+        ChatMessage(content="Which movie is the best?"),
+        ChatMessage(content="It's Die Hard for sure.", role=MessageRole.ASSISTANT),
+        ChatMessage(content="Can you explain why?"),
+    ]
+
+
+@pytest.mark.complete
+def test_modelscope_complete(modelscope_llm, prompt):
+    response = modelscope_llm.complete(prompt)
+    assert response is not None
+    assert str(response).strip() != ""
+    print(response)
+
+
+@pytest.mark.complete
+def test_modelscope_stream_complete(modelscope_llm, prompt):
+    response = modelscope_llm.stream_complete(prompt)
+    assert response is not None
+    for r in response:
+        assert r is not None
+        assert str(r).strip() != ""
+        print(r)
+
+
+@pytest.mark.xfail(reason="20 is the default max_length of the generation config")
+def test_modelscope_chat_clear(modelscope_llm, messages):
+    response = modelscope_llm.chat(messages)
+    assert response is not None
+    assert str(response).strip() != ""
+    print(response)
+
+
+@pytest.mark.chat
+def test_modelscope_chat(modelscope_llm, messages):
+    response = modelscope_llm.chat(messages, max_new_tokens=100)
+    assert response is not None
+    assert str(response).strip() != ""
+    print(response)
+
+
+@pytest.mark.chat
+def test_modelscope_stream_chat(modelscope_llm, messages):
+    gen = modelscope_llm.stream_chat(messages, max_new_tokens=100)
+    assert gen is not None
+    for r in gen:
+        assert r is not None
+        assert str(r).strip() != ""
+        print(r)

--- a/llama-index-integrations/llms/llama-index-llms-modelscope/tests/test_modelscope.py
+++ b/llama-index-integrations/llms/llama-index-llms-modelscope/tests/test_modelscope.py
@@ -6,17 +6,17 @@ from llama_index.core.base.llms.types import (
 from llama_index.llms.modelscope.base import ModelScopeLLM
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def modelscope_llm():
     return ModelScopeLLM()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def prompt():
     return "Hi, my name is"
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture()
 def messages():
     return [
         ChatMessage(content="Which movie is the best?"),
@@ -25,7 +25,7 @@ def messages():
     ]
 
 
-@pytest.mark.complete
+@pytest.mark.complete()
 def test_modelscope_complete(modelscope_llm, prompt):
     response = modelscope_llm.complete(prompt)
     assert response is not None
@@ -33,7 +33,7 @@ def test_modelscope_complete(modelscope_llm, prompt):
     print(response)
 
 
-@pytest.mark.complete
+@pytest.mark.complete()
 def test_modelscope_stream_complete(modelscope_llm, prompt):
     response = modelscope_llm.stream_complete(prompt)
     assert response is not None
@@ -51,7 +51,7 @@ def test_modelscope_chat_clear(modelscope_llm, messages):
     print(response)
 
 
-@pytest.mark.chat
+@pytest.mark.chat()
 def test_modelscope_chat(modelscope_llm, messages):
     response = modelscope_llm.chat(messages, max_new_tokens=100)
     assert response is not None
@@ -59,7 +59,7 @@ def test_modelscope_chat(modelscope_llm, messages):
     print(response)
 
 
-@pytest.mark.chat
+@pytest.mark.chat()
 def test_modelscope_stream_chat(modelscope_llm, messages):
     gen = modelscope_llm.stream_chat(messages, max_new_tokens=100)
     assert gen is not None


### PR DESCRIPTION
# Description

When using `llama-index-llms-modelscope`, local variable 'pipeline' referenced before assignment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format`
