### PR TITLE
fix: support anyof, optional and union in google-genai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -369,7 +369,9 @@ class GoogleGenAI(FunctionCallingLLM):
         tool_declarations = []
         for tool in tools:
             if tool.metadata.fn_schema:
-                function_declaration = convert_schema_to_function_declaration(tool)
+                function_declaration = convert_schema_to_function_declaration(
+                    self._client, tool
+                )
                 tool_declarations.append(function_declaration)
 
         if isinstance(user_msg, str):

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -119,8 +119,9 @@ class GoogleGenAI(FunctionCallingLLM):
         # API keys are optional. The API can be authorised via OAuth (detected
         # environmentally) or by the GOOGLE_API_KEY environment variable.
         api_key = api_key or os.getenv("GOOGLE_API_KEY", None)
-        vertexai = vertexai_config is not None or os.getenv(
-            "GOOGLE_GENAI_USE_VERTEXAI", False
+        vertexai = (
+            vertexai_config is not None
+            or os.getenv("GOOGLE_GENAI_USE_VERTEXAI", "false") != "false"
         )
         project = (vertexai_config or {}).get("project") or os.getenv(
             "GOOGLE_CLOUD_PROJECT", None

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -8,6 +8,8 @@ from typing import (
 import typing
 
 import google.genai.types as types
+import google.genai
+from google.genai import _transformers
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
@@ -152,70 +154,18 @@ def chat_message_to_gemini(message: ChatMessage) -> types.Content:
     )
 
 
-def convert_schema_to_function_declaration(tool: "BaseTool"):
-    """
-    Converts a tool's JSON schema into a function declaration.
-    Handles $ref resolution and nested property structures.
-    """
-
-    def resolve_ref(schema_dict, ref_path):
-        """
-        Resolves a $ref in the schema by navigating the reference path.
-        """
-        if not ref_path.startswith("#/$defs/"):
-            raise ValueError(f"Unsupported reference format: {ref_path}")
-
-        ref_parts = ref_path[8:].split("/")  # Remove '#/$defs/' and split
-        current = schema_dict["$defs"]
-        for part in ref_parts:
-            current = current[part]
-        return current
-
-    def process_property(prop_schema, schema_dict):
-        """
-        Processes a property schema, handling references and nested structures.
-        Returns a Schema object.
-        """
-        if "$ref" in prop_schema:
-            resolved_schema = resolve_ref(schema_dict, prop_schema["$ref"])
-            return process_property(resolved_schema, schema_dict)
-
-        prop_type = prop_schema["type"].upper()
-        description = prop_schema.get("description", "")
-        schema_args = {
-            "type": getattr(types.Type, prop_type),
-            "description": description,
-        }
-
-        if prop_type == "OBJECT":
-            if "properties" in prop_schema:
-                schema_args["properties"] = {
-                    name: process_property(nested_prop, schema_dict)
-                    for name, nested_prop in prop_schema["properties"].items()
-                }
-                schema_args["required"] = prop_schema.get("required", [])
-
-        elif prop_type == "ARRAY" and "items" in prop_schema:
-            schema_args["items"] = process_property(prop_schema["items"], schema_dict)
-
-        return types.Schema(**schema_args)
-
+def convert_schema_to_function_declaration(
+    client: google.genai.client, tool: "BaseTool"
+):
     if not tool.metadata.fn_schema:
         raise ValueError("fn_schema is missing")
 
     # Get the JSON schema
     json_schema = tool.metadata.fn_schema.model_json_schema()
 
-    # Create the root schema
     if json_schema.get("properties"):
-        root_schema = types.Schema(
-            type=types.Type.OBJECT,
-            required=json_schema.get("required", []),
-            properties={
-                name: process_property(prop_schema, json_schema)
-                for name, prop_schema in json_schema["properties"].items()
-            },
-        )
+        _transformers.process_schema(json_schema, client)
+        root_schema = json_schema
     else:
         root_schema = None
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-google-genai"
 readme = "README.md"
-version = "0.1.4"
+version = "0.1.5"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1,4 +1,6 @@
 import asyncio
+from datetime import datetime
+from enum import Enum
 import os
 from typing import List, Optional, Union
 
@@ -22,6 +24,14 @@ from llama_index.llms.google_genai import GoogleGenAI
 from llama_index.llms.google_genai.utils import convert_schema_to_function_declaration
 
 
+SKIP_GEMINI = (
+    os.environ.get("GOOGLE_API_KEY") is None
+    or os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "false") == "true"
+)
+
+SKIP_VERTEXAI = os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "false") == "false"
+
+
 class Poem(BaseModel):
     content: str
 
@@ -41,9 +51,7 @@ class Schema(BaseModel):
     tables: List[Table] = Field(description="List of random Table objects")
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_complete_and_acomplete() -> None:
     """Test both sync and async complete methods."""
     llm = GoogleGenAI(
@@ -64,9 +72,7 @@ def test_complete_and_acomplete() -> None:
     assert len(async_response.text) > 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_chat_and_achat() -> None:
     """Test both sync and async chat methods."""
     llm = GoogleGenAI(
@@ -87,9 +93,7 @@ def test_chat_and_achat() -> None:
     assert async_response.message.content and len(async_response.message.content) > 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_stream_chat_and_astream_chat() -> None:
     """Test both sync and async stream chat methods."""
     llm = GoogleGenAI(
@@ -116,9 +120,7 @@ def test_stream_chat_and_astream_chat() -> None:
     assert all(isinstance(chunk.message.content, str) for chunk in async_chunks)
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_stream_complete_and_astream_complete() -> None:
     """Test both sync and async stream complete methods."""
     llm = GoogleGenAI(
@@ -145,9 +147,7 @@ def test_stream_complete_and_astream_complete() -> None:
     assert all(isinstance(chunk.text, str) for chunk in async_chunks)
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_simple_astructured_predict() -> None:
     """Test async structured prediction with a simple schema."""
     llm = GoogleGenAI(
@@ -168,9 +168,7 @@ def test_simple_astructured_predict() -> None:
     assert len(response.content) > 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_simple_stream_structured_predict() -> None:
     """Test stream structured prediction with a simple schema."""
     llm = GoogleGenAI(
@@ -193,9 +191,7 @@ def test_simple_stream_structured_predict() -> None:
     assert len(result.content) > 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_simple_astream_structured_predict() -> None:
     """Test async stream structured prediction with a simple schema."""
     llm = GoogleGenAI(
@@ -221,9 +217,7 @@ def test_simple_astream_structured_predict() -> None:
     asyncio.run(run())
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_simple_structured_predict() -> None:
     """Test structured prediction with a simple schema."""
     llm = GoogleGenAI(
@@ -242,9 +236,7 @@ def test_simple_structured_predict() -> None:
     assert len(response.content) > 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_complex_structured_predict() -> None:
     """Test structured prediction with a complex nested schema."""
     llm = GoogleGenAI(
@@ -264,11 +256,8 @@ def test_complex_structured_predict() -> None:
     assert all(len(table.columns) > 0 for table in response.tables)
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
-def test_anyof_structured_predict() -> None:
-    """Test anyof with a complex nested schema."""
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
+def test_anyof_optional_structured_predict() -> None:
     llm = GoogleGenAI(
         model="models/gemini-2.0-flash-001",
         api_key=os.environ["GOOGLE_API_KEY"],
@@ -287,9 +276,7 @@ def test_anyof_structured_predict() -> None:
     assert isinstance(response.first_name, None | str)
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_as_structured_llm() -> None:
     llm = GoogleGenAI(
         model="models/gemini-2.0-flash-001",
@@ -314,9 +301,7 @@ def test_as_structured_llm() -> None:
     assert len(schema_response.raw.tables) > 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_as_structured_llm_async() -> None:
     llm = GoogleGenAI(
         model="models/gemini-2.0-flash-001",
@@ -345,9 +330,7 @@ def test_as_structured_llm_async() -> None:
     assert len(schema_response.raw.tables) > 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_as_structure_llm_with_config() -> None:
     llm = GoogleGenAI(
         model="models/gemini-2.0-flash-001",
@@ -377,9 +360,7 @@ def test_as_structure_llm_with_config() -> None:
     assert isinstance(response, Poem)
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_structured_predict_multiple_block() -> None:
     chat_messages = [
         ChatMessage(
@@ -407,9 +388,7 @@ def test_structured_predict_multiple_block() -> None:
     assert "wiki" in support.answer.lower()
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_get_tool_calls_from_response() -> None:
     def add(a: int, b: int) -> int:
         """Add two integers and returns the result integer."""
@@ -433,9 +412,7 @@ def test_get_tool_calls_from_response() -> None:
     assert tool_calls[0].tool_kwargs == {"a": 2, "b": 3}
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_convert_llama_index_schema_to_gemini_function_declaration() -> None:
     """Test conversion of a llama_index schema to a gemini function declaration."""
     llm = GoogleGenAI(
@@ -465,9 +442,7 @@ def test_convert_llama_index_schema_to_gemini_function_declaration() -> None:
     assert converted.parameters
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_convert_llama_index_schema_to_gemini_function_declaration_nested_case() -> (
     None
 ):
@@ -497,9 +472,7 @@ def test_convert_llama_index_schema_to_gemini_function_declaration_nested_case()
     assert converted.parameters.required == ["schema_name", "tables"]
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_anyof_not_supported_gemini() -> None:
     class Content(BaseModel):
         content: Union[int, str]
@@ -514,8 +487,29 @@ def test_anyof_not_supported_gemini() -> None:
 
 
 @pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
+    SKIP_VERTEXAI,
+    reason="GOOGLE_GENAI_USE_VERTEXAI not set",
 )
+def test_anyof_supported_vertexai() -> None:
+    class Content(BaseModel):
+        content: Union[int, str]
+
+    llm = GoogleGenAI(
+        model="gemini-2.0-flash-001",
+    )
+    function_tool = get_function_tool(Content)
+    _ = convert_schema_to_function_declaration(llm._client, function_tool)
+
+    content = (
+        llm.as_structured_llm(output_cls=Content)
+        .complete(prompt="Generate a small content")
+        .raw
+    )
+    assert isinstance(content, Content)
+    assert isinstance(content.content, int | str)
+
+
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_default_value_not_supported_gemini() -> None:
     class ContentWithDefaultValue(BaseModel):
         content: str = Field(default="default_value")
@@ -530,7 +524,7 @@ def test_default_value_not_supported_gemini() -> None:
 
 
 @pytest.mark.skipif(
-    os.environ.get("GOOGLE_GENAI_USE_VERTEXAI") is None,
+    SKIP_VERTEXAI,
     reason="GOOGLE_GENAI_USE_VERTEXAI not set",
 )
 def test_default_value_supported_vertexai() -> None:
@@ -554,9 +548,7 @@ def test_default_value_supported_vertexai() -> None:
     assert isinstance(content, ContentWithDefaultValue)
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_optional_value_gemini() -> None:
     class OptionalContent(BaseModel):
         content: Optional[str] = Field(default=None)
@@ -577,9 +569,7 @@ def test_optional_value_gemini() -> None:
     assert decl.parameters.properties["content2"].default is None
 
 
-@pytest.mark.skipif(
-    os.environ.get("GOOGLE_API_KEY") is None, reason="GOOGLE_API_KEY not set"
-)
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_optional_lists_nested_gemini() -> None:
     class TextContent(BaseModel):
         text: str
@@ -639,3 +629,77 @@ def test_optional_lists_nested_gemini() -> None:
     )
     assert isinstance(blogpost, BlogPost)
     assert len(blogpost.contents) >= 3
+
+
+@pytest.mark.skipif(
+    SKIP_VERTEXAI,
+    reason="GOOGLE_GENAI_USE_VERTEXAI not set",
+)
+def test_optional_lists_nested_vertexai() -> None:
+    class Address(BaseModel):
+        street: str
+        city: str
+        country: str = Field(default="USA")
+
+    class ContactInfo(BaseModel):
+        email: str
+        phone: Optional[str] = None
+        address: Address
+
+    class Department(Enum):
+        ENGINEERING = "engineering"
+        MARKETING = "marketing"
+        SALES = "sales"
+        HR = "human_resources"
+
+    class Employee(BaseModel):
+        name: str
+        contact: ContactInfo
+        department: Department
+        hire_date: datetime
+
+    class Company(BaseModel):
+        name: str
+        founded_year: int
+        website: str
+        employees: List[Employee]
+        headquarters: Address
+
+    llm = GoogleGenAI(
+        model="gemini-2.0-flash-001",
+    )
+
+    function_tool = get_function_tool(Company)
+    converted = convert_schema_to_function_declaration(llm._client, function_tool)
+
+    assert converted.name == "Company"
+    assert converted.description is not None
+    assert converted.parameters.required is not None
+
+    assert list(converted.parameters.properties) == [
+        "name",
+        "founded_year",
+        "website",
+        "employees",
+        "headquarters",
+    ]
+
+    assert "name" in converted.parameters.required
+    assert "founded_year" in converted.parameters.required
+    assert "website" in converted.parameters.required
+    assert "employees" in converted.parameters.required
+    assert "headquarters" in converted.parameters.required
+
+    # call the model and check the output
+    company = (
+        llm.as_structured_llm(output_cls=Company)
+        .complete(prompt="Create a fake company with at least 3 employees")
+        .raw
+    )
+    assert isinstance(company, Company)
+
+    assert len(company.employees) >= 3
+    assert all(
+        employee.department in Department.__members__.values()
+        for employee in company.employees
+    )


### PR DESCRIPTION
# Description

When using Field that can be optional, the structured generation was crashing.

After looking a bit around, it seems that all this logic is implemented inside the GenAI package already. The files starts with an underscore (`_`) so we might not want to use it, but I think this could be much more resilient that re-implementing it again.

https://github.com/googleapis/python-genai/blob/e5bbb0e6b77f12e7e6877ae0e976fda3f8beb604/google/genai/_transformers.py#L520

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
