### PR TITLE
Fix: [Bug] NameError: name 'p' is not defined #15581

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -67,8 +67,8 @@ def parse_code_markdown(text: str, only_last: bool) -> List[str]:
 
     # Regular expression pattern to match code within triple backticks with 
     # a Python marker. Like: ```python df.columns```
-    python_str_pattern = re.compile(r'^```python', re.IGNORECASE)
-    text = python_str_pattern.sub('```', text)
+    python_str_pattern = re.compile(r"^```python", re.IGNORECASE)
+    text = python_str_pattern.sub("```", text)
 
     # Find all matches of the pattern in the text
     matches = re.findall(pattern, text, re.DOTALL)

--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -65,6 +65,11 @@ def parse_code_markdown(text: str, only_last: bool) -> List[str]:
     # Regular expression pattern to match code within triple-backticks
     pattern = r"```(.*?)```"
 
+    # Regular expression pattern to match code within triple backticks with 
+    # a Python marker. Like: ```python df.columns```
+    python_str_pattern = re.compile(r'^```python', re.IGNORECASE)
+    text = python_str_pattern.sub('```', text)
+
     # Find all matches of the pattern in the text
     matches = re.findall(pattern, text, re.DOTALL)
 

--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -65,7 +65,7 @@ def parse_code_markdown(text: str, only_last: bool) -> List[str]:
     # Regular expression pattern to match code within triple-backticks
     pattern = r"```(.*?)```"
 
-    # Regular expression pattern to match code within triple backticks with 
+    # Regular expression pattern to match code within triple backticks with
     # a Python marker. Like: ```python df.columns```
     python_str_pattern = re.compile(r"^```python", re.IGNORECASE)
     text = python_str_pattern.sub("```", text)

--- a/llama-index-experimental/llama_index/experimental/query_engine/pandas/output_parser.py
+++ b/llama-index-experimental/llama_index/experimental/query_engine/pandas/output_parser.py
@@ -32,7 +32,9 @@ def default_output_processor(
     local_vars = {"df": df, "pd": pd}
     global_vars = {"np": np}
 
-    output = parse_code_markdown(output, only_last=True)[0]
+    output = parse_code_markdown(output, only_last=True)
+    if not isinstance(output, str):
+        output = output[0]
 
     # NOTE: inspired from langchain's tool
     # see langchain.tools.python.tool (PythonAstREPLTool)


### PR DESCRIPTION
Modification of the markdown parser method to remove "python" from the markdown before processing it, if it exists

# Description

Fixes [#15581](https://github.com/run-llama/llama_index/issues/15581)
When VertexAI is used, the return of the markdown text passed to the parse_code_markdown function uses language markup. For example \`\`\`python df.columns\`\`\`. The previous code only considered removing the backticks. Treatment has been implemented to remove the language markup when it is present. Additionally, for string type returns, the snippet ```parse_code_markdown(output, only_last=True)[0]``` only returned the first letter of the string.

Error example:
```
> Pandas Instructions:
\```
\```python
df.groupby('filial')['forma_pagamento'].agg(lambda x: x.value_counts().idxmax())
\```
\```
Traceback (most recent call last):
  File "C:\...\llama_index\.venv\Lib\site-packages\llama_index\experimental\query_engine\pandas\output_parser.py", line 63, in default_output_processor
    output_str = str(safe_eval(module_end_str, global_vars, local_vars))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\...\llama_index\.venv\Lib\site-packages\llama_index\experimental\exec_utils.py", line 159, in safe_eval
    return eval(__source, _get_restricted_globals(__globals), __locals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
NameError: name 'p' is not defined
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
