### PR TITLE
support content blocks in chat templates

### DIFF
--- a/llama-index-core/llama_index/core/prompts/base.py
+++ b/llama-index-core/llama_index/core/prompts/base.py
@@ -47,6 +47,7 @@ from llama_index.core.base.llms.generic_utils import (
 from llama_index.core.base.llms.generic_utils import (
     prompt_to_messages,
 )
+from llama_index.core.base.llms.types import TextBlock
 from llama_index.core.prompts.prompt_type import PromptType
 from llama_index.core.prompts.utils import get_template_vars, format_string
 from llama_index.core.types import BaseOutputParser
@@ -305,20 +306,30 @@ class ChatPromptTemplate(BasePromptTemplate):  # type: ignore[no-redef]
 
         messages: List[ChatMessage] = []
         for message_template in self.message_templates:
-            message_content = message_template.content or ""
+            # Handle messages with multiple blocks
+            if message_template.blocks:
+                formatted_blocks = []
+                for block in message_template.blocks:
+                    if isinstance(block, TextBlock):
+                        template_vars = get_template_vars(block.text)
+                        relevant_kwargs = {
+                            k: v
+                            for k, v in mapped_all_kwargs.items()
+                            if k in template_vars
+                        }
+                        formatted_text = format_string(block.text, **relevant_kwargs)
+                        formatted_blocks.append(TextBlock(text=formatted_text))
+                    else:
+                        # For non-text blocks (like images), keep them as is
+                        # TODO: can images be formatted as variables?
+                        formatted_blocks.append(block)
 
-            template_vars = get_template_vars(message_content)
-            relevant_kwargs = {
-                k: v for k, v in mapped_all_kwargs.items() if k in template_vars
-            }
-            content_template = message_template.content or ""
-
-            # if there's mappings specified, make sure those are used
-            content = format_string(content_template, **relevant_kwargs)
-
-            message: ChatMessage = message_template.model_copy()
-            message.content = content
-            messages.append(message)
+                message = message_template.model_copy()
+                message.blocks = formatted_blocks
+                messages.append(message)
+            else:
+                # Handle empty messages (if any)
+                messages.append(message_template.model_copy())
 
         if self.output_parser is not None:
             messages = self.output_parser.format_messages(messages)

--- a/llama-index-core/llama_index/core/prompts/base.py
+++ b/llama-index-core/llama_index/core/prompts/base.py
@@ -47,7 +47,7 @@ from llama_index.core.base.llms.generic_utils import (
 from llama_index.core.base.llms.generic_utils import (
     prompt_to_messages,
 )
-from llama_index.core.base.llms.types import TextBlock
+from llama_index.core.base.llms.types import ContentBlock, TextBlock
 from llama_index.core.prompts.prompt_type import PromptType
 from llama_index.core.prompts.utils import get_template_vars, format_string
 from llama_index.core.types import BaseOutputParser
@@ -308,7 +308,7 @@ class ChatPromptTemplate(BasePromptTemplate):  # type: ignore[no-redef]
         for message_template in self.message_templates:
             # Handle messages with multiple blocks
             if message_template.blocks:
-                formatted_blocks = []
+                formatted_blocks: List[ContentBlock] = []
                 for block in message_template.blocks:
                     if isinstance(block, TextBlock):
                         template_vars = get_template_vars(block.text)


### PR DESCRIPTION
Now, you can use a structured LLM with content blocks.

This change updates the `ChatPromptTemplate` class to handle the new block parameters. 

In the future, we might be able to support passing in images/other types into templates?

Example code:

```
from pydantic import BaseModel
from llama_index.core.llms import ChatMessage, ImageBlock, TextBlock
from llama_index.llms.openai import OpenAI

llm = OpenAI(model="gpt-4o")

class CodeBlock(BaseModel):
    class_name:str
    params: list[str]

structured_llm = llm.as_structured_llm(CodeBlock)
response = structured_llm.chat([ChatMessage(blocks=[TextBlock(text="Can you extract the class from this image?"),ImageBlock(path="./code_block.png")])])

print(response.raw)
```

Fixes https://github.com/run-llama/llama_index/issues/17597