### PR TITLE
build: 🆙 replace `pinecone-client` with `pinecone` package

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-pinecone/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-pinecone"
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
-pinecone-client = ">=3.2.2,<6.0.0"
+pinecone = ">=3.2.2,<6.0.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

The `pinecone-client` package used by this `llama-index-vector-store-pinecone` is no longer maintained by the pinecone team. The last version of `pinecone-client` (5.0.1) which is released on August 2nd, 2024, is far way behind compared to the officially documented `pinecone` package which already includes new features such as the [Reranking](https://docs.pinecone.io/guides/inference/rerank) support and the [_`query_namespaces`_](https://docs.pinecone.io/guides/data/query-data#query-across-multiple-namespaces) method.

This change will replace `pinecone-client` dependency with `pinecone` dependency since it's no longer maintained by pinecone team, this also opens up new possibilities for feature development in the future.

Reference:
[Reranking Support](https://docs.pinecone.io/release-notes/2024#2024-09-17)
[query_namespaces Method](https://docs.pinecone.io/release-notes/2024#2024-11-13)
[Full Release Notes](https://docs.pinecone.io/release-notes/2024)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
