### PR TITLE
GoogleDriveReader support file extensions

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -451,7 +451,7 @@ class GoogleDriveReader(
                 )
             else:
                 # we should have a file extension to allow the readers to work
-                _, download_extension = os.path.splitext(file.get("name",""))
+                _, download_extension = os.path.splitext(file.get("name", ""))
                 new_file_name = filename + download_extension
 
                 # Download file without conversion

--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -450,7 +450,9 @@ class GoogleDriveReader(
                     fileId=fileid, mimeType=download_mimetype
                 )
             else:
-                new_file_name = filename
+                # we should have a file extension to allow the readers to work
+                _, download_extension = os.path.splitext(file.get("name",""))
+                new_file_name = filename + download_extension
 
                 # Download file without conversion
                 request = service.files().get_media(fileId=fileid)

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -47,7 +47,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.5.0"
+version = "0.6.0"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Previously GoogleDrive folders that had file extensions besides Google Sheets/Docs/Presentation would have their extensions stripped because the filename was the Google Drive file ID which doesn't have an extension. However this meant that reading other types of file formats (like PDFs) wouldn't work and the "file_extractor" capability wouldn't be used, instead everything would just be reading bytes. That works ok for .txt or .md docs, but for a PDF it's generates a bunch of garbage.

This change adds the file extension if it can be returned, otherwise it'll just add empty string and shouldn't create any issues

It's possible in GoogleDrive to also remove the extension of a file or upload a file without an extension. In that case this should make no change.

Note, depending on how you use this reader it _could_ be a breaking change if some files were previously being parsed as bytes/text but would now be getting parsed by the file_extractor, but it seems like this may be the expected behavior already.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes (not sure if a minor version)
- [ ] No

## Type of Change

Depending on usage, I suppose it could be any of these... :smile: 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

I also ran a script against my Google Drive where I uploaded some some PDFs:

```python
# drive.py
from llama_index.readers.google import GoogleDriveReader

reader = GoogleDriveReader(
        folder_id="1Iv9Gb0wPKWznXFbnse0PSK87wMbkivC-" # https://drive.google.com/drive/u/0/folders/1Iv9Gb0wPKWznXFbnse0PSK87wMbkivC-
)

docs = reader.load_data()
for d in docs:
    print("============ document ==========\n")
    print(f"file id {d.metadata["file id"]}, file path {d.metadata["file path"]}")
    print(d.text)
```

```
(env) ➜  llama_index git:(google-drive-reader-extensions) ✗ python3 drive.py
============ document ==========

file id 1OLBPt8_N4ygsPyIE5xc56WE4QPhROQLyE7N8APOn03c, file path llama-index-google-drive/test
Test docs
============ document ==========

file id 1j2_WFOB1S1ZMwaEsl7EjrQYbLN279lz5, file path llama-index-google-drive/hello world.pdf
hello world!
============ document ==========

file id 1ltDc3o0nXEK7V2iESTzwpfAKzBjOUCEk, file path llama-index-google-drive/hello world again
%PDF-1.7
%
4 0 obj
<< /Length 5 0 R
   /Filter /FlateDecode
>>
stream
x-
@DK#{V
... 
etc etc

```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
