### PR TITLE
Add Verbose to Vectara as_query_engine

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
@@ -332,7 +332,7 @@ class VectaraRetriever(BaseRetriever):
         """
         body = self._build_vectara_query_body(query_bundle.query_str)
         if verbose:
-            _logger.info(f"Vectara streaming query request body: {body}")
+            print(f"Vectara streaming query request body: {body}")
         response = self._index._session.post(
             headers=self._get_post_headers(),
             url="https://api.vectara.io/v1/stream-query",
@@ -448,7 +448,7 @@ class VectaraRetriever(BaseRetriever):
         data = self._build_vectara_query_body(query_bundle.query_str, chat, conv_id)
 
         if verbose:
-            _logger.info(f"Vectara query request body: {data}")
+            print(f"Vectara query request body: {data}")
         response = self._index._session.post(
             headers=self._get_post_headers(),
             url="https://api.vectara.io/v1/query",
@@ -466,7 +466,7 @@ class VectaraRetriever(BaseRetriever):
 
         result = response.json()
         if verbose:
-            _logger.info(f"Vectara query response: {result}")
+            print(f"Vectara query response: {result}")
         status = result["responseSet"][0]["status"]
         if len(status) > 0 and status[0]["code"] != "OK":
             _logger.error(

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
@@ -319,6 +319,7 @@ class VectaraRetriever(BaseRetriever):
         query_bundle: QueryBundle,
         chat: bool = False,
         conv_id: Optional[str] = None,
+        verbose: bool = False,
         **kwargs: Any,
     ) -> TokenGen:
         """
@@ -330,6 +331,8 @@ class VectaraRetriever(BaseRetriever):
             conv_id: conversation ID, if chat enabled
         """
         body = self._build_vectara_query_body(query_bundle.query_str)
+        if verbose:
+            _logger.info(f"Vectara streaming query request body: {body}")
         response = self._index._session.post(
             headers=self._get_post_headers(),
             url="https://api.vectara.io/v1/stream-query",
@@ -424,6 +427,7 @@ class VectaraRetriever(BaseRetriever):
         query_bundle: QueryBundle,
         chat: bool = False,
         conv_id: Optional[str] = None,
+        verbose: bool = False,
         **kwargs: Any,
     ) -> Tuple[List[NodeWithScore], Dict, str]:
         """
@@ -431,6 +435,9 @@ class VectaraRetriever(BaseRetriever):
 
         Args:
             query: Query Bundle
+            chat: whether to enable chat in Vectara
+            conv_id: conversation ID, if chat enabled
+            verbose: whether to print verbose output (e.g. for debugging)
             Additional keyword arguments
 
         Returns:
@@ -440,6 +447,8 @@ class VectaraRetriever(BaseRetriever):
         """
         data = self._build_vectara_query_body(query_bundle.query_str, chat, conv_id)
 
+        if verbose:
+            _logger.info(f"Vectara query request body: {data}")
         response = self._index._session.post(
             headers=self._get_post_headers(),
             url="https://api.vectara.io/v1/query",
@@ -456,6 +465,8 @@ class VectaraRetriever(BaseRetriever):
             return [], {"text": ""}, ""
 
         result = response.json()
+        if verbose:
+            _logger.info(f"Vectara query response: {result}")
         status = result["responseSet"][0]["status"]
         if len(status) > 0 and status[0]["code"] != "OK":
             _logger.error(
@@ -509,15 +520,29 @@ class VectaraRetriever(BaseRetriever):
         return top_nodes[: self._similarity_top_k], summary, conv_id
 
     async def _avectara_query(
-        self, query_bundle: QueryBundle
+        self,
+        query_bundle: QueryBundle,
+        chat: bool = False,
+        conv_id: Optional[str] = None,
+        verbose: bool = False,
+        **kwargs: Any,
     ) -> Tuple[List[NodeWithScore], Dict]:
         """
-        Asynchronously retrieve nodes given query.
+        Asynchronously query Vectara index to get for top k most similar nodes.
 
-        Implemented by the user.
+        Args:
+            query: Query Bundle
+            chat: whether to enable chat in Vectara
+            conv_id: conversation ID, if chat enabled
+            verbose: whether to print verbose output (e.g. for debugging)
+            Additional keyword arguments
 
+        Returns:
+            List[NodeWithScore]: list of nodes with scores
+            Dict: summary
+            str: conversation ID, if applicable
         """
-        return await self._vectara_query(query_bundle)
+        return await self._vectara_query(query_bundle, chat, conv_id, verbose, **kwargs)
 
 
 class VectaraAutoRetriever(VectorIndexAutoRetriever):

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
@@ -31,7 +31,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-vectara"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/tests/test_indices_managed_vectara.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/tests/test_indices_managed_vectara.py
@@ -276,12 +276,14 @@ def test_file_upload(vectara2) -> None:
     assert "paul graham" in summary.lower() and "software" in summary.lower()
 
     # test query with VectorStoreQuery (using OpenAI for summarization)
-    query_engine = vectara2.as_query_engine(similarity_top_k=3, summary_enabled=False)
+    query_engine = vectara2.as_query_engine(
+        similarity_top_k=3, summary_enabled=False, verbose=True
+    )
     res = query_engine.query("What software did Paul Graham write?")
     assert "paul graham" in str(res).lower() and "software" in str(res).lower()
 
     # test query with Vectara summarization (default)
-    query_engine = vectara2.as_query_engine(similarity_top_k=3)
+    query_engine = vectara2.as_query_engine(similarity_top_k=3, verbose=True)
     res = query_engine.query("How is Paul related to Reddit?")
     summary = res.response
     assert "paul graham" in summary.lower() and "reddit" in summary.lower()


### PR DESCRIPTION
# Description

Added verbose argument to as_query_engine, that if enabled prints the Vectara API details (body and response).
Can be helpful when debugging

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Minor change - new argument but with default so backwards compatible.

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests, I just added verbose=True in an existing test.

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
