### PR TITLE
only modify delta if 'Answer:' was actually detected

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/step.py
+++ b/llama-index-core/llama_index/core/agent/react/step.py
@@ -691,8 +691,8 @@ class ReActAgentWorker(BaseAgentWorker):
                     start_idx + len("Answer:") :
                 ].strip()
 
-            # set delta to the content, minus the "Answer: "
-            latest_chunk.delta = latest_chunk.message.content
+                # set delta to the content, minus the "Answer: "
+                latest_chunk.delta = latest_chunk.message.content
 
             # add back the chunks that were missed
             response_stream = self._add_back_chunk_to_stream(


### PR DESCRIPTION
# Description

I noticed duplicated generation, if and only if the LLM fails to follow the designated format. Happened to me with Llama 3.3 70B and gpt-4o.
In the following picture you can see what happened:
The LLM failed to follow the format, i.e. "Answer:" was missing from the response. Accordingly missed_chunks_storage was filled, `latest_chunk.delta = latest_chunk.message.content` overwrites with the full content, as the "Answer:" filter fails to find anything. As such we would get the following deltas: `I`, `am` and `I am always` which is wrong as `I am` is duplicated.

![Debug session](https://github.com/user-attachments/assets/65e8a03f-818d-4377-93e1-643a40d9ae34)

![Seeing the impact inside the UI](https://github.com/user-attachments/assets/e5a11a44-0181-486f-8c2a-22baaefaeb86)

Do I need to create an Issue?

## Version Bump? -> No, it is a core update.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Also used the new version inside a create-llama app with a quick .venv edit. Hope the change is small enough for that to be sufficient.
