### PR TITLE
Update upstage solar pro model tokenizer

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-upstage/llama_index/llms/upstage/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-upstage/llama_index/llms/upstage/utils.py
@@ -17,7 +17,7 @@ DOC_PARSING_MODELS = ["solar-pro"]
 ALL_AVAILABLE_MODELS = {**CHAT_MODELS}
 
 SOLAR_TOKENIZERS = {
-    "solar-pro": "upstage/solar-pro-preview-tokenizer",
+    "solar-pro": "upstage/solar-pro-tokenizer",
     "solar-1-mini-chat": "upstage/solar-1-mini-tokenizer",
     "solar-docvision": "upstage/solar-docvision-preview-tokenizer",
 }

--- a/llama-index-integrations/llms/llama-index-llms-upstage/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-upstage/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-llms-upstage"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR updates the tokenizer for the upstage `solar-pro` model ([api ref](https://console.upstage.ai/docs/capabilities/chat)) from `upstage/solar-pro-preview-tokenizer` to `upstage/solar-pro-tokenizer` ([huggingface link](https://huggingface.co/upstage/solar-pro-tokenizer)).

The solar-pro model has officially launched, transitioning from the preview version to the official version. Accordingly, this change replaces the preview tokenizer with the tokenizer specifically designed for the official release.


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
