### PR TITLE
Connect new phoenix tracing option

### DIFF
--- a/llama-index-integrations/callbacks/llama-index-callbacks-arize-phoenix/llama_index/callbacks/arize_phoenix/base.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-arize-phoenix/llama_index/callbacks/arize_phoenix/base.py
@@ -21,7 +21,9 @@ def arize_phoenix_callback_handler(**kwargs: Any) -> BaseCallbackHandler:
 
         return LlamaIndexInstrumentor().instrument(
             tracer_provider=kwargs.get("tracer_provider", tracer_provider),
-            separate_trace_from_runtime_context=kwargs.get("separate_trace_from_runtime_context"),
+            separate_trace_from_runtime_context=kwargs.get(
+                "separate_trace_from_runtime_context"
+            ),
         )
     except ImportError:
         # using an older version of arize

--- a/llama-index-integrations/callbacks/llama-index-callbacks-arize-phoenix/llama_index/callbacks/arize_phoenix/base.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-arize-phoenix/llama_index/callbacks/arize_phoenix/base.py
@@ -20,7 +20,8 @@ def arize_phoenix_callback_handler(**kwargs: Any) -> BaseCallbackHandler:
         )
 
         return LlamaIndexInstrumentor().instrument(
-            tracer_provider=kwargs.get("tracer_provider", tracer_provider)
+            tracer_provider=kwargs.get("tracer_provider", tracer_provider),
+            separate_trace_from_runtime_context=kwargs.get("separate_trace_from_runtime_context"),
         )
     except ImportError:
         # using an older version of arize

--- a/llama-index-integrations/callbacks/llama-index-callbacks-arize-phoenix/pyproject.toml
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-arize-phoenix/pyproject.toml
@@ -28,11 +28,11 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-callbacks-arize-phoenix"
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
-openinference-instrumentation-llama-index = ">=3.0.0"
+openinference-instrumentation-llama-index = ">=4.1.0"
 llama-index-core = "^0.12.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

`separate_trace_from_runtime_context` makes it possible to separate LLM traces from perf traces (which resolves phoenix issues for projects using opentelemetry for both)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tried it locally with the new option omitted (default) and with the new option set to `True` (enabled).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
