### PR TITLE
Fixed provider-resolution for `foundation-model` ARNs

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock/CHANGELOG.md
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG — llama-index-llms-bedrock
+
+## [0.3.8]
+
+- Fixed provider-resolution for `foundation-model` ARNs

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
@@ -297,7 +297,7 @@ def get_provider(model: str) -> Provider:
     if len(model_split) == 3:
         provider_name = model_split[1]
     # Handle foundation-model ARNs like
-    # 'arn:aws:bedrock:eu-central-1:143111710283:inference-profile/eu.meta.llama3-2-1b-instruct-v1:0'
+    # 'arn:aws:bedrock:us-east-2::foundation-model/meta.llama3-3-70b-instruct-v1:0'
     elif len(model_split) == 2 and "::foundation-model/" in provider_name:
         provider_name = provider_name.split("/")[-1]
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
@@ -289,17 +289,16 @@ def _get_provider_type_by_name(provider_name: str) -> ProviderType:
 
 def get_provider(model: str) -> Provider:
     """Get provider from model ID or ARN."""
-    model_split = model.split(".")
+    # Strip deployment info from ARN like arn:aws:bedrock:us-east-2::foundation-model/meta.llama3-3-70b-instruct-v1:0
+    model_name = model.split("/")[-1]
+
+    model_split = model_name.split(".")
     provider_name = model_split[0]
 
-    # Handle inference-profile ARNs like
+    # Handle region prefixes like
     # 'arn:aws:bedrock:eu-central-1:143111710283:inference-profile/eu.meta.llama3-2-1b-instruct-v1:0'
     if len(model_split) == 3:
         provider_name = model_split[1]
-    # Handle foundation-model ARNs like
-    # 'arn:aws:bedrock:us-east-2::foundation-model/meta.llama3-3-70b-instruct-v1:0'
-    elif len(model_split) == 2 and "::foundation-model/" in provider_name:
-        provider_name = provider_name.split("/")[-1]
 
     try:
         provider_type = _get_provider_type_by_name(provider_name)

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
@@ -288,11 +288,18 @@ def _get_provider_type_by_name(provider_name: str) -> ProviderType:
 
 
 def get_provider(model: str) -> Provider:
+    """Get provider from model ID or ARN."""
     model_split = model.split(".")
     provider_name = model_split[0]
 
+    # Handle inference-profile ARNs like
+    # 'arn:aws:bedrock:eu-central-1:143111710283:inference-profile/eu.meta.llama3-2-1b-instruct-v1:0'
     if len(model_split) == 3:
         provider_name = model_split[1]
+    # Handle foundation-model ARNs like
+    # 'arn:aws:bedrock:eu-central-1:143111710283:inference-profile/eu.meta.llama3-2-1b-instruct-v1:0'
+    elif len(model_split) == 2 and "::foundation-model/" in provider_name:
+        provider_name = provider_name.split("/")[-1]
 
     try:
         provider_type = _get_provider_type_by_name(provider_name)

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock"
 readme = "README.md"
-version = "0.3.7"
+version = "0.3.8"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_utils.py
@@ -1,0 +1,55 @@
+import pytest
+
+from llama_index.llms.bedrock.utils import (
+    get_provider,
+    MetaProvider,
+    MistralProvider,
+    AmazonProvider,
+    AnthropicProvider,
+    CohereProvider,
+    Ai21Provider,
+)
+
+
+@pytest.mark.parametrize(
+    ("model", "provider_cls"),
+    [
+        ("meta.llama3-3-70b-instruct-v1:0", MetaProvider),
+        (
+            "arn:aws:bedrock:us-east-2::foundation-model/meta.llama3-3-70b-instruct-v1:0",
+            MetaProvider,
+        ),
+        (
+            "arn:aws:bedrock:eu-central-1:143111710283:inference-profile/eu.meta.llama3-2-1b-instruct-v1:0",
+            MetaProvider,
+        ),
+        ("amazon.titan-text-express-v1", AmazonProvider),
+        (
+            "arn:aws:bedrock:eu-central-1:143111710283:inference-profile/eu.amazon.nova-lite-v1:0",
+            AmazonProvider,
+        ),
+        ("anthropic.claude-3-5-sonnet-20240620-v1:0", AnthropicProvider),
+        (
+            "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0",
+            AnthropicProvider,
+        ),
+        ("mistral.mistral-large-2402", MistralProvider),
+        (
+            "arn:aws:bedrock:eu-west-2::foundation-model/mistral.mistral-large-2402-v1:0",
+            MistralProvider,
+        ),
+        ("cohere.command-text-v14", CohereProvider),
+        (
+            "arn:aws:bedrock:us-east-1::foundation-model/cohere.command-text-v14",
+            CohereProvider,
+        ),
+        ("ai21.jamba-1-5-large-v1:0", Ai21Provider),
+        (
+            "arn:aws:bedrock:us-east-1::foundation-model/ai21.jamba-1-5-large-v1:0",
+            Ai21Provider,
+        ),
+    ],
+)
+def test_get_provider(model: str, provider_cls):
+    """Test that get_provider returns the expected provider class."""
+    assert isinstance(get_provider(model=model), provider_cls)


### PR DESCRIPTION
# Description

Fixes the AWS Bedrock provider-resolution where an Unknown Provider Error was thrown for `foundation-model` ARNs such as `arn:aws:bedrock:us-east-2::foundation-model/meta.llama3-3-70b-instruct-v1:0`.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
