### PR TITLE
[fix] Handling of WorkflowDone exception

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -228,6 +228,8 @@ class Workflow(metaclass=WorkflowMeta):
                             try:
                                 new_ev = await instrumented_step(**kwargs)
                                 break  # exit the retrying loop
+                            except WorkflowDone:
+                                raise
                             except Exception as e:
                                 if config.retry_policy is None:
                                     raise WorkflowRuntimeError(
@@ -256,6 +258,8 @@ class Workflow(metaclass=WorkflowMeta):
                             new_ev = await asyncio.get_event_loop().run_in_executor(
                                 None, run_task
                             )
+                        except WorkflowDone:
+                            raise
                         except Exception as e:
                             raise WorkflowRuntimeError(
                                 f"Error in step '{name}': {e!s}"

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -66,7 +66,9 @@ async def test_task_raised():
             assert ev.test_param == "foo"
 
     # Make sure the await actually caught the exception
-    with pytest.raises(ValueError, match="The step raised an error!"):
+    with pytest.raises(
+        WorkflowRuntimeError, match="Error in step 'step': The step raised an error!"
+    ):
         await r
 
 

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -406,7 +406,9 @@ async def test_workflow_task_raises():
             raise ValueError("The step raised an error!")
 
     workflow = DummyWorkflow()
-    with pytest.raises(ValueError, match="The step raised an error!"):
+    with pytest.raises(
+        WorkflowRuntimeError, match="Error in step 'step': The step raised an error!"
+    ):
         await workflow.run()
 
 
@@ -418,7 +420,9 @@ async def test_workflow_task_raises_step():
             raise ValueError("The step raised an error!")
 
     workflow = DummyWorkflow()
-    with pytest.raises(ValueError, match="The step raised an error!"):
+    with pytest.raises(
+        WorkflowRuntimeError, match="Error in step 'step': The step raised an error!"
+    ):
         handler = workflow.run(stepwise=True)
         await handler.run_step()
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/pyproject.toml
@@ -27,11 +27,12 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-nebius"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.12.0"
+llama-index-embeddings-openai = "^0.3.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"


### PR DESCRIPTION
# Description

#17043 introduced a bug in our `Workflow` execution by wrapping `WorkflowDone` exceptions with a `WorkflowRuntimeError`. This PR handles such exceptions as required for successful workflow execution. Tests that assert error's raised are also adjusted to match the new `WorkflowRuntimeError`.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests
