### PR TITLE
feat: support typing.Annotated for adding parameter descriptions

### DIFF
--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -1,5 +1,18 @@
 from inspect import signature
-from typing import Any, Awaitable, Callable, List, Optional, Tuple, Type, Union, cast
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+    get_origin,
+    get_args,
+)
+import typing
 
 from llama_index.core.bridge.pydantic import BaseModel, FieldInfo, create_model
 
@@ -17,18 +30,28 @@ def create_schema_from_function(
     for param_name in params:
         param_type = params[param_name].annotation
         param_default = params[param_name].default
+        description = None
+
+        if get_origin(param_type) is typing.Annotated:
+            args = get_args(param_type)
+            param_type = args[0]
+            if isinstance(args[1], str):
+                description = args[1]
 
         if param_type is params[param_name].empty:
             param_type = Any
 
         if param_default is params[param_name].empty:
             # Required field
-            fields[param_name] = (param_type, FieldInfo())
+            fields[param_name] = (param_type, FieldInfo(description=description))
         elif isinstance(param_default, FieldInfo):
             # Field with pydantic.Field as default value
             fields[param_name] = (param_type, param_default)
         else:
-            fields[param_name] = (param_type, FieldInfo(default=param_default))
+            fields[param_name] = (
+                param_type,
+                FieldInfo(default=param_default, description=description),
+            )
 
     additional_fields = additional_fields or []
     for field_info in additional_fields:

--- a/llama-index-core/tests/tools/test_utils.py
+++ b/llama-index-core/tests/tools/test_utils.py
@@ -1,6 +1,6 @@
 """Test utils."""
 
-from typing import List
+from typing import List, Annotated
 
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.tools.utils import create_schema_from_function
@@ -35,6 +35,28 @@ def test_create_schema_from_function_with_field() -> None:
     """Test create_schema_from_function with pydantic.Field."""
 
     def tmp_function(x: int = Field(3, description="An integer")) -> str:
+        return str(x)
+
+    schema = create_schema_from_function("TestSchema", tmp_function)
+    actual_schema = schema.model_json_schema()
+
+    assert "x" in actual_schema["properties"]
+    assert actual_schema["properties"]["x"]["type"] == "integer"
+    assert actual_schema["properties"]["x"]["default"] == 3
+    assert actual_schema["properties"]["x"]["description"] == "An integer"
+
+    # Test the created schema
+    instance = schema()
+    assert instance.x == 3  # type: ignore
+
+    instance = schema(x=5)
+    assert instance.x == 5  # type: ignore
+
+
+def test_create_schema_from_function_with_typing_annotated() -> None:
+    """Test create_schema_from_function with pydantic.Field."""
+
+    def tmp_function(x: Annotated[int, "An integer"] = 3) -> str:
         return str(x)
 
     schema = create_schema_from_function("TestSchema", tmp_function)


### PR DESCRIPTION
# Description

Supports using [typing.Annotated](https://docs.python.org/3/library/typing.html#typing.Annotated) for adding function parameter descriptions. Using pydantic.Field works fine, but typing.Annotation is a more Pythonic and less library-dependent way to add description strings to function parameters. So now you can write a function like this:

```python
from typing import Annotated

def tmp_function(x: Annotated[int, 'An integer'] = 3) -> str:
    return str(x)
```

And it will pass the description of `x` to the LLM in the tool description. It doesn't remove the existing behavior of using `Field`, but it gives a new option that makes use of Python's built-in way to do this, rather than relying on Pydantic.

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
