### PR TITLE
implement client_kwargs["custom_batch"] for weaviate

### DIFF
--- a/docs/docs/examples/vector_stores/WeaviateIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/WeaviateIndexDemo.ipynb
@@ -212,7 +212,9 @@
     "from weaviate.classes.config import ConsistencyLevel\n",
     "\n",
     "custom_batch = client.batch.fixed_size(\n",
-    "    batch_size=123, concurrent_requests=3, consistency_level=ConsistencyLevel.ALL\n",
+    "    batch_size=123,\n",
+    "    concurrent_requests=3,\n",
+    "    consistency_level=ConsistencyLevel.ALL,\n",
     ")\n",
     "vector_store_fixed = WeaviateVectorStore(\n",
     "    weaviate_client=client,\n",
@@ -435,8 +437,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/docs/examples/vector_stores/WeaviateIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/WeaviateIndexDemo.ipynb
@@ -190,6 +190,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9add1bd1",
+   "metadata": {},
+   "source": [
+    "#### Using a custom batch configuration\n",
+    "\n",
+    "Llamaindex defaults to Weaviate's dynamic batching, optimized for most common scenarios. However, in low-latency setups, this can overload the server or max out any GRPC Message limits in place. For more control and a better ingestion process, consider adjusting batch size by using the fixed size batch.\n",
+    "\n",
+    "\n",
+    "Here is how you can fine tune WeaviateVectorStore and define a custom batch:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "936caf33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from weaviate.classes.config import ConsistencyLevel\n",
+    "\n",
+    "custom_batch = client.batch.fixed_size(\n",
+    "    batch_size=123, concurrent_requests=3, consistency_level=ConsistencyLevel.ALL\n",
+    ")\n",
+    "vector_store_fixed = WeaviateVectorStore(\n",
+    "    weaviate_client=client,\n",
+    "    index_name=\"LlamaIndex\",\n",
+    "    # we pass our custom batch as a client_kwargs\n",
+    "    client_kwargs={\"custom_batch\": custom_batch},\n",
+    ")"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "04304299-fc3e-40a0-8600-f50c3292767e",
@@ -389,7 +422,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -402,7 +435,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -35,6 +35,10 @@ from llama_index.vector_stores.weaviate._exceptions import (
 import weaviate
 import weaviate.classes as wvc
 
+from weaviate.collections.batch.batch_wrapper import (
+    _ContextManagerWrapper as BatchWrapper,
+)
+
 _logger = logging.getLogger(__name__)
 
 
@@ -155,6 +159,7 @@ class WeaviateVectorStore(BasePydanticVectorStore):
     _is_self_created_weaviate_client: bool = (
         PrivateAttr()
     )  # States if the Weaviate client was created within this class and therefore closing it lies in our responsibility
+    _custom_batch: Optional[BatchWrapper] = PrivateAttr()
 
     def __init__(
         self,
@@ -187,6 +192,7 @@ class WeaviateVectorStore(BasePydanticVectorStore):
             auth_config=auth_config.__dict__ if auth_config else {},
             client_kwargs=client_kwargs or {},
         )
+
         if isinstance(weaviate_client, weaviate.WeaviateClient):
             self._client = weaviate_client
             self._aclient = None
@@ -207,7 +213,16 @@ class WeaviateVectorStore(BasePydanticVectorStore):
             self._is_self_created_weaviate_client = True
         else:  # weaviate_client neither one of the expected types nor None
             raise ValueError(
-                f"Unsupported weaviate_client of type {type(weaviate_client)}. Either provide an instance of `WeaviateClient` or `WeaviateAsyncClient` or set `weaviate_client` to None to have a sync client automatically created using the setting provided in `auth_config` and `client_kwargs`."
+                f"Unsupported weaviate_client of type {type(
+                    weaviate_client)}. Either provide an instance of `WeaviateClient` or `WeaviateAsyncClient` or set `weaviate_client` to None to have a sync client automatically created using the setting provided in `auth_config` and `client_kwargs`."
+            )
+        # validate custom batch
+        self._custom_batch = (
+            client_kwargs.get("custom_batch") if client_kwargs else None
+        )
+        if self._custom_batch and not isinstance(self._custom_batch, BatchWrapper):
+            raise ValueError(
+                "client_kwargs['custom_batch'] must be an instance of client.batch.dynamic() or client.batch.fixed_size()"
             )
 
         # create default schema if does not exist
@@ -253,8 +268,10 @@ class WeaviateVectorStore(BasePydanticVectorStore):
 
         """
         ids = [r.node_id for r in nodes]
-
-        with self.client.batch.dynamic() as batch:
+        provided_batch = self._custom_batch
+        if not provided_batch:
+            provided_batch = self.client.batch.dynamic()
+        with provided_batch as batch:
             for node in nodes:
                 data_object = get_data_object(node=node, text_key=self.text_key)
                 batch.add_object(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -213,8 +213,7 @@ class WeaviateVectorStore(BasePydanticVectorStore):
             self._is_self_created_weaviate_client = True
         else:  # weaviate_client neither one of the expected types nor None
             raise ValueError(
-                f"Unsupported weaviate_client of type {type(
-                    weaviate_client)}. Either provide an instance of `WeaviateClient` or `WeaviateAsyncClient` or set `weaviate_client` to None to have a sync client automatically created using the setting provided in `auth_config` and `client_kwargs`."
+                f"Unsupported weaviate_client of type {type(weaviate_client)}. Either provide an instance of `WeaviateClient` or `WeaviateAsyncClient` or set `weaviate_client` to None to have a sync client automatically created using the setting provided in `auth_config` and `client_kwargs`."
             )
         # validate custom batch
         self._custom_batch = (

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
 readme = "README.md"
-version = "1.3.0"
+version = "1.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -37,8 +37,7 @@ def test_no_weaviate_client_instance_provided():
     )
 
     # Make sure that the vector store is functional by calling some basic methods
-    vector_store.add(
-        [TextNode(text="Hello world.", embedding=[0.0, 0.0, 0.3])])
+    vector_store.add([TextNode(text="Hello world.", embedding=[0.0, 0.0, 0.3])])
     query = VectorStoreQuery(
         query_embedding=[0.3, 0.0, 0.0],
         similarity_top_k=10,
@@ -125,10 +124,8 @@ class TestWeaviateAsync:
         assert len(results.nodes) == 1
 
     async def test_async_delete_nodes(self, async_vector_store):
-        node_to_be_deleted = TextNode(
-            text="Hello world.", embedding=[0.0, 0.0, 0.3])
-        node_to_keep = TextNode(text="This is a test.",
-                                embedding=[0.3, 0.0, 0.0])
+        node_to_be_deleted = TextNode(text="Hello world.", embedding=[0.0, 0.0, 0.3])
+        node_to_keep = TextNode(text="This is a test.", embedding=[0.3, 0.0, 0.0])
         nodes = [node_to_be_deleted, node_to_keep]
 
         await async_vector_store.async_add(nodes)
@@ -147,8 +144,7 @@ class TestWeaviateAsync:
         node_to_be_deleted = TextNode(
             text="Hello world.",
             relationships={
-                NodeRelationship.SOURCE: RelatedNodeInfo(
-                    node_id="to_be_deleted")
+                NodeRelationship.SOURCE: RelatedNodeInfo(node_id="to_be_deleted")
             },
             embedding=[0.0, 0.0, 0.3],
         )
@@ -186,16 +182,14 @@ class TestWeaviateAsync:
         assert results.nodes[0].node_id == node_to_keep.node_id
 
     def test_async_client_properties(self, async_vector_store):
-        assert isinstance(async_vector_store.async_client,
-                          weaviate.WeaviateAsyncClient)
+        assert isinstance(async_vector_store.async_client, weaviate.WeaviateAsyncClient)
         with pytest.raises(SyncClientNotProvidedError):
             async_vector_store.client
 
 
 class TestWeaviateSync:
     def test_class(self):
-        names_of_base_classes = [
-            b.__name__ for b in WeaviateVectorStore.__mro__]
+        names_of_base_classes = [b.__name__ for b in WeaviateVectorStore.__mro__]
         assert BasePydanticVectorStore.__name__ in names_of_base_classes
 
     @pytest.fixture(scope="class")
@@ -239,16 +233,20 @@ class TestWeaviateSync:
         custom_batch = client.batch.fixed_size(
             batch_size=123,
             concurrent_requests=3,
-            consistency_level=weaviate.classes.config.ConsistencyLevel.ONE
+            consistency_level=weaviate.classes.config.ConsistencyLevel.ONE,
         )
         vector_store_fixed = WeaviateVectorStore(
-            weaviate_client=client, index_name=TEST_COLLECTION_NAME, client_kwargs={
-                "custom_batch": custom_batch}
+            weaviate_client=client,
+            index_name=TEST_COLLECTION_NAME,
+            client_kwargs={"custom_batch": custom_batch},
         )
         assert isinstance(client.batch._batch_mode, _FixedSizeBatching)
         assert client.batch._batch_mode.batch_size == 123
         assert client.batch._batch_mode.concurrent_requests == 3
-        assert client.batch._consistency_level == weaviate.classes.config.ConsistencyLevel.ONE
+        assert (
+            client.batch._consistency_level
+            == weaviate.classes.config.ConsistencyLevel.ONE
+        )
 
         vector_store_default_dynamic.clear()
         vector_store_fixed.clear()
@@ -256,10 +254,11 @@ class TestWeaviateSync:
         # test wrong value
         try:
             WeaviateVectorStore(
-                weaviate_client=client, index_name=TEST_COLLECTION_NAME,
-                client_kwargs={"custom_batch": "wrong_value"}
+                weaviate_client=client,
+                index_name=TEST_COLLECTION_NAME,
+                client_kwargs={"custom_batch": "wrong_value"},
             )
-            assert False
+            AssertionError()
         except ValueError:
             assert True
 
@@ -360,8 +359,7 @@ class TestWeaviateSync:
         node_to_be_deleted = TextNode(
             text="Hello world.",
             relationships={
-                NodeRelationship.SOURCE: RelatedNodeInfo(
-                    node_id="to_be_deleted")
+                NodeRelationship.SOURCE: RelatedNodeInfo(node_id="to_be_deleted")
             },
             embedding=[0.0, 0.0, 0.3],
         )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -216,9 +216,6 @@ class TestWeaviateSync:
         vector_store.add(nodes)
         return vector_store
 
-    # because of the last test, we need to ignore this warning
-    # AttributeError: 'WeaviateVectorStore' object has no attribute
-    # @pytest.mark.filterwarnings("ignore:'WeaviateVectorStore' object has no attribute '.*'")
     def test_vector_store_with_custom_batch(self, client):
         nodes = [
             TextNode(text="Hello world.", embedding=[0.0, 0.0, 0.3]),


### PR DESCRIPTION
# Description

It is now possible to provide a custom batch while initializing WeaviateVectorStore.

This gives the developer a fine grained control over Weaviate batch. By default, the integration will use dynamic batch, that can overload the server or max out grpc messages in low latency scenarios between client and server.

Fixes #17345

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
