### PR TITLE
Fix Sharepoint folder path encoding issue

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.5.1] - 2025-04-02
+
+- Fix issue with folder path encoding when a file path contains special characters
+
 ## [0.1.7] - 2024-04-03
 
 - Use recursive strategy by default for reading from a folder

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import tempfile
 from typing import Any, Dict, List, Union, Optional
+from urllib.parse import quote
 
 import requests
 from llama_index.core.readers import SimpleDirectoryReader, FileSystemReaderMixin
@@ -763,7 +764,9 @@ class SharePointReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReade
         # Get the file ID
         # remove the site_name prefix
         parts = [part for part in input_file.parts if part != self.sharepoint_site_name]
-        file_path = "/".join(parts)
+        # URI escape each part of the path
+        escaped_parts = [quote(part) for part in parts]
+        file_path = "/".join(escaped_parts)
         endpoint = f"{self._drive_id_endpoint}/{self._drive_id}/root:/{file_path}"
 
         response = self._send_get_with_retry(endpoint)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["arun-soliton"]
 name = "llama-index-readers-microsoft-sharepoint"
 readme = "README.md"
-version = "0.5.0"
+version = "0.5.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Fix Sharepoint folder path encoding issue when file paths have special characters

## New Package?
- [x] No

## Version Bump?
- [x] Yes

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
