### PR TITLE
Don't unnecessarily generate metadata string in TextNode.get_content

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -711,10 +711,10 @@ class TextNode(BaseNode):
 
     def get_content(self, metadata_mode: MetadataMode = MetadataMode.NONE) -> str:
         """Get object content."""
-        metadata_str = self.get_metadata_str(mode=metadata_mode).strip()
         if not metadata_str:
             return self.text
 
+        metadata_str = self.get_metadata_str(mode=metadata_mode).strip()
         return self.text_template.format(
             content=self.text, metadata_str=metadata_str
         ).strip()


### PR DESCRIPTION
# Description

The `TextNode.get_content` method generates a metadata string on every call, even when metadata should be ignored (which is _the default_).  The metadata string should only be generated if necessary (faster is better!).

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
