### PR TITLE
Fix for llama_index.packs.raptor tree_traversal retrieval

### DIFF
--- a/llama-index-packs/llama-index-packs-raptor/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-raptor/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-packs-raptor"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-packs/llama-index-packs-raptor/tests/test_packs_raptor.py
+++ b/llama-index-packs/llama-index-packs-raptor/tests/test_packs_raptor.py
@@ -27,4 +27,4 @@ def test_raptor() -> None:
     assert len(nodes) == 2
 
     nodes = retriever.retrieve("text", mode="tree_traversal")
-    assert len(nodes) == 2
+    assert len(nodes) == 5


### PR DESCRIPTION
# Description

"tree_traversal" mode from the `RaptorRetriever` was only returning leaf nodes when it should also be returning cluster nodes visited during traversal. An example can be found [here](https://github.com/parthsarthi03/raptor/blob/master/raptor/tree_retriever.py#L236) by the RAPTOR authors. I had to do some `id_` tracking to avoid duplicates.

Fixes https://github.com/run-llama/llama_index/issues/15480

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I believe this change is already covered by existing unit test that I updated.
