### PR TITLE
add token counts to the chat and achat methods of BedrockConverse

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -336,6 +336,7 @@ class BedrockConverse(FunctionCallingLLM):
                 },
             ),
             raw=dict(response),
+            additional_kwargs=self._get_response_token_counts(dict(response)),
         )
 
     @llm_completion_callback()
@@ -392,6 +393,9 @@ class BedrockConverse(FunctionCallingLLM):
                         ),
                         delta=content_delta.get("text", ""),
                         raw=response,
+                        additional_kwargs=self._get_response_token_counts(
+                            dict(response)
+                        ),
                     )
                 elif content_block_start := chunk.get("contentBlockStart"):
                     tool_use = content_block_start["start"]["toolUse"]
@@ -414,6 +418,9 @@ class BedrockConverse(FunctionCallingLLM):
                             },
                         ),
                         raw=response,
+                        additional_kwargs=self._get_response_token_counts(
+                            dict(response)
+                        ),
                     )
 
         return gen()
@@ -462,6 +469,7 @@ class BedrockConverse(FunctionCallingLLM):
                 },
             ),
             raw=dict(response),
+            additional_kwargs=self._get_response_token_counts(dict(response)),
         )
 
     @llm_completion_callback()
@@ -519,6 +527,7 @@ class BedrockConverse(FunctionCallingLLM):
                         ),
                         delta=content_delta.get("text", ""),
                         raw=chunk,
+                        additional_kwargs=self._get_response_token_counts(dict(chunk)),
                     )
                 elif content_block_start := chunk.get("contentBlockStart"):
                     tool_use = content_block_start["start"]["toolUse"]
@@ -641,3 +650,21 @@ class BedrockConverse(FunctionCallingLLM):
             )
 
         return tool_selections
+
+    def _get_response_token_counts(
+        self, response: Optional[Dict[str, Any]] = None
+    ) -> dict:
+        """Get the token usage reported by the response."""
+        if not response or not isinstance(response, dict):
+            return {}
+
+        usage = response.get("usage", {})
+        if not usage:
+            return {}
+
+        # Convert Bedrock's token count format to match OpenAI's format
+        return {
+            "prompt_tokens": usage.get("inputTokens", 0),
+            "completion_tokens": usage.get("outputTokens", 0),
+            "total_tokens": usage.get("totalTokens", 0),
+        }

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock-converse"
 readme = "README.md"
-version = "0.4.8"
+version = "0.4.9"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

While testing us.amazon.nova-pro-v1:0 with BedrockConverse, the token counts were not being sent to our instrumentation tool. This adds them to some of the methods of BedrockConverse. I was not able to add this to streamable methods.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
