### PR TITLE
force pytest asyncio dep

### DIFF
--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -1,19 +1,24 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
 ignore-words-list = "astroid,gallary,momento,narl,ot,rouge"
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "./llama_index/core/_static,./examples,./experimental,*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 explicit_package_bases = true
 ignore_missing_imports = true
 namespace_packages = true
@@ -21,7 +26,9 @@ plugins = "pydantic.mypy"
 python_version = "3.10"
 
 [tool.poetry]
-authors = ["Jerry Liu <jerry@llamaindex.ai>"]
+authors = [
+    "Jerry Liu <jerry@llamaindex.ai>",
+]
 classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
@@ -29,10 +36,24 @@ classifiers = [
 ]
 description = "Interface between LLMs and your data"
 documentation = "https://docs.llamaindex.ai/en/stable/"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 homepage = "https://llamaindex.ai"
-include = ["llama_index/core/_static/nltk_cache/corpora/stopwords/*", "llama_index/core/_static/nltk_cache/tokenizers/punkt_tab/*", "llama_index/core/_static/tiktoken_cache/*"]
-keywords = ["LLM", "NLP", "RAG", "data", "devtools", "index", "retrieval"]
+include = [
+    "llama_index/core/_static/nltk_cache/corpora/stopwords/*",
+    "llama_index/core/_static/nltk_cache/tokenizers/punkt_tab/*",
+    "llama_index/core/_static/tiktoken_cache/*",
+]
+keywords = [
+    "LLM",
+    "NLP",
+    "RAG",
+    "data",
+    "devtools",
+    "index",
+    "retrieval",
+]
 license = "MIT"
 maintainers = [
     "Andrei Fajardo <andrei@runllama.ai>",
@@ -43,13 +64,17 @@ maintainers = [
     "Sourabh Desai <sourabh@llamaindex.ai>",
 ]
 name = "llama-index-core"
-packages = [{include = "llama_index"}]
+packages = [
+    {include = "llama_index"},
+]
 readme = "README.md"
 repository = "https://github.com/run-llama/llama_index"
+source = [
+    {name = "nvidia-pypi", priority = "supplemental", url = "https://pypi.nvidia.com"},
+]
 version = "0.12.28"
 
 [tool.poetry.dependencies]
-SQLAlchemy = {extras = ["asyncio"], version = ">=1.4.49"}
 dataclasses-json = "*"
 deprecated = ">=1.2.9.3"
 fsspec = ">=2023.5.0"
@@ -58,11 +83,11 @@ nest-asyncio = "^1.5.8"
 nltk = ">3.8.1"
 numpy = "*"
 python = ">=3.9,<4.0"
-tenacity = ">=8.2.0,!=8.4.0,<10.0.0"  # Avoid 8.4.0 which lacks tenacity.asyncio
+tenacity = ">=8.2.0,!=8.4.0,<10.0.0"
 tiktoken = ">=0.3.3"
 typing-extensions = ">=4.5.0"
 typing-inspect = ">=0.8.0"
-requests = ">=2.31.0"  # Pin to avoid CVE-2023-32681 in requests 2.3 to 2.30
+requests = ">=2.31.0"
 aiohttp = "^3.8.6"
 networkx = ">=3.0"
 dirtyjson = "^1.0.8"
@@ -71,15 +96,22 @@ pillow = ">=9.0.0"
 PyYAML = ">=6.0.1"
 wrapt = "*"
 pydantic = ">=2.8.0"
-filetype = "^1.2.0"  # Used for multi-modal MIME utils
-eval-type-backport = {python = "<3.10", version = "^0.2.0"}
+filetype = "^1.2.0"
 banks = "^2.0.0"
 
+[tool.poetry.dependencies.SQLAlchemy]
+extras = [
+    "asyncio",
+]
+version = ">=1.4.49"
+
+[tool.poetry.dependencies.eval-type-backport]
+python = "<3.10"
+version = "^0.2.0"
+
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = ">=23.7.0,<=24.3.0"}
-boto3 = "1.33.6"  # needed for tests
+boto3 = "1.33.6"
 botocore = ">=1.33.13"
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 docker = "^7.0.0"
 ipython = "8.10.0"
 jupyter = "^1.0.0"
@@ -97,17 +129,36 @@ pytest-asyncio = "0.21.0"
 pytest-cov = "^5.0"
 pytest-dotenv = "0.5.2"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 rake-nltk = "1.0.6"
 ruff = "0.0.292"
-tree-sitter = {python = "<3.12", version = "0.20.0"}  # 0.22 seems to break for now
-tree-sitter-languages = {python = "<3.12", version = "1.9.1"}
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = ">=2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = ">=2.28.11.8"
 types-setuptools = "67.1.0.0"
 vellum-ai = "^0.7.8"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = ">=23.7.0,<=24.3.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"
+
+[tool.poetry.group.dev.dependencies.tree-sitter]
+python = "<3.12"
+version = "0.20.0"
+
+[tool.poetry.group.dev.dependencies.tree-sitter-languages]
+python = "<3.12"
+version = "1.9.1"
 
 [tool.poetry.group.docs]
 optional = true
@@ -127,25 +178,19 @@ sphinx-reredirects = "^0.1.3"
 sphinx-rtd-theme = "^1.3.0"
 sphinxcontrib-gtagjs = "^0.2.1"
 
-[[tool.poetry.source]]
-name = "nvidia-pypi"
-priority = "supplemental"
-url = "https://pypi.nvidia.com"
-
 [tool.ruff]
 exclude = [
     "notebooks",
 ]
 ignore = [
-    "COM812",  # Too aggressive
-    "D213",  # LlamaIndex uses Google docstring style
-    "D417",  # Too aggressive
-    "F541",  # Messes with prompts.py
+    "COM812",
+    "D213",
+    "D417",
+    "F541",
     "TCH002",
-    "UP006",  # Messes with pydantic
-    "UP007",  # Wants | over Union, which breaks 3.8
+    "UP006",
+    "UP007",
 ]
-# Feel free to add more here
 select = [
     "ANN204",
     "B009",
@@ -239,8 +284,8 @@ convention = "google"
 [tool.tomlsort]
 all = true
 in_place = true
-spaces_before_inline_comment = 2  # Match Python PEP 8
-spaces_indent_inline_array = 4  # Match Python PEP 8
+spaces_before_inline_comment = 2
+spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 
 [tool.tomlsort.overrides."tool.poetry.dependencies"]

--- a/llama-index-core/tests/agent/custom/test_query_pipeline.py
+++ b/llama-index-core/tests/agent/custom/test_query_pipeline.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test query pipeline worker."""
 
 from typing import Any, Dict, Set, Tuple

--- a/llama-index-core/tests/agent/custom/test_simple_function.py
+++ b/llama-index-core/tests/agent/custom/test_simple_function.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test simple function agent."""
 
 from typing import Any, Dict, Tuple

--- a/llama-index-core/tests/agent/function_calling/test_step.py
+++ b/llama-index-core/tests/agent/function_calling/test_step.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import uuid
 import pytest
 from typing import Any, AsyncGenerator, Coroutine, List, Optional, Sequence, Union, Dict

--- a/llama-index-core/tests/agent/react/test_react_agent.py
+++ b/llama-index-core/tests/agent/react/test_react_agent.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import re
 from typing import Any, List, Sequence
 

--- a/llama-index-core/tests/agent/workflow/test_code_act_agent.py
+++ b/llama-index-core/tests/agent/workflow/test_code_act_agent.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from typing import Any

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import Any, List
 
 import pytest

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import List, Any
 
 import pytest

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 
 from llama_index.core import MockEmbedding

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 
 from llama_index.core import MockEmbedding

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import gc
 import asyncio
 from llama_index.core.memory import ChatMemoryBuffer

--- a/llama-index-core/tests/extractors/test_document_context_extractor.py
+++ b/llama-index-core/tests/extractors/test_document_context_extractor.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 
 from llama_index.core.extractors import DocumentContextExtractor

--- a/llama-index-core/tests/indices/response/test_tree_summarize.py
+++ b/llama-index-core/tests/indices/response/test_tree_summarize.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test tree summarize."""
 
 from typing import Any, List, Sequence, Optional

--- a/llama-index-core/tests/instrumentation/test_dispatcher.py
+++ b/llama-index-core/tests/instrumentation/test_dispatcher.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import inspect
 import threading

--- a/llama-index-core/tests/llms/test_callbacks.py
+++ b/llama-index-core/tests/llms/test_callbacks.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from llama_index.core.base.llms.types import ChatMessage
 from llama_index.core.llms.llm import LLM

--- a/llama-index-core/tests/llms/test_function_calling.py
+++ b/llama-index-core/tests/llms/test_function_calling.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import Any, AsyncGenerator, Coroutine, Dict, List, Optional, Sequence, Union
 
 import pytest

--- a/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_rankgpt_rerank.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import Any
 from unittest.mock import patch
 import asyncio

--- a/llama-index-core/tests/program/test_function_program.py
+++ b/llama-index-core/tests/program/test_function_program.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test LLM program."""
 
 from unittest.mock import MagicMock

--- a/llama-index-core/tests/query_pipeline/test_query.py
+++ b/llama-index-core/tests/query_pipeline/test_query.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Query pipeline."""
 
 from typing import Any, Dict

--- a/llama-index-core/tests/readers/file/test_base.py
+++ b/llama-index-core/tests/readers/file/test_base.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from pathlib import Path
 from unittest import mock
 

--- a/llama-index-core/tests/response_synthesizers/test_generate.py
+++ b/llama-index-core/tests/response_synthesizers/test_generate.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 
 from llama_index.core.llms import MockLLM

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from collections import OrderedDict
 from typing import Any, Dict, Optional, Type, cast
 

--- a/llama-index-core/tests/sparse_embeddings/test_mock_sparse_embeddings.py
+++ b/llama-index-core/tests/sparse_embeddings/test_mock_sparse_embeddings.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 
 from llama_index.core.sparse_embeddings.mock_sparse_embedding import MockSparseEmbedding

--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test utils."""
 
 from typing import Optional, Type, Union

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test tools."""
 
 import json

--- a/llama-index-core/tests/tools/test_retriever_tool.py
+++ b/llama-index-core/tests/tools/test_retriever_tool.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test retriever tool."""
 
 from typing import List, Optional

--- a/llama-index-core/tests/tools/tool_spec/test_base.py
+++ b/llama-index-core/tests/tools/tool_spec/test_base.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test tool spec."""
 
 from typing import List, Optional, Tuple, Type, Union

--- a/llama-index-core/tests/workflow/test_checkpointer.py
+++ b/llama-index-core/tests/workflow/test_checkpointer.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import random
 from unittest.mock import MagicMock, patch

--- a/llama-index-core/tests/workflow/test_context.py
+++ b/llama-index-core/tests/workflow/test_context.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import json
 from typing import Optional, Union

--- a/llama-index-core/tests/workflow/test_handler.py
+++ b/llama-index-core/tests/workflow/test_handler.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from unittest import mock
 
 import pytest

--- a/llama-index-core/tests/workflow/test_retry_policy.py
+++ b/llama-index-core/tests/workflow/test_retry_policy.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 
 from llama_index.core.workflow.context import Context

--- a/llama-index-core/tests/workflow/test_service.py
+++ b/llama-index-core/tests/workflow/test_service.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow.decorators import step

--- a/llama-index-core/tests/workflow/test_stepwise.py
+++ b/llama-index-core/tests/workflow/test_stepwise.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import Event, StartEvent, StopEvent

--- a/llama-index-core/tests/workflow/test_streaming.py
+++ b/llama-index-core/tests/workflow/test_streaming.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 
 import pytest

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import logging
 import time

--- a/llama-index-core/tests/workflow/test_workflow_postponed_annotations.py
+++ b/llama-index-core/tests/workflow/test_workflow_postponed_annotations.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from __future__ import annotations
 
 import pytest

--- a/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -17,16 +19,29 @@ OpenAIAssistantAgent = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index agent openai integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-agent-openai"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.6"
 
@@ -44,6 +59,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "~1.9.0"
 types-Deprecated = ">=0.1.0"
@@ -54,12 +70,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/agent/llama-index-agent-openai/tests/test_openai_agent.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/tests/test_openai_agent.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import json
 import uuid
 from typing import (

--- a/llama-index-integrations/agent/llama-index-agent-openai/tests/test_openai_assistant_agent.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/tests/test_openai_assistant_agent.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import List
 from unittest.mock import MagicMock, patch
 

--- a/llama-index-integrations/callbacks/llama-index-callbacks-agentops/pyproject.toml
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-agentops/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,17 +18,26 @@ AgentOpsEventHandler = "joelrorseth"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index instrumentation agentops integration"
 license = "MIT"
 name = "llama-index-callbacks-agentops"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.0"
 
@@ -38,8 +47,6 @@ agentops = "^0.2.2"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -47,11 +54,24 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/callbacks/llama-index-callbacks-agentops/tests/test_instrumentation_agentops.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-agentops/tests/test_instrumentation_agentops.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 import uuid
 import llama_index.core.instrumentation as instrument

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ BedrockEmbedding = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index embeddings bedrock integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-embeddings-bedrock"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.5.0"
 
@@ -43,6 +58,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import json
 import aioboto3.session
 import pytest

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ CohereEmbedding = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index embeddings cohere integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-embeddings-cohere"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.0"
 
@@ -43,6 +58,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.6"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/test_embeddings.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/test_embeddings.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 
 import httpx

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,18 +18,29 @@ WatsonxEmbeddings = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.10"
 
 [tool.poetry]
-authors = ["IBM"]
+authors = [
+    "IBM",
+]
 description = "llama-index embeddings IBM watsonx.ai integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-embeddings-ibm"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.0"
 
@@ -40,8 +51,6 @@ pyarrow = "*"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -50,11 +59,24 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "0.23.7"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/tests/test_ibm.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from typing import List
 from unittest.mock import patch, MagicMock

--- a/llama-index-integrations/embeddings/llama-index-embeddings-mixedbreadai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-mixedbreadai/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,17 +18,26 @@ MixedbreadAIEmbedding = "mixedbread-ai"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Mixedbread AI <support@mixedbread.ai>"]
+authors = [
+    "Mixedbread AI <support@mixedbread.ai>",
+]
 description = "llama-index embeddings mixedbreadai integration"
 license = "MIT"
 name = "llama-index-embeddings-mixedbreadai"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.0"
 
@@ -36,8 +47,6 @@ mixedbread-ai = "^2.2.2"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -45,6 +54,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,3 +63,15 @@ types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
 types-requests = ">=2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-mixedbreadai/tests/test_embeddings_mixedbreadai.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-mixedbreadai/tests/test_embeddings_mixedbreadai.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 
 import pytest

--- a/llama-index-integrations/embeddings/llama-index-embeddings-modelscope/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-modelscope/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,29 +18,49 @@ ModelScopeEmbedding = "ModelScope"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["ModelScope <modelscope@list.alibaba-inc.com>"]
+authors = [
+    "ModelScope <modelscope@list.alibaba-inc.com>",
+]
 description = "llama-index embeddings modelscope integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-embeddings-modelscope"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-modelscope = {extras = ["framework"], version = ">=1.12.0"}
 torch = "^2.1.2"
 llama-index-core = "^0.12.0"
 sentencepiece = "*"
 ms-swift = "*"
 
+[tool.poetry.dependencies.modelscope]
+extras = [
+    "framework",
+]
+version = ">=1.12.0"
+
 [tool.poetry.dependencies.transformers]
-extras = ["torch"]
+extras = [
+    "torch",
+]
 version = "^4.37.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -49,6 +71,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -59,12 +82,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-modelscope/tests/test_modelscope.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-modelscope/tests/test_modelscope.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from llama_index.embeddings.modelscope.base import ModelScopeEmbedding
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ NVIDIA = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index embeddings nvidia integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-embeddings-nvidia"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.3"
 
@@ -34,7 +49,6 @@ python = ">=3.9,<4.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-# Unpin when https://github.com/lundberg/respx/issues/277 is fixed
 httpx = "<0.28.0"
 ipython = "8.10.0"
 jupyter = "^1.0.0"
@@ -44,6 +58,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.6"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 respx = "^0.21.1"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
@@ -55,19 +70,20 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
 
 [tool.poetry.group.test_integration.dependencies]
 pytest-httpx = "*"
 requests-mock = "^1.12.1"
-
-[[tool.poetry.packages]]
-include = "llama_index/"
 
 [tool.pytest.ini_options]
 markers = [

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/test_truncate.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/test_truncate.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 import respx
 from llama_index.embeddings.nvidia import NVIDIAEmbedding

--- a/llama-index-integrations/embeddings/llama-index-embeddings-oci-data-science/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-oci-data-science/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,16 +18,29 @@ OCIDataScienceEmbedding = "mrdzurb"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.9"
 
 [tool.poetry]
-authors = ["Dmitrii Cherkasov <dmitrii.cherkasov@oracle.com>"]
+authors = [
+    "Dmitrii Cherkasov <dmitrii.cherkasov@oracle.com>",
+]
 description = "llama-index embeddings OCI Data Science integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-embeddings-oci-data-science"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.0"
 
@@ -44,6 +57,7 @@ pylint = "2.15.10"
 pytest = ">=7.2.1"
 pytest-asyncio = ">=0.24.0"
 pytest-mock = ">=3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -54,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-oci-data-science/tests/test_embeddings_oci_data_science.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-oci-data-science/tests/test_embeddings_oci_data_science.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from unittest.mock import AsyncMock, Mock
 
 import pytest

--- a/llama-index-integrations/embeddings/llama-index-embeddings-oci-data-science/tests/test_oci_data_science_client.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-oci-data-science/tests/test_oci_data_science_client.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx

--- a/llama-index-integrations/embeddings/llama-index-embeddings-siliconflow/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-siliconflow/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ SiliconFlowEmbedding = "nightosong"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["nightosong <nightosong2013@gmail.com>"]
+authors = [
+    "nightosong <nightosong2013@gmail.com>",
+]
 description = "llama-index embeddings siliconflow integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-embeddings-siliconflow"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.1"
 
@@ -43,6 +58,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.7"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-siliconflow/tests/test_embeddings_siliconflow.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-siliconflow/tests/test_embeddings_siliconflow.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import json
 import pytest
 import types

--- a/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/pyproject.toml
+++ b/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,25 +18,46 @@ GraphRag = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index graph rag cognee integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-graph-rag-cognee"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.3"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-cognee = {extras = ["neo4j", "postgres", "qdrant", "weaviate"], version = "0.1.26"}
 httpx = "~=0.27.0"
 llama-index-core = "^0.12.5"
 pytest-cov = "^6.0.0"
+
+[tool.poetry.dependencies.cognee]
+extras = [
+    "neo4j",
+    "postgres",
+    "qdrant",
+    "weaviate",
+]
+version = "0.1.26"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"
@@ -45,6 +68,7 @@ pylint = "2.15.10"
 pytest = "8.2"
 pytest-asyncio = "^0.25.0"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -55,15 +79,16 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"

--- a/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/tests/test_add_data.py
+++ b/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/tests/test_add_data.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from llama_index.core import Document
 import asyncio
 import pytest

--- a/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/tests/test_get_graph_url.py
+++ b/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/tests/test_get_graph_url.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import pytest
 from llama_index.graph_rag.cognee import CogneeGraphRAG

--- a/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/tests/test_graph_rag_cognee.py
+++ b/llama-index-integrations/graph_rag/llama-index-graph-rag-cognee/tests/test_graph_rag_cognee.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 import asyncio
 

--- a/llama-index-integrations/llms/llama-index-llms-ai21/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ai21/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ AI21 = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms ai21 integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-ai21"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.0"
 
@@ -43,6 +58,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.7"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-ai21/tests/test_llms_ai21.py
+++ b/llama-index-integrations/llms/llama-index-llms-ai21/tests/test_llms_ai21.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from __future__ import annotations
 
 import json

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,23 +18,42 @@ Anthropic = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.9"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms anthropic integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-anthropic"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.6.10"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-anthropic = {extras = ["bedrock", "vertex"], version = ">=0.49.0"}
 llama-index-core = "^0.12.5"
+
+[tool.poetry.dependencies.anthropic]
+extras = [
+    "bedrock",
+    "vertex",
+]
+version = ">=0.49.0"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "8.10.0"
@@ -43,6 +64,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.5"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,15 +75,16 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 from unittest.mock import MagicMock
 

--- a/llama-index-integrations/llms/llama-index-llms-asi/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-asi/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ ASI = "Fetch.ai Inc."
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Fetch.ai Inc. <info@fetch.ai>"]
+authors = [
+    "Fetch.ai Inc. <info@fetch.ai>",
+]
 description = "llama-index llms asi integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-asi"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.1"
 
@@ -43,6 +58,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-asi/tests/test_integration_asi.py
+++ b/llama-index-integrations/llms/llama-index-llms-asi/tests/test_integration_asi.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 import pytest
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ BedrockConverse = "AndreCNF"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms bedrock converse integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-bedrock-converse"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.13"
 
@@ -44,6 +59,7 @@ pylint = "2.15.10"
 pytest = ">=7.2.1"
 pytest-asyncio = "^0.24.0"
 pytest-mock = ">=3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -54,12 +70,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_llms_bedrock_converse.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_llms_bedrock_converse.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from llama_index.llms.bedrock_converse import BedrockConverse
 from llama_index.core.base.llms.types import (

--- a/llama-index-integrations/llms/llama-index-llms-cortex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cortex/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,17 +18,26 @@ Cortex = "q-maze"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Quinton Mays <qmazedev@gmail.com>"]
+authors = [
+    "Quinton Mays <qmazedev@gmail.com>",
+]
 description = "llama-index llms cortex integration"
 license = "MIT"
 name = "llama-index-llms-cortex"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.0"
 
@@ -40,8 +49,6 @@ aiohttp = "^3.11.11"
 cryptography = ">=44.0.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -49,11 +56,24 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/llms/llama-index-llms-cortex/tests/test_integration_cortex.py
+++ b/llama-index-integrations/llms/llama-index-llms-cortex/tests/test_integration_cortex.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import inspect
 import os
 from typing import AsyncIterator

--- a/llama-index-integrations/llms/llama-index-llms-dashscope/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-dashscope/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ DashScope = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms dashscope integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-dashscope"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.2"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-dashscope/tests/test_dashscope.py
+++ b/llama-index-integrations/llms/llama-index-llms-dashscope/tests/test_dashscope.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from http import HTTPStatus
 from types import SimpleNamespace
 from typing import AsyncGenerator, List, Sequence

--- a/llama-index-integrations/llms/llama-index-llms-gigachat/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-gigachat/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,17 +18,26 @@ GigaChatLLM = "afaneor"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Pavlin Nikolay <afaneor@gmail.com>"]
+authors = [
+    "Pavlin Nikolay <afaneor@gmail.com>",
+]
 description = "llama-index llms gigachat integration"
 license = "MIT"
 name = "llama-index-llms-gigachat-ru"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.0"
 
@@ -38,8 +47,6 @@ gigachat = "^0.1.33"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -47,11 +54,24 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/llms/llama-index-llms-gigachat/tests/test_llms_gigachat.py
+++ b/llama-index-integrations/llms/llama-index-llms-gigachat/tests/test_llms_gigachat.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import TypeVar, Iterable, AsyncIterator
 
 import pytest

--- a/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,18 +18,29 @@ WatsonxLLM = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.10"
 
 [tool.poetry]
-authors = ["IBM"]
+authors = [
+    "IBM",
+]
 description = "llama-index llms IBM watsonx.ai integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-ibm"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.4"
 
@@ -40,8 +51,6 @@ pyarrow = "*"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -50,11 +59,24 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "0.23.7"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import Any, Dict, Generator
 from unittest.mock import MagicMock, patch
 import warnings

--- a/llama-index-integrations/llms/llama-index-llms-litellm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-litellm/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ LiteLLM = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms litellm integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-litellm"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.1"
 
@@ -43,6 +58,7 @@ pylint = "2.15.10"
 pytest = "^8.3.5"
 pytest-asyncio = "0.23.7"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 respx = "^0.22.0"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
@@ -54,12 +70,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-litellm/tests/test_llms_litellm.py
+++ b/llama-index-integrations/llms/llama-index-llms-litellm/tests/test_llms_litellm.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from decimal import Decimal
 import httpx
 from llama_index.core.base.llms.base import BaseLLM

--- a/llama-index-integrations/llms/llama-index-llms-novita/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-novita/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ NovitaAI = "wanye"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms novita integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-novita"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.0"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,15 +68,16 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"

--- a/llama-index-integrations/llms/llama-index-llms-novita/tests/test_llms_novita.py
+++ b/llama-index-integrations/llms/llama-index-llms-novita/tests/test_llms_novita.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 from datetime import datetime
 

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,17 +18,26 @@ NVIDIA = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Chris Alexiuk <calexiuk@nvidia.com>"]
+authors = [
+    "Chris Alexiuk <calexiuk@nvidia.com>",
+]
 description = "llama-index llms nvidia api catalog integration"
 license = "MIT"
 name = "llama-index-llms-nvidia"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.3"
 
@@ -39,9 +48,6 @@ llama-index-llms-openai-like = "^0.3.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
-# Unpin when https://github.com/lundberg/respx/issues/277 is fixed
 httpx = "<0.28.0"
 ipython = "8.10.0"
 jupyter = "^1.0.0"
@@ -51,6 +57,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.0"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 respx = "^0.21.1"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
@@ -58,8 +65,20 @@ types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"
 
 [tool.poetry.group.test_integration.dependencies]
 pytest-httpx = "*"

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from llama_index.core.base.llms.types import (
     ChatMessage,

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_nvidia.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_nvidia.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 from typing import Any, AsyncGenerator, Generator, Optional
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_text-completion.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_text-completion.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 from typing import Any, Optional, Generator, AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_tools.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_tools.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import json
 import uuid
 from typing import (

--- a/llama-index-integrations/llms/llama-index-llms-oci-data-science/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-oci-data-science/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ OCIDataScience = "mrdzurb"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Dmitrii Cherkasov <dmitrii.cherkasov@oracle.com>"]
+authors = [
+    "Dmitrii Cherkasov <dmitrii.cherkasov@oracle.com>",
+]
 description = "llama-index llms OCI Data Science integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-oci-data-science"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.0"
 
@@ -42,6 +57,7 @@ pylint = "2.15.10"
 pytest = ">=7.2.1"
 pytest-asyncio = ">=0.24.0"
 pytest-mock = ">=3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-oci-data-science/tests/test_llms_oci_data_science.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-data-science/tests/test_llms_oci_data_science.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from unittest.mock import AsyncMock, Mock
 
 import pytest

--- a/llama-index-integrations/llms/llama-index-llms-oci-data-science/tests/test_oci_data_science_client.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-data-science/tests/test_oci_data_science_client.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import json
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, Mock, patch

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ Ollama = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms ollama integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-ollama"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.5.4"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 
 import pytest

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -17,16 +19,29 @@ OpenAIResponses = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["llama-index"]
+authors = [
+    "llama-index",
+]
 description = "llama-index llms openai integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-openai"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.30"
 
@@ -43,6 +58,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,15 +69,16 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = true

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 from typing import Any, AsyncGenerator, Generator, Optional
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 import pytest
 from unittest.mock import MagicMock, patch

--- a/llama-index-integrations/llms/llama-index-llms-perplexity/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-perplexity/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ Perplexity = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index llms perplexity integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-perplexity"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.2"
 
@@ -41,6 +56,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -51,12 +67,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-perplexity/tests/test_perplexity.py
+++ b/llama-index-integrations/llms/llama-index-llms-perplexity/tests/test_perplexity.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import inspect
 from typing import AsyncIterator
 import pytest

--- a/llama-index-integrations/llms/llama-index-llms-reka/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-reka/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,17 +18,26 @@ RekaAI = "findalexli"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Alex Li <alexli@reka.ai>"]
+authors = [
+    "Alex Li <alexli@reka.ai>",
+]
 description = "llama-index llms reka integration"
 license = "MIT"
 name = "llama-index-llms-reka"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -36,8 +47,6 @@ llama-index-core = "^0.12.0"
 reka-api = "^3.0.8"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -45,11 +54,24 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "^8.3.2"
 pytest-mock = "^3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/llms/llama-index-llms-reka/tests/test_reka.py
+++ b/llama-index-integrations/llms/llama-index-llms-reka/tests/test_reka.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 import os
 import inspect

--- a/llama-index-integrations/llms/llama-index-llms-sambanovasystems/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-sambanovasystems/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -17,14 +19,25 @@ SambaStudio = "rodrigo-92"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Rodrigo Maldonado <rodrigo.maldonado@pucp.edu.pe>"]
+authors = [
+    "Rodrigo Maldonado <rodrigo.maldonado@pucp.edu.pe>",
+]
 description = "llama-index llms sambanova cloud and sambastudio integration"
 name = "llama-index-llms-sambanovasystems"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.3"
 
@@ -42,6 +55,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,8 +66,7 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-sambanovasystems/tests/test_llms_sambanovasystems.py
+++ b/llama-index-integrations/llms/llama-index-llms-sambanovasystems/tests/test_llms_sambanovasystems.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import time
 import os

--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ SiliconFlow = "nightosong"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["nightosong"]
+authors = [
+    "nightosong",
+]
 description = "llama-index llms siliconflow integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-siliconflow"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.1"
 
@@ -43,6 +58,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.7"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import json
 import pytest
 import types

--- a/llama-index-integrations/llms/llama-index-llms-zhipuai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-zhipuai/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ ZhipuAI = "nightosong"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["nightosong"]
+authors = [
+    "nightosong",
+]
 description = "llama-index llms zhipuai integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-llms-zhipuai"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.1"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/llms/llama-index-llms-zhipuai/tests/test_llms_zhipuai.py
+++ b/llama-index-integrations/llms/llama-index-llms-zhipuai/tests/test_llms_zhipuai.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 import pytest
 from unittest import mock

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-bedrock/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-bedrock/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ BedrockMultiModal = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["LlamaIndex"]
+authors = [
+    "LlamaIndex",
+]
 description = "llama-index multi-modal llms bedrock integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-multi-modal-llms-bedrock"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.0"
 
@@ -44,6 +59,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.5"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -54,15 +70,16 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-bedrock/tests/test_multi_modal_llms_bedrock.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-bedrock/tests/test_multi_modal_llms_bedrock.py
@@ -1,3 +1,6 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
+
 """Test Bedrock multi-modal LLM."""
 import json
 from io import BytesIO

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ GeminiMultiModal = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index multi-modal-llms gemini integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-multi-modal-llms-gemini"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.5.0"
 
@@ -43,6 +58,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/tests/test_multi-modal-llms_gemini.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-gemini/tests/test_multi-modal-llms_gemini.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import base64
 import os
 

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,31 +18,43 @@ HuggingFaceMultiModal = "M.Cihan Yalçın"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["M.Cihan Yalçın <mcihan.yalcin@outlook.com>"]
+authors = [
+    "M.Cihan Yalçın <mcihan.yalcin@outlook.com>",
+]
 description = "llama-index multi_modal_llms HuggingFace integration by [Cihan Yalçın](https://www.linkedin.com/in/chanyalcin/)"
 license = "MIT"
 name = "llama-index-multi-modal-llms-huggingface"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 llama-index-core = "^0.12.0"
-transformers = {extras = ["torch"], version = "^4.45"}
 qwen-vl-utils = ">=0.0.8"
 torchvision = "^0.19.1"
 Pillow = "^10.0.0"
 
+[tool.poetry.dependencies.transformers]
+extras = [
+    "torch",
+]
+version = "^4.45"
+
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -50,6 +62,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 torchvision = "0.19.1"
 tree-sitter-languages = "^1.8.0"
@@ -57,5 +70,17 @@ types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/tests/test_multi_modal_llms_huggingface.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/tests/test_multi_modal_llms_huggingface.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import numpy as np
 import pytest
 import tempfile

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-nvidia/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-nvidia/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,17 +18,26 @@ NVIDIAMultiModal = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index multi_modal nvidia integration"
 license = "MIT"
 name = "llama-index-multi-modal-llms-nvidia"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.0"
 
@@ -39,8 +48,6 @@ filetype = "^1.2.0"
 
 [tool.poetry.group.dev.dependencies]
 aiohttp = "^3.10.10"
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -50,11 +57,24 @@ pylint = "2.15.10"
 pytest = "^8.2"
 pytest-asyncio = "^0.24.0"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-nvidia/tests/test_multi_modal_nvidia.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-nvidia/tests/test_multi_modal_nvidia.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from llama_index.core.multi_modal_llms.base import MultiModalLLM
 from llama_index.multi_modal_llms.nvidia import NVIDIAMultiModal
 from llama_index.multi_modal_llms.nvidia.utils import (

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-reka/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-reka/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,17 +18,26 @@ RekaMultiModalLLM = "findalexli"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Alex Li <alexli@reka.ai>"]
+authors = [
+    "Alex Li <alexli@reka.ai>",
+]
 description = "llama-index multi_modal_llms reka integration"
 license = "MIT"
 name = "llama-index-multi-modal-llms-reka"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -36,8 +47,6 @@ llama-index-core = "^0.12.0"
 reka-api = "^3.0.8"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -45,11 +54,24 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "^8.3.2"
 pytest-mock = "^3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-reka/tests/test_multi_modal_llms_reka.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-reka/tests/test_multi_modal_llms_reka.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 import os
 import inspect

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-zhipuai/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-zhipuai/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ ZhipuAIMultiModal = "nightosong"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["nightosong"]
+authors = [
+    "nightosong",
+]
 description = "llama-index multi modal llms zhipuai integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-multi-modal-llms-zhipuai"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-zhipuai/tests/test_multi_modal_llms_zhipuai.py
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-zhipuai/tests/test_multi_modal_llms_zhipuai.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import base64
 import os
 import pytest

--- a/llama-index-integrations/readers/llama-index-readers-whisper/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-whisper/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,17 +18,32 @@ WhisperReader = "logan-markewich"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Logan Markewich <logan@runllama.ai>"]
+authors = [
+    "Logan Markewich <logan@runllama.ai>",
+]
 description = "llama-index readers openai whisper integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
-maintainers = ["logan-markewich"]
+maintainers = [
+    "logan-markewich",
+]
 name = "llama-index-readers-whisper"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.0"
 
@@ -43,6 +60,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +71,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/readers/llama-index-readers-whisper/tests/test_readers_whisper.py
+++ b/llama-index-integrations/readers/llama-index-readers-whisper/tests/test_readers_whisper.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import requests
 import pytest
 import os

--- a/llama-index-integrations/selectors/llama-index-selectors-notdiamond/pyproject.toml
+++ b/llama-index-integrations/selectors/llama-index-selectors-notdiamond/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-# Feel free to un-skip examples, and experimental, you will just need to
-# work through many typos (--write-changes and --interactive will help)
 skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
 
 [tool.llamahub]
@@ -18,16 +18,25 @@ NotDiamondSelector = "acompa"
 
 [tool.mypy]
 disallow_untyped_defs = true
-# Remove venv skip when integrated with pre-commit
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.11"
 
 [tool.poetry]
-authors = ["Not Diamond <support@notdiamond.ai>"]
+authors = [
+    "Not Diamond <support@notdiamond.ai>",
+]
 description = "llama-index selectors Not Diamond integration"
 name = "llama-index-selectors-notdiamond"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -38,8 +47,6 @@ notdiamond = "^0.3.5"
 litellm = "*"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -47,11 +54,24 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/selectors/llama-index-selectors-notdiamond/tests/test_selectors_notdiamond.py
+++ b/llama-index-integrations/selectors/llama-index-selectors-notdiamond/tests/test_selectors_notdiamond.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 import pytest
 from typing import List

--- a/llama-index-integrations/sparse_embeddings/llama-index-sparse-embeddings-fastembed/pyproject.toml
+++ b/llama-index-integrations/sparse_embeddings/llama-index-sparse-embeddings-fastembed/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ FastEmbedEmbedding = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index sparse embeddings fastembed integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-sparse-embeddings-fastembed"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/sparse_embeddings/llama-index-sparse-embeddings-fastembed/tests/test_sparse_embeddings_fastembed.py
+++ b/llama-index-integrations/sparse_embeddings/llama-index-sparse-embeddings-fastembed/tests/test_sparse_embeddings_fastembed.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 
 from llama_index.core.base.embeddings.base_sparse import BaseSparseEmbedding

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-mongo/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-mongo/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ MongoChatStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Vrushab Ghodke <vrushab.ghodke@gmail.com>"]
+authors = [
+    "Vrushab Ghodke <vrushab.ghodke@gmail.com>",
+]
 description = "llama-index storage-chat-store mongo integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-storage-chat-store-mongo"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.1.0"
 
@@ -46,6 +61,7 @@ pytest = "^8.3.5"
 pytest-asyncio = "^0.25.3"
 pytest-cov = "^6.0.0"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -56,12 +72,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-mongo/tests/test_chat_store_mongo_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-mongo/tests/test_chat_store_mongo_chat_store.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import time
 import pytest
 import docker

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ PostgresChatStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index storage-chat-store postgres integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-storage-chat-store-postgres"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -44,6 +59,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -54,12 +70,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import time
 from typing import Dict, Generator, Union
 import pytest

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ UpstashChatStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Fahreddin Özcan <fahreddin@upstash.com>"]
+authors = [
+    "Fahreddin Özcan <fahreddin@upstash.com>",
+]
 description = "llama-index storage-chat-store upstash integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-storage-chat-store-upstash"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/tests/test_chat_store_upstash_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-upstash/tests/test_chat_store_upstash_chat_store.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from llama_index.storage.chat_store.upstash import UpstashChatStore
 import os

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-postgres/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-postgres/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ PostgresKVStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index kvstore postgres integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-storage-kvstore-postgres"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.0"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-postgres/tests/test_postgres.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from typing import Dict, Generator, Union
 
 import pytest

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ ChromaVectorStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores chroma integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-chroma"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.1"
 
@@ -42,6 +57,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -52,12 +68,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/tests/test_chromadb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/tests/test_chromadb.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 from typing import Dict, List, Generator
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ ElasticsearchStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores elasticsearch integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.2"
 
@@ -45,6 +60,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "0.23.6"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -55,12 +71,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ LanternVectorStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores lantern integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-lantern"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.1"
 
@@ -36,7 +51,9 @@ asyncpg = "^0.29.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.dependencies.sqlalchemy]
-extras = ["asyncio"]
+extras = [
+    "asyncio",
+]
 version = "^2.0.25"
 
 [tool.poetry.group.dev.dependencies]
@@ -47,6 +64,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -57,12 +75,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/tests/test_lantern.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/tests/test_lantern.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 from typing import Any, Dict, Generator, List, Union
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,27 @@ MilvusVectorStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
 authors = []
 description = "llama-index vector_stores milvus integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.7.2"
 
@@ -43,6 +56,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "^0.23.6"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +67,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ OpensearchVectorStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores opensearch integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-opensearch"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.5.2"
 
@@ -34,7 +49,9 @@ python = ">=3.9,<4.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.dependencies.opensearch-py]
-extras = ["async"]
+extras = [
+    "async",
+]
 version = "^2.4.2"
 
 [tool.poetry.group.dev.dependencies]
@@ -45,6 +62,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -55,12 +73,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import logging
 import pytest

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ PGVectorStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores postgres integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.4.2"
 
@@ -37,7 +52,9 @@ asyncpg = ">=0.29.0,<1.0.0"
 llama-index-core = "^0.12.6"
 
 [tool.poetry.dependencies.sqlalchemy]
-extras = ["asyncio"]
+extras = [
+    "asyncio",
+]
 version = ">=1.4.49,<2.1"
 
 [tool.poetry.group.dev.dependencies]
@@ -48,6 +65,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -58,17 +76,22 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-filterwarnings = ["ignore::DeprecationWarning:"]
-markers = ["asyncio"]
+filterwarnings = [
+    "ignore::DeprecationWarning:",
+]
+markers = [
+    "asyncio",
+]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 from typing import Any, Dict, Generator, List, Union, Optional
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ QdrantVectorStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores qdrant integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-qdrant"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.6.0"
 
@@ -36,10 +51,11 @@ grpcio = "^1.60.0"
 llama-index-core = "^0.12.7"
 
 [tool.poetry.extras]
-fastembed = ["fastembed"]
+fastembed = [
+    "fastembed",
+]
 
 [tool.poetry.group.dev.dependencies]
-fastembed = {optional = true, version = ">=0.2.5"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -48,6 +64,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "*"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -58,12 +75,17 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
 
-[[tool.poetry.packages]]
-include = "llama_index/"
+[tool.poetry.group.dev.dependencies.fastembed]
+optional = true
+version = ">=0.2.5"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import pytest
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import (

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ VespaVectorStore = "thomasht86"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Thomas Thoresen <thomas@vespa.ai>"]
+authors = [
+    "Thomas Thoresen <thomas@vespa.ai>",
+]
 description = "llama-index vector_stores vespa integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-vespa"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.2.0"
 
@@ -43,6 +58,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "0.23.6"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 pyvespa = "0.40.0"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
@@ -54,12 +70,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespavectorstore.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/tests/test_vespavectorstore.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import asyncio
 import pytest
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,29 @@ WeaviateVectorStore = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores weaviate integration"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-vector-stores-weaviate"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "1.3.1"
 
@@ -40,9 +55,10 @@ jupyter = "^1.0.0"
 mypy = "0.991"
 pre-commit = "3.2.0"
 pylint = "2.15.10"
-pytest = "<8"  # Pants always uses pytest 7.0.1 as of now, so we need to be compatible with pytest 7
+pytest = "<8"
 pytest-asyncio = "*"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -53,12 +69,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = "<=23.9.1,>=23.7.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -16,16 +18,26 @@ WordliftVectorStore = "ziodave"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index vector_stores wordlift integration"
 license = "MIT"
 name = "llama-index-vector-stores-wordlift"
-packages = [{include = "llama_index/"}]
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.5.0"
 
@@ -41,8 +53,6 @@ docker = "^7.1.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "<=23.9.1,>=23.7.0"}
-codespell = {extras = ["toml"], version = ">=v2.2.6"}
 ipython = "8.10.0"
 jupyter = "^1.0.0"
 mypy = "0.991"
@@ -51,6 +61,7 @@ pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-asyncio = "*"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 requests = ">=2.31.0,<2.32.0"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
@@ -58,6 +69,18 @@ types-Deprecated = ">=0.1.0"
 types-PyYAML = "^6.0.12.12"
 types-protobuf = "^4.24.0.4"
 types-redis = "4.5.5.0"
-types-requests = "2.28.11.8"  # TODO: unpin when mypy>0.991
+types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 wordlift-client = ">=1.30.0,<2"
+
+[tool.poetry.group.dev.dependencies.black]
+extras = [
+    "jupyter",
+]
+version = "<=23.9.1,>=23.7.0"
+
+[tool.poetry.group.dev.dependencies.codespell]
+extras = [
+    "toml",
+]
+version = ">=v2.2.6"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/tests/test_wordlift.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/tests/test_wordlift.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 import os
 import random
 from typing import List

--- a/llama-index-utils/llama-index-utils-workflow/pyproject.toml
+++ b/llama-index-utils/llama-index-utils-workflow/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core"]
+requires = [
+    "poetry-core",
+]
 
 [tool.codespell]
 check-filenames = true
@@ -13,16 +15,29 @@ import_path = "llama_index.utils.workflow"
 
 [tool.mypy]
 disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
+exclude = [
+    "_static",
+    "build",
+    "examples",
+    "notebooks",
+    "venv",
+]
 ignore_missing_imports = true
 python_version = "3.8"
 
 [tool.poetry]
-authors = ["Your Name <you@example.com>"]
+authors = [
+    "Your Name <you@example.com>",
+]
 description = "llama-index utils for workflows"
-exclude = ["**/BUILD"]
+exclude = [
+    "**/BUILD",
+]
 license = "MIT"
 name = "llama-index-utils-workflow"
+packages = [
+    {include = "llama_index/"},
+]
 readme = "README.md"
 version = "0.3.0"
 
@@ -39,6 +54,7 @@ pre-commit = "3.2.0"
 pylint = "2.15.10"
 pytest = "7.2.1"
 pytest-mock = "3.11.1"
+pytest_asyncio = "*"
 ruff = "0.0.292"
 tree-sitter-languages = "^1.8.0"
 types-Deprecated = ">=0.1.0"
@@ -49,12 +65,13 @@ types-requests = "2.28.11.8"
 types-setuptools = "67.1.0.0"
 
 [tool.poetry.group.dev.dependencies.black]
-extras = ["jupyter"]
+extras = [
+    "jupyter",
+]
 version = ">=24.3.0"
 
 [tool.poetry.group.dev.dependencies.codespell]
-extras = ["toml"]
+extras = [
+    "toml",
+]
 version = ">=v2.2.6"
-
-[[tool.poetry.packages]]
-include = "llama_index/"

--- a/llama-index-utils/llama-index-utils-workflow/tests/test_drawing.py
+++ b/llama-index-utils/llama-index-utils-workflow/tests/test_drawing.py
@@ -1,3 +1,5 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
As flagged by [Adrian here](https://github.com/run-llama/llama_index/pull/18314#discussion_r2020351113), pytest_asyncio is an implicit dependency

AFAIK there was not an easy way to force pants to install this for every package that needs it besides importing it, so I scripted a change to add the imports needed.

Now, async tests will properly run in pants