### PR TITLE
feat: create client kwargs for ollama client

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-ollama/llama_index/embeddings/ollama/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ollama/llama_index/embeddings/ollama/base.py
@@ -34,6 +34,7 @@ class OllamaEmbedding(BaseEmbedding):
         embed_batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
         ollama_additional_kwargs: Optional[Dict[str, Any]] = None,
         callback_manager: Optional[CallbackManager] = None,
+        client_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -45,8 +46,9 @@ class OllamaEmbedding(BaseEmbedding):
             **kwargs,
         )
 
-        self._client = Client(host=self.base_url)
-        self._async_client = AsyncClient(host=self.base_url)
+    client_kwargs = client_kwargs or {}
+    self._client = Client(host=self.base_url, **client_kwargs)
+    self._async_client = AsyncClient(host=self.base_url, **client_kwargs)
 
     @classmethod
     def class_name(cls) -> str:


### PR DESCRIPTION
This is crucial if the ollama server is expecting Auth to be provided

# Description

This PR introduces a new client_kwargs parameter to the OllamaEmbedding class. The client_kwargs parameter allows users to pass additional keyword arguments to both the Client and AsyncClient instances. This enhancement provides greater flexibility and customization when initializing the clients, enabling users to configure headers, authentication, and other settings as needed.  Changes:  
Added **_client_kwargs_** parameter to the ___init___ method of OllamaEmbedding.

Updated the initialization of Client and AsyncClient to include client_kwargs.
## Example Usage:
```python
client_kwargs = {"headers": {"auth": "your_auth_token"}}
embedding = OllamaEmbedding(
    model_name="your_model_name",
    base_url="http://localhost:11434",
    client_kwargs=client_kwargs
)
```
Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.


- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
