### PR TITLE
Support for Additional paramters for Elasticsearch Connection

### DIFF
--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-elasticsearch/llama_index/storage/kvstore/elasticsearch/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-elasticsearch/llama_index/storage/kvstore/elasticsearch/base.py
@@ -26,6 +26,7 @@ def _get_elasticsearch_client(
     api_key: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
+    **kwargs
 ) -> elasticsearch.AsyncElasticsearch:
     """Get AsyncElasticsearch client.
 
@@ -35,6 +36,12 @@ def _get_elasticsearch_client(
         api_key: Elasticsearch API key.
         username: Elasticsearch username.
         password: Elasticsearch password.
+        **kwargs: Additional parameters to be passed to the Elasticsearch
+                  client. This can include parameters such as request_timeout,
+                  retry_on_timeout, max_retries, ca_certs, verify_certs, and
+                  any other valid Elasticsearch client parameters. These
+                  parameters will be passed directly to the connection
+                  creation function.
 
     Returns:
         AsyncElasticsearch client.
@@ -60,6 +67,8 @@ def _get_elasticsearch_client(
         connection_params["api_key"] = api_key
     elif username and password:
         connection_params["basic_auth"] = (username, password)
+
+    connection_params.update(kwargs)
 
     sync_es_client = elasticsearch.Elasticsearch(
         **connection_params,
@@ -110,6 +119,7 @@ class ElasticsearchKVStore(BaseKVStore):
         es_api_key: Optional[str] = None,
         es_user: Optional[str] = None,
         es_password: Optional[str] = None,
+        **kwargs,
     ) -> None:
         nest_asyncio.apply()
 
@@ -130,6 +140,7 @@ class ElasticsearchKVStore(BaseKVStore):
                 password=es_password,
                 cloud_id=es_cloud_id,
                 api_key=es_api_key,
+                **kwargs,
             )
         else:
             raise ValueError(

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-storage-kvstore-elasticsearch"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -140,6 +140,12 @@ class ElasticsearchStore(BasePydanticVectorStore):
         retrieval_strategy: Retrieval strategy to use. AsyncBM25Strategy /
             AsyncSparseVectorStrategy / AsyncDenseVectorStrategy / AsyncRetrievalStrategy.
             Defaults to AsyncDenseVectorStrategy.
+        **kwargs: Additional parameters to be passed to the Elasticsearch
+                  client. This can include parameters such as request_timeout,
+                  retry_on_timeout, max_retries, ca_certs, verify_certs, and
+                  any other valid Elasticsearch client parameters. These
+                  parameters will be passed directly to the connection
+                  creation function.
 
     Raises:
         ConnectionError: If AsyncElasticsearch client cannot connect to Elasticsearch.
@@ -229,6 +235,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
                 api_key=es_api_key,
                 username=es_user,
                 password=es_password,
+                **kwargs,
             )
 
         if retrieval_strategy is None:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
@@ -17,6 +17,7 @@ def get_elasticsearch_client(
     api_key: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
+    **kwargs,
 ) -> AsyncElasticsearch:
     if url and cloud_id:
         raise ValueError(
@@ -36,6 +37,8 @@ def get_elasticsearch_client(
         connection_params["api_key"] = api_key
     elif username and password:
         connection_params["basic_auth"] = (username, password)
+
+    connection_params.update(kwargs)
 
     sync_es_client = Elasticsearch(
         **connection_params, headers={"user-agent": get_user_agent()}

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
This patch adds support for additional parameters when connecting to an Elasticsearch server. This can include request_timeout, retry_on_timeout, max_retries, ca_certs, verify_certs, and any other valid Elasticsearch client parameters. These parameters will be passed directly to the connection creation function.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
