### PR TITLE
Add ILIKE feature for PGVectorStore and NileVectorStore.

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/types.py
+++ b/llama-index-core/llama_index/core/vector_stores/types.py
@@ -75,7 +75,9 @@ class FilterOperator(str, Enum):
     ANY = "any"  # Contains any (array of strings)
     ALL = "all"  # Contains all (array of strings)
     TEXT_MATCH = "text_match"  # full text match (allows you to search for a specific substring, token or phrase within the text field)
-    ILIKE = "ilike"  # full text match (case insensitive)
+    TEXT_MATCH_INSENSITIVE = (
+        "text_match_insensitive"  # full text match (case insensitive)
+    )
     CONTAINS = "contains"  # metadata array contains value (string or number)
     IS_EMPTY = "is_empty"  # the field is not exist or empty (null or empty array)
 

--- a/llama-index-core/llama_index/core/vector_stores/types.py
+++ b/llama-index-core/llama_index/core/vector_stores/types.py
@@ -75,6 +75,7 @@ class FilterOperator(str, Enum):
     ANY = "any"  # Contains any (array of strings)
     ALL = "all"  # Contains all (array of strings)
     TEXT_MATCH = "text_match"  # full text match (allows you to search for a specific substring, token or phrase within the text field)
+    ILIKE = "ilike"  # full text match (case insensitive)
     CONTAINS = "contains"  # metadata array contains value (string or number)
     IS_EMPTY = "is_empty"  # the field is not exist or empty (null or empty array)
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
@@ -282,6 +282,13 @@ class NileVectorStore(BasePydanticVectorStore):
                             sql.Literal(filter.key), sql.Literal(filter.value)
                         )
                     )
+                elif filter.operator == FilterOperator.TEXT_MATCH or filter.operator == FilterOperator.ILIKE:
+                    # Where the operator is text_match or ilike, we need to wrap the filter in '%' characters
+                    where_clauses.append(
+                        f"metadata_->>'{filter.key}' "
+                        f"{self._to_postgres_operator(filter.operator)} "
+                        f"'%{filter.value}%'"
+                    )
                 else:
                     where_clauses.append(
                         sql.SQL(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
@@ -282,7 +282,10 @@ class NileVectorStore(BasePydanticVectorStore):
                             sql.Literal(filter.key), sql.Literal(filter.value)
                         )
                     )
-                elif filter.operator == FilterOperator.TEXT_MATCH or filter.operator == FilterOperator.ILIKE:
+                elif (
+                    filter.operator == FilterOperator.TEXT_MATCH
+                    or filter.operator == FilterOperator.ILIKE
+                ):
                     # Where the operator is text_match or ilike, we need to wrap the filter in '%' characters
                     where_clauses.append(
                         f"metadata_->>'{filter.key}' "

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
@@ -244,6 +244,10 @@ class NileVectorStore(BasePydanticVectorStore):
             return "NOT IN"
         elif operator == FilterOperator.CONTAINS:
             return "@>"
+        elif operator == FilterOperator.TEXT_MATCH:
+            return "LIKE"
+        elif operator == FilterOperator.ILIKE:
+            return "ILIKE"
         else:
             _logger.warning(f"Unknown operator: {operator}, fallback to '='")
             return "="

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-nile/llama_index/vector_stores/nile/base.py
@@ -246,7 +246,7 @@ class NileVectorStore(BasePydanticVectorStore):
             return "@>"
         elif operator == FilterOperator.TEXT_MATCH:
             return "LIKE"
-        elif operator == FilterOperator.ILIKE:
+        elif operator == FilterOperator.TEXT_MATCH_INSENSITIVE:
             return "ILIKE"
         else:
             _logger.warning(f"Unknown operator: {operator}, fallback to '='")
@@ -284,7 +284,7 @@ class NileVectorStore(BasePydanticVectorStore):
                     )
                 elif (
                     filter.operator == FilterOperator.TEXT_MATCH
-                    or filter.operator == FilterOperator.ILIKE
+                    or filter.operator == FilterOperator.TEXT_MATCH_INSENSITIVE
                 ):
                     # Where the operator is text_match or ilike, we need to wrap the filter in '%' characters
                     where_clauses.append(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -522,7 +522,10 @@ class PGVectorStore(BasePydanticVectorStore):
                 f"{self._to_postgres_operator(filter_.operator)} "
                 f"'[\"{filter_.value}\"]'"
             )
-        elif filter_.operator == FilterOperator.TEXT_MATCH or filter_.operator == FilterOperator.ILIKE:
+        elif (
+            filter_.operator == FilterOperator.TEXT_MATCH
+            or filter_.operator == FilterOperator.ILIKE
+        ):
             # Where the operator is text_match or ilike, we need to wrap the filter in '%' characters
             return text(
                 f"metadata_->>'{filter_.key}' "

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -523,7 +523,7 @@ class PGVectorStore(BasePydanticVectorStore):
                 f"'[\"{filter_.value}\"]'"
             )
         elif filter_.operator == FilterOperator.TEXT_MATCH or filter_.operator == FilterOperator.ILIKE:
-            # Where the operator is text_match, we need to wrap the filter in '%' characters
+            # Where the operator is text_match or ilike, we need to wrap the filter in '%' characters
             return text(
                 f"metadata_->>'{filter_.key}' "
                 f"{self._to_postgres_operator(filter_.operator)} "

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -494,7 +494,7 @@ class PGVectorStore(BasePydanticVectorStore):
             return "@>"
         elif operator == FilterOperator.TEXT_MATCH:
             return "LIKE"
-        elif operator == FilterOperator.ILIKE:
+        elif operator == FilterOperator.TEXT_MATCH_INSENSITIVE:
             return "ILIKE"
         else:
             _logger.warning(f"Unknown operator: {operator}, fallback to '='")
@@ -524,7 +524,7 @@ class PGVectorStore(BasePydanticVectorStore):
             )
         elif (
             filter_.operator == FilterOperator.TEXT_MATCH
-            or filter_.operator == FilterOperator.ILIKE
+            or filter_.operator == FilterOperator.TEXT_MATCH_INSENSITIVE
         ):
             # Where the operator is text_match or ilike, we need to wrap the filter in '%' characters
             return text(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -494,6 +494,8 @@ class PGVectorStore(BasePydanticVectorStore):
             return "@>"
         elif operator == FilterOperator.TEXT_MATCH:
             return "LIKE"
+        elif operator == FilterOperator.ILIKE:
+            return "ILIKE"
         else:
             _logger.warning(f"Unknown operator: {operator}, fallback to '='")
             return "="
@@ -520,7 +522,7 @@ class PGVectorStore(BasePydanticVectorStore):
                 f"{self._to_postgres_operator(filter_.operator)} "
                 f"'[\"{filter_.value}\"]'"
             )
-        elif filter_.operator == FilterOperator.TEXT_MATCH:
+        elif filter_.operator == FilterOperator.TEXT_MATCH or filter_.operator == FilterOperator.ILIKE:
             # Where the operator is text_match, we need to wrap the filter in '%' characters
             return text(
                 f"metadata_->>'{filter_.key}' "


### PR DESCRIPTION
# Description

In this pull request, I have added a new `TEXT_MATCH_INSENSITIVE` operator that will handle case insensitive text matches. I have implemented this feature in PGVectorStore and NileVectorStore classes.



## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
