### PR TITLE
Support for custom vectara_base_url

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/Changelog.md
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/Changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG — llama-index-indices-managed-vectara
 
+## [0.4.1]
+
+Added vectara_base_url to support custom Vectara server, and vectara_verify_ssl to enable ignoring SSL when needed.
+
 ## [0.4.0]
 
 Implementation switched from using Vectara API v1 to API v2.

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
@@ -104,7 +104,7 @@ class VectaraIndex(BaseManagedIndex):
         # for calling Vectara API
         self._session = requests.Session()  # to reuse connections
         if not vectara_verify_ssl:
-            self._session.verify = False    # to ignore SSL verification
+            self._session.verify = False  # to ignore SSL verification
         adapter = requests.adapters.HTTPAdapter(max_retries=3)
         self._session.mount("https://", adapter)
         self.vectara_api_timeout = 90

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
@@ -71,7 +71,7 @@ class VectaraIndex(BaseManagedIndex):
     ) -> None:
         """Initialize the Vectara API."""
         self.parallelize_ingest = parallelize_ingest
-        self.vectara_base_url = vectara_base_url.rstrip("/")
+        self._base_url = vectara_base_url.rstrip("/")
 
         index_struct = VectaraIndexStruct(
             index_id=str(vectara_corpus_key),

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
@@ -65,10 +65,14 @@ class VectaraIndex(BaseManagedIndex):
         vectara_api_key: Optional[str] = None,
         parallelize_ingest: bool = False,
         x_source_str: str = "llama_index",
+        vectara_base_url: str = "https://api.vectara.io",
+        vectara_verify_ssl: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize the Vectara API."""
         self.parallelize_ingest = parallelize_ingest
+        self.vectara_base_url = vectara_base_url.rstrip("/")
+
         index_struct = VectaraIndexStruct(
             index_id=str(vectara_corpus_key),
             summary="Vectara Index",
@@ -99,6 +103,8 @@ class VectaraIndex(BaseManagedIndex):
         # setup requests session with max 3 retries and 90s timeout
         # for calling Vectara API
         self._session = requests.Session()  # to reuse connections
+        if not vectara_verify_ssl:
+            self._session.verify = False    # to ignore SSL verification
         adapter = requests.adapters.HTTPAdapter(max_retries=3)
         self._session.mount("https://", adapter)
         self.vectara_api_timeout = 90
@@ -138,7 +144,7 @@ class VectaraIndex(BaseManagedIndex):
         valid_corpus_key = self._get_corpus_key(corpus_key)
         body = {}
         response = self._session.delete(
-            f"https://api.vectara.io/v2/corpora/{valid_corpus_key}/documents/{doc_id}",
+            f"{self._base_url}/v2/corpora/{valid_corpus_key}/documents/{doc_id}",
             data=json.dumps(body),
             verify=True,
             headers=self._get_post_headers(),
@@ -156,7 +162,7 @@ class VectaraIndex(BaseManagedIndex):
     def _index_doc(self, doc: dict, corpus_key) -> str:
         response = self._session.post(
             headers=self._get_post_headers(),
-            url=f"https://api.vectara.io/v2/corpora/{corpus_key}/documents",
+            url=f"{self._base_url}/v2/corpora/{corpus_key}/documents",
             data=json.dumps(doc),
             timeout=self.vectara_api_timeout,
             verify=True,
@@ -366,7 +372,7 @@ class VectaraIndex(BaseManagedIndex):
         headers.pop("Content-Type")
         valid_corpus_key = self._get_corpus_key(corpus_key)
         response = self._session.post(
-            f"https://api.vectara.io/v2/corpora/{valid_corpus_key}/upload_file",
+            f"{self._base_url}/v2/corpora/{valid_corpus_key}/upload_file",
             files=files,
             verify=True,
             headers=headers,
@@ -426,7 +432,7 @@ class VectaraIndex(BaseManagedIndex):
             doc_id = document.doc_id
             body = {"metadata": update_kwargs["metadata"]}
             response = self._session.patch(
-                f"https://api.vectara.io/v2/corpora/{valid_corpus_key}/documents/{doc_id}",
+                f"{self._base_url}/v2/corpora/{valid_corpus_key}/documents/{doc_id}",
                 data=json.dumps(body),
                 verify=True,
                 headers=self._get_post_headers(),

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
@@ -338,7 +338,7 @@ class VectaraRetriever(BaseRetriever):
                 model_parameters["presence_penalty"] = self._presence_penalty
 
             if len(model_parameters) > 0:
-                summary_config["model_parameters"] = model_paramters
+                summary_config["model_parameters"] = model_parameters
 
             citations_config = {}
             if self._citations_style:

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
@@ -533,7 +533,7 @@ class VectaraRetriever(BaseRetriever):
         else:
             response = self._index._session.post(
                 headers=self._get_post_headers(),
-                url=f"{self._indedx._base_url}/v2/query",
+                url=f"{self._index._base_url}/v2/query",
                 data=json.dumps(data),
                 timeout=self._index.vectara_api_timeout,
             )

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/retriever.py
@@ -392,7 +392,7 @@ class VectaraRetriever(BaseRetriever):
                 conv_id = conv_id or self._conv_id
                 response = self._index._session.post(
                     headers=self._get_post_headers(),
-                    url=f"https://api.vectara.io/v2/chats/{conv_id}/turns",
+                    url=f"{self._index._base_url}/v2/chats/{conv_id}/turns",
                     data=json.dumps(body),
                     timeout=self._index.vectara_api_timeout,
                     stream=True,
@@ -400,7 +400,7 @@ class VectaraRetriever(BaseRetriever):
             else:
                 response = self._index._session.post(
                     headers=self._get_post_headers(),
-                    url="https://api.vectara.io/v2/chats",
+                    url=f"{self._index._base_url}/v2/chats",
                     data=json.dumps(body),
                     timeout=self._index.vectara_api_timeout,
                     stream=True,
@@ -409,7 +409,7 @@ class VectaraRetriever(BaseRetriever):
         else:
             response = self._index._session.post(
                 headers=self._get_post_headers(),
-                url="https://api.vectara.io/v2/query",
+                url=f"{self._index._base_url}/v2/query",
                 data=json.dumps(body),
                 timeout=self._index.vectara_api_timeout,
                 stream=True,
@@ -518,14 +518,14 @@ class VectaraRetriever(BaseRetriever):
             if conv_id:
                 response = self._index._session.post(
                     headers=self._get_post_headers(),
-                    url=f"https://api.vectara.io/v2/chats/{conv_id}/turns",
+                    url=f"{self._index._base_url}/v2/chats/{conv_id}/turns",
                     data=json.dumps(data),
                     timeout=self._index.vectara_api_timeout,
                 )
             else:
                 response = self._index._session.post(
                     headers=self._get_post_headers(),
-                    url="https://api.vectara.io/v2/chats",
+                    url=f"{self._index._base_url}/v2/chats",
                     data=json.dumps(data),
                     timeout=self._index.vectara_api_timeout,
                 )
@@ -533,7 +533,7 @@ class VectaraRetriever(BaseRetriever):
         else:
             response = self._index._session.post(
                 headers=self._get_post_headers(),
-                url="https://api.vectara.io/v2/query",
+                url=f"{self._indedx._base_url}/v2/query",
                 data=json.dumps(data),
                 timeout=self._index.vectara_api_timeout,
             )

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/pyproject.toml
@@ -31,7 +31,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-indices-managed-vectara"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This adds support for custom vectara_base_url in case you have a local installation that is not pointing to the default api.vectara.io. Also supporting ssl_verify, if set to false then it sets the SSL connection to ignore Certificate Authority checks.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
