### PR TITLE
fix: python version requirement in redis vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/pyproject.toml
@@ -30,7 +30,8 @@ readme = "README.md"
 version = "0.5.0"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+# Use same python version requirement as redisvl
+python = ">=3.9,<3.14"
 redisvl = "^0.4.1"
 llama-index-core = "^0.12.0"
 


### PR DESCRIPTION
# Description

Set Python version requirements to ">=3.9,<3.14", same as redisvl, otherwise poetry won't build the package.

Fixes https://github.com/run-llama/llama_index/actions/runs/13516754821/job/37766874758


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

