### PR TITLE
Refined the default documentation generation for ReAct function tools

### DIFF
--- a/llama-index-core/llama_index/core/tools/types.py
+++ b/llama-index-core/llama_index/core/tools/types.py
@@ -48,7 +48,7 @@ class ToolMetadata:
         if self.fn_schema is None:
             raise ValueError("fn_schema is None.")
         parameters = self.get_parameters_dict()
-        return json.dumps(parameters)
+        return json.dumps(parameters, ensure_ascii=False)
 
     def get_name(self) -> str:
         """Get name."""


### PR DESCRIPTION
# Description

The pull request changes the tool documentation generation of the default ReAct agent, including:
1. Avoided non-ASCII texts to be formatted as Unicode escape sequences.
2. Reduced the documentation token usage for functions annotated with Pydantic Field.

Consider the following Python code:

```python
from llama_index.core.tools import FunctionTool
from llama_index.core.bridge.pydantic import Field
from llama_index.core.agent.react.formatter import get_react_tool_descriptions


def get_weather_with_default_value(location: str = "基隆") -> str:
    """Usfeful for getting the weather for a given location."""
    _ = location
    return "Rainy"


def get_weather_with_param_annotation(
    location: str = Field(description="A city name such as 台北, 基隆, 宜蘭, ..."),
) -> str:
    """Usfeful for getting the weather for a given location."""
    _ = location
    return "Rainy"


if __name__ == "__main__":
    # Initialize tools
    tools = [
        FunctionTool.from_defaults(get_weather_with_default_value),
        FunctionTool.from_defaults(get_weather_with_param_annotation),
    ]

    # Show tool description
    print("\n".join(get_react_tool_descriptions(tools)))
```

With the main branch, the Chinese texts are formatted as Unicode escape sequences in `Tool Args`, which are hard to be understood:  
![image](https://github.com/user-attachments/assets/023abc9d-c168-4976-b8f7-02047a1ed081)

Thus, bb22ed802695bbe4bce6f8835f48fb467f6e6f28 is made to allow non-ASCII texts in `Tool Args`:  
![image](https://github.com/user-attachments/assets/5ea79c99-8e4c-41fb-a5c2-0feb93dc42e2)

However, if a parameter is annotated with Pydantic Field, the parameter description appears in both `Tool Description` and `Tool Args`. The behavior gives no extra information to LLMs, but cost more tokens.  
Finally, 84d513c2e65b6868401e10defca54f27943ca6ae is made to remove duplicated parameters description in `Tool Description`:  
![image](https://github.com/user-attachments/assets/2537ca07-7c1b-4c75-8046-85d63adbad56)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
