### PR TITLE
fix nebula index ddl

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-nebula/llama_index/graph_stores/nebula/nebula_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-nebula/llama_index/graph_stores/nebula/nebula_property_graph.py
@@ -61,13 +61,13 @@ CREATE EDGE IF NOT EXISTS `__meta__rel_label__` (`label` STRING, `props_json` ST
 
 # TODO: need to define Props__ Indexes based on all the properties
 INDEX_DDL = """
-CREATE TAG INDEX IF NOT EXISTS idx_Entity__ ON `Entity__`(`name`);
-CREATE TAG INDEX IF NOT EXISTS idx_Chunk__ ON `Chunk__`(`text`);
-CREATE TAG INDEX IF NOT EXISTS idx_Node__ ON `Node__`(`label`);
-CREATE EDGE INDEX IF NOT EXISTS idx_Relation__ ON `Relation__`(`label`);
+CREATE TAG INDEX IF NOT EXISTS idx_Entity__ ON `Entity__`(`name`(256));
+CREATE TAG INDEX IF NOT EXISTS idx_Chunk__ ON `Chunk__`(`text`(256));
+CREATE TAG INDEX IF NOT EXISTS idx_Node__ ON `Node__`(`label`(256));
+CREATE EDGE INDEX IF NOT EXISTS idx_Relation__ ON `Relation__`(`label`(256));
 
-CREATE EDGE INDEX IF NOT EXISTS idx_meta__node_label__ ON `__meta__node_label__`(`label`);
-CREATE EDGE INDEX IF NOT EXISTS idx_meta__rel_label__ ON `__meta__rel_label__`(`label`);
+CREATE EDGE INDEX IF NOT EXISTS idx_meta__node_label__ ON `__meta__node_label__`(`label`(256));
+CREATE EDGE INDEX IF NOT EXISTS idx_meta__rel_label__ ON `__meta__rel_label__`(`label`(256));
 """
 
 # Hard coded default schema, which is union of

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-nebula/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-nebula/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "Apache-2.0"
 name = "llama-index-graph-stores-nebula"
 readme = "README.md"
-version = "0.4.1"
+version = "0.4.2"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
https://docs.nebula-graph.io/3.8.0/3.ngql-guide/14.native-index-statements/1.create-native-index/#create_single-property_indexes

```
# To index a variable-length string property, you need to specify the index length.
nebula> CREATE TAG IF NOT EXISTS var_string(p1 string);
nebula> CREATE TAG INDEX IF NOT EXISTS var ON var_string(p1(10));

# To index a fixed-length string property, you do not need to specify the index length.
nebula> CREATE TAG IF NOT EXISTS fix_string(p1 FIXED_STRING(10));
nebula> CREATE TAG INDEX IF NOT EXISTS fix ON fix_string(p1);
```

<img width="759" alt="image" src="https://github.com/user-attachments/assets/bfc3089d-af2c-4879-bcf6-fa16a5ec802a" />
