### PR TITLE
feat[confluence]: Permit passing params to Confluence client

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/README.md
@@ -68,7 +68,11 @@ base_url = "https://yoursite.atlassian.com/wiki"
 page_ids = ["<page_id_1>", "<page_id_2>", "<page_id_3"]
 space_key = "<space_key>"
 
-reader = ConfluenceReader(base_url=base_url, oauth2=oauth2_dict)
+reader = ConfluenceReader(
+    base_url=base_url,
+    oauth2=oauth2_dict,
+    client_args={"backoff_and_retry": True},
+)
 documents = reader.load_data(
     space_key=space_key, include_attachments=True, page_status="current"
 )

--- a/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
@@ -33,6 +33,7 @@ class ConfluenceReader(BaseReader):
         api_token (str): Confluence API token, see https://confluence.atlassian.com/cloud/api-tokens-938839638.html
         user_name (str): Confluence username, used for basic auth. Must be used with `password`.
         password (str): Confluence password, used for basic auth. Must be used with `user_name`.
+        client_args (dict): Additional keyword arguments to pass directly to the Atlassian Confluence client constructor, for example `{'backoff_and_retry': True}`.
 
     """
 
@@ -44,6 +45,7 @@ class ConfluenceReader(BaseReader):
         api_token: Optional[str] = None,
         user_name: Optional[str] = None,
         password: Optional[str] = None,
+        client_args: Optional[dict] = None,
     ) -> None:
         if base_url is None:
             raise ValueError("Must provide `base_url`")
@@ -58,20 +60,30 @@ class ConfluenceReader(BaseReader):
                 " atlassian-python-api`"
             )
         self.confluence: Confluence = None
+        if client_args is None:
+            client_args = {}
         if oauth2:
-            self.confluence = Confluence(url=base_url, oauth2=oauth2, cloud=cloud)
+            self.confluence = Confluence(
+                url=base_url, oauth2=oauth2, cloud=cloud, **client_args
+            )
         else:
             if api_token is not None:
-                self.confluence = Confluence(url=base_url, token=api_token, cloud=cloud)
+                self.confluence = Confluence(
+                    url=base_url, token=api_token, cloud=cloud, **client_args
+                )
             elif user_name is not None and password is not None:
                 self.confluence = Confluence(
-                    url=base_url, username=user_name, password=password, cloud=cloud
+                    url=base_url,
+                    username=user_name,
+                    password=password,
+                    cloud=cloud,
+                    **client_args,
                 )
             else:
                 api_token = os.getenv(CONFLUENCE_API_TOKEN)
                 if api_token is not None:
                     self.confluence = Confluence(
-                        url=base_url, token=api_token, cloud=cloud
+                        url=base_url, token=api_token, cloud=cloud, **client_args
                     )
                 else:
                     user_name = os.getenv(CONFLUENCE_USERNAME)
@@ -82,6 +94,7 @@ class ConfluenceReader(BaseReader):
                             username=user_name,
                             password=password,
                             cloud=cloud,
+                            **client_args,
                         )
                     else:
                         raise ValueError(

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["zywilliamli"]
 name = "llama-index-readers-confluence"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from llama_index.readers.confluence import ConfluenceReader
 
@@ -29,6 +31,22 @@ def test_confluence_reader_with_api_token():
         api_token="example_api_token",
     )
     assert reader.confluence is not None
+
+
+def test_confluence_reader_with_client_args():
+    with patch("atlassian.Confluence") as MockConstructor:
+        reader = ConfluenceReader(
+            base_url="https://example.atlassian.net/wiki",
+            api_token="example_api_token",
+            client_args={"backoff_and_retry": True},
+        )
+        assert reader.confluence is not None
+        MockConstructor.assert_called_once_with(
+            url="https://example.atlassian.net/wiki",
+            token="example_api_token",
+            cloud=True,
+            backoff_and_retry=True,
+        )
 
 
 def test_confluence_reader_with_basic_auth():


### PR DESCRIPTION
- This enables use of parameters such as backoff_and_retry which is important for the client to react well to rate limit (429) responses, as described in
https://developer.atlassian.com/cloud/confluence/rate-limiting/ For available parameters, refer also to:
https://github.com/atlassian-api/atlassian-python-api/blob/3.41.16/atlassian/rest_client.py#L48

# Description

The LlamaIndex Confluence reader doesn't today permit devs to make use of many of the parameters that the underlying Atlassian Confluence Python client supports. For example, timeout, backoff_and_retry, max_backoff_seconds, and such. This change adds a `client_args` parameter to enable that.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
