### PR TITLE
more exception handling in schema llm extractor

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -348,7 +348,7 @@ class SchemaLLMPathExtractor(TransformComponent):
                 max_triplets_per_chunk=self.max_triplets_per_chunk,
             )
             triplets = self._prune_invalid_triplets(kg_schema)
-        except ValueError:
+        except (ValueError, TypeError, AttributeError):
             triplets = []
 
         existing_nodes = node.metadata.pop(KG_NODES_KEY, [])


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/17424

Just excepting more error types. Stuctured Prediction can return non-class objects if it fails to predict