### PR TITLE
Be more lenient with leading whitespaces emitted by some models when doing ReAct

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -486,7 +486,9 @@ class ReActAgentWorker(BaseAgentWorker):
         Returns:
             bool: Boolean on whether the chunk is the start of the final response
         """
-        latest_content = chunk.message.content
+        latest_content = (
+            None if chunk.message.content is None else chunk.message.content.strip()
+        )
         if latest_content:
             # doesn't follow thought-action format
             # keep first chunks


### PR DESCRIPTION
 (llama 3.1, im looking at you)

# Description

Be more lenient when parsing models who love emitting leading whitespaces.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

To be honest i can't find the tests directory for this

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
