### PR TITLE
remove open telemetry docs

### DIFF
--- a/docs/docs/api_reference/callbacks/opentelemetry.md
+++ b/docs/docs/api_reference/callbacks/opentelemetry.md
@@ -1,6 +1,0 @@
-::: llama_index.callbacks.opentelemetry
-    options:
-      members:
-        - OpenTelemetryEventHandler
-        - OpenTelemetrySpanHandler
-        - instrument_opentelemetry


### PR DESCRIPTION
Just realized this has been failing for ages, accidentally added a beta package from my local env to docs