### PR TITLE
fix: make Document serialization backward compatible

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -959,6 +959,7 @@ class Document(Node):
 
         super().__init__(**data)
 
+    @model_serializer(mode="wrap")
     def custom_model_dump(self, handler: Any) -> Dict[str, Any]:
         """For full backward compatibility with the text field, we customize the model serializer."""
         data = super().custom_model_dump(handler)

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -934,24 +934,36 @@ class Document(Node):
         If 'extra_info' was passed, store it in 'metadata'.
         """
         if "doc_id" in data:
+            value = data.pop("doc_id")
             if "id_" in data:
-                msg = "Cannot pass both 'doc_id' and 'id_' to create a Document, use 'id_'"
-                raise ValueError(msg)
-            data["id_"] = data.pop("doc_id")
+                msg = "'doc_id' is deprecated and 'id_' will be used instead"
+                logging.warning(msg)
+            else:
+                data["id_"] = value
 
         if "extra_info" in data:
+            value = data.pop("extra_info")
             if "metadata" in data:
-                msg = "Cannot pass both 'extra_info' and 'metadata' to create a Document, use 'metadata'"
-                raise ValueError(msg)
-            data["metadata"] = data.pop("extra_info")
+                msg = "'extra_info' is deprecated and 'metadata' will be used instead"
+                logging.warning(msg)
+            else:
+                data["metadata"] = value
 
         if "text" in data:
+            text = data.pop("text")
             if "text_resource" in data:
-                msg = "Cannot pass both 'text' and 'text_resource' to create a Document, use 'text_resource'"
-                raise ValueError(msg)
-            data["text_resource"] = MediaResource(text=data.pop("text"))
+                msg = "'text' is deprecated and 'text_resource' will be used instead"
+                logging.warning(msg)
+            else:
+                data["text_resource"] = MediaResource(text=text)
 
         super().__init__(**data)
+
+    def custom_model_dump(self, handler: Any) -> Dict[str, Any]:
+        """For full backward compatibility with the text field, we customize the model serializer."""
+        data = super().custom_model_dump(handler)
+        data["text"] = self.text
+        return data
 
     @property
     def text(self) -> str:

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 from io import BytesIO
 from pathlib import Path
 from unittest import mock
@@ -100,33 +101,46 @@ def test_build_text_node_text_resource() -> None:
     assert node.text == "test data"
 
 
-def test_document_init() -> None:
-    doc = Document(doc_id="test")
-    assert doc.doc_id == "test"
-    assert doc.id_ == "test"
-    with pytest.raises(
-        ValueError,
-        match="Cannot pass both 'doc_id' and 'id_' to create a Document, use 'id_'",
-    ):
-        doc = Document(id_="test", doc_id="test")
+def test_document_init(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        # Legacy init
+        doc = Document(doc_id="test")
+        assert doc.doc_id == "test"
+        assert doc.id_ == "test"
+        # Legacy init mixed with new
+        doc = Document(id_="test", doc_id="legacy_test")
+        assert "'doc_id' is deprecated and 'id_' will be used instead" in caplog.text
+        assert doc.id_ == "test"
+        caplog.clear()
 
-    doc = Document(extra_info={"key": "value"})
-    assert doc.metadata == {"key": "value"}
-    with pytest.raises(
-        ValueError,
-        match="Cannot pass both 'extra_info' and 'metadata' to create a Document, use 'metadata'",
-    ):
-        doc = Document(extra_info={}, metadata={})
+        # Legacy init
+        doc = Document(extra_info={"key": "value"})
+        assert doc.metadata == {"key": "value"}
+        assert doc.extra_info == {"key": "value"}
+        # Legacy init mixed with new
+        doc = Document(extra_info={"old_key": "old_value"}, metadata={"key": "value"})
+        assert (
+            "'extra_info' is deprecated and 'metadata' will be used instead"
+            in caplog.text
+        )
+        assert doc.metadata == {"key": "value"}
+        assert doc.extra_info == {"key": "value"}
+        caplog.clear()
 
-    doc = Document(text="test")
-    assert doc.text == "test"
-    assert doc.text_resource
-    assert doc.text_resource.text == "test"
-    with pytest.raises(
-        ValueError,
-        match="Cannot pass both 'text' and 'text_resource' to create a Document, use 'text_resource'",
-    ):
-        doc = Document(text="test", text_resource="test")
+        # Legacy init
+        doc = Document(text="test")
+        assert doc.text == "test"
+        assert doc.text_resource
+        assert doc.text_resource.text == "test"
+        # Legacy init mixed with new
+        doc = Document(text="legacy_test", text_resource=MediaResource(text="test"))
+        assert (
+            "'text' is deprecated and 'text_resource' will be used instead"
+            in caplog.text
+        )
+        assert doc.text == "test"
+        assert doc.text_resource
+        assert doc.text_resource.text == "test"
 
 
 def test_document_properties():
@@ -143,6 +157,35 @@ def test_document_str():
             text="Lorem ipsum dolor sit amet, consectetur adipiscing elit",
         )
         assert str(doc) == "Doc ID: test_id\nText: Lo..."
+
+
+def test_document_legacy_roundtrip():
+    origin = Document(id_="test_id", text="this is a test")
+    assert origin.model_dump() == {
+        "id_": "test_id",
+        "embedding": None,
+        "metadata": {},
+        "excluded_embed_metadata_keys": [],
+        "excluded_llm_metadata_keys": [],
+        "relationships": {},
+        "metadata_template": "{key}: {value}",
+        "metadata_separator": "\n",
+        "text": "this is a test",
+        "text_resource": {
+            "embeddings": None,
+            "text": "this is a test",
+            "mimetype": None,
+            "path": None,
+            "url": None,
+        },
+        "image_resource": None,
+        "audio_resource": None,
+        "video_resource": None,
+        "text_template": "{metadata_str}\n\n{content}",
+        "class_name": "Document",
+    }
+    dest = Document(**origin.model_dump())
+    assert dest.text == "this is a test"
 
 
 def test_image_document_empty():

--- a/llama-index-integrations/readers/llama-index-readers-docling/tests/test_readers_docling.py
+++ b/llama-index-integrations/readers/llama-index-readers-docling/tests/test_readers_docling.py
@@ -79,6 +79,7 @@ out_json_obj = {
             "video_resource": None,
             "text_template": "{metadata_str}\n\n{content}",
             "class_name": "Document",
+            "text": '{"schema_name": "DoclingDocument", "version": "1.0.0", "name": "sample", "origin": {"mimetype": "text/html", "binary_hash": 42, "filename": "sample.html"}, "furniture": {"self_ref": "#/furniture", "children": [], "name": "_root_", "label": "unspecified"}, "body": {"self_ref": "#/body", "children": [{"$ref": "#/texts/0"}, {"$ref": "#/texts/1"}], "name": "_root_", "label": "unspecified"}, "groups": [], "texts": [{"self_ref": "#/texts/0", "parent": {"$ref": "#/body"}, "children": [], "label": "paragraph", "prov": [], "orig": "Some text", "text": "Some text"}, {"self_ref": "#/texts/1", "parent": {"$ref": "#/body"}, "children": [], "label": "paragraph", "prov": [], "orig": "Another paragraph", "text": "Another paragraph"}], "pictures": [], "tables": [], "key_value_items": [], "pages": {}}',
         }
     ]
 }
@@ -106,6 +107,7 @@ out_md_obj = {
             "video_resource": None,
             "text_template": "{metadata_str}\n\n{content}",
             "class_name": "Document",
+            "text": "Some text\n\nAnother paragraph",
         }
     ]
 }


### PR DESCRIPTION
# Description

`Document` supports the `text` field but it doesn't include it in the model dump. This PR fixes the model serializer.

In order to make the serde roundtrip easier for the user, I also changed the `ValueError` raised when calling the model constructor with both old and new fields into a warning log.

Fixes issue reported on LlamaCloud