### PR TITLE
Added support to allow only public slack channels

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-slack/llama_index/readers/slack/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-slack/llama_index/readers/slack/base.py
@@ -243,14 +243,12 @@ class SlackReader(BasePydanticReader):
         except re.error:
             return False
 
-    def _list_channels(self) -> List[Dict[str, Any]]:
-        """List all channels (public and private)."""
+    def _list_channels(self, types: str) -> List[Dict[str, Any]]:
+        """List channels based on the types."""
         from slack_sdk.errors import SlackApiError
 
         try:
-            result = self._client.conversations_list(
-                types="public_channel,private_channel"
-            )
+            result = self._client.conversations_list(types=types)
             return result["channels"]
         except SlackApiError as e:
             logger.error(f"Error fetching channels: {e.response['error']}")
@@ -275,7 +273,9 @@ class SlackReader(BasePydanticReader):
                     filtered_channels.append(channel)
         return filtered_channels
 
-    def get_channel_ids(self, channel_patterns: List[str]) -> List[str]:
+    def get_channel_ids(
+        self, channel_patterns: List[str], types: str = "public_channel,private_channel"
+    ) -> List[str]:
         """Get list of channel IDs based on names and regex patterns.
 
         Args:
@@ -287,7 +287,7 @@ class SlackReader(BasePydanticReader):
         if not channel_patterns:
             raise ValueError("No channel patterns provided.")
 
-        channels = self._list_channels()
+        channels = self._list_channels(types)
         logger.info(f"Total channels fetched: {len(channels)}")
 
         if not channels:


### PR DESCRIPTION
# Description

The Slack reader by default lists both public and private channels. Accessing Private channels requires an extra permission to **groups.read** API on the slack bot app. So, it is good to have flexibility to filter only public channels. Added changes to support to passing channel types

Fixes # (issue) NA

## New Package? 
NA
Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump? NA

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
