### PR TITLE
fix clickhouse init in vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
@@ -233,7 +233,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
                 "extract_func": lambda x: json.dumps(x.metadata),
             },
         }
-        column_names = list(self._column_config.keys())
+        column_names = list(column_config.keys())
         column_type_names = [
             column_config[column_name]["type"] for column_name in column_names
         ]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-clickhouse"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/16900

Shouldn't use self until super init is called