### PR TITLE
Remove base url validation

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-nvidia"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/test_base_url.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/test_base_url.py
@@ -56,6 +56,8 @@ def test_base_url_priority(public_class: type, monkeypatch) -> None:
         assert get_base_url(base_url=PARAM_URL) == PARAM_URL
 
 
+# marking as skip because base_url validation is removed
+@pytest.mark.skip(reason="base_url validation is removed")
 @pytest.mark.parametrize(
     "base_url",
     [
@@ -75,6 +77,8 @@ def test_param_base_url_negative(
     assert "Invalid base_url" in str(e.value)
 
 
+# marking as skip because base_url validation is removed
+@pytest.mark.skip(reason="base_url validation is removed")
 @pytest.mark.parametrize(
     "base_url",
     [

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
@@ -11,7 +11,6 @@ from llama_index.core.base.llms.generic_utils import (
 
 from llama_index.llms.openai_like import OpenAILike
 from llama_index.core.llms.function_calling import FunctionCallingLLM
-from urllib.parse import urlparse
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
@@ -127,27 +126,6 @@ class NVIDIA(OpenAILike, FunctionCallingLLM):
                 raise ValueError("No locally hosted model was found.")
         else:
             self.model = DEFAULT_MODEL
-
-    def _validate_url(self, base_url):
-        """
-        validate the base_url.
-        if the base_url is not a url, raise an error
-        if the base_url does not end in /v1, e.g. /completions, /chat/completions,
-        emit a warning. old documentation told users to pass in the full
-        inference url, which is incorrect and prevents model listing from working.
-        normalize base_url to end in /v1.
-        """
-        if base_url is not None:
-            base_url = base_url.rstrip("/")
-            parsed = urlparse(base_url)
-
-            # Ensure scheme and netloc (domain name) are present
-            if not (parsed.scheme and parsed.netloc):
-                expected_format = "Expected format is: http://host:port"
-                raise ValueError(
-                    f"Invalid base_url format. {expected_format} Got: {base_url}"
-                )
-        return base_url
 
     def _validate_model(self, model_name: str) -> None:
         """

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-llms-nvidia"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
@@ -1,6 +1,5 @@
 from typing import Any, List, Optional, Generator, Literal
 import os
-from urllib.parse import urlparse, urlunparse
 import httpx
 
 from llama_index.core.bridge.pydantic import Field, PrivateAttr, ConfigDict
@@ -110,8 +109,6 @@ class NVIDIARerank(BaseNodePostprocessor):
         if self._is_hosted:  # hosted on API Catalog (build.nvidia.com)
             if (not self._api_key) or (self._api_key == "NO_API_KEY_PROVIDED"):
                 raise ValueError("An API key is required for hosted NIM.")
-        else:  # not hosted
-            self.base_url = self._validate_url(self.base_url)
 
         self.model = model
         if not self.model:
@@ -209,65 +206,6 @@ class NVIDIARerank(BaseNodePostprocessor):
             ]
         else:
             return RANKING_MODEL_TABLE
-
-    def _validate_url(self, base_url):
-        """
-        validate the base_url.
-        if the base_url is not a url, raise an error
-        if the base_url does not end in /v1, e.g. /embeddings
-        emit a warning. old documentation told users to pass in the full
-        inference url, which is incorrect and prevents model listing from working.
-        normalize base_url to end in /v1.
-        validate the base_url.
-        if the base_url is not a url, raise an error
-        if the base_url does not end in /v1, e.g. /embeddings
-        emit a warning. old documentation told users to pass in the full
-        inference url, which is incorrect and prevents model listing from working.
-        normalize base_url to end in /v1.
-        """
-        if base_url is not None:
-            parsed = urlparse(base_url)
-
-            # Ensure scheme and netloc (domain name) are present
-            if not (parsed.scheme and parsed.netloc):
-                expected_format = "Expected format is: http://host:port"
-                raise ValueError(
-                    f"Invalid base_url format. {expected_format} Got: {base_url}"
-                )
-
-            normalized_path = parsed.path.rstrip("/")
-            if not normalized_path.endswith("/v1"):
-                warnings.warn(
-                    f"{base_url} does not end in /v1, you may "
-                    "have inference and listing issues"
-                )
-                normalized_path += "/v1"
-
-                base_url = urlunparse(
-                    (parsed.scheme, parsed.netloc, normalized_path, None, None, None)
-                )
-        if base_url is not None:
-            parsed = urlparse(base_url)
-
-            # Ensure scheme and netloc (domain name) are present
-            if not (parsed.scheme and parsed.netloc):
-                expected_format = "Expected format is: http://host:port"
-                raise ValueError(
-                    f"Invalid base_url format. {expected_format} Got: {base_url}"
-                )
-
-            normalized_path = parsed.path.rstrip("/")
-            if not normalized_path.endswith("/v1"):
-                warnings.warn(
-                    f"{base_url} does not end in /v1, you may "
-                    "have inference and listing issues"
-                )
-                normalized_path += "/v1"
-
-                base_url = urlunparse(
-                    (parsed.scheme, parsed.netloc, normalized_path, None, None, None)
-                )
-        return base_url
 
     def _validate_model(self, model_name: str) -> None:
         """

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-postprocessor-nvidia-rerank"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_base_url.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/tests/test_base_url.py
@@ -31,7 +31,8 @@ def mock_v1_local_models2(respx_mock: respx.MockRouter, base_url: str) -> None:
     )
 
 
-# Updated test for non-hosted URLs that may need normalization.
+# marking as skip because base_url validation is removed
+@pytest.mark.skip(reason="base_url validation is removed")
 @pytest.mark.parametrize(
     "base_url",
     [
@@ -98,6 +99,8 @@ def test_proxy_base_url(base_url: str, mock_v1_local_models2: None) -> None:
     assert client.base_url == base_url
 
 
+# marking as skip because base_url validation is removed
+@pytest.mark.skip(reason="base_url validation is removed")
 @pytest.mark.parametrize(
     "base_url",
     [


### PR DESCRIPTION
## Description
This PR removes the base URL validation logic from then nvidia connectors. The current validation is overly restrictive and prevents users from using certain valid URLs, especially in custom or internal environments. By removing this validation, we allow more flexibility for users to configure their own base URLs without unnecessary constraints.

### New Package?
No

### Version Bump?
Yes

### Type of Change
Bug fix (non-breaking change which fixes an issue)

cc: @dglogo @sumitb