### PR TITLE
Silence nltk downloader

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -62,12 +62,12 @@ class GlobalsHelper:
         try:
             nltk.data.find("corpora/stopwords")
         except LookupError:
-            nltk.download("stopwords", download_dir=self._nltk_data_dir)
+            nltk.download("stopwords", download_dir=self._nltk_data_dir, quiet=True)
 
         try:
             nltk.data.find("tokenizers/punkt_tab")
         except LookupError:
-            nltk.download("punkt_tab", download_dir=self._nltk_data_dir)
+            nltk.download("punkt_tab", download_dir=self._nltk_data_dir, quiet=True)
 
     @property
     def stopwords(self) -> List[str]:
@@ -84,7 +84,7 @@ class GlobalsHelper:
             try:
                 nltk.data.find("corpora/stopwords", paths=[self._nltk_data_dir])
             except LookupError:
-                nltk.download("stopwords", download_dir=self._nltk_data_dir)
+                nltk.download("stopwords", download_dir=self._nltk_data_dir, quiet=True)
             self._stopwords = stopwords.words("english")
         return self._stopwords
 


### PR DESCRIPTION
# Description
The nltk downloader prints unnecessarily to the console unless it is set to `quiet=True`. Because it uses `print`, it cannot be silenced using logging. The GlobalsHelper does not set `quiet=True`, so every project that uses llama_index.core.utils has messages like this printing to the console, all the time:

```python
>>> from llama_index import core
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /home/my_project/nltk_data...
[nltk_data]   Package punkt_tab is already up-to-date!
``` 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] I believe this change is already covered by existing unit tests

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
