### PR TITLE
Update to Kuzu 0.9.0

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/llama_index/graph_stores/kuzu/utils.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/llama_index/graph_stores/kuzu/utils.py
@@ -127,7 +127,7 @@ def create_relation_tables(
     for src, rel_label, dst in relationship_schema:
         create_entity_relationship_table(connection, rel_label, src, dst)
 
-    ddl = "CREATE REL TABLE GROUP IF NOT EXISTS MENTIONS ("
+    ddl = "CREATE REL TABLE IF NOT EXISTS MENTIONS ("
     table_names = []
     for entity in entities:
         table_names.append(f"FROM Chunk TO {entity}")

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-kuzu/pyproject.toml
@@ -28,11 +28,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-graph-stores-kuzu"
 readme = "README.md"
-version = "0.6.0"
+version = "0.7.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-kuzu = "^0.7.0"
+kuzu = "^0.9.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

This PR bumps the Kuzu graph database integration to v0.7.0. No user facing changes are exposed. The only change is that `utils.py` now removes the `GROUP` keyword when creating relationship tables (which has been deprecated in Kuzu). The remaining functionality is identical.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Minor change to keyword in DDL statement (no user facing changes).

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
