### PR TITLE
fix: max_tokens in O1

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -424,7 +424,7 @@ class OpenAI(FunctionCallingLLM):
         all_kwargs = {**base_kwargs, **self.additional_kwargs}
         if "stream" not in all_kwargs and "stream_options" in all_kwargs:
             del all_kwargs["stream_options"]
-        if self.model in O1_MODELS and base_kwargs["max_tokens"] is not None:
+        if self.model in O1_MODELS and base_kwargs.get("max_tokens") is not None:
             # O1 models use max_completion_tokens instead of max_tokens
             all_kwargs["max_completion_tokens"] = all_kwargs.get(
                 "max_completion_tokens", all_kwargs["max_tokens"]

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.16"
+version = "0.3.17"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This bug has been introduced in https://github.com/run-llama/llama_index/commit/89396ae11da5dba7a99c95024137342d3613f06f and is assuming that a `max_tokens` exists for O1 models, which is not the case, failing with a KeyError.

Stacktrace:

```
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
                                     ^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.runtime/python/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.runtime/python/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    result = await fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/llama_index/llms/openai/base.py", line 700, in _achat
    messages=message_dicts, stream=False, **self._get_model_kwargs(**kwargs)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.12/site-packages/llama_index/llms/openai/base.py", line 427, in _get_model_kwargs
    if self.model in O1_MODELS and base_kwargs["max_tokens"] is not None:
                                   ~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'max_tokens'
```

We could add a test for `_get_model_kwargs` but there are no tests for private method in this package.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
