### PR TITLE
Change top_n if number of input nodes are less

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/llama_index/postprocessor/bedrock_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/llama_index/postprocessor/bedrock_rerank/base.py
@@ -208,6 +208,9 @@ class AWSBedrockRerank(BaseNodePostprocessor):
                         },
                     }
                 )
+            # change top_n if the number of nodes is less than top_n
+            if len(nodes) < self.top_n:
+                self.top_n = len(nodes)
 
             queries = [
                 {


### PR DESCRIPTION
Right now, the bedrock call fails in the input nodes is less than top_n. This patch fixes it, by setting top_n = num_nodes in such cases.