### PR TITLE
add trust_remote_code argument, make default = False for other classes

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/sbert_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/sbert_rerank.py
@@ -21,7 +21,7 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
         description="Whether to keep the retrieval score in metadata.",
     )
     trust_remote_code: bool = Field(
-        default=True,
+        default=False,
         description="Whether to trust remote code.",
     )
     _model: Any = PrivateAttr()
@@ -49,7 +49,10 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
             keep_retrieval_score=keep_retrieval_score,
         )
         self._model = CrossEncoder(
-            model, max_length=DEFAULT_SENTENCE_TRANSFORMER_MAX_LENGTH, device=device, trust_remote_code=trust_remote_code
+            model,
+            max_length=DEFAULT_SENTENCE_TRANSFORMER_MAX_LENGTH,
+            device=device,
+            trust_remote_code=trust_remote_code,
         )
 
     @classmethod

--- a/llama-index-core/llama_index/core/postprocessor/sbert_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/sbert_rerank.py
@@ -20,6 +20,10 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
         default=False,
         description="Whether to keep the retrieval score in metadata.",
     )
+    trust_remote_code: bool = Field(
+        default=True,
+        description="Whether to trust remote code.",
+    )
     _model: Any = PrivateAttr()
 
     def __init__(
@@ -28,6 +32,7 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
         model: str = "cross-encoder/stsb-distilroberta-base",
         device: Optional[str] = None,
         keep_retrieval_score: Optional[bool] = False,
+        trust_remote_code: Optional[bool] = True,
     ):
         try:
             from sentence_transformers import CrossEncoder  # pants: no-infer-dep
@@ -44,7 +49,7 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
             keep_retrieval_score=keep_retrieval_score,
         )
         self._model = CrossEncoder(
-            model, max_length=DEFAULT_SENTENCE_TRANSFORMER_MAX_LENGTH, device=device
+            model, max_length=DEFAULT_SENTENCE_TRANSFORMER_MAX_LENGTH, device=device, trust_remote_code=trust_remote_code
         )
 
     @classmethod

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -150,7 +150,7 @@ class Vllm(LLM):
         model: str = "facebook/opt-125m",
         temperature: float = 1.0,
         tensor_parallel_size: int = 1,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         n: int = 1,
         best_of: Optional[int] = None,
         presence_penalty: float = 0.0,

--- a/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vllm"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/llama_index/multi_modal_llms/huggingface/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/llama_index/multi_modal_llms/huggingface/base.py
@@ -54,7 +54,8 @@ class HuggingFaceMultiModal(MultiModalLLM):
         description="The torch dtype to use.",
     )
     trust_remote_code: bool = Field(
-        default=True, description="Whether to trust remote code when loading the model."
+        default=False,
+        description="Whether to trust remote code when loading the model.",
     )
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-multi-modal-llms-huggingface"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.1"
+version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openvino/llama_index/multi_modal_llms/openvino/base.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openvino/llama_index/multi_modal_llms/openvino/base.py
@@ -35,7 +35,8 @@ class OpenVINOMultiModal(MultiModalLLM):
         description="The device to run the model on.",
     )
     trust_remote_code: bool = Field(
-        default=True, description="Whether to trust remote code when loading the model."
+        default=False,
+        description="Whether to trust remote code when loading the model.",
     )
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openvino/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-openvino/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-multi-modal-llms-openvino"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Fixes issue with loading rerank model that needs to be loaded using 'trust_remote_code' argument, as stated here https://github.com/run-llama/llama_index/issues/17131

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
