### PR TITLE
Make Weaviate Vector Store integration work with complex properties

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -22,7 +22,6 @@ from llama_index.vector_stores.weaviate.utils import (
     add_node,
     class_schema_exists,
     create_default_schema,
-    get_all_properties,
     get_node_similarity,
     to_node,
 )
@@ -314,7 +313,6 @@ class WeaviateVectorStore(BasePydanticVectorStore):
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
         """Query index for top k most similar nodes."""
-        all_properties = get_all_properties(self._client, self.index_name)
         collection = self._client.collections.get(self.index_name)
         filters = None
 
@@ -355,7 +353,6 @@ class WeaviateVectorStore(BasePydanticVectorStore):
                 limit=limit,
                 filters=filters,
                 return_metadata=return_metatada,
-                return_properties=all_properties,
                 include_vector=True,
                 **kwargs,
             )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/utils.py
@@ -87,16 +87,6 @@ def create_default_schema(client: Any, class_name: str) -> None:
     client.collections.create_from_dict(class_schema)
 
 
-def get_all_properties(client: Any, class_name: str) -> List[str]:
-    """Get all properties of a class."""
-    validate_client(client)
-    if not client.collections.exists(class_name):
-        raise ValueError(f"{class_name} schema does not exist.")
-
-    properties = client.collections.get(class_name).config.get().properties
-    return [p.name for p in properties]
-
-
 def get_node_similarity(entry: Dict, similarity_key: str = "score") -> float:
     """Get converted node similarity from distance."""
     score = getattr(entry["metadata"], similarity_key)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
 readme = "README.md"
-version = "1.2.1"
+version = "1.2.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -1,7 +1,5 @@
 import weaviate.classes as wvc
-import pydantic
 import weaviate
-from typing import List
 import pytest
 from llama_index.core.schema import TextNode
 from llama_index.vector_stores.weaviate import WeaviateVectorStore
@@ -95,14 +93,6 @@ def test_query_kwargs(vector_store):
 
 def test_can_query_collection_with_complex_property_types(client):
     """Verifies that it is possible to query data from collections that contain complex properties (e.g. a list of nested objects in one of the properties)."""
-
-    class ArrayPropElement(pydantic.BaseModel):
-        nested_prop: str
-
-    class ComplexTypeInArrayTest(pydantic.BaseModel):
-        text: str
-        array_prop: List[ArrayPropElement]
-
     collection_name = "ComplexTypeInArrayTest"
     client.collections.delete(collection_name)
     collection = client.collections.create(
@@ -125,14 +115,11 @@ def test_can_query_collection_with_complex_property_types(client):
         ],
     )
 
-    arr = ComplexTypeInArrayTest(
-        text="Text of object containing complex properties",
-        array_prop=[ArrayPropElement(nested_prop="nested_prop content")],
-    )
-    arr_obj = arr.model_dump()
-
     collection.data.insert(
-        arr_obj,
+        {
+            "text": "Text of object containing complex properties",
+            "array_prop": [{"nested_prop": "nested_prop content"}],
+        },
         vector=[1.0, 0.0, 0.0],
     )
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -105,7 +105,6 @@ def test_can_query_collection_with_complex_property_types(client):
     client.collections.delete(collection_name)
     collection = client.collections.create(
         name=collection_name,
-        # vectorizer_config=wvc.config.Configure.Vectorizer.text2vec_contextionary(),
         properties=[
             wvc.config.Property(
                 name="text",
@@ -114,7 +113,6 @@ def test_can_query_collection_with_complex_property_types(client):
             wvc.config.Property(
                 name="array_prop",
                 data_type=wvc.config.DataType.OBJECT_ARRAY,
-                # skip_vectorization=True,
                 nested_properties=[
                     wvc.config.Property(
                         name="nested_prop",
@@ -131,19 +129,15 @@ def test_can_query_collection_with_complex_property_types(client):
     )
     arr_obj = arr.model_dump()
 
-    # collection = client.collections.get("ComplexTypeInArrayTest")
     collection.data.insert(
         arr_obj,
         vector=[1.0, 0.0, 0.0],
     )
 
-    # print(f'{collection_with_complex_properties=}')
-    # assert False
     vector_store = WeaviateVectorStore(
         weaviate_client=client,
         index_name=collection_name,
     )
-    # VectorStoreIndex.from_vector_store(vector_store)
     query = VectorStoreQuery(
         query_embedding=[1.0, 0.0, 0.0],
         similarity_top_k=2,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -22,11 +22,9 @@ def test_class():
 
 @pytest.fixture(scope="module")
 def client():
-    try:
-        client = weaviate.connect_to_embedded()
-        yield client
-    finally:
-        client.close()
+    client = weaviate.connect_to_embedded()
+    yield client
+    client.close()
 
 
 @pytest.fixture(scope="module")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -94,6 +94,8 @@ def test_query_kwargs(vector_store):
 
 
 def test_can_query_collection_with_complex_property_types(client):
+    """Verifies that it is possible to query data from collections that contain complex properties (e.g. a list of nested objects in one of the properties)."""
+
     class ArrayPropElement(pydantic.BaseModel):
         nested_prop: str
 
@@ -149,7 +151,6 @@ def test_can_query_collection_with_complex_property_types(client):
 
     assert len(results.nodes) == 1
     assert results.nodes[0].text == "Text of object containing complex properties"
-    assert results.similarities[0] == 1.0
 
 
 def test_to_weaviate_filter_with_various_operators():


### PR DESCRIPTION
# Description

As the new test `test_can_query_collection_with_complex_property_types` demonstrates, the previous code fails when presented with complex types in the metadata (e.g. a list of nested objects within a property). This can happen if Llama Index was not used to create the collection, but the data was ingested externally. The following error happens in that case without the change proposed in this PR:

```
E           ValueError: Invalid query, got errors: <AioRpcError of RPC that terminated with:
E               status = StatusCode.UNKNOWN
E               details = "creating primitive value for array_prop: proto: invalid type: []interface {}"
E               debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"creating primitive value for array_prop: proto:\xc2\xa0invalid type: []interface {}", grpc_status:2, created_time:"2024-12-02T19:20:55.014354529+00:00"}"
E           >
```

The solution to the problem is quite simple: the problem only occurs when manually passing a list of the properties to be retrieved in the `return_properties` argument. But returning all properties is already the standard in the Weaviate v4 client, so manually setting this to a list of all attribute names is not required. So this change both solves this issue and simplifies the code.

I wondered if this is also a problem on the Weaviate (client?) side - still not quite sure about it - but there seems to be at least some way of using `return_properties` also with nested properties (which requires the caller to know the structure of the nested data, though): https://github.com/weaviate/weaviate-python-client/issues/630#issuecomment-1924152015

_Hint: please first merge https://github.com/run-llama/llama_index/pull/17128 so that the version numbers have the correct order._

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests
