### PR TITLE
fix: update the upsert_triplet method in neptune integration

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
@@ -65,12 +65,14 @@ class NeptuneBaseGraphStore(GraphStore):
         """
 
         prepared_statement = query % (
-            self.node_label.replace("`",""),
-            self.node_label.replace("`",""),
-            rel.replace(" ", "_").replace("`","").upper(),
+            self.node_label.replace("`", ""),
+            rel.replace(" ", "_").replace("`", "").upper(),
         )
 
-        self.query(prepared_statement, {"subj": subj.replace("`",""), "obj": obj.replace("`","")})
+        self.query(
+            prepared_statement,
+            {"subj": subj.replace("`", ""), "obj": obj.replace("`", "")},
+        )
 
     def delete(self, subj: str, rel: str, obj: str) -> None:
         """Delete triplet from the graph."""

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
@@ -65,12 +65,12 @@ class NeptuneBaseGraphStore(GraphStore):
         """
 
         prepared_statement = query % (
-            self.node_label,
-            self.node_label,
-            rel.replace(" ", "_").upper(),
+            self.node_label.replace("`",""),
+            self.node_label.replace("`",""),
+            rel.replace(" ", "_").replace("`","").upper(),
         )
 
-        self.query(prepared_statement, {"subj": subj, "obj": obj})
+        self.query(prepared_statement, {"subj": subj.replace("`",""), "obj": obj.replace("`","")})
 
     def delete(self, subj: str, rel: str, obj: str) -> None:
         """Delete triplet from the graph."""

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
@@ -30,7 +30,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-neptune"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

The goal of this PR is to fix issue #17358, implementing the solution suggested there with sanitizing the inputs for upstart_triplet in graph_stores_neptune. No dependencies need to be updated for this to work. I created a PR(#17363) for this before but I ran into some issues so I had to close it.

## New Package?

No

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
