### PR TITLE
Add posibility to use URI as doc id in WholeSiteReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/whole_site/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/whole_site/base.py
@@ -24,12 +24,14 @@ class WholeSiteReader(BaseReader):
     Args:
         prefix (str): URL prefix for scraping.
         max_depth (int, optional): Maximum depth for BFS. Defaults to 10.
+        uri_as_id (bool, optional): Whether to use the URI as the document ID. Defaults to False.
     """
 
     def __init__(
         self,
         prefix: str,
         max_depth: int = 10,
+        uri_as_id: bool = False,
         driver: Optional[webdriver.Chrome] = None,
     ) -> None:
         """
@@ -37,6 +39,7 @@ class WholeSiteReader(BaseReader):
         """
         self.prefix = prefix
         self.max_depth = max_depth
+        self.uri_as_id = uri_as_id
         self.driver = driver if driver else self.setup_driver()
 
     def setup_driver(self):
@@ -125,9 +128,10 @@ class WholeSiteReader(BaseReader):
                         except Exception:
                             continue
 
-                documents.append(
-                    Document(text=page_content, extra_info={"URL": current_url})
-                )
+                doc = Document(text=page_content, extra_info={"URL": current_url})
+                if self.uri_as_id:
+                    doc.id_ = current_url
+                documents.append(doc)
                 time.sleep(1)
 
             except WebDriverException:

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -45,7 +45,7 @@ license = "MIT"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Adds the option to use URI as id in WholeSiteReader to avoid call embeddings api when the document is already indexed and content is not changed.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
