### PR TITLE
fix: remove llama-index-legacy dependency in llama-index-core

### DIFF
--- a/docs/docs/getting_started/installation.md
+++ b/docs/docs/getting_started/installation.md
@@ -17,7 +17,6 @@ pip install llama-index
 This is a starter bundle of packages, containing
 
 - `llama-index-core`
-- `llama-index-legacy  # temporarily included`
 - `llama-index-llms-openai`
 - `llama-index-embeddings-openai`
 - `llama-index-program-openai`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ version = "0.12.5"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-llama-index-legacy = "^0.9.48"
 llama-index-llms-openai = "^0.3.0"
 llama-index-embeddings-openai = "^0.3.0"
 llama-index-program-openai = "^0.3.0"


### PR DESCRIPTION
# Description

Follow-up on discussion in #16974 

Removing the mention to llama-index-legacy which has side effects like requiring `tenacity<0.9.0`

Let me know if there is anything else to change. I assume the corresponding lock files are generated automatically on merge

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
