### PR TITLE
Make Weaviate Vector Store integration support nested metadata filtering

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -75,6 +75,9 @@ def _to_weaviate_filter(
 
     if standard_filters.filters:
         for filter in standard_filters.filters:
+            if isinstance(filter, MetadataFilters):
+                filters_list.append(_to_weaviate_filter(filter))
+                continue
             filters_list.append(
                 getattr(
                     wvc.query.Filter.by_property(filter.key),

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
 readme = "README.md"
-version = "1.2.0"
+version = "1.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -1,10 +1,20 @@
 import weaviate
 import pytest
 
-from llama_index.core.vector_stores.types import BasePydanticVectorStore
+
 from llama_index.core.schema import TextNode
-from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode
 from llama_index.vector_stores.weaviate import WeaviateVectorStore
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    FilterCondition,
+    FilterOperator,
+    MetadataFilters,
+    MetadataFilter,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+)
+from llama_index.vector_stores.weaviate.base import _to_weaviate_filter
+from weaviate.collections.classes.filters import _FilterOr, _FilterAnd
 
 
 def test_class():
@@ -76,3 +86,113 @@ def test_query_kwargs(vector_store):
         max_vector_distance=0.0,
     )
     assert len(results.nodes) == 0
+
+
+def test_to_weaviate_filter_with_various_operators():
+    filters = MetadataFilters(filters=[MetadataFilter(key="a", value=1)])
+    filter = _to_weaviate_filter(filters)
+    assert filter.target == 'a'
+    assert filter.operator == 'Equal'
+    assert filter.value == 1
+
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.NE)]
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.target == 'a'
+    assert filter.operator == 'NotEqual'
+    assert filter.value == 1
+
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.GT)]
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.target == 'a'
+    assert filter.operator == 'GreaterThan'
+    assert filter.value == 1
+
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.GTE)]
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.target == 'a'
+    assert filter.operator == 'GreaterThanEqual'
+    assert filter.value == 1
+
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.LT)]
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.target == 'a'
+    assert filter.operator == 'LessThan'
+    assert filter.value == 1
+
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.LTE)]
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.target == 'a'
+    assert filter.operator == 'LessThanEqual'
+    assert filter.value == 1
+
+
+def test_to_weaviate_filter_with_multiple_filters():
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="a", value=1, operator=FilterOperator.GTE),
+            MetadataFilter(key="a", value=10, operator=FilterOperator.LTE),
+        ],
+        condition=FilterCondition.AND,
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.operator == 'And'
+    assert len(filter.filters) == 2
+    assert filter.filters[0].target == 'a'
+    assert filter.filters[0].operator == 'GreaterThanEqual'
+    assert filter.filters[0].value == 1
+    assert filter.filters[1].target == 'a'
+    assert filter.filters[1].operator == 'LessThanEqual'
+    assert filter.filters[1].value == 10
+
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="a", value=1, operator=FilterOperator.LT),
+            MetadataFilter(key="a", value=10, operator=FilterOperator.GT),
+        ],
+        condition=FilterCondition.OR,
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.operator == 'Or'
+    assert len(filter.filters) == 2
+    assert filter.filters[0].target == 'a'
+    assert filter.filters[0].operator == 'LessThan'
+    assert filter.filters[0].value == 1
+    assert filter.filters[1].target == 'a'
+    assert filter.filters[1].operator == 'GreaterThan'
+    assert filter.filters[1].value == 10
+
+
+def test_to_weaviate_filter_with_nested_filters():
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="a", value=1, operator=FilterOperator.EQ),
+            MetadataFilters(
+                filters=[
+                    MetadataFilter(key="b", value=2, operator=FilterOperator.EQ),
+                    MetadataFilter(key="c", value=3, operator=FilterOperator.GT),
+                ],
+                condition=FilterCondition.OR,
+            ),
+        ],
+        condition=FilterCondition.AND,
+    )
+    filter = _to_weaviate_filter(filters)
+    print(f'{filter=}')
+    assert filter.operator == 'And'
+    assert len(filter.filters) == 2
+    assert filter.filters[0].operator == 'Equal'
+    assert filter.filters[1].operator == 'Or'
+    or_filters = filter.filters[1].filters
+    assert len(or_filters) == 2
+    assert or_filters[0].operator == 'Equal'
+    assert or_filters[1].operator == 'GreaterThan'

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -184,7 +184,6 @@ def test_to_weaviate_filter_with_nested_filters():
         condition=FilterCondition.AND,
     )
     filter = _to_weaviate_filter(filters)
-    print(f"{filter=}")
     assert filter.operator == "And"
     assert len(filter.filters) == 2
     assert filter.filters[0].operator == "Equal"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -1,7 +1,5 @@
 import weaviate
 import pytest
-
-
 from llama_index.core.schema import TextNode
 from llama_index.vector_stores.weaviate import WeaviateVectorStore
 from llama_index.core.vector_stores.types import (

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -186,9 +186,15 @@ def test_to_weaviate_filter_with_nested_filters():
     filter = _to_weaviate_filter(filters)
     assert filter.operator == "And"
     assert len(filter.filters) == 2
+    assert filter.filters[0].target == "a"
     assert filter.filters[0].operator == "Equal"
+    assert filter.filters[0].value == 1
     assert filter.filters[1].operator == "Or"
     or_filters = filter.filters[1].filters
     assert len(or_filters) == 2
+    assert or_filters[0].target == "b"
     assert or_filters[0].operator == "Equal"
+    assert or_filters[0].value == 2
+    assert or_filters[1].target == "c"
     assert or_filters[1].operator == "GreaterThan"
+    assert or_filters[1].value == 3

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -14,7 +14,6 @@ from llama_index.core.vector_stores.types import (
     VectorStoreQueryMode,
 )
 from llama_index.vector_stores.weaviate.base import _to_weaviate_filter
-from weaviate.collections.classes.filters import _FilterOr, _FilterAnd
 
 
 def test_class():
@@ -91,48 +90,48 @@ def test_query_kwargs(vector_store):
 def test_to_weaviate_filter_with_various_operators():
     filters = MetadataFilters(filters=[MetadataFilter(key="a", value=1)])
     filter = _to_weaviate_filter(filters)
-    assert filter.target == 'a'
-    assert filter.operator == 'Equal'
+    assert filter.target == "a"
+    assert filter.operator == "Equal"
     assert filter.value == 1
 
     filters = MetadataFilters(
         filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.NE)]
     )
     filter = _to_weaviate_filter(filters)
-    assert filter.target == 'a'
-    assert filter.operator == 'NotEqual'
+    assert filter.target == "a"
+    assert filter.operator == "NotEqual"
     assert filter.value == 1
 
     filters = MetadataFilters(
         filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.GT)]
     )
     filter = _to_weaviate_filter(filters)
-    assert filter.target == 'a'
-    assert filter.operator == 'GreaterThan'
+    assert filter.target == "a"
+    assert filter.operator == "GreaterThan"
     assert filter.value == 1
 
     filters = MetadataFilters(
         filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.GTE)]
     )
     filter = _to_weaviate_filter(filters)
-    assert filter.target == 'a'
-    assert filter.operator == 'GreaterThanEqual'
+    assert filter.target == "a"
+    assert filter.operator == "GreaterThanEqual"
     assert filter.value == 1
 
     filters = MetadataFilters(
         filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.LT)]
     )
     filter = _to_weaviate_filter(filters)
-    assert filter.target == 'a'
-    assert filter.operator == 'LessThan'
+    assert filter.target == "a"
+    assert filter.operator == "LessThan"
     assert filter.value == 1
 
     filters = MetadataFilters(
         filters=[MetadataFilter(key="a", value=1, operator=FilterOperator.LTE)]
     )
     filter = _to_weaviate_filter(filters)
-    assert filter.target == 'a'
-    assert filter.operator == 'LessThanEqual'
+    assert filter.target == "a"
+    assert filter.operator == "LessThanEqual"
     assert filter.value == 1
 
 
@@ -145,13 +144,13 @@ def test_to_weaviate_filter_with_multiple_filters():
         condition=FilterCondition.AND,
     )
     filter = _to_weaviate_filter(filters)
-    assert filter.operator == 'And'
+    assert filter.operator == "And"
     assert len(filter.filters) == 2
-    assert filter.filters[0].target == 'a'
-    assert filter.filters[0].operator == 'GreaterThanEqual'
+    assert filter.filters[0].target == "a"
+    assert filter.filters[0].operator == "GreaterThanEqual"
     assert filter.filters[0].value == 1
-    assert filter.filters[1].target == 'a'
-    assert filter.filters[1].operator == 'LessThanEqual'
+    assert filter.filters[1].target == "a"
+    assert filter.filters[1].operator == "LessThanEqual"
     assert filter.filters[1].value == 10
 
     filters = MetadataFilters(
@@ -162,13 +161,13 @@ def test_to_weaviate_filter_with_multiple_filters():
         condition=FilterCondition.OR,
     )
     filter = _to_weaviate_filter(filters)
-    assert filter.operator == 'Or'
+    assert filter.operator == "Or"
     assert len(filter.filters) == 2
-    assert filter.filters[0].target == 'a'
-    assert filter.filters[0].operator == 'LessThan'
+    assert filter.filters[0].target == "a"
+    assert filter.filters[0].operator == "LessThan"
     assert filter.filters[0].value == 1
-    assert filter.filters[1].target == 'a'
-    assert filter.filters[1].operator == 'GreaterThan'
+    assert filter.filters[1].target == "a"
+    assert filter.filters[1].operator == "GreaterThan"
     assert filter.filters[1].value == 10
 
 
@@ -187,12 +186,12 @@ def test_to_weaviate_filter_with_nested_filters():
         condition=FilterCondition.AND,
     )
     filter = _to_weaviate_filter(filters)
-    print(f'{filter=}')
-    assert filter.operator == 'And'
+    print(f"{filter=}")
+    assert filter.operator == "And"
     assert len(filter.filters) == 2
-    assert filter.filters[0].operator == 'Equal'
-    assert filter.filters[1].operator == 'Or'
+    assert filter.filters[0].operator == "Equal"
+    assert filter.filters[1].operator == "Or"
     or_filters = filter.filters[1].filters
     assert len(or_filters) == 2
-    assert or_filters[0].operator == 'Equal'
-    assert or_filters[1].operator == 'GreaterThan'
+    assert or_filters[0].operator == "Equal"
+    assert or_filters[1].operator == "GreaterThan"


### PR DESCRIPTION
# Description

Before this, the `_to_weaviate_filter` method fails when presented with nested metadata filters. This is fixed by performing the recursive call analogously to how it is implemented in other integrations (e.g. milvus, pinecone).


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
