### PR TITLE
Fix: Properly add documents from Gitlab Repo

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
@@ -84,9 +84,9 @@ class GitLabRepositoryReader(BaseReader):
 
         for item in repo_items:
             if item["type"] == "blob":
-                document = self._load_single_file(item["path"], ref)
-
-            documents.append(document)
+                documents.append(
+                    self._load_single_file(item["path"], ref)
+                )
 
         return documents
 

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
@@ -84,9 +84,7 @@ class GitLabRepositoryReader(BaseReader):
 
         for item in repo_items:
             if item["type"] == "blob":
-                documents.append(
-                    self._load_single_file(item["path"], ref)
-                )
+                documents.append(self._load_single_file(item["path"], ref))
 
         return documents
 

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = ["jiachengzhang1"]
 name = "llama-index-readers-gitlab"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fix: Properly add documents from Gitlab Repo

When reading files from a gitlab repo, previous implementation
would skip all non-blob files, but still would try to add them
to the list. This would cause a crash.

This patch only adds the document to the list if its a blob.


## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
