### PR TITLE
VoyageAI Reranker optional API Key

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-voyageai-rerank/llama_index/postprocessor/voyageai_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-voyageai-rerank/llama_index/postprocessor/voyageai_rerank/base.py
@@ -26,8 +26,8 @@ class VoyageAIRerank(BaseNodePostprocessor):
 
     def __init__(
         self,
-        api_key: str,
         model: str,
+        api_key: Optional[str] = None,
         top_n: Optional[int] = None,
         truncation: Optional[bool] = None,
         # deprecated

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-voyageai-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-voyageai-rerank/pyproject.toml
@@ -30,11 +30,11 @@ license = "MIT"
 name = "llama-index-postprocessor-voyageai-rerank"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-voyageai = "^0.2.1"
+voyageai = {python = ">=3.9,<3.13", version = ">=0.3.2,<0.4.0"}
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

API key was a previously a required argument for the VoyageAIRerank class but the `voyageai` client defaults to the `VOYAGE_API_KEY` environment variable if no api key is provided to its constructor. Now `api_key` is an optional argument to this class which is consistent with other llama-index voyage integrations.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests
