### PR TITLE
Vector index support for Memgraph's integration

### DIFF
--- a/docs/docs/examples/property_graph/property_graph_memgraph.ipynb
+++ b/docs/docs/examples/property_graph/property_graph_memgraph.ipynb
@@ -103,10 +103,8 @@
     "with open(output_path, \"r\", encoding=\"utf-8\") as file:\n",
     "    content = file.read()\n",
     "\n",
-    "modified_content = content.replace(\"'\", \"\\\\'\")\n",
-    "\n",
     "with open(output_path, \"w\", encoding=\"utf-8\") as file:\n",
-    "    file.write(modified_content)\n",
+    "    file.write(content)\n",
     "\n",
     "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()"
    ]

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/property_graph.py
@@ -1,4 +1,9 @@
-from typing import Any, List, Dict, Optional, Tuple
+from typing import (Any, List, Dict, Optional, Tuple)
+import logging
+import json
+import ast
+import neo4j
+
 from llama_index.core.graph_stores.prompts import DEFAULT_CYPHER_TEMPALTE
 from llama_index.core.graph_stores.types import (
     PropertyGraphStore,
@@ -13,10 +18,8 @@ from llama_index.core.graph_stores.utils import (
     value_sanitize,
     LIST_LIMIT,
 )
-
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.vector_stores.types import VectorStoreQuery
-import neo4j
 
 
 def remove_empty_values(input_dict):
@@ -26,37 +29,41 @@ def remove_empty_values(input_dict):
     return {key: value for key, value in input_dict.items() if value}
 
 
+logger = logging.getLogger(__name__)
+
 BASE_ENTITY_LABEL = "__Entity__"
 BASE_NODE_LABEL = "__Node__"
-EXCLUDED_LABELS = ["_Bloom_Perspective_", "_Bloom_Scene_"]
-EXCLUDED_RELS = ["_Bloom_HAS_SCENE_"]
 EXHAUSTIVE_SEARCH_LIMIT = 10000
 # Threshold for returning all available prop values in graph schema
 DISTINCT_VALUE_LIMIT = 10
 CHUNK_SIZE = 1000
+VECTOR_INDEX_NAME = "entity"
 # Threshold for max number of returned triplets
 LIMIT = 100
 
-node_properties_query = """
+SHOW_SCHEMA_INFO = "SHOW SCHEMA INFO;"
+
+NODE_PROPERTIES_QUERY = """
 MATCH (n)
-UNWIND labels(n) AS label
-WITH label, COUNT(n) AS count
-CALL schema.node_type_properties()
-YIELD propertyName, nodeLabels, propertyTypes
-WITH label, nodeLabels, count, collect({property: propertyName, type: propertyTypes[0]}) AS properties
+UNWIND labels(n) AS label WITH label,
+COUNT(n) AS count
+CALL schema.node_type_properties() YIELD propertyName, nodeLabels,
+propertyTypes
+WITH label, nodeLabels, count, collect({property: propertyName, type:
+propertyTypes[0]}) AS properties
 WHERE label IN nodeLabels
 RETURN {labels: label, count: count, properties: properties} AS output
 ORDER BY count DESC
 """
 
-rel_properties_query = """
+REL_PROPERTIES_QUERY = """
 CALL schema.rel_type_properties()
 YIELD relType AS label, propertyName AS property, propertyTypes AS type
 WITH label, collect({property: property, type: type}) AS properties
 RETURN {type: label, properties: properties} AS output
 """
 
-rel_query = """
+REL_QUERY = """
 MATCH (start_node)-[r]->(end_node)
 WITH DISTINCT labels(start_node) AS start_labels, type(r) AS relationship_type, labels(end_node) AS end_labels, keys(r) AS relationship_properties
 UNWIND start_labels AS start_label
@@ -100,8 +107,8 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
         graph_store.close()
         ```
     """
-
     supports_structured_queries: bool = True
+    supports_vector_queries: bool = True
     text_to_cypher_template: PromptTemplate = DEFAULT_CYPHER_TEMPALTE
 
     def __init__(
@@ -113,6 +120,7 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
         refresh_schema: bool = True,
         sanitize_query_output: bool = True,
         enhanced_schema: bool = False,
+        create_indexes: bool = True,
         **neo4j_kwargs: Any,
     ) -> None:
         self.sanitize_query_output = sanitize_query_output
@@ -124,45 +132,145 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
         self.structured_schema = {}
         if refresh_schema:
             self.refresh_schema()
-
-        # Create index for faster imports and retrieval
-        self.structured_query(f"""CREATE INDEX ON :{BASE_NODE_LABEL}(id);""")
-        self.structured_query(f"""CREATE INDEX ON :{BASE_ENTITY_LABEL}(id);""")
+        # Check if we can use vector index
+        self.verify_vector_support()
+        if create_indexes:
+            # Create index for faster imports and retrieval
+            self.structured_query(f"""CREATE INDEX ON :{BASE_NODE_LABEL}(id);""")
+            self.structured_query(f"""CREATE INDEX ON :{BASE_ENTITY_LABEL}(id);""")
 
     @property
     def client(self):
         return self._driver
 
     def close(self) -> None:
+        """Close the database driver connection."""
         self._driver.close()
+
+    def get_schema_subset(self, schema_result: Dict[str, Any]) -> None:
+        """Refresh the schema using the SHOW SCHEMA INFO."""
+        # Parse the 'schema' field for each entry
+        parsed_data = []
+        for entry in schema_result:
+            schema_str = entry.get("schema", "{}")
+            try:
+                parsed_schema = json.loads(schema_str)
+                parsed_data.append(parsed_schema)
+            except json.JSONDecodeError as decode_error:
+                print(f"Failed to parse schema: {decode_error}")
+                continue
+        node_properties = []
+        rel_properties = []
+        relationships = []
+
+        for schema in parsed_data:
+            # Extract node properties
+            for node in schema.get("nodes", []):
+                node_label = node.get("labels", [None])[0]
+                if node_label in [
+                    BASE_ENTITY_LABEL,
+                    BASE_NODE_LABEL,
+                ]:
+                    continue
+                properties = [
+                    {
+                        "property": prop.get("key"),
+                        "type": prop.get("types", [{}])[0].get("type")
+                    }
+                    for prop in node.get("properties", [])
+                ]
+                if node_label and properties:
+                    node_properties.append({
+                        "labels": node_label,
+                        "properties": properties
+                    })
+            # Extract relationship properties, types & count
+            for edge in schema.get("edges", []):
+                rel_type = edge.get("type")
+                properties = [
+                    {
+                        "property": prop.get("key"),
+                        "type": prop.get("types", [{}])[0].get("type")
+                    }
+                    for prop in edge.get("properties", [])
+                ]
+                if rel_type and properties:
+                    rel_properties.append({
+                        "properties": properties,
+                        "type": f":`{rel_type}`"
+                    })
+
+                start = edge.get("start_node_labels", [None])[0]
+                end = edge.get("end_node_labels", [None])[0]
+                if start and end and rel_type:
+                    relationships.append({
+                        "start": start,
+                        "end": end,
+                        "type": rel_type
+                    })
+        self.structured_schema = {
+            "node_props": {el["labels"]: el["properties"] for el in node_properties},
+            "rel_props": {el["type"]: el["properties"] for el in rel_properties},
+            "relationships": relationships,
+        }
 
     def refresh_schema(self) -> None:
         """Refresh the schema."""
+
         # Leave schema empty if db is empty
         if self.structured_query("MATCH (n) RETURN n LIMIT 1") == []:
             return
 
+        # First try with SHOW SCHEMA INFO
+        try:
+            node_query_results = self.structured_query(
+                SHOW_SCHEMA_INFO,
+                param_map={
+                    "EXCLUDED_LABELS": [
+                        BASE_ENTITY_LABEL,
+                        BASE_NODE_LABEL,
+                    ]
+                },
+            )
+            if node_query_results is not None and isinstance(node_query_results, (str, ast.AST)):
+                schema_result = ast.literal_eval(node_query_results)
+            else:
+                schema_result = node_query_results
+            assert schema_result is not None
+
+            self.get_schema_subset(schema_result)
+            return
+        except neo4j.exceptions.Neo4jError as decode_error:
+            if (
+                decode_error.code == "Memgraph.ClientError.MemgraphError.MemgraphError"
+                and "SchemaInfo disabled" in decode_error.message
+            ):
+                logger.info(
+                    "Schema generation with SHOW SCHEMA INFO query failed. "
+                    "Set --schema-info-enabled=true to use SHOW SCHEMA INFO query. "
+                    "Falling back to alternative queries."
+                )
+
+        # fallback on Cypher without SHOW SCHEMA INFO
         node_query_results = self.structured_query(
-            node_properties_query,
+            NODE_PROPERTIES_QUERY,
             param_map={
                 "EXCLUDED_LABELS": [
-                    *EXCLUDED_LABELS,
                     BASE_ENTITY_LABEL,
                     BASE_NODE_LABEL,
                 ]
             },
         )
         node_properties = {}
-        for el in node_query_results:
-            if el["output"]["labels"] in [
-                *EXCLUDED_LABELS,
+        for result in node_query_results:
+            if result["output"]["labels"] in [
                 BASE_ENTITY_LABEL,
                 BASE_NODE_LABEL,
             ]:
                 continue
 
-            label = el["output"]["labels"]
-            properties = el["output"]["properties"]
+            label = result["output"]["labels"]
+            properties = result["output"]["properties"]
             if label in node_properties:
                 node_properties[label]["properties"].extend(
                     prop
@@ -175,23 +283,20 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
         node_properties = [
             {"labels": label, **value} for label, value in node_properties.items()
         ]
-        rels_query_result = self.structured_query(
-            rel_properties_query, param_map={"EXCLUDED_LABELS": EXCLUDED_RELS}
-        )
+        rels_query_result = self.structured_query(REL_PROPERTIES_QUERY)
         rel_properties = (
             [
-                el["output"]
-                for el in rels_query_result
-                if any(prop["property"] for prop in el["output"].get("properties", []))
+                result["output"]
+                for result in rels_query_result
+                if any(prop["property"] for prop in result["output"].get("properties", []))
             ]
             if rels_query_result
             else []
         )
         rel_objs_query_result = self.structured_query(
-            rel_query,
+            REL_QUERY,
             param_map={
                 "EXCLUDED_LABELS": [
-                    *EXCLUDED_LABELS,
                     BASE_ENTITY_LABEL,
                     BASE_NODE_LABEL,
                 ]
@@ -202,71 +307,15 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
             for el in rel_objs_query_result
             if rel_objs_query_result
             and el["output"]["start"]
-            not in [*EXCLUDED_LABELS, BASE_ENTITY_LABEL, BASE_NODE_LABEL]
+            not in [BASE_ENTITY_LABEL, BASE_NODE_LABEL]
             and el["output"]["end"]
-            not in [*EXCLUDED_LABELS, BASE_ENTITY_LABEL, BASE_NODE_LABEL]
+            not in [BASE_ENTITY_LABEL, BASE_NODE_LABEL]
         ]
         self.structured_schema = {
             "node_props": {el["labels"]: el["properties"] for el in node_properties},
             "rel_props": {el["type"]: el["properties"] for el in rel_properties},
             "relationships": relationships,
         }
-        schema_nodes = self.structured_query(
-            "MATCH (n) UNWIND labels(n) AS label RETURN label AS node, COUNT(n) AS count ORDER BY count DESC"
-        )
-        schema_rels = self.structured_query(
-            "MATCH ()-[r]->() RETURN TYPE(r) AS relationship_type, COUNT(r) AS count"
-        )
-        schema_counts = [
-            {
-                "nodes": [
-                    {"name": item["node"], "count": item["count"]}
-                    for item in schema_nodes
-                ],
-                "relationships": [
-                    {"name": item["relationship_type"], "count": item["count"]}
-                    for item in schema_rels
-                ],
-            }
-        ]
-        # Update node info
-        for node in schema_counts[0].get("nodes", []):
-            # Skip bloom labels
-            if node["name"] in EXCLUDED_LABELS:
-                continue
-            node_props = self.structured_schema["node_props"].get(node["name"])
-            if not node_props:  # The node has no properties
-                continue
-
-            enhanced_cypher = self._enhanced_schema_cypher(
-                node["name"], node_props, node["count"] < EXHAUSTIVE_SEARCH_LIMIT
-            )
-            output = self.structured_query(enhanced_cypher)
-            enhanced_info = output[0]["output"]
-            for prop in node_props:
-                if prop["property"] in enhanced_info:
-                    prop.update(enhanced_info[prop["property"]])
-
-        # Update rel info
-        for rel in schema_counts[0].get("relationships", []):
-            if rel["name"] in EXCLUDED_RELS:
-                continue
-            rel_props = self.structured_schema["rel_props"].get(f":`{rel['name']}`")
-            if not rel_props:  # The rel has no properties
-                continue
-            enhanced_cypher = self._enhanced_schema_cypher(
-                rel["name"],
-                rel_props,
-                rel["count"] < EXHAUSTIVE_SEARCH_LIMIT,
-                is_relationship=True,
-            )
-            try:
-                enhanced_info = self.structured_query(enhanced_cypher)[0]["output"]
-                for prop in rel_props:
-                    if prop["property"] in enhanced_info:
-                        prop.update(enhanced_info[prop["property"]])
-            except neo4j.exceptions.ClientError:
-                pass
 
     def upsert_nodes(self, nodes: List[LabelledNode]) -> None:
         # Lists to hold separated types
@@ -283,67 +332,59 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                 pass
         if chunk_dicts:
             for index in range(0, len(chunk_dicts), CHUNK_SIZE):
-                chunked_params = chunk_dicts[index : index + CHUNK_SIZE]
-                for param in chunked_params:
-                    formatted_properties = ", ".join(
-                        [
-                            f"{key}: {value!r}"
-                            for key, value in param["properties"].items()
-                        ]
-                    )
-                    self.structured_query(
-                        f"""
-                        MERGE (c:{BASE_NODE_LABEL} {{id: '{param["id"]}'}})
-                        SET c.`text` = '{param["text"]}', c:Chunk
-                        WITH c
-                        SET c += {{{formatted_properties}}}
-                        RETURN count(*)
-                        """
-                    )
+                chunked_params = chunk_dicts[index: index + CHUNK_SIZE]
+                self.structured_query(
+                    f"""
+                    UNWIND $data AS row
+                    MERGE (c:{BASE_NODE_LABEL} {{id: row.id}})
+                    SET c.`text` = row.text, c:Chunk
+                    WITH c, row
+                    SET c += row.properties
+                    WITH c, row.embedding as embedding
+                    WHERE embedding IS NOT NULL
+                    SET c.embedding = embedding
+                    RETURN count(*)
+                    """,
+                    param_map={"data": chunked_params},
+                )
+
         if entity_dicts:
             for index in range(0, len(entity_dicts), CHUNK_SIZE):
-                chunked_params = entity_dicts[index : index + CHUNK_SIZE]
-                for param in chunked_params:
-                    formatted_properties = ", ".join(
-                        [
-                            f"{key}: {value!r}"
-                            for key, value in param["properties"].items()
-                        ]
-                    )
-                    self.structured_query(
-                        f"""
-                        MERGE (e:{BASE_NODE_LABEL} {{id: '{param["id"]}'}})
-                        SET e += {{{formatted_properties}}}
-                        SET e.name = '{param["name"]}', e:`{BASE_ENTITY_LABEL}`
-                        WITH e
-                        SET e :{param["label"]}
-                        """
-                    )
-                    triplet_source_id = param["properties"].get("triplet_source_id")
-                    if triplet_source_id:
-                        self.structured_query(
-                            f"""
-                            MERGE (e:{BASE_NODE_LABEL} {{id: '{param["id"]}'}})
-                            MERGE (c:{BASE_NODE_LABEL} {{id: '{triplet_source_id}'}})
-                            MERGE (e)<-[:MENTIONS]-(c)
-                            """
-                        )
+                chunked_params = entity_dicts[index: index + CHUNK_SIZE]
+                self.structured_query(
+                    f"""
+                    UNWIND $data AS row
+                    MERGE (e:{BASE_NODE_LABEL} {{id: row.id}})
+                    SET e += CASE WHEN row.properties IS NOT NULL THEN row.properties ELSE e END
+                    SET e.name = CASE WHEN row.name IS NOT NULL THEN row.name ELSE e.name END,
+                        e:{BASE_ENTITY_LABEL}
+                    WITH e, row
+                    SET e:row.label
+                    WITH e, row
+                    WHERE row.embedding IS NOT NULL
+                    SET e.embedding = row.embedding
+                    WITH e, row
+                    WHERE row.properties.triplet_source_id IS NOT NULL
+                    MERGE (c:{BASE_NODE_LABEL} {{id: row.properties.triplet_source_id}})
+                    MERGE (e)<-[:MENTIONS]-(c)
+                    """,
+                    param_map={"data": chunked_params},
+                )
 
     def upsert_relations(self, relations: List[Relation]) -> None:
         """Add relations."""
         params = [r.dict() for r in relations]
         for index in range(0, len(params), CHUNK_SIZE):
-            chunked_params = params[index : index + CHUNK_SIZE]
+            chunked_params = params[index: index + CHUNK_SIZE]
             for param in chunked_params:
                 formatted_properties = ", ".join(
                     [f"{key}: {value!r}" for key, value in param["properties"].items()]
                 )
-
                 self.structured_query(
                     f"""
-                    MERGE (source: {BASE_NODE_LABEL} {{id: '{param["source_id"]}'}})
+                    MERGE (source: {BASE_NODE_LABEL} {{id: "{param["source_id"]}"}})
                     ON CREATE SET source:Chunk
-                    MERGE (target: {BASE_NODE_LABEL} {{id: '{param["target_id"]}'}})
+                    MERGE (target: {BASE_NODE_LABEL} {{id: "{param["target_id"]}"}})
                     ON CREATE SET target:Chunk
                     WITH source, target
                     MERGE (source)-[r:{param["label"]}]->(target)
@@ -432,11 +473,11 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
             params["entity_names"] = entity_names
 
         if relation_names and entity_names:
-            cypher_statement += f"AND "
+            cypher_statement += "AND "
 
         if relation_names:
             cypher_statement += "type(r) in $relation_names "
-            params[f"relation_names"] = relation_names
+            params["relation_names"] = relation_names
 
         if ids:
             cypher_statement += "e.id in $ids "
@@ -624,9 +665,43 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
     def vector_query(
         self, query: VectorStoreQuery, **kwargs: Any
     ) -> Tuple[List[LabelledNode], List[float]]:
-        raise NotImplementedError(
-            "Vector query is not currently implemented for MemgraphPropertyGraphStore."
-        )
+        """Query the graph store with a vector store query."""
+        if self._supports_vector_index:
+            data = self.structured_query(
+                f"""CALL vector_search.search('{VECTOR_INDEX_NAME}', $limit, $embedding)
+                    YIELD node, similarity
+                    WITH node, similarity, labels(node) AS all_labels
+                    UNWIND all_labels AS label
+                    WITH node, similarity, label
+                    WHERE NOT label IN ['{BASE_ENTITY_LABEL}', '{BASE_NODE_LABEL}']
+                    WITH node, similarity, label, properties(node) AS originalProperties
+                    RETURN
+                        node.id AS name,
+                        label AS type,
+                        node{{.* , embedding: Null, name: Null, id: Null}} AS properties,
+                        similarity
+                """,
+                param_map={
+                    "embedding": query.query_embedding,
+                    "limit": query.similarity_top_k,
+                },
+            )
+        else:
+            data = []
+        data = data if data else []
+
+        nodes = []
+        scores = []
+        for record in data:
+            node = EntityNode(
+                name=record["name"],
+                label=record["type"],
+                properties=remove_empty_values(record["properties"]),
+            )
+            nodes.append(node)
+            scores.append(record["similarity"])
+
+        return (nodes, scores)
 
     def delete(
         self,
@@ -695,8 +770,10 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                         f" distinct_count: size(`{prop_name}_values`)"
                     )
                 elif prop_type in [
+                    "Integer",
                     "Int",
                     "Double",
+                    "Float",
                     "Date",
                     "LocalTime",
                     "LocalDateTime",
@@ -732,7 +809,6 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
             for prop in properties:
                 prop_name = prop["property"]
                 prop_type = prop["type"]
-
                 # Check if indexed property, we can still do exhaustive
                 prop_index = [
                     el
@@ -752,7 +828,7 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                             RETURN DISTINCT n.`{prop_name}` AS value
                             LIMIT {DISTINCT_VALUE_LIMIT}
                         """
-                        distinct_values = self.query(distinct_values_query)
+                        distinct_values = self.structured_query(distinct_values_query)
 
                         # Extract values from the result set
                         distinct_values = [
@@ -770,6 +846,7 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                         )
                         return_clauses.append(f"values: `{prop_name}_values`")
                 elif prop_type in [
+                    "Integer",
                     "Int",
                     "Double",
                     "Float",
@@ -860,6 +937,7 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                             )
 
                     elif prop["type"] in [
+                        "Integer",
                         "Int",
                         "Double",
                         "Float",
@@ -906,6 +984,7 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                                 else ""
                             )
                     elif prop["type"] in [
+                        "Integer",
                         "Int",
                         "Double",
                         "Float",
@@ -938,11 +1017,11 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                 formatted_node_props.append(f"{label} {{{props_str}}}")
 
             # Format relationship properties using structured_schema
-            for type, props in schema["rel_props"].items():
+            for label, props in schema["rel_props"].items():
                 props_str = ", ".join(
                     [f"{prop['property']}: {prop['type']}" for prop in props]
                 )
-                formatted_rel_props.append(f"{type} {{{props_str}}}")
+                formatted_rel_props.append(f"{label} {{{props_str}}}")
 
         # Format relationships
         formatted_rels = [
@@ -960,3 +1039,46 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                 "\n".join(formatted_rels),
             ]
         )
+
+    def verify_vector_support(self) -> None:
+        """
+        Check if the connected Memgraph database supports vector indices.
+
+        Compares the current version with the required version (2.22.0) that
+        supports vector indexing.
+        """
+        response = self.structured_query("SHOW VERSION;")
+        current_version = response[0]['version']
+        current_version = tuple(map(int, current_version.split('.')))
+        required_version = '2.22'
+        required_version = tuple(map(int, required_version.split('.')))
+
+        # Check if the version is equal to or larger than the required version
+        if current_version >= required_version:
+            # Check if vector index is configured
+            try:
+                self.structured_query(
+                    """CALL vector_search.show_index_info() YIELD * RETURN *;"""
+                )
+                self._supports_vector_index = True
+                return
+            except neo4j.exceptions.Neo4jError as decode_error:
+                self._supports_vector_index = False
+                if (
+                    decode_error.code == "Memgraph.ClientError.MemgraphError.MemgraphError"
+                    and "vector_search.show_index_info" in decode_error.message
+                ):
+                    logger.info(
+                        """To use vector indices and vector search, start
+                        Memgraph with the experimental vector search feature
+                        flag and configure vector index. Falling back to
+                        alternative queries."""
+                    )
+        else:
+            self._supports_vector_index = False
+            logger.info(
+                """Vector indexing is not supported by your current Memgraph
+                version (%s). Please upgrade to version 2.22.0 or newer to use
+                vector indices.""",
+                '.'.join(map(str, current_version))
+            )

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-graph-stores-memgraph"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/tests/test_pg_stores_memgraph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/tests/test_pg_stores_memgraph.py
@@ -12,14 +12,15 @@ memgraph_pass = os.environ.get("MEMGRAPH_TEST_PASS")
 memgraph_url = os.environ.get("MEMGRAPH_TEST_URL")
 
 if not memgraph_user or not memgraph_pass or not memgraph_url:
-    memgraph_available = False
+    MEMGRAPH_AVAILABLE = False
 else:
-    memgraph_available = True
+    MEMGRAPH_AVAILABLE = True
 
 
 @pytest.fixture()
 def pg_store() -> MemgraphPropertyGraphStore:
-    if not memgraph_available:
+    """Define Memgraph graph store."""
+    if not MEMGRAPH_AVAILABLE:
         pytest.skip("No Memgraph credentials provided")
     return MemgraphPropertyGraphStore(
         username=memgraph_user, password=memgraph_pass, url=memgraph_url
@@ -27,18 +28,19 @@ def pg_store() -> MemgraphPropertyGraphStore:
 
 
 def test_memgraph_pg_store(pg_store: MemgraphPropertyGraphStore) -> None:
+    """Test functions for Memgraph graph store."""
     # Clear the database
     pg_store.structured_query("STORAGE MODE IN_MEMORY_ANALYTICAL")
     pg_store.structured_query("DROP GRAPH")
     pg_store.structured_query("STORAGE MODE IN_MEMORY_TRANSACTIONAL")
 
-    # Test upsert nodes
+    # Test inserting nodes into Memgraph.
     entity1 = EntityNode(label="PERSON", name="Logan", properties={"age": 28})
     entity2 = EntityNode(label="ORGANIZATION", name="LlamaIndex")
     pg_store.upsert_nodes([entity1, entity2])
-
     # Assert the nodes are inserted correctly
     kg_nodes = pg_store.get(ids=[entity1.id])
+    assert kg_nodes[0].name == entity1.name
 
     # Test inserting relations into Memgraph.
     relation = Relation(
@@ -49,13 +51,12 @@ def test_memgraph_pg_store(pg_store: MemgraphPropertyGraphStore) -> None:
     )
 
     pg_store.upsert_relations([relation])
-
     # Assert the relation is inserted correctly by retrieving the relation map
     kg_nodes = pg_store.get(ids=[entity1.id])
-    paths = pg_store.get_rel_map(kg_nodes, depth=1)
+    pg_store.get_rel_map(kg_nodes, depth=1)
 
     # Test inserting a source text node and 'MENTIONS' relations.
-    source_node = TextNode(text="Logan (age 28), works for LlamaIndex since 2023.")
+    source_node = TextNode(text="Logan (age 28), works for 'LlamaIndex' since 2023.")
 
     relations = [
         Relation(label="MENTIONS", target_id=entity1.id, source_id=source_node.node_id),
@@ -66,27 +67,28 @@ def test_memgraph_pg_store(pg_store: MemgraphPropertyGraphStore) -> None:
     pg_store.upsert_relations(relations)
 
     # Assert the source node and relations are inserted correctly
-    llama_nodes = pg_store.get_llama_nodes([source_node.node_id])
+    pg_store.get_llama_nodes([source_node.node_id])
 
     # Test retrieving nodes by properties.
     kg_nodes = pg_store.get(properties={"age": 28})
 
     # Test executing a structured query in Memgraph.
     query = "MATCH (n:`__Entity__`) RETURN n"
-    result = pg_store.structured_query(query)
+    pg_store.structured_query(query)
 
     # Test upserting a new node with additional properties.
     new_node = EntityNode(
         label="PERSON", name="Logan", properties={"age": 28, "location": "Canada"}
     )
     pg_store.upsert_nodes([new_node])
-
+    
     # Assert the node has been updated with the new property
     kg_nodes = pg_store.get(properties={"age": 28})
-
+    
     # Test deleting nodes from Memgraph.
     pg_store.delete(ids=[source_node.node_id])
     pg_store.delete(ids=[entity1.id, entity2.id])
 
     # Assert the nodes have been deleted
-    nodes = pg_store.get(ids=[entity1.id, entity2.id])
+    pg_store.get(ids=[entity1.id, entity2.id])
+    

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/tests/test_pg_stores_memgraph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/tests/test_pg_stores_memgraph.py
@@ -81,14 +81,13 @@ def test_memgraph_pg_store(pg_store: MemgraphPropertyGraphStore) -> None:
         label="PERSON", name="Logan", properties={"age": 28, "location": "Canada"}
     )
     pg_store.upsert_nodes([new_node])
-    
+
     # Assert the node has been updated with the new property
     kg_nodes = pg_store.get(properties={"age": 28})
-    
+
     # Test deleting nodes from Memgraph.
     pg_store.delete(ids=[source_node.node_id])
     pg_store.delete(ids=[entity1.id, entity2.id])
 
     # Assert the nodes have been deleted
     pg_store.get(ids=[entity1.id, entity2.id])
-    


### PR DESCRIPTION
Hi! Memgraph recently introduced a vector search feature and I took the opportunity to update the integration with LlamaIndex by adding new capabilities :)

This PR enhances the Memgraph integration with LlamaIndex with several significant improvements and new functionalities:
1. **Support for vector indices**
Added the ability to leverage vector indices in Memgraph using Memgraph's vector search
2. **Optimized schema refresh**
Introduced the SHOW SCHEMA INFO; query to efficiently refresh and synchronize the schema during runtime. This reduces overhead and ensures up-to-date schema information without unnecessary latency.
3. **Bug fixes for parameterized queries**

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests
