### PR TITLE
Ollama LLM: Added TypeError exception to _get_response_token_counts

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -203,6 +203,8 @@ class Ollama(FunctionCallingLLM):
             total_tokens = prompt_tokens + completion_tokens
         except KeyError:
             return {}
+        except TypeError:
+            return {}
         return {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ollama"
 readme = "README.md"
-version = "0.4.1"
+version = "0.4.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description
I encountered the problem below while using the Ollama (function calling version) as the llm.
```
File "<xxx>/.venv/lib/python3.12/site-packages/llama_index/llms/ollama/base.py", line 203, in _get_response_token_counts
    total_tokens = prompt_tokens + completion_tokens
                   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
```
Clearly, this was because prompt_tokens and completion_tokens were 'None' when accessing the 'raw_response' dict. 

My understanding is that this logic is merely for storing usage stats, and is not mission critical (i.e., negatively impacts LLM inference in the future), and hence we can return an empty dict when a 'TypeError' is encountered. This follows the error handling logic for the 'except KeyError' block which just returns an empty dict if either of the keys don't exist in the raw_response dict.

Fixes https://github.com/run-llama/llama_index/issues/17151

Return an empty dict when a 'TypeError' is encountered, like the 'KeyError' error handler does.

After applying this fix, the llm generated responses as normal without erroring out due to this TypeError.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

