### PR TITLE
Get description from pydantic field

### DIFF
--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -42,6 +42,8 @@ def create_schema_from_function(
             param_type = args[0]
             if isinstance(args[1], str):
                 description = args[1]
+            elif isinstance(args[1], FieldInfo):
+                description = args[1].description
 
         if param_type is params[param_name].empty:
             param_type = Any

--- a/llama-index-core/tests/tools/test_utils.py
+++ b/llama-index-core/tests/tools/test_utils.py
@@ -73,3 +73,25 @@ def test_create_schema_from_function_with_typing_annotated() -> None:
 
     instance = schema(x=5)
     assert instance.x == 5  # type: ignore
+
+
+def test_create_schema_from_function_with_field_annotated() -> None:
+    """Test create_schema_from_function with Annotated[pydantic.Field]."""
+
+    def tmp_function(x: Annotated[int, Field(description="An integer")] = 3) -> str:
+        return str(x)
+
+    schema = create_schema_from_function("TestSchema", tmp_function)
+    actual_schema = schema.model_json_schema()
+
+    assert "x" in actual_schema["properties"]
+    assert actual_schema["properties"]["x"]["type"] == "integer"
+    assert actual_schema["properties"]["x"]["default"] == 3
+    assert actual_schema["properties"]["x"]["description"] == "An integer"
+
+    # Test the created schema
+    instance = schema()
+    assert instance.x == 3  # type: ignore
+
+    instance = schema(x=5)
+    assert instance.x == 5  # type: ignore


### PR DESCRIPTION
# Description

Adds support for specifying description through Annotated pyndatic fields.

Fixes https://github.com/run-llama/llama_index/issues/17662

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
