### PR TITLE
add async to memory and postprocessor base classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
 	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
 
 test:	## Run tests via pants
-	pants --level=info --no-local-cache --changed-since=origin/main --changed-dependents=transitive --no-test-use-coverage test
+	pants --level=error --no-local-cache --changed-since=origin/main --changed-dependents=transitive --no-test-use-coverage test
 
 test-core:	## Run tests via pants
 	pants --no-local-cache test llama-index-core/::

--- a/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
@@ -344,8 +344,7 @@ class CodeActAgent(SingleAgentRunnerMixin, BaseWorkflowAgent):
         Adds all in-progress messages to memory.
         """
         scratchpad: List[ChatMessage] = await ctx.get(self.scratchpad_key, default=[])
-        for msg in scratchpad:
-            await memory.aput(msg)
+        await memory.aput_messages(scratchpad)
 
         # reset scratchpad
         await ctx.set(self.scratchpad_key, [])

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -122,8 +122,7 @@ class FunctionAgent(SingleAgentRunnerMixin, BaseWorkflowAgent):
         Adds all in-progress messages to memory.
         """
         scratchpad: List[ChatMessage] = await ctx.get(self.scratchpad_key, default=[])
-        for msg in scratchpad:
-            await memory.aput(msg)
+        await memory.aput_messages(scratchpad)
 
         # reset scratchpad
         await ctx.set(self.scratchpad_key, [])

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -308,7 +308,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
 
         # First set chat history if it exists
         if chat_history:
-            memory.set(chat_history)
+            await memory.aset(chat_history)
 
         # Then add user message if it exists
         if user_msg:
@@ -335,7 +335,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             raise ValueError("Must provide either user_msg or chat_history")
 
         # Get all messages from memory
-        input_messages = memory.get()
+        input_messages = await memory.aget()
 
         # send to the current agent
         current_agent_name: str = await ctx.get("current_agent_name")
@@ -526,7 +526,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 return StopEvent(result=result)
 
         user_msg_str = await ctx.get("user_msg_str")
-        input_messages = memory.get(input=user_msg_str)
+        input_messages = await memory.aget(input=user_msg_str)
 
         # get this again, in case it changed
         agent_name = await ctx.get("current_agent_name")

--- a/llama-index-core/llama_index/core/postprocessor/types.py
+++ b/llama-index-core/llama_index/core/postprocessor/types.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
@@ -65,6 +66,7 @@ class BaseNodePostprocessor(ChainableMixin, BaseComponent, DispatcherSpanMixin, 
         self,
         nodes: List[NodeWithScore],
         query_bundle: Optional[QueryBundle] = None,
+        query_str: Optional[str] = None,
     ) -> List[NodeWithScore]:
         """Postprocess nodes (async)."""
         if query_str is not None and query_bundle is not None:

--- a/llama-index-core/llama_index/core/postprocessor/types.py
+++ b/llama-index-core/llama_index/core/postprocessor/types.py
@@ -61,6 +61,28 @@ class BaseNodePostprocessor(ChainableMixin, BaseComponent, DispatcherSpanMixin, 
     ) -> List[NodeWithScore]:
         """Postprocess nodes."""
 
+    async def apostprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        """Postprocess nodes (async)."""
+        if query_str is not None and query_bundle is not None:
+            raise ValueError("Cannot specify both query_str and query_bundle")
+        elif query_str is not None:
+            query_bundle = QueryBundle(query_str)
+        else:
+            pass
+        return await self._apostprocess_nodes(nodes, query_bundle)
+
+    async def _apostprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        """Postprocess nodes (async)."""
+        return await asyncio.to_thread(self._postprocess_nodes, nodes, query_bundle)
+
     def _as_query_component(self, **kwargs: Any) -> QueryComponent:
         """As query component."""
         return PostprocessorComponent(postprocessor=self)

--- a/llama-index-core/llama_index/core/storage/chat_store/base.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/base.py
@@ -1,4 +1,5 @@
 """Base interface class for storing chat history per user."""
+import asyncio
 from abc import abstractmethod
 from typing import List, Optional
 
@@ -49,28 +50,28 @@ class BaseChatStore(BaseComponent):
 
     async def aset_messages(self, key: str, messages: List[ChatMessage]) -> None:
         """Async version of Get messages for a key."""
-        self.set_messages(key, messages)
+        await asyncio.to_thread(self.set_messages, key, messages)
 
     async def aget_messages(self, key: str) -> List[ChatMessage]:
         """Async version of Get messages for a key."""
-        return self.get_messages(key)
+        return await asyncio.to_thread(self.get_messages, key)
 
     async def async_add_message(self, key: str, message: ChatMessage) -> None:
         """Async version of Add a message for a key."""
-        self.add_message(key, message)
+        await asyncio.to_thread(self.add_message, key, message)
 
     async def adelete_messages(self, key: str) -> Optional[List[ChatMessage]]:
         """Async version of Delete messages for a key."""
-        return self.delete_messages(key)
+        return await asyncio.to_thread(self.delete_messages, key)
 
     async def adelete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
         """Async version of Delete specific message for a key."""
-        return self.delete_message(key, idx)
+        return await asyncio.to_thread(self.delete_message, key, idx)
 
     async def adelete_last_message(self, key: str) -> Optional[ChatMessage]:
         """Async version of Delete last message for a key."""
-        return self.delete_last_message(key)
+        return await asyncio.to_thread(self.delete_last_message, key)
 
     async def aget_keys(self) -> List[str]:
         """Async version of Get all keys."""
-        return self.get_keys()
+        return await asyncio.to_thread(self.get_keys)

--- a/llama-index-core/tests/agent/workflow/test_code_act_agent.py
+++ b/llama-index-core/tests/agent/workflow/test_code_act_agent.py
@@ -166,4 +166,4 @@ async def test_code_act_agent_tool_handling(
     # Finalize
     final_output = await agent.finalize(ctx, output, mock_memory)
     assert isinstance(final_output, AgentOutput)
-    assert mock_memory.aput.called  # Verify memory was updated
+    assert mock_memory.aput_messages.called  # Verify memory was updated


### PR DESCRIPTION
This PR updates some baseclasses to add some "bandaid" async
1. BaseMemory
2. BaseChatStore
3. BaseChatStoreMemory
4. BaseNodePostprocessor

However, relying on `asyncio.to_thread()` is not ideal. Once this is released onto stable, I will make a followup PR to adjust integrations where possible 