### PR TITLE
Add endpoint parameter to TextEmbeddingsInference

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/llama_index/embeddings/text_embeddings_inference/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/llama_index/embeddings/text_embeddings_inference/base.py
@@ -10,6 +10,7 @@ from llama_index.core.callbacks import CallbackManager
 from llama_index.utils.huggingface import format_query, format_text
 
 DEFAULT_URL = "http://127.0.0.1:8080"
+DEFAULT_ENDPOINT = "/embed"
 
 
 class TextEmbeddingsInference(BaseEmbedding):
@@ -35,6 +36,10 @@ class TextEmbeddingsInference(BaseEmbedding):
         default=None,
         description="Authentication token or authentication token generating function for authenticated requests",
     )
+    endpoint: str = Field(
+        default=DEFAULT_ENDPOINT,
+        description="Endpoint for the text embeddings service.",
+    )
 
     def __init__(
         self,
@@ -47,6 +52,7 @@ class TextEmbeddingsInference(BaseEmbedding):
         truncate_text: bool = True,
         callback_manager: Optional[CallbackManager] = None,
         auth_token: Optional[Union[str, Callable[[str], str]]] = None,
+        endpoint: str = DEFAULT_ENDPOINT,
     ):
         super().__init__(
             base_url=base_url,
@@ -58,6 +64,7 @@ class TextEmbeddingsInference(BaseEmbedding):
             truncate_text=truncate_text,
             callback_manager=callback_manager,
             auth_token=auth_token,
+            endpoint=endpoint,
         )
 
     @classmethod
@@ -79,7 +86,7 @@ class TextEmbeddingsInference(BaseEmbedding):
 
         with httpx.Client() as client:
             response = client.post(
-                f"{self.base_url}/embed",
+                f"{self.base_url}{self.endpoint}",
                 headers=headers,
                 json=json_data,
                 timeout=self.timeout,
@@ -100,7 +107,7 @@ class TextEmbeddingsInference(BaseEmbedding):
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{self.base_url}/embed",
+                f"{self.base_url}{self.endpoint}",
                 headers=headers,
                 json=json_data,
                 timeout=self.timeout,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-text-embeddings-inference"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/tests/test_embeddings_text_embeddings_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-text-embeddings-inference/tests/test_embeddings_text_embeddings_inference.py
@@ -5,3 +5,26 @@ from llama_index.embeddings.text_embeddings_inference import TextEmbeddingsInfer
 def test_text_inference_embedding_class():
     names_of_base_classes = [b.__name__ for b in TextEmbeddingsInference.__mro__]
     assert BaseEmbedding.__name__ in names_of_base_classes
+
+
+def test_text_inference_embedding_init():
+    text_inference = TextEmbeddingsInference(
+        model_name="some-model",
+        base_url="some-url",
+        text_instruction="some-text-instruction",
+        query_instruction="some-query-instruction",
+        embed_batch_size=42,
+        timeout=42.0,
+        truncate_text=False,
+        auth_token="some-token",
+        endpoint="some-endpoint",
+    )
+    assert text_inference.model_name == "some-model"
+    assert text_inference.base_url == "some-url"
+    assert text_inference.text_instruction == "some-text-instruction"
+    assert text_inference.query_instruction == "some-query-instruction"
+    assert text_inference.embed_batch_size == 42
+    assert int(text_inference.timeout) == 42
+    assert text_inference.truncate_text is False
+    assert text_inference.auth_token == "some-token"
+    assert text_inference.endpoint == "some-endpoint"


### PR DESCRIPTION
… to allow overwriting the default endpoint "/embed"

# Description

Allow for a custom endpoint in the `TextEmbeddingInference` class. This allows to overwrite the default "/embed" endpoint. This is needed to use the "/embedding" endpoint of services like the llama.cpp server.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
