### PR TITLE
feat: Resolving UserWarning about llama-index-llms-dashscope

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-dashscope/llama_index/llms/dashscope/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-dashscope/llama_index/llms/dashscope/base.py
@@ -2,6 +2,7 @@
 
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Sequence, Tuple
+from pydantic import ConfigDict
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -120,6 +121,12 @@ class DashScope(CustomLLM):
         print(response.text)
         ```
     """
+
+
+    """ In Pydantic V2, protected_namespaces is a configuration option used to prevent certain namespace keywords
+      (such as model_, etc.) from being used as field names. so we need to disable it here.
+    """
+    model_config = ConfigDict(protected_namespaces=())
 
     model_name: str = Field(
         default=DashScopeGenerationModels.QWEN_MAX,

--- a/llama-index-integrations/llms/llama-index-llms-dashscope/llama_index/llms/dashscope/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-dashscope/llama_index/llms/dashscope/base.py
@@ -122,7 +122,6 @@ class DashScope(CustomLLM):
         ```
     """
 
-
     """ In Pydantic V2, protected_namespaces is a configuration option used to prevent certain namespace keywords
       (such as model_, etc.) from being used as field names. so we need to disable it here.
     """

--- a/llama-index-integrations/llms/llama-index-llms-dashscope/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-dashscope/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-dashscope"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"


### PR DESCRIPTION
In Pydantic V2, protected_namespaces is a configuration option used to prevent certain namespace keywords
          (such as model_, etc.) from being used as field names. so we need to disable it here.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
