### PR TITLE
add example notebook; add quickstart link

### DIFF
--- a/docs/docs/community/integrations/vector_stores.md
+++ b/docs/docs/community/integrations/vector_stores.md
@@ -47,7 +47,7 @@ as the storage backend for `VectorStoreIndex`.
 - Upstash (`UpstashVectorStore`). [Quickstart](https://upstash.com/docs/vector/overall/getstarted)
 - Vertex AI Vector Search (`VertexAIVectorStore`). [Quickstart](https://cloud.google.com/vertex-ai/docs/vector-search/quickstart)
 - Weaviate (`WeaviateVectorStore`). [Installation](https://weaviate.io/developers/weaviate/installation). [Python Client](https://weaviate.io/developers/weaviate/client-libraries/python).
-- WordLift (`WordliftVectorStore`). [Python Client](https://pypi.org/project/wordlift-client/).
+- WordLift (`WordliftVectorStore`). [Quickstart](https://docs.wordlift.io/llm-connectors/wordlift-vector-store/). [Python Client](https://pypi.org/project/wordlift-client/).
 - Zep (`ZepVectorStore`). [Installation](https://docs.getzep.com/deployment/quickstart/). [Python Client](https://docs.getzep.com/sdk/).
 - Zilliz (`MilvusVectorStore`). [Quickstart](https://zilliz.com/doc/quick_start)
 

--- a/docs/docs/module_guides/storing/vector_stores.md
+++ b/docs/docs/module_guides/storing/vector_stores.md
@@ -118,4 +118,5 @@ For more details, see [Vector Store Integrations](../../community/integrations/v
 - [Vertex AI Vector Search](../../examples/vector_stores/VertexAIVectorSearchDemo.ipynb)
 - [Weaviate](../../examples/vector_stores/WeaviateIndexDemo.ipynb)
 - [Weaviate Hybrid Search](../../examples/vector_stores/WeaviateIndexDemo-Hybrid.ipynb)
+- [WordLift](../../examples/vector_stores/WordLiftDemo.ipynb)
 - [Zep](../../examples/vector_stores/ZepIndexDemo.ipynb)


### PR DESCRIPTION
# Description

A small documentation update adding link to the example notebook and to the quickstart for WordLift Vector Store.