### PR TITLE
fix: escape user input before shelling out command

### DIFF
--- a/llama-index-cli/llama_index/cli/rag/base.py
+++ b/llama-index-cli/llama_index/cli/rag/base.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import shlex
 import shutil
 from argparse import ArgumentParser
 from glob import iglob
@@ -14,8 +15,8 @@ from llama_index.core import (
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.base.response.schema import (
     RESPONSE_TYPE,
-    StreamingResponse,
     Response,
+    StreamingResponse,
 )
 from llama_index.core.bridge.pydantic import BaseModel, Field, field_validator
 from llama_index.core.chat_engine import CondenseQuestionChatEngine
@@ -159,7 +160,7 @@ class RagCLI(BaseModel):
         if chat_engine is not None:
             return chat_engine
 
-        if values.get("query_pipeline", None) is None:
+        if values.get("query_pipeline") is None:
             values["query_pipeline"] = cls.query_pipeline_from_ingestion_pipeline(
                 query_pipeline=None, values=values
             )
@@ -231,7 +232,8 @@ class RagCLI(BaseModel):
 
             # Append the `--files` argument to the history file
             with open(f"{self.persist_dir}/{RAG_HISTORY_FILE_NAME}", "a") as f:
-                f.write(str(files) + "\n")
+                for file in files:
+                    f.write(str(file) + "\n")
 
         if create_llama:
             if shutil.which("npx") is None:
@@ -289,7 +291,7 @@ class RagCLI(BaseModel):
                                 "none",
                                 "--engine",
                                 "context",
-                                f"--files {path}",
+                                f"--files {shlex.quote(path)}",
                             ]
                             os.system(" ".join(command_args))
 

--- a/llama-index-cli/pyproject.toml
+++ b/llama-index-cli/pyproject.toml
@@ -14,7 +14,7 @@ disallow_untyped_defs = true
 # Remove venv skip when integrated with pre-commit
 exclude = ["_static", "build", "examples", "notebooks", "venv"]
 ignore_missing_imports = true
-python_version = "3.8"
+python_version = "3.9"
 
 [tool.poetry]
 authors = ["llamaindex"]
@@ -32,7 +32,7 @@ maintainers = [
 name = "llama-index-cli"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Escape user input before formatting the shell command string. While I was there, I fixed a bug in handling the `--files` option.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests
