### PR TITLE
adding OpenAI API key to environment

### DIFF
--- a/docs/docs/examples/agent/agent_builder.ipynb
+++ b/docs/docs/examples/agent/agent_builder.ipynb
@@ -23,7 +23,8 @@
    "source": [
     "%pip install llama-index-agent-openai\n",
     "%pip install llama-index-embeddings-openai\n",
-    "%pip install llama-index-llms-openai"
+    "%pip install llama-index-llms-openai\n",
+    "%pip install llama-index-readers-file"
    ]
   },
   {

--- a/docs/docs/examples/agent/openai_agent_context_retrieval.ipynb
+++ b/docs/docs/examples/agent/openai_agent_context_retrieval.ipynb
@@ -78,6 +78,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "36f37aa5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "9d47283b-025e-4874-88ed-76245b22f82e",
    "metadata": {},
    "outputs": [],

--- a/docs/docs/examples/agent/openai_agent_lengthy_tools.ipynb
+++ b/docs/docs/examples/agent/openai_agent_lengthy_tools.ipynb
@@ -28,7 +28,7 @@
    "id": "dc72e6f9",
    "metadata": {},
    "source": [
-    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex 🦙."
+    "If you're opening this Notebook on Colab, you will probably need to install LlamaIndex 🦙."
    ]
   },
   {
@@ -72,6 +72,18 @@
    "source": [
     "from llama_index.core import SimpleDirectoryReader, VectorStoreIndex\n",
     "from llama_index.llms.openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9e9373c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\""
    ]
   },
   {

--- a/docs/docs/examples/agent/openai_agent_query_plan.ipynb
+++ b/docs/docs/examples/agent/openai_agent_query_plan.ipynb
@@ -97,6 +97,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9184acae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "35364259-f1c3-4df0-b8c9-79e0afca7436",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. I also added a missing package that was causing an error.

Fixes # (issue)
Colab notebooks that use OpenAI fail when the API key is not set. I added this step where missing.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [X]  I have made corresponding changes to the documentation
- [N/A] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [X]  New and existing unit tests pass locally with my changes
- [X]  I ran `make format; make lint` to appease the lint gods
