### PR TITLE
improve async search client handling

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-azureaisearch"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/15350

The code here is kind of a mess, but did my best to salvage what I could. I think the main issue stems from the user not passing in an async client (or sync), which is then set to None, and will fail when those operations take place.

This PR updates so that you can pass both clients in. Furthermore, an error is logged if you only pass one in.