### PR TITLE
Fix: update documentation to add poetry shell plugin

### DIFF
--- a/docs/docs/CONTRIBUTING.md
+++ b/docs/docs/CONTRIBUTING.md
@@ -13,15 +13,19 @@ If you're ready to dive in, here’s a quick setup guide to get you going:
    ```bash
    cd llama_index
    ```
-3. Set up a new virtual environment with `Poetry`:
+3. if the shell plugin is not installed, add the plugin by running:
+      ```bash
+      poetry self add poetry-plugin-shell
+      ```
+5. Set up a new virtual environment with `Poetry`:
    ```bash
    poetry shell
    ```
-4. Install development (and/or docs) dependencies:
+6. Install development (and/or docs) dependencies:
    ```bash
    poetry install --only dev,docs --no-root
    ```
-5. Install the package(s) you want to work on. You will for sure need to install `llama-index-core`:
+7. Install the package(s) you want to work on. You will for sure need to install `llama-index-core`:
 
    ```bash
    pip install -e llama-index-core

--- a/docs/docs/getting_started/installation.md
+++ b/docs/docs/getting_started/installation.md
@@ -58,6 +58,10 @@ A full guide to using and configuring embedding models is available [here](../mo
 Git clone this repository: `git clone https://github.com/run-llama/llama_index.git`. Then do the following:
 
 - [Install poetry](https://python-poetry.org/docs/#installation) - this will help you manage package dependencies
+- If you need to run shell commands using Poetry but the shell plugin is not installed, add the plugin by running:
+  ```
+  poetry self add poetry-plugin-shell
+  ```
 - `poetry shell` - this command creates a virtual environment, which keeps installed packages contained to this project
 - `poetry install` - this will install the core starter package requirements
 - (Optional) `poetry install --with dev, docs` - this will install all dependencies needed for most local development


### PR DESCRIPTION
# Description

As per the latest [Poetry Docs](https://python-poetry.org/docs/cli/#shell), the poetry shell command has been moved to a separate plugin: [poetry-plugin-shell](https://github.com/python-poetry/poetry-plugin-shell).

Contributors performing a fresh installation of Poetry will encounter a "The command "shell" does not exist." error due to this change. To prevent confusion, the official documentation should mention this alongside the shell command and guide users on how to install the required plugin.

The shell plugin can be installed via self add command of Poetry.
```
poetry self add poetry-plugin-shell
```
More instructions for the poetry-plugin-shell can be found [here](https://github.com/python-poetry/poetry-plugin-shell).

So I updated the CONTRIBUTING.md and getting started page in the docs, let me know if there are other places in the docs that need `poetry shell.`

Fixes #17758 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- 
## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
