### PR TITLE
update ClipEmbedding deps

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-clip/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-clip/pyproject.toml
@@ -27,14 +27,10 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-clip"
 readme = "README.md"
-version = "0.3.1"
+version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-torch = "^2.1.2"
-pillow = "^10.2.0"
-torchvision = "^0.17.0"
-ftfy = "^6.1.3"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/18162

While clip can't be in the pyproject.toml (since pypi blocks installs from git), we can remove the other deps, since clip already manages its own deps