### PR TITLE
Unrestrict clip models to use

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-clip/llama_index/embeddings/clip/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-clip/llama_index/embeddings/clip/base.py
@@ -7,22 +7,10 @@ from llama_index.core.constants import DEFAULT_EMBED_BATCH_SIZE
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.core.schema import ImageType
 from PIL import Image
-import os
 
 logger = logging.getLogger(__name__)
 
 
-AVAILABLE_CLIP_MODELS = (
-    "RN50",
-    "RN101",
-    "RN50x4",
-    "RN50x16",
-    "RN50x64",
-    "ViT-B/32",
-    "ViT-B/16",
-    "ViT-L/14",
-    "ViT-L/14@336px",
-)
 DEFAULT_CLIP_MODEL = "ViT-B/32"
 
 
@@ -87,11 +75,6 @@ class ClipEmbedding(MultiModalEmbedding):
 
         try:
             self._device = "cuda" if torch.cuda.is_available() else "cpu"
-            is_local_path = os.path.exists(self.model_name)
-            if not is_local_path and self.model_name not in AVAILABLE_CLIP_MODELS:
-                raise ValueError(
-                    f"Model name {self.model_name} is not available in CLIP."
-                )
             self._model, self._preprocess = clip.load(
                 self.model_name, device=self._device
             )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-clip/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-clip/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-clip"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/17147

There are way too many CLIP models to reasonably restrict users to. Just remove the check