### PR TITLE
type safe structured predict in overriden methods

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -540,7 +540,7 @@ class Gemini(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None, None]:
+    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -471,18 +471,17 @@ class Gemini(FunctionCallingLLM):
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self._is_function_call_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return super().structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
 
     @dispatcher.span
@@ -495,18 +494,17 @@ class Gemini(FunctionCallingLLM):
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self._is_function_call_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return await super().astructured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
 
     @dispatcher.span
@@ -519,18 +517,17 @@ class Gemini(FunctionCallingLLM):
     ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self._is_function_call_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return super().stream_structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
 
     @dispatcher.span
@@ -543,16 +540,15 @@ class Gemini(FunctionCallingLLM):
     ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self._is_function_call_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return await super().astream_structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -39,6 +39,7 @@ from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_ca
 from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.prompts import PromptTemplate
+from llama_index.core.program.utils import FlexibleModel
 from llama_index.core.utilities.gemini_utils import merge_neighboring_same_role_messages
 
 from .utils import (
@@ -64,7 +65,6 @@ GEMINI_MODELS = (
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
-    from llama_index.core.program.utils import FlexibleModel
 
 
 @deprecated.deprecated(
@@ -514,7 +514,7 @@ class Gemini(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
+    ) -> Generator[Union[Model, FlexibleModel], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 
@@ -537,7 +537,7 @@ class Gemini(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
+    ) -> AsyncGenerator[Union[Model, FlexibleModel], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 

--- a/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/llama_index/llms/gemini/base.py
@@ -7,11 +7,13 @@ import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncGenerator,
     Dict,
     Generator,
     List,
     Optional,
     Sequence,
+    Type,
     Union,
     cast,
 )
@@ -30,13 +32,13 @@ from llama_index.core.base.llms.types import (
     LLMMetadata,
     MessageRole,
 )
-from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.constants import DEFAULT_NUM_OUTPUTS, DEFAULT_TEMPERATURE
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.function_calling import FunctionCallingLLM
-from llama_index.core.llms.llm import ToolSelection
-from llama_index.core.types import Model
+from llama_index.core.llms.llm import ToolSelection, Model
+from llama_index.core.prompts import PromptTemplate
 from llama_index.core.utilities.gemini_utils import merge_neighboring_same_role_messages
 
 from .utils import (
@@ -62,6 +64,7 @@ GEMINI_MODELS = (
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
+    from llama_index.core.program.utils import FlexibleModel
 
 
 @deprecated.deprecated(
@@ -460,8 +463,12 @@ class Gemini(FunctionCallingLLM):
 
     @dispatcher.span
     def structured_predict(
-        self, *args: Any, llm_kwargs: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> BaseModel:
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -474,12 +481,18 @@ class Gemini(FunctionCallingLLM):
             )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
-        return super().structured_predict(*args, llm_kwargs=llm_kwargs, **kwargs)
+        return super().structured_predict(
+            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+        )
 
     @dispatcher.span
     async def astructured_predict(
-        self, *args: Any, llm_kwargs: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> BaseModel:
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -492,12 +505,18 @@ class Gemini(FunctionCallingLLM):
             )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
-        return await super().astructured_predict(*args, llm_kwargs=llm_kwargs, **kwargs)
+        return await super().astructured_predict(
+            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+        )
 
     @dispatcher.span
     def stream_structured_predict(
-        self, *args: Any, llm_kwargs: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> Generator[Union[Model, List[Model]], None, None]:
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -510,12 +529,18 @@ class Gemini(FunctionCallingLLM):
             )
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
-        return super().stream_structured_predict(*args, llm_kwargs=llm_kwargs, **kwargs)
+        return super().stream_structured_predict(
+            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+        )
 
     @dispatcher.span
     async def astream_structured_predict(
-        self, *args: Any, llm_kwargs: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> Generator[Union[Model, List[Model]], None, None]:
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -529,5 +554,5 @@ class Gemini(FunctionCallingLLM):
         # by default structured prediction uses function calling to extract structured outputs
         # here we force tool_choice to be required
         return await super().astream_structured_predict(
-            *args, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
         )

--- a/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gemini/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-gemini"
 readme = "README.md"
-version = "0.4.13"
+version = "0.4.14"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -466,13 +466,12 @@ class GoogleGenAI(FunctionCallingLLM):
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self.is_function_calling_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
 
         return super().structured_predict(
@@ -489,13 +488,12 @@ class GoogleGenAI(FunctionCallingLLM):
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self.is_function_calling_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
 
         return await super().astructured_predict(
@@ -512,13 +510,12 @@ class GoogleGenAI(FunctionCallingLLM):
     ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self.is_function_calling_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
         return super().stream_structured_predict(
             output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
@@ -531,16 +528,15 @@ class GoogleGenAI(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None, None]:
+    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
         if self.is_function_calling_model:
             llm_kwargs["tool_choice"] = (
                 "required"
-                if "tool_choice" not in all_kwargs
-                else all_kwargs["tool_choice"]
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
             )
         return await super().astream_structured_predict(
             output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -5,11 +5,13 @@ import typing
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncGenerator,
     Dict,
     Generator,
     List,
     Optional,
     Sequence,
+    Type,
     Union,
 )
 
@@ -36,9 +38,8 @@ from llama_index.core.callbacks import CallbackManager
 from llama_index.core.constants import DEFAULT_TEMPERATURE, DEFAULT_NUM_OUTPUTS
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.function_calling import FunctionCallingLLM
-from llama_index.core.llms.llm import ToolSelection
+from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.prompts import PromptTemplate
-from llama_index.core.types import Model
 from llama_index.llms.google_genai.utils import (
     chat_from_gemini_response,
     chat_message_to_gemini,
@@ -57,6 +58,7 @@ DEFAULT_MODEL = "gemini-2.0-flash"
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
+    from llama_index.core.program.utils import FlexibleModel
 
 
 class VertexAIConfig(typing.TypedDict):
@@ -425,11 +427,11 @@ class GoogleGenAI(FunctionCallingLLM):
     @dispatcher.span
     def structured_predict_without_function_calling(
         self,
-        output_cls: type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> BaseModel:
+    ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -457,11 +459,11 @@ class GoogleGenAI(FunctionCallingLLM):
     @dispatcher.span
     def structured_predict(
         self,
-        output_cls: type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> BaseModel:
+    ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -480,11 +482,11 @@ class GoogleGenAI(FunctionCallingLLM):
     @dispatcher.span
     async def astructured_predict(
         self,
-        output_cls: type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> BaseModel:
+    ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -503,11 +505,11 @@ class GoogleGenAI(FunctionCallingLLM):
     @dispatcher.span
     def stream_structured_predict(
         self,
-        output_cls: type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> Generator[Union[Model, List[Model]], None, None]:
+    ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}
@@ -525,11 +527,11 @@ class GoogleGenAI(FunctionCallingLLM):
     @dispatcher.span
     async def astream_structured_predict(
         self,
-        output_cls: type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
-    ) -> Generator[Union[Model, List[Model]], None, None]:
+    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
         all_kwargs = {**llm_kwargs, **kwargs}

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -430,18 +430,17 @@ class GoogleGenAI(FunctionCallingLLM):
         output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
+        **prompt_args: Any,
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
-        all_kwargs = {**llm_kwargs, **kwargs}
 
-        messages = prompt.format_messages()
+        messages = prompt.format_messages(**prompt_args)
         response = self._client.models.generate_content(
             model=self.model,
             contents=list(map(chat_message_to_gemini, messages)),
             **{
-                **all_kwargs,
+                **llm_kwargs,
                 **{
                     "config": {
                         "response_mime_type": "application/json",
@@ -462,7 +461,7 @@ class GoogleGenAI(FunctionCallingLLM):
         output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
+        **prompt_args: Any,
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
@@ -475,7 +474,7 @@ class GoogleGenAI(FunctionCallingLLM):
             )
 
         return super().structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
 
     @dispatcher.span
@@ -484,7 +483,7 @@ class GoogleGenAI(FunctionCallingLLM):
         output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
+        **prompt_args: Any,
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
@@ -497,7 +496,7 @@ class GoogleGenAI(FunctionCallingLLM):
             )
 
         return await super().astructured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
 
     @dispatcher.span
@@ -506,7 +505,7 @@ class GoogleGenAI(FunctionCallingLLM):
         output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
+        **prompt_args: Any,
     ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
@@ -518,7 +517,7 @@ class GoogleGenAI(FunctionCallingLLM):
                 else llm_kwargs["tool_choice"]
             )
         return super().stream_structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
 
     @dispatcher.span
@@ -527,7 +526,7 @@ class GoogleGenAI(FunctionCallingLLM):
         output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
+        **prompt_args: Any,
     ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
@@ -539,5 +538,5 @@ class GoogleGenAI(FunctionCallingLLM):
                 else llm_kwargs["tool_choice"]
             )
         return await super().astream_structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **kwargs
+            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -40,6 +40,7 @@ from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_ca
 from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.prompts import PromptTemplate
+from llama_index.core.program.utils import FlexibleModel
 from llama_index.llms.google_genai.utils import (
     chat_from_gemini_response,
     chat_message_to_gemini,
@@ -58,7 +59,6 @@ DEFAULT_MODEL = "gemini-2.0-flash"
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
-    from llama_index.core.program.utils import FlexibleModel
 
 
 class VertexAIConfig(typing.TypedDict):
@@ -506,7 +506,7 @@ class GoogleGenAI(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
+    ) -> Generator[Union[Model, FlexibleModel], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 
@@ -527,7 +527,7 @@ class GoogleGenAI(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
+    ) -> AsyncGenerator[Union[Model, FlexibleModel], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-google-genai"
 readme = "README.md"
-version = "0.1.6"
+version = "0.1.7"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -33,18 +33,19 @@ from llama_index.core.base.llms.types import (
     MessageRole,
     TextBlock,
 )
-from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
 from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.function_calling import FunctionCallingLLM
+from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.program.utils import process_streaming_objects
 from llama_index.core.prompts import PromptTemplate
-from llama_index.core.tools import ToolSelection
 from llama_index.core.types import PydanticProgramMode
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
+    from llama_index.core.program.utils import FlexibleModel
 
 DEFAULT_REQUEST_TIMEOUT = 30.0
 dispatcher = get_dispatcher(__name__)
@@ -533,11 +534,11 @@ class Ollama(FunctionCallingLLM):
     @dispatcher.span
     def structured_predict(
         self,
-        output_cls: Type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> BaseModel:
+    ) -> Model:
         if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
             llm_kwargs = llm_kwargs or {}
             llm_kwargs["format"] = output_cls.model_json_schema()
@@ -554,11 +555,11 @@ class Ollama(FunctionCallingLLM):
     @dispatcher.span
     async def astructured_predict(
         self,
-        output_cls: Type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> BaseModel:
+    ) -> Model:
         if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
             llm_kwargs = llm_kwargs or {}
             llm_kwargs["format"] = output_cls.model_json_schema()
@@ -575,11 +576,11 @@ class Ollama(FunctionCallingLLM):
     @dispatcher.span
     def stream_structured_predict(
         self,
-        output_cls: Type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> Generator[Union[BaseModel, List[BaseModel]], None, None]:
+    ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
         """Stream structured predictions as they are generated.
 
         Args:
@@ -594,11 +595,11 @@ class Ollama(FunctionCallingLLM):
         if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
 
             def gen(
-                output_cls: Type[BaseModel],
+                output_cls: Type[Model],
                 prompt: PromptTemplate,
                 llm_kwargs: Dict[str, Any],
                 prompt_args: Dict[str, Any],
-            ) -> Generator[Union[BaseModel, List[BaseModel]], None, None]:
+            ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
                 llm_kwargs = llm_kwargs or {}
                 llm_kwargs["format"] = output_cls.model_json_schema()
 
@@ -631,20 +632,20 @@ class Ollama(FunctionCallingLLM):
     @dispatcher.span
     async def astream_structured_predict(
         self,
-        output_cls: Type[BaseModel],
+        output_cls: Type[Model],
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> AsyncGenerator[Union[BaseModel, List[BaseModel]], None]:
+    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
         """Async version of stream_structured_predict."""
         if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
 
             async def gen(
-                output_cls: Type[BaseModel],
+                output_cls: Type[Model],
                 prompt: PromptTemplate,
                 llm_kwargs: Dict[str, Any],
                 prompt_args: Dict[str, Any],
-            ) -> AsyncGenerator[Union[BaseModel, List[BaseModel]], None]:
+            ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
                 llm_kwargs = llm_kwargs or {}
                 llm_kwargs["format"] = output_cls.model_json_schema()
 

--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -39,13 +39,12 @@ from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection, Model
-from llama_index.core.program.utils import process_streaming_objects
+from llama_index.core.program.utils import process_streaming_objects, FlexibleModel
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.types import PydanticProgramMode
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
-    from llama_index.core.program.utils import FlexibleModel
 
 DEFAULT_REQUEST_TIMEOUT = 30.0
 dispatcher = get_dispatcher(__name__)
@@ -580,7 +579,7 @@ class Ollama(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
+    ) -> Generator[Union[Model, FlexibleModel], None, None]:
         """Stream structured predictions as they are generated.
 
         Args:
@@ -599,7 +598,7 @@ class Ollama(FunctionCallingLLM):
                 prompt: PromptTemplate,
                 llm_kwargs: Dict[str, Any],
                 prompt_args: Dict[str, Any],
-            ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
+            ) -> Generator[Union[Model, FlexibleModel], None, None]:
                 llm_kwargs = llm_kwargs or {}
                 llm_kwargs["format"] = output_cls.model_json_schema()
 
@@ -636,7 +635,7 @@ class Ollama(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
+    ) -> AsyncGenerator[Union[Model, FlexibleModel], None]:
         """Async version of stream_structured_predict."""
         if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
 
@@ -645,7 +644,7 @@ class Ollama(FunctionCallingLLM):
                 prompt: PromptTemplate,
                 llm_kwargs: Dict[str, Any],
                 prompt_args: Dict[str, Any],
-            ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
+            ) -> AsyncGenerator[Union[Model, FlexibleModel], None]:
                 llm_kwargs = llm_kwargs or {}
                 llm_kwargs["format"] = output_cls.model_json_schema()
 

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-ollama"
 readme = "README.md"
-version = "0.5.3"
+version = "0.5.4"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -1059,7 +1059,7 @@ class OpenAI(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None, None]:
+    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -60,6 +60,7 @@ from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.llms.utils import parse_partial_json
 from llama_index.core.prompts import PromptTemplate
+from llama_index.core.program.utils import FlexibleModel
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.llms.openai.utils import (
     O1_MODELS,
@@ -88,7 +89,6 @@ dispatcher = instrument.get_dispatcher(__name__)
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
-    from llama_index.core.program.utils import FlexibleModel
 
 DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo"
 
@@ -1039,7 +1039,7 @@ class OpenAI(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> Generator[Union[Model, "FlexibleModel"], None, None]:
+    ) -> Generator[Union[Model, FlexibleModel], None, None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 
@@ -1059,7 +1059,7 @@ class OpenAI(FunctionCallingLLM):
         prompt: PromptTemplate,
         llm_kwargs: Optional[Dict[str, Any]] = None,
         **prompt_args: Any,
-    ) -> AsyncGenerator[Union[Model, "FlexibleModel"], None]:
+    ) -> AsyncGenerator[Union[Model, FlexibleModel], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.27"
+version = "0.3.28"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Some LLMs overwrote the `structured_predict` methods and did not use proper generics, this PR remedies that