### PR TITLE
feat: allow to exclude empty file simple directory reader

### DIFF
--- a/docs/docs/examples/data_connectors/simple_directory_reader.ipynb
+++ b/docs/docs/examples/data_connectors/simple_directory_reader.ipynb
@@ -465,6 +465,7 @@
     "            (Optional; overrides input_dir, exclude)\n",
     "        exclude (List): glob of python file paths to exclude (Optional)\n",
     "        exclude_hidden (bool): Whether to exclude hidden files (dotfiles).\n",
+    "        exclude_empty (bool): Whether to exclude empty files (Optional).\n",
     "        encoding (str): Encoding of the files.\n",
     "            Default is utf-8.\n",
     "        errors (str): how encoding and decoding errors are to be handled,\n",

--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -287,6 +287,8 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         )
 
     def is_empty_file(self, path: Path | PurePosixPath) -> bool:
+        if isinstance(path, PurePosixPath):
+            path = Path(path)
         return path.is_file() and len(path.read_bytes()) == 0
 
     def _add_files(self, input_dir: Path | PurePosixPath) -> list[Path | PurePosixPath]:

--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -199,6 +199,7 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
             (Optional; overrides input_dir, exclude)
         exclude (List): glob of python file paths to exclude (Optional)
         exclude_hidden (bool): Whether to exclude hidden files (dotfiles).
+        exclude_empty (bool): Whether to exclude empty files (Optional).
         encoding (str): Encoding of the files.
             Default is utf-8.
         errors (str): how encoding and decoding errors are to be handled,
@@ -231,6 +232,7 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         input_files: list | None = None,
         exclude: list | None = None,
         exclude_hidden: bool = True,
+        exclude_empty: bool = False,
         errors: str = "ignore",
         recursive: bool = False,
         encoding: str = "utf-8",
@@ -255,6 +257,7 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         self.exclude = exclude
         self.recursive = recursive
         self.exclude_hidden = exclude_hidden
+        self.exclude_empty = exclude_empty
         self.required_exts = required_exts
         self.num_files_limit = num_files_limit
         self.raise_on_error = raise_on_error
@@ -282,6 +285,9 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         return any(
             part.startswith(".") and part not in [".", ".."] for part in path.parts
         )
+
+    def is_empty_file(self, path: Path | PurePosixPath) -> bool:
+        return path.is_file() and len(path.read_bytes()) == 0
 
     def _add_files(self, input_dir: Path | PurePosixPath) -> list[Path | PurePosixPath]:
         """Add files."""
@@ -317,6 +323,7 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
             ref = _Path(_ref)
             is_dir = self.fs.isdir(ref)
             skip_because_hidden = self.exclude_hidden and self.is_hidden(ref)
+            skip_because_empty = self.exclude_empty and self.is_empty_file(ref)
             skip_because_bad_ext = (
                 self.required_exts is not None and ref.suffix not in self.required_exts
             )
@@ -342,6 +349,7 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
                 or skip_because_hidden
                 or skip_because_bad_ext
                 or skip_because_excluded
+                or skip_because_empty
             ):
                 continue
             else:

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
@@ -569,19 +569,20 @@ def test_read_file_content(tmp_dir_type: Type[Union[Path, str]]) -> None:
             checksum = hashlib.md5(content).hexdigest()
             assert checksum == files_checksum[file]
 
+
 @pytest.mark.parametrize("tmp_dir_type", [Path, str])
 @pytest.mark.skipif(PDFReader is None, reason="llama-index-readers-file not installed")
 def test_exclude_empty(tmp_dir_type: Type[Union[Path, str]]) -> None:
     """Test if exclude_empty flag excludes empty files."""
     with TemporaryDirectory() as tmp_dir:
         tmp_dir = tmp_dir_type(tmp_dir)
-        
+
         # Create non-empty files
         with open(f"{tmp_dir}/test1.txt", "w") as f:
             f.write("test1")
         with open(f"{tmp_dir}/test2.txt", "w") as f:
             f.write("test2")
-        
+
         # Create empty files
         open(f"{tmp_dir}/empty1.txt", "w").close()
         open(f"{tmp_dir}/empty2.txt", "w").close()
@@ -589,13 +590,21 @@ def test_exclude_empty(tmp_dir_type: Type[Union[Path, str]]) -> None:
         # Test with exclude_empty=True
         reader_exclude = SimpleDirectoryReader(tmp_dir, exclude_empty=True)
         documents_exclude = reader_exclude.load_data()
-        
+
         assert len(documents_exclude) == 2
-        assert set(doc.metadata["file_name"] for doc in documents_exclude) == {"test1.txt", "test2.txt"}
+        assert [doc.metadata["file_name"] for doc in documents_exclude] == {
+            "test1.txt",
+            "test2.txt",
+        }
 
         # Test with exclude_empty=False (default behavior)
         reader_include = SimpleDirectoryReader(tmp_dir, exclude_empty=False)
         documents_include = reader_include.load_data()
-        
+
         assert len(documents_include) == 4
-        assert set(doc.metadata["file_name"] for doc in documents_include) == {"test1.txt", "test2.txt", "empty1.txt", "empty2.txt"}
+        assert [doc.metadata["file_name"] for doc in documents_include] == {
+            "test1.txt",
+            "test2.txt",
+            "empty1.txt",
+            "empty2.txt",
+        }

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
@@ -603,8 +603,8 @@ def test_exclude_empty(tmp_dir_type: Type[Union[Path, str]]) -> None:
 
         assert len(documents_include) == 4
         assert [doc.metadata["file_name"] for doc in documents_include] == [
-            "test1.txt",
-            "test2.txt",
             "empty1.txt",
             "empty2.txt",
+            "test1.txt",
+            "test2.txt",
         ]

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
@@ -568,3 +568,34 @@ def test_read_file_content(tmp_dir_type: Type[Union[Path, str]]) -> None:
             content = reader.read_file_content(file)
             checksum = hashlib.md5(content).hexdigest()
             assert checksum == files_checksum[file]
+
+@pytest.mark.parametrize("tmp_dir_type", [Path, str])
+@pytest.mark.skipif(PDFReader is None, reason="llama-index-readers-file not installed")
+def test_exclude_empty(tmp_dir_type: Type[Union[Path, str]]) -> None:
+    """Test if exclude_empty flag excludes empty files."""
+    with TemporaryDirectory() as tmp_dir:
+        tmp_dir = tmp_dir_type(tmp_dir)
+        
+        # Create non-empty files
+        with open(f"{tmp_dir}/test1.txt", "w") as f:
+            f.write("test1")
+        with open(f"{tmp_dir}/test2.txt", "w") as f:
+            f.write("test2")
+        
+        # Create empty files
+        open(f"{tmp_dir}/empty1.txt", "w").close()
+        open(f"{tmp_dir}/empty2.txt", "w").close()
+
+        # Test with exclude_empty=True
+        reader_exclude = SimpleDirectoryReader(tmp_dir, exclude_empty=True)
+        documents_exclude = reader_exclude.load_data()
+        
+        assert len(documents_exclude) == 2
+        assert set(doc.metadata["file_name"] for doc in documents_exclude) == {"test1.txt", "test2.txt"}
+
+        # Test with exclude_empty=False (default behavior)
+        reader_include = SimpleDirectoryReader(tmp_dir, exclude_empty=False)
+        documents_include = reader_include.load_data()
+        
+        assert len(documents_include) == 4
+        assert set(doc.metadata["file_name"] for doc in documents_include) == {"test1.txt", "test2.txt", "empty1.txt", "empty2.txt"}

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_file.py
@@ -592,19 +592,19 @@ def test_exclude_empty(tmp_dir_type: Type[Union[Path, str]]) -> None:
         documents_exclude = reader_exclude.load_data()
 
         assert len(documents_exclude) == 2
-        assert [doc.metadata["file_name"] for doc in documents_exclude] == {
+        assert [doc.metadata["file_name"] for doc in documents_exclude] == [
             "test1.txt",
             "test2.txt",
-        }
+        ]
 
         # Test with exclude_empty=False (default behavior)
         reader_include = SimpleDirectoryReader(tmp_dir, exclude_empty=False)
         documents_include = reader_include.load_data()
 
         assert len(documents_include) == 4
-        assert [doc.metadata["file_name"] for doc in documents_include] == {
+        assert [doc.metadata["file_name"] for doc in documents_include] == [
             "test1.txt",
             "test2.txt",
             "empty1.txt",
             "empty2.txt",
-        }
+        ]


### PR DESCRIPTION
# Description

Add a new optional argument to the SimpleDirectoryReader class to exclude empty files from the file list. This is implemented to prevent the file limit for extraction from being consumed by empty files, which does not align with my intended use case.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
