### PR TITLE
Fixed case when json_type is a list (multiple possible types)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -39,6 +39,8 @@ def create_model_from_json_schema(
 
     for field_name, field_schema in properties.items():
         json_type = field_schema.get("type", "string")
+        json_type = json_type[0] if isinstance(json_type, list) else json_type
+
         field_type = json_type_mapping.get(json_type, str)
         if field_name in required_fields:
             default_value = ...

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["psiace"]
 name = "llama-index-tools-mcp"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

When creating a Pydantic model from the JSON schema each field actually can have multiple possible types at once, for example number and string. In this case `field_schema.get("type", "string")` will have the value `["number", "string"]`, not the string with only one type. This Pull Requests fixes the issue with it.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)