### PR TITLE
feat: support adding images to ChatMessage through additional_kwargs

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -162,15 +162,14 @@ class ChatMessage(BaseModel):
         """Keeps backward compatibility with the old `content` field.
 
         Returns:
-            The cumulative content of the blocks if they're all of type TextBlock, None otherwise.
+            The cumulative content of the TextBlock blocks, None if there are none.
         """
         content = ""
         for block in self.blocks:
-            if not isinstance(block, TextBlock):
-                return None
-            content += block.text
+            if isinstance(block, TextBlock):
+                content += block.text
 
-        return content
+        return content or None
 
     @content.setter
     def content(self, content: str) -> None:

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -6,11 +6,14 @@ from unittest import mock
 import pytest
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    ChatResponse,
+    CompletionResponse,
     ImageBlock,
     MessageRole,
     TextBlock,
 )
 from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.schema import ImageDocument
 from pydantic import AnyUrl
 
 
@@ -172,3 +175,21 @@ def test_image_block_store_as_base64(png_1px_b64: bytes, png_1px: bytes):
     assert ImageBlock(image=png_1px).image == png_1px_b64
     # Store already encoded data
     assert ImageBlock(image=png_1px_b64).image == png_1px_b64
+
+
+def test_legacy_image_additional_kwargs(png_1px_b64: bytes):
+    image_doc = ImageDocument(image=png_1px_b64)
+    msg = ChatMessage(additional_kwargs={"images": [image_doc]})
+    assert len(msg.blocks) == 1
+    assert msg.blocks[0].image == png_1px_b64
+
+
+def test_chat_response():
+    message = ChatMessage("some content")
+    cr = ChatResponse(message=message)
+    assert str(cr) == str(message)
+
+
+def test_completion_response():
+    cr = CompletionResponse(text="some text")
+    assert str(cr) == "some text"

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -77,6 +77,8 @@ def test_chat_message_content_legacy_set():
 
 def test_chat_message_content_returns_empty_string():
     m = ChatMessage(content=[TextBlock(text="test content"), ImageBlock()])
+    assert m.content == "test content"
+    m = ChatMessage()
     assert m.content is None
 
 

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/tests/test_multi-modal-llms_gemini_utils.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/tests/test_multi-modal-llms_gemini_utils.py
@@ -26,8 +26,10 @@ def test_generate_message_empty_image_documents():
 
 
 def test_generate_message_with_image_documents():
-    image1 = MagicMock(spec=ImageDocument, resolve_image=BytesIO(b"foo"))
-    image2 = MagicMock(spec=ImageDocument, resolve_image=BytesIO(b"bar"))
+    image1 = MagicMock(spec=ImageDocument)
+    image1.resolve_image.return_value = BytesIO(b"foo")
+    image2 = MagicMock(spec=ImageDocument)
+    image2.resolve_image.return_value = BytesIO(b"bar")
     image_documents = [image1, image2]
 
     result = generate_gemini_multi_modal_chat_message(

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/tests/test_multi-modal-llms_gemini_utils.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/tests/test_multi-modal-llms_gemini_utils.py
@@ -1,4 +1,6 @@
+from io import BytesIO
 from unittest.mock import MagicMock
+
 from llama_index.core.schema import ImageDocument
 from llama_index.multi_modal_llms.gemini.utils import (
     generate_gemini_multi_modal_chat_message,
@@ -24,8 +26,8 @@ def test_generate_message_empty_image_documents():
 
 
 def test_generate_message_with_image_documents():
-    image1 = MagicMock(spec=ImageDocument)
-    image2 = MagicMock(spec=ImageDocument)
+    image1 = MagicMock(spec=ImageDocument, resolve_image=BytesIO(b"foo"))
+    image2 = MagicMock(spec=ImageDocument, resolve_image=BytesIO(b"bar"))
     image_documents = [image1, image2]
 
     result = generate_gemini_multi_modal_chat_message(


### PR DESCRIPTION
# Description

As part of the work to supersede multimodal-LLM abstractions, add support for building `ChatMessage`s via `additional_kwargs`. This will help reducing the code changes to transition existing multimodal-LLMs  to their plain-LLM counterparts.

Part of #15950
