### PR TITLE
PGVectorStore: query with metadata filters only

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/types.py
+++ b/llama-index-core/llama_index/core/vector_stores/types.py
@@ -51,6 +51,9 @@ class VectorStoreQueryMode(str, Enum):
     TEXT_SEARCH = "text_search"
     SEMANTIC_HYBRID = "semantic_hybrid"
 
+    # NOTE: currently only used by postgres filters search
+    FILTERS = "filters"
+
     # fit learners
     SVM = "svm"
     LOGISTIC_REGRESSION = "logistic_regression"
@@ -257,6 +260,8 @@ class VectorStoreQuery:
     sparse_top_k: Optional[int] = None
     # NOTE: return top k results from hybrid search. similarity_top_k is used for dense search top k
     hybrid_top_k: Optional[int] = None
+    # NOTE: currently only used by postgres filters search
+    filters_top_k: Optional[int] = None
 
 
 @runtime_checkable


### PR DESCRIPTION
# Description

This pull request introduces the ability to query PostgreSQL using only metadata filters in LlamaIndex. Previously, queries could only be executed using an embedding or a query_str. The new functionality expands query options, making the system more flexible and allowing metadata filtering as a standalone query mechanism.

Key changes include:

A new VectorStoreQueryMode type named FILTERS has been added.
A filters_top_k parameter has been added to the VectorStoreQuery class.
Additionally, modifications were made to the PGVectorStore class to support the new FILTERS query mode. These changes are isolated to LlamaIndex Core.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Has been tested on the forked branch.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
