### PR TITLE
Add extra scalar field collection function for MilvusVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -398,6 +398,18 @@ class MilvusVectorStore(BasePydanticVectorStore):
         """Get async client."""
         return self._async_milvusclient
 
+    def _scalar_field_collector(self, entry: Dict, node: BaseNode):
+        """Collect scalar field values"""
+        if self.scalar_field_names is None:
+            return entry
+        else:
+            for scalar_field_name in self.scalar_field_names:
+                if scalar_field_name == 'content':
+                    entry['content'] = node.get_content()
+                else:
+                    entry[scalar_field_name] = node.metadata.get(scalar_field_name)
+            return entry
+
     def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """Add the embeddings and their nodes into Milvus.
 
@@ -430,7 +442,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
                 for node, sparse_embedding in zip(nodes, sparse_embeddings)
             }
         for node in nodes:
-            entry = node_to_metadata_dict(node)
+            entry = self._scalar_field_collector(node_to_metadata_dict(node), node)
             entry[MILVUS_ID_FIELD] = node.node_id
             entry[self.embedding_field] = node.embedding
 
@@ -480,7 +492,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
                 for node, sparse_embedding in zip(nodes, sparse_embeddings)
             }
         for node in nodes:
-            entry = node_to_metadata_dict(node)
+            entry = self._scalar_field_collector(node_to_metadata_dict(node), node)
             entry[MILVUS_ID_FIELD] = node.node_id
             entry[self.embedding_field] = node.embedding
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.6.1"
+version = "0.6.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR implements the collection of extra scalar field values in MilvusVectorStore. The main improvements include:
﻿
1. Added the '_scalar_field_collector' method in MilvusVectorStore to collect additional scalar field values from metadata (the 'content' field uses the 'get_content' method).
2.  Call '_scalar_field_collector' in the 'add' and 'async_add' methods, save the collected results to the Milvus.
﻿
Fix # (No specific issues)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
