### PR TITLE
fix: Broken links in documentation

### DIFF
--- a/docs/docs/module_guides/deploying/agents/index.md
+++ b/docs/docs/module_guides/deploying/agents/index.md
@@ -26,7 +26,7 @@ The reasoning loop depends on the type of agent. We have support for the followi
 
 ### Tool Abstractions
 
-You can learn more about our Tool abstractions in our [Tools section](tools/index.md).
+You can learn more about our Tool abstractions in our [Tools section](./tools.md).
 
 ### Blog Post
 
@@ -66,4 +66,4 @@ Learn more about our different agent types and use cases in our [module guides](
 
 We also have a [lower-level api guide](./agent_runner.md) for agent runenrs and workers.
 
-Also take a look at our [tools section](tools/index.md)!
+Also take a look at our [tools section](./tools.md)!

--- a/docs/docs/module_guides/deploying/agents/modules.md
+++ b/docs/docs/module_guides/deploying/agents/modules.md
@@ -2,7 +2,7 @@
 
 These guide provide an overview of how to use our agent classes.
 
-For more detailed guides on how to use specific tools, check out our [tools module guides](tools/index.md).
+For more detailed guides on how to use specific tools, check out our [tools module guides](./tools.md).
 
 ## Agent with OpenAI Models
 

--- a/docs/docs/use_cases/agents.md
+++ b/docs/docs/use_cases/agents.md
@@ -50,7 +50,7 @@ LlamaIndex Workflows allow you to build very custom, agentic workflows through a
 - [Workflows Tutorial Sequence](../understanding/workflows/index.md)
 - [Workflows Component Guide](../module_guides/workflow/index.md)
 - [Building a ReAct agent workflow](../examples/workflow/react_agent.ipynb)
-- [Deploying Workflows](../module_guides/workflow/deployment.md)
+- [Deploying Workflows](../module_guides/workflow/index.md#deploying-a-workflow)
 
 **Building with Agentic Ingredients**
 


### PR DESCRIPTION
Tools link, Deploying workflows links is broken in documentation. This patch fixes those.


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
