### PR TITLE
bugfix when initializing with async aoss vector store

### DIFF
--- a/docs/docs/examples/agent/nvidia_document_research_assistant_for_blog_creation.ipynb
+++ b/docs/docs/examples/agent/nvidia_document_research_assistant_for_blog_creation.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Document Research Assistant for Blog Creation\n",
     "\n",
+    "[![ Click here to deploy.](https://uohmivykqgnnbiouffke.supabase.co/storage/v1/object/public/landingpage/brevdeploynavy.svg)](https://console.brev.dev/launchable/deploy?launchableID=env-2qRrBuBdUGzzauhql87XCd7U1wR)\n",
+    "\n",
     "In this notebook, you will use NVIDIA NIM Microservices for the LLM, llama-3.3-70b, to generate a report on a given topic. You will also use a NIM for an NVIDIA text embedding model, nv-embedqa-e5-v5. Given a set of documents, LlamaIndex will create an Index which it can run queries against. \n",
     "\n",
     "You can get started by leveraging NVIDIA API Catalog and call a hosted model's NIM API Endpoint. Once you familiarize yourself with this blueprint, you may want to self-host models with NIM Microservices.\n",
@@ -20,7 +22,7 @@
     "5. Performs Quality Assurance: A critic agent reviews the content for accuracy, coherence, and completeness, determining if revisions are necessary.\n",
     "6. Iterative Refinement: If improvements are needed, the workflow repeats by generating additional questions and gathering more information until the desired quality is reached.\n",
     "\n",
-    "This workflow combines modularity, automation, and iterative refinement to ensure the output meets the highest standards of quality."
+    "This workflow combines modularity, automation, and iterative refinement to ensure the output meets the highest standards of quality. "
    ]
   },
   {

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -630,7 +630,7 @@ class OpensearchVectorClient:
             ef_enabled = False
         else :
             self._os_version = self._get_opensearch_version()
-            major, minor, patch = os_version.split(".")
+            major, minor, patch = self.os_version.split(".")
             ef_enabled = int(major) >= 2 and int(minor) >= 9
         return ef_enabled
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
-
+import asyncio
 from llama_index.core.bridge.pydantic import PrivateAttr
 
 from llama_index.core.schema import BaseNode, MetadataMode, TextNode
@@ -123,14 +123,18 @@ class OpensearchVectorClient:
         self._os_async_client = os_async_client or self._get_async_opensearch_client(
             self._endpoint, **kwargs
         )
-        self._os_version = self._get_opensearch_version()
-        self._efficient_filtering_enabled = self._is_efficient_filtering_enabled(
-            self._os_version
-        )
+        self._efficient_filtering_enabled = self._is_efficient_filtering_enabled()
         not_found_error = self._import_not_found_error()
 
         try:
             self._os_client.indices.get(index=self._index)
+        except TypeError:
+            # Probably using async so switch to async client
+            try:
+                asyncio.run(self._os_async_client.indices.get(index=self._index))
+            except not_found_error:
+                asyncio.run(self._os_async_client.indices.create(index=self._index, body=idx_conf))
+                asyncio.run(self._os_async_client.indices.refresh(index=self._index))
         except not_found_error:
             self._os_client.indices.create(index=self._index, body=idx_conf)
             self._os_client.indices.refresh(index=self._index)
@@ -617,10 +621,18 @@ class OpensearchVectorClient:
             return True
         return False
 
-    def _is_efficient_filtering_enabled(self, os_version: str) -> bool:
+    def _is_efficient_filtering_enabled(self) -> bool:
         """Check if kNN with efficient filtering is enabled."""
-        major, minor, patch = os_version.split(".")
-        return int(major) >= 2 and int(minor) >= 9
+        # Technically, AOSS supports efficient filtering, 
+        # but we can't check the version number using .info(); AOSS doesn't support 'GET /'
+        #  so we must skip and disable by default.
+        if self.is_aoss: 
+            ef_enabled = False
+        else :
+            self._os_version = self._get_opensearch_version()
+            major, minor, patch = os_version.split(".")
+            ef_enabled = int(major) >= 2 and int(minor) >= 9
+        return ef_enabled
 
     def index_results(self, nodes: List[BaseNode], **kwargs: Any) -> List[str]:
         """Store results in the index."""

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -3,9 +3,9 @@
 import uuid
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
-import asyncio
-from llama_index.core.bridge.pydantic import PrivateAttr
 
+from llama_index.core.async_utils import asyncio_run
+from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode, TextNode
 from llama_index.core.vector_stores.types import (
     FilterCondition,
@@ -131,14 +131,14 @@ class OpensearchVectorClient:
         except TypeError:
             # Probably using async so switch to async client
             try:
-                asyncio.run(self._os_async_client.indices.get(index=self._index))
+                asyncio_run(self._os_async_client.indices.get(index=self._index))
             except not_found_error:
-                asyncio.run(
+                asyncio_run(
                     self._os_async_client.indices.create(
                         index=self._index, body=idx_conf
                     )
                 )
-                asyncio.run(self._os_async_client.indices.refresh(index=self._index))
+                asyncio_run(self._os_async_client.indices.refresh(index=self._index))
         except not_found_error:
             self._os_client.indices.create(index=self._index, body=idx_conf)
             self._os_client.indices.refresh(index=self._index)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -133,7 +133,11 @@ class OpensearchVectorClient:
             try:
                 asyncio.run(self._os_async_client.indices.get(index=self._index))
             except not_found_error:
-                asyncio.run(self._os_async_client.indices.create(index=self._index, body=idx_conf))
+                asyncio.run(
+                    self._os_async_client.indices.create(
+                        index=self._index, body=idx_conf
+                    )
+                )
                 asyncio.run(self._os_async_client.indices.refresh(index=self._index))
         except not_found_error:
             self._os_client.indices.create(index=self._index, body=idx_conf)
@@ -623,12 +627,12 @@ class OpensearchVectorClient:
 
     def _is_efficient_filtering_enabled(self) -> bool:
         """Check if kNN with efficient filtering is enabled."""
-        # Technically, AOSS supports efficient filtering, 
+        # Technically, AOSS supports efficient filtering,
         # but we can't check the version number using .info(); AOSS doesn't support 'GET /'
         #  so we must skip and disable by default.
-        if self.is_aoss: 
+        if self.is_aoss:
             ef_enabled = False
-        else :
+        else:
             self._os_version = self._get_opensearch_version()
             major, minor, patch = self.os_version.split(".")
             ef_enabled = int(major) >= 2 and int(minor) >= 9

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-opensearch"
 readme = "README.md"
-version = "0.5.0"
+version = "0.5.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description
@logan-markewich 
Following up this issue [[Bug]: Can't initialize OpensearchVectorClient through AWS endpoint in async mode #16746
16746](https://github.com/run-llama/llama_index/issues/16746)

At the moment, we can't initialize a OpensSearchVectorClient using AOSS (amazon opensearch serverless) and/or an async connection. There are 2 problems here:

- Problem 1: If initializing with AOSS (async or not), the code will fail when fetching the version number because this requires a `GET /` call to the endpoint. This works on standard Opensearch but OpenSearch Serverless doesn't support that command. 
- When using an async connection, the code will fail when getting or creating/refreshing the indices in the `__init__()`. This is because the code doesn't use the async client but only the "sync" one, this raises a TypeError due to a coroutine appearing somewhere.

Fixes # (issue)

- Problem 1: The version number is used only to check the eligibility of the efficient-kNN filtering. I couldn't find any other ways to check the version of the cluster so I decided to remove that efficient-kNN filtering feature completely when we're using AOSS (we check `self.aoss`). Ideally, we'd like to find a workaround to check the version so we can still use efficient-kNN filtering while using AOSS.
- Problem 2:  I fix that with an extra `except` clause that catches a TypeError and retry with the async client this time.

## New Package?

Had to import asyncio to run the async client but it's a python built-in anyway

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not sure how to test that, we'd need to simulate an endpoint ?
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
