### PR TITLE
Add support for IS_EMPTY metadata filters to Weaviate Vector Store integration

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
 readme = "README.md"
-version = "1.2.1"
+version = "1.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -132,6 +132,14 @@ def test_to_weaviate_filter_with_various_operators():
     assert filter.operator == "LessThanEqual"
     assert filter.value == 1
 
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="a", value=None, operator=FilterOperator.IS_EMPTY)]
+    )
+    filter = _to_weaviate_filter(filters)
+    assert filter.target == "a"
+    assert filter.operator == "IsNull"
+    assert filter.value is True
+
 
 def test_to_weaviate_filter_with_multiple_filters():
     filters = MetadataFilters(


### PR DESCRIPTION
# Description

This allows for using the `IS_EMPTY` metadata filter also when using a Weaviate Vector Store. This filter was introduced in https://github.com/run-llama/llama_index/pull/15167 and is supposed to filter for objects for which a property is set to `null` or has an otherwise empty value. The `IsNull` operator in Weaviate is a good match to what `IS_EMPTY` is expected to do: https://weaviate.io/developers/weaviate/api/graphql/filters#by-null-state

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests
