### PR TITLE
fix: `FunctionAgent` and `ReActAgent` error out when LLM response contains no chat messages

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -7,6 +7,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentStream,
     ToolCallResult,
 )
+from llama_index.core.base.llms.types import ChatResponse
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.llms import ChatMessage
 from llama_index.core.memory import BaseMemory
@@ -40,15 +41,22 @@ class FunctionAgent(BaseWorkflowAgent):
         response = await self.llm.astream_chat_with_tools(  # type: ignore
             tools, chat_history=current_llm_input, allow_parallel_tool_calls=True
         )
-        async for r in response:
+        # last_chat_response will be used later, after the loop.
+        # We initialize it so it's valid even when 'response' is empty
+        last_chat_response = ChatResponse(message=ChatMessage())
+        async for last_chat_response in response:
             tool_calls = self.llm.get_tool_calls_from_response(  # type: ignore
-                r, error_on_no_tool_call=False
+                last_chat_response, error_on_no_tool_call=False
             )
-            raw = r.raw.model_dump() if isinstance(r.raw, BaseModel) else r.raw
+            raw = (
+                last_chat_response.raw.model_dump()
+                if isinstance(last_chat_response.raw, BaseModel)
+                else last_chat_response.raw
+            )
             ctx.write_event_to_stream(
                 AgentStream(
-                    delta=r.delta or "",
-                    response=r.message.content or "",
+                    delta=last_chat_response.delta or "",
+                    response=last_chat_response.message.content or "",
                     tool_calls=tool_calls or [],
                     raw=raw,
                     current_agent_name=self.name,
@@ -56,16 +64,20 @@ class FunctionAgent(BaseWorkflowAgent):
             )
 
         tool_calls = self.llm.get_tool_calls_from_response(  # type: ignore
-            r, error_on_no_tool_call=False
+            last_chat_response, error_on_no_tool_call=False
         )
 
         # only add to scratchpad if we didn't select the handoff tool
-        scratchpad.append(r.message)
+        scratchpad.append(last_chat_response.message)
         await ctx.set(self.scratchpad_key, scratchpad)
 
-        raw = r.raw.model_dump() if isinstance(r.raw, BaseModel) else r.raw
+        raw = (
+            last_chat_response.raw.model_dump()
+            if isinstance(last_chat_response.raw, BaseModel)
+            else last_chat_response.raw
+        )
         return AgentOutput(
-            response=r.message,
+            response=last_chat_response.message,
             tool_calls=tool_calls or [],
             raw=raw,
             current_agent_name=self.name,

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -1,13 +1,6 @@
 import uuid
 from typing import List, Sequence, cast
 
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
-from llama_index.core.agent.workflow.workflow_events import (
-    AgentInput,
-    AgentOutput,
-    AgentStream,
-    ToolCallResult,
-)
 from llama_index.core.agent.react.formatter import ReActChatFormatter
 from llama_index.core.agent.react.output_parser import ReActOutputParser
 from llama_index.core.agent.react.types import (
@@ -16,6 +9,14 @@ from llama_index.core.agent.react.types import (
     ObservationReasoningStep,
     ResponseReasoningStep,
 )
+from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+from llama_index.core.agent.workflow.workflow_events import (
+    AgentInput,
+    AgentOutput,
+    AgentStream,
+    ToolCallResult,
+)
+from llama_index.core.base.llms.types import ChatResponse
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.llms import ChatMessage
 from llama_index.core.llms.llm import ToolSelection
@@ -90,12 +91,19 @@ class ReActAgent(BaseWorkflowAgent):
 
         # Initial LLM call
         response = await self.llm.astream_chat(input_chat)
-        async for r in response:
-            raw = r.raw.model_dump() if isinstance(r.raw, BaseModel) else r.raw
+        # last_chat_response will be used later, after the loop.
+        # We initialize it so it's valid even when 'response' is empty
+        last_chat_response = ChatResponse(message=ChatMessage())
+        async for last_chat_response in response:
+            raw = (
+                last_chat_response.raw.model_dump()
+                if isinstance(last_chat_response.raw, BaseModel)
+                else last_chat_response.raw
+            )
             ctx.write_event_to_stream(
                 AgentStream(
-                    delta=r.delta or "",
-                    response=r.message.content or "",
+                    delta=last_chat_response.delta or "",
+                    response=last_chat_response.message.content or "",
                     tool_calls=[],
                     raw=raw,
                     current_agent_name=self.name,
@@ -103,7 +111,7 @@ class ReActAgent(BaseWorkflowAgent):
             )
 
         # Parse reasoning step and check if done
-        message_content = r.message.content
+        message_content = last_chat_response.message.content
         if not message_content:
             raise ValueError("Got empty message")
 
@@ -111,12 +119,16 @@ class ReActAgent(BaseWorkflowAgent):
             reasoning_step = output_parser.parse(message_content, is_streaming=False)
         except ValueError as e:
             error_msg = f"Error: Could not parse output. Please follow the thought-action-input format. Try again. Details: {e!s}"
-            await memory.aput(r.message)
+            await memory.aput(last_chat_response.message)
             await memory.aput(ChatMessage(role="user", content=error_msg))
 
-            raw = r.raw.model_dump() if isinstance(r.raw, BaseModel) else r.raw
+            raw = (
+                last_chat_response.raw.model_dump()
+                if isinstance(last_chat_response.raw, BaseModel)
+                else last_chat_response.raw
+            )
             return AgentOutput(
-                response=r.message,
+                response=last_chat_response.message,
                 tool_calls=[],
                 raw=raw,
                 current_agent_name=self.name,
@@ -127,10 +139,14 @@ class ReActAgent(BaseWorkflowAgent):
         await ctx.set(self.reasoning_key, current_reasoning)
 
         # If response step, we're done
-        raw = r.raw.model_dump() if isinstance(r.raw, BaseModel) else r.raw
+        raw = (
+            last_chat_response.raw.model_dump()
+            if isinstance(last_chat_response.raw, BaseModel)
+            else last_chat_response.raw
+        )
         if reasoning_step.is_done:
             return AgentOutput(
-                response=r.message,
+                response=last_chat_response.message,
                 tool_calls=[],
                 raw=raw,
                 current_agent_name=self.name,
@@ -149,9 +165,8 @@ class ReActAgent(BaseWorkflowAgent):
             )
         ]
 
-        raw = r.raw.model_dump() if isinstance(r.raw, BaseModel) else r.raw
         return AgentOutput(
-            response=r.message,
+            response=last_chat_response.message,
             tool_calls=tool_calls,
             raw=raw,
             current_agent_name=self.name,


### PR DESCRIPTION
# Description

With this PR we handle the case when an LLM returns no chat messages in the response, propagating the right error and setting a fallback default value. Previously the agent would fail on something like this:
```
UnboundLocalError: cannot access local variable 'r' where it is not associated with a value
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

