### PR TITLE
Fix the costly pop(0) in SentenceSplitter when parsing numerous texts

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/sentence.py
+++ b/llama-index-core/llama_index/core/node_parser/text/sentence.py
@@ -262,8 +262,9 @@ class SentenceSplitter(MetadataAwareTextSplitter):
                     cur_chunk.insert(0, (text, length))
                     last_index -= 1
 
-        while len(splits) > 0:
-            cur_split = splits[0]
+        split_idx = 0
+        while split_idx < len(splits):
+            cur_split = splits[split_idx]
             if cur_split.token_size > chunk_size:
                 raise ValueError("Single token exceeded chunk size")
             if cur_chunk_len + cur_split.token_size > chunk_size and not new_chunk:
@@ -278,7 +279,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
                     # add split to chunk
                     cur_chunk_len += cur_split.token_size
                     cur_chunk.append((cur_split.text, cur_split.token_size))
-                    splits.pop(0)
+                    split_idx += 1
                     new_chunk = False
                 else:
                     # close out chunk


### PR DESCRIPTION
# Description

When parsing numerous texts with SentenceSplitter, parsing is extremely slow. After doing some profiling work, I found out that the **SentenceSplitter traverses the List by popping the first element, which introduces a costly copy for each iteration.** When there are numerous texts, the parsing process is extremely slow.

Fixes # (issue)

I just use an idx variable to traverse the List, rather than popping the first element every iteration.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] I ran `make format; make lint` to appease the lint gods
