### PR TITLE
Update Cerebras examples to use Llama 3.3 70b

### DIFF
--- a/docs/docs/examples/llm/cerebras.ipynb
+++ b/docs/docs/examples/llm/cerebras.ipynb
@@ -103,7 +103,7 @@
     "    \"Enter your Cerebras API key: \"\n",
     ")\n",
     "\n",
-    "llm = Cerebras(model=\"llama3.1-70b\", api_key=os.environ[\"CEREBRAS_API_KEY\"])"
+    "llm = Cerebras(model=\"llama-3.3-70b\", api_key=os.environ[\"CEREBRAS_API_KEY\"])"
    ]
   },
   {

--- a/llama-index-integrations/llms/llama-index-llms-cerebras/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/README.md
@@ -44,7 +44,7 @@ import os
 from llama_index.core.llms import ChatMessage
 from llama_index.llms.cerebras import Cerebras
 
-llm = Cerebras(model="llama3.1-70b", api_key=os.environ["CEREBRAS_API_KEY"])
+llm = Cerebras(model="llama-3.3-70b", api_key=os.environ["CEREBRAS_API_KEY"])
 
 messages = [
     ChatMessage(
@@ -63,7 +63,7 @@ import os
 
 from llama_index.llms.cerebras import Cerebras
 
-llm = Cerebras(model="llama3.1-70b", api_key=os.environ["CEREBRAS_API_KEY"])
+llm = Cerebras(model="llama-3.3-70b", api_key=os.environ["CEREBRAS_API_KEY"])
 
 response = llm.stream_complete("What is Generative AI?")
 for r in response:

--- a/llama-index-integrations/llms/llama-index-llms-cerebras/llama_index/llms/cerebras/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/llama_index/llms/cerebras/base.py
@@ -15,7 +15,7 @@ class Cerebras(OpenAILike):
         from llama_index.llms.cerebras import Cerebras
 
         # Set up the Cerebras class with the required model and API key
-        llm = Cerebras(model="llama3.1-70b", api_key="your_api_key")
+        llm = Cerebras(model="llama-3.3-70b", api_key="your_api_key")
 
         # Call the complete method with a query
         response = llm.complete("Why is fast inference important?")

--- a/llama-index-integrations/llms/llama-index-llms-cerebras/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-llms-cerebras"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Cerebras now supports Llama 3.3 70b, so references to Llama 3.1 70b are removed in this PR.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
