### PR TITLE
Replace deprecated predict with invoke in llama-index-llms-langchain

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-langchain/llama_index/llms/langchain/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-langchain/llama_index/llms/langchain/base.py
@@ -21,6 +21,7 @@ from llama_index.core.llms.llm import LLM
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode, Thread
 
 from langchain.base_language import BaseLanguageModel
+from langchain.schema import AIMessage
 
 
 class LangChainLLM(LLM):
@@ -103,7 +104,9 @@ class LangChainLLM(LLM):
         if not formatted:
             prompt = self.completion_to_prompt(prompt)
 
-        output_str = self._llm.predict(prompt, **kwargs)
+        output_str = self._llm.invoke(prompt, **kwargs)
+        if isinstance(output_str, AIMessage):
+            output_str = output_str.content
         return CompletionResponse(text=output_str)
 
     @llm_chat_callback()

--- a/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-langchain"
 readme = "README.md"
-version = "0.6.0"
+version = "0.6.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Currently, the module uses the obsolete `predict` function, which throws a deprication warning.  
These changes update it to the recommended `invoke` API. 

## New Package?

Not a new package.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
