### PR TITLE
safer workflow cancel + fix restored context bug

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -496,6 +496,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         state_prompt: Optional[Union[str, BasePromptTemplate]] = None,
         initial_state: Optional[dict] = None,
         timeout: Optional[float] = None,
+        verbose: bool = False,
     ) -> "AgentWorkflow":
         """Initializes an AgentWorkflow from a list of tools or functions.
 
@@ -528,4 +529,5 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             state_prompt=state_prompt,
             initial_state=initial_state,
             timeout=timeout,
+            verbose=verbose,
         )


### PR DESCRIPTION
Two things I ran into:
1. Stopping and resuming AgentWorkflow with HITL, I was getting stuck at `await handler`. One task was not cancelling and so the code hangs forever
2. We were adding `in_progress` events twice -- once on `Context.from_dict()` and another in `workflow._start()`