### PR TITLE
bugfix: Duplicated citation nodes

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
@@ -217,7 +217,7 @@ class CitationQueryEngine(BaseQueryEngine):
                 text = f"Source {len(new_nodes) + 1}:\n{text_chunk}\n"
 
                 new_node = NodeWithScore(
-                    node=TextNode(metadata=node.node.metadata), score=node.score
+                    node=TextNode.model_validate(node.node.model_dump()), score=node.score
                 )
                 new_node.node.set_content(text)
                 new_nodes.append(new_node)

--- a/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
@@ -217,7 +217,7 @@ class CitationQueryEngine(BaseQueryEngine):
                 text = f"Source {len(new_nodes) + 1}:\n{text_chunk}\n"
 
                 new_node = NodeWithScore(
-                    node=TextNode.model_validate(node.node), score=node.score
+                    node=TextNode(metadata=node.node.metadata), score=node.score
                 )
                 new_node.node.set_content(text)
                 new_nodes.append(new_node)

--- a/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
@@ -217,7 +217,8 @@ class CitationQueryEngine(BaseQueryEngine):
                 text = f"Source {len(new_nodes) + 1}:\n{text_chunk}\n"
 
                 new_node = NodeWithScore(
-                    node=TextNode.model_validate(node.node.model_dump()), score=node.score
+                    node=TextNode.model_validate(node.node.model_dump()),
+                    score=node.score,
                 )
                 new_node.node.set_content(text)
                 new_nodes.append(new_node)


### PR DESCRIPTION
bugfix:
Duplicated citation nodes in CitationQueryEngine when chunk_size is less than the content length.

# Description

TextNode.model_validate dosen't create a new instance but return node.node itself, which cause a duplicated context.


![a1](https://github.com/user-attachments/assets/2c4e0d12-56d7-44a5-bb64-ea6605689c11)



Fixes #17439

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
