### PR TITLE
feat: auto-detect custom start and stop events in workflow classes

### DIFF
--- a/llama-index-core/tests/workflow/conftest.py
+++ b/llama-index-core/tests/workflow/conftest.py
@@ -44,4 +44,4 @@ def events():
 
 @pytest.fixture()
 def ctx():
-    return Context(workflow=Workflow())
+    return Context(workflow=DummyWorkflow())

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -1,10 +1,9 @@
 import re
 
 import pytest
-
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.errors import WorkflowValidationError
-from llama_index.core.workflow.events import Event
+from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.core.workflow.workflow import Workflow
 
 
@@ -22,12 +21,12 @@ def test_decorated_config(workflow):
 def test_decorate_method():
     class TestWorkflow(Workflow):
         @step
-        def f1(self, ev: Event) -> Event:
+        def f1(self, ev: StartEvent) -> Event:
             return ev
 
         @step
-        def f2(self, ev: Event) -> Event:
-            return ev
+        def f2(self, ev: Event) -> StopEvent:
+            return StopEvent()
 
     wf = TestWorkflow()
     assert getattr(wf.f1, "__step_config")

--- a/llama-index-core/tests/workflow/test_service.py
+++ b/llama-index-core/tests/workflow/test_service.py
@@ -1,10 +1,9 @@
 import pytest
-
+from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import Event, StartEvent, StopEvent
-from llama_index.core.workflow.workflow import Workflow
-from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.service import ServiceManager, ServiceNotFoundError
+from llama_index.core.workflow.workflow import Workflow
 
 
 class ServiceWorkflow(Workflow):
@@ -67,17 +66,15 @@ async def test_default_value_for_service():
     assert res == 84
 
 
-def test_service_manager_add():
+def test_service_manager_add(workflow):
     s = ServiceManager()
-    w = Workflow()
-    s.add("test_id", w)
-    assert s._services["test_id"] == w
+    s.add("test_id", workflow)
+    assert s._services["test_id"] == workflow
 
 
-def test_service_manager_get():
+def test_service_manager_get(workflow):
     s = ServiceManager()
-    w = Workflow()
-    s._services["test_id"] = w
-    assert s.get("test_id") == w
+    s._services["test_id"] = workflow
+    assert s.get("test_id") == workflow
     with pytest.raises(ServiceNotFoundError):
         s.get("not_found")

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -34,6 +34,14 @@ class EventWithName(Event):
     name: str
 
 
+class MyStart(StartEvent):
+    query: str
+
+
+class MyStop(StopEvent):
+    outcome: str
+
+
 def test_fn():
     print("test_fn")
 
@@ -126,12 +134,11 @@ async def test_workflow_validation_unproduced_events():
         async def invalid_step(self, ev: StartEvent) -> None:
             pass
 
-    workflow = InvalidWorkflow()
     with pytest.raises(
-        WorkflowValidationError,
-        match="No event of type StopEvent is produced.",
+        WorkflowConfigurationError,
+        match="At least one Event of type StopEvent must be returned by any step.",
     ):
-        await workflow.run()
+        workflow = InvalidWorkflow()
 
 
 @pytest.mark.asyncio()
@@ -164,12 +171,11 @@ async def test_workflow_validation_start_event_not_consumed():
         async def another_step(self, ev: OneTestEvent) -> OneTestEvent:
             return OneTestEvent()
 
-    workflow = InvalidWorkflow()
     with pytest.raises(
-        WorkflowValidationError,
-        match="The following events are produced but never consumed: StartEvent",
+        WorkflowConfigurationError,
+        match="At least one Event of type StartEvent must be received by any step.",
     ):
-        await workflow.run()
+        workflow = InvalidWorkflow()
 
 
 @pytest.mark.asyncio()
@@ -221,7 +227,7 @@ async def test_workflow_num_workers():
             ctx.send_event(OneTestEvent(test_param="test3"))
 
             # send one extra event
-            ctx.session.send_event(AnotherTestEvent(another_test_param="test4"))
+            ctx.send_event(AnotherTestEvent(another_test_param="test4"))
 
             return LastEvent()
 
@@ -362,22 +368,21 @@ async def test_workflow_multiple_runs():
     assert set(results) == {6, 84, -198}
 
 
-def test_deprecated_send_event():
+def test_deprecated_send_event(workflow):
     ev = StartEvent()
-    wf = Workflow()
     ctx = mock.MagicMock()
 
     # One context, assert step emits a warning
-    wf._contexts.add(ctx)
+    workflow._contexts.add(ctx)
     with pytest.warns(UserWarning):
-        wf.send_event(message=ev)
+        workflow.send_event(message=ev)
     ctx.send_event.assert_called_with(message=ev, step=None)
 
     # Second context, assert step raises an exception
     ctx = mock.MagicMock()
-    wf._contexts.add(ctx)
+    workflow._contexts.add(ctx)
     with pytest.raises(WorkflowRuntimeError):
-        wf.send_event(message=ev)
+        workflow.send_event(message=ev)
     ctx.send_event.assert_not_called()
 
 
@@ -443,7 +448,12 @@ async def test_workflow_task_raises_step():
 
 
 def test_workflow_disable_validation():
-    w = Workflow(disable_validation=True)
+    class DummyWorkflow(Workflow):
+        @step
+        async def step(self, ev: StartEvent) -> StopEvent:
+            raise ValueError("The step raised an error!")
+
+    w = DummyWorkflow(disable_validation=True)
     w._get_steps = mock.MagicMock()
     w._validate()
     w._get_steps.assert_not_called()
@@ -722,12 +732,6 @@ async def test_workflow_run_num_concurrent(
 
 @pytest.mark.asyncio()
 async def test_custom_stop_event():
-    class MyStart(StartEvent):
-        query: str
-
-    class MyStop(StopEvent):
-        outcome: str
-
     class CustomEventsWorkflow(Workflow):
         @step
         async def start_step(self, ev: MyStart) -> OneTestEvent:
@@ -742,6 +746,12 @@ async def test_custom_stop_event():
             return MyStop(outcome="Workflow completed")
 
     wf = CustomEventsWorkflow(start_event_class=MyStart, stop_event_class=MyStop)
+    assert wf._start_event_class == MyStart
+    assert wf._stop_event_class == MyStop
+    result = await wf.run(query="foo")
+
+    # Ensure the event types can be inferred when not passed to the init
+    wf = CustomEventsWorkflow()
     assert wf._start_event_class == MyStart
     assert wf._stop_event_class == MyStop
     result = await wf.run(query="foo")
@@ -770,7 +780,7 @@ def test_wrong_event_types():
         DummyWorkflow(stop_event_class=CustomEvent)  # type: ignore
 
 
-def test__get_start_event(caplog):
+def test__get_start_event_instance(caplog):
     class CustomEvent(StartEvent):
         field: str
 
@@ -782,20 +792,54 @@ def test__get_start_event(caplog):
         ValueError,
         match="The 'start_event' argument must be an instance of 'StartEvent'.",
     ):
-        d._get_start_event(start_event="wrong type", arg="foo")  # type: ignore
+        d._get_start_event_instance(start_event="wrong type", arg="foo")  # type: ignore
 
     # Invoke run() passing a legit start event but with additional kwargs
     with caplog.at_level(logging.WARN):
-        assert d._get_start_event(e, this_will_be_ignored=True) == e
+        assert d._get_start_event_instance(e, this_will_be_ignored=True) == e
         assert (
             "Keyword arguments are not supported when 'run()' is invoked with the 'start_event' parameter."
             in caplog.text
         )
 
     # Old style kwargs passed to the designed StartEvent
-    assert type(d._get_start_event(None, field="test")) is CustomEvent
+    assert type(d._get_start_event_instance(None, field="test")) is CustomEvent
 
     # Old style but wrong kwargs passed to the designed StartEvent
     err = "Failed creating a start event of type 'CustomEvent' with the keyword arguments: {'wrong_field': 'test'}"
     with pytest.raises(WorkflowRuntimeError, match=err):
-        d._get_start_event(None, wrong_field="test")
+        d._get_start_event_instance(None, wrong_field="test")
+
+
+def test__ensure_start_event_class_multiple_types():
+    class DummyWorkflow(Workflow):
+        @step
+        def one(self, ev: MyStart) -> None:
+            pass
+
+        @step
+        def two(self, ev: StartEvent) -> StopEvent:
+            return StopEvent()
+
+    with pytest.raises(
+        WorkflowConfigurationError,
+        match="Only one type of StartEvent is allowed per workflow, found 2",
+    ):
+        wf = DummyWorkflow()
+
+
+def test__ensure_stop_event_class_multiple_types():
+    class DummyWorkflow(Workflow):
+        @step
+        def one(self, ev: MyStart) -> MyStop:
+            return MyStop(outcome="nope")
+
+        @step
+        def two(self, ev: MyStart) -> StopEvent:
+            return StopEvent()
+
+    with pytest.raises(
+        WorkflowConfigurationError,
+        match="Only one type of StopEvent is allowed per workflow, found 2",
+    ):
+        wf = DummyWorkflow()


### PR DESCRIPTION
# Description

With https://github.com/run-llama/llama_index/pull/17767 we introduced the ability to use custom start and stop events in workflow. I wasn't happy with the UX, because in order to use custom events you had to pass them to the workflow init like this (or a variation of this):
```
wf = MyWorkflow(start_event_class=MyStart, stop_event_class=MyStop)
```

With this PR, start and stop events are inferred from the step definitions, so if your workflow is using `MyStart` and `MyStop`, you can intantiate the workflow without caring about that: `wf = MyWorkflow()`.

Question: the current PR is backward compatible, but `start_event_class` and `stop_event_class` were added very recently and not documented. Should we just kill them and always rely on introspection?

**Update**: I removed the `start_event_class` and `stop_event_class`  from the constructor. We discussed offline that the feature has been around for a very short period of time and it was not documented, so we're trading off a possibly very low-impact breaking change with a better UX and less tech debt.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests


