### PR TITLE
Feature/expand cohere model support

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/utils.py
@@ -36,10 +36,15 @@ from cohere.types import (
 
 
 COMMAND_MODELS = {
+    "command-a-03-2025": 256000,
+    "command-r7b-12-2024": 128000,
     "command-r": 128000,
+    "command-r-08-2024": 128000,
     "command-r-plus": 128000,
+    "command-r-plus-04-2024": 128000,
+    "command-r-plus-08-2024": 128000,
     "command": 4096,
-    "command-nightly": 4096,
+    "command-nightly": 128000,
     "command-light": 4096,
     "command-light-nightly": 4096,
     "c4ai-aya-expanse-32b": 128000,
@@ -51,11 +56,29 @@ GENERATION_MODELS = {"base": 2048, "base-light": 2048}
 REPRESENTATION_MODELS = {
     "embed-english-light-v2.0": 512,
     "embed-english-v2.0": 512,
+    "embed-english-v3.0": 512,
     "embed-multilingual-v2.0": 256,
+    "embed-english-light-v3.0": 512,
+    "embed-multilingual-v3.0": 512,
+    "embed-multilingual-light-v3.0": 512,
 }
 
-FUNCTION_CALLING_MODELS = {"command-r", "command-r-plus"}
-ALL_AVAILABLE_MODELS = {**COMMAND_MODELS, **GENERATION_MODELS, **REPRESENTATION_MODELS}
+FUNCTION_CALLING_MODELS = {
+    "command-a-03-2025",
+    "command-r7b-12-2024",
+    "command-r",
+    "command-r-08-2024",
+    "command-r-plus",
+    "command-r-plus-04-2024",
+    "command-r-plus-08-2024",
+}
+
+ALL_AVAILABLE_MODELS = {
+    **COMMAND_MODELS,
+    **GENERATION_MODELS,
+    **REPRESENTATION_MODELS,
+}
+
 CHAT_MODELS = {**COMMAND_MODELS}
 
 JSON_TO_PYTHON_TYPES = {

--- a/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-cohere"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION

# Description

Updated Cohere models' context window sizes to match official documentation, with specific focus on fixing `command-nightly` from 4096 to 128000. Also added new Cohere models including command-a-03-2025, command-r7b-12-2024, and other models in the Command and Aya series with their correct context window sizes. 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
