### PR TITLE
Remove unused `store_checkpoints` var in tests and example notebook

### DIFF
--- a/docs/docs/examples/workflow/checkpointing_workflows.ipynb
+++ b/docs/docs/examples/workflow/checkpointing_workflows.ipynb
@@ -138,7 +138,6 @@
    "source": [
     "handler = wflow_ckptr.run(\n",
     "    topic=\"chemistry\",\n",
-    "    store_checkpoints=True,\n",
     ")\n",
     "await handler"
    ]
@@ -506,9 +505,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llama-index-core",
+   "display_name": "llama-index-core-nrCJU7vQ-py3.10",
    "language": "python",
-   "name": "llama-index-core"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/docs/examples/workflow/parallel_execution.ipynb
+++ b/docs/docs/examples/workflow/parallel_execution.ipynb
@@ -363,7 +363,6 @@
    ],
    "source": [
     "ckpt = wflow_ckptr.checkpoints[run_id][0]\n",
-    "ckpt\n",
     "handler = wflow_ckptr.run_from(ckpt)\n",
     "await handler"
    ]
@@ -450,7 +449,6 @@
     "ckpt = wflow_ckptr.checkpoints[first_run_id][\n",
     "    1\n",
     "]  # checkpoint after the second \"process_data\" step\n",
-    "ckpt\n",
     "handler = wflow_ckptr.run_from(ckpt)\n",
     "await handler"
    ]
@@ -502,7 +500,6 @@
     "ckpt = wflow_ckptr.checkpoints[first_run_id][\n",
     "    2\n",
     "]  # checkpoint after the third \"process_data\" step\n",
-    "ckpt\n",
     "handler = wflow_ckptr.run_from(ckpt)\n",
     "await handler"
    ]

--- a/llama-index-core/tests/workflow/test_checkpointer.py
+++ b/llama-index-core/tests/workflow/test_checkpointer.py
@@ -72,7 +72,7 @@ async def test_checkpoints_after_successive_runs(
 async def test_filter_checkpoints(workflow_checkpointer: WorkflowCheckpointer):
     num_runs = 2
     for _ in range(num_runs):
-        handler: WorkflowHandler = workflow_checkpointer.run(store_checkpoints=True)
+        handler: WorkflowHandler = workflow_checkpointer.run()
         await handler
 
     # filter by last complete step
@@ -139,7 +139,7 @@ async def test_checkpoints_works_with_new_instances_concurrently(
 async def test_run_from_checkpoint(workflow_checkpointer: WorkflowCheckpointer):
     num_steps = len(workflow_checkpointer.workflow._get_steps())
     num_ckpts_in_single_run = num_steps - 1
-    handler: WorkflowHandler = workflow_checkpointer.run(store_checkpoints=True)
+    handler: WorkflowHandler = workflow_checkpointer.run()
     await handler
 
     assert len(workflow_checkpointer.checkpoints) == 1


### PR DESCRIPTION
# Description

The `store_checkpoint` param was used for an older candidate design of workflow checkpointing -- specifically when checkpointing responsibilities was housed under `Workflow`. With `WorkflowCheckpointer` the act of wrapping a workflow with this object already is explicit enough to indicate the user wants to checkpoint a workflow and thus the `store_checkpoint` param was removed.

This PR removes instances where this param was mistakenly retained into the merged design.

Fixes # (issue)

## New Package?


## Type of Change

Please delete options that are not relevant.

- [x] chore

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests
