### PR TITLE
Fixing header_path bug re: markdown level vs. stack depth

### DIFF
--- a/llama-index-core/tests/node_parser/test_markdown.py
+++ b/llama-index-core/tests/node_parser/test_markdown.py
@@ -144,3 +144,25 @@ Content
     assert splits[1].metadata == {"header_path": "/Main Header/"}
     assert splits[2].metadata == {"header_path": "/Main Header/Sub-header/"}
     assert splits[3].metadata == {"header_path": "/"}
+
+
+def test_header_metadata_with_level_jump() -> None:
+    markdown_parser = MarkdownNodeParser()
+
+    splits = markdown_parser.get_nodes_from_documents(
+        [
+            Document(
+                text="""# Main Header
+Content
+### Sub-header
+Content
+### Sub-sub header
+Content
+"""
+            )
+        ]
+    )
+    assert len(splits) == 3
+    assert splits[0].metadata == {"header_path": "/"}
+    assert splits[1].metadata == {"header_path": "/Main Header/"}
+    assert splits[2].metadata == {"header_path": "/Main Header/"}


### PR DESCRIPTION
# Description

Fixes issue https://github.com/run-llama/llama_index/issues/17599

There's a bug in the existing `MarkdownNodeParser` when forming the `header_path` of a node.

When attempting to pop items off of a header_stack, the existing code uses the size of the stack to determine the current markdown header depth. This is a bug. For example:

```python
header_stack = ["# Root header", "### Subsection"]
```

The above header stack is `length: 2` but the top of the stack has a markdown header at level 3.

This means markdown that skips one header level or more between header tags doesn't build its parent hierarchy correctly.


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
