### PR TITLE
proper auth token in TEI

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/llama_index/embeddings/text_embeddings_inference/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/llama_index/embeddings/text_embeddings_inference/base.py
@@ -70,9 +70,11 @@ class TextEmbeddingsInference(BaseEmbedding):
         headers = {"Content-Type": "application/json"}
         if self.auth_token is not None:
             if callable(self.auth_token):
-                headers["Authorization"] = self.auth_token(self.base_url)
+                auth_token = self.auth_token(self.base_url)
             else:
-                headers["Authorization"] = self.auth_token
+                auth_token = self.auth_token
+            headers["Authorization"] = f"Bearer {auth_token}"
+
         json_data = {"inputs": texts, "truncate": self.truncate_text}
 
         with httpx.Client() as client:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-text-embeddings-inference"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/17130

The auth token was improperly passed in the headers, needed the bearer prefix 