### PR TITLE
fix: update vcrpy in vllm tests

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
@@ -50,7 +50,7 @@ types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
 types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
-vcrpy = "6.0.1"
+vcrpy = "7.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
 extras = ["jupyter"]


### PR DESCRIPTION
# Description

update vcrpy so it can work with the latest version of the underlying http client

Fixes failures in CI

