### PR TITLE
fix: bug in MediaResource validator

### DIFF
--- a/llama-index-core/tests/schema/test_media_resource.py
+++ b/llama-index-core/tests/schema/test_media_resource.py
@@ -14,8 +14,8 @@ def test_defaults():
 
 
 def test_mimetype():
-    png_1px = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
-    m = MediaResource(data=png_1px.encode("utf-8"), mimetype=None)
+    png_1px = b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    m = MediaResource(data=png_1px, mimetype=None)
     assert m.mimetype == "image/png"
 
 

--- a/llama-index-core/tests/schema/test_media_resource.py
+++ b/llama-index-core/tests/schema/test_media_resource.py
@@ -19,14 +19,26 @@ def test_mimetype():
     assert m.mimetype == "image/png"
 
 
+def test_mimetype_raw_data():
+    import requests
+
+    resp = requests.get(
+        "https://storage.googleapis.com/generativeai-downloads/data/scene.jpg"
+    )
+    m = MediaResource(data=resp.content)
+    assert m.mimetype == "image/jpeg"
+
+
 def test_mimetype_from_path():
-    m = MediaResource(path="my-image.jpg", mimetype=None)
+    m = MediaResource(path=Path("my-image.jpg"), mimetype=None)
     assert m.mimetype == "image/jpeg"
 
 
 def test_mimetype_prioritizes_data():
     png_1px = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
-    m = MediaResource(data=png_1px.encode("utf-8"), mimetype=None, path="my_image.jpg")
+    m = MediaResource(
+        data=png_1px.encode("utf-8"), mimetype=None, path=Path("my_image.jpg")
+    )
     assert m.mimetype == "image/png"
 
 


### PR DESCRIPTION
# Description

There was a regression in https://github.com/run-llama/llama_index/pull/17422 where moving from a model validator to field validators prevented the validation from running in case a field wasn't passed to the model constructor, relying on the default value.

While working on the fix I also noticed base64 decoding can give false positives on random bytes, making the validation logic fail. That's also fixed now.

Fixes regression in #17422