### PR TITLE
fix: merge text blocks into a plain string when role is assistant or …

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -289,7 +289,9 @@ def to_openai_message_dict(
 
     message_dict = {
         "role": message.role.value,
-        "content": content_txt or content,
+        "content": content_txt
+        if message.role.value in ("assistant", "tool")
+        else content,
     }
 
     # TODO: O1 models do not support system prompts

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -289,7 +289,7 @@ def to_openai_message_dict(
 
     message_dict = {
         "role": message.role.value,
-        "content": content or "",
+        "content": content_txt or content,
     }
 
     # TODO: O1 models do not support system prompts

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -260,9 +260,9 @@ def to_openai_message_dict(
     content_txt = ""
     for block in message.blocks:
         if isinstance(block, TextBlock):
-            if message.role.value in ("assistant", "tool"):
-                # Despite the docs say otherwise, when role is ASSISTANT or TOOL,
-                # 'content' cannot be a list and must be string instead.
+            if message.role.value in ("assistant", "tool", "system"):
+                # Despite the docs say otherwise, when role is ASSISTANT, SYSTEM
+                # or TOOL, 'content' cannot be a list and must be string instead.
                 content_txt += block.text
             else:
                 content.append({"type": "text", "text": block.text})
@@ -290,7 +290,7 @@ def to_openai_message_dict(
     message_dict = {
         "role": message.role.value,
         "content": content_txt
-        if message.role.value in ("assistant", "tool")
+        if message.role.value in ("assistant", "tool", "system")
         else content,
     }
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -257,9 +257,15 @@ def to_openai_message_dict(
 ) -> ChatCompletionMessageParam:
     """Convert a ChatMessage to an OpenAI message dict."""
     content = []
+    content_txt = ""
     for block in message.blocks:
         if isinstance(block, TextBlock):
-            content.append({"type": "text", "text": block.text})
+            if message.role.value in ("assistant", "tool"):
+                # Despite the docs say otherwise, when role is ASSISTANT or TOOL,
+                # 'content' cannot be a list and must be string instead.
+                content_txt += block.text
+            else:
+                content.append({"type": "text", "text": block.text})
         elif isinstance(block, ImageBlock):
             if block.url:
                 content.append(
@@ -283,7 +289,7 @@ def to_openai_message_dict(
 
     message_dict = {
         "role": message.role.value,
-        "content": content,
+        "content": content or "",
     }
 
     # TODO: O1 models do not support system prompts

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -33,7 +33,7 @@ version = "0.3.4"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-openai = "^1.40.0"
+openai = "^1.57.1"
 llama-index-core = "^0.12.4"
 
 [tool.poetry.group.dev.dependencies]

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -65,7 +65,7 @@ def openi_message_dicts_with_function_calling() -> List[ChatCompletionMessagePar
         },
         {
             "role": "assistant",
-            "content": [],
+            "content": "",
             "function_call": {
                 "name": "get_current_weather",
                 "arguments": '{ "location": "Boston, MA"}',
@@ -73,12 +73,7 @@ def openi_message_dicts_with_function_calling() -> List[ChatCompletionMessagePar
         },
         {
             "role": "tool",
-            "content": [
-                {
-                    "type": "text",
-                    "text": '{"temperature": "22", "unit": "celsius", "description": "Sunny"}',
-                }
-            ],
+            "content": '{"temperature": "22", "unit": "celsius", "description": "Sunny"}',
             "tool_call_id": "get_current_weather",
         },
     ]
@@ -139,7 +134,7 @@ def test_to_openai_message_dicts_basic_enum() -> None:
     openai_messages = to_openai_message_dicts(chat_messages)
     assert openai_messages == [
         {"role": "user", "content": [{"type": "text", "text": "test question"}]},
-        {"role": "assistant", "content": [{"type": "text", "text": "test answer"}]},
+        {"role": "assistant", "content": "test answer"},
     ]
 
 
@@ -151,7 +146,7 @@ def test_to_openai_message_dicts_basic_string() -> None:
     openai_messages = to_openai_message_dicts(chat_messages)
     assert openai_messages == [
         {"role": "user", "content": [{"type": "text", "text": "test question"}]},
-        {"role": "assistant", "content": [{"type": "text", "text": "test answer"}]},
+        {"role": "assistant", "content": "test answer"},
     ]
 
 


### PR DESCRIPTION
…tool

# Description

Despite OpenAI docs say otherwise, when the message type is TOOL or ASSISTANT `content` must be a string.

Fixes https://github.com/run-llama/llama_index/issues/17214
FIxes https://github.com/run-llama/llama_index/issues/17215

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
