### PR TITLE
fix: wrong project id variable in LlamaCloudRetriever

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
@@ -162,7 +162,7 @@ class LlamaCloudRetriever(BaseRetriever):
                     client=self._client,
                     file_id=raw_image_node.node.file_id,
                     page_index=raw_image_node.node.page_index,
-                    project_id=self.project_id,
+                    project_id=self.project.id,
                 )
                 # Convert image bytes to base64 encoded string
                 image_base64 = base64.b64encode(image_bytes).decode("utf-8")
@@ -187,7 +187,7 @@ class LlamaCloudRetriever(BaseRetriever):
                     client=self._aclient,
                     file_id=raw_image_node.node.file_id,
                     page_index=raw_image_node.node.page_index,
-                    project_id=self.project_id,
+                    project_id=self.project.id,
                 )
                 for raw_image_node in raw_image_nodes
             ]


### PR DESCRIPTION
# Description

The `self.project_id` is no longer exist.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
