### PR TITLE
fix: make base64 detection more robust across the board

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from binascii import Error as BinasciiError
 from enum import Enum
 from io import BytesIO
 from typing import (
@@ -78,11 +79,12 @@ class ImageBlock(BaseModel):
             return self
 
         try:
-            # Check if image is already base64 encoded
-            decoded_img = base64.b64decode(self.image)
-        except Exception:
+            # Check if self.image is already base64 encoded.
+            # b64decode() can succeed on random binary data, so we
+            # pass verify=True to make sure it's not a false positive
+            decoded_img = base64.b64decode(self.image, validate=True)
+        except BinasciiError:
             decoded_img = self.image
-            # Not base64 - encode it
             self.image = base64.b64encode(self.image)
 
         self._guess_mimetype(decoded_img)

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -9,6 +9,7 @@ import pickle
 import textwrap
 import uuid
 from abc import abstractmethod
+from binascii import Error as BinasciiError
 from dataclasses import dataclass
 from enum import Enum, auto
 from hashlib import sha256
@@ -531,14 +532,10 @@ class MediaResource(BaseModel):
 
         try:
             # Check if data is already base64 encoded.
-            # b64decode() can succeed on random binary data, we make
-            # a full roundtrip to make sure it's not a false positive
-            decoded = base64.b64decode(v)
-            encoded = base64.b64encode(decoded)
-            if encoded != v:
-                # Roundtrip failed, this is a false positive, return encoded
-                return base64.b64encode(v)
-        except Exception:
+            # b64decode() can succeed on random binary data, so we
+            # pass verify=True to make sure it's not a false positive
+            decoded = base64.b64decode(v, validate=True)
+        except BinasciiError:
             # b64decode failed, return encoded
             return base64.b64encode(v)
 

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -4,11 +4,11 @@ import asyncio
 import base64
 import os
 import random
-import requests
 import sys
 import time
 import traceback
 import uuid
+from binascii import Error as BinasciiError
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial, wraps
@@ -30,6 +30,8 @@ from typing import (
     Union,
     runtime_checkable,
 )
+
+import requests
 
 
 class GlobalsHelper:
@@ -600,6 +602,15 @@ def resolve_binary(
         try:
             decoded_bytes = base64.b64decode(raw_bytes)
         except Exception:
+            decoded_bytes = raw_bytes
+
+        try:
+            # Check if raw_bytes is already base64 encoded.
+            # b64decode() can succeed on random binary data, so we
+            # pass verify=True to make sure it's not a false positive
+            decoded_bytes = base64.b64decode(raw_bytes, validate=True)
+        except BinasciiError:
+            # b64decode failed, leave as is
             decoded_bytes = raw_bytes
 
         if as_base64:


### PR DESCRIPTION
# Description

Avoid false positives when checking if some bytes are base64 encoded. Also added the same logic to another part of the code that can benefit from it.

Fixes #17924 


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

