### PR TITLE
allow skipping waiting for ingestion when uploading file

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
@@ -130,6 +130,40 @@ class LlamaCloudIndex(BaseManagedIndex):
                 if verbose:
                     print("Done!")
 
+    def _wait_for_file_ingestion(
+        self,
+        file_id: str,
+        verbose: bool = False,
+        raise_on_error: bool = False,
+    ) -> None:
+        pipeline_id = self._get_pipeline_id()
+        client = self._client
+        if verbose:
+            print("Loading file: ", end="")
+
+        # wait until the file is loaded
+        is_done = False
+        while not is_done:
+            status = client.pipelines.get_pipeline_file_status(
+                pipeline_id=pipeline_id, file_id=file_id
+            ).status
+            if status == ManagedIngestionStatus.ERROR:
+                if verbose:
+                    print(f"File ingestion failed for {file_id}")
+                if raise_on_error:
+                    raise ValueError(f"File ingestion failed for {file_id}")
+            elif status in [
+                ManagedIngestionStatus.NOT_STARTED,
+                ManagedIngestionStatus.IN_PROGRESS,
+            ]:
+                if verbose:
+                    print(".", end="")
+                time.sleep(0.5)
+            else:
+                is_done = True
+                if verbose:
+                    print("Done!")
+
     def _wait_for_documents_ingestion(
         self,
         doc_ids: List[str],
@@ -462,6 +496,7 @@ class LlamaCloudIndex(BaseManagedIndex):
         resource_info: Optional[Dict[str, Any]] = None,
         verbose: bool = False,
         wait_for_ingestion: bool = True,
+        raise_on_error: bool = False,
     ) -> str:
         """Upload a file to the index."""
         with open(file_path, "rb") as f:
@@ -480,8 +515,8 @@ class LlamaCloudIndex(BaseManagedIndex):
         )
 
         if wait_for_ingestion:
-            self._wait_for_pipeline_ingestion(
-                verbose=verbose, raise_on_partial_success=False
+            self._wait_for_file_ingestion(
+                file.id, verbose=verbose, raise_on_error=raise_on_error
             )
         return file.id
 
@@ -495,6 +530,7 @@ class LlamaCloudIndex(BaseManagedIndex):
         follow_redirects: bool = True,
         verbose: bool = False,
         wait_for_ingestion: bool = True,
+        raise_on_error: bool = False,
     ) -> str:
         """Upload a file from a URL to the index."""
         file = self._client.files.upload_file_from_url(
@@ -516,8 +552,8 @@ class LlamaCloudIndex(BaseManagedIndex):
         )
 
         if wait_for_ingestion:
-            self._wait_for_pipeline_ingestion(
-                verbose=verbose, raise_on_partial_success=False
+            self._wait_for_file_ingestion(
+                file.id, verbose=verbose, raise_on_error=raise_on_error
             )
         return file.id
 

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
@@ -461,6 +461,7 @@ class LlamaCloudIndex(BaseManagedIndex):
         file_path: str,
         resource_info: Optional[Dict[str, Any]] = None,
         verbose: bool = False,
+        wait_for_ingestion: bool = True,
     ) -> str:
         """Upload a file to the index."""
         with open(file_path, "rb") as f:
@@ -478,9 +479,10 @@ class LlamaCloudIndex(BaseManagedIndex):
             pipeline_id=pipeline_id, request=[pipeline_file_create]
         )
 
-        self._wait_for_pipeline_ingestion(
-            verbose=verbose, raise_on_partial_success=False
-        )
+        if wait_for_ingestion:
+            self._wait_for_pipeline_ingestion(
+                verbose=verbose, raise_on_partial_success=False
+            )
         return file.id
 
     def upload_file_from_url(
@@ -492,6 +494,7 @@ class LlamaCloudIndex(BaseManagedIndex):
         verify_ssl: bool = True,
         follow_redirects: bool = True,
         verbose: bool = False,
+        wait_for_ingestion: bool = True,
     ) -> str:
         """Upload a file from a URL to the index."""
         file = self._client.files.upload_file_from_url(
@@ -512,9 +515,10 @@ class LlamaCloudIndex(BaseManagedIndex):
             pipeline_id=pipeline_id, request=[pipeline_file_create]
         )
 
-        self._wait_for_pipeline_ingestion(
-            verbose=verbose, raise_on_partial_success=False
-        )
+        if wait_for_ingestion:
+            self._wait_for_pipeline_ingestion(
+                verbose=verbose, raise_on_partial_success=False
+            )
         return file.id
 
     # Nodes related methods (not implemented for LlamaCloudIndex)

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
@@ -38,7 +38,7 @@ version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-llama-cloud = ">=0.0.11"
+llama-cloud = ">=0.1.5"
 llama-index-core = "^0.11.13.post1"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
@@ -34,7 +34,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-llama-cloud"
 readme = "README.md"
-version = "0.4.1"
+version = "0.4.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
@@ -34,7 +34,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-llama-cloud"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
# Description

adding `wait_for_intestion` flag in case some clients dont want to poll for ingestion completion.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
