### PR TITLE
[docs] Fix typo in BM25 Retriever Example

### DIFF
--- a/docs/docs/examples/retrievers/bm25_retriever.ipynb
+++ b/docs/docs/examples/retrievers/bm25_retriever.ipynb
@@ -621,7 +621,7 @@
    "source": [
     "storage_context.docstore.persist(\"./docstore.json\")\n",
     "\n",
-    "# or, we could ignore the docstore and just persist the bm25 retriever as shown above\n",
+    "# or, we could ignore the docstore and just persist the bm25 retriever as shown below\n",
     "# bm25_retriever.persist(\"./bm25_retriever\")"
    ]
   },


### PR DESCRIPTION
Fix typo in "Save and Load w/ a Vector Store" subsection in [BM25 Examples section](https://docs.llamaindex.ai/en/stable/examples/retrievers/bm25_retriever/#save-and-load-w-a-vector-store)