### PR TITLE
Update pgvector dependency to version 0.3.6

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-pgvector = "^0.2.4"
+pgvector = "^0.3.6"
 psycopg2-binary = "^2.9.9"
 asyncpg = "^0.29.0"
 llama-index-core = "^0.12.0"


### PR DESCRIPTION
# Description

Updates the pgvector dependency from ^0.2.4 to ^0.3.6 in the llama-index-vector-stores-postgres package. This update ensures compatibility with newer versions of pgvector and resolves dependency issues reported in #17166.

Fixes #17166

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No (Not applicable - this is an update to an existing package)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (Version bump not required for dependency update only)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests
  - The existing Postgres vector store tests in `tests/test_vector_stores_postgres.py` cover the functionality
  - The pgvector update is backward compatible and doesn't introduce breaking changes

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks (Not applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods