### PR TITLE
fix: Remove `cache_dir` Pydantic field validation

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-gaudi/llama_index/embeddings/gaudi/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-gaudi/llama_index/embeddings/gaudi/base.py
@@ -63,9 +63,6 @@ class GaudiEmbedding(BaseEmbedding):
     text_instruction: Optional[str] = Field(
         description="Instruction to prepend to text."
     )
-    cache_folder: Optional[str] = Field(
-        description="Cache folder for Hugging Face files."
-    )
 
     _model: Any = PrivateAttr()
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-gaudi/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-gaudi/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-gaudi"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Error trace
```
ValidationError: 1 validation error for GaudiEmbedding
cache_folder
  Field required [type=missing, input_value={'embed_batch_size': 10, ...text_instruction': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
```

# Description
This change prevents pydantic validation error for `cache_dir` field.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
