### PR TITLE
[docs] Fix 404 link for Q&A Patterns

### DIFF
--- a/docs/docs/understanding/putting_it_all_together/index.md
+++ b/docs/docs/understanding/putting_it_all_together/index.md
@@ -2,7 +2,7 @@
 
 Congratulations! You've loaded your data, indexed it, stored your index, and queried your index. Now you've got to ship something to production. We can show you how to do that!
 
-- In [Q&A Patterns](q_and_a.md) we'll go into some of the more advanced and subtle ways you can build a query engine beyond the basics.
+- In [Q&A Patterns](q_and_a/index.md) we'll go into some of the more advanced and subtle ways you can build a query engine beyond the basics.
   - The [terms definition tutorial](q_and_a/terms_definitions_tutorial.md) is a detailed, step-by-step tutorial on creating a subtle query application including defining your prompts and supporting images as input.
   - We have a guide to [creating a unified query framework over your indexes](../../examples/retrievers/reciprocal_rerank_fusion.ipynb) which shows you how to run queries across multiple indexes.
   - And also over [structured data like SQL](structured_data.md)


### PR DESCRIPTION
Update link to "Q&A Patterns" in https://docs.llamaindex.ai/en/stable/understanding/putting_it_all_together/