### PR TITLE
improve traceback logging for workflows

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/dispatcher.py
+++ b/llama-index-core/llama_index/core/instrumentation/dispatcher.py
@@ -277,6 +277,8 @@ class Dispatcher(BaseModel):
                 instance: Any,
                 context: Context,
             ) -> None:
+                from llama_index.core.workflow.errors import WorkflowCancelledByUser
+
                 try:
                     exception = future.exception()
                     if exception is not None:
@@ -290,6 +292,14 @@ class Dispatcher(BaseModel):
                         result=result,
                     )
                     return result
+                except WorkflowCancelledByUser:
+                    self.span_exit(
+                        id_=span_id,
+                        bound_args=bound_args,
+                        instance=instance,
+                        result=None,
+                    )
+                    return None
                 except BaseException as e:
                     self.event(SpanDropEvent(span_id=span_id, err_str=str(e)))
                     self.span_drop(

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -230,14 +230,18 @@ class Workflow(metaclass=WorkflowMeta):
                                 break  # exit the retrying loop
                             except Exception as e:
                                 if config.retry_policy is None:
-                                    raise e from None
+                                    raise WorkflowRuntimeError(
+                                        f"Error in step '{name}': {e!s}"
+                                    ) from e
 
                                 delay = config.retry_policy.next(
                                     retry_start_at + time.time(), attempts, e
                                 )
                                 if delay is None:
                                     # We're done retrying
-                                    raise e from None
+                                    raise WorkflowRuntimeError(
+                                        f"Error in step '{name}': {e!s}"
+                                    ) from e
 
                                 attempts += 1
                                 if self._verbose:
@@ -247,10 +251,15 @@ class Workflow(metaclass=WorkflowMeta):
                                 await asyncio.sleep(delay)
 
                     else:
-                        run_task = functools.partial(instrumented_step, **kwargs)
-                        new_ev = await asyncio.get_event_loop().run_in_executor(
-                            None, run_task
-                        )
+                        try:
+                            run_task = functools.partial(instrumented_step, **kwargs)
+                            new_ev = await asyncio.get_event_loop().run_in_executor(
+                                None, run_task
+                            )
+                        except Exception as e:
+                            raise WorkflowRuntimeError(
+                                f"Error in step '{name}': {e!s}"
+                            ) from e
 
                     if self._verbose and name != "_done":
                         if new_ev is not None:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-nebius"
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
-llama-index-core = "^0.11.0"
+python = ">=3.9,<4.0"
+llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/llms/llama-index-llms-nebius/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/pyproject.toml
@@ -27,12 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-nebius"
 readme = "README.md"
-version = "0.0.1"
+version = "0.1.0"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
-llama-index-llms-openai-like = "^0.2.0"
-llama-index-core = "^0.11.0"
+python = ">=3.9,<4.0"
+llama-index-llms-openai-like = "^0.3.0"
+llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
This PR fixes two major annoyances
1. Exceptions in workflows had their actual tracebacks/code-paths swallowed. While the error was the same, the code path pointed to our dispatcher. This change fixes that
2. When `cancel_run()` is used, there is a scary looking tracback printed from the dispatcher. This PR removes that