### PR TITLE
Add property graph Memgraph jupyter notebook example to the docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -531,6 +531,7 @@ nav:
           - ./examples/property_graph/property_graph_basic.ipynb
           - ./examples/property_graph/property_graph_custom_retriever.ipynb
           - ./examples/property_graph/property_graph_neo4j.ipynb
+          - ./examples/property_graph/property_graph_memgraph.ipynb
       - Query Engines:
           - ./examples/query_engine/CustomRetrievers.ipynb
           - ./examples/query_engine/JSONalyze_query_engine.ipynb


### PR DESCRIPTION
# Description

I noticed the property graph [Memgraph jupyter notebook](https://docs.llamaindex.ai/en/stable/examples/property_graph/property_graph_memgraph/) example wasn't showing up in the docs, even though it's available directly via URL so I included a quick fix for that. 

## Type of Change

Please delete options that are not relevant.

- [x] documentation update
