### PR TITLE
feat: add tests for gemini, fix function calling parameters

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -404,9 +404,11 @@ class Gemini(FunctionCallingLLM):
 
         return {
             "messages": messages,
-            "tools": ToolDict(function_declarations=tool_declarations)
-            if tool_declarations
-            else None,
+            "tools": (
+                ToolDict(function_declarations=tool_declarations)
+                if tool_declarations
+                else None
+            ),
             "tool_config": tool_config,
             **kwargs,
         }
@@ -451,9 +453,12 @@ class Gemini(FunctionCallingLLM):
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
 
-        llm_kwargs["tool_choice"] = (
-            "required" if "tool_choice" not in all_kwargs else all_kwargs["tool_choice"]
-        )
+        if self._is_function_call_model:
+            llm_kwargs["tool_choice"] = (
+                "required"
+                if "tool_choice" not in all_kwargs
+                else all_kwargs["tool_choice"]
+            )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return super().structured_predict(*args, llm_kwargs=llm_kwargs, **kwargs)
@@ -466,9 +471,12 @@ class Gemini(FunctionCallingLLM):
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
 
-        llm_kwargs["tool_choice"] = (
-            "required" if "tool_choice" not in all_kwargs else all_kwargs["tool_choice"]
-        )
+        if self._is_function_call_model:
+            llm_kwargs["tool_choice"] = (
+                "required"
+                if "tool_choice" not in all_kwargs
+                else all_kwargs["tool_choice"]
+            )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return await super().astructured_predict(*args, llm_kwargs=llm_kwargs, **kwargs)
@@ -481,9 +489,12 @@ class Gemini(FunctionCallingLLM):
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
 
-        llm_kwargs["tool_choice"] = (
-            "required" if "tool_choice" not in all_kwargs else all_kwargs["tool_choice"]
-        )
+        if self._is_function_call_model:
+            llm_kwargs["tool_choice"] = (
+                "required"
+                if "tool_choice" not in all_kwargs
+                else all_kwargs["tool_choice"]
+            )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return super().stream_structured_predict(*args, llm_kwargs=llm_kwargs, **kwargs)
@@ -496,9 +507,12 @@ class Gemini(FunctionCallingLLM):
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
 
-        llm_kwargs["tool_choice"] = (
-            "required" if "tool_choice" not in all_kwargs else all_kwargs["tool_choice"]
-        )
+        if self._is_function_call_model:
+            llm_kwargs["tool_choice"] = (
+                "required"
+                if "tool_choice" not in all_kwargs
+                else all_kwargs["tool_choice"]
+            )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return await super().astream_structured_predict(

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-gemini"
 readme = "README.md"
-version = "0.4.10"
+version = "0.4.11"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

We notice all kind of weird issues upgrading some our applications from gemini 0.4.6 to 0.4.10, probably related to the support of function calling. We would get MAX_TOKENS error, always failing structure generation, increases (x5) latency.

The original bug I wanted to highlight is shown in `test_function_call_deeply_nested_structured_generation` (which still does not pass).
While trying to investigate what was happening trying to isolate the bug I wanted to try disabling support for function calling (in order to mimic the behavior of 0.4.6), which was exactly the reasons why we added the private `_is_function_call_model` on the class to be able to easily toggle the support on and off.

However when setting the function calling support to off, `tool_choice` is not a valid argument to be passed to the LLM and it fails with a ValueError. This explain the fixes that I did in `base.py` to check whether or not this model is a function calling model.

Regarding the original bug, the one that I'm still not able to fix, there is definitely something wrong going on with "deeply nested" structured generation when using function calling. The `Schema` > `Table` > `Column` generation is crashing (because of Pydantic issues), reliabliy, all the time. What is even weirder is that commenting some fields, for instance `name: str = Field(description="Table name field")` in the table and ` data_type: str = Field(description="Data type field")
` in the column make the test success.

I used the `structured_predict` because it's the lowest (AFAIK) possible method that I could use to make structure generation, isolating the bug the best I could.

Another thing I noticed is that in case of failure, the result of this method is actually a string containing the following:
```
1 validation error for Schema
columns.0.columns
  Field required [type=missing, input_value=<proto.marshal.collection...e object at 0x10c333230>, input_type=MapComposite]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
```

Which leads to all kind of weir error such as `'str' object has no attribute 'columns'`.

I don't really where to start investigating this issue tbh, and I would love some kind of pointers in order to dig deeper into this rabbit hole.
The structure generation without function calling is working perfectly fine which makes all of this even more confusing to me.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
