### PR TITLE
Update to SentenceTransformersFinetuneEngine to expose transformer checkpoint related arguments

### DIFF
--- a/llama-index-finetuning/llama_index/finetuning/embeddings/sentence_transformer.py
+++ b/llama-index-finetuning/llama_index/finetuning/embeddings/sentence_transformer.py
@@ -1,4 +1,5 @@
 """Sentence Transformer Finetuning Engine."""
+import os
 
 from typing import Any, Optional
 
@@ -15,7 +16,7 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
 
     def __init__(
         self,
-        dataset: EmbeddingQAFinetuneDataset,
+        dataset: EmbeddingQAFinetuneDataset, 
         model_id: str = "BAAI/bge-small-en",
         model_output_path: str = "exp_finetune",
         batch_size: int = 10,
@@ -27,6 +28,10 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         use_all_docs: bool = False,
         trust_remote_code: bool = False,
         device: Optional[Any] = None,
+        save_checkpoints: bool = False,
+        resume_from_checkpoint: bool = False,
+        checkpoint_save_steps: int = 500,
+        checkpoint_save_total_limit: int = 0, 
     ) -> None:
         """Init params."""
         from sentence_transformers import InputExample, SentenceTransformer, losses
@@ -77,6 +82,11 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         self.evaluation_steps = evaluation_steps
         self.warmup_steps = int(len(self.loader) * epochs * 0.1)
 
+        self.checkpoint_path =  os.path.join("checkpoints", model_output_path) if save_checkpoints else None
+        self.resume_from_checkpoint = resume_from_checkpoint
+        self.checkpoint_save_steps = checkpoint_save_steps
+        self.checkpoint_save_total_limit = checkpoint_save_total_limit
+
     def finetune(self, **train_kwargs: Any) -> None:
         """Finetune model."""
         self.model.fit(
@@ -87,6 +97,10 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
             show_progress_bar=self.show_progress_bar,
             evaluator=self.evaluator,
             evaluation_steps=self.evaluation_steps,
+            checkpoint_path= self.checkpoint_path,
+            resume_from_checkpoint = self.resume_from_checkpoint,
+            checkpoint_save_steps = self.checkpoint_save_steps,
+            checkpoint_save_total_limit = self.checkpoint_save_total_limit,
         )
 
     def get_finetuned_model(self, **model_kwargs: Any) -> BaseEmbedding:

--- a/llama-index-finetuning/llama_index/finetuning/embeddings/sentence_transformer.py
+++ b/llama-index-finetuning/llama_index/finetuning/embeddings/sentence_transformer.py
@@ -1,13 +1,10 @@
 """Sentence Transformer Finetuning Engine."""
 import os
-
 from typing import Any, Optional
 
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.embeddings.utils import resolve_embed_model
-from llama_index.finetuning.embeddings.common import (
-    EmbeddingQAFinetuneDataset,
-)
+from llama_index.finetuning.embeddings.common import EmbeddingQAFinetuneDataset
 from llama_index.finetuning.types import BaseEmbeddingFinetuneEngine
 
 
@@ -16,7 +13,7 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
 
     def __init__(
         self,
-        dataset: EmbeddingQAFinetuneDataset, 
+        dataset: EmbeddingQAFinetuneDataset,
         model_id: str = "BAAI/bge-small-en",
         model_output_path: str = "exp_finetune",
         batch_size: int = 10,
@@ -31,7 +28,7 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         save_checkpoints: bool = False,
         resume_from_checkpoint: bool = False,
         checkpoint_save_steps: int = 500,
-        checkpoint_save_total_limit: int = 0, 
+        checkpoint_save_total_limit: int = 0,
     ) -> None:
         """Init params."""
         from sentence_transformers import InputExample, SentenceTransformer, losses
@@ -82,7 +79,9 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
         self.evaluation_steps = evaluation_steps
         self.warmup_steps = int(len(self.loader) * epochs * 0.1)
 
-        self.checkpoint_path =  os.path.join("checkpoints", model_output_path) if save_checkpoints else None
+        self.checkpoint_path = (
+            os.path.join("checkpoints", model_output_path) if save_checkpoints else None
+        )
         self.resume_from_checkpoint = resume_from_checkpoint
         self.checkpoint_save_steps = checkpoint_save_steps
         self.checkpoint_save_total_limit = checkpoint_save_total_limit
@@ -97,10 +96,10 @@ class SentenceTransformersFinetuneEngine(BaseEmbeddingFinetuneEngine):
             show_progress_bar=self.show_progress_bar,
             evaluator=self.evaluator,
             evaluation_steps=self.evaluation_steps,
-            checkpoint_path= self.checkpoint_path,
-            resume_from_checkpoint = self.resume_from_checkpoint,
-            checkpoint_save_steps = self.checkpoint_save_steps,
-            checkpoint_save_total_limit = self.checkpoint_save_total_limit,
+            checkpoint_path=self.checkpoint_path,
+            resume_from_checkpoint=self.resume_from_checkpoint,
+            checkpoint_save_steps=self.checkpoint_save_steps,
+            checkpoint_save_total_limit=self.checkpoint_save_total_limit,
         )
 
     def get_finetuned_model(self, **model_kwargs: Any) -> BaseEmbedding:

--- a/llama-index-finetuning/pyproject.toml
+++ b/llama-index-finetuning/pyproject.toml
@@ -25,7 +25,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-finetuning"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION


# Description

Exposes checkpoint_save_steps, checkpoint_save_total_limit and resume_from_checkpoint parameters from SentenceTransformers to allow for saving of checkpoints and resuming of checkpoint. The only dependency that is necessary for this change is os. My motivation for this change is either a faulty PSU or some mismatched RAM sticks, because those were the things cutting off a 10+ hour fine-tuning session that was otherwise going smoothly.

I noticed the ability to save checkpoints was already present in the library that SentenceTransformersFinetuneEngine uses and was pleased to see that it worked too!

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Potentially insofar as it adds new parameters that can be useful to people who are fine-tuning.

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

I do not believe unit testing is applicable as the functionality that is added by this PR is through exposing arguments in a function defined in another library
https://github.com/UKPLab/sentence-transformers/pull/3269

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I ran `make format; make lint` to appease the lint gods (and accidentally did it from the project root)
