### PR TITLE
Fix `Context._events_queue` when loaded from `Context.from_dict`

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -172,10 +172,10 @@ class Context:
         context._streaming_queue = context._deserialize_queue(
             data["streaming_queue"], serializer
         )
-        context._events_buffer = {
+        context._events_buffer = defaultdict(list, {
             k: [serializer.deserialize(ev) for ev in v]
             for k, v in data["events_buffer"].items()
-        }
+        })
         if len(context._events_buffer) == 0:
             context._events_buffer = defaultdict(list)
         context._accepted_events = data["accepted_events"]

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -172,10 +172,13 @@ class Context:
         context._streaming_queue = context._deserialize_queue(
             data["streaming_queue"], serializer
         )
-        context._events_buffer = defaultdict(list, {
-            k: [serializer.deserialize(ev) for ev in v]
-            for k, v in data["events_buffer"].items()
-        })
+        context._events_buffer = defaultdict(
+            list,
+            {
+                k: [serializer.deserialize(ev) for ev in v]
+                for k, v in data["events_buffer"].items()
+            },
+        )
         if len(context._events_buffer) == 0:
             context._events_buffer = defaultdict(list)
         context._accepted_events = data["accepted_events"]


### PR DESCRIPTION
# Description

`_events_queue` must be a default dict (<https://github.com/InAnYan/llama_index/blob/main/llama-index-core/llama_index/core/workflow/context.py#L96>).

When loaded from `from_dict` it's just `dict`, not a `defaultdict`.

It's just two lines (semantically just one call) 😄 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [/] I have commented my code, particularly in hard-to-understand areas
- [/] I have made corresponding changes to the documentation
- [/] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
