### PR TITLE
fix: Optimize memory management of the Context object

### DIFF
--- a/llama-index-core/llama_index/core/workflow/checkpointer.py
+++ b/llama-index-core/llama_index/core/workflow/checkpointer.py
@@ -18,13 +18,13 @@ from llama_index.core.bridge.pydantic import (
     ConfigDict,
     Field,
 )
-from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.context_serializers import BaseSerializer, JsonSerializer
 from llama_index.core.workflow.errors import WorkflowStepDoesNotExistError
 from llama_index.core.workflow.events import Event
-from llama_index.core.workflow.handler import WorkflowHandler
 
 if TYPE_CHECKING:  # pragma: no cover
+    from .context import Context
+    from .handler import WorkflowHandler
     from .workflow import Workflow
 
 
@@ -35,7 +35,7 @@ class CheckpointCallback(Protocol):
         last_completed_step: Optional[str],
         input_ev: Optional[Event],
         output_ev: Optional[Event],
-        ctx: Context,
+        ctx: "Context",
     ) -> Awaitable[None]:
         ...
 
@@ -102,14 +102,14 @@ class WorkflowCheckpointer:
         except KeyError:
             pass
 
-    def run(self, **kwargs: Any) -> WorkflowHandler:
+    def run(self, **kwargs: Any) -> "WorkflowHandler":
         """Run the workflow with checkpointing."""
         return self.workflow.run(
             checkpoint_callback=self.new_checkpoint_callback_for_run(),
             **kwargs,
         )
 
-    def run_from(self, checkpoint: Checkpoint, **kwargs: Any) -> WorkflowHandler:
+    def run_from(self, checkpoint: Checkpoint, **kwargs: Any) -> "WorkflowHandler":
         """Run the attached workflow from the specified checkpoint."""
         return self.workflow.run_from(
             checkpoint=checkpoint,
@@ -130,7 +130,7 @@ class WorkflowCheckpointer:
             last_completed_step: Optional[str],
             input_ev: Optional[Event],
             output_ev: Optional[Event],
-            ctx: Context,
+            ctx: "Context",
         ) -> None:
             """Build a checkpoint around the last completed step."""
             if last_completed_step not in self.enabled_checkpoints:

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,11 +1,14 @@
 import asyncio
+import functools
 import json
+import time
 import uuid
 import warnings
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     DefaultDict,
     Dict,
     List,
@@ -16,10 +19,12 @@ from typing import (
     TypeVar,
 )
 
+from .checkpointer import CheckpointCallback
 from .context_serializers import BaseSerializer, JsonSerializer
 from .decorators import StepConfig
-from .errors import WorkflowRuntimeError
-from .events import Event
+from .errors import WorkflowCancelledByUser, WorkflowDone, WorkflowRuntimeError
+from .events import Event, InputRequiredEvent
+from .service import ServiceManager
 from .types import RunResultT
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -394,3 +399,205 @@ class Context:
         """Clear any data stored in the context."""
         # Clear the user data storage
         self._globals.clear()
+
+    async def shutdown(self) -> None:
+        """To be called when a workflow ends."""
+        self.is_running = False
+        # Cancel all running tasks
+        for task in self._tasks:
+            task.cancel()
+        # Wait for all tasks to complete
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+        # Clear all queues
+        for queue in self._queues.values():
+            while not queue.empty():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+        self._queues.clear()
+
+    def add_step_worker(
+        self,
+        name: str,
+        step: Callable,
+        config: StepConfig,
+        stepwise: bool,
+        verbose: bool,
+        checkpoint_callback: Optional[CheckpointCallback],
+        run_id: str,
+        service_manager: ServiceManager,
+    ):
+        self._tasks.add(
+            asyncio.create_task(
+                self._step_worker(
+                    name=name,
+                    step=step,
+                    config=config,
+                    stepwise=stepwise,
+                    verbose=verbose,
+                    checkpoint_callback=checkpoint_callback,
+                    run_id=run_id,
+                    service_manager=service_manager,
+                ),
+                name=name,
+            )
+        )
+
+    async def _step_worker(
+        self,
+        name: str,
+        step: Callable,
+        config: StepConfig,
+        stepwise: bool,
+        verbose: bool,
+        checkpoint_callback: Optional[CheckpointCallback],
+        run_id: str,
+        service_manager: ServiceManager,
+    ) -> None:
+        while True:
+            ev = await self._queues[name].get()
+            if type(ev) not in config.accepted_events:
+                continue
+
+            # do we need to wait for the step flag?
+            if stepwise:
+                await self._step_flags[name].wait()
+
+                # clear all flags so that we only run one step
+                for flag in self._step_flags.values():
+                    flag.clear()
+
+            if verbose and name != "_done":
+                print(f"Running step {name}")
+
+            # run step
+            kwargs: Dict[str, Any] = {}
+            if config.context_parameter:
+                kwargs[config.context_parameter] = self
+            for service_definition in config.requested_services:
+                service = service_manager.get(
+                    service_definition.name, service_definition.default_value
+                )
+                kwargs[service_definition.name] = service
+            kwargs[config.event_name] = ev
+
+            # wrap the step with instrumentation
+            instrumented_step = step
+
+            # - check if its async or not
+            # - if not async, run it in an executor
+            if asyncio.iscoroutinefunction(step):
+                retry_start_at = time.time()
+                attempts = 0
+                while True:
+                    await self.mark_in_progress(name=name, ev=ev)
+                    await self.add_running_step(name)
+                    try:
+                        new_ev = await instrumented_step(**kwargs)
+                        kwargs.clear()
+                        break  # exit the retrying loop
+                    except WorkflowDone:
+                        await self.remove_from_in_progress(name=name, ev=ev)
+                        raise
+                    except Exception as e:
+                        if config.retry_policy is None:
+                            raise WorkflowRuntimeError(
+                                f"Error in step '{name}': {e!s}"
+                            ) from e
+
+                        delay = config.retry_policy.next(
+                            retry_start_at + time.time(), attempts, e
+                        )
+                        if delay is None:
+                            # We're done retrying
+                            raise WorkflowRuntimeError(
+                                f"Error in step '{name}': {e!s}"
+                            ) from e
+
+                        attempts += 1
+                        if verbose:
+                            print(
+                                f"Step {name} produced an error, retry in {delay} seconds"
+                            )
+                        await asyncio.sleep(delay)
+                    finally:
+                        await self.remove_running_step(name)
+
+            else:
+                try:
+                    run_task = functools.partial(instrumented_step, **kwargs)
+                    kwargs.clear()
+                    new_ev = await asyncio.get_event_loop().run_in_executor(
+                        None, run_task
+                    )
+                except WorkflowDone:
+                    await self.remove_from_in_progress(name=name, ev=ev)
+                    raise
+                except Exception as e:
+                    raise WorkflowRuntimeError(f"Error in step '{name}': {e!s}") from e
+
+            if verbose and name != "_done":
+                if new_ev is not None:
+                    print(f"Step {name} produced event {type(new_ev).__name__}")
+                else:
+                    print(f"Step {name} produced no event")
+
+            # Store the accepted event for the drawing operations
+            if new_ev is not None:
+                self._accepted_events.append((name, type(ev).__name__))
+
+            # Fail if the step returned something that's not an event
+            if new_ev is not None and not isinstance(new_ev, Event):
+                msg = f"Step function {name} returned {type(new_ev).__name__} instead of an Event instance."
+                raise WorkflowRuntimeError(msg)
+
+            if stepwise:
+                async with self._step_condition:
+                    await self._step_condition.wait()
+
+                    if new_ev is not None:
+                        self.add_holding_event(new_ev)
+                    self._step_event_written.notify()  # shares same lock
+
+                    await self.remove_from_in_progress(name=name, ev=ev)
+
+                    # for stepwise Checkpoint after handler.run_step() call
+                    if checkpoint_callback:
+                        await checkpoint_callback(
+                            run_id=run_id,
+                            ctx=self,
+                            last_completed_step=name,
+                            input_ev=ev,
+                            output_ev=new_ev,
+                        )
+            else:
+                # for regular execution, Checkpoint just before firing the next event
+                await self.remove_from_in_progress(name=name, ev=ev)
+                if checkpoint_callback:
+                    await checkpoint_callback(
+                        run_id=run_id,
+                        ctx=self,
+                        last_completed_step=name,
+                        input_ev=ev,
+                        output_ev=new_ev,
+                    )
+
+                # InputRequiredEvent's are special case and need to be written to the stream
+                # this way, the user can access and respond to the event
+                if isinstance(new_ev, InputRequiredEvent):
+                    self.write_event_to_stream(new_ev)
+                elif new_ev is not None:
+                    self.send_event(new_ev)
+
+    def add_cancel_worker(self):
+        self._tasks.add(asyncio.create_task(self._cancel_worker()))
+
+    async def _cancel_worker(self) -> None:
+        try:
+            await self._cancel_flag.wait()
+            raise WorkflowCancelledByUser
+        except asyncio.CancelledError:
+            return

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -429,7 +429,7 @@ class Context:
         checkpoint_callback: Optional[CheckpointCallback],
         run_id: str,
         service_manager: ServiceManager,
-    ):
+    ) -> None:
         self._tasks.add(
             asyncio.create_task(
                 self._step_worker(
@@ -592,7 +592,7 @@ class Context:
                 elif new_ev is not None:
                     self.send_event(new_ev)
 
-    def add_cancel_worker(self):
+    def add_cancel_worker(self) -> None:
         self._tasks.add(asyncio.create_task(self._cancel_worker()))
 
     async def _cancel_worker(self) -> None:

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -392,7 +392,5 @@ class Context:
 
     def clear(self) -> None:
         """Clear any data stored in the context."""
-        # Re-init broker machinery
-        self._init_broker_data()
         # Clear the user data storage
-        self._globals = {}
+        self._globals.clear()

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -97,13 +97,7 @@ class WorkflowHandler(asyncio.Future[RunResultT]):
                     exception_raised = e
 
             if we_done:
-                # Remove any reference to the tasks
-                for t in self.ctx._tasks:
-                    t.cancel()
-                    await asyncio.sleep(0)
-
-                # the context is no longer running
-                self.ctx.is_running = False
+                await self.ctx.shutdown()
 
                 if exception_raised:
                     raise exception_raised

--- a/llama-index-core/llama_index/core/workflow/handler.py
+++ b/llama-index-core/llama_index/core/workflow/handler.py
@@ -1,5 +1,4 @@
 import asyncio
-import weakref
 from typing import Any, AsyncGenerator, List, Optional
 
 from llama_index.core.workflow.context import Context
@@ -20,15 +19,11 @@ class WorkflowHandler(asyncio.Future[RunResultT]):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.run_id = run_id
-        self._ctx = None
-        if ctx:
-            self._ctx = weakref.ref(ctx)
+        self._ctx = ctx
 
     @property
     def ctx(self) -> Optional[Context]:
-        if self._ctx is not None:
-            return self._ctx()
-        return None
+        return self._ctx
 
     def __str__(self) -> str:
         return str(self.result())

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -13,6 +13,7 @@ from typing import (
     Set,
     Tuple,
 )
+from weakref import WeakSet
 
 from llama_index.core.bridge.pydantic import ValidationError
 from llama_index.core.instrumentation import get_dispatcher
@@ -100,7 +101,7 @@ class Workflow(metaclass=WorkflowMeta):
             asyncio.Semaphore(num_concurrent_runs) if num_concurrent_runs else None
         )
         # Broker machinery
-        self._contexts: Set[Context] = set()
+        self._contexts: WeakSet[Context] = WeakSet()
         self._stepwise_context: Optional[Context] = None
         # Services management
         self._service_manager = service_manager or ServiceManager()

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -265,6 +265,7 @@ class Workflow(metaclass=WorkflowMeta):
                     checkpoint_callback=checkpoint_callback,
                     run_id=run_id,
                     service_manager=self._service_manager,
+                    dispatcher=dispatcher,
                 )
 
         # add dedicated cancel task

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -303,6 +303,7 @@ class Workflow(metaclass=WorkflowMeta):
                             await ctx.add_running_step(name)
                             try:
                                 new_ev = await instrumented_step(**kwargs)
+                                kwargs.clear()
                                 break  # exit the retrying loop
                             except WorkflowDone:
                                 await ctx.remove_from_in_progress(name=name, ev=ev)
@@ -334,6 +335,7 @@ class Workflow(metaclass=WorkflowMeta):
                     else:
                         try:
                             run_task = functools.partial(instrumented_step, **kwargs)
+                            kwargs.clear()
                             new_ev = await asyncio.get_event_loop().run_in_executor(
                                 None, run_task
                             )

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -1,7 +1,5 @@
 import asyncio
-import functools
 import logging
-import time
 import uuid
 import warnings
 from typing import (
@@ -257,168 +255,20 @@ class Workflow(metaclass=WorkflowMeta):
             ):
                 step_config.accepted_events.append(self._stop_event_class)
 
-            async def _task(
-                name: str,
-                queue: asyncio.Queue,
-                step: Callable,
-                config: StepConfig,
-            ) -> None:
-                while True:
-                    ev = await queue.get()
-                    if type(ev) not in config.accepted_events:
-                        continue
-
-                    # do we need to wait for the step flag?
-                    if stepwise:
-                        await ctx._step_flags[name].wait()
-
-                        # clear all flags so that we only run one step
-                        for flag in ctx._step_flags.values():
-                            flag.clear()
-
-                    if self._verbose and name != "_done":
-                        print(f"Running step {name}")
-
-                    # run step
-                    kwargs: Dict[str, Any] = {}
-                    if config.context_parameter:
-                        kwargs[config.context_parameter] = ctx
-                    for service_definition in config.requested_services:
-                        service = self._service_manager.get(
-                            service_definition.name, service_definition.default_value
-                        )
-                        kwargs[service_definition.name] = service
-                    kwargs[config.event_name] = ev
-
-                    # wrap the step with instrumentation
-                    instrumented_step = dispatcher.span(step)
-
-                    # - check if its async or not
-                    # - if not async, run it in an executor
-                    if asyncio.iscoroutinefunction(step):
-                        retry_start_at = time.time()
-                        attempts = 0
-                        while True:
-                            await ctx.mark_in_progress(name=name, ev=ev)
-                            await ctx.add_running_step(name)
-                            try:
-                                new_ev = await instrumented_step(**kwargs)
-                                kwargs.clear()
-                                break  # exit the retrying loop
-                            except WorkflowDone:
-                                await ctx.remove_from_in_progress(name=name, ev=ev)
-                                raise
-                            except Exception as e:
-                                if config.retry_policy is None:
-                                    raise WorkflowRuntimeError(
-                                        f"Error in step '{name}': {e!s}"
-                                    ) from e
-
-                                delay = config.retry_policy.next(
-                                    retry_start_at + time.time(), attempts, e
-                                )
-                                if delay is None:
-                                    # We're done retrying
-                                    raise WorkflowRuntimeError(
-                                        f"Error in step '{name}': {e!s}"
-                                    ) from e
-
-                                attempts += 1
-                                if self._verbose:
-                                    print(
-                                        f"Step {name} produced an error, retry in {delay} seconds"
-                                    )
-                                await asyncio.sleep(delay)
-                            finally:
-                                await ctx.remove_running_step(name)
-
-                    else:
-                        try:
-                            run_task = functools.partial(instrumented_step, **kwargs)
-                            kwargs.clear()
-                            new_ev = await asyncio.get_event_loop().run_in_executor(
-                                None, run_task
-                            )
-                        except WorkflowDone:
-                            await ctx.remove_from_in_progress(name=name, ev=ev)
-                            raise
-                        except Exception as e:
-                            raise WorkflowRuntimeError(
-                                f"Error in step '{name}': {e!s}"
-                            ) from e
-
-                    if self._verbose and name != "_done":
-                        if new_ev is not None:
-                            print(f"Step {name} produced event {type(new_ev).__name__}")
-                        else:
-                            print(f"Step {name} produced no event")
-
-                    # Store the accepted event for the drawing operations
-                    if new_ev is not None:
-                        ctx._accepted_events.append((name, type(ev).__name__))
-
-                    # Fail if the step returned something that's not an event
-                    if new_ev is not None and not isinstance(new_ev, Event):
-                        msg = f"Step function {name} returned {type(new_ev).__name__} instead of an Event instance."
-                        raise WorkflowRuntimeError(msg)
-
-                    if stepwise:
-                        async with ctx._step_condition:
-                            await ctx._step_condition.wait()
-
-                            if new_ev is not None:
-                                ctx.add_holding_event(new_ev)
-                            ctx._step_event_written.notify()  # shares same lock
-
-                            await ctx.remove_from_in_progress(name=name, ev=ev)
-
-                            # for stepwise Checkpoint after handler.run_step() call
-                            if checkpoint_callback:
-                                await checkpoint_callback(
-                                    run_id=run_id,
-                                    ctx=ctx,
-                                    last_completed_step=name,
-                                    input_ev=ev,
-                                    output_ev=new_ev,
-                                )
-                    else:
-                        # for regular execution, Checkpoint just before firing the next event
-                        await ctx.remove_from_in_progress(name=name, ev=ev)
-                        if checkpoint_callback:
-                            await checkpoint_callback(
-                                run_id=run_id,
-                                ctx=ctx,
-                                last_completed_step=name,
-                                input_ev=ev,
-                                output_ev=new_ev,
-                            )
-
-                        # InputRequiredEvent's are special case and need to be written to the stream
-                        # this way, the user can access and respond to the event
-                        if isinstance(new_ev, InputRequiredEvent):
-                            ctx.write_event_to_stream(new_ev)
-                        elif new_ev is not None:
-                            ctx.send_event(new_ev)
-
             for _ in range(step_config.num_workers):
-                ctx._tasks.add(
-                    asyncio.create_task(
-                        _task(name, ctx._queues[name], step_func, step_config),
-                        name=name,
-                    )
+                ctx.add_step_worker(
+                    name=name,
+                    step=step_func,
+                    config=step_config,
+                    stepwise=stepwise,
+                    verbose=self._verbose,
+                    checkpoint_callback=checkpoint_callback,
+                    run_id=run_id,
+                    service_manager=self._service_manager,
                 )
 
         # add dedicated cancel task
-        async def _cancel_workflow_task() -> None:
-            try:
-                await ctx._cancel_flag.wait()
-                raise WorkflowCancelledByUser
-            except asyncio.CancelledError:
-                return
-
-        ctx._tasks.add(
-            asyncio.create_task(_cancel_workflow_task(), name="cancel_workflow_task")
-        )
+        ctx.add_cancel_worker()
 
         return ctx, run_id
 
@@ -555,6 +405,7 @@ class Workflow(metaclass=WorkflowMeta):
             finally:
                 if self._sem:
                     self._sem.release()
+                await ctx.shutdown()
 
         asyncio.create_task(_run_workflow())
         return result
@@ -605,7 +456,9 @@ class Workflow(metaclass=WorkflowMeta):
 
         ctx.write_event_to_stream(ev)
 
-        # Signal we want to stop the workflow
+        # Signal we want to stop the workflow. Since we're about to raise, delete
+        # the reference to ctx explicitly to avoid it becoming dangling
+        del ctx
         raise WorkflowDone
 
     def _validate(self) -> bool:

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -597,7 +597,7 @@ class Workflow(metaclass=WorkflowMeta):
         """Checks if the workflow is done."""
         return self._stepwise_context is None
 
-    @step
+    @step(num_workers=1)
     async def _done(self, ctx: Context, ev: StopEvent) -> None:
         """Tears down the whole workflow and stop execution."""
         if self._stop_event_class is StopEvent:

--- a/llama-index-core/llama_index/core/workflow/workflow.py
+++ b/llama-index-core/llama_index/core/workflow/workflow.py
@@ -408,19 +408,17 @@ class Workflow(metaclass=WorkflowMeta):
                     )
                 )
 
-            # add dedicated cancel task
-            async def _cancel_workflow_task() -> None:
-                try:
-                    await ctx._cancel_flag.wait()
-                    raise WorkflowCancelledByUser
-                except asyncio.CancelledError:
-                    return
+        # add dedicated cancel task
+        async def _cancel_workflow_task() -> None:
+            try:
+                await ctx._cancel_flag.wait()
+                raise WorkflowCancelledByUser
+            except asyncio.CancelledError:
+                return
 
-            ctx._tasks.add(
-                asyncio.create_task(
-                    _cancel_workflow_task(), name="cancel_workflow_task"
-                )
-            )
+        ctx._tasks.add(
+            asyncio.create_task(_cancel_workflow_task(), name="cancel_workflow_task")
+        )
 
         return ctx, run_id
 

--- a/llama-index-core/tests/workflow/test_handler.py
+++ b/llama-index-core/tests/workflow/test_handler.py
@@ -14,7 +14,6 @@ def test_str():
 @pytest.mark.asyncio()
 async def test_stream_no_context():
     h = WorkflowHandler()
-    h.ctx = None
     with pytest.raises(ValueError, match="Context is not set!"):
         async for ev in h.stream_events():
             pass
@@ -23,7 +22,6 @@ async def test_stream_no_context():
 @pytest.mark.asyncio()
 async def test_run_step_no_context():
     h = WorkflowHandler()
-    h.ctx = None
     with pytest.raises(
         ValueError,
         match="Context must be set to run a workflow step-wise!",

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -145,6 +145,7 @@ async def test_resume_streams():
     async for _ in handler_1.stream_events():
         pass
     await handler_1
+    assert handler_1.ctx
 
     handler_2 = wf.run(ctx=handler_1.ctx)
     async for _ in handler_2.stream_events():

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/BUILD
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    dependencies=["llama-index-core:poetry#pillow"]
+)

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vertex/tests/BUILD
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vertex/tests/BUILD
@@ -1,1 +1,3 @@
-python_tests()
+python_tests(
+    dependencies=["llama-index-core:poetry#pillow"]
+)


### PR DESCRIPTION
# Description

This PR contains several optimizations to better manage references to the Context and make sure instances release memory when they go out of scope, without waiting for the gc to stop the world and collect.

Notes: 
- to ease reviewing, each optimization lives in its own commit.
- the dispatcher setup was removed initially to avoid noise, I re-introduced it in the last commit
- Initially I tried making the ref to the Context in WorkflowHandler a weakref, but forgot that we want to support resume and we want `hander.ctx` to survive its workflow run, so I reverted to storing a regular ref.

Fixes #18107

This is the example from the original issue, running with 1000 iterations without manually cleaning the context with the code in this branch (the example code allocates a 1M items list for 1k times fragmenting like crazy, you can ignore the blue line):

<img width="1079" alt="immagine" src="https://github.com/user-attachments/assets/582750b2-c86d-4642-87c2-c87b37e469ef" />
