### PR TITLE
[bug fix] Ensure that `StopEvent` gets cleared from `Context._in_progress["_done"]` after a Workflow run

### DIFF
--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -247,6 +247,7 @@ class Workflow(metaclass=WorkflowMeta):
                                 new_ev = await instrumented_step(**kwargs)
                                 break  # exit the retrying loop
                             except WorkflowDone:
+                                await ctx.remove_from_in_progress(name=name, ev=ev)
                                 raise
                             except Exception as e:
                                 if config.retry_policy is None:
@@ -277,6 +278,7 @@ class Workflow(metaclass=WorkflowMeta):
                                 None, run_task
                             )
                         except WorkflowDone:
+                            await ctx.remove_from_in_progress(name=name, ev=ev)
                             raise
                         except Exception as e:
                             raise WorkflowRuntimeError(

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -120,3 +120,13 @@ async def test_deprecated_params(ctx):
         DeprecationWarning, match="`make_private` is deprecated and will be ignored"
     ):
         await ctx.set("foo", 42, make_private=True)
+
+
+@pytest.mark.asyncio()
+async def test_empty_inprogress_when_workflow_done(workflow):
+    h = workflow.run()
+    _ = await h
+
+    # there shouldn't be any in progress events
+    for inprogress_list in h.ctx._in_progress.values():
+        assert len(inprogress_list) == 0

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -76,6 +76,9 @@ async def test_workflow_run_step(workflow):
     result = await handler
     assert handler.is_done()
     assert result == "Workflow completed"
+    # there shouldn't be any in progress events
+    for inprogress_list in handler.ctx._in_progress.values():
+        assert len(inprogress_list) == 0
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
# Description

With the addition of Checkpointing feature, we added the `Context._in_progress` field that marks which steps/events are in progress at the time of the snapshot. (The purpose being that if you reload from a Checkpoint that had some steps/events in progress, then these would have to re-started from scratch when re-running the Workflow.)

In doing so, I introduced a bug that didn't clear (`_done` step, `StopEvent`) from the `_in_progress` attribute when a Workflow has successfully ran. This PR fixes this.

Fixes issues that were observed in `llama-deploy`:
- https://github.com/run-llama/llama_deploy/issues/401 (see related discussion https://github.com/run-llama/llama_deploy/discussions/400)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change and adapted an existing one with a new assertion
