### PR TITLE
Add OpenAILikeEmbedding, update docs

### DIFF
--- a/docs/docs/api_reference/embeddings/openai_like.md
+++ b/docs/docs/api_reference/embeddings/openai_like.md
@@ -1,0 +1,4 @@
+::: llama_index.embeddings.openai_like
+    options:
+      members:
+        - OpenAILikeEmbedding

--- a/docs/docs/api_reference/readers/myscale.md
+++ b/docs/docs/api_reference/readers/myscale.md
@@ -1,0 +1,4 @@
+::: llama_index.readers.myscale
+    options:
+      members:
+        - MyScaleReader

--- a/docs/docs/getting_started/starter_example.md
+++ b/docs/docs/getting_started/starter_example.md
@@ -22,7 +22,7 @@ set OPENAI_API_KEY=XXXXX
 ```
 
 !!! tip
-    If you are using an OpenAI-Compatible API, you can use the `OpenAILike` LLM class. You can find more information in the [OpenAILike LLM](https://docs.llamaindex.ai/en/stable/api_reference/llms/openai_like/#llama_index.llms.openai_like.OpenAILike) integration.
+    If you are using an OpenAI-Compatible API, you can use the `OpenAILike` LLM class. You can find more information in the [OpenAILike LLM](https://docs.llamaindex.ai/en/stable/api_reference/llms/openai_like/) integration and [OpenAILike Embeddings](https://docs.llamaindex.ai/en/stable/api_reference/embeddings/openai_like/) integration.
 
 ## Basic Agent Example
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
           - ./examples/data_connectors/MboxReaderDemo.ipynb
           - ./examples/data_connectors/MilvusReaderDemo.ipynb
           - ./examples/data_connectors/MongoDemo.ipynb
+          - ./examples/data_connectors/MyScaleReaderDemo.ipynb
           - ./examples/data_connectors/NotionDemo.ipynb
           - ./examples/data_connectors/ObsidianReaderDemo.ipynb
           - ./examples/data_connectors/PathwayReaderDemo.ipynb
@@ -923,6 +924,7 @@ nav:
           - ./api_reference/embeddings/ollama.md
           - ./api_reference/embeddings/opea.md
           - ./api_reference/embeddings/openai.md
+          - ./api_reference/embeddings/openai_like.md
           - ./api_reference/embeddings/oracleai.md
           - ./api_reference/embeddings/premai.md
           - ./api_reference/embeddings/sagemaker_endpoint.md
@@ -1420,6 +1422,7 @@ nav:
           - ./api_reference/readers/minio.md
           - ./api_reference/readers/mondaydotcom.md
           - ./api_reference/readers/mongodb.md
+          - ./api_reference/readers/myscale.md
           - ./api_reference/readers/notion.md
           - ./api_reference/readers/nougat_ocr.md
           - ./api_reference/readers/obsidian.md
@@ -2403,6 +2406,8 @@ plugins:
             - ../llama-index-integrations/llms/llama-index-llms-netmind
             - ../llama-index-integrations/tools/llama-index-tools-dappier
             - ../llama-index-integrations/llms/llama-index-llms-asi
+            - ../llama-index-integrations/embeddings/llama-index-embeddings-openai-like
+            - ../llama-index-integrations/readers/llama-index-readers-myscale
   - redirects:
       redirect_maps:
         ./api/llama_index.vector_stores.MongoDBAtlasVectorSearch.html: api_reference/storage/vector_store/mongodb.md

--- a/docs/scripts/prepare_for_build.py
+++ b/docs/scripts/prepare_for_build.py
@@ -65,6 +65,9 @@ INTEGRATION_FOLDERS = [
     "../llama-index-integrations",
     # "../llama-index-cli",
 ]
+EXCLUDED_INTEGRATION_FOLDERS = [
+    "llama-index-integrations/agent",
+]
 INTEGRATION_FOLDER_TO_LABEL = {
     "finetuning": "Fine-tuning",
     "llms": "LLMs",
@@ -188,6 +191,13 @@ def main():
     for folder in INTEGRATION_FOLDERS:
         for root, dirs, files in os.walk(folder):
             for file in files:
+                # check if the current root is in the excluded integration folders
+                if any(
+                    excluded_folder in root
+                    for excluded_folder in EXCLUDED_INTEGRATION_FOLDERS
+                ):
+                    continue
+
                 if file == "pyproject.toml":
                     toml_path = os.path.join(root, file)
                     with open(toml_path) as f:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/.gitignore
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/BUILD
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/BUILD
@@ -1,0 +1,3 @@
+poetry_requirements(
+    name="poetry",
+)

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/LICENSE
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/Makefile
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/README.md
@@ -1,0 +1,1 @@
+# LlamaIndex Embeddings Integration: Openai

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/README.md
@@ -1,1 +1,22 @@
-# LlamaIndex Embeddings Integration: Openai
+# OpenAILike Embeddings
+
+This integration allows you to use OpenAI-like embeddings APIs with LlamaIndex.
+
+## Installation
+
+```bash
+pip install llama-index-embeddings-openai-like
+```
+
+## Usage
+
+```python
+from llama_index.embeddings.openai_like import OpenAILikeEmbedding
+
+embedding = OpenAILikeEmbedding(
+    model_name="my-model-name",
+    api_key="fake",
+    api_base="http://localhost:1234/v1",
+    embed_batch_size=10,
+)
+```

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/BUILD
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/__init__.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/__init__.py
@@ -1,0 +1,7 @@
+from llama_index.embeddings.openai_like.base import (
+    OpenAILikeEmbedding,
+)
+
+__all__ = [
+    "OpenAILikeEmbedding",
+]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/base.py
@@ -1,0 +1,94 @@
+"""OpenAI-Like embeddings."""
+
+from typing import Any, Dict, Optional
+
+import httpx
+from llama_index.core.callbacks.base import CallbackManager
+from llama_index.embeddings.openai import OpenAIEmbedding
+
+
+class OpenAILikeEmbedding(OpenAIEmbedding):
+    """OpenAI-Like class for embeddings.
+
+    Args:
+        model_name (str):
+            Model for embedding.
+        api_key (str):
+            The API key (if any) to use for the embedding API.
+        api_base (str):
+            The base URL for the embedding API.
+        api_version (str):
+            The version for the embedding API.
+        max_retries (int):
+            The maximum number of retries for the embedding API.
+        timeout (float):
+            The timeout for the embedding API.
+        reuse_client (bool):
+            Whether to reuse the client for the embedding API.
+        callback_manager (CallbackManager):
+            The callback manager for the embedding API.
+        default_headers (Dict[str, str]):
+            The default headers for the embedding API.
+        additional_kwargs (Dict[str, Any]):
+            Additional kwargs for the embedding API.
+        dimensions (int):
+            The number of dimensions for the embedding API.
+
+    Example:
+        ```bash
+        pip install llama-index-embeddings-openai-like
+        ```
+
+        ```python
+        from llama_index.embeddings.openai_like import OpenAILikeEmbedding
+
+        embedding = OpenAILikeEmbedding(
+            model_name="my-model-name",
+            api_base="http://localhost:1234/v1",
+            api_key="fake",
+            embed_batch_size=10,
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        embed_batch_size: int = 10,
+        dimensions: Optional[int] = None,
+        additional_kwargs: Optional[Dict[str, Any]] = None,
+        api_key: str = "fake",
+        api_base: Optional[str] = None,
+        api_version: Optional[str] = None,
+        max_retries: int = 10,
+        timeout: float = 60.0,
+        reuse_client: bool = True,
+        callback_manager: Optional[CallbackManager] = None,
+        default_headers: Optional[Dict[str, str]] = None,
+        http_client: Optional[httpx.Client] = None,
+        async_http_client: Optional[httpx.AsyncClient] = None,
+        num_workers: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        # ensure model is not passed in kwargs, will cause error in parent class
+        if "model" in kwargs:
+            raise ValueError(
+                "Use `model_name` instead of `model` to initialize OpenAILikeEmbedding"
+            )
+
+        super().__init__(
+            model_name=model_name,
+            embed_batch_size=embed_batch_size,
+            dimensions=dimensions,
+            callback_manager=callback_manager,
+            additional_kwargs=additional_kwargs,
+            api_key=api_key,
+            api_base=api_base,
+            api_version=api_version,
+            max_retries=max_retries,
+            reuse_client=reuse_client,
+            timeout=timeout,
+            default_headers=default_headers,
+            num_workers=num_workers,
+            **kwargs,
+        )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.embeddings.openai_like"
+
+[tool.llamahub.class_authors]
+OpenAILikeEmbedding = "llama-index"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"
+
+[tool.poetry]
+authors = ["Your Name <you@example.com>"]
+description = "llama-index embeddings openai integration"
+exclude = ["**/BUILD"]
+license = "MIT"
+name = "llama-index-embeddings-openai-like"
+readme = "README.md"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = ">=3.9,<4.0"
+openai = ">=1.1.0"
+llama-index-core = "^0.12.0"
+
+[tool.poetry.group.dev.dependencies]
+ipython = "8.10.0"
+jupyter = "^1.0.0"
+mypy = "0.991"
+pre-commit = "3.2.0"
+pylint = "2.15.10"
+pytest = "7.2.1"
+pytest-mock = "3.11.1"
+ruff = "0.0.292"
+tree-sitter-languages = "^1.8.0"
+types-Deprecated = ">=0.1.0"
+types-PyYAML = "^6.0.12.12"
+types-protobuf = "^4.24.0.4"
+types-redis = "4.5.5.0"
+types-requests = "2.28.11.8"
+types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = ["jupyter"]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = ["toml"]
+version = ">=v2.2.6"
+
+[[tool.poetry.packages]]
+include = "llama_index/"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/pyproject.toml
@@ -31,8 +31,7 @@ version = "0.1.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-openai = ">=1.1.0"
-llama-index-core = "^0.12.0"
+llama-index-embeddings-openai = "^0.3.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/BUILD
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    dependencies=["llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py"]
+)

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
@@ -20,7 +20,7 @@ def test_init():
     assert embed_model.api_base == "http://localhost:1234/v1"
     assert embed_model.embed_batch_size == 1
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         embed_model = OpenAILikeEmbedding(
             model="model-name",
         )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
@@ -1,3 +1,4 @@
+import pytest
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.embeddings.openai_like import OpenAILikeEmbedding
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
@@ -1,0 +1,25 @@
+from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.embeddings.openai_like import OpenAILikeEmbedding
+
+
+def test_openai_embedding_class():
+    names_of_base_classes = [b.__name__ for b in OpenAILikeEmbedding.__mro__]
+    assert BaseEmbedding.__name__ in names_of_base_classes
+
+
+def test_init():
+    embed_model = OpenAILikeEmbedding(
+        model="model-name",
+        api_key="fake",
+        api_base="http://localhost:1234/v1",
+        embed_batch_size=1,
+    )
+    assert embed_model.model_name == "model-name"
+    assert embed_model.api_key == "fake"
+    assert embed_model.api_base == "http://localhost:1234/v1"
+    assert embed_model.embed_batch_size == 1
+
+    embed_model = OpenAILikeEmbedding(
+        model_name="model-name",
+    )
+    assert embed_model.model_name == "model-name"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
@@ -9,7 +9,7 @@ def test_openai_embedding_class():
 
 def test_init():
     embed_model = OpenAILikeEmbedding(
-        model="model-name",
+        model_name="model-name",
         api_key="fake",
         api_base="http://localhost:1234/v1",
         embed_batch_size=1,
@@ -19,7 +19,7 @@ def test_init():
     assert embed_model.api_base == "http://localhost:1234/v1"
     assert embed_model.embed_batch_size == 1
 
-    embed_model = OpenAILikeEmbedding(
-        model_name="model-name",
-    )
-    assert embed_model.model_name == "model-name"
+    with pytest.raises(ValueError):
+        embed_model = OpenAILikeEmbedding(
+            model_name="model-name",
+        )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/tests/test_embeddings_openai_like.py
@@ -22,5 +22,5 @@ def test_init():
 
     with pytest.raises(ValueError):
         embed_model = OpenAILikeEmbedding(
-            model_name="model-name",
+            model="model-name",
         )

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
@@ -1,1 +1,23 @@
 # LlamaIndex Llms Integration: Openai Like
+
+`pip install llama-index-llms-openai-like`
+
+This package is a thin wrapper around the OpenAI API. It is designed to be used with the OpenAI API, but can be used with any OpenAI-compatible API.
+
+## Usage
+
+```python
+from llama_index.llms.openai_like import OpenAILike
+
+llm = OpenAILike(
+    model="model-name",
+    api_base="http://localhost:1234/v1",
+    api_key="fake",
+    # Explicitly set the context window to match the model's context window
+    context_window=128000,
+    # Controls whether the model uses chat or completion endpoint
+    is_chat_model=True,
+    # Controls whether the model supports function calling
+    is_function_calling_model=False,
+)
+```


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/14340

While OpenAIEmbedding could already be used for openai-like endpoints, it was a little janky (and perhaps unexpected)

This is a light wrapper to make it official 