### PR TITLE
add get_nodes to pinecone

### DIFF
--- a/docs/docs/examples/vector_stores/PineconeIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/PineconeIndexDemo.ipynb
@@ -31,17 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index-vector-stores-pinecone"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6807106d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install llama-index>=0.9.31 pinecone-client>=3.0.0"
+    "%pip install llama-index llama-index-vector-stores-pinecone"
    ]
   },
   {
@@ -84,10 +74,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.environ[\n",
-    "    \"PINECONE_API_KEY\"\n",
-    "] = \"<Your Pinecone API key, from app.pinecone.io>\"\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"\n",
+    "os.environ[\"PINECONE_API_KEY\"] = \"...\"\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\"\n",
     "\n",
     "api_key = os.environ[\"PINECONE_API_KEY\"]\n",
     "\n",
@@ -118,7 +106,7 @@
     "    name=\"quickstart\",\n",
     "    dimension=1536,\n",
     "    metric=\"euclidean\",\n",
-    "    spec=ServerlessSpec(cloud=\"aws\", region=\"us-west-2\"),\n",
+    "    spec=ServerlessSpec(cloud=\"aws\", region=\"us-east-1\"),\n",
     ")\n",
     "\n",
     "# If you need to create a PodBased Pinecone index, you could alternatively do this:\n",
@@ -183,27 +171,7 @@
    "execution_count": null,
    "id": "5104674e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Will not apply HSTS. The HSTS database must be a regular and non-world-writable file.\n",
-      "ERROR: could not open HSTS store at '/home/loganm/.wget-hsts'. HSTS will be disabled.\n",
-      "--2024-01-16 11:56:25--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
-      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.111.133, 185.199.110.133, ...\n",
-      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 75042 (73K) [text/plain]\n",
-      "Saving to: ‘data/paul_graham/paul_graham_essay.txt’\n",
-      "\n",
-      "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.04s   \n",
-      "\n",
-      "2024-01-16 11:56:25 (1.79 MB/s) - ‘data/paul_graham/paul_graham_essay.txt’ saved [75042/75042]\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!mkdir -p 'data/paul_graham/'\n",
     "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
@@ -225,30 +193,7 @@
    "execution_count": null,
    "id": "ba1558b3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
-      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b9ce8a4615fe4162be2eaa2a5573f948",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Upserted vectors:   0%|          | 0/22 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# initialize without metadata filter\n",
     "from llama_index.core import StorageContext\n",
@@ -317,6 +262,101 @@
    ],
    "source": [
     "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3a0de01",
+   "metadata": {},
+   "source": [
+    "## Filtering\n",
+    "\n",
+    "You can also fetch a list of nodes directly with filters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53546a8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.vector_stores.types import (\n",
+    "    MetadataFilter,\n",
+    "    MetadataFilters,\n",
+    "    FilterOperator,\n",
+    "    FilterCondition,\n",
+    ")\n",
+    "\n",
+    "filter = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(\n",
+    "            key=\"file_path\",\n",
+    "            value=\"/Users/loganmarkewich/giant_change/llama_index/docs/docs/examples/vector_stores/data/paul_graham/paul_graham_essay.txt\",\n",
+    "            operator=FilterOperator.EQ,\n",
+    "        )\n",
+    "    ],\n",
+    "    condition=FilterCondition.AND,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9551a4dd",
+   "metadata": {},
+   "source": [
+    "You can fetch nodes directly with the filters. The below will return all nodes that match the filter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "035e17f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "22\n"
+     ]
+    }
+   ],
+   "source": [
+    "nodes = vector_store.get_nodes(filters=filter, limit=100)\n",
+    "print(len(nodes))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2811d766",
+   "metadata": {},
+   "source": [
+    "You can also fetch using top-k and filters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e8a5014",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/embeddings \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "query_engine = index.as_query_engine(similarity_top_k=2, filters=filter)\n",
+    "response = query_engine.query(\"What did the author do growing up?\")\n",
+    "print(len(response.source_nodes))"
    ]
   }
  ],

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/llama_index/vector_stores/pinecone/base.py
@@ -366,6 +366,38 @@ class PineconeVectorStore(BasePydanticVectorStore):
         )
         return ids
 
+    def get_nodes(
+        self,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[List[MetadataFilters]] = None,
+        limit: int = 100,
+    ) -> List[BaseNode]:
+        filter = None
+        if filters is not None:
+            filter = _to_pinecone_filter(filters)
+
+        if node_ids is not None:
+            raise ValueError(
+                "Getting nodes by node id not supported by Pinecone at the time of writing."
+            )
+
+        if node_ids is None and filters is None:
+            raise ValueError("Filters must be specified")
+
+        # Pinecone requires a query vector, so default to 0s if not provided
+        query_vector = [0.0] * self._pinecone_index.describe_index_stats()["dimension"]
+
+        response = self._pinecone_index.query(
+            top_k=limit,
+            vector=query_vector,
+            namespace=self.namespace,
+            filter=filter,
+            include_values=True,
+            include_metadata=True,
+        )
+
+        return [metadata_dict_to_node(match.metadata) for match in response.matches]
+
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """
         Delete nodes using with ref_doc_id.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-pinecone"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
Added `get_nodes()` method to pinecone

Since pinecone does not support fetching entire objects by ID, this is not supported. You can call `get_nodes()` with filters though

Updated the notebook example to show how it works.