### PR TITLE
text is required in boto3 model

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -182,7 +182,7 @@ def messages_to_converse_messages(
                     "toolUseId": message.additional_kwargs["tool_call_id"],
                     "content": [
                         {
-                            "text": message.content,
+                            "text": message.content or "",
                         },
                     ],
                 }


### PR DESCRIPTION
# Description

This PR addresses a mismatch between a LlamaIndex model and a Botocore library model. Specifically, the tool result is optional in the [ChatMessage](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/base/llms/types.py#L210) model, whereas it is required in the [Botocore converse client](toolResult).

One case where `message.content` is converted to `None` is when a tool returns an empty string.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually
