### PR TITLE
fix: respect max_depth in KnowledgeBaseWebReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/knowledge_base/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/knowledge_base/base.py
@@ -127,7 +127,12 @@ class KnowledgeBaseWebReader(BaseReader):
         return {"title": title, "subtitle": subtitle, "body": body, "url": url}
 
     def get_article_urls(
-        self, browser: Any, root_url: str, current_url: str, max_depth: int = 100
+        self,
+        browser: Any,
+        root_url: str,
+        current_url: str,
+        max_depth: int = 100,
+        depth: int = 0,
     ) -> List[str]:
         """
         Recursively crawl through the knowledge base to find a list of articles.
@@ -136,11 +141,17 @@ class KnowledgeBaseWebReader(BaseReader):
             browser (Any): a Playwright Chromium browser.
             root_url (str): root URL of the knowledge base.
             current_url (str): current URL that is being crawled.
+            max_depth (int): maximum recursion level for the crawler
+            depth (int): current depth level
 
         Returns:
             List[str]: a list of URLs of found articles.
 
         """
+        if depth >= max_depth:
+            print(f"Reached max depth ({max_depth}): {current_url}")
+            return []
+
         page = browser.new_page(ignore_https_errors=True)
         page.set_default_timeout(60000)
         page.goto(current_url, wait_until="domcontentloaded")
@@ -162,7 +173,7 @@ class KnowledgeBaseWebReader(BaseReader):
         for link in links:
             url = root_url + page.evaluate("(node) => node.getAttribute('href')", link)
             article_urls.extend(
-                self.get_article_urls(browser, root_url, url, max_depth)
+                self.get_article_urls(browser, root_url, url, max_depth, depth + 1)
             )
 
         page.close()

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -46,7 +46,7 @@ license = "GPL-3.0-or-later"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.3.5"
+version = "0.3.6"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

With  #17360 we introduced a recursion limit for the crawler, but the limit was never actually used.


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

