### PR TITLE
chore: skip tests if ZEN_API_KEY is not set

### DIFF
--- a/llama-index-packs/llama-index-packs-zenguard/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-zenguard/pyproject.toml
@@ -44,7 +44,7 @@ version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-zenguard = "^0.1.13"
+zenguard = "^0.2.1"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-packs/llama-index-packs-zenguard/tests/test_packs_zenguard.py
+++ b/llama-index-packs/llama-index-packs-zenguard/tests/test_packs_zenguard.py
@@ -1,19 +1,23 @@
-import pytest
-
+import os
 from typing import Dict
 
+import pytest
 from llama_index.core.llama_pack import BaseLlamaPack
 from llama_index.packs.zenguard import (
-    ZenGuardPack,
-    ZenGuardConfig,
     Credentials,
     Detector,
+    ZenGuardConfig,
+    ZenGuardPack,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ZEN_API_KEY") is None, reason="ZEN_API_KEY not set"
 )
 
 
 @pytest.fixture()
 def zenguard_pack():
-    api_key = "3Ev_DGvELv7EnlgWMTlpmWTo82tpstyz4Li_R7kTDQw"  # mock key. whitelisted only for LlamaIndex tests.
+    api_key = os.environ.get("ZEN_API_KEY")
     config = ZenGuardConfig(credentials=Credentials(api_key=api_key))
     return ZenGuardPack(config)
 


### PR DESCRIPTION
# Description

The hardcoded api key seems invalid, skipping the tests while we get a new one

Fixes [example failure](https://github.com/run-llama/llama_index/actions/runs/12155778109/job/33904752125)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
