### PR TITLE
optimize initial imports

### DIFF
--- a/llama-index-core/llama_index/core/BUILD
+++ b/llama-index-core/llama_index/core/BUILD
@@ -1,4 +1,6 @@
-python_sources()
+python_sources(
+    dependencies=["llama-index-core:poetry#platformdirs"],
+)
 
 resource(
     name="py_typed",

--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -2,9 +2,6 @@ import re
 import string
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from nltk.corpus import stopwords
-from nltk.tokenize import word_tokenize
-
 from llama_index.core.node_parser.interface import NodeParser
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.callbacks.base import CallbackManager
@@ -16,7 +13,7 @@ from llama_index.core.node_parser.node_utils import (
 )
 from llama_index.core.node_parser.text.utils import split_by_sentence_tokenizer
 from llama_index.core.schema import BaseNode, Document, NodeRelationship
-from llama_index.core.utils import get_tqdm_iterable
+from llama_index.core.utils import get_tqdm_iterable, globals_helper
 
 DEFAULT_OG_TEXT_METADATA_KEY = "original_text"
 
@@ -59,7 +56,7 @@ class LanguageConfig:
                 "Spacy is not installed, please install it with `pip install spacy`."
             )
         self.nlp = spacy.load(self.spacy_model)  # type: ignore
-        self.stopwords = set(stopwords.words(self.language))  # type: ignore
+        self.stopwords = set(globals_helper.stopwords)  # type: ignore
 
 
 class SemanticDoubleMergingSplitterNodeParser(NodeParser):
@@ -394,7 +391,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
         # Remove punctuations
         text = text.translate(str.maketrans("", "", string.punctuation))
         # Remove stopwords
-        tokens = word_tokenize(text)
+        tokens = globals_helper.punkt_tokenizer.tokenize(text)
         filtered_words = [w for w in tokens if w not in self.language_config.stopwords]
 
         return " ".join(filtered_words)

--- a/llama-index-core/llama_index/core/node_parser/text/utils.py
+++ b/llama-index-core/llama_index/core/node_parser/text/utils.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Callable, List
 
 from llama_index.core.node_parser.interface import TextSplitter
+from llama_index.core.utils import globals_helper
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +80,9 @@ def split_by_sentence_tokenizer_internal(text: str, tokenizer: Any) -> List[str]
 
 
 def split_by_sentence_tokenizer() -> Callable[[str], List[str]]:
-    import nltk
-
-    tokenizer = nltk.tokenize.PunktSentenceTokenizer()
-    return lambda text: split_by_sentence_tokenizer_internal(text, tokenizer)
+    return lambda text: split_by_sentence_tokenizer_internal(
+        text, globals_helper.punkt_tokenizer
+    )
 
 
 def split_by_regex(regex: str) -> Callable[[str], List[str]]:

--- a/llama-index-core/llama_index/core/postprocessor/optimizer.py
+++ b/llama-index-core/llama_index/core/postprocessor/optimizer.py
@@ -9,6 +9,7 @@ from llama_index.core.indices.query.embedding_utils import get_top_k_embeddings
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
 from llama_index.core.settings import Settings
+from llama_index.core.utils import globals_helper
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +86,7 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
                 )
 
         if tokenizer_fn is None:
-            import nltk
-
-            tokenizer = nltk.tokenize.PunktSentenceTokenizer()
+            tokenizer = globals_helper.punkt_tokenizer
             tokenizer_fn = tokenizer.tokenize
         self._tokenizer_fn = tokenizer_fn
 

--- a/llama-index-core/llama_index/core/prompts/__init__.py
+++ b/llama-index-core/llama_index/core/prompts/__init__.py
@@ -10,6 +10,7 @@ from llama_index.core.prompts.base import (
     PromptType,
     SelectorPromptTemplate,
 )
+from llama_index.core.prompts.rich import RichPromptTemplate
 from llama_index.core.prompts.display_utils import display_prompt_dict
 
 __all__ = [
@@ -23,4 +24,5 @@ __all__ = [
     "ChatMessage",
     "MessageRole",
     "display_prompt_dict",
+    "RichPromptTemplate",
 ]

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -84,9 +84,9 @@ class GlobalsHelper:
 
             # Download punkt tokenizer
             try:
-                nltk_find("tokenizers/punkt", paths=[self._nltk_data_dir])
+                nltk_find("tokenizers/punkt_tab", paths=[self._nltk_data_dir])
             except LookupError:
-                download("punkt", download_dir=self._nltk_data_dir, quiet=True)
+                download("punkt_tab", download_dir=self._nltk_data_dir, quiet=True)
 
         except Exception as e:
             print(f"NLTK download error: {e}")

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -72,7 +72,7 @@ class GlobalsHelper:
         download_thread = threading.Thread(target=self._download_nltk_data, daemon=True)
         download_thread.start()
 
-    def _download_nltk_data(self):
+    def _download_nltk_data(self) -> None:
         """Download NLTK data packages in the background."""
         from nltk.data import find as nltk_find
         from nltk import download
@@ -96,7 +96,7 @@ class GlobalsHelper:
             # Signal that download is complete
             self._download_complete.set()
 
-    def _wait_for_download(self, resource: str):
+    def _wait_for_download(self, resource: str) -> None:
         """Wait for NLTK download to complete and check specific resource."""
         if self._download_complete is None:
             self.start_nltk_download()

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -50,8 +50,6 @@ class GlobalsHelper:
         """Initialize NLTK data download in a background thread."""
         from nltk.data import path as nltk_path
 
-        self._download_complete = threading.Event()
-
         # Set up NLTK data directory
         self._nltk_data_dir = os.environ.get(
             "NLTK_DATA",
@@ -99,10 +97,12 @@ class GlobalsHelper:
 
     def _wait_for_download(self, resource: str) -> None:
         """Wait for NLTK download to complete and check specific resource."""
-        if self._download_complete is not None:
+        if self._download_complete is None:
+            self._download_complete = threading.Event()
+
             self.start_nltk_download()
 
-        assert self._download_complete is not None
+        assert self._download_complete
 
         # Wait for download to complete with a timeout
         if not self._download_complete.wait(timeout=60):

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -50,6 +50,8 @@ class GlobalsHelper:
         """Initialize NLTK data download in a background thread."""
         from nltk.data import path as nltk_path
 
+        self._download_complete = threading.Event()
+
         # Set up NLTK data directory
         self._nltk_data_dir = os.environ.get(
             "NLTK_DATA",
@@ -74,8 +76,6 @@ class GlobalsHelper:
         """Download NLTK data packages in the background."""
         from nltk.data import find as nltk_find
         from nltk import download
-
-        self._download_complete = threading.Event()
 
         try:
             # Download stopwords

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -50,8 +50,6 @@ class GlobalsHelper:
         """Initialize NLTK data download in a background thread."""
         from nltk.data import path as nltk_path
 
-        self._download_complete = threading.Event()
-
         # Set up NLTK data directory
         self._nltk_data_dir = os.environ.get(
             "NLTK_DATA",
@@ -77,6 +75,8 @@ class GlobalsHelper:
         from nltk.data import find as nltk_find
         from nltk import download
 
+        self._download_complete = threading.Event()
+
         try:
             # Download stopwords
             try:
@@ -94,11 +94,12 @@ class GlobalsHelper:
             print(f"NLTK download error: {e}")
         finally:
             # Signal that download is complete
-            self._download_complete.set()
+            if self._download_complete is not None:
+                self._download_complete.set()
 
     def _wait_for_download(self, resource: str) -> None:
         """Wait for NLTK download to complete and check specific resource."""
-        if self._download_complete is None:
+        if self._download_complete is not None:
             self.start_nltk_download()
 
         assert self._download_complete is not None

--- a/llama-index-core/tests/BUILD
+++ b/llama-index-core/tests/BUILD
@@ -8,7 +8,8 @@ python_test_utils(
         "llama-index-core/tests/mock_utils/mock_text_splitter.py",
         "llama-index-core/tests/mock_utils/mock_prompts.py",
         "llama-index-core/tests/mock_utils/mock_utils.py",
-        "llama-index-core:poetry#eval-type-backport"
+        "llama-index-core:poetry#eval-type-backport",
+        "./llama-index-core:poetry#platformdirs",
     ],
 )
 

--- a/llama-index-core/tests/BUILD
+++ b/llama-index-core/tests/BUILD
@@ -9,7 +9,7 @@ python_test_utils(
         "llama-index-core/tests/mock_utils/mock_prompts.py",
         "llama-index-core/tests/mock_utils/mock_utils.py",
         "llama-index-core:poetry#eval-type-backport",
-        "./llama-index-core:poetry#platformdirs",
+        "llama-index-core:poetry#platformdirs",
     ],
 )
 


### PR DESCRIPTION
After some debugging, it seemed like even the act of importing NLTK causes a huge delay -- and this is before we even check the disk for files and possibly download

The solution here is
1. Make imports to nltk lazy
2. Make any downloads lazy and put them in a thread

Published under `llama-index-core==0.12.27a3`, you can install and see that the initial import goes from 30s to 8s -- a huge improvement

Here is the "before" flamegraph
![image](https://github.com/user-attachments/assets/bed89465-b99f-45f1-9bd1-e30cae50efbd)

And here is the "after"
![image](https://github.com/user-attachments/assets/920cd3dc-c615-4574-887e-f2cd1953fed9)

Obviously our codebase is still huge and is slowed by memory allocation and RAM speed. Other targets could be sqlalchemy imports but the impact is smaller.