### PR TITLE
Fix `api_base` and `azure_deployment` mutually exclusive in AzureOpenAIEmbedding class

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -168,7 +168,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             "azure_ad_token_provider": self.azure_ad_token_provider,
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
-            "base_url": self.api_base,
+            "base_url": self.api_base if not self.azure_endpoint else None,
             "api_version": self.api_version,
             "default_headers": self.default_headers,
             "http_client": self._async_http_client if is_async else self._http_client,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py
@@ -15,6 +15,7 @@ from llama_index.embeddings.openai import (
     OpenAIEmbeddingMode,
     OpenAIEmbeddingModelType,
 )
+from llama_index.embeddings.openai.utils import DEFAULT_OPENAI_API_BASE
 from llama_index.llms.azure_openai.utils import (
     resolve_from_aliases,
     refresh_openai_azuread_token,
@@ -120,6 +121,10 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             **kwargs,
         )
 
+        # reset api_base to None if it is the default
+        if self.api_base == DEFAULT_OPENAI_API_BASE:
+            self.api_base = None
+
     @model_validator(mode="before")
     @classmethod
     def validate_env(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -168,7 +173,7 @@ class AzureOpenAIEmbedding(OpenAIEmbedding):
             "azure_ad_token_provider": self.azure_ad_token_provider,
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
-            "base_url": self.api_base if not self.azure_endpoint else None,
+            "base_url": self.api_base,
             "api_version": self.api_version,
             "default_headers": self.default_headers,
             "http_client": self._async_http_client if is_async else self._http_client,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-embeddings-azure-openai"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

As pointed out in https://github.com/run-llama/llama_index/pull/18191#issuecomment-2741724739, passing `"base_url": self.api_base` to `_get_credential_kwargs` introduces an issue.  

When `api_base` is not explicitly defined by the user, the following code sets it to `DEFAULT_OPENAI_API_BASE`:  

https://github.com/run-llama/llama_index/blob/fc03a7a784321987ae7f56e9db531d97495e9dc9/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/utils.py#L93

Before #18191, the `api_base` parameter was also set to the default value, but since it wasn’t included in `_get_credential_kwargs`, it was not passed to `AzureOpenAI`. As a result, it's constructor left it as `None`.  

However, after #18191 introduced the change to pass `api_base` down, a new issue arose: if the user defines `azure_endpoint` but does not specify `api_base`, the above code also sets `api_base = DEFAULT_OPENAI_API_BASE`. Consequently, both `azure_endpoint` and `api_base` are passed, triggering the error:  

> `base_url and azure_endpoint are mutually exclusive`  

This means that even when the user only sets `azure_endpoint`, they encounter this error.  

Fixes https://github.com/run-llama/llama_index/issues/18223

## Solution

This solution appears to be the simplest way to resolve the issue, as it preserves the existing behavior while introducing the new feature without modifying other framework packages. 

With this approach, either `azure_endpoint` is passed while `base_url` is passed as `None`, or `base_url` is passed with `azure_endpoint` explicitly set to `None`, as introduced in #18191.

https://github.com/run-llama/llama_index/blob/fc03a7a784321987ae7f56e9db531d97495e9dc9/llama-index-integrations/embeddings/llama-index-embeddings-azure-openai/llama_index/embeddings/azure_openai/base.py#L93-L95


Fixes #18191, https://github.com/run-llama/llama_index/pull/18191#issuecomment-2741724739, #18186

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
