### PR TITLE
fix repeated sources when doing parallel tool calling

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
@@ -700,8 +700,8 @@ class OpenAIAgentWorker(BaseAgentWorker):
             )
 
             # Process results
-            for return_direct in tool_results:
-                task.extra_state["sources"].append(latest_tool_outputs[-1])
+            for index, return_direct in enumerate(tool_results):
+                task.extra_state["sources"].append(latest_tool_outputs[index])
 
                 # change function call to the default value if a custom function was given
                 if tool_choice not in ("auto", "none"):
@@ -711,7 +711,7 @@ class OpenAIAgentWorker(BaseAgentWorker):
                 # If any tool call requests direct return and it's the only call
                 if return_direct and len(latest_tool_calls) == 1:
                     is_done = True
-                    response_str = latest_tool_outputs[-1].content
+                    response_str = latest_tool_outputs[index].content
                     chat_response = ChatResponse(
                         message=ChatMessage(
                             role=MessageRole.ASSISTANT, content=response_str

--- a/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-agent-openai"
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Issue

When using Async Parallel Tool Call from OpenAIAgent, only the last source is being returned via response.sources. It is being repeated the same number of times as how many tools were called.

# Fix 

Instead of appending the last latest_tool_outputs, enumerate the tool_results and use the index from that to index the latest_tool_outputs list, and return that.