### PR TITLE
fix: Set proper origin for requests from WebReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/agentql_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/agentql_web/base.py
@@ -12,6 +12,8 @@ logging.getLogger("root").setLevel(logging.INFO)
 QUERY_DATA_ENDPOINT = "https://api.agentql.com/v1/query-data"
 API_TIMEOUT_SECONDS = 900
 
+REQUEST_ORIGIN = "llamaindex"
+
 
 class AgentQLWebReader(BasePydanticReader):
     """
@@ -50,7 +52,11 @@ class AgentQLWebReader(BasePydanticReader):
         """
         payload = {"url": url, "query": query, "prompt": prompt, "params": self.params}
 
-        headers = {"X-API-Key": f"{self.api_key}", "Content-Type": "application/json"}
+        headers = {
+            "X-API-Key": f"{self.api_key}",
+            "Content-Type": "application/json",
+            "X-TF-Request-Origin": REQUEST_ORIGIN,
+        }
 
         try:
             response = httpx.post(

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -47,7 +47,7 @@ license = "GPL-3.0-or-later"
 maintainers = ["HawkClaws", "Hironsan", "NA", "an-bluecat", "bborn", "jasonwcfan", "kravetsmic", "pandazki", "ruze00", "selamanse", "thejessezhang"]
 name = "llama-index-readers-web"
 readme = "README.md"
-version = "0.3.7"
+version = "0.3.8"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-agentql/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-agentql/README.md
@@ -44,7 +44,7 @@ await agentql_rest_api_tool.extract_web_data_with_rest_api(
 In order to use the `extract_web_data_from_browser` and `get_web_element_from_browser`, you need to have a Playwright browser instance. If you do not have an active instance, you can initiate one using the `create_async_playwright_browser` utility method from LlamaIndex's Playwright ToolSpec.
 
 > **Note**
-> Agentql browser tools are best used along with LlamaIndex's [Playwright tools](https://docs.llamaindex.ai/en/stable/api_reference/tools/playwright/).
+> AgentQL browser tools are best used along with LlamaIndex's [Playwright tools](https://docs.llamaindex.ai/en/stable/api_reference/tools/playwright/).
 
 ```python
 from llama_index.tools.playwright.base import PlaywrightToolSpec

--- a/llama-index-integrations/tools/llama-index-tools-agentql/examples/AgentQL_browser_agent.ipynb
+++ b/llama-index-integrations/tools/llama-index-tools-agentql/examples/AgentQL_browser_agent.ipynb
@@ -136,14 +136,14 @@
    "metadata": {},
    "source": [
     "### `AgentQLBrowserToolSpec`\n",
-    "`AgentQLBrowserToolSpec` provides 2 tools: `extract_web_data_from_browser` and `get_web_element_from_browser` function tools."
+    "`AgentQLBrowserToolSpec` provides 2 tools: `extract_web_data_from_browser` and `get_web_element_from_browser`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`AgentQLBrowserToolSpec` take the following params:\n",
+    "This tool spec can be instantiated with the following params:\n",
     "- `async_browser`: An async playwright browser instance.\n",
     "- `timeout_for_data`: The number of seconds to wait for a extract data request before timing out. **Defaults to `900`.**\n",
     "- `timeout_for_element`: The number of seconds to wait for a get element request before timing out. **Defaults to `900`.**\n",


### PR DESCRIPTION
We need to mark all integrations REST API request to understand the origin