### PR TITLE
qdrant filter fix for `query_str is None`

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1136,14 +1136,9 @@ class QdrantVectorStore(BasePydanticVectorStore):
             filter.must = conditions
         elif filters.condition == FilterCondition.OR:
             filter.should = conditions
-        elif filters.condition == FilterCondition.NOT:
-            filter.must_not = conditions
         return filter
 
     def _build_query_filter(self, query: VectorStoreQuery) -> Optional[Any]:
-        if not query.doc_ids and not query.query_str:
-            return None
-
         must_conditions = []
 
         if query.doc_ids:
@@ -1167,6 +1162,9 @@ class QdrantVectorStore(BasePydanticVectorStore):
 
         if query.filters and query.filters.filters:
             must_conditions.append(self._build_subfilter(query.filters))
+
+        if len(must_conditions) == 0:
+            return None
 
         return Filter(must=must_conditions)
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1136,6 +1136,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
             filter.must = conditions
         elif filters.condition == FilterCondition.OR:
             filter.should = conditions
+        elif filters.condition == FilterCondition.NOT:
+            filter.must_not = conditions
         return filter
 
     def _build_query_filter(self, query: VectorStoreQuery) -> Optional[Any]:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-qdrant"
 readme = "README.md"
-version = "0.4.1"
+version = "0.4.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
An unneeded check was being done in qdrant, so that if query_str was none, filters were not built.

Removed the check.