### PR TITLE
chore: add tests for latest gemini structured gen

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -48,21 +48,11 @@ from .utils import (
 dispatcher = instrument.get_dispatcher(__name__)
 
 GEMINI_MODELS = (
-    "models/gemini-2.0-flash-exp",
-    "models/gemini-2.0-flash-001",
-    # Gemini 1.0 Pro Vision has been deprecated on July 12, 2024.
-    # According to official recommendations, switch the default model to gemini-1.5-flash
+    "models/gemini-2.0-flash",
+    "models/gemini-2.0-flash-thinking",
+    "models/gemini-2.0-flash-lite",
     "models/gemini-1.5-flash",
-    "models/gemini-1.5-flash-latest",
-    "models/gemini-pro",
-    "models/gemini-pro-latest",
-    "models/gemini-1.5-pro",
-    "models/gemini-1.5-pro-latest",
     "models/gemini-1.0-pro",
-    # for some reason, google lists this without the models prefix
-    "gemini-1.5-flash",
-    "gemini-1.5-flash-latest",
-    "gemini-1.0-pro",
 )
 
 if TYPE_CHECKING:

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
@@ -12,8 +12,11 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.multi_modal_llms.base import ChatMessage
 from llama_index.core.utilities.gemini_utils import ROLES_FROM_GEMINI, ROLES_TO_GEMINI
 
+# These are the shortened model names
+# Any model that contains one of these names will not support function calling
 MODELS_WITHOUT_FUNCTION_CALLING_SUPPORT = [
-    "models/gemini-2.0-flash-thinking-exp-01-21",
+    "gemini-2.0-flash-thinking",
+    "gemini-2.0-flash-lite",
 ]
 
 
@@ -127,4 +130,7 @@ def chat_message_to_gemini(message: ChatMessage) -> "genai.types.ContentDict":
 
 
 def is_function_calling_model(model: str) -> bool:
-    return model not in MODELS_WITHOUT_FUNCTION_CALLING_SUPPORT
+    for model_name in MODELS_WITHOUT_FUNCTION_CALLING_SUPPORT:
+        if model_name in model:
+            return False
+    return True

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
@@ -12,6 +12,10 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.multi_modal_llms.base import ChatMessage
 from llama_index.core.utilities.gemini_utils import ROLES_FROM_GEMINI, ROLES_TO_GEMINI
 
+MODELS_WITHOUT_FUNCTION_CALLING_SUPPORT = [
+    "models/gemini-2.0-flash-thinking-exp-01-21",
+]
+
 
 def _error_if_finished_early(candidate: "glm.Candidate") -> None:  # type: ignore[name-defined] # only until release
     if (finish_reason := candidate.finish_reason) > 1:  # 1=STOP (normally)
@@ -116,3 +120,7 @@ def chat_message_to_gemini(message: ChatMessage) -> "genai.types.ContentDict":
         "role": ROLES_TO_GEMINI[message.role],
         "parts": parts,
     }
+
+
+def is_function_calling_model(model: str) -> bool:
+    return model not in MODELS_WITHOUT_FUNCTION_CALLING_SUPPORT

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-gemini"
 readme = "README.md"
-version = "0.4.9"
+version = "0.4.10"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
@@ -1,16 +1,17 @@
 import os
 
-from llama_index.core.tools.function_tool import FunctionTool
 import pytest
-from llama_index.core.base.llms.base import BaseLLM
-from llama_index.core.base.llms.types import ChatMessage, ImageBlock, MessageRole
-from llama_index.llms.gemini import Gemini
-from llama_index.llms.gemini.utils import chat_message_to_gemini
-
 from google.ai.generativelanguage_v1beta.types import (
     FunctionCallingConfig,
     ToolConfig,
 )
+from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.base.llms.types import ChatMessage, ImageBlock, MessageRole
+from llama_index.core.prompts.base import ChatPromptTemplate
+from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.llms.gemini import Gemini
+from llama_index.llms.gemini.utils import chat_message_to_gemini
+from pydantic import BaseModel
 
 
 def test_embedding_class() -> None:
@@ -83,3 +84,25 @@ def test_chat_with_tools() -> None:
     assert tool_calls[0].tool_kwargs == {"a": 2, "b": 3}
 
     assert len(response.additional_kwargs["tool_calls"]) >= 1
+
+
+@pytest.mark.skipif(
+    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
+)
+def test_structured_llm() -> None:
+    class Test(BaseModel):
+        test: str
+
+    gemini_flash = Gemini(
+        model="models/gemini-2.0-flash-001",
+        api_key=os.environ["GOOGLE_API_KEY"],
+        additional_kwargs={"seed": 4242},
+    )
+
+    chat_prompt = ChatPromptTemplate(message_templates=[ChatMessage(content="test")])
+    direct_prediction_response = gemini_flash.structured_predict(
+        output_cls=Test, prompt=chat_prompt
+    )
+    assert direct_prediction_response.test is not None
+    structured_llm_response = gemini_flash.as_structured_llm(Test).complete("test")
+    assert structured_llm_response.raw.test is not None

--- a/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
@@ -106,3 +106,25 @@ def test_structured_llm() -> None:
     assert direct_prediction_response.test is not None
     structured_llm_response = gemini_flash.as_structured_llm(Test).complete("test")
     assert structured_llm_response.raw.test is not None
+
+
+@pytest.mark.skipif(
+    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
+)
+def test_is_function_calling_model() -> None:
+    assert Gemini(
+        model="models/gemini-2.0-flash-001"
+    ).metadata.is_function_calling_model
+
+    # this model is the only one that does not support function calling
+    assert not Gemini(
+        model="models/gemini-2.0-flash-thinking-exp-01-21"
+    ).metadata.is_function_calling_model
+
+    # in case of un-released models it should be possible to override the
+    # capabilities of the current model
+    manual_override = Gemini(model="models/gemini-2.0-flash-001")
+    assert manual_override.metadata.is_function_calling_model
+    manual_override._is_function_call_model = False
+    assert not manual_override._is_function_call_model
+    assert not manual_override.metadata.is_function_calling_model


### PR DESCRIPTION
# Description

This test covers the changes introduced between 0.4.7 and 0.4.8 of the Gemini adapter.
When moving Gemini to a FunctionCallingLLM the way structured generation was performed changed, it has been fixed in 0.4.8 (thanks for that), but before I noticed this release I was investigating the bug as well.

I used this test to locate the issue and I thought it would not hurt adding it to the test suite.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Add tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
