### PR TITLE
fix: Update AgentQLWebReader on llamahub

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -12,6 +12,7 @@ contains_example = false
 import_path = "llama_index.readers.web"
 
 [tool.llamahub.class_authors]
+AgentQLWebReader = "jayfish0"
 AsyncWebPageReader = "Hironsan"
 BeautifulSoupWebReader = "thejessezhang"
 BrowserbaseWebReader = "llama-index"


### PR DESCRIPTION
# Description

Noticed that the AgentQLWebReader is not on llamahub, missed filling the pyproject.toml

Fixes: https://github.com/run-llama/llama_index/pull/17575

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update (on llamahub)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests
