### PR TITLE
Include Node metadata in hash calculation

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -646,7 +646,11 @@ class Node(BaseNode):
 
     @property
     def hash(self) -> str:
-        doc_identities = []
+        """Generate a hash representing the state of the node.
+
+        The hash is generated based on the available resources (audio, image, text or video) and its metadata.
+        """
+        doc_identities = [self.get_metadata_str(mode=MetadataMode.ALL)]
         if self.audio_resource is not None:
             doc_identities.append(self.audio_resource.hash)
         if self.image_resource is not None:

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -650,7 +650,10 @@ class Node(BaseNode):
 
         The hash is generated based on the available resources (audio, image, text or video) and its metadata.
         """
-        doc_identities = [self.get_metadata_str(mode=MetadataMode.ALL)]
+        doc_identities = []
+        metadata_str = self.get_metadata_str(mode=MetadataMode.ALL)
+        if metadata_str:
+            doc_identities.append(metadata_str)
         if self.audio_resource is not None:
             doc_identities.append(self.audio_resource.hash)
         if self.image_resource is not None:


### PR DESCRIPTION
# Description

Include `Node` metadata in hash calculation to fix bugged metadata update in `IngestionPipeline`. Before, the pipeline would not run if only the metadata changed, as the hash did not change.

**Note:** The failing tests in `llama-index-llms-modelscope` and `llama-index-vector-stores-lancedb` seem to be unrelated to this change, as they seem to fail due to missing dependencies and the direct initialization of an abstract class.

Fixes #17871

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
