### PR TITLE
cache watsonx context window

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
@@ -306,7 +306,10 @@ class WatsonxLLM(FunctionCallingLLM):
         return LLMMetadata(
             context_window=self._context_window or DEFAULT_CONTEXT_WINDOW,
             num_output=self.max_new_tokens or DEFAULT_MAX_TOKENS,
-            model_name=self.model_id or self._model.deployment_id,
+            model_name=self.model_id
+            or self.deployment_info.get("entity", {}).get(
+                "base_model_id", self._model.deployment_id
+            ),
         )
 
     @property

--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
@@ -290,23 +290,21 @@ class WatsonxLLM(FunctionCallingLLM):
 
     @property
     def metadata(self) -> LLMMetadata:
-        if self.model_id:
+        if self.model_id and self._context_window is None:
             model_id = self.model_id
-            context_window = self.model_info.get("model_limits", {}).get(
+            self._context_window = self.model_info.get("model_limits", {}).get(
                 "max_sequence_length"
             )
-        else:
+        elif self._context_window is None:
             model_id = self.deployment_info.get("entity", {}).get("base_model_id")
-            context_window = (
+            self._context_window = (
                 self._model._client.foundation_models.get_model_specs(model_id=model_id)
                 .get("model_limits", {})
                 .get("max_sequence_length")
             )
 
         return LLMMetadata(
-            context_window=context_window
-            or self._context_window
-            or DEFAULT_CONTEXT_WINDOW,
+            context_window=self._context_window or DEFAULT_CONTEXT_WINDOW,
             num_output=self.max_new_tokens or DEFAULT_MAX_TOKENS,
             model_name=model_id or self._model.deployment_id,
         )

--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
@@ -306,7 +306,7 @@ class WatsonxLLM(FunctionCallingLLM):
         return LLMMetadata(
             context_window=self._context_window or DEFAULT_CONTEXT_WINDOW,
             num_output=self.max_new_tokens or DEFAULT_MAX_TOKENS,
-            model_name=model_id or self._model.deployment_id,
+            model_name=self.model_id or self._model.deployment_id,
         )
 
     @property

--- a/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-llms-ibm"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"

--- a/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
@@ -179,7 +179,7 @@ class TestWasonxLLMInference:
                 }
             },
             TEST_CONTEXT_WINDOW,
-            TEST_MAX_SEQUENCE_LENGTH,
+            TEST_CONTEXT_WINDOW,
             id="max_sequence_length_with_context_window",
         ),
         pytest.param(


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/18299

Don't make a network request every time `.metadata` is accessed, instead, cache the context window