### PR TITLE
fix: make filename hashing more robust

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-papers/llama_index/readers/papers/arxiv/base.py
@@ -11,7 +11,8 @@ from llama_index.core.schema import Document
 
 
 class ArxivReader(BaseReader):
-    """Arxiv Reader.
+    """
+    Arxiv Reader.
 
     Gets a search query, return a list of Documents of the top corresponding scientific papers on Arxiv.
     """
@@ -31,7 +32,8 @@ class ArxivReader(BaseReader):
         papers_dir: Optional[str] = ".papers",
         max_results: Optional[int] = 10,
     ) -> List[Document]:
-        """Search for a topic on Arxiv, download the PDFs of the top results locally, then read them.
+        """
+        Search for a topic on Arxiv, download the PDFs of the top results locally, then read them.
 
         Args:
             search_query (str): A topic to search for (e.g. "Artificial Intelligence").
@@ -58,7 +60,8 @@ class ArxivReader(BaseReader):
         paper_lookup = {}
         for paper in search_results:
             # Hash filename to avoid bad characters in file path
-            filename = f"{self._hacky_hash(paper.title)}.pdf"
+            hashed_name = self._hacky_hash(f"{paper.title}{paper.entry_id}")
+            filename = f"{hashed_name}.pdf"
             paper_lookup[filename] = {
                 "Title of this paper": paper.title,
                 "Authors": (", ").join([a.name for a in paper.authors]),
@@ -104,7 +107,8 @@ class ArxivReader(BaseReader):
         papers_dir: Optional[str] = ".papers",
         max_results: Optional[int] = 10,
     ) -> Tuple[List[Document], List[Document]]:
-        """Search for a topic on Arxiv, download the PDFs of the top results locally, then read them.
+        """
+        Search for a topic on Arxiv, download the PDFs of the top results locally, then read them.
 
         Args:
             search_query (str): A topic to search for (e.g. "Artificial Intelligence").
@@ -132,7 +136,8 @@ class ArxivReader(BaseReader):
         paper_lookup = {}
         for paper in search_results:
             # Hash filename to avoid bad characters in file path
-            filename = f"{self._hacky_hash(paper.title)}.pdf"
+            hashed_name = self._hacky_hash(f"{paper.title}{paper.entry_id}")
+            filename = f"{hashed_name}.pdf"
             paper_lookup[filename] = {
                 "Title of this paper": paper.title,
                 "Authors": (", ").join([a.name for a in paper.authors]),

--- a/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-papers/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["thejessezhang"]
 name = "llama-index-readers-papers"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Different papers can have the same title, causing collision in the file naming. 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


