### PR TITLE
max alpha not none in weaviate

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -334,11 +334,8 @@ class WeaviateVectorStore(BasePydanticVectorStore):
 
         vector = query.query_embedding
         similarity_key = "score"
-        if query.mode == VectorStoreQueryMode.DEFAULT:
-            _logger.debug("Using vector search")
-            if vector is not None:
-                alpha = 1
-        elif query.mode == VectorStoreQueryMode.HYBRID:
+        alpha = 1
+        if query.mode == VectorStoreQueryMode.HYBRID:
             _logger.debug(f"Using hybrid search with alpha {query.alpha}")
             if vector is not None and query.query_str:
                 alpha = query.alpha or 0.5

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
 readme = "README.md"
-version = "1.2.3"
+version = "1.2.4"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/17152

Should just set alpha to 1 by default, unless otherwise needed