### PR TITLE
improve prompt helper multimodal support

### DIFF
--- a/llama-index-core/llama_index/core/indices/prompt_helper.py
+++ b/llama-index-core/llama_index/core/indices/prompt_helper.py
@@ -28,7 +28,7 @@ from llama_index.core.prompts import (
     SelectorPromptTemplate,
 )
 from llama_index.core.prompts.prompt_utils import get_empty_prompt_txt
-from llama_index.core.prompts.utils import format_string
+from llama_index.core.prompts.utils import format_content_blocks
 from llama_index.core.schema import BaseComponent
 from llama_index.core.utilities.token_counting import TokenCounter
 
@@ -198,9 +198,10 @@ class PromptHelper(BaseComponent):
             for message in messages:
                 partial_message = deepcopy(message)
 
+                # TODO: This does not count tokens in non-text blocks
                 prompt_kwargs = prompt.kwargs or {}
-                partial_message.content = format_string(
-                    partial_message.content or "", **prompt_kwargs
+                partial_message.blocks = format_content_blocks(
+                    partial_message.blocks, **prompt_kwargs
                 )
 
                 # add to list of partial messages

--- a/llama-index-core/llama_index/core/prompts/utils.py
+++ b/llama-index-core/llama_index/core/prompts/utils.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 import re
 
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.base.llms.types import ContentBlock, TextBlock
 
 
 class SafeFormatter:
@@ -25,6 +26,21 @@ def format_string(string_to_format: str, **kwargs: str) -> str:
     """Format a string with kwargs."""
     formatter = SafeFormatter(format_dict=kwargs)
     return formatter.format(string_to_format)
+
+
+def format_content_blocks(
+    content_blocks: List[ContentBlock], **kwargs: str
+) -> List[ContentBlock]:
+    """Format content blocks with kwargs."""
+    formatter = SafeFormatter(format_dict=kwargs)
+    formatted_blocks: List[ContentBlock] = []
+    for block in content_blocks:
+        if isinstance(block, TextBlock):
+            formatted_blocks.append(TextBlock(text=formatter.format(block.text)))
+        else:
+            formatted_blocks.append(block)
+
+    return formatted_blocks
 
 
 def get_template_vars(template_str: str) -> List[str]:


### PR DESCRIPTION
The prompt helper would try to directly set `.content`, which causes errors when the chat message has mixed content types.

Instead, we can format and update the text blocks only.

This PR adds a new util to format only the text blocks in a message and uses that in the prompt helper