### PR TITLE
Fix "Invalid value for 'content': expected a string, got null." openai error in case of empty assistant messages

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -323,11 +323,16 @@ def to_openai_message_dict(
             raise ValueError(msg)
 
     # NOTE: Sending a null value (None) for Tool Message to OpenAI will cause error
-    # It's only Allowed to send None if it's an Assistant Message
+    # It's only Allowed to send None if it's an Assistant Message and either a function call or tool calls were performed
     # Reference: https://platform.openai.com/docs/api-reference/chat/create
     content_txt = (
         None
-        if content_txt == "" and message.role == MessageRole.ASSISTANT
+        if content_txt == ""
+        and message.role == MessageRole.ASSISTANT
+        and (
+            "function_call" in message.additional_kwargs
+            or "tool_calls" in message.additional_kwargs
+        )
         else content_txt
     )
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.20"
+version = "0.3.21"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -156,6 +156,22 @@ def test_to_openai_message_dicts_basic_string() -> None:
     ]
 
 
+def test_to_openai_message_dicts_empty_content() -> None:
+    """If neither `tool_calls` nor `function_call` is set, content must not be set to None,
+    see: https://platform.openai.com/docs/api-reference/chat/create"""
+    chat_messages = [
+        ChatMessage(role="user", content="test question"),
+        ChatMessage(role="assistant", content=""),
+    ]
+    openai_messages = to_openai_message_dicts(
+        chat_messages,
+    )
+    assert openai_messages == [
+        {"role": "user", "content": "test question"},
+        {"role": "assistant", "content": ""},
+    ]
+
+
 def test_to_openai_message_dicts_function_calling(
     chat_messages_with_function_calling: List[ChatMessage],
     openai_message_dicts_with_function_calling: List[ChatCompletionMessageParam],


### PR DESCRIPTION
# Description
This is a fix for OpenAI errors such as:
```
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid value for 'content': expected a string, got null.", 'type': 'invalid_request_error', 'param': 'messages.[24].content', 'code': None}}
```

They happen when there are messages in the chat history from the assistant that do not contain text, but are also not function or tool calls. E.g. in our application, that can happen if the user cancels a request and therefore there was no response received.

According to docs at https://platform.openai.com/docs/api-reference/chat/create, if neither `tool_calls` nor `function_call` is set, content must not be set to None.

Please check if maybe additional checks are required additionally to the pure check for existance of `'function_call'` / `'tool_calls'` keys in `message.additional_kwargs` being performed right now - should we maybe also check that those are not `None`?

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
