### PR TITLE
Fix: TGI context window

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/base.py
@@ -48,7 +48,7 @@ from llama_index.llms.huggingface.utils import (
     to_tgi_messages,
     force_single_tool_call,
     resolve_tgi_function_call,
-    get_max_input_length,
+    get_max_total_tokens,
     resolve_tool_choice,
 )
 from transformers import (
@@ -137,7 +137,9 @@ class HuggingFaceLLM(CustomLLM):
     )
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,
-        description="The maximum number of tokens available for input.",
+        description=(
+            LLMMetadata.model_fields["context_window"].description
+        ),
         gt=0,
     )
     max_new_tokens: int = Field(
@@ -752,7 +754,10 @@ class TextGenerationInference(FunctionCallingLLM):
 
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,
-        description=("Maximum input length in tokens returned from TGI endpoint"),
+        description=(
+            LLMMetadata.model_fields["context_window"].description
+            + " Maximum total tokens returned from TGI endpoint."
+        ),
     )
     is_chat_model: bool = Field(
         default=True,
@@ -819,7 +824,7 @@ class TextGenerationInference(FunctionCallingLLM):
             logger.warning(f"TGI client has no function call support: {e}")
             is_function_calling_model = False
 
-        context_window = get_max_input_length(model_url) or DEFAULT_CONTEXT_WINDOW
+        context_window = get_max_total_tokens(model_url) or DEFAULT_CONTEXT_WINDOW
 
         super().__init__(
             context_window=context_window,

--- a/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/base.py
@@ -137,9 +137,7 @@ class HuggingFaceLLM(CustomLLM):
     )
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,
-        description=(
-            LLMMetadata.model_fields["context_window"].description
-        ),
+        description=(LLMMetadata.model_fields["context_window"].description),
         gt=0,
     )
     max_new_tokens: int = Field(

--- a/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/llama_index/llms/huggingface/utils.py
@@ -24,10 +24,20 @@ def resolve_tgi_function_call(url: str) -> bool:
         )
 
 
-def get_max_input_length(url: str) -> Union[int, None]:
+def get_max_input_tokens(url: str) -> Union[int, None]:
     url = f"{url}/info"
     model_info = dict(requests.get(url).json())
-    return model_info.get("max_input_length", None)
+    tgi_version = model_info.get("version", None)
+    if version.parse(tgi_version) >= version.parse("2.1.0"):
+        return model_info.get("max_input_tokens", None)
+    else:
+        return model_info.get("max_input_length", None)
+
+
+def get_max_total_tokens(url: str) -> Union[int, None]:
+    url = f"{url}/info"
+    model_info = dict(requests.get(url).json())
+    return model_info.get("max_total_tokens", None)
 
 
 def to_tgi_messages(messages: Sequence[ChatMessage]) -> Sequence[Message]:

--- a/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-huggingface/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-huggingface"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
@@ -62,10 +62,7 @@ class TextGenerationInference(FunctionCallingLLM):
     )
     max_tokens: int = Field(
         default=DEFAULT_NUM_OUTPUTS,
-        description=(
-            LLMMetadata.model_fields["context_window"].description
-            + " Maximum total tokens returned from TGI endpoint."
-        ),
+        description=("The maximum number of tokens to generate."),
         gt=0,
     )
     token: Union[str, bool, None] = Field(
@@ -104,7 +101,10 @@ class TextGenerationInference(FunctionCallingLLM):
 
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,
-        description=("Maximum input length in tokens returned from TGI endpoint"),
+        description=(
+            LLMMetadata.model_fields["context_window"].description
+            + " Maximum total tokens returned from TGI endpoint."
+        ),
     )
     is_chat_model: bool = Field(
         default=True,

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
@@ -38,7 +38,7 @@ from llama_index.llms.text_generation_inference.utils import (
     to_tgi_messages,
     force_single_tool_call,
     resolve_tgi_function_call,
-    get_max_input_length,
+    get_max_total_tokens,
     resolve_tool_choice,
 )
 from text_generation import (
@@ -62,7 +62,10 @@ class TextGenerationInference(FunctionCallingLLM):
     )
     max_tokens: int = Field(
         default=DEFAULT_NUM_OUTPUTS,
-        description=("The maximum number of tokens to generate."),
+        description=(
+            LLMMetadata.model_fields["context_window"].description
+            + " Maximum total tokens returned from TGI endpoint."
+        ),
         gt=0,
     )
     token: Union[str, bool, None] = Field(
@@ -155,7 +158,7 @@ class TextGenerationInference(FunctionCallingLLM):
             logger.warning(f"TGI client has no function call support: {e}")
             is_function_calling_model = False
 
-        context_window = get_max_input_length(model_url) or DEFAULT_CONTEXT_WINDOW
+        context_window = get_max_total_tokens(model_url) or DEFAULT_CONTEXT_WINDOW
 
         super().__init__(
             context_window=context_window,

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/utils.py
@@ -28,7 +28,7 @@ def get_max_input_tokens(url: str) -> Union[int, None]:
     url = f"{url}/info"
     model_info = dict(requests.get(url).json())
     tgi_version = model_info.get("version", None)
-    if version.parse(tgi_version) < version.parse("2.1.0"):
+    if version.parse(tgi_version) >= version.parse("2.1.0"):
         return model_info.get("max_input_tokens", None)
     else:
         return model_info.get("max_input_length", None)

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/utils.py
@@ -24,10 +24,20 @@ def resolve_tgi_function_call(url: str) -> bool:
         )
 
 
-def get_max_input_length(url: str) -> Union[int, None]:
+def get_max_input_tokens(url: str) -> Union[int, None]:
     url = f"{url}/info"
     model_info = dict(requests.get(url).json())
-    return model_info.get("max_input_length", None)
+    tgi_version = model_info.get("version", None)
+    if version.parse(tgi_version) < version.parse("2.1.0"):
+        return model_info.get("max_input_tokens", None)
+    else:
+        return model_info.get("max_input_length", None)
+
+
+def get_max_total_tokens(url: str) -> Union[int, None]:
+    url = f"{url}/info"
+    model_info = dict(requests.get(url).json())
+    return model_info.get("max_total_tokens", None)
 
 
 def to_tgi_messages(messages: Sequence[ChatMessage]) -> Sequence[Message]:

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-text-generation-inference"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Changes:
- Rename the function `get_max_input_length` to `get_max_input_tokens` and check TGI version for returning the value of the max input tokens.
- Change the context window for TGI LLM to use the `max_total_tokens`.

Both changes take place in the packages `llama-index-integrations/llms/llama-index-llms-huggingface` and `llama-index-integrations/llms/llama-index-llms-text-generation-inference`.

Fixes #17251.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
