### PR TITLE
Update the llama-index-llms-langchain to latest langchain API - removes the deprication warning

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-langchain/llama_index/llms/langchain/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-langchain/llama_index/llms/langchain/base.py
@@ -92,7 +92,7 @@ class LangChainLLM(LLM):
             return completion_response_to_chat_response(completion_response)
 
         lc_messages = to_lc_messages(messages)
-        lc_message = self._llm.predict_messages(messages=lc_messages, **kwargs)
+        lc_message = self._llm.invoke(input=lc_messages, **kwargs)
         message = from_lc_messages([lc_message])[0]
         return ChatResponse(message=message)
 

--- a/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
@@ -27,11 +27,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-langchain"
 readme = "README.md"
-version = "0.5.1"
+version = "0.6.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain = ">=0.1.3"
+langchain = ">=0.1.7"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

Currently the module is using the obsolate `predict_messages` function, which throws a deprication warning. The changes updates it to the recommended `invoke` API. The dependency on langchain was updated to the version when the `predict_messages` was marked obsolete.

Fixes # (issue)

## New Package?

Not a new package.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] Verified locally that change works
