### PR TITLE
remove assert for multimodal llms

### DIFF
--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -25,7 +25,6 @@ from llama_index.core.indices.multi_modal.retriever import (
 )
 from llama_index.core.indices.vector_store.base import VectorStoreIndex
 from llama_index.core.llms.utils import LLMType
-from llama_index.core.multi_modal_llms import MultiModalLLM
 from llama_index.core.query_engine.multi_modal import SimpleMultiModalQueryEngine
 from llama_index.core.schema import BaseNode, ImageNode, TextNode
 from llama_index.core.settings import Settings
@@ -140,7 +139,6 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
         retriever = cast(MultiModalVectorIndexRetriever, self.as_retriever(**kwargs))
 
         llm = llm or Settings.llm
-        assert isinstance(llm, MultiModalLLM)
 
         return SimpleMultiModalQueryEngine(
             retriever,

--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -150,7 +150,7 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
 
         return SimpleMultiModalQueryEngine(
             retriever,
-            multi_modal_llm=llm,
+            multi_modal_llm=llm,  # type: ignore
             **kwargs,
         )
 

--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -139,6 +139,10 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
         retriever = cast(MultiModalVectorIndexRetriever, self.as_retriever(**kwargs))
 
         llm = llm or Settings.llm
+        if "multi" not in llm.class_name():
+            logger.warning(
+                f"Warning: {llm.class_name()} does not appear to be a multi-modal LLM. This may not work as expected."
+            )
 
         return SimpleMultiModalQueryEngine(
             retriever,

--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any, List, Optional, Sequence, cast
 
 from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.base.llms.base import BaseLLM
 from llama_index.core.data_structs.data_structs import (
     IndexDict,
     MultiModelIndexDict,
@@ -25,6 +26,7 @@ from llama_index.core.indices.multi_modal.retriever import (
 )
 from llama_index.core.indices.vector_store.base import VectorStoreIndex
 from llama_index.core.llms.utils import LLMType
+from llama_index.core.multi_modal_llms.base import MultiModalLLM
 from llama_index.core.query_engine.multi_modal import SimpleMultiModalQueryEngine
 from llama_index.core.schema import BaseNode, ImageNode, TextNode
 from llama_index.core.settings import Settings
@@ -139,7 +141,8 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
         retriever = cast(MultiModalVectorIndexRetriever, self.as_retriever(**kwargs))
 
         llm = llm or Settings.llm
-        class_name = llm.class_name()  # type: ignore
+        assert isinstance(llm, (BaseLLM, MultiModalLLM))
+        class_name = llm.class_name()
         if "multi" not in class_name:
             logger.warning(
                 f"Warning: {class_name} does not appear to be a multi-modal LLM. This may not work as expected."

--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -139,9 +139,10 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
         retriever = cast(MultiModalVectorIndexRetriever, self.as_retriever(**kwargs))
 
         llm = llm or Settings.llm
-        if "multi" not in llm.class_name():
+        class_name = llm.class_name()  # type: ignore
+        if "multi" not in class_name:
             logger.warning(
-                f"Warning: {llm.class_name()} does not appear to be a multi-modal LLM. This may not work as expected."
+                f"Warning: {class_name} does not appear to be a multi-modal LLM. This may not work as expected."
             )
 
         return SimpleMultiModalQueryEngine(


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/18111

Many multi-modal LLMs have been converted to wrap their native `LLM` class, since the base LLM class is starting to support images. This means this assert will fail even if it will work, so we add a softer check