### PR TITLE
feat(elasticsearch): implement missing BasePydanticVectorStore methods

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 import nest_asyncio
 from llama_index.core.bridge.pydantic import PrivateAttr
-from llama_index.core.schema import BaseNode, MetadataMode, TextNode
+from llama_index.core.schema import BaseNode, MetadataMode
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
     MetadataFilters,
@@ -15,7 +15,6 @@ from llama_index.core.vector_stores.types import (
     VectorStoreQueryResult,
 )
 from llama_index.core.vector_stores.utils import (
-    metadata_dict_to_node,
     node_to_metadata_dict,
 )
 from elasticsearch.helpers.vectorstore import AsyncVectorStore
@@ -30,6 +29,7 @@ from elasticsearch.helpers.vectorstore import (
 from llama_index.vector_stores.elasticsearch.utils import (
     get_elasticsearch_client,
     get_user_agent,
+    convert_es_hit_to_node,
 )
 
 logger = getLogger(__name__)
@@ -543,42 +543,93 @@ class ElasticsearchStore(BasePydanticVectorStore):
         top_k_scores = []
 
         for hit in hits:
-            source = hit["_source"]
-            metadata = source.get("metadata", {})
-            text = source.get(self.text_field, None)
-            node_id = hit["_id"]
-            score = hit["_score"]
-
-            try:
-                node = metadata_dict_to_node(metadata)
-                node.text = text
-            except Exception:
-                # Legacy support for old metadata format
-                logger.warning(
-                    f"Could not parse metadata from hit {hit['_source'].get('metadata')}"
-                )
-                node_info = source.get("node_info")
-                relationships = source.get("relationships", {})
-                start_char_idx = None
-                end_char_idx = None
-                if isinstance(node_info, dict):
-                    start_char_idx = node_info.get("start", None)
-                    end_char_idx = node_info.get("end", None)
-
-                node = TextNode(
-                    text=text,
-                    metadata=metadata,
-                    id_=node_id,
-                    start_char_idx=start_char_idx,
-                    end_char_idx=end_char_idx,
-                    relationships=relationships,
-                )
+            node = convert_es_hit_to_node(hit, self.text_field)
             top_k_nodes.append(node)
-            top_k_ids.append(node_id)
-            top_k_scores.append(score)
+            top_k_ids.append(hit["_id"])
+            top_k_scores.append(hit["_score"])
 
         return VectorStoreQueryResult(
             nodes=top_k_nodes,
             ids=top_k_ids,
             similarities=_to_llama_similarities(top_k_scores),
         )
+
+    def get_nodes(
+        self,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
+    ) -> List[BaseNode]:
+        """
+        Get nodes from Elasticsearch index.
+
+        Args:
+            node_ids (Optional[List[str]]): List of node IDs to retrieve.
+            filters (Optional[MetadataFilters]): Metadata filters to apply.
+
+        Returns:
+            List[BaseNode]: List of nodes retrieved from the index.
+        """
+        return asyncio.get_event_loop().run_until_complete(
+            self.aget_nodes(node_ids, filters)
+        )
+
+    async def aget_nodes(
+        self,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
+    ) -> List[BaseNode]:
+        """
+        Asynchronously get nodes from Elasticsearch index.
+
+        Args:
+            node_ids (Optional[List[str]]): List of node IDs to retrieve.
+            filters (Optional[MetadataFilters]): Metadata filters to apply.
+
+        Returns:
+            List[BaseNode]: List of nodes retrieved from the index.
+
+        Raises:
+            ValueError: If neither node_ids nor filters is provided.
+        """
+        if not node_ids and not filters:
+            raise ValueError("Either node_ids or filters must be provided.")
+
+        query = {"bool": {"must": []}}
+
+        if node_ids is not None:
+            query["bool"]["must"].append({"terms": {"_id": node_ids}})
+
+        if filters:
+            es_filter = _to_elasticsearch_filter(filters)
+            if "bool" in es_filter and "must" in es_filter["bool"]:
+                query["bool"]["must"].extend(es_filter["bool"]["must"])
+            else:
+                query["bool"]["must"].append(es_filter)
+
+        response = await self._store.client.search(
+            index=self.index_name,
+            body={"query": query, "size": 10000},
+        )
+
+        hits = response.get("hits", {}).get("hits", [])
+        nodes = []
+
+        for hit in hits:
+            nodes.append(convert_es_hit_to_node(hit, self.text_field))
+
+        return nodes
+
+    def clear(self) -> None:
+        """
+        Clear all nodes from Elasticsearch index.
+        This method deletes and recreates the index.
+        """
+        return asyncio.get_event_loop().run_until_complete(self.aclear())
+
+    async def aclear(self) -> None:
+        """
+        Asynchronously clear all nodes from Elasticsearch index.
+        This method deletes and recreates the index.
+        """
+        if await self._store.client.indices.exists(index=self.index_name):
+            await self._store.client.indices.delete(index=self.index_name)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
@@ -1,6 +1,12 @@
 from typing import Any, Dict, Optional
 
 from elasticsearch import AsyncElasticsearch, Elasticsearch
+from logging import getLogger
+
+from llama_index.core.schema import BaseNode, TextNode
+from llama_index.core.vector_stores.utils import metadata_dict_to_node
+
+logger = getLogger(__name__)
 
 
 def get_user_agent() -> str:
@@ -47,3 +53,47 @@ def get_elasticsearch_client(
     sync_es_client.info()  # use sync client so don't have to 'await' to just get info
 
     return async_es_client
+
+
+def convert_es_hit_to_node(
+    hit: Dict[str, Any], text_field: str = "content"
+) -> BaseNode:
+    """
+    Convert an Elasticsearch search hit to a BaseNode.
+
+    Args:
+        hit: The Elasticsearch search hit
+        text_field: The field name that contains the text content
+
+    Returns:
+        BaseNode: The converted node
+    """
+    source = hit.get("_source", {})
+    metadata = source.get("metadata", {})
+    text = source.get(text_field, None)
+    node_id = hit.get("_id")
+
+    try:
+        node = metadata_dict_to_node(metadata)
+        node.text = text
+    except Exception:
+        # Legacy support for old metadata format
+        logger.warning(f"Could not parse metadata from hit {source.get('metadata')}")
+        node_info = source.get("node_info")
+        relationships = source.get("relationships", {})
+        start_char_idx = None
+        end_char_idx = None
+        if isinstance(node_info, dict):
+            start_char_idx = node_info.get("start", None)
+            end_char_idx = node_info.get("end", None)
+
+        node = TextNode(
+            text=text,
+            metadata=metadata,
+            id_=node_id,
+            start_char_idx=start_char_idx,
+            end_char_idx=end_char_idx,
+            relationships=relationships,
+        )
+
+    return node

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-elasticsearch"
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Implementation of Missing Methods in ElasticsearchStore

## Description

This PR implements the missing methods required by the `BasePydanticVectorStore` interface in the ElasticsearchStore class. The implementation adds the ability to retrieve nodes directly by ID or filters and to clear all nodes from an index. Additionally, common conversion logic for Elasticsearch hits to nodes has been extracted to a utility function to promote code reuse and maintainability.

Fixes #N/A

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
