### PR TITLE
fix: make `ImageDocument` derive from `Document`, backward compatible

### DIFF
--- a/llama-index-core/llama_index/core/multi_modal_llms/base.py
+++ b/llama-index-core/llama_index/core/multi_modal_llms/base.py
@@ -30,7 +30,7 @@ from llama_index.core.constants import (
 )
 from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
-from llama_index.core.schema import BaseComponent, ImageNode
+from llama_index.core.schema import BaseComponent, ImageDocument, ImageNode
 
 
 class MultiModalLLMMetadata(BaseModel):
@@ -217,7 +217,7 @@ class MultiModalCompleteComponent(BaseMultiModalComponent):
             if not isinstance(input["image_documents"], list):
                 raise ValueError("image_documents must be a list.")
             for doc in input["image_documents"]:
-                if not isinstance(doc, ImageNode):
+                if not isinstance(doc, ImageDocument):
                     raise ValueError(
                         "image_documents must be a list of ImageNode objects."
                     )

--- a/llama-index-core/llama_index/core/multi_modal_llms/base.py
+++ b/llama-index-core/llama_index/core/multi_modal_llms/base.py
@@ -217,7 +217,7 @@ class MultiModalCompleteComponent(BaseMultiModalComponent):
             if not isinstance(input["image_documents"], list):
                 raise ValueError("image_documents must be a list.")
             for doc in input["image_documents"]:
-                if not isinstance(doc, ImageDocument):
+                if not isinstance(doc, (ImageDocument, ImageNode)):
                     raise ValueError(
                         "image_documents must be a list of ImageNode objects."
                     )

--- a/llama-index-core/llama_index/core/node_parser/node_utils.py
+++ b/llama-index-core/llama_index/core/node_parser/node_utils.py
@@ -54,7 +54,7 @@ def build_nodes_from_splits(
                 image_url=document.image_url,
                 excluded_embed_metadata_keys=document.excluded_embed_metadata_keys,
                 excluded_llm_metadata_keys=document.excluded_llm_metadata_keys,
-                metadata_seperator=document.metadata_seperator,
+                metadata_seperator=document.metadata_separator,
                 metadata_template=document.metadata_template,
                 text_template=document.text_template,
                 relationships=relationships,

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -634,7 +634,10 @@ class TextNode(BaseNode):
         """Make TextNode forward-compatible with Node by supporting 'text_resource' in the constructor."""
         if "text_resource" in kwargs:
             tr = kwargs.pop("text_resource")
-            kwargs["text"] = tr.text
+            if isinstance(tr, MediaResource):
+                kwargs["text"] = tr.text
+            else:
+                kwargs["text"] = tr["text"]
         super().__init__(*args, **kwargs)
 
     text: str = Field(default="", description="Text content of the node.")

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -1125,14 +1125,14 @@ class ImageDocument(Document):
         super().__init__(**kwargs)
 
     @property
-    def image(self) -> bytes | None:
+    def image(self) -> str | None:
         if self.image_resource and self.image_resource.data:
-            return self.image_resource.data
+            return self.image_resource.data.decode("utf-8")
         return None
 
     @image.setter
-    def image(self, image: bytes) -> None:
-        self.image_resource = MediaResource(data=image)
+    def image(self, image: str) -> None:
+        self.image_resource = MediaResource(data=image.encode("utf-8"))
 
     @property
     def image_path(self) -> str | None:

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -982,7 +982,7 @@ class Document(Node):
         version="0.12.2",
         reason="'get_doc_id' is deprecated, access the 'id_' property instead.",
     )
-    def get_doc_id(self) -> str:
+    def get_doc_id(self) -> str:  # pragma: nocover
         return self.id_
 
     def to_langchain_format(self) -> LCDocument:
@@ -1122,10 +1122,9 @@ class ImageDocument(Document):
         super().__init__(**kwargs)
 
     @property
-    def image(self) -> str | None:
-        assert self.image_resource
-        if self.image_resource.data:
-            return self.image_resource.data.decode("utf-8")
+    def image(self) -> bytes | None:
+        if self.image_resource and self.image_resource.data:
+            return self.image_resource.data
         return None
 
     @image.setter
@@ -1172,8 +1171,9 @@ class ImageDocument(Document):
     @text_embedding.setter
     def text_embedding(self, embeddings: list[float]) -> None:
         if self.text_resource:
-            emb_dict = self.text_resource.embeddings or {}
-            emb_dict["dense"] = embeddings
+            if self.text_resource.embeddings is None:
+                self.text_resource.embeddings = {}
+            self.text_resource.embeddings["dense"] = embeddings
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -1105,7 +1105,7 @@ class Document(Node):
 class ImageDocument(Document):
     """Backward compatible wrapper around Document containing an image."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         image = kwargs.pop("image", None)
         image_path = kwargs.pop("image_path", None)
         image_url = kwargs.pop("image_url", None)
@@ -1132,7 +1132,7 @@ class ImageDocument(Document):
         return None
 
     @image.setter
-    def set_image(self, image: bytes):
+    def image(self, image: bytes) -> None:
         self.image_resource = MediaResource(data=image)
 
     @property
@@ -1143,7 +1143,7 @@ class ImageDocument(Document):
         return None
 
     @image_path.setter
-    def set_image_path(self, image_path: str):
+    def image_path(self, image_path: str) -> None:
         self.image_resource = MediaResource(path=Path(image_path))
 
     @property
@@ -1154,7 +1154,7 @@ class ImageDocument(Document):
         return None
 
     @image_url.setter
-    def set_image_url(self, image_url: str):
+    def image_url(self, image_url: str) -> None:
         self.image_resource = MediaResource(url=AnyUrl(url=image_url))
 
     @property
@@ -1163,7 +1163,7 @@ class ImageDocument(Document):
         return self.image_resource.mimetype
 
     @image_mimetype.setter
-    def set_image_mimetype(self, image_mimetype: str):
+    def image_mimetype(self, image_mimetype: str) -> None:
         assert self.image_resource
         self.image_resource.mimetype = image_mimetype
 
@@ -1174,7 +1174,7 @@ class ImageDocument(Document):
         return None
 
     @text_embedding.setter
-    def set_text_embedding(self, embeddings: list[float]):
+    def text_embedding(self, embeddings: list[float]) -> None:
         if self.text_resource:
             emb_dict = self.text_resource.embeddings or {}
             emb_dict["dense"] = embeddings

--- a/llama-index-core/tests/schema/test_media_resource.py
+++ b/llama-index-core/tests/schema/test_media_resource.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from llama_index.core.bridge.pydantic import AnyUrl
 from llama_index.core.schema import MediaResource
 
@@ -21,10 +23,10 @@ def test_hash():
     assert (
         MediaResource(
             data=b"test bytes",
-            path="foo/bar/baz",
+            path=Path("foo/bar/baz"),
             url=AnyUrl("http://example.com"),
             text="some text",
         ).hash
-        == "7ac964db7843a9ffb37cda7b5b9822b0f84111d6a271b4991dd26d1fc68490d3"
+        == "04414a5f03ad7fa055229b4d3690d47427cb0b65bc7eb8f770d1ecbd54ab4909"
     )
     assert MediaResource().hash == ""

--- a/llama-index-core/tests/schema/test_node.py
+++ b/llama-index-core/tests/schema/test_node.py
@@ -17,5 +17,5 @@ def test_hash():
     node.text_resource = MediaResource(text="some text", mimetype="text/plain")
     node.video_resource = MediaResource(data=b"some video", mimetype="video/mpeg")
     assert (
-        node.hash == "ee411edd3dffb27470eef165ccf4df9fabaa02e7c7c39415950d3ac4d7e35e61"
+        node.hash == "6f08712269634de7e53e62a3aaee59d60e9a32a43bc05284a21244f960f0cda4"
     )

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -1,5 +1,5 @@
 import pytest
-from llama_index.core.schema import ImageNode, Node, NodeWithScore, TextNode
+from llama_index.core.schema import ImageNode, MediaResource, NodeWithScore, TextNode
 
 
 @pytest.fixture()
@@ -62,5 +62,6 @@ def test_image_node_hash() -> None:
     assert node3.hash == node4.hash
 
 
-def test_node() -> None:
-    node = Node(id_="test_node")
+def test_build_text_node_text_resource() -> None:
+    node = TextNode(id_="test_node", text_resource=MediaResource(text="test data"))
+    assert node.text == "test data"

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -73,6 +73,16 @@ def test_text_node_hash() -> None:
     assert node3.hash != node.hash
 
 
+def test_text_node_with_text_resource():
+    tr = MediaResource(text="This is a test")
+    text_node = TextNode(text_resource=tr)
+    assert text_node.text == "This is a test"
+
+    tr_dict = tr.model_dump()
+    text_node = TextNode(text_resource=tr_dict)
+    assert text_node.text == "This is a test"
+
+
 def test_image_node_hash() -> None:
     """Test hash for ImageNode."""
     node = ImageNode(image="base64", image_path="path")

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -1,5 +1,18 @@
+import base64
+from io import BytesIO
+from pathlib import Path
+from unittest import mock
+
 import pytest
-from llama_index.core.schema import ImageNode, MediaResource, NodeWithScore, TextNode
+from llama_index.core.schema import (
+    Document,
+    ImageDocument,
+    ImageNode,
+    MediaResource,
+    NodeWithScore,
+    ObjectType,
+    TextNode,
+)
 
 
 @pytest.fixture()
@@ -17,6 +30,16 @@ def node_with_score(text_node: TextNode) -> NodeWithScore:
         node=text_node,
         score=0.5,
     )
+
+
+@pytest.fixture()
+def png_1px_b64() -> bytes:
+    return b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+
+@pytest.fixture()
+def png_1px(png_1px_b64) -> bytes:
+    return base64.b64decode(png_1px_b64)
 
 
 def test_node_with_score_passthrough(node_with_score: NodeWithScore) -> None:
@@ -65,3 +88,111 @@ def test_image_node_hash() -> None:
 def test_build_text_node_text_resource() -> None:
     node = TextNode(id_="test_node", text_resource=MediaResource(text="test data"))
     assert node.text == "test data"
+
+
+def test_document_init() -> None:
+    doc = Document(doc_id="test")
+    assert doc.doc_id == "test"
+    assert doc.id_ == "test"
+    with pytest.raises(
+        ValueError,
+        match="Cannot pass both 'doc_id' and 'id_' to create a Document, use 'id_'",
+    ):
+        doc = Document(id_="test", doc_id="test")
+
+    doc = Document(extra_info={"key": "value"})
+    assert doc.metadata == {"key": "value"}
+    with pytest.raises(
+        ValueError,
+        match="Cannot pass both 'extra_info' and 'metadata' to create a Document, use 'metadata'",
+    ):
+        doc = Document(extra_info={}, metadata={})
+
+    doc = Document(text="test")
+    assert doc.text == "test"
+    assert doc.text_resource
+    assert doc.text_resource.text == "test"
+    with pytest.raises(
+        ValueError,
+        match="Cannot pass both 'text' and 'text_resource' to create a Document, use 'text_resource'",
+    ):
+        doc = Document(text="test", text_resource="test")
+
+
+def test_document_properties():
+    doc = Document()
+    assert doc.get_type() == ObjectType.DOCUMENT
+    doc.doc_id = "test"
+    assert doc.id_ == "test"
+
+
+def test_document_str():
+    with mock.patch("llama_index.core.schema.TRUNCATE_LENGTH", 5):
+        doc = Document(
+            id_="test_id",
+            text="Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+        )
+        assert str(doc) == "Doc ID: test_id\nText: Lo..."
+
+
+def test_image_document_empty():
+    doc = ImageDocument(id_="test")
+    assert doc.id_ == "test"
+    assert doc.image is None
+    assert doc.image_path is None
+    assert doc.image_url is None
+    assert doc.image_mimetype is None
+    assert doc.class_name() == "ImageDocument"
+
+
+def test_image_document_image():
+    doc = ImageDocument(id_="test", image=b"123456")
+    assert doc.image == b"MTIzNDU2"
+    doc.image = b"123456789"
+    assert doc.image == b"MTIzNDU2Nzg5"
+
+
+def test_image_document_path():
+    mock_path = Path(__file__)
+    doc = ImageDocument(id_="test", image_path=mock_path)
+    assert doc.image_path == str(mock_path)
+    doc.image_path = str(mock_path.parent)
+    assert doc.image_path == str(mock_path.parent)
+
+
+def test_image_document_url():
+    doc = ImageDocument(id_="test", image_url="https://example.com/")
+    assert doc.image_url == "https://example.com/"
+    doc.image_url = "https://foo.org"
+    assert doc.image_url == "https://foo.org/"
+
+
+def test_image_document_mimetype():
+    doc = ImageDocument(image=b"123456")
+    assert doc.image_mimetype is None
+    doc.image_mimetype = "foo"
+    assert doc.image_mimetype == "foo"
+
+
+def test_image_document_embeddings():
+    doc = ImageDocument(text="foo")
+    assert doc.text_resource is not None
+    assert doc.text_embedding is None
+    doc.text_embedding = [1.0, 2.0, 3.0]
+    assert doc.text_embedding == [1.0, 2.0, 3.0]
+    assert doc.text_resource.embeddings == {"dense": [1.0, 2.0, 3.0]}
+
+
+def test_image_block_resolve_image(png_1px: bytes, png_1px_b64: bytes):
+    doc = ImageDocument()
+    assert doc.resolve_image().read() == b""
+
+    doc = ImageDocument(image=png_1px)
+
+    img = doc.resolve_image()
+    assert isinstance(img, BytesIO)
+    assert img.read() == png_1px
+
+    img = doc.resolve_image(as_base64=True)
+    assert isinstance(img, BytesIO)
+    assert img.read() == png_1px_b64

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -157,9 +157,9 @@ def test_image_document_empty():
 
 def test_image_document_image():
     doc = ImageDocument(id_="test", image=b"123456")
-    assert doc.image == b"MTIzNDU2"
-    doc.image = b"123456789"
-    assert doc.image == b"MTIzNDU2Nzg5"
+    assert doc.image == "MTIzNDU2"
+    doc.image = "123456789"
+    assert doc.image == "MTIzNDU2Nzg5"
 
 
 def test_image_document_path():


### PR DESCRIPTION
# Description

In preparation of making readers aware of the new multimodal `Document`, make the existing `ImageDocument` use the new multimodal fields while keeping a backward compatible interface.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

