### PR TITLE
Remove forgotten print in ChatMemoryBuffer

### DIFF
--- a/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
@@ -84,7 +84,6 @@ class ChatMemoryBuffer(BaseChatStoreMemory):
     def from_string(cls, json_str: str) -> "ChatMemoryBuffer":
         """Create a chat memory buffer from a string."""
         dict_obj = json.loads(json_str)
-        print(f"dict_obj: {dict_obj}", flush=True)
         return cls.from_dict(dict_obj)
 
     def to_dict(self, **kwargs: Any) -> dict:


### PR DESCRIPTION
# Description

This PR removes an annoying `print` call occurring occasionally in our logs:

```
dict_obj: {'chat_store': {'store': {'chat_history': ...
```

This took me some time to find where it is coming from but it seems it's left in the `ChatMemoryBuffer` code by mistake.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
