### PR TITLE
Add new operator for Qdrant Vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1083,7 +1083,10 @@ class QdrantVectorStore(BasePydanticVectorStore):
                         range=Range(lte=subfilter.value),
                     )
                 )
-            elif subfilter.operator == FilterOperator.TEXT_MATCH:
+            elif (
+                subfilter.operator == FilterOperator.TEXT_MATCH
+                or subfilter.operator == FilterOperator.TEXT_MATCH_INSENSITIVE
+            ):
                 conditions.append(
                     FieldCondition(
                         key=subfilter.key,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -27,13 +27,13 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-qdrant"
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 qdrant-client = ">=1.7.1"
 grpcio = "^1.60.0"
-llama-index-core = "^0.12.6"
+llama-index-core = "^0.12.7"
 
 [tool.poetry.extras]
 fastembed = ["fastembed"]


### PR DESCRIPTION
# Description

In this PR, I have added the `TEXT_MATCH_INSENSITIVE` operator for Qdrant vector store class. 

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
