### PR TITLE
Fix box api - mypy breakage

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
@@ -18,11 +18,6 @@ from box_sdk_gen import (
     SearchResults,
 )
 
-# from llama_index.readers.box.BoxAPI.box_ai_extract_beta import (
-#     AiExtractManager,
-#     CreateAiExtractItems,
-# )
-
 logger = logging.getLogger(__name__)
 
 
@@ -387,18 +382,8 @@ def search_files(
     recent_updater_user_ids: Optional[List[str]] = None,
     ancestor_folder_ids: Optional[List[str]] = None,
     content_types: Optional[List[SearchForContentContentTypes]] = None,
-    # type: Optional[SearchForContentType] = None,
-    # trash_content: Optional[SearchForContentTrashContent] = None,
-    # mdfilters: Optional[List[MetadataFilter]] = None,
-    # sort: Optional[SearchForContentSort] = None,
-    # direction: Optional[SearchForContentDirection] = None,
     limit: Optional[int] = None,
-    # include_recent_shared_links: Optional[bool] = None,
-    # fields: Optional[List[str]] = None,
     offset: Optional[int] = None,
-    # deleted_user_ids: Optional[List[str]] = None,
-    # deleted_at_range: Optional[List[str]] = None,
-    # extra_headers: Optional[Dict[str, Optional[str]]] = None,
 ) -> List[File]:
     """
     Searches for files in Box based on a query string.
@@ -444,11 +429,8 @@ def search_files_by_metadata(
     ancestor_folder_id: str,
     query: Optional[str] = None,
     query_params: Optional[Dict[str, str]] = None,
-    # order_by: Optional[List[SearchByMetadataQueryOrderBy]] = None,
     limit: Optional[int] = None,
     marker: Optional[str] = None,
-    # fields: Optional[List[str]] = None,
-    # extra_headers: Optional[Dict[str, Optional[str]]] = None,
 ) -> List[File]:
     """
     Searches for files in Box based on metadata filters.
@@ -477,9 +459,6 @@ def search_files_by_metadata(
     except BoxAPIError as e:
         logger.error(f"An error occurred while searching for files: {e}", exc_info=True)
         return []
-
-    # return only files from the entries
-    return [file for file in search_results.entries if file.type == "file"]
 
     # return only files from the entries
     return [file for file in search_results.entries if file.type == "file"]

--- a/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
@@ -37,7 +37,7 @@ maintainers = [
 name = "llama-index-readers-box"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

The current box API comments mess with mypy's interpretter.

site-packages/llama_index/readers/box/BoxAPI/box_api.py:389: error: Function has duplicate type signatures

Tested by re-running mypy locally with the modified files.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
