### PR TITLE
Fix exclude text in document serialization

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -25,7 +25,7 @@ from typing import (
     Sequence,
     Union,
 )
-
+from pydantic import SerializationInfo, SerializerFunctionWrapHandler
 import filetype
 import requests
 from dataclasses_json import DataClassJsonMixin
@@ -960,10 +960,13 @@ class Document(Node):
         super().__init__(**data)
 
     @model_serializer(mode="wrap")
-    def custom_model_dump(self, handler: Any) -> Dict[str, Any]:
+    def custom_model_dump(
+        self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
+    ) -> Dict[str, Any]:
         """For full backward compatibility with the text field, we customize the model serializer."""
         data = super().custom_model_dump(handler)
-        data["text"] = self.text
+        if "text" not in info.exclude:
+            data["text"] = self.text
         return data
 
     @property

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -188,6 +188,34 @@ def test_document_legacy_roundtrip():
     assert dest.text == "this is a test"
 
 
+def test_document_exclude_text():
+    doc = Document(id_="test_id", text="this is a test")
+    model_dump = doc.model_dump(exclude={"text"})
+    assert "text" not in model_dump
+    assert doc.model_dump(exclude={"text"}) == {
+        "id_": "test_id",
+        "embedding": None,
+        "metadata": {},
+        "excluded_embed_metadata_keys": [],
+        "excluded_llm_metadata_keys": [],
+        "relationships": {},
+        "metadata_template": "{key}: {value}",
+        "metadata_separator": "\n",
+        "text_resource": {
+            "embeddings": None,
+            "text": "this is a test",
+            "mimetype": None,
+            "path": None,
+            "url": None,
+        },
+        "image_resource": None,
+        "audio_resource": None,
+        "video_resource": None,
+        "text_template": "{metadata_str}\n\n{content}",
+        "class_name": "Document",
+    }
+
+
 def test_image_document_empty():
     doc = ImageDocument(id_="test")
     assert doc.id_ == "test"


### PR DESCRIPTION
# Description

When users call `model_dump(exclude={"text"})`, the text field should be excluded

Fixes # (issue)

## New Package?
- [x] No

## Version Bump?
- [x] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change
