### PR TITLE
feat: Make start and stop events user-configurable in Workflows

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -225,7 +225,7 @@ class Context:
         Use `get` and `set` instead.
         """
         msg = "`data` is deprecated, please use the `get` and `set` method to store data into the Context."
-        warnings.warn(msg, DeprecationWarning)
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
         return self._globals
 
     @property
@@ -237,7 +237,7 @@ class Context:
     def session(self) -> "Context":
         """This property is provided for backward compatibility."""
         msg = "`session` is deprecated, please use the Context instance directly."
-        warnings.warn(msg, DeprecationWarning)
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
         return self
 
     def _get_full_path(self, ev_type: Type[Event]) -> str:

--- a/llama-index-core/llama_index/core/workflow/errors.py
+++ b/llama-index-core/llama_index/core/workflow/errors.py
@@ -20,3 +20,7 @@ class WorkflowCancelledByUser(Exception):
 
 class WorkflowStepDoesNotExistError(Exception):
     pass
+
+
+class WorkflowConfigurationError(Exception):
+    pass

--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -1,11 +1,11 @@
+from _collections_abc import dict_items, dict_keys, dict_values
 from typing import Any, Dict, Type
-from _collections_abc import dict_keys, dict_items, dict_values
 
 from llama_index.core.bridge.pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     PrivateAttr,
-    ConfigDict,
     model_serializer,
 )
 
@@ -142,9 +142,9 @@ class StopEvent(Event):
 
     result: Any = Field(default=None)
 
-    def __init__(self, result: Any = None) -> None:
+    def __init__(self, result: Any = None, **kwargs) -> None:
         # forces the user to provide a result
-        super().__init__(result=result)
+        super().__init__(result=result, **kwargs)
 
 
 class InputRequiredEvent(Event):

--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -142,7 +142,7 @@ class StopEvent(Event):
 
     _result: Any = PrivateAttr(default=None)
 
-    def __init__(self, result: Any = None, **kwargs) -> None:
+    def __init__(self, result: Any = None, **kwargs: Any) -> None:
         # forces the user to provide a result
         super().__init__(_result=result, **kwargs)
 

--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -140,11 +140,19 @@ class StartEvent(Event):
 class StopEvent(Event):
     """EndEvent signals the workflow to stop."""
 
-    result: Any = Field(default=None)
+    _result: Any = PrivateAttr(default=None)
 
     def __init__(self, result: Any = None, **kwargs) -> None:
         # forces the user to provide a result
-        super().__init__(result=result, **kwargs)
+        super().__init__(_result=result, **kwargs)
+
+    def _get_result(self) -> Any:
+        """This can be overridden by subclasses to return the desired result."""
+        return self._result
+
+    @property
+    def result(self) -> Any:
+        return self._get_result()
 
 
 class InputRequiredEvent(Event):

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -398,8 +398,21 @@ class Workflow(metaclass=WorkflowMeta):
 
     def _get_start_event(self, start_event: Optional[StartEvent], **kwargs):
         if start_event is not None:
+            # start_event was used wrong
+            if not isinstance(start_event, StartEvent):
+                msg = "The 'start_event' argument must be an instance of 'StartEvent'."
+                raise ValueError(msg)
+
+            # start_event is ok but point out that additional kwargs will be ignored in this case
+            if kwargs:
+                msg = (
+                    "Keyword arguments are not supported when 'run()' is invoked with the 'start_event' parameter.",
+                    f" These keyword arguments will be ignored: {kwargs}",
+                )
+                logger.warning(msg)
             return start_event
 
+        # Old style start event creation, with kwargs used to create an instance of self._start_event_class
         try:
             return self._start_event_class(**kwargs)
         except ValidationError as e:

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -396,7 +396,9 @@ class Workflow(metaclass=WorkflowMeta):
         ctx = next(iter(self._contexts))
         ctx.send_event(message=message, step=step)
 
-    def _get_start_event(self, start_event: Optional[StartEvent], **kwargs):
+    def _get_start_event(
+        self, start_event: Optional[StartEvent], **kwargs: Any
+    ) -> StartEvent:
         if start_event is not None:
             # start_event was used wrong
             if not isinstance(start_event, StartEvent):
@@ -406,8 +408,8 @@ class Workflow(metaclass=WorkflowMeta):
             # start_event is ok but point out that additional kwargs will be ignored in this case
             if kwargs:
                 msg = (
-                    "Keyword arguments are not supported when 'run()' is invoked with the 'start_event' parameter.",
-                    f" These keyword arguments will be ignored: {kwargs}",
+                    "Keyword arguments are not supported when 'run()' is invoked with the 'start_event' parameter."
+                    f" These keyword arguments will be ignored: {kwargs}"
                 )
                 logger.warning(msg)
             return start_event
@@ -451,8 +453,8 @@ class Workflow(metaclass=WorkflowMeta):
             try:
                 if not ctx.is_running:
                     # Send the first event
-                    ev = self._get_start_event(start_event, **kwargs)
-                    ctx.send_event(ev)
+                    start_event_instance = self._get_start_event(start_event, **kwargs)
+                    ctx.send_event(start_event_instance)
 
                     # the context is now running
                     ctx.is_running = True

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -68,8 +68,8 @@ class Workflow(metaclass=WorkflowMeta):
         verbose: bool = False,
         service_manager: Optional[ServiceManager] = None,
         num_concurrent_runs: Optional[int] = None,
-        stop_event_class: type = StopEvent,
-        start_event_class: type = StartEvent,
+        stop_event_class: type[StopEvent] = StopEvent,
+        start_event_class: type[StartEvent] = StartEvent,
     ) -> None:
         """Create an instance of the workflow.
 

--- a/llama-index-core/tests/workflow/conftest.py
+++ b/llama-index-core/tests/workflow/conftest.py
@@ -1,10 +1,9 @@
 import pytest
-
-from llama_index.core.workflow.decorators import step
-from llama_index.core.workflow.events import StartEvent, StopEvent, Event
-from llama_index.core.workflow.context import Context
-from llama_index.core.workflow.workflow import Workflow
 from llama_index.core.bridge.pydantic import Field
+from llama_index.core.workflow.context import Context
+from llama_index.core.workflow.decorators import step
+from llama_index.core.workflow.events import Event, StartEvent, StopEvent
+from llama_index.core.workflow.workflow import Workflow
 
 
 class OneTestEvent(Event):

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -1,11 +1,11 @@
 import asyncio
-import pytest
 
+import pytest
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.decorators import step
+from llama_index.core.workflow.errors import WorkflowRuntimeError, WorkflowTimeoutError
 from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.core.workflow.workflow import Workflow
-from llama_index.core.workflow.errors import WorkflowRuntimeError, WorkflowTimeoutError
 
 from .conftest import OneTestEvent
 
@@ -124,6 +124,8 @@ async def test_multiple_ongoing_streams():
     async for ev in stream_2.stream_events():
         if not isinstance(ev, StopEvent):
             assert "msg" in ev
+
+    await asyncio.gather(stream_1, stream_2)
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
# Description

This PR introduces the ability for users to use custom classes for stop and start events in a Workflow, and to pass a `StartEvent` instance to the `run()` method directly with the `start_event` parameter instead of relying on kwargs.

The feature comes from different requests and different use cases:
- Passing a `StartEvent` instance to `run` effectively enables type annotations on workflows input, see https://github.com/run-llama/llama_index/issues/16334
- Customizing the `StopEvent` provides stronger typing to workflows output
- Workflows classes with typed start and stop events can be introspected to ease workflows integration within external APIs (for example, a workflow returning a typed stop event is easier to manage behind a REST API)

## Example usage
```
    class MyStart(StartEvent):
        query: str

    class MyStop(StopEvent):
        outcome: str

        # This will provide backward compatiblitly with ev.result
        def _get_result(self):
             return self.outcome

    class CustomEventsWorkflow(Workflow):
        def __init__(self, *args, **kwargs):
            super().__init__(*args, start_event_class=MyStart, stop_event_class=MyStop, **kwargs)

        @step
        async def start_step(self, ev: MyStart) -> OneTestEvent:
            return OneTestEvent()

        @step
        async def middle_step(self, ev: OneTestEvent) -> LastEvent:
            return LastEvent()

        @step
        async def end_step(self, ev: LastEvent) -> MyStop:
            return MyStop(outcome="Workflow completed")


    wf = CustomEventsWorkflow()    
    # New style run invokation, passing the start event instance, also possible with the default StartEvent
    result = await wf.run(start_event=MyStart(query="this is a string")
    # This will keep working and kwargs will be validated against the custom event MyStart
    result = await wf.run(query="foo")
```

## Notes
- This feature is opt-in, and existing code will keep working
- The only breaking change is that we reserve the keyword argument `start_event` in the `run()` method, meaning that if existing code was using the name `start_event` for a field of the start event itself, that code will now raise a `ValueError` explaining what's the problem. Even if technically breaking, I propose we treat this corner case as very unlikely to happen.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

