### PR TITLE
- Mem0Memory Integration Issue: Update Required for Mem0 API Parameter Changes

### DIFF
--- a/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
@@ -92,8 +92,8 @@ class Mem0Memory(BaseMem0):
         context: Dict[str, Any],
         api_key: Optional[str] = None,
         host: Optional[str] = None,
-        organization: Optional[str] = None,
-        project: Optional[str] = None,
+        org_id: Optional[str] = None,
+        project_id: Optional[str] = None,
         search_msg_limit: int = 5,
         **kwargs: Any,
     ):
@@ -105,7 +105,7 @@ class Mem0Memory(BaseMem0):
             raise ValidationError(f"Context validation error: {e}")
 
         client = MemoryClient(
-            api_key=api_key, host=host, organization=organization, project=project
+            api_key=api_key, host=host, org_id=org_id, project_id=project_id
         )
         return cls(
             primary_memory=primary_memory,

--- a/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
@@ -30,7 +30,7 @@ license = "MIT"
 name = "llama-index-memory-mem0"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.2.2"
+version = "0.3.0"
 
 [tool.poetry.dependencies]
 python = "<4.0,>=3.9"

--- a/llama-index-integrations/memory/llama-index-memory-mem0/tests/test_mem0.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/tests/test_mem0.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock
+
 from llama_index.memory.mem0.base import Mem0Memory, Mem0Context
 from llama_index.core.memory.chat_memory_buffer import ChatMessage, MessageRole
 from llama_index.memory.mem0.utils import (
@@ -28,8 +29,8 @@ def test_mem0_memory_from_client():
             context=context,
             api_key=api_key,
             host=host,
-            org_id=organization,
-            project_id=project,
+            org_id=org_id,
+            project_id=project_id,
             search_msg_limit=search_msg_limit,  # Add this line
         )
 

--- a/llama-index-integrations/memory/llama-index-memory-mem0/tests/test_mem0.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/tests/test_mem0.py
@@ -14,8 +14,8 @@ def test_mem0_memory_from_client():
     # Mock arguments for MemoryClient
     api_key = "test_api_key"
     host = "test_host"
-    organization = "test_org"
-    project = "test_project"
+    org_id = "test_org"
+    project_id = "test_project"
     search_msg_limit = 10  # Add this line
 
     # Patch MemoryClient
@@ -28,14 +28,14 @@ def test_mem0_memory_from_client():
             context=context,
             api_key=api_key,
             host=host,
-            organization=organization,
-            project=project,
+            org_id=organization,
+            project_id=project,
             search_msg_limit=search_msg_limit,  # Add this line
         )
 
         # Assert that MemoryClient was called with the correct arguments
         MockMemoryClient.assert_called_once_with(
-            api_key=api_key, host=host, organization=organization, project=project
+            api_key=api_key, host=host, org_id=org_id, project_id=project_id
         )
 
         # Assert that the returned object is an instance of Mem0Memory
@@ -88,8 +88,8 @@ def test_mem0_memory_set():
     # Mock arguments for MemoryClient
     api_key = "test_api_key"
     host = "test_host"
-    organization = "test_org"
-    project = "test_project"
+    org_id = "test_org"
+    project_id = "test_project"
 
     # Patch MemoryClient
     with patch("llama_index.memory.mem0.base.MemoryClient") as MockMemoryClient:
@@ -101,8 +101,8 @@ def test_mem0_memory_set():
             context=context,
             api_key=api_key,
             host=host,
-            organization=organization,
-            project=project,
+            org_id=org_id,
+            project_id=project_id,
         )
 
         # Create a list of alternating user and assistant messages
@@ -155,8 +155,8 @@ def test_mem0_memory_get():
     # Mock arguments for MemoryClient
     api_key = "test_api_key"
     host = "test_host"
-    organization = "test_org"
-    project = "test_project"
+    org_id = "test_org"
+    project_id = "test_project"
 
     # Patch MemoryClient
     with patch("llama_index.memory.mem0.base.MemoryClient") as MockMemoryClient:
@@ -168,8 +168,8 @@ def test_mem0_memory_get():
             context=context,
             api_key=api_key,
             host=host,
-            organization=organization,
-            project=project,
+            org_id=org_id,
+            project_id=project_id,
         )
 
         # Set dummy chat history
@@ -240,8 +240,8 @@ def test_mem0_memory_put():
     # Mock arguments for MemoryClient
     api_key = "test_api_key"
     host = "test_host"
-    organization = "test_org"
-    project = "test_project"
+    org_id = "test_org"
+    project_id = "test_project"
 
     # Patch MemoryClient
     with patch("llama_index.memory.mem0.base.MemoryClient") as MockMemoryClient:
@@ -253,8 +253,8 @@ def test_mem0_memory_put():
             context=context,
             api_key=api_key,
             host=host,
-            organization=organization,
-            project=project,
+            org_id=org_id,
+            project_id=project_id,
         )
 
         # Create a test message


### PR DESCRIPTION
Hi Team,

I was experimenting with the LlamaIndex Mem0 memory in my application and encountered the following error:

```
>>> from llama_index.memory.mem0 import Mem0Memory
>>> context = {"user_id": "user_123"}
>>> memory = Mem0Memory.from_client(context=context, host="https://api.mem0.ai", search_msg_limit=5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/younis/miniconda3/envs/llama/lib/python3.12/site-packages/llama_index/memory/mem0/base.py", line 107, in from_client
    client = MemoryClient(
             ^^^^^^^^^^^^^
TypeError: MemoryClient.__init__() got an unexpected keyword argument 'organization'
```

After reviewing the Mem0 documentation and comparing it to the implementation in LlamaIndex, I noticed that Mem0 now requires `org_id` and `project_id` parameters when initializing the MemoryClient:

```python
from mem0 import MemoryClient
client = MemoryClient(org_id='YOUR_ORG_ID', project_id='YOUR_PROJECT_ID')
```
[reference](https://docs.mem0.ai/api-reference/overview)
However, in LlamaIndex, the implementation is using:

```python
client = MemoryClient(
    api_key=api_key, host=host, organization=organization, project=project
)
```

This discrepancy is likely causing the issue. It seems that the LlamaIndex integration should be updated to use `org_id` and `project_id` as expected by the latest Mem0 API.

Thanks in advance,  
Younis