### PR TITLE
Fix content blocks again

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai-like"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-llama-index-llms-openai = "^0.3.7"
+llama-index-llms-openai = "^0.3.9"
 transformers = "^4.37.0"
 llama-index-core = "^0.12.0"
 

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_openai_like.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_openai_like.py
@@ -130,7 +130,6 @@ def test_chat(MockSyncOpenAI: MagicMock) -> None:
         model=STUB_MODEL_NAME,
         is_chat_model=True,
         tokenizer=StubTokenizer(),
-        supports_content_blocks=False,
     )
 
     response = llm.chat([ChatMessage(role=MessageRole.USER, content="test message")])
@@ -146,15 +145,12 @@ def test_chat(MockSyncOpenAI: MagicMock) -> None:
         model=STUB_MODEL_NAME,
         is_chat_model=True,
         tokenizer=StubTokenizer(),
-        supports_content_blocks=True,
     )
 
     response = llm.chat([ChatMessage(role=MessageRole.USER, content="test message")])
     assert response.message.content == content
     mock_instance.chat.completions.create.assert_called_with(
-        messages=[
-            {"role": "user", "content": [{"type": "text", "text": "test message"}]}
-        ],
+        messages=[{"role": "user", "content": "test message"}],
         stream=False,
         model=STUB_MODEL_NAME,
         temperature=0.1,

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -59,7 +59,6 @@ from llama_index.core.llms.llm import ToolSelection
 from llama_index.core.llms.utils import parse_partial_json
 from llama_index.core.types import BaseOutputParser, Model, PydanticProgramMode
 from llama_index.llms.openai.utils import (
-    ALL_AVAILABLE_MODELS,
     O1_MODELS,
     OpenAIToolCall,
     create_retry_decorator,
@@ -218,10 +217,6 @@ class OpenAI(FunctionCallingLLM):
         default=False,
         description="Whether to use strict mode for invoking tools/using schemas.",
     )
-    supports_content_blocks: bool = Field(
-        default=False,
-        description="Whether the model supports content blocks in chat messages.",
-    )
 
     _client: Optional[SyncOpenAI] = PrivateAttr()
     _aclient: Optional[AsyncOpenAI] = PrivateAttr()
@@ -267,10 +262,6 @@ class OpenAI(FunctionCallingLLM):
         if model in O1_MODELS:
             temperature = 1.0
 
-        supports_content_blocks = kwargs.pop(
-            "supports_content_blocks", model in ALL_AVAILABLE_MODELS
-        )
-
         super().__init__(
             model=model,
             temperature=temperature,
@@ -290,7 +281,6 @@ class OpenAI(FunctionCallingLLM):
             pydantic_program_mode=pydantic_program_mode,
             output_parser=output_parser,
             strict=strict,
-            supports_content_blocks=supports_content_blocks,
             **kwargs,
         )
 
@@ -436,7 +426,6 @@ class OpenAI(FunctionCallingLLM):
         message_dicts = to_openai_message_dicts(
             messages,
             model=self.model,
-            supports_content_blocks=self.supports_content_blocks,
         )
 
         if self.reuse_client:
@@ -475,7 +464,6 @@ class OpenAI(FunctionCallingLLM):
         message_dicts = to_openai_message_dicts(
             messages,
             model=self.model,
-            supports_content_blocks=self.supports_content_blocks,
         )
 
         def gen() -> ChatResponseGen:
@@ -689,7 +677,6 @@ class OpenAI(FunctionCallingLLM):
         message_dicts = to_openai_message_dicts(
             messages,
             model=self.model,
-            supports_content_blocks=self.supports_content_blocks,
         )
 
         if self.reuse_client:
@@ -726,7 +713,6 @@ class OpenAI(FunctionCallingLLM):
         message_dicts = to_openai_message_dicts(
             messages,
             model=self.model,
-            supports_content_blocks=self.supports_content_blocks,
         )
 
         async def gen() -> ChatResponseAsyncGen:

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.8"
+version = "0.3.9"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -16,8 +16,10 @@ from openai.types.completion_choice import Logprobs
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
+    ImageBlock,
     LogProb,
     MessageRole,
+    TextBlock,
 )
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.llms.openai import OpenAI
@@ -61,7 +63,7 @@ def openi_message_dicts_with_function_calling() -> List[ChatCompletionMessagePar
     return [
         {
             "role": "user",
-            "content": [{"type": "text", "text": "test question with functions"}],
+            "content": "test question with functions",
         },
         {
             "role": "assistant",
@@ -132,10 +134,10 @@ def test_to_openai_message_dicts_basic_enum() -> None:
         ChatMessage(role=MessageRole.ASSISTANT, content="test answer"),
     ]
     openai_messages = to_openai_message_dicts(
-        chat_messages, supports_content_blocks=True
+        chat_messages,
     )
     assert openai_messages == [
-        {"role": "user", "content": [{"type": "text", "text": "test question"}]},
+        {"role": "user", "content": "test question"},
         {"role": "assistant", "content": "test answer"},
     ]
 
@@ -146,10 +148,10 @@ def test_to_openai_message_dicts_basic_string() -> None:
         ChatMessage(role="assistant", content="test answer"),
     ]
     openai_messages = to_openai_message_dicts(
-        chat_messages, supports_content_blocks=True
+        chat_messages,
     )
     assert openai_messages == [
-        {"role": "user", "content": [{"type": "text", "text": "test question"}]},
+        {"role": "user", "content": "test question"},
         {"role": "assistant", "content": "test answer"},
     ]
 
@@ -159,7 +161,7 @@ def test_to_openai_message_dicts_function_calling(
     openi_message_dicts_with_function_calling: List[ChatCompletionMessageParam],
 ) -> None:
     message_dicts = to_openai_message_dicts(
-        chat_messages_with_function_calling, supports_content_blocks=True
+        chat_messages_with_function_calling,
     )
     assert message_dicts == openi_message_dicts_with_function_calling
 
@@ -224,6 +226,52 @@ def test_to_openai_message_with_pydantic_description() -> None:
             "description": "Pydantic description.",
             "parameters": TestOutput.schema(),
         },
+    }
+
+
+def test_to_openai_message_dicts_with_content_blocks() -> None:
+    chat_message = ChatMessage(
+        role=MessageRole.USER,
+        blocks=[
+            TextBlock(text="test question"),
+            ImageBlock(url="https://example.com/image.jpg"),
+        ],
+    )
+
+    # user messages are converted to blocks
+    openai_message = to_openai_message_dicts([chat_message])[0]
+    assert openai_message == {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "test question"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.jpg"},
+            },
+        ],
+    }
+
+    chat_message = ChatMessage(
+        role=MessageRole.USER,
+        blocks=[
+            TextBlock(text="test question"),
+            ImageBlock(url="https://example.com/image.jpg"),
+        ],
+    )
+
+    # other messages do not support blocks
+    chat_message = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            TextBlock(text="test question"),
+            ImageBlock(url="https://example.com/image.jpg"),
+        ],
+    )
+
+    openai_message = to_openai_message_dicts([chat_message])[0]
+    assert openai_message == {
+        "role": "assistant",
+        "content": "test question",
     }
 
 


### PR DESCRIPTION
Ok, this PR updates some of the changes from #17240 so that its a bit more straightforward. Basically don't even send content blocks over the API until multiple non-text content block types are present in a message

Fixes tests, bumps versions