### PR TITLE
Ky/dynamic pg triplet retrieval limit

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
@@ -107,24 +107,24 @@ class LLMSynonymRetriever(BasePGRetriever):
 
         return self._get_nodes_with_score(triplets)
 
-    def retrieve_from_graph(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: int = 30) -> List[NodeWithScore]:
         response = self._llm.predict(
             self._synonym_prompt,
             query_str=query_bundle.query_str,
             max_keywords=self._max_keywords,
         )
-        matches = self._parse_llm_output(response)
+        matches = self._parse_llm_output(response, limit=limit)
 
         return self._prepare_matches(matches)
 
     async def aretrieve_from_graph(
-        self, query_bundle: QueryBundle
+        self, query_bundle: QueryBundle, limit: int = 30
     ) -> List[NodeWithScore]:
         response = await self._llm.apredict(
             self._synonym_prompt,
             query_str=query_bundle.query_str,
             max_keywords=self._max_keywords,
         )
-        matches = self._parse_llm_output(response)
+        matches = self._parse_llm_output(response, limit=limit)
 
         return await self._aprepare_matches(matches)

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
@@ -88,12 +88,12 @@ class LLMSynonymRetriever(BasePGRetriever):
         # capitalize to normalize with ingestion
         return [x.strip().capitalize() for x in matches if x.strip()]
 
-    def _prepare_matches(self, matches: List[str], limit: Optional[int] = 30) -> List[NodeWithScore]:
+    def _prepare_matches(self, matches: List[str], limit: Optional[int] = None) -> List[NodeWithScore]:
         kg_nodes = self._graph_store.get(ids=matches)
         triplets = self._graph_store.get_rel_map(
             kg_nodes,
             depth=self._path_depth,
-            limit=limit,
+            limit=limit or self._limit,
             ignore_rels=[KG_SOURCE_REL],
         )
 
@@ -104,7 +104,7 @@ class LLMSynonymRetriever(BasePGRetriever):
         triplets = await self._graph_store.aget_rel_map(
             kg_nodes,
             depth=self._path_depth,
-            limit=limit,
+            limit=limit or self._limit,
             ignore_rels=[KG_SOURCE_REL],
         )
 

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
@@ -86,11 +86,12 @@ class LLMSynonymRetriever(BasePGRetriever):
         # capitalize to normalize with ingestion
         return [x.strip().capitalize() for x in matches if x.strip()]
 
-    def _prepare_matches(self, matches: List[str]) -> List[NodeWithScore]:
+    def _prepare_matches(self, matches: List[str], limit: int = 30) -> List[NodeWithScore]:
         kg_nodes = self._graph_store.get(ids=matches)
         triplets = self._graph_store.get_rel_map(
             kg_nodes,
             depth=self._path_depth,
+            limit=limit,
             ignore_rels=[KG_SOURCE_REL],
         )
 

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
@@ -88,7 +88,9 @@ class LLMSynonymRetriever(BasePGRetriever):
         # capitalize to normalize with ingestion
         return [x.strip().capitalize() for x in matches if x.strip()]
 
-    def _prepare_matches(self, matches: List[str], limit: Optional[int] = None) -> List[NodeWithScore]:
+    def _prepare_matches(
+        self, matches: List[str], limit: Optional[int] = None
+    ) -> List[NodeWithScore]:
         kg_nodes = self._graph_store.get(ids=matches)
         triplets = self._graph_store.get_rel_map(
             kg_nodes,
@@ -99,7 +101,9 @@ class LLMSynonymRetriever(BasePGRetriever):
 
         return self._get_nodes_with_score(triplets)
 
-    async def _aprepare_matches(self, matches: List[str], limit: Optional[int] = None) -> List[NodeWithScore]:
+    async def _aprepare_matches(
+        self, matches: List[str], limit: Optional[int] = None
+    ) -> List[NodeWithScore]:
         kg_nodes = await self._graph_store.aget(ids=matches)
         triplets = await self._graph_store.aget_rel_map(
             kg_nodes,
@@ -110,7 +114,9 @@ class LLMSynonymRetriever(BasePGRetriever):
 
         return self._get_nodes_with_score(triplets)
 
-    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: Optional[int] = None) -> List[NodeWithScore]:
+    def retrieve_from_graph(
+        self, query_bundle: QueryBundle, limit: Optional[int] = None
+    ) -> List[NodeWithScore]:
         response = self._llm.predict(
             self._synonym_prompt,
             query_str=query_bundle.query_str,

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/llm_synonym.py
@@ -59,6 +59,7 @@ class LLMSynonymRetriever(BasePGRetriever):
         ] = DEFAULT_SYNONYM_EXPAND_TEMPLATE,
         max_keywords: int = 10,
         path_depth: int = 1,
+        limit: int = 30,
         output_parsing_fn: Optional[Callable] = None,
         llm: Optional[LLM] = None,
         **kwargs: Any,
@@ -70,6 +71,7 @@ class LLMSynonymRetriever(BasePGRetriever):
         self._output_parsing_fn = output_parsing_fn
         self._max_keywords = max_keywords
         self._path_depth = path_depth
+        self._limit = limit
         super().__init__(
             graph_store=graph_store,
             include_text=include_text,
@@ -86,7 +88,7 @@ class LLMSynonymRetriever(BasePGRetriever):
         # capitalize to normalize with ingestion
         return [x.strip().capitalize() for x in matches if x.strip()]
 
-    def _prepare_matches(self, matches: List[str], limit: int = 30) -> List[NodeWithScore]:
+    def _prepare_matches(self, matches: List[str], limit: Optional[int] = 30) -> List[NodeWithScore]:
         kg_nodes = self._graph_store.get(ids=matches)
         triplets = self._graph_store.get_rel_map(
             kg_nodes,
@@ -97,34 +99,35 @@ class LLMSynonymRetriever(BasePGRetriever):
 
         return self._get_nodes_with_score(triplets)
 
-    async def _aprepare_matches(self, matches: List[str]) -> List[NodeWithScore]:
+    async def _aprepare_matches(self, matches: List[str], limit: Optional[int] = None) -> List[NodeWithScore]:
         kg_nodes = await self._graph_store.aget(ids=matches)
         triplets = await self._graph_store.aget_rel_map(
             kg_nodes,
             depth=self._path_depth,
+            limit=limit,
             ignore_rels=[KG_SOURCE_REL],
         )
 
         return self._get_nodes_with_score(triplets)
 
-    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: int = 30) -> List[NodeWithScore]:
+    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: Optional[int] = None) -> List[NodeWithScore]:
         response = self._llm.predict(
             self._synonym_prompt,
             query_str=query_bundle.query_str,
             max_keywords=self._max_keywords,
         )
-        matches = self._parse_llm_output(response, limit=limit)
+        matches = self._parse_llm_output(response)
 
-        return self._prepare_matches(matches)
+        return self._prepare_matches(matches, limit=limit or self._limit)
 
     async def aretrieve_from_graph(
-        self, query_bundle: QueryBundle, limit: int = 30
+        self, query_bundle: QueryBundle, limit: Optional[int] = None
     ) -> List[NodeWithScore]:
         response = await self._llm.apredict(
             self._synonym_prompt,
             query_str=query_bundle.query_str,
             max_keywords=self._max_keywords,
         )
-        matches = self._parse_llm_output(response, limit=limit)
+        matches = self._parse_llm_output(response)
 
-        return await self._aprepare_matches(matches)
+        return await self._aprepare_matches(matches, limit=limit or self._limit)

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
@@ -49,6 +49,7 @@ class VectorContextRetriever(BasePGRetriever):
         vector_store: Optional[BasePydanticVectorStore] = None,
         similarity_top_k: int = 4,
         path_depth: int = 1,
+        limit: int = 30,
         similarity_score: Optional[float] = None,
         filters: Optional[MetadataFilters] = None,
         **kwargs: Any,
@@ -58,6 +59,7 @@ class VectorContextRetriever(BasePGRetriever):
         self._similarity_top_k = similarity_top_k
         self._vector_store = vector_store
         self._path_depth = path_depth
+        self._limit = limit
         self._similarity_score = similarity_score
         self._filters = filters
 
@@ -112,7 +114,7 @@ class VectorContextRetriever(BasePGRetriever):
             **self._retriever_kwargs,
         )
 
-    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: int = 30) -> List[NodeWithScore]:
+    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: Optional[int] = None) -> List[NodeWithScore]:
         vector_store_query = self._get_vector_store_query(query_bundle)
 
         triplets = []
@@ -126,7 +128,7 @@ class VectorContextRetriever(BasePGRetriever):
 
             kg_ids = [node.id for node in kg_nodes]
             triplets = self._graph_store.get_rel_map(
-                kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
+                kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
             )
 
         elif self._vector_store is not None:
@@ -136,7 +138,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = self._graph_store.get(ids=kg_ids)
                 triplets = self._graph_store.get_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
             elif query_result.ids is not None and query_result.similarities is not None:
@@ -144,7 +146,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = self._graph_store.get(ids=kg_ids)
                 triplets = self._graph_store.get_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
         for triplet in triplets:
@@ -174,7 +176,7 @@ class VectorContextRetriever(BasePGRetriever):
         return self._get_nodes_with_score([x[0] for x in top_k], [x[1] for x in top_k])
 
     async def aretrieve_from_graph(
-        self, query_bundle: QueryBundle, limit: int = 30
+        self, query_bundle: QueryBundle, limit: Optional[int] = None
     ) -> List[NodeWithScore]:
         vector_store_query = await self._aget_vector_store_query(query_bundle)
 
@@ -189,7 +191,7 @@ class VectorContextRetriever(BasePGRetriever):
             kg_nodes, scores = result
             kg_ids = [node.id for node in kg_nodes]
             triplets = await self._graph_store.aget_rel_map(
-                kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
+                kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
             )
 
         elif self._vector_store is not None:
@@ -199,7 +201,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = await self._graph_store.aget(ids=kg_ids)
                 triplets = await self._graph_store.aget_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
             elif query_result.ids is not None and query_result.similarities is not None:
@@ -207,7 +209,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = await self._graph_store.aget(ids=kg_ids)
                 triplets = await self._graph_store.aget_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
         for triplet in triplets:

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
@@ -114,7 +114,9 @@ class VectorContextRetriever(BasePGRetriever):
             **self._retriever_kwargs,
         )
 
-    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: Optional[int] = None) -> List[NodeWithScore]:
+    def retrieve_from_graph(
+        self, query_bundle: QueryBundle, limit: Optional[int] = None
+    ) -> List[NodeWithScore]:
         vector_store_query = self._get_vector_store_query(query_bundle)
 
         triplets = []
@@ -128,7 +130,10 @@ class VectorContextRetriever(BasePGRetriever):
 
             kg_ids = [node.id for node in kg_nodes]
             triplets = self._graph_store.get_rel_map(
-                kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
+                kg_nodes,
+                depth=self._path_depth,
+                limit=limit or self._limit,
+                ignore_rels=[KG_SOURCE_REL],
             )
 
         elif self._vector_store is not None:
@@ -138,7 +143,10 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = self._graph_store.get(ids=kg_ids)
                 triplets = self._graph_store.get_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes,
+                    depth=self._path_depth,
+                    limit=limit or self._limit,
+                    ignore_rels=[KG_SOURCE_REL],
                 )
 
             elif query_result.ids is not None and query_result.similarities is not None:
@@ -146,7 +154,10 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = self._graph_store.get(ids=kg_ids)
                 triplets = self._graph_store.get_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes,
+                    depth=self._path_depth,
+                    limit=limit or self._limit,
+                    ignore_rels=[KG_SOURCE_REL],
                 )
 
         for triplet in triplets:
@@ -191,7 +202,10 @@ class VectorContextRetriever(BasePGRetriever):
             kg_nodes, scores = result
             kg_ids = [node.id for node in kg_nodes]
             triplets = await self._graph_store.aget_rel_map(
-                kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
+                kg_nodes,
+                depth=self._path_depth,
+                limit=limit or self._limit,
+                ignore_rels=[KG_SOURCE_REL],
             )
 
         elif self._vector_store is not None:
@@ -201,7 +215,10 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = await self._graph_store.aget(ids=kg_ids)
                 triplets = await self._graph_store.aget_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes,
+                    depth=self._path_depth,
+                    limit=limit or self._limit,
+                    ignore_rels=[KG_SOURCE_REL],
                 )
 
             elif query_result.ids is not None and query_result.similarities is not None:
@@ -209,7 +226,10 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = await self._graph_store.aget(ids=kg_ids)
                 triplets = await self._graph_store.aget_rel_map(
-                    kg_nodes, depth=self._path_depth, limit=limit or self._limit, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes,
+                    depth=self._path_depth,
+                    limit=limit or self._limit,
+                    ignore_rels=[KG_SOURCE_REL],
                 )
 
         for triplet in triplets:

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
@@ -112,7 +112,7 @@ class VectorContextRetriever(BasePGRetriever):
             **self._retriever_kwargs,
         )
 
-    def retrieve_from_graph(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+    def retrieve_from_graph(self, query_bundle: QueryBundle, limit: int = 30) -> List[NodeWithScore]:
         vector_store_query = self._get_vector_store_query(query_bundle)
 
         triplets = []
@@ -126,7 +126,7 @@ class VectorContextRetriever(BasePGRetriever):
 
             kg_ids = [node.id for node in kg_nodes]
             triplets = self._graph_store.get_rel_map(
-                kg_nodes, depth=self._path_depth, ignore_rels=[KG_SOURCE_REL]
+                kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
             )
 
         elif self._vector_store is not None:
@@ -136,7 +136,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = self._graph_store.get(ids=kg_ids)
                 triplets = self._graph_store.get_rel_map(
-                    kg_nodes, depth=self._path_depth, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
             elif query_result.ids is not None and query_result.similarities is not None:
@@ -144,7 +144,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = self._graph_store.get(ids=kg_ids)
                 triplets = self._graph_store.get_rel_map(
-                    kg_nodes, depth=self._path_depth, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
         for triplet in triplets:
@@ -174,7 +174,7 @@ class VectorContextRetriever(BasePGRetriever):
         return self._get_nodes_with_score([x[0] for x in top_k], [x[1] for x in top_k])
 
     async def aretrieve_from_graph(
-        self, query_bundle: QueryBundle
+        self, query_bundle: QueryBundle, limit: int = 30
     ) -> List[NodeWithScore]:
         vector_store_query = await self._aget_vector_store_query(query_bundle)
 
@@ -189,7 +189,7 @@ class VectorContextRetriever(BasePGRetriever):
             kg_nodes, scores = result
             kg_ids = [node.id for node in kg_nodes]
             triplets = await self._graph_store.aget_rel_map(
-                kg_nodes, depth=self._path_depth, ignore_rels=[KG_SOURCE_REL]
+                kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
             )
 
         elif self._vector_store is not None:
@@ -199,7 +199,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = await self._graph_store.aget(ids=kg_ids)
                 triplets = await self._graph_store.aget_rel_map(
-                    kg_nodes, depth=self._path_depth, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
             elif query_result.ids is not None and query_result.similarities is not None:
@@ -207,7 +207,7 @@ class VectorContextRetriever(BasePGRetriever):
                 scores = query_result.similarities
                 kg_nodes = await self._graph_store.aget(ids=kg_ids)
                 triplets = await self._graph_store.aget_rel_map(
-                    kg_nodes, depth=self._path_depth, ignore_rels=[KG_SOURCE_REL]
+                    kg_nodes, depth=self._path_depth, limit=limit, ignore_rels=[KG_SOURCE_REL]
                 )
 
         for triplet in triplets:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

PropertyGraphStores has a method called get_rel_map that takes in parameters such as nodes, depth and limit. These control the nodes to find the rel_map on, the depth to search to and the overall limit to the number of triplets returned. Both depth and limit have default values, the latter defaults to 30 nodes.

When the get_rel_map/aget_rel_map method is called by a subretriever in another the limit parameter is never used so we can only return up to 30 triplets. This seems to be a random number and may not encapsulate all the possible paths of a search as the graph grows larger. My change is to add a default and dynamic parameter to if necessary.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
