### PR TITLE
Make the LLM object to support a unique ID attribute

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -1,11 +1,12 @@
 """Base embeddings file."""
-
 import asyncio
+import uuid
 from abc import abstractmethod
 from enum import Enum
 from typing import Any, Callable, Coroutine, List, Optional, Sequence, Tuple
 
 import numpy as np
+from llama_index.core.async_utils import run_jobs
 from llama_index.core.bridge.pydantic import (
     Field,
     ConfigDict,
@@ -19,11 +20,9 @@ from llama_index.core.constants import (
 from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.schema import BaseNode, MetadataMode, TransformComponent
 from llama_index.core.utils import get_tqdm_iterable
-from llama_index.core.async_utils import run_jobs
 
 # TODO: change to numpy array
 Embedding = List[float]
-
 
 from llama_index.core.instrumentation.events.embedding import (
     EmbeddingEndEvent,
@@ -85,6 +84,11 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
     num_workers: Optional[int] = Field(
         default=None,
         description="The number of workers to use for async embedding calls.",
+    )
+
+    id_: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique ID of the Embedding Instance.",
     )
 
     @field_validator("callback_manager")

--- a/llama-index-core/llama_index/core/base/llms/base.py
+++ b/llama-index-core/llama_index/core/base/llms/base.py
@@ -1,3 +1,4 @@
+import uuid
 from abc import abstractmethod
 from typing import (
     Any,
@@ -31,6 +32,11 @@ class BaseLLM(ChainableMixin, BaseComponent, DispatcherSpanMixin):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     callback_manager: CallbackManager = Field(
         default_factory=lambda: CallbackManager([]), exclude=True
+    )
+
+    id_: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique ID of the LLM Instance.",
     )
 
     @model_validator(mode="after")

--- a/llama-index-core/llama_index/core/multi_modal_llms/base.py
+++ b/llama-index-core/llama_index/core/multi_modal_llms/base.py
@@ -1,3 +1,4 @@
+import uuid
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Sequence, get_args
 
@@ -84,6 +85,11 @@ class MultiModalLLM(ChainableMixin, BaseComponent, DispatcherSpanMixin):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     callback_manager: CallbackManager = Field(
         default_factory=CallbackManager, exclude=True
+    )
+
+    id_: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique ID of the LLM Instance.",
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/llama-index-core/tests/llms/test_custom.py
+++ b/llama-index-core/tests/llms/test_custom.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from llama_index.core.base.llms.types import (
@@ -12,8 +13,8 @@ from llama_index.core.llms.custom import CustomLLM
 class TestLLM(CustomLLM):
     __test__ = False
 
-    def __init__(self) -> None:
-        super().__init__(callback_manager=None)
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(callback_manager=None, **kwargs)
 
     @property
     def metadata(self) -> LLMMetadata:
@@ -66,3 +67,9 @@ def test_streaming() -> None:
 
     llm.stream_complete(prompt)
     llm.stream_chat([message])
+
+
+def test_llm_id():
+    llm_id = uuid.uuid4().hex
+    llm = TestLLM(id_=llm_id)
+    assert llm.id_ == llm_id


### PR DESCRIPTION
# Description

In our business scenario, we will have multiple large model instances. The LLM object will persist in the application's context after initialization and be passed as one of the parameters for business methods. Within different business methods, the LLM object will be called to complete AIGC-related logic, and its configuration and parameter information will also be marked as statistical data. Additionally, the unique value of the current LLM object will be used to determine within the global QPS limit of the application system. Therefore, we need to set an independent and unique attribute for each LLM object to mark that instance.

Fixes #17174

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
