### PR TITLE
fix gemini multi-turn tool calling

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -295,13 +295,18 @@ class Gemini(FunctionCallingLLM):
 
         def gen() -> ChatResponseGen:
             content = ""
+            existing_tool_calls = []
             for r in response:
                 top_candidate = r.candidates[0]
                 content_delta = top_candidate.content.parts[0].text
                 content += content_delta
                 llama_resp = chat_from_gemini_response(r)
+                existing_tool_calls.extend(
+                    llama_resp.message.additional_kwargs.get("tool_calls", [])
+                )
                 llama_resp.delta = content_delta
                 llama_resp.message.content = content
+                llama_resp.message.additional_kwargs["tool_calls"] = existing_tool_calls
                 yield llama_resp
 
         return gen()
@@ -320,13 +325,18 @@ class Gemini(FunctionCallingLLM):
 
         async def gen() -> ChatResponseAsyncGen:
             content = ""
+            existing_tool_calls = []
             async for r in response:
                 top_candidate = r.candidates[0]
                 content_delta = top_candidate.content.parts[0].text
                 content += content_delta
                 llama_resp = chat_from_gemini_response(r)
+                existing_tool_calls.extend(
+                    llama_resp.message.additional_kwargs.get("tool_calls", [])
+                )
                 llama_resp.delta = content_delta
                 llama_resp.message.content = content
+                llama_resp.message.additional_kwargs["tool_calls"] = existing_tool_calls
                 yield llama_resp
 
         return gen()

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/utils.py
@@ -99,7 +99,8 @@ def chat_message_to_gemini(message: ChatMessage) -> "genai.types.ContentDict":
     parts = []
     for block in message.blocks:
         if isinstance(block, TextBlock):
-            parts.append(block.text)
+            if block.text:
+                parts.append({"text": block.text})
         elif isinstance(block, ImageBlock):
             base64_bytes = block.resolve_image(as_base64=False).read()
             parts.append(
@@ -111,6 +112,9 @@ def chat_message_to_gemini(message: ChatMessage) -> "genai.types.ContentDict":
         else:
             msg = f"Unsupported content block type: {type(block).__name__}"
             raise ValueError(msg)
+
+    for tool_call in message.additional_kwargs.get("tool_calls", []):
+        parts.append(tool_call)
 
     return {
         "role": ROLES_TO_GEMINI[message.role],

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-gemini"
 readme = "README.md"
-version = "0.4.8"
+version = "0.4.9"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
@@ -22,7 +22,7 @@ def test_chat_message_to_gemini() -> None:
     msg = ChatMessage("Some content")
     assert chat_message_to_gemini(msg) == {
         "role": MessageRole.USER,
-        "parts": ["Some content"],
+        "parts": [{"text": "Some content"}],
     }
 
     msg = ChatMessage("Some content")

--- a/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/tests/test_llms_gemini.py
@@ -29,7 +29,7 @@ def test_chat_message_to_gemini() -> None:
     msg.blocks.append(ImageBlock(image=b"foo", image_mimetype="image/png"))
     assert chat_message_to_gemini(msg) == {
         "role": MessageRole.USER,
-        "parts": ["Some content", {"data": b"foo", "mime_type": "image/png"}],
+        "parts": [{"text": "Some content"}, {"data": b"foo", "mime_type": "image/png"}],
     }
 
 


### PR DESCRIPTION
There were two issues 
- the original tool call was not being included in the messages when converting from llama-index to gemini messages
- streaming tool calls that mix text and tool calls were clobbering tool calls. Now we track them