### PR TITLE
feat: improve data retrieval by adding headers with the columns

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/tabular/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/tabular/base.py
@@ -130,37 +130,42 @@ class PandasCSVReader(BaseReader):
 
 
 class PandasExcelReader(BaseReader):
-    r"""Pandas-based Excel parser.
-
-    Parses Excel files using the Pandas `read_excel`function.
-    If special parameters are required, use the `pandas_config` dict.
-
+    """Custom Excel parser that includes header names in each row.
+    
+    Parses Excel files using Pandas' `read_excel` function, but formats
+    each row to include the header name, for example: "name: joao, position: analyst".
+    The first row (header) is not included in the generated documents.
+    
     Args:
-        concat_rows (bool): whether to concatenate all rows into one document.
-            If set to False, a Document will be created for each row.
-            True by default.
-
-        sheet_name (str | int | None): Defaults to None, for all sheets, otherwise pass a str or int to specify the sheet to read.
-
+        concat_rows (bool): Determines whether to concatenate all rows into one document.
+            If set to False, one Document is created for each row.
+            Defaults to True.
+        sheet_name (str | int | None): Defaults to None, meaning all sheets.
+            Alternatively, pass a string or an integer to specify the sheet to be read.
+        field_separator (str): Character or string to separate each field. Default: ", ".
+        key_value_separator (str): Character or string to separate the key from the value. Default: ": ".
         pandas_config (dict): Options for the `pandas.read_excel` function call.
             Refer to https://pandas.pydata.org/docs/reference/api/pandas.read_excel.html
-            for more information.
-            Set to empty dict by default.
-
+            for more details.
+            Defaults to an empty dictionary.
     """
-
+    
     def __init__(
         self,
         *args: Any,
         concat_rows: bool = True,
         sheet_name=None,
+        field_separator: str = ", ",
+        key_value_separator: str = ": ",
         pandas_config: dict = {},
         **kwargs: Any
     ) -> None:
-        """Init params."""
+        """Initializes the parameters."""
         super().__init__(*args, **kwargs)
         self._concat_rows = concat_rows
         self._sheet_name = sheet_name
+        self._field_separator = field_separator
+        self._key_value_separator = key_value_separator
         self._pandas_config = pandas_config
 
     def load_data(
@@ -169,7 +174,7 @@ class PandasExcelReader(BaseReader):
         extra_info: Optional[Dict] = None,
         fs: Optional[AbstractFileSystem] = None,
     ) -> List[Document]:
-        """Parse file."""
+        """Parses the file."""
         openpyxl_spec = importlib.util.find_spec("openpyxl")
         if openpyxl_spec is not None:
             pass
@@ -177,25 +182,34 @@ class PandasExcelReader(BaseReader):
             raise ImportError(
                 "Please install openpyxl to read Excel files. You can install it with 'pip install openpyxl'"
             )
-
-        # sheet_name of None is all sheets, otherwise indexing starts at 0
+        
+        # A sheet_name of None means all sheets; otherwise, indexing starts at 0
         if fs:
             with fs.open(file) as f:
                 dfs = pd.read_excel(f, self._sheet_name, **self._pandas_config)
         else:
             dfs = pd.read_excel(file, self._sheet_name, **self._pandas_config)
-
+        
         documents = []
-
-        # handle the case where only a single DataFrame is returned
+        
+        # Handle the case where only a single DataFrame is returned
         if isinstance(dfs, pd.DataFrame):
             df = dfs.fillna("")
-
-            # Convert DataFrame to list of rows
-            text_list = (
-                df.astype(str).apply(lambda row: " ".join(row.values), axis=1).tolist()
-            )
-
+            # Get the headers/column names
+            headers = df.columns.tolist()
+            
+            # Convert the DataFrame into a list of rows formatted with header names
+            text_list = []
+            
+            # Start from index 0 to include all data rows
+            # The header is already in 'headers', not in the data rows
+            for _, row in df.iterrows():
+                # Format each row as "header1: value1, header2: value2, ..."
+                formatted_row = self._field_separator.join(
+                    [f"{header}{self._key_value_separator}{str(row[header])}" for header in headers]
+                )
+                text_list.append(formatted_row)
+            
             if self._concat_rows:
                 documents.append(
                     Document(text="\n".join(text_list), metadata=extra_info or {})
@@ -208,14 +222,18 @@ class PandasExcelReader(BaseReader):
                     ]
                 )
         else:
+            # Handle multiple sheets
             for df in dfs.values():
                 df = df.fillna("")
-
-                # Convert DataFrame to list of rows
-                text_list = (
-                    df.astype(str).apply(lambda row: " ".join(row), axis=1).tolist()
-                )
-
+                headers = df.columns.tolist()
+                
+                text_list = []
+                for _, row in df.iterrows():
+                    formatted_row = self._field_separator.join(
+                        [f"{header}{self._key_value_separator}{str(row[header])}" for header in headers]
+                    )
+                    text_list.append(formatted_row)
+                
                 if self._concat_rows:
                     documents.append(
                         Document(text="\n".join(text_list), metadata=extra_info or {})
@@ -227,5 +245,5 @@ class PandasExcelReader(BaseReader):
                             for text in text_list
                         ]
                     )
-
+        
         return documents

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -51,7 +51,7 @@ license = "MIT"
 maintainers = ["FarisHijazi", "Haowjy", "ephe-meral", "hursh-desai", "iamarunbrahma", "jon-chuang", "mmaatouk", "ravi03071991", "sangwongenip", "thejessezhang"]
 name = "llama-index-readers-file"
 readme = "README.md"
-version = "0.4.6"
+version = "0.4.7"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
By adding this change, we achieve improved information retrieval. For example, when we previously concatenated the document, the header and data were usually only present in the first chunk, so the model correctly understood the context there. However, in the subsequent chunks, the model lost track of what each column or row represented due to the cutoff. Now, by formatting the data as 'header: value', we provide additional context whether the lines are sent separately or concatenated. This is particularly beneficial for approaches like Text-to-SQL with PGVector, as it enables a straightforward way to process Excel files. Furthermore, we can extend this improvement to other tabular readers such as CSV, which currently has an issue where it skips the first line and needs to be updated.

### Example, each row as a document:

**Before:**


| Minecraft | 300,000,000 | Minecraft | Multi-platform| November 18, 2011[b] | Mojang Studios | Mojang Studios / Xbox Game Studios | 
| --------- | ----------- | --------- | ------------- | -------------------- | -------------- | ---------------------------------- |

**Now:**


| Title: Minecraft          | Sales: 300,000,000       | Series: Minecraft        | Platform(s): Multi-platform     | Initial release date: November 18, 2011[b] | Developer: Mojang Studios    | Publisher: Mojang Studios / Xbox Game Studios"
| --------- | ----------- | --------- | ------------- | -------------------- | -------------- | ---------------------------------- |

### Example, concatenated, sentence splitter
**Node 1:**

Title,Sales,Series,Platform(s),Initial release date,Developer(s)[a],Publisher(s)[a]   Minecraft,300,000,000,Minecraft,Multi-platform,November 18, 2011[b],Mojang Studios,Mojang Studios / Xbox Game Studios   Grand Theft Auto V,210,000,000,Grand Theft Auto,Multi-platform,September 17, 2013,Rockstar North,Rockstar Games   Wii Sports,82,900,000,Wii,Wii,November 19, 2006

**Node 2 (without headers, less data, not organized, incomprehensible):**

Nintendo EAD,Nintendo Ark: Survival Evolved,76,000,000,Ark,Multi-platform,August 29, 2017,Studio Wildcard,Studio Wildcard   Mario Kart 8 / Deluxe,75,810,000,Mario Kart,Wii U / Switch,May 29, 2014,Nintendo EAD / Nintendo EPD (Deluxe),Nintendo

### After
**just with Node 2:**

Developer: Nintendo EAD, Publisher: Nintendo, Title: Ark: Survival Evolved, Sales: 76,000,000, Series: Ark, Platform: Multi-platform, Initial release date: August 29, 2017, Developer: Studio Wildcard, Publisher: Studio Wildcard  
Title: Mario Kart 8 / Deluxe, Sales: 75,810,000, Series: Mario Kart, Platform(s): Wii U / Switch, Initial release date: May 29, 2014, Developer: Nintendo EAD / Nintendo EPD (Deluxe), Publisher: Nintendo

Reference data: https://en.wikipedia.org/wiki/List_of_best-selling_video_games

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
