### PR TITLE
WatsonxLLM/WatsonxEmbeddings: persistent_connection configurable

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/llama_index/embeddings/ibm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/llama_index/embeddings/ibm/base.py
@@ -103,6 +103,12 @@ class WatsonxEmbeddings(BaseEmbedding):
         allow_mutation=False,
     )
 
+    # Enabled by default since IBM watsonx SDK 1.1.2 but it can cause problems
+    # in environments where long-running connections are not supported.
+    persistent_connection: bool = Field(
+        default=True, description="Use persistent connection"
+    )
+
     _embed_model: Embeddings = PrivateAttr()
 
     def __init__(
@@ -121,6 +127,7 @@ class WatsonxEmbeddings(BaseEmbedding):
         version: Optional[str] = None,
         verify: Union[str, bool, None] = None,
         api_client: Optional[APIClient] = None,
+        persistent_connection: bool = True,
         callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ):
@@ -168,6 +175,7 @@ class WatsonxEmbeddings(BaseEmbedding):
             instance_id=instance_id,
             version=version,
             verify=verify,
+            persistent_connection=persistent_connection,
             callback_manager=callback_manager,
             embed_batch_size=embed_batch_size,
             **kwargs,
@@ -190,6 +198,7 @@ class WatsonxEmbeddings(BaseEmbedding):
             project_id=self.project_id,
             space_id=self.space_id,
             api_client=api_client,
+            persistent_connection=self.persistent_connection,
         )
 
     class Config:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-embeddings-ibm"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
@@ -148,6 +148,12 @@ class WatsonxLLM(FunctionCallingLLM):
         default=True, description="Model id validation", frozen=True
     )
 
+    # Enabled by default since IBM watsonx SDK 1.1.2 but it can cause problems
+    # in environments where long-running connections are not supported.
+    persistent_connection: bool = Field(
+        default=True, description="Use persistent connection"
+    )
+
     _model: ModelInference = PrivateAttr()
     _client: Optional[APIClient] = PrivateAttr()
     _model_info: Optional[Dict[str, Any]] = PrivateAttr()
@@ -174,6 +180,7 @@ class WatsonxLLM(FunctionCallingLLM):
         verify: Union[str, bool, None] = None,
         api_client: Optional[APIClient] = None,
         validate_model: bool = True,
+        persistent_connection: bool = True,
         callback_manager: Optional[CallbackManager] = None,
         **kwargs: Any,
     ) -> None:
@@ -214,6 +221,7 @@ class WatsonxLLM(FunctionCallingLLM):
             verify=verify,
             _client=api_client,
             validate_model=validate_model,
+            persistent_connection=persistent_connection,
             callback_manager=callback_manager,
             **kwargs,
         )
@@ -254,6 +262,7 @@ class WatsonxLLM(FunctionCallingLLM):
             space_id=self.space_id,
             api_client=api_client,
             validate=validate_model,
+            persistent_connection=persistent_connection,
         )
         self._model_info = None
         self._deployment_info = None

--- a/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
@@ -31,7 +31,7 @@ license = "MIT"
 name = "llama-index-llms-ibm"
 packages = [{include = "llama_index/"}]
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"


### PR DESCRIPTION
# Description

In the IBM watsonx Python SDK, persistent connections were enabled in
version 1.1.2 and higher. However, this causes problems in some
environments where network connections are cut from time to time. This
creates a connection error and the inference fails.

Add a `persistent_connection` boolean for the WatsonxLLM class set to
True by default (to match upstream), but allow it to be disabled if
needed.

Fixes #18400

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
