### PR TITLE
Update broken notebook URLs

### DIFF
--- a/docs/docs/examples/property_graph/property_graph_advanced.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_advanced.ipynb
@@ -339,7 +339,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For information on all `kg_extractors`, see [the documentation](../../module_guides/indexing/lpg_index_guide.md#construction)."
+    "For information on all `kg_extractors`, see [the documentation](/../../module_guides/indexing/lpg_index_guide#construction)."
    ]
   },
   {
@@ -455,7 +455,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more info on all retrievers, see the [complete guide](../../module_guides/indexing/lpg_index_guide.md#retrieval-and-querying)."
+    "For more info on all retrievers, see the [complete guide](/../../module_guides/indexing/lpg_index_guide#retrieval-and-querying)."
    ]
   }
  ],

--- a/docs/docs/examples/property_graph/property_graph_basic.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_basic.ipynb
@@ -195,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For a full guide on all extractors, see the [detailed usage page](../../module_guides/indexing/lpg_index_guide.md#construction)."
+    "For a full guide on all extractors, see the [detailed usage page](/../../module_guides/indexing/lpg_index_guide#construction)."
    ]
   },
   {
@@ -294,7 +294,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For full details on customizing retrieval and querying, see [the docs page](../../module_guides/indexing/lpg_index_guide.md#retrieval-and-querying)."
+    "For full details on customizing retrieval and querying, see [the docs page](/../../module_guides/indexing/lpg_index_guide#retrieval-and-querying)."
    ]
   },
   {

--- a/docs/docs/examples/property_graph/property_graph_falkordb.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_falkordb.ipynb
@@ -241,7 +241,7 @@
     "\n",
     "If you have an existing graph (either created with LlamaIndex or otherwise), we can connect to and use it!\n",
     "\n",
-    "**NOTE:** If your graph was created outside of LlamaIndex, the most useful retrievers will be [text to cypher](../../module_guides/indexing/lpg_index_guide.md#texttocypherretriever) or [cypher templates](../../module_guides/indexing/lpg_index_guide.md#cyphertemplateretriever). Other retrievers rely on properties that LlamaIndex inserts."
+    "**NOTE:** If your graph was created outside of LlamaIndex, the most useful retrievers will be [text to cypher](/../../module_guides/indexing/lpg_index_guide#texttocypherretriever) or [cypher templates](/../../module_guides/indexing/lpg_index_guide#cyphertemplateretriever). Other retrievers rely on properties that LlamaIndex inserts."
    ]
   },
   {
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](../../module_guides/indexing/lpg_index_guide.md)."
+    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](/../../module_guides/indexing/lpg_index_guide)."
    ]
   }
  ],

--- a/docs/docs/examples/property_graph/property_graph_kuzu.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_kuzu.ipynb
@@ -423,7 +423,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](../../module_guides/indexing/lpg_index_guide.md)."
+    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](/../../module_guides/indexing/lpg_index_guide)."
    ]
   }
  ],

--- a/docs/docs/examples/property_graph/property_graph_memgraph.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_memgraph.ipynb
@@ -243,7 +243,7 @@
    "source": [
     "If you have an existing graph (either created with LlamaIndex or otherwise), we can connect to and use it!\n",
     "\n",
-    "**NOTE:** If your graph was created outside of LlamaIndex, the most useful retrievers will be [text to cypher](../../module_guides/indexing/lpg_index_guide.md#texttocypherretriever) or [cypher templates](../../module_guides/indexing/lpg_index_guide.md#cyphertemplateretriever). Other retrievers rely on properties that LlamaIndex inserts."
+    "**NOTE:** If your graph was created outside of LlamaIndex, the most useful retrievers will be [text to cypher](/../../module_guides/indexing/lpg_index_guide#texttocypherretriever) or [cypher templates](/../../module_guides/indexing/lpg_index_guide#cyphertemplateretriever). Other retrievers rely on properties that LlamaIndex inserts."
    ]
   },
   {

--- a/docs/docs/examples/property_graph/property_graph_neo4j.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_neo4j.ipynb
@@ -259,7 +259,7 @@
     "\n",
     "If you have an existing graph (either created with LlamaIndex or otherwise), we can connect to and use it!\n",
     "\n",
-    "**NOTE:** If your graph was created outside of LlamaIndex, the most useful retrievers will be [text to cypher](../../module_guides/indexing/lpg_index_guide.md#texttocypherretriever) or [cypher templates](../../module_guides/indexing/lpg_index_guide.md#cyphertemplateretriever). Other retrievers rely on properties that LlamaIndex inserts."
+    "**NOTE:** If your graph was created outside of LlamaIndex, the most useful retrievers will be [text to cypher](/../../module_guides/indexing/lpg_index_guide#texttocypherretriever) or [cypher templates](/../../module_guides/indexing/lpg_index_guide#cyphertemplateretriever). Other retrievers rely on properties that LlamaIndex inserts."
    ]
   },
   {
@@ -329,7 +329,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](../../module_guides/indexing/lpg_index_guide.md)."
+    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](/../../module_guides/indexing/lpg_index_guide)."
    ]
   }
  ],

--- a/docs/docs/examples/property_graph/property_graph_tidb.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_tidb.ipynb
@@ -290,7 +290,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](../../module_guides/indexing/lpg_index_guide.md)."
+    "For full details on construction, retrieval, querying of a property graph, see the [full docs page](/../../module_guides/indexing/lpg_index_guide)."
    ]
   }
  ],

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["poetry-core"]
 [tool.poetry]
 authors = ["Laurie Voss <github@seldo.com>"]
 description = ""
-name = "scripts"
+name = "docs"
 readme = "README.md"
 version = "0.1.0"
 


### PR DESCRIPTION
# Description

It looks like mkdocs doesn't update link correctly when building notebook files that ref relative URLs. Workaround by adjusting the build URLs.

Tested by building locally and serving.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
