### PR TITLE
fix: remove warnings from workflow tests

### DIFF
--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -168,6 +168,7 @@ async def test_wait_for_event_in_workflow():
 
     workflow = TestWorkflow()
     handler = workflow.run()
+    assert handler.ctx
     async for ev in handler.stream_events():
         if isinstance(ev, Event) and ev.msg == "foo":
             handler.ctx.send_event(Event(msg="bar"))

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -65,7 +65,7 @@ async def test_get_not_found(ctx):
 async def test_legacy_data(workflow):
     c1 = Context(workflow)
     await c1.set(key="test_key", value=42)
-    assert c1.data["test_key"] == 42
+    assert await c1.get("test_key") == 42
 
 
 def test_send_event_step_is_none(ctx):

--- a/llama-index-core/tests/workflow/test_decorator.py
+++ b/llama-index-core/tests/workflow/test_decorator.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.errors import WorkflowValidationError
 from llama_index.core.workflow.events import Event
@@ -82,6 +81,6 @@ def test_decorate_free_function_wrong_num_workers():
         WorkflowValidationError, match="num_workers must be an integer greater than 0"
     ):
 
-        @step(workflow=TestWorkflow, num_workers=0.5)
+        @step(workflow=TestWorkflow, num_workers=0.5)  # type: ignore
         def f2(ev: Event) -> Event:
             return Event()

--- a/llama-index-core/tests/workflow/test_event.py
+++ b/llama-index-core/tests/workflow/test_event.py
@@ -1,9 +1,9 @@
-import pytest
+from typing import Any, cast
 
-from llama_index.core.workflow.events import Event
+import pytest
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.workflow.context_serializers import JsonSerializer
-from typing import Any, cast
+from llama_index.core.workflow.events import Event
 
 
 class _TestEvent(Event):
@@ -91,7 +91,7 @@ def test_event_dict_api():
 
 
 def test_event_serialization():
-    ev = _TestEvent(param="foo", not_a_field="bar")
+    ev = _TestEvent(param="foo", not_a_field="bar")  # type: ignore
     serializer = JsonSerializer()
     serialized_ev = serializer.serialize(ev)
     deseriazlied_ev = serializer.deserialize(serialized_ev)

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -19,7 +19,7 @@ class StreamingWorkflow(Workflow):
                 yield word
 
         async for w in stream_messages():
-            ctx.session.write_event_to_stream(Event(msg=w))
+            ctx.write_event_to_stream(Event(msg=w))
 
         return StopEvent(result=None)
 

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -151,4 +151,5 @@ async def test_resume_streams():
         pass
     await handler_2
 
+    assert handler_2.ctx
     assert await handler_2.ctx.get("cur_count") == 2

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -251,6 +251,7 @@ async def test_workflow_num_workers():
     assert set(result) == {"test1", "test2", "test4"}
 
     # ctx should have 1 extra event
+    assert handler.ctx
     assert (
         len(handler.ctx._events_buffer["tests.workflow.conftest.AnotherTestEvent"]) == 1
     )
@@ -463,18 +464,21 @@ async def test_workflow_continue_context():
     # first run
     r = wf.run()
     result = await r
+    assert r.ctx
     assert result == "Done"
     assert await r.ctx.get("number") == 1
 
     # second run -- independent from the first
     r = wf.run()
     result = await r
+    assert r.ctx
     assert result == "Done"
     assert await r.ctx.get("number") == 1
 
     # third run -- continue from the second run
     r = wf.run(ctx=r.ctx)
     result = await r
+    assert r.ctx
     assert result == "Done"
     assert await r.ctx.get("number") == 2
 
@@ -493,6 +497,7 @@ async def test_workflow_pickle():
 
     wf = DummyWorkflow()
     handler = wf.run()
+    assert handler.ctx
     _ = await handler
 
     # by default, we can't pickle the LLM/embedding object
@@ -504,6 +509,7 @@ async def test_workflow_pickle():
     new_handler = WorkflowHandler(
         ctx=Context.from_dict(wf, state_dict, serializer=JsonPickleSerializer())
     )
+    assert new_handler.ctx
 
     # check that the step count is the same
     cur_step = await handler.ctx.get("step")
@@ -521,6 +527,7 @@ async def test_workflow_pickle():
     assert new_llm.max_tokens == llm.max_tokens
 
     handler = wf.run(ctx=new_handler.ctx)
+    assert handler.ctx
     _ = await handler
 
     # check that the step count is incremented
@@ -626,6 +633,7 @@ async def test_human_in_the_loop():
     workflow = HumanInTheLoopWorkflow()
 
     handler: WorkflowHandler = workflow.run()
+    assert handler.ctx
     async for event in handler.stream_events():
         if isinstance(event, InputRequiredEvent):
             assert event.prefix == "Enter a number: "

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -221,7 +221,7 @@ async def test_workflow_num_workers():
             ctx.send_event(OneTestEvent(test_param="test3"))
 
             # send one extra event
-            ctx.session.send_event(AnotherTestEvent(another_test_param="test4"))
+            ctx.send_event(AnotherTestEvent(another_test_param="test4"))
 
             return LastEvent()
 


### PR DESCRIPTION
# Description

Remove warnings from tests.

Blocked on https://github.com/run-llama/llama_index/pull/17942
