### PR TITLE
update doc id for unstructured reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/unstructured/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/unstructured/base.py
@@ -196,7 +196,7 @@ class UnstructuredReader(BaseReader):
 
         text_chunks = [" ".join(str(el).split()) for el in elements]
         metadata = _merge_metadata(elements[0])
-        filename = metadata["filename"]
+        filename = metadata.get("file_path", None) or metadata["filename"]
         source = Document(
             text="\n\n".join(text_chunks),
             extra_info=metadata,

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -51,7 +51,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/17144

Using the base `filename` could lead to ID collisions. I have a feeling using the filename here was an attempt to make deduplication and upserts easier later on, so I'm hesitant to fully remove it. Instead, lets use the full absolute path