### PR TITLE
Fix mem0 version check

### DIFF
--- a/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
@@ -144,7 +144,12 @@ class Mem0Memory(BaseMem0):
 
         search_results = self.search(query=input, **self.context.get_context())
 
-        if isinstance(self._client, Memory) and self._client.version == "v1.1":
+        version = (
+            self._client.api_version
+            if hasattr(self._client, "api_version")
+            else self._client.version
+        )
+        if isinstance(self._client, Memory) and version == "v1.1":
             search_results = search_results["results"]
 
         system_message = convert_memory_to_system_message(search_results)

--- a/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-memory-mem0"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = "<4.0,>=3.9"


### PR DESCRIPTION
Mem0 client changed slightly which attribute the api version is stored under. Fixed in a backward compatible way

Fixes https://github.com/run-llama/llama_index/issues/17137