### PR TITLE
fix not valid redirections in docs `getting_started/concepts`

### DIFF
--- a/docs/docs/getting_started/concepts.md
+++ b/docs/docs/getting_started/concepts.md
@@ -4,7 +4,7 @@ This is a quick guide to the high-level concepts you'll encounter frequently whe
 
 ## Large Language Models (LLMs)
 
-LLMs are the fundamental innovation that launched LlamaIndex. They are an artificial intelligence (AI) computer system that can understand, generate, and manipulate natural language, including answering questions based on their training data or data provided to them at query time. You can [learn more about using LLMs](../understanding/using_llms/using_llms/).
+LLMs are the fundamental innovation that launched LlamaIndex. They are an artificial intelligence (AI) computer system that can understand, generate, and manipulate natural language, including answering questions based on their training data or data provided to them at query time. You can [learn more about using LLMs](../understanding/using_llms/using_llms.md).
 
 ## Retrieval Augmented Generation (RAG)
 
@@ -12,13 +12,13 @@ Retrieval-Augmented Generation (RAG) is a core technique for building data-backe
 
 ## Agents
 
-An agent is a piece of software that semi-autonomously performs tasks by combining LLMs with other tools. You can [learn more about agents](../understanding/agents/index.md).
+An agent is a piece of software that semi-autonomously performs tasks by combining LLMs with other tools. You can [learn more about agents](../understanding/agent/index.md).
 
 ## Use cases
 
 There are endless use cases for data-backed LLM applications but they can be roughly grouped into four categories:
 
-[**Structured Data Extraction**](../use_cases/extraction.md/)
+[**Structured Data Extraction**](../use_cases/extraction.md)
 Pydantic extractors allow you to specify a precise data structure to extract from your data and use LLMs to fill in the missing pieces in a type-safe way. This is useful for extracting structured data from unstructured sources like PDFs, websites, and more, and is key to automating workflows.
 
 [**Query Engines**](../module_guides/deploying/query_engine/index.md):


### PR DESCRIPTION
# Description

This PR fixes wrong redirections on the document `getting_started/concepts`
Currently in stable version document, those links fallback to 404 page error.
I fixed to redirect desired pages.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Update documents (no breaking changes)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
