### PR TITLE
llamaindex-cli to handle glob patterns correctly

### DIFF
--- a/docs/docs/getting_started/starter_tools/rag_cli.md
+++ b/docs/docs/getting_started/starter_tools/rag_cli.md
@@ -22,14 +22,15 @@ After that, you can start using the tool:
 
 ```shell
 $ llamaindex-cli rag -h
-usage: llamaindex-cli rag [-h] [-q QUESTION] [-f FILES] [-c] [-v] [--clear] [--create-llama]
+usage: llamaindex-cli rag [-h] [-q QUESTION] [-f FILES [FILES ...]] [-c] [-v] [--clear] [--create-llama]
 
 options:
   -h, --help            show this help message and exit
   -q QUESTION, --question QUESTION
                         The question you want to ask.
-  -f FILES, --files FILES
-                        The name of the file or directory you want to ask a question about,such as "file.pdf".
+  -f, --files FILES [FILES ...]
+                        The name of the file(s) or directory you want to ask a question about,such
+                        as "file.pdf". Supports globs like "*.py".
   -c, --chat            If flag is present, opens a chat REPL.
   -v, --verbose         Whether to print out verbose information during execution.
   --clear               Clears out all currently embedded data.

--- a/llama-index-cli/pyproject.toml
+++ b/llama-index-cli/pyproject.toml
@@ -45,6 +45,7 @@ black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
 codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
+llama-index-vector-stores-chroma = "^0.4.1"
 mypy = "0.991"
 pre-commit = "3.2.0"
 pylint = "2.15.10"

--- a/llama-index-cli/tests/test_rag.py
+++ b/llama-index-cli/tests/test_rag.py
@@ -1,0 +1,16 @@
+import glob
+from unittest import mock
+
+
+from llama_index.cli import command_line
+from llama_index.cli.rag import RagCLI
+
+
+@mock.patch.object(RagCLI, "handle_cli", return_value="noop")
+@mock.patch(
+    "sys.argv",
+    ["llamaindex-cli", "rag", "--files", *glob.glob("**/*.py", recursive=True)],
+)
+def test_handle_cli_files(mock_handle_cli) -> None:
+    command_line.main()
+    mock_handle_cli.assert_called_once()


### PR DESCRIPTION
# Description

This change modifies the llamaindex-cli such that it can handle the --files argument to properly handle glob patterns.

In order to handle globs like the example given in the issue, the number of arguments (nargs) value must be set to + in order to return a list of files or patterns in this case.

Because argparse now returns a list, so restructuring on how the files are processed needed to be changed along with the signature of the function.

I have also added a unit test where none existed before to test this specific error.

Fixes #11798

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
