### PR TITLE
api_key typo in llama-cloud-index

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
@@ -369,7 +369,7 @@ class LlamaCloudIndex(BaseManagedIndex):
         return LlamaCloudRetriever(
             project_id=self.project.id,
             pipeline_id=self.pipeline.id,
-            aoi_key=self._api_key,
+            api_key=self._api_key,
             base_url=self._base_url,
             app_url=self._app_url,
             timeout=self._timeout,


### PR DESCRIPTION
Typo fix, aoi_key != api_key