### PR TITLE
BUG FIX: llama-index-vectorstore-chromadb to work with chromadb v0.5.17

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
@@ -331,10 +331,11 @@ class ChromaVectorStore(BasePydanticVectorStore):
 
         if filters:
             where = _to_chroma_filter(filters)
-        else:
-            where = None
+            self._collection.delete(ids=node_ids, where=where)
 
-        self._collection.delete(ids=node_ids, where=where)
+        else:
+            self._collection.delete(ids=node_ids)
+
 
     def clear(self) -> None:
         """Clear the collection."""
@@ -378,12 +379,19 @@ class ChromaVectorStore(BasePydanticVectorStore):
     def _query(
         self, query_embeddings: List["float"], n_results: int, where: dict, **kwargs
     ) -> VectorStoreQueryResult:
-        results = self._collection.query(
-            query_embeddings=query_embeddings,
-            n_results=n_results,
-            where=where,
-            **kwargs,
-        )
+        if where:
+            results = self._collection.query(
+                query_embeddings=query_embeddings,
+                n_results=n_results,
+                where=where,
+                **kwargs,
+            )
+        else:
+            results = self._collection.query(
+                query_embeddings=query_embeddings,
+                n_results=n_results,
+                **kwargs,
+            )  
 
         logger.debug(f"> Top {len(results['documents'][0])} nodes:")
         nodes = []
@@ -429,11 +437,17 @@ class ChromaVectorStore(BasePydanticVectorStore):
     def _get(
         self, limit: Optional[int], where: dict, **kwargs
     ) -> VectorStoreQueryResult:
-        results = self._collection.get(
-            limit=limit,
-            where=where,
-            **kwargs,
-        )
+        if where:
+            results = self._collection.get(
+                limit=limit,
+                where=where,
+                **kwargs,
+            )
+        else:
+            results = self._collection.get(
+                limit=limit,
+                **kwargs,
+            )     
 
         logger.debug(f"> Top {len(results['documents'])} nodes:")
         nodes = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/llama_index/vector_stores/chroma/base.py
@@ -336,7 +336,6 @@ class ChromaVectorStore(BasePydanticVectorStore):
         else:
             self._collection.delete(ids=node_ids)
 
-
     def clear(self) -> None:
         """Clear the collection."""
         ids = self._collection.get()["ids"]
@@ -391,7 +390,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
                 query_embeddings=query_embeddings,
                 n_results=n_results,
                 **kwargs,
-            )  
+            )
 
         logger.debug(f"> Top {len(results['documents'][0])} nodes:")
         nodes = []
@@ -447,7 +446,7 @@ class ChromaVectorStore(BasePydanticVectorStore):
             results = self._collection.get(
                 limit=limit,
                 **kwargs,
-            )     
+            )
 
         logger.debug(f"> Top {len(results['documents'])} nodes:")
         nodes = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-chroma"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
…0.5.17

# Description

ChromaDB version 0.5.17 doesn't support empty where dictionaries in its get or delete queries. Added a quick fix to make sure it works with their new version API

reference to their comment 

https://github.com/chroma-core/chroma/issues/3248

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
