### PR TITLE
Improved Obsidian Reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-obsidian/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/README.md
@@ -7,6 +7,7 @@ files into a List of Documents. Documents are split by header in
 the Markdown Reader we use.
 
 Each document will contain the following metadata:
+
 - file_name: the name of the markdown file
 - folder_path: the full path to the folder containing the file
 - folder_name: the relative path to the folder containing the file
@@ -22,17 +23,21 @@ Optionally, tasks can be extracted from the text and stored in metadata.
 from llama_index.readers.obsidian import ObsidianReader
 
 # Initialize ObsidianReader with the path to the Obsidian vault
-reader = ObsidianReader(input_dir="<Path to Obsidian Vault>", extract_tasks=False, remove_tasks_from_text=False)
+reader = ObsidianReader(
+    input_dir="<Path to Obsidian Vault>",
+    extract_tasks=False,
+    remove_tasks_from_text=False,
+)
 
 # Load data from the Obsidian vault
 documents = reader.load_data()
 ```
 
 ##### Arguments
+
 - **input_dir** (str): Path to the Obsidian vault.
 - **extract_tasks** (bool): If True, extract tasks from the text and store them in metadata. Default is False.
 - **remove_tasks_from_text** (bool): If True and extract_tasks is True, remove the task lines from the main document text. Default is False.
-
 
 Implementation for Obsidian reader can be found [here](https://docs.llamaindex.ai/en/stable/examples/data_connectors/ObsidianReaderDemo/)
 

--- a/llama-index-integrations/readers/llama-index-readers-obsidian/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/README.md
@@ -2,7 +2,19 @@
 
 ## Overview
 
-Obsidian Reader is a utility class for loading data from an Obsidian Vault. It parses all markdown files in the vault and extracts text from under Obsidian headers, returning a list of documents, each containing text from a separate header.
+Pass in the path to an Obsidian vault and it will parse all markdown
+files into a List of Documents. Documents are split by header in
+the Markdown Reader we use.
+
+Each document will contain the following metadata:
+- file_name: the name of the markdown file
+- folder_path: the full path to the folder containing the file
+- folder_name: the relative path to the folder containing the file
+- note_name: the name of the note (without the .md extension)
+- wikilinks: a list of all wikilinks found in the document
+- backlinks: a list of all notes that link to this note
+
+Optionally, tasks can be extracted from the text and stored in metadata.
 
 ### Usage
 
@@ -10,11 +22,17 @@ Obsidian Reader is a utility class for loading data from an Obsidian Vault. It p
 from llama_index.readers.obsidian import ObsidianReader
 
 # Initialize ObsidianReader with the path to the Obsidian vault
-reader = ObsidianReader(input_dir="<Path to Obsidian Vault>")
+reader = ObsidianReader(input_dir="<Path to Obsidian Vault>", extract_tasks=False, remove_tasks_from_text=False)
 
 # Load data from the Obsidian vault
 documents = reader.load_data()
 ```
+
+##### Arguments
+- **input_dir** (str): Path to the Obsidian vault.
+- **extract_tasks** (bool): If True, extract tasks from the text and store them in metadata. Default is False.
+- **remove_tasks_from_text** (bool): If True and extract_tasks is True, remove the task lines from the main document text. Default is False.
+
 
 Implementation for Obsidian reader can be found [here](https://docs.llamaindex.ai/en/stable/examples/data_connectors/ObsidianReaderDemo/)
 

--- a/llama-index-integrations/readers/llama-index-readers-obsidian/llama_index/readers/obsidian/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/llama_index/readers/obsidian/base.py
@@ -1,14 +1,25 @@
 """Obsidian reader class.
 
 Pass in the path to an Obsidian vault and it will parse all markdown
-files into a List of Documents,
-with each Document containing text from under an Obsidian header.
+files into a List of Documents. Documents are split by header in
+the Markdown Reader we use.
+
+Each document will contain the following metadata:
+- file_name: the name of the markdown file
+- folder_path: the full path to the folder containing the file
+- folder_name: the relative path to the folder containing the file
+- note_name: the name of the note (without the .md extension)
+- wikilinks: a list of all wikilinks found in the document
+- backlinks: a list of all notes that link to this note
+
+Optionally, tasks can be extracted from the text and stored in metadata.
 
 """
 
 import os
+import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List, Tuple
 
 if TYPE_CHECKING:
     from langchain.docstore.document import Document as LCDocument
@@ -19,30 +30,117 @@ from llama_index.core.schema import Document
 
 
 class ObsidianReader(BaseReader):
-    """Utilities for loading data from an Obsidian Vault.
-
-    Args:
-        input_dir (str): Path to the vault.
-
+    """
+    input_dir (str): Path to the Obsidian vault.
+    extract_tasks (bool): If True, extract tasks from the text and store them in metadata.
+                            Default is False.
+    remove_tasks_from_text (bool): If True and extract_tasks is True, remove the task
+                                    lines from the main document text.
+                                    Default is False.
     """
 
-    def __init__(self, input_dir: str):
-        """Init params."""
+    def __init__(
+        self,
+        input_dir: str,
+        extract_tasks: bool = False,
+        remove_tasks_from_text: bool = False,
+    ):
         self.input_dir = Path(input_dir)
+        self.extract_tasks = extract_tasks
+        self.remove_tasks_from_text = remove_tasks_from_text
 
     def load_data(self, *args: Any, **load_kwargs: Any) -> List[Document]:
-        """Load data from the input directory."""
+        """
+        Walks through the vault, loads each markdown file, and adds extra metadata
+        (file name, folder path, wikilinks, backlinks, and optionally tasks).
+        """
         docs: List[Document] = []
+        # This map will hold: {target_note: [linking_note1, linking_note2, ...]}
+        backlinks_map = {}
+
         for dirpath, dirnames, filenames in os.walk(self.input_dir):
+            # Skip hidden directories.
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
             for filename in filenames:
                 if filename.endswith(".md"):
                     filepath = os.path.join(dirpath, filename)
-                    content = MarkdownReader().load_data(Path(filepath))
-                    docs.extend(content)
+                    md_docs = MarkdownReader().load_data(Path(filepath))
+                    for i, doc in enumerate(md_docs):
+                        file_path_obj = Path(filepath)
+                        note_name = file_path_obj.stem
+                        doc.metadata["file_name"] = file_path_obj.name
+                        doc.metadata["folder_path"] = str(file_path_obj.parent)
+                        doc.metadata["folder_name"] = str(
+                            file_path_obj.parent.relative_to(self.input_dir)
+                        )
+                        doc.metadata["note_name"] = note_name
+                        wikilinks = self._extract_wikilinks(doc.text)
+                        doc.metadata["wikilinks"] = wikilinks
+                        # For each wikilink found in this document, record a backlink from this note.
+                        for link in wikilinks:
+                            # Each link is expected to match a note name (without .md)
+                            backlinks_map.setdefault(link, []).append(note_name)
+
+                        # Optionally, extract tasks from the text.
+                        if self.extract_tasks:
+                            tasks, cleaned_text = self._extract_tasks(doc.text)
+                            doc.metadata["tasks"] = tasks
+                            if self.remove_tasks_from_text:
+                                md_docs[i] = Document(
+                                    text=cleaned_text, metadata=doc.metadata
+                                )
+                    docs.extend(md_docs)
+
+        # Now that we have processed all files, assign backlinks metadata.
+        for doc in docs:
+            note_name = doc.metadata.get("note_name")
+            # If no backlinks exist for this note, default to an empty list.
+            doc.metadata["backlinks"] = backlinks_map.get(note_name, [])
         return docs
 
     def load_langchain_documents(self, **load_kwargs: Any) -> List["LCDocument"]:
-        """Load data in LangChain document format."""
+        """
+        Loads data in the LangChain document format.
+        """
         docs = self.load_data(**load_kwargs)
         return [d.to_langchain_format() for d in docs]
+
+    def _extract_wikilinks(self, text: str) -> List[str]:
+        """
+        Extracts Obsidian wikilinks from the given text.
+
+        Matches patterns like:
+          - [[Note Name]]
+          - [[Note Name|Alias]]
+
+        Returns a list of unique wikilink targets (aliases are ignored).
+        """
+        pattern = r"\[\[([^\]]+)\]\]"
+        matches = re.findall(pattern, text)
+        links = []
+        for match in matches:
+            # If a pipe is present (e.g. [[Note|Alias]]), take only the part before it.
+            target = match.split("|")[0].strip()
+            links.append(target)
+        return list(set(links))
+
+    def _extract_tasks(self, text: str) -> Tuple[List[str], str]:
+        """
+        Extracts markdown tasks from the text.
+
+        A task is expected to be a checklist item in markdown, for example:
+            - [ ] Do something
+            - [x] Completed task
+
+        Returns a tuple:
+            (list of task strings, text with task lines removed if removal is enabled).
+        """
+        # This regex matches lines starting with '-' or '*' followed by a checkbox.
+        task_pattern = re.compile(
+            r"^\s*[-*]\s*\[\s*(?:x|X| )\s*\]\s*(.*)$", re.MULTILINE
+        )
+        tasks = task_pattern.findall(text)
+        cleaned_text = text
+        if self.remove_tasks_from_text:
+            cleaned_text = task_pattern.sub("", text)
+        return tasks, cleaned_text

--- a/llama-index-integrations/readers/llama-index-readers-obsidian/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/pyproject.toml
@@ -12,7 +12,7 @@ contains_example = false
 import_path = "llama_index.readers.obsidian"
 
 [tool.llamahub.class_authors]
-ObsidianReader = "hursh-desai"
+ObsidianReader = ["bitsofchris", "hursh-desai"]
 
 [tool.mypy]
 disallow_untyped_defs = true
@@ -25,10 +25,10 @@ authors = ["Your Name <you@example.com>"]
 description = "llama-index readers obsidian integration"
 exclude = ["**/BUILD"]
 license = "MIT"
-maintainers = ["hursh-desai"]
+maintainers = ["bitsofchris", "hursh-desai"]
 name = "llama-index-readers-obsidian"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-obsidian/tests/test_readers_obsidian.py
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/tests/test_readers_obsidian.py
@@ -1,5 +1,3 @@
-import os
-import pytest
 from pathlib import Path
 from typing import List
 

--- a/llama-index-integrations/readers/llama-index-readers-obsidian/tests/test_readers_obsidian.py
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/tests/test_readers_obsidian.py
@@ -1,3 +1,8 @@
+import os
+import pytest
+from pathlib import Path
+from typing import List
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.obsidian import ObsidianReader
 
@@ -5,3 +10,246 @@ from llama_index.readers.obsidian import ObsidianReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in ObsidianReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+# Helper function to create a markdown file in the given directory.
+def create_markdown_file(directory: Path, file_name: str, content: str) -> Path:
+    file_path = directory / file_name
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+
+
+###########################################
+# File Metadata (file_name & folder_path)
+###########################################
+
+
+def test_file_metadata(tmp_path: Path):
+    """
+    Test that a simple markdown file returns a document with correct file metadata.
+    """
+    content = "This is a simple document."
+    create_markdown_file(tmp_path, "test.md", content)
+
+    reader = ObsidianReader(input_dir=str(tmp_path))
+    docs = reader.load_data()
+    assert len(docs) == 1
+    doc = docs[0]
+    # Check that file metadata was added
+    assert doc.metadata.get("file_name") == "test.md"
+    # folder_path should match the temporary directory
+    assert Path(doc.metadata.get("folder_path")).resolve() == tmp_path.resolve()
+
+
+def test_file_metadata_nested(tmp_path: Path):
+    """
+    Test that a markdown file in a subdirectory gets the correct folder path metadata.
+    """
+    subdir = tmp_path / "subfolder"
+    subdir.mkdir()
+    content = "Nested file content."
+    create_markdown_file(subdir, "nested.md", content)
+
+    reader = ObsidianReader(input_dir=str(tmp_path))
+    docs = reader.load_data()
+    # Expect one document loaded from the nested directory
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc.metadata.get("file_name") == "nested.md"
+    assert Path(doc.metadata.get("folder_path")).resolve() == subdir.resolve()
+
+
+###########################################
+# Wikilink Extraction
+###########################################
+
+
+def test_wikilink_extraction(tmp_path: Path):
+    """
+    Test that wikilinks (including alias links) are extracted and stored in metadata.
+    """
+    content = "Refer to [[NoteOne]] and [[NoteTwo|Alias]] for more details."
+    create_markdown_file(tmp_path, "wikilinks.md", content)
+
+    reader = ObsidianReader(input_dir=str(tmp_path))
+    docs = reader.load_data()
+    assert len(docs) == 1
+    doc = docs[0]
+    wikilinks: List[str] = doc.metadata.get("wikilinks", [])
+    # Order does not matter; both targets should be present.
+    assert set(wikilinks) == {"NoteOne", "NoteTwo"}
+
+
+def test_wikilink_extraction_duplicates(tmp_path: Path):
+    """
+    Test that duplicate wikilinks (with or without aliases) are only stored once.
+    """
+    content = "See [[Note]] and also [[Note|Alias]]."
+    create_markdown_file(tmp_path, "dup_wikilinks.md", content)
+
+    reader = ObsidianReader(input_dir=str(tmp_path))
+    docs = reader.load_data()
+    assert len(docs) == 1
+    doc = docs[0]
+    wikilinks: List[str] = doc.metadata.get("wikilinks", [])
+    # Only one unique wikilink should be present.
+    assert set(wikilinks) == {"Note"}
+
+
+###########################################
+# Tasks Extraction (without removal)
+###########################################
+
+
+def test_tasks_extraction(tmp_path: Path):
+    """
+    Test that markdown tasks are correctly extracted into metadata when removal is disabled.
+    """
+    content = (
+        "Task list:\n"
+        "- [ ] Task A\n"
+        "Some intervening text\n"
+        "- [x] Task B\n"
+        "More text follows."
+    )
+    create_markdown_file(tmp_path, "tasks.md", content)
+
+    reader = ObsidianReader(
+        input_dir=str(tmp_path), extract_tasks=True, remove_tasks_from_text=False
+    )
+    docs = reader.load_data()
+    assert len(docs) == 1
+    doc = docs[0]
+    tasks: List[str] = doc.metadata.get("tasks", [])
+    # Check that tasks are extracted.
+    assert "Task A" in tasks
+    assert "Task B" in tasks
+    # Since removal is disabled, the original text should still contain the task lines.
+    assert "- [ ] Task A" in doc.text
+    assert "- [x] Task B" in doc.text
+
+
+###########################################
+# Tasks Removal from Text
+###########################################
+
+
+def test_remove_tasks_from_text(tmp_path: Path):
+    """
+    Test that when removal is enabled, task lines are removed from the document text.
+    """
+    content = "Intro text\n" "- [ ] Task 1\n" "- [x] Task 2\n" "Conclusion text"
+    create_markdown_file(tmp_path, "tasks_removed.md", content)
+
+    reader = ObsidianReader(
+        input_dir=str(tmp_path), extract_tasks=True, remove_tasks_from_text=True
+    )
+    docs = reader.load_data()
+    assert len(docs) == 1
+    doc = docs[0]
+    tasks: List[str] = doc.metadata.get("tasks", [])
+    assert "Task 1" in tasks
+    assert "Task 2" in tasks
+    # Ensure the task lines have been removed from the main text.
+    assert "- [ ] Task 1" not in doc.text
+    assert "- [x] Task 2" not in doc.text
+    # Ensure that non-task text is still present.
+    assert "Intro text" in doc.text
+    assert "Conclusion text" in doc.text
+
+
+###########################################
+# Backlink Extraction
+###########################################
+
+
+def get_doc_by_note_name(docs, note_name: str):
+    """
+    Utility function to return the first document with the specified note name.
+    """
+    for doc in docs:
+        if doc.metadata.get("note_name") == note_name:
+            return doc
+    return None
+
+
+def test_single_backlink(tmp_path: Path):
+    """
+    Test a simple case where one note (A.md) links to another (B.md).
+
+    Expected behavior:
+      - Note A should have no backlinks.
+      - Note B should have a backlink from A.
+    """
+    # Create two markdown files:
+    # A.md links to B, while B.md contains no wikilinks.
+    create_markdown_file(tmp_path, "A.md", "This is note A linking to [[B]].")
+    create_markdown_file(tmp_path, "B.md", "This is note B with no links.")
+
+    reader = ObsidianReader(input_dir=str(tmp_path))
+    docs = reader.load_data()
+
+    doc_a = get_doc_by_note_name(docs, "A")
+    doc_b = get_doc_by_note_name(docs, "B")
+
+    # Verify that doc_a exists and has no backlinks.
+    assert doc_a is not None
+    assert doc_a.metadata.get("backlinks") == []
+
+    # Verify that doc_b exists and has a backlink from A.
+    assert doc_b is not None
+    assert doc_b.metadata.get("backlinks") == ["A"]
+
+
+def test_multiple_backlinks(tmp_path: Path):
+    """
+    Test a scenario with multiple notes linking to a single note.
+
+    Create three files:
+      - A.md: links to B and C.
+      - B.md: links to C.
+      - C.md: contains no wikilinks.
+
+    Expected behavior:
+      - Note A should have no backlinks.
+      - Note B should have a backlink from A.
+      - Note C should have backlinks from both A and B.
+    """
+    create_markdown_file(tmp_path, "A.md", "Linking to [[B]] and [[C]].")
+    create_markdown_file(tmp_path, "B.md", "Linking to [[C]].")
+    create_markdown_file(tmp_path, "C.md", "No links here.")
+
+    reader = ObsidianReader(input_dir=str(tmp_path))
+    docs = reader.load_data()
+
+    doc_a = get_doc_by_note_name(docs, "A")
+    doc_b = get_doc_by_note_name(docs, "B")
+    doc_c = get_doc_by_note_name(docs, "C")
+
+    # Verify note A has no backlinks.
+    assert doc_a is not None
+    assert doc_a.metadata.get("backlinks") == []
+
+    # Verify note B has a backlink from A.
+    assert doc_b is not None
+    assert doc_b.metadata.get("backlinks") == ["A"]
+
+    # Note C should have backlinks from A and B.
+    # Since file processing order might vary, we compare as sets.
+    assert doc_c is not None
+    backlinks_c = doc_c.metadata.get("backlinks")
+    assert set(backlinks_c) == {"A", "B"}
+
+
+def test_no_links(tmp_path: Path):
+    """
+    Test that a note with no outgoing links gets an empty backlinks list.
+    """
+    create_markdown_file(tmp_path, "A.md", "This is a note with no links.")
+    reader = ObsidianReader(input_dir=str(tmp_path))
+    docs = reader.load_data()
+
+    doc_a = get_doc_by_note_name(docs, "A")
+    assert doc_a is not None
+    # Since no note links to A, its backlinks should be an empty list.
+    assert doc_a.metadata.get("backlinks") == []


### PR DESCRIPTION
# Description
This PR enhances the Obsidian Reader integration by improving metadata extraction and adding support for backlinks. These improvements provide richer context for Obsidian notes and enhance the ability to navigate between linked documents.

Summary of Changes:

- **File Metadata Extraction**: Added file_name, folder_path, folder_name, and note_name metadata fields.
- **Wikilinks Extraction**: Extracts and stores outgoing links (e.g., [[Note Name]]).
- **Backlinks Support**: When Note A links to Note B, Note B’s metadata now contains a backlinks field listing Note A.
- **Task Extraction & Filtering**: Extracts markdown checklist items (- [ ] Task) and optionally removes them from the main content.

The tests are AI generated, but I reviewed and incrementally added them as I add features.

## New Package?

(updates an existing package)

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
