### PR TITLE
Use int type for redirect URI port

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/docs/base.py
@@ -119,7 +119,7 @@ class GoogleDocsReader(BasePydanticReader):
                     client_config = json.load(json_file)
                     redirect_uris = client_config["web"].get("redirect_uris", [])
                     if len(redirect_uris) > 0:
-                        port = redirect_uris[0].strip("/").split(":")[-1]
+                        port = int(redirect_uris[0].strip("/").split(":")[-1])
 
                 creds = flow.run_local_server(port=port)
             # Save the credentials for the next run

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -47,7 +47,7 @@ maintainers = [
 ]
 name = "llama-index-readers-google"
 readme = "README.md"
-version = "0.6.0"
+version = "0.6.1"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Google Docs Reader would read the redirect URI port number from the users credentials.json file as a string and was not converting this to an integer which was causing a type mismatch error. This wraps the string with int() to fix the problem.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests
