### PR TITLE
ci: temprary fix nvidia tests

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
@@ -34,6 +34,8 @@ python = ">=3.9,<4.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
+# Unpin when https://github.com/lundberg/respx/issues/277 is fixed
+httpx = "<0.28.0"
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
@@ -41,6 +41,8 @@ llama-index-core = "^0.12.0"
 [tool.poetry.group.dev.dependencies]
 black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
 codespell = {extras = ["toml"], version = ">=v2.2.6"}
+# Unpin when https://github.com/lundberg/respx/issues/277 is fixed
+httpx = "<0.28.0"
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"


### PR DESCRIPTION
# Description

Some tests are failing because `respx` can't mock `httpx` >= 0.28

Pin added only to dev dependencies, where mocking is used.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

