### PR TITLE
fix: Update `WatsonxLLM.stream_chat()` to adapt to upcoming `ibm-watsonx-ai 1.2.7` and avoid error.

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
@@ -526,7 +526,9 @@ class WatsonxLLM(FunctionCallingLLM):
                         tools_available = True
 
                     if tools_available:
-                        tool_calls = update_tool_calls(tool_calls, wx_message["tool_calls"])
+                        tool_calls = update_tool_calls(
+                            tool_calls, wx_message["tool_calls"]
+                        )
                         if tool_calls:
                             additional_kwargs["tool_calls"] = tool_calls
 

--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
@@ -513,20 +513,22 @@ class WatsonxLLM(FunctionCallingLLM):
 
             for response in stream_response:
                 tools_available = False
-                wx_message = response["choices"][0]["delta"]
-
-                role = wx_message.get("role") or role or MessageRole.ASSISTANT
-                delta = wx_message.get("content", "")
-                content += delta
-
-                if "tool_calls" in wx_message:
-                    tools_available = True
-
+                delta = ""
                 additional_kwargs = {}
-                if tools_available:
-                    tool_calls = update_tool_calls(tool_calls, wx_message["tool_calls"])
-                    if tool_calls:
-                        additional_kwargs["tool_calls"] = tool_calls
+                if response["choices"]:
+                    wx_message = response["choices"][0]["delta"]
+
+                    role = wx_message.get("role") or role or MessageRole.ASSISTANT
+                    delta = wx_message.get("content", "")
+                    content += delta
+
+                    if "tool_calls" in wx_message:
+                        tools_available = True
+
+                    if tools_available:
+                        tool_calls = update_tool_calls(tool_calls, wx_message["tool_calls"])
+                        if tool_calls:
+                            additional_kwargs["tool_calls"] = tool_calls
 
                 yield ChatResponse(
                     message=ChatMessage(
@@ -641,7 +643,7 @@ class WatsonxLLM(FunctionCallingLLM):
         """Get the token usage reported by the response."""
         if isinstance(raw_response, dict):
             usage = raw_response.get("usage", {})
-            if usage is None:
+            if not usage:
                 return {}
 
             prompt_tokens = usage.get("prompt_tokens", 0)

--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/utils.py
@@ -155,6 +155,5 @@ def update_tool_calls(tool_calls: list, tool_calls_update: list):
         else:
             t["function"]["arguments"] += tc_delta["function"]["arguments"] or ""
             t["function"]["name"] += tc_delta["function"]["name"] or ""
-            t["id"] += tc_delta.get("id", "")
 
     return tool_calls

--- a/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-llms-ibm"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"

--- a/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
@@ -89,6 +89,13 @@ def mock_stream_chat(*args: Any, **kwargs: Any) -> Generator[dict, None, None]:
                 {"index": 0, "finish_reason": "stop", "delta": {"content": content}}
             ],
         }
+    else:
+        yield {
+            "model_id": "mistralai/mistral-large",
+            "created_at": "2024-10-17T11:41:26.140Z",
+            "choices": [],
+            'usage': {'completion_tokens': 6, 'prompt_tokens': 10, 'total_tokens': 16}
+        }
 
 
 def mock_completion_stream(*args: Any, **kwargs: Any) -> Generator[dict, None, None]:
@@ -237,6 +244,10 @@ class TestWasonxLLMInference:
         chat_response_stream = llm.stream_chat([message])
         chat_responses = list(chat_response_stream)
         assert chat_responses[-1].message.content == "I like it"
+        assert chat_responses[-1].delta == ""
+        assert chat_responses[-1].additional_kwargs["prompt_tokens"] == 10
+        assert chat_responses[-1].additional_kwargs["completion_tokens"] == 6
+        assert chat_responses[-1].additional_kwargs["total_tokens"] == 16
 
     @patch("llama_index.llms.ibm.base.ModelInference")
     def test_completion_model_streaming(self, MockModelInference: MagicMock) -> None:
@@ -263,6 +274,10 @@ class TestWasonxLLMInference:
         chat_response_stream = llm.stream_chat([message], raw_response=True)
         chat_responses = list(chat_response_stream)
         assert chat_responses[-1].message.content == "I like it"
+        assert chat_responses[-1].delta == ""
+        assert chat_responses[-1].additional_kwargs["prompt_tokens"] == 10
+        assert chat_responses[-1].additional_kwargs["completion_tokens"] == 6
+        assert chat_responses[-1].additional_kwargs["total_tokens"] == 16
 
     @pytest.mark.asyncio()
     @patch("llama_index.llms.ibm.base.ModelInference")
@@ -313,3 +328,7 @@ class TestWasonxLLMInference:
         chat_response_stream = await llm.astream_chat([message], raw_response=True)
         chat_responses = [el async for el in chat_response_stream]
         assert chat_responses[-1].message.content == "I like it"
+        assert chat_responses[-1].delta == ""
+        assert chat_responses[-1].additional_kwargs["prompt_tokens"] == 10
+        assert chat_responses[-1].additional_kwargs["completion_tokens"] == 6
+        assert chat_responses[-1].additional_kwargs["total_tokens"] == 16

--- a/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
@@ -94,7 +94,7 @@ def mock_stream_chat(*args: Any, **kwargs: Any) -> Generator[dict, None, None]:
             "model_id": "mistralai/mistral-large",
             "created_at": "2024-10-17T11:41:26.140Z",
             "choices": [],
-            'usage': {'completion_tokens': 6, 'prompt_tokens': 10, 'total_tokens': 16}
+            "usage": {"completion_tokens": 6, "prompt_tokens": 10, "total_tokens": 16},
         }
 
 


### PR DESCRIPTION
# Description

Update stream generation for `WatsonxLLM.stream_chat()` due to upcoming changes in `ibm-watsonx-ai 1.2.7`. The last chunk that is being returned doesn't contain `delta` (`choice` list is empty) but token usage is included there (and only there, in this last chunk). This last chunk isn't returned now, but it will be, so these changes allow avoiding error with a new IBM package that is about to release.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests
- [x] I updated unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
