### PR TITLE
Fix `api_base` parameter in AzureOpenAIEmbedding class

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -70,6 +70,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
         additional_kwargs: Optional[Dict[str, Any]] = None,
         api_key: Optional[str] = None,
         api_version: Optional[str] = None,
+        api_base: Optional[str] = None,
         # azure specific
         azure_endpoint: Optional[str] = None,
         azure_deployment: Optional[str] = None,
@@ -89,6 +90,10 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             "azure_endpoint", azure_endpoint, "AZURE_OPENAI_ENDPOINT", ""
         )
 
+        # OpenAI base_url and azure_endpoint are mutually exclusive
+        if api_base:
+            azure_endpoint = None
+
         azure_deployment = resolve_from_aliases(
             azure_deployment,
             deployment_name,
@@ -101,6 +106,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             additional_kwargs=additional_kwargs,
             api_key=api_key,
             api_version=api_version,
+            api_base=api_base,
             azure_endpoint=azure_endpoint,
             azure_deployment=azure_deployment,
             azure_ad_token_provider=azure_ad_token_provider,
@@ -162,6 +168,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             "azure_ad_token_provider": self.azure_ad_token_provider,
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
+            "base_url": self.api_base,
             "api_version": self.api_version,
             "default_headers": self.default_headers,
             "http_client": self._async_http_client if is_async else self._http_client,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-azure-openai"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Building #18186 and similar to #17996, I noticed that the `api_base` parameter was not being passed down to `AzureOpenAI` in the `_get_credential_kwargs(...)` method. 

This PR adds `api_base` to the `AzureOpenAIEmbedding` class, enabling it to pass fully customized URLs to `AzureOpenAI`. Previously, URLs were automatically constructed using `deployment_endpoint` and `deployment_name` in the format:  

```
https://<deployment_endpoint>/openai/deployments/
```  

With this change, users can provide non-standard URLs, such as those leveraging an API Gateway proxy, expanding the flexibility of endpoint configurations.


Fixes #18186

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
