### PR TITLE
remove asserts from schema llm extractor

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -263,8 +263,6 @@ class SchemaLLMPathExtractor(TransformComponent):
 
     def _prune_invalid_triplets(self, kg_schema: Any) -> Sequence[Triplet]:
         """Prune invalid triplets."""
-        assert isinstance(kg_schema, self.kg_schema_cls)
-
         valid_triplets = []
         for triplet in kg_schema.triplets:
             subject = triplet.subject.name
@@ -341,8 +339,6 @@ class SchemaLLMPathExtractor(TransformComponent):
 
     async def _aextract(self, node: BaseNode) -> BaseNode:
         """Extract triplets from a node."""
-        assert hasattr(node, "text")
-
         text = node.get_content(metadata_mode=MetadataMode.LLM)
         try:
             kg_schema = await self.llm.astructured_predict(


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/17424

Some unneeded (and slightly breaking) asserts are in the code. This likely broke at some point depending on your pydantic version. But in any case, they aren't needed, so removing