### PR TITLE
chore: add title and keywords to semantic config

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -384,7 +384,15 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         semantic_config = SemanticConfiguration(
             name=self._semantic_configuration_name or "mySemanticConfig",
             prioritized_fields=SemanticPrioritizedFields(
+                title_field=SemanticField(
+                    field_name=self._field_mapping["metadata"].get("title", None)
+                ),
                 content_fields=[SemanticField(field_name=self._field_mapping["chunk"])],
+                keywords_fields=[
+                    SemanticField(
+                        field_name=self._field_mapping["metadata"].get("keyWords", None)
+                    )
+                ],
             ),
         )
 
@@ -506,7 +514,15 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         semantic_config = SemanticConfiguration(
             name=self._semantic_configuration_name or "mySemanticConfig",
             prioritized_fields=SemanticPrioritizedFields(
+                title_field=SemanticField(
+                    field_name=self._field_mapping["metadata"].get("title", None)
+                ),
                 content_fields=[SemanticField(field_name=self._field_mapping["chunk"])],
+                keywords_fields=[
+                    SemanticField(
+                        field_name=self._field_mapping["metadata"].get("keyWords", None)
+                    )
+                ],
             ),
         )
 


### PR DESCRIPTION
# Description

Very simple fix to get full functionality out of azure ai search semantic functionality. At the moment there is no relation between in the semantic configuration because we only use content fields. The title or keywords metadata it is now taken into account the moment the semantic search functionality is used. 
- Added only the semantic search title and keywords if present in the metadata
- This will only affect search functionality when semantic is configured

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
