### PR TITLE
Support Confluence cookies

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/README.md
@@ -18,9 +18,10 @@ The following order is used for checking authentication credentials:
 
 1. `oauth2`
 2. `api_token`
-3. `user_name` and `password`
-4. Environment variable `CONFLUENCE_API_TOKEN`
-5. Environment variable `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD`
+3. `cookies`
+4. `user_name` and `password`
+5. Environment variable `CONFLUENCE_API_TOKEN`
+6. Environment variable `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD`
 
 For more on authenticating using OAuth 2.0, checkout:
 

--- a/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
@@ -31,6 +31,7 @@ class ConfluenceReader(BaseReader):
         base_url (str): 'base_url' for confluence cloud instance, this is suffixed with '/wiki', eg 'https://yoursite.atlassian.com/wiki'
         cloud (bool): connecting to Confluence Cloud or self-hosted instance
         api_token (str): Confluence API token, see https://confluence.atlassian.com/cloud/api-tokens-938839638.html
+        cookies (dict): Confluence cookies, see https://atlassian-python-api.readthedocs.io/index.html
         user_name (str): Confluence username, used for basic auth. Must be used with `password`.
         password (str): Confluence password, used for basic auth. Must be used with `user_name`.
         client_args (dict): Additional keyword arguments to pass directly to the Atlassian Confluence client constructor, for example `{'backoff_and_retry': True}`.
@@ -43,6 +44,7 @@ class ConfluenceReader(BaseReader):
         oauth2: Optional[Dict] = None,
         cloud: bool = True,
         api_token: Optional[str] = None,
+        cookies: Optional[dict] = None,
         user_name: Optional[str] = None,
         password: Optional[str] = None,
         client_args: Optional[dict] = None,
@@ -70,6 +72,10 @@ class ConfluenceReader(BaseReader):
             if api_token is not None:
                 self.confluence = Confluence(
                     url=base_url, token=api_token, cloud=cloud, **client_args
+                )
+            elif cookies is not None:
+                self.confluence = Confluence(
+                    url=base_url, cookies=cookies, cloud=cloud, **client_args
                 )
             elif user_name is not None and password is not None:
                 self.confluence = Confluence(

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 maintainers = ["zywilliamli"]
 name = "llama-index-readers-confluence"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
@@ -32,6 +32,13 @@ def test_confluence_reader_with_api_token():
     )
     assert reader.confluence is not None
 
+def test_confluence_reader_with_cookies():
+    reader = ConfluenceReader(
+        base_url="https://example.atlassian.net/wiki",
+        cookies="key=value",
+    )
+    assert reader.confluence is not None
+
 
 def test_confluence_reader_with_client_args():
     with patch("atlassian.Confluence") as MockConstructor:

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
@@ -35,7 +35,7 @@ def test_confluence_reader_with_api_token():
 def test_confluence_reader_with_cookies():
     reader = ConfluenceReader(
         base_url="https://example.atlassian.net/wiki",
-        cookies="key=value",
+        cookies={'key': 'value'},
     )
     assert reader.confluence is not None
 

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
@@ -32,10 +32,11 @@ def test_confluence_reader_with_api_token():
     )
     assert reader.confluence is not None
 
+
 def test_confluence_reader_with_cookies():
     reader = ConfluenceReader(
         base_url="https://example.atlassian.net/wiki",
-        cookies={'key': 'value'},
+        cookies={"key": "value"},
     )
     assert reader.confluence is not None
 


### PR DESCRIPTION
# Description

Some confluence instances don't support personal access token, then cookie is a convenient way to authenticate. This PR adds support for Confluence cookies.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
