### PR TITLE
fix: Chat messages with tool calls incorrectly mapping to Vertex message

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/gemini_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/gemini_utils.py
@@ -46,7 +46,9 @@ def convert_chat_message_to_gemini_content(
             raise ValueError("Only text and image_url types are supported!")
         return Part.from_image(image)
 
-    if message.content == "" and "tool_calls" in message.additional_kwargs:
+    if (
+        message.content == "" or message.content is None
+    ) and "tool_calls" in message.additional_kwargs:
         tool_calls = message.additional_kwargs["tool_calls"]
         parts = [
             Part._from_gapic(raw_part=gapic_content_types.Part(function_call=tool_call))

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-vertex"
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-vertex/tests/test_gemini_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/tests/test_gemini_utils.py
@@ -1,0 +1,63 @@
+from google.cloud.aiplatform_v1beta1 import FunctionCall
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+from llama_index.llms.vertex.gemini_utils import (
+    convert_chat_message_to_gemini_content,
+    is_gemini_model,
+)
+
+
+def test_is_gemini_model():
+    assert is_gemini_model("gemini-2.0-flash") is True
+    assert is_gemini_model("chat-bison") is False
+
+
+def test_convert_chat_message_to_gemini_content_with_function_call():
+    message = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        content="",
+        additional_kwargs={
+            "tool_calls": [
+                FunctionCall(
+                    name="test_fn",
+                    args={"arg1": "val1"},
+                )
+            ]
+        },
+    )
+
+    result = convert_chat_message_to_gemini_content(message=message, is_history=True)
+
+    assert result.role == "model"
+    assert len(result.parts) == 1
+    assert result.parts[0].function_call is not None
+    assert result.parts[0].function_call.name == "test_fn"
+    assert result.parts[0].function_call.args == {"arg1": "val1"}
+
+
+def test_convert_chat_message_to_gemini_content_with_content():
+    message = ChatMessage(
+        role=MessageRole.USER,
+        content="test content",
+    )
+
+    result = convert_chat_message_to_gemini_content(message=message, is_history=True)
+
+    assert result.role == "user"
+    assert result.text == "test content"
+    assert len(result.parts) == 1
+    assert result.parts[0].text == "test content"
+    assert result.parts[0].function_call is None
+
+
+def test_convert_chat_message_to_gemini_content_no_history():
+    message = ChatMessage(
+        role=MessageRole.USER,
+        content="test content",
+    )
+
+    result = convert_chat_message_to_gemini_content(message=message, is_history=False)
+
+    assert len(result) == 1
+    assert result[0].text == "test content"
+    assert result[0].function_call is None


### PR DESCRIPTION
# Description

This PR includes a fix to include tool call information when ChatMessage is converted to the VertexAI Part class.
Previously when a chat message includes `tool_calls` in `additional_kwargs`, the Part would not include the tool call information and would like below:

```
role: "model"
parts {
  text: "None"
}
```

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No (This is an update to an existing package)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X]  My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
