### PR TITLE
Update Vectara Tool for Metadata Changes to VectaraIndex

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-vectara-query/examples/vectara_query.ipynb
+++ b/llama-index-integrations/tools/llama-index-tools-vectara-query/examples/vectara_query.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "You are now ready to use the Vectara query tool.\n",
     "\n",
-    "To initialize the tool, provide your Vectara information and any query parameters that you want to adjust, such as the reranker, summarizer prompt, etc. To see the entire list of parameters, see the [VectaraQueryToolSpec class definition](https://github.com/david-oplatka/llama_index/blob/main/llama-index-integrations/tools/llama-index-tools-vectara-query/llama_index/tools/vectara_query/base.py#L11)."
+    "To initialize the tool, provide your Vectara information and any query parameters that you want to adjust, such as the reranker, summarizer prompt, etc. To see the entire list of parameters, see the [VectaraQueryToolSpec class definition](https://github.com/run-llama/llama_index/blob/05828d6d099e78df51c76b8c98aa3ecbd45162ec/llama-index-integrations/tools/llama-index-tools-vectara-query/llama_index/tools/vectara_query/base.py#L11)."
    ]
   },
   {

--- a/llama-index-integrations/tools/llama-index-tools-vectara-query/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-vectara-query/pyproject.toml
@@ -28,7 +28,7 @@ license = "MIT"
 name = "llama-index-tools-vectara-query"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-vectara-query/tests/test_tools_vectara_query.py
+++ b/llama-index-integrations/tools/llama-index-tools-vectara-query/tests/test_tools_vectara_query.py
@@ -1,5 +1,5 @@
 from typing import List
-from llama_index.core.schema import Document, MediaResource
+from llama_index.core.schema import Document, Node, MediaResource
 from llama_index.indices.managed.vectara import VectaraIndex
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.tools.vectara_query import VectaraQueryToolSpec
@@ -62,6 +62,35 @@ def get_docs() -> List[Document]:
     return docs
 
 
+def get_nodes() -> List[Node]:
+    inputs = [
+        {
+            "text": "This is test text for Vectara integration with LlamaIndex",
+            "metadata": {"test_num": "1", "test_score": 10, "date": "2020-02-25"},
+        },
+        {
+            "text": "And now for something completely different",
+            "metadata": {"test_num": "2", "test_score": 2, "date": "2015-10-13"},
+        },
+        {
+            "text": "when 900 years you will be, look as good you will not",
+            "metadata": {"test_num": "3", "test_score": 20, "date": "2023-09-12"},
+        },
+        {
+            "text": "when 850 years you will be, look as good you will not",
+            "metadata": {"test_num": "4", "test_score": 50, "date": "2022-01-01"},
+        },
+    ]
+
+    nodes: List[Node] = []
+    for inp in inputs:
+        node = Node(
+            text_resource=MediaResource(text=inp["text"]), metadata=inp["metadata"]
+        )
+        nodes.append(node)
+    return nodes
+
+
 @pytest.fixture()
 def vectara1():
     docs = get_docs()
@@ -83,6 +112,10 @@ def test_simple_retrieval(vectara1) -> None:
     res = tool_spec.semantic_search("Find me something different.")
     assert len(res) == 1
     assert res[0]["text"] == docs[1].text_resource.text
+    assert (
+        res[0]["citation_metadata"]["document"]["test_score"]
+        == docs[1].metadata["test_score"]
+    )
 
 
 def test_mmr_retrieval(vectara1) -> None:
@@ -303,6 +336,40 @@ def test_citations(vectara2) -> None:
     res = tool_spec.rag_query("What colleges has Paul attended?")
     summary = res["summary"]
     assert re.search(r"\[\d+\]", summary)
+
+
+@pytest.fixture()
+def vectara3():
+    nodes = get_nodes()
+    try:
+        vectara3 = VectaraIndex()
+        vectara3.add_nodes(
+            nodes,
+            document_id="doc_1",
+            document_metadata={"author": "Vectara", "title": "LlamaIndex Integration"},
+            corpus_key="llamaindex-testing-2",
+        )
+    except ValueError:
+        pytest.skip("Missing Vectara credentials, skipping test")
+
+    yield vectara3
+
+    # Tear down code
+    for id in vectara3.doc_ids:
+        vectara3.delete_ref_doc(id, corpus_key="llamaindex-testing-2")
+
+
+def test_metadata_format(vectara3) -> None:
+    nodes = get_nodes()
+    tool_spec = VectaraQueryToolSpec(
+        num_results=1, n_sentences_before=0, n_sentences_after=0
+    )
+    res = tool_spec.semantic_search("Find me something different")
+    assert len(res) == 1
+    assert res[0]["citation_metadata"]["document"]["author"] == "Vectara"
+    assert res[0]["citation_metadata"]["document"]["title"] == "LlamaIndex Integration"
+    assert res[0]["text"] == nodes[1].text_resource.text
+    assert res[0]["citation_metadata"]["test_score"] == nodes[1].metadata["test_score"]
 
 
 def test_agent_basic(vectara2) -> None:


### PR DESCRIPTION
# Description

This update simply ensures that the Vectara Query Tool is working properly with the latest changes to how metadata is structured in output from VectaraIndex, per its latest [PR](https://github.com/run-llama/llama_index/pull/17976). I also made one minor change to the example notebook which had a bad link to the `base.py` file for this tool spec.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I added a new assert statement to one test function to ensure that document-level metadata are being returned in the correct format as well as a new test function `test_metadata_format()` to test that part-level metadata are being returned properly by the query tool.

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
