### PR TITLE
fix tenacity depends confilct with GraphRAG: llama-index-core(<9.0.0) and GraphRAG(>=9.0.0)

### DIFF
--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -58,7 +58,7 @@ nest-asyncio = "^1.5.8"
 nltk = ">3.8.1"
 numpy = "<2.0.0"  # Pin until we adapt to Numpy v2
 python = ">=3.8.1,<4.0"
-tenacity = ">=8.2.0,!=8.4.0,<9.0.0"  # Avoid 8.4.0 which lacks tenacity.asyncio
+tenacity = ">=8.2.0,!=8.4.0,<10"  # Avoid 8.4.0 which lacks tenacity.asyncio
 tiktoken = ">=0.3.3"
 typing-extensions = ">=4.5.0"
 typing-inspect = ">=0.8.0"


### PR DESCRIPTION
# Description
When my project use llama-index and [GraphRAG](https://github.com/microsoft/graphrag), there is a tenacity depends:
```
The conflict is caused by:
    graphrag 0.4.0 depends on tenacity<10.0.0 and >=9.0.0
    llama-index-core 0.11.22 depends on tenacity!=8.4.0, <9.0.0 and >=8.2.0
```

Here are the release notes for tenacity 9 (https://github.com/jd/tenacity/releases/tag/9.0.0)
And I found langchain has already updated tenacity version:
https://github.com/langchain-ai/langchain/pull/27201

Now, I wish llama-index can do the same change.

Fixes # (issue)
This should fixes the compatibility issue with graprag as in:
https://github.com/microsoft/graphrag/issues/929

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change
Fix depends version conflict.

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
