### PR TITLE
feat(bedrock): add Claude 3.7 Sonnet model support

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
@@ -67,6 +67,7 @@ CHAT_ONLY_MODELS = {
     "us.anthropic.claude-3-5-haiku-20241022-v1:0": 200000,
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0": 200000,
     "us.anthropic.claude-3-5-sonnet-20241022-v2:0": 200000,
+    "us.anthropic.claude-3-7-sonnet-20250219-v1:0": 200000,
     "us.meta.llama3-1-70b-instruct-v1:0": 8192,
     "us.meta.llama3-1-8b-instruct-v1:0": 8192,
     "us.meta.llama3-2-11b-instruct-v1:0": 8192,
@@ -79,6 +80,7 @@ CHAT_ONLY_MODELS = {
     "eu.anthropic.claude-3-5-haiku-20241022-v1:0": 200000,
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": 200000,
     "eu.anthropic.claude-3-5-sonnet-20241022-v2:0": 200000,
+    "eu.anthropic.claude-3-7-sonnet-20250219-v1:0": 200000,
     "eu.meta.llama3-1-70b-instruct-v1:0": 8192,
     "eu.meta.llama3-1-8b-instruct-v1:0": 8192,
     "eu.meta.llama3-2-11b-instruct-v1:0": 8192,
@@ -115,12 +117,14 @@ STREAMING_MODELS = {
     "us.anthropic.claude-3-5-haiku-20241022-v1:0",
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
     "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
     "eu.anthropic.claude-3-haiku-20240307-v1:0",
     "eu.anthropic.claude-3-opus-20240229-v1:0",
     "eu.anthropic.claude-3-sonnet-20240229-v1:0",
     "eu.anthropic.claude-3-5-haiku-20241022-v1:0",
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
     "eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
 }
 
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Add support for anthropic.claude-3-7-sonnet-20250219-v1:0 model with 200k token context window

# Description

This PR adds support for the new Claude 3.7 Sonnet model (anthropic.claude-3-7-sonnet-20250219-v1:0) with 200k token context window to the Bedrock integration. This allows users to leverage this powerful model through the AWS Bedrock service.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
