### PR TITLE
chore: skip deeplake tests when running on CI

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-deeplake/tests/test_vector_stores_deeplake.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-deeplake/tests/test_vector_stores_deeplake.py
@@ -1,15 +1,19 @@
+import os
+
 import jwt  # noqa
 import pytest
-
 from llama_index.core import Document
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
-    MetadataFilter,
-    MetadataFilters,
     FilterCondition,
     FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
 )
 from llama_index.vector_stores.deeplake import DeepLakeVectorStore
+
+if os.getenv("GITHUB_ACTIONS") == "true":
+    pytest.skip("tests are flaky on Github runners", allow_module_level=True)
 
 
 def test_class():


### PR DESCRIPTION
# Description

Deeplake tests segfault randomly in the CI but I couldn't reproduce locally. Let's skip them, they still work for local development.
