### PR TITLE
feat:add Bedrock application inference profile support

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/__init__.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/__init__.py
@@ -3,5 +3,11 @@ from llama_index.llms.bedrock.base import (
     completion_response_to_chat_response,
     completion_with_retry,
 )
+from llama_index.llms.bedrock.utils import ProviderType
 
-__all__ = ["Bedrock", "completion_with_retry", "completion_response_to_chat_response"]
+__all__ = [
+    "Bedrock",
+    "completion_with_retry",
+    "completion_response_to_chat_response",
+    "ProviderType",
+]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
@@ -32,8 +32,10 @@ from llama_index.llms.bedrock.utils import (
     CHAT_ONLY_MODELS,
     STREAMING_MODELS,
     Provider,
+    ProviderType,
     completion_with_retry,
     get_provider,
+    get_provider_by_type,
 )
 
 
@@ -143,12 +145,13 @@ class Bedrock(LLM):
         guardrail_identifier: Optional[str] = None,
         guardrail_version: Optional[str] = None,
         trace: Optional[str] = None,
+        provider_type: Optional[ProviderType] = None,
         **kwargs: Any,
     ) -> None:
         if context_size is None and model not in BEDROCK_FOUNDATION_LLMS:
             raise ValueError(
                 "`context_size` argument not provided and"
-                "model provided refers to a non-foundation model."
+                " model provided refers to a non-foundation model."
                 " Please specify the context_size"
             )
 
@@ -209,7 +212,10 @@ class Bedrock(LLM):
             guardrail_version=guardrail_version,
             trace=trace,
         )
-        self._provider = get_provider(model)
+        if provider_type is not None:
+            self._provider = get_provider_by_type(provider_type)
+        else:
+            self._provider = get_provider(model)
         self.messages_to_prompt = (
             messages_to_prompt
             or self._provider.messages_to_prompt

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Feature Description

This feature aims to add support for Application Inference Profiles in Bedrock within llama_index.


Fixes # [(issue)](https://github.com/run-llama/llama_index/issues/18189)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
