### PR TITLE
fix: accept already base64-encoded data in ImageBlock

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -75,11 +75,17 @@ class ImageBlock(BaseModel):
         if not self.image:
             return self
 
-        if not self.image_mimetype:
-            guess = filetype.guess(self.image)
-            self.image_mimetype = guess.mime if guess else None
+        try:
+            # Check if image is already base64 encoded
+            decoded_img = base64.b64decode(self.image)
+        except Exception:
+            decoded_img = self.image
+            # Not base64 - encode it
+            self.image = base64.b64encode(self.image)
 
-        self.image = base64.b64encode(self.image)
+        if not self.image_mimetype:
+            guess = filetype.guess(decoded_img)
+            self.image_mimetype = guess.mime if guess else None
 
         return self
 

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -165,3 +165,10 @@ def test_image_block_store_as_anyurl():
     url_str = "http://example.com"
     b = ImageBlock(url=url_str)
     assert b.url == AnyUrl(url=url_str)
+
+
+def test_image_block_store_as_base64(png_1px_b64: bytes, png_1px: bytes):
+    # Store regular bytes
+    assert ImageBlock(image=png_1px).image == png_1px_b64
+    # Store already encoded data
+    assert ImageBlock(image=png_1px_b64).image == png_1px_b64


### PR DESCRIPTION
# Description

Passing an image to `ImageBlock` that's already base64-encoded will encode it again, which works just fine but prevents the auto-detection of the mime type.

With this PR, if for whatever reason the user already has base64 images, they can build an `ImageBlock` directly and the mime type will still be detected (to the extent of what's possible of course).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests