### PR TITLE
feat: Add OpenSearch Binary & Byte data_type support

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -269,7 +269,7 @@ class BaseNode(BaseComponent):
     id_: str = Field(
         default_factory=lambda: str(uuid.uuid4()), description="Unique ID of the node."
     )
-    embedding: Optional[List[float]] = Field(
+    embedding: Optional[List[Union[float, int]]] = Field(
         default=None, description="Embedding of the node."
     )
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-opensearch"
 readme = "README.md"
-version = "0.5.2"
+version = "0.6.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR adds support for byte and binary vector storage in the OpenSearch vector store integration, leveraging OpenSearch 2.17's new vector capabilities. This enhancement enables more efficient vector storage by supporting 8-bit integers (-128 to 127) instead of only floats, significantly reducing storage requirements while maintaining search quality.

Fixes #17271 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

Added comprehensive test suite including:

- Initialisation tests for different vector types and configurations
- Validation tests for engine and space type requirements
- Functionality tests for both synchronous and asynchronous operations
- Tests covering the full range of byte values (-128 to 127)
- Tests ensuring binary vector dimension requirements
- Tests for both lucene and faiss engines with byte vectors

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
