### PR TITLE
Add stream_chat and conditionally set AutoModelClass to MllamaForConditionalGeneration

### DIFF
--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/llama_index/multi_modal_llms/huggingface/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/llama_index/multi_modal_llms/huggingface/base.py
@@ -19,6 +19,7 @@ from transformers import (
     AutoConfig,
     Qwen2VLForConditionalGeneration,
     PaliGemmaForConditionalGeneration,
+    MllamaForConditionalGeneration
 )
 from qwen_vl_utils import (
     process_vision_info,
@@ -93,6 +94,8 @@ class HuggingFaceMultiModal(MultiModalLLM):
                 AutoModelClass = Qwen2VLForConditionalGeneration
             if "PaliGemmaForConditionalGeneration" in architecture:
                 AutoModelClass = PaliGemmaForConditionalGeneration
+            if "MllamaForConditionalGeneration" in architecture:
+                AutoModelClass = MllamaForConditionalGeneration
 
             # Load the model based on the architecture
             self._model = AutoModelClass.from_pretrained(
@@ -173,6 +176,13 @@ class HuggingFaceMultiModal(MultiModalLLM):
         )
 
     async def astream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        raise NotImplementedError(
+            "HuggingFaceMultiModal does not support async streaming chat yet."
+        )
+
+    async def stream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
         raise NotImplementedError(

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/llama_index/multi_modal_llms/huggingface/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/llama_index/multi_modal_llms/huggingface/base.py
@@ -19,7 +19,7 @@ from transformers import (
     AutoConfig,
     Qwen2VLForConditionalGeneration,
     PaliGemmaForConditionalGeneration,
-    MllamaForConditionalGeneration
+    MllamaForConditionalGeneration,
 )
 from qwen_vl_utils import (
     process_vision_info,
@@ -186,7 +186,7 @@ class HuggingFaceMultiModal(MultiModalLLM):
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
         raise NotImplementedError(
-            "HuggingFaceMultiModal does not support async streaming chat yet."
+            "HuggingFaceMultiModal does not support streaming chat yet."
         )
 
     async def astream_complete(

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-multi-modal-llms-huggingface"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Adding a definition for `stream_chat` fixed this error: `TypeError: Can't instantiate abstract class LlamaMultiModal with abstract method stream_chat`

Setting `AutoModelClass = MllamaForConditionalGeneration` means model weights init on the GPU instead of the CPU, which massively speeds up model load time