### PR TITLE
Guess `image_mimetype` for `ImageNode`

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -44,7 +44,8 @@ from llama_index.core.bridge.pydantic import (
     SerializeAsAny,
     SerializerFunctionWrapHandler,
     model_serializer,
-    model_validator,
+    field_validator,
+    ValidationInfo,
 )
 from llama_index.core.bridge.pydantic_core import CoreSchema
 from llama_index.core.instrumentation import DispatcherSpanMixin
@@ -503,38 +504,56 @@ class MediaResource(BaseModel):
     text: str | None = Field(
         default=None, description="Text representation of this resource."
     )
-    mimetype: str | None = Field(
-        default=None, description="MIME type of this resource."
-    )
     path: Path | None = Field(
         default=None, description="Filesystem path of this resource."
     )
     url: AnyUrl | None = Field(default=None, description="URL to reach this resource.")
+    mimetype: str | None = Field(
+        default=None, description="MIME type of this resource."
+    )
 
-    @model_validator(mode="after")
-    def data_to_base64(self) -> Self:
+    @field_validator("data", mode="after")
+    @classmethod
+    def validate_data(cls, v: bytes | None, info: ValidationInfo) -> bytes | None:
         """If binary data was passed, store the resource as base64 and guess the mimetype when possible.
 
         In case the model was built passing binary data but without a mimetype,
         we try to guess it using the filetype library. To avoid resource-intense
         operations, we won't load the path or the URL to guess the mimetype.
         """
-        if not self.data:
-            return self
+        if v is None:
+            return v
 
         try:
             # Check if data is already base64 encoded
-            decoded_data = base64.b64decode(self.data)
+            base64.b64decode(v)
         except Exception:
-            decoded_data = self.data
-            # Not base64 - encode it
-            self.data = base64.b64encode(self.data)
+            v = base64.b64encode(v)
 
-        if not self.mimetype:
-            guess = filetype.guess(decoded_data)
-            self.mimetype = guess.mime if guess else None
+        return v
 
-        return self
+    @field_validator("mimetype", mode="after")
+    @classmethod
+    def validate_mimetype(cls, v: str | None, info: ValidationInfo) -> str | None:
+        if v is not None:
+            return v
+
+        # Since this field validator runs after the one for `data`
+        # then the contents of `data` should be encoded already
+        b64_data = info.data["data"]
+        if b64_data:  # encoded bytes
+            decoded_data = base64.b64decode(b64_data)
+            if guess := filetype.guess(decoded_data):
+                return guess.mime
+
+        # guess from path
+        rpath: str | None = info.data["path"]
+        if rpath:
+            extension = Path(rpath).suffix.replace(".", "")
+            if ftype := filetype.get_type(ext=extension):
+                return ftype.mime
+
+        return v
 
     @property
     def hash(self) -> str:
@@ -747,6 +766,28 @@ class ImageNode(TextNode):
         default=None,
         description="Text embedding of image node, if text field is filled out",
     )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Make ImageNode forward-compatible with Node by supporting 'image_resource' in the constructor."""
+        if "image_resource" in kwargs:
+            ir = kwargs.pop("image_resource")
+            if isinstance(ir, MediaResource):
+                kwargs["image_path"] = ir.path
+                kwargs["image_url"] = ir.url
+                kwargs["image_mimetype"] = ir.mimetype
+            else:
+                kwargs["image_path"] = ir.get("path", None)
+                kwargs["image_url"] = ir.get("url", None)
+                kwargs["image_mimetype"] = ir.get("mimetype", None)
+
+        mimetype = kwargs.get("image_mimetype", None)
+        if not mimetype and "image_path" in kwargs:
+            # guess mimetype from image_path
+            extension = Path(kwargs["image_path"]).suffix.replace(".", "")
+            if ftype := filetype.get_type(ext=extension):
+                kwargs["image_mimetype"] = ftype.mime
+
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def get_type(cls) -> str:

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -772,7 +772,7 @@ class ImageNode(TextNode):
         if "image_resource" in kwargs:
             ir = kwargs.pop("image_resource")
             if isinstance(ir, MediaResource):
-                kwargs["image_path"] = ir.path
+                kwargs["image_path"] = ir.path.as_posix()
                 kwargs["image_url"] = ir.url
                 kwargs["image_mimetype"] = ir.mimetype
             else:

--- a/llama-index-core/tests/schema/test_media_resource.py
+++ b/llama-index-core/tests/schema/test_media_resource.py
@@ -19,6 +19,17 @@ def test_mimetype():
     assert m.mimetype == "image/png"
 
 
+def test_mimetype_from_path():
+    m = MediaResource(path="my-image.jpg", mimetype=None)
+    assert m.mimetype == "image/jpeg"
+
+
+def test_mimetype_prioritizes_data():
+    png_1px = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    m = MediaResource(data=png_1px.encode("utf-8"), mimetype=None, path="my_image.jpg")
+    assert m.mimetype == "image/png"
+
+
 def test_hash():
     assert (
         MediaResource(

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -96,6 +96,22 @@ def test_image_node_hash() -> None:
     assert node3.hash == node4.hash
 
 
+def test_image_node_mimetype() -> None:
+    node = ImageNode(image_path="path")
+    node2 = ImageNode(image_path="path.png")
+
+    assert node.image_mimetype is None
+    assert node2.image_mimetype == "image/png"
+
+
+def test_build_image_node_image_resource() -> None:
+    ir = MediaResource(path="my-image.jpg", mimetype=None)
+    tr = MediaResource(text="test data")
+    node = ImageNode(id_="test_node", image_resource=ir, text_resource=tr)
+    assert node.text == "test data"
+    assert node.image_mimetype == "image/jpeg"
+
+
 def test_build_text_node_text_resource() -> None:
     node = TextNode(id_="test_node", text_resource=MediaResource(text="test data"))
     assert node.text == "test data"


### PR DESCRIPTION
# Description

This PR introduces a couple of enhancements when working with `ImageNode`'s:

1. It guesses the `image_mimetype` field from `image_path` if provided. (This is somewhat breaking as before we were guessing the mimetype from the path)
2. Similar to `TextNode` we add forward-compatibility by enabling construction via a image media resource type.

Also, I made an implementation change for validating `data` and `mimetype` fields of a `MediaResource`. Specifically, I opt to use `field_validator` over `model_validator` to be able to handle the validation of these two separate fields "separately".

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
