### PR TITLE
clean up type hints in schema extractor

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -150,7 +150,7 @@ class SchemaLLMPathExtractor(TransformComponent):
 
         # Build a pydantic model on the fly
         if kg_schema_cls is None:
-            possible_entities = possible_entities or DEFAULT_ENTITIES
+            possible_entities = possible_entities or DEFAULT_ENTITIES  # type: ignore
             if possible_entity_props and isinstance(possible_entity_props[0], tuple):
                 entity_props = [  # type: ignore
                     f"Property label `{k}` with description ({v})"
@@ -160,7 +160,7 @@ class SchemaLLMPathExtractor(TransformComponent):
                 entity_props = possible_entity_props  # type: ignore
             entity_cls = get_entity_class(possible_entities, entity_props, strict)
 
-            possible_relations = possible_relations or DEFAULT_RELATIONS
+            possible_relations = possible_relations or DEFAULT_RELATIONS  # type: ignore
             if possible_relation_props and isinstance(
                 possible_relation_props[0], tuple
             ):

--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -1,11 +1,5 @@
 import asyncio
-from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
-
-try:
-    from typing import TypeAlias  # type: ignore
-except ImportError:
-    # python 3.8 and 3.9 compatibility
-    from typing import Any as TypeAlias  # type: ignore
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Type, Union
 
 from llama_index.core.async_utils import run_jobs
 from llama_index.core.bridge.pydantic import create_model, field_validator
@@ -101,12 +95,12 @@ class SchemaLLMPathExtractor(TransformComponent):
             The language model to use.
         extract_prompt (Union[PromptTemplate, str], optional):
             The template to use for the extraction query. Defaults to None.
-        possible_entities (Optional[TypeAlias], optional):
+        possible_entities (Optional[Type[Any]], optional):
             The possible entities to extract. Defaults to None.
         possible_entity_props (Optional[Union[List[str], List[Tuple[str, str]]], optional):
             The possible entity properties to extract. Defaults to None.
             Can be a list of strings or a list of tuples with the format (name, description).
-        possible_relations (Optional[TypeAlias], optional):
+        possible_relations (Optional[Type[Any]], optional):
             The possible relations to extract. Defaults to None.
         possible_relation_props (Optional[Union[List[str], List[Tuple[str, str]]], optional):
             The possible relation properties to extract. Defaults to None.
@@ -138,9 +132,9 @@ class SchemaLLMPathExtractor(TransformComponent):
         self,
         llm: LLM,
         extract_prompt: Optional[Union[PromptTemplate, str]] = None,
-        possible_entities: Optional[TypeAlias] = None,
+        possible_entities: Optional[Type[Any]] = None,
         possible_entity_props: Optional[Union[List[str], List[Tuple[str, str]]]] = None,
-        possible_relations: Optional[TypeAlias] = None,
+        possible_relations: Optional[Type[Any]] = None,
         possible_relation_props: Optional[
             Union[List[str], List[Tuple[str, str]]]
         ] = None,


### PR DESCRIPTION
Some users report getting a type error in this file. I can't reproduce, but, we can clean up the typing a bit to avoid this in the future for users

Fixes https://github.com/run-llama/llama_parse/issues/572