### PR TITLE
Fix IndexError in LLM Reranking when handling malformed LLM responses

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -116,8 +116,18 @@ def default_parse_choice_select_answer_fn(
             continue
         answer_nums.append(answer_num)
         # extract just the first digits after the colon.
-        _answer_relevance = re.findall(r"\d+", line_tokens[1].split(":")[1].strip())[0]
-        answer_relevances.append(float(_answer_relevance))
+        try:
+            _answer_relevance = re.findall(r"\d+", line_tokens[1].split(":")[1].strip())[0]
+            answer_relevances.append(float(_answer_relevance))
+        except (IndexError, ValueError) as e:
+            if not raise_error:
+                continue
+            else:
+                raise ValueError(
+                    f"Invalid answer line: {answer_line}. "
+                    "Answer line must be of the form: "
+                    "answer_num: <int>, answer_relevance: <float>"
+                )
     return answer_nums, answer_relevances
 
 

--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -117,7 +117,9 @@ def default_parse_choice_select_answer_fn(
         answer_nums.append(answer_num)
         # extract just the first digits after the colon.
         try:
-            _answer_relevance = re.findall(r"\d+", line_tokens[1].split(":")[1].strip())[0]
+            _answer_relevance = re.findall(
+                r"\d+", line_tokens[1].split(":")[1].strip()
+            )[0]
             answer_relevances.append(float(_answer_relevance))
         except (IndexError, ValueError) as e:
             if not raise_error:


### PR DESCRIPTION
# Description

When parsing LLMRerank responses, lines of the answer containing a valid reference to a document and a comma but no relevance score (like `Doc: 5, because it is the most relevant`) would throw an IndexError. As the bug is pretty similar, the PR is also quite similar to #16736.

Fixes #17352 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
