### PR TITLE
Add deprecation message to Bedrock integration example

### DIFF
--- a/docs/docs/examples/llm/bedrock.ipynb
+++ b/docs/docs/examples/llm/bedrock.ipynb
@@ -19,6 +19,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4114707982a08d18",
+   "metadata": {},
+   "source": [
+    "**Deprecated**: Use [llama-index-llms-bedrock-converse](https://docs.llamaindex.ai/en/stable/examples/llm/bedrock_converse/) instead, the converse API is the recommended way to use Bedrock. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b007403c-6b7a-420c-92f1-4171d05ed9bb",
    "metadata": {},
    "source": [


### PR DESCRIPTION
# Description

I noticed in the code of the Bedrock LLM integration, that it was deprecated. I added this info to the example page, so users chose the correct integration immediately.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
