### PR TITLE
feat: Add NOT filter condition to MetadataFilter and QdrantVectorStore

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/types.py
+++ b/llama-index-core/llama_index/core/vector_stores/types.py
@@ -88,6 +88,7 @@ class FilterCondition(str, Enum):
     # TODO add more conditions
     AND = "and"
     OR = "or"
+    NOT = "not"  # negates the filter condition
 
 
 class MetadataFilter(BaseModel):

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1136,6 +1136,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
             filter.must = conditions
         elif filters.condition == FilterCondition.OR:
             filter.should = conditions
+        elif filters.condition == FilterCondition.NOT:
+            filter.must_not = conditions
         return filter
 
     def _build_query_filter(self, query: VectorStoreQuery) -> Optional[Any]:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -1,8 +1,15 @@
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
 from llama_index.vector_stores.qdrant import QdrantVectorStore
 import pytest
-
-from qdrant_client.http.models import PointsList, PointStruct
+from unittest.mock import MagicMock
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import (
+    PointsList,
+    PointStruct,
+    Filter,
+    FieldCondition,
+    MatchText,
+)
 
 
 def test_class():
@@ -103,3 +110,84 @@ async def test_get_with_embedding(vector_store: QdrantVectorStore) -> None:
     )
 
     assert all(node.embedding is not None for node in existing_nodes)
+
+
+def test_filter_conditions():
+    """Test AND, OR, and NOT filter conditions."""
+    from llama_index.core.vector_stores.types import (
+        MetadataFilter,
+        MetadataFilters,
+        FilterCondition,
+        FilterOperator,
+    )
+
+    # Create a mock Qdrant client
+    mock_client = MagicMock(spec=QdrantClient)
+    vector_store = QdrantVectorStore(
+        collection_name="test_collection",
+        client=mock_client,
+    )
+
+    # Test AND condition
+    and_filter = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", value="books", operator=FilterOperator.EQ),
+            MetadataFilter(key="price", value=10, operator=FilterOperator.GT),
+        ],
+        condition=FilterCondition.AND,
+    )
+    filter_and = vector_store._build_subfilter(and_filter)
+    assert filter_and.must is not None
+    assert len(filter_and.must) == 2
+    assert filter_and.must[0].key == "category"
+    assert filter_and.must[0].match.value == "books"
+    assert filter_and.must[1].key == "price"
+    assert filter_and.must[1].range.gt == 10
+
+    # Test OR condition
+    or_filter = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", value="books", operator=FilterOperator.EQ),
+            MetadataFilter(
+                key="category", value="electronics", operator=FilterOperator.EQ
+            ),
+        ],
+        condition=FilterCondition.OR,
+    )
+    filter_or = vector_store._build_subfilter(or_filter)
+    assert filter_or.should is not None
+    assert len(filter_or.should) == 2
+    assert filter_or.should[0].key == "category"
+    assert filter_or.should[0].match.value == "books"
+    assert filter_or.should[1].key == "category"
+    assert filter_or.should[1].match.value == "electronics"
+
+    # Test NOT condition by creating a Filter directly
+    not_filter = Filter(
+        must_not=[
+            FieldCondition(
+                key="content",
+                match=MatchText(text="unwanted text"),
+            )
+        ]
+    )
+    assert not_filter.must_not is not None
+    assert len(not_filter.must_not) == 1
+    assert not_filter.must_not[0].key == "content"
+    assert not_filter.must_not[0].match.text == "unwanted text"
+
+    # Test complex nested condition (AND with NOT)
+    complex_filter = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", value="books", operator=FilterOperator.EQ),
+            MetadataFilter(key="price", value=10, operator=FilterOperator.GT),
+        ],
+        condition=FilterCondition.AND,
+    )
+    filter_complex = vector_store._build_subfilter(complex_filter)
+    assert filter_complex.must is not None
+    assert len(filter_complex.must) == 2
+    assert filter_complex.must[0].key == "category"
+    assert filter_complex.must[0].match.value == "books"
+    assert filter_complex.must[1].key == "price"
+    assert filter_complex.must[1].range.gt == 10


### PR DESCRIPTION
# Description

This PR adds support for NOT filter condition in MetadataFilter and updates QdrantVectorStore to handle it. The NOT condition allows negating filter conditions, providing more flexibility in metadata filtering operations. This enhancement enables users to exclude specific metadata matches from their search results.

Fixes #17206

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods