### PR TITLE
Feat/fix Azure AI Search Hybrid Semantic Search Unusability due to hardcoded parameter

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -555,7 +555,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         # https://learn.microsoft.com/en-us/azure/search/index-add-language-analyzers
         language_analyzer: str = "en.lucene",
         compression_type: str = "none",
-        semantic_configuration_name : Optional[str] = None,
+        semantic_configuration_name: Optional[str] = None,
         user_agent: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
@@ -1178,8 +1178,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                     odata_filter,
                     self._search_client,
                     self._async_search_client,
-                    semantic_configuration_name
-                    
+                    semantic_configuration_name,
                 )
             )
         if query.mode == VectorStoreQueryMode.SPARSE:
@@ -1189,7 +1188,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
-                semantic_configuration_name
+                semantic_configuration_name,
             )
         elif query.mode == VectorStoreQueryMode.HYBRID:
             azure_query_result_search = AzureQueryResultSearchHybrid(
@@ -1198,7 +1197,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
-                semantic_configuration_name
+                semantic_configuration_name,
             )
         elif query.mode == VectorStoreQueryMode.SEMANTIC_HYBRID:
             azure_query_result_search = AzureQueryResultSearchSemanticHybrid(
@@ -1391,7 +1390,7 @@ class AzureQueryResultSearchBase:
         odata_filter: Optional[str],
         search_client: SearchClient,
         async_search_client: AsyncSearchClient,
-        semantic_configuration_name : Optional[str],
+        semantic_configuration_name: Optional[str],
     ) -> None:
         self._query = query
         self._field_mapping = field_mapping

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -115,6 +115,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             doc_id_field_key="doc_id",
             language_analyzer="en.lucene",
             vector_algorithm_type="exhaustiveKnn",
+            semantic_configuration_name="mySemanticConfig",
         )
         ```
     """
@@ -141,6 +142,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
     _vector_profile_name: str = PrivateAttr()
     _compression_type: str = PrivateAttr()
     _user_agent: str = PrivateAttr()
+    _semantic_configuration_name: str = PrivateAttr()
 
     def _normalise_metadata_to_index_fields(
         self,
@@ -369,7 +371,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         )
         logger.info(f"Configuring {index_name} semantic search")
         semantic_config = SemanticConfiguration(
-            name="mySemanticConfig",
+            name=self._semantic_configuration_name,
             prioritized_fields=SemanticPrioritizedFields(
                 content_fields=[SemanticField(field_name=self._field_mapping["chunk"])],
             ),
@@ -491,7 +493,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         )
         logger.info(f"Configuring {index_name} semantic search")
         semantic_config = SemanticConfiguration(
-            name="mySemanticConfig",
+            name=self._semantic_configuration_name,
             prioritized_fields=SemanticPrioritizedFields(
                 content_fields=[SemanticField(field_name=self._field_mapping["chunk"])],
             ),
@@ -553,6 +555,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         # https://learn.microsoft.com/en-us/azure/search/index-add-language-analyzers
         language_analyzer: str = "en.lucene",
         compression_type: str = "none",
+        semantic_configuration_name : Optional[str] = None,
         user_agent: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
@@ -633,7 +636,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             raise ValueError(
                 "Only 'exhaustiveKnn' and 'hnsw' are supported for vector_algorithm_type"
             )
-
+        self._semantic_configuration_name = semantic_configuration_name
         self._language_analyzer = language_analyzer
         self._compression_type = compression_type.lower()
 
@@ -1162,17 +1165,23 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
         odata_filter = None
+        semantic_configuration_name = None
         if query.filters is not None:
             odata_filter = self._create_odata_filter(query.filters)
-        azure_query_result_search: AzureQueryResultSearchBase = (
-            AzureQueryResultSearchDefault(
-                query,
-                self._field_mapping,
-                odata_filter,
-                self._search_client,
-                self._async_search_client,
+        if self._semantic_configuration_name is not None:
+            semantic_configuration_name = self._semantic_configuration_name
+        if query.mode == VectorStoreQueryMode.DEFAULT:
+            azure_query_result_search: AzureQueryResultSearchBase = (
+                AzureQueryResultSearchDefault(
+                    query,
+                    self._field_mapping,
+                    odata_filter,
+                    self._search_client,
+                    self._async_search_client,
+                    semantic_configuration_name
+                    
+                )
             )
-        )
         if query.mode == VectorStoreQueryMode.SPARSE:
             azure_query_result_search = AzureQueryResultSearchSparse(
                 query,
@@ -1180,6 +1189,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                semantic_configuration_name
             )
         elif query.mode == VectorStoreQueryMode.HYBRID:
             azure_query_result_search = AzureQueryResultSearchHybrid(
@@ -1188,6 +1198,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                semantic_configuration_name
             )
         elif query.mode == VectorStoreQueryMode.SEMANTIC_HYBRID:
             azure_query_result_search = AzureQueryResultSearchSemanticHybrid(
@@ -1196,6 +1207,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                self._semantic_configuration_name,
             )
         return azure_query_result_search.search()
 
@@ -1244,6 +1256,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                self._semantic_configuration_name,
             )
         return await azure_query_result_search.asearch()
 
@@ -1378,12 +1391,14 @@ class AzureQueryResultSearchBase:
         odata_filter: Optional[str],
         search_client: SearchClient,
         async_search_client: AsyncSearchClient,
+        semantic_configuration_name : Optional[str],
     ) -> None:
         self._query = query
         self._field_mapping = field_mapping
         self._odata_filter = odata_filter
         self._search_client = search_client
         self._async_search_client = async_search_client
+        self._semantic_configuration_name = semantic_configuration_name
 
     @property
     def _select_fields(self) -> List[str]:
@@ -1409,6 +1424,7 @@ class AzureQueryResultSearchBase:
             top=self._query.similarity_top_k,
             select=self._select_fields,
             filter=self._odata_filter,
+            semantic_configuration_name=self._semantic_configuration_name,
         )
 
         id_result = []
@@ -1462,6 +1478,7 @@ class AzureQueryResultSearchBase:
             top=self._query.similarity_top_k,
             select=self._select_fields,
             filter=self._odata_filter,
+            semantic_configuration_name=self._semantic_configuration_name,
         )
 
         id_result = []
@@ -1585,7 +1602,7 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
             select=self._select_fields,
             filter=self._odata_filter,
             query_type="semantic",
-            semantic_configuration_name="mySemanticConfig",
+            semantic_configuration_name=self._semantic_configuration_name,
         )
 
         id_result = []
@@ -1641,7 +1658,7 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
             select=self._select_fields,
             filter=self._odata_filter,
             query_type="semantic",
-            semantic_configuration_name="mySemanticConfig",
+            semantic_configuration_name=self._semantic_configuration_name,
         )
 
         id_result = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-azureaisearch"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -54,6 +54,7 @@ def create_mock_vector_store(
         index_name=index_name,
         index_management=index_management,
         embedding_dimensionality=2,  # Assuming a dimensionality of 2 for simplicity
+        semantic_configuration_name="default",
     )
 
 
@@ -243,6 +244,7 @@ def test_azureaisearch_query() -> None:
         top=2,
         select=["id", "content", "metadata", "doc_id"],
         filter=None,
+        semantic_configuration_name="default",
     )
 
     # Assert the result structure


### PR DESCRIPTION
# Description

Dear colleagues,

Currently the Azure AI Search Integration is not able to use efectively the VectorStoreQueryMode.SEMANTIC_HYBRID. This is due to the fact that the semantic config name is hardcoded in the current code. If we create the index with llama_index this is not a problem. However if we are trying to plug an play an already existing Azure AI search index that does not have the same semantic config name this will fail.

## Fixes # (issue)

This fixes #17636 


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods

## Results of checklists

### Tests

![image](https://github.com/user-attachments/assets/3be0e568-3d74-479c-b6b3-11938c7dc7cf)

### Pre-commits

![image](https://github.com/user-attachments/assets/ad53a342-384c-4f2e-927f-b1009e02d28e)



