### PR TITLE
Don't create a sync openai client when using async methods with Azure

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
@@ -1,14 +1,19 @@
-from typing import Any
-from unittest.mock import MagicMock, patch
-
+import pytest
+from openai import AzureOpenAI as SyncAzureOpenAI
+from openai import AsyncAzureOpenAI
+from typing import Any, Generator, AsyncGenerator
+from unittest.mock import MagicMock, AsyncMock, patch
 import httpx
 from llama_index.llms.azure_openai import AzureOpenAI
+from llama_index.core.base.llms.types import ChatMessage
 from openai.types.chat.chat_completion import (
     ChatCompletion,
     ChatCompletionMessage,
     Choice,
 )
 from openai.types.completion import CompletionUsage
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk, ChoiceDelta
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 
 
 def mock_chat_completion_v1(*args: Any, **kwargs: Any) -> ChatCompletion:
@@ -69,3 +74,147 @@ def test_custom_azure_ad_token_provider(sync_azure_openai_mock: MagicMock):
     )
     azure_openai.complete("test prompt")
     assert azure_openai.api_key == "mock_api_key"
+
+
+def mock_chat_completion_stream_with_filter_results(
+    *args: Any, **kwargs: Any
+) -> Generator[ChatCompletionChunk, None, None]:
+    """Azure sends a chunk without text content (empty `choices` attribute) as the first chunk.
+    It only contains prompt filter results. Documentation on this can be found here: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter?tabs=warning%2Cuser-prompt%2Cpython-new#sample-response-stream-passes-filters.
+    """
+    responses = [
+        ChatCompletionChunk.model_construct(
+            id="",
+            object="",
+            created=0,
+            model="",
+            prompt_filter_results=[
+                {
+                    "prompt_index": 0,
+                    "content_filter_results": {
+                        "hate": {"filtered": False, "severity": "safe"},
+                        "self_harm": {"filtered": False, "severity": "safe"},
+                        "sexual": {"filtered": False, "severity": "safe"},
+                        "violence": {"filtered": False, "severity": "safe"},
+                    },
+                }
+            ],
+            choices=[],
+            usage=None,
+        ),
+        ChatCompletionChunk(
+            id="chatcmpl-6ptKyqKOGXZT6iQnqiXAH8adNLUzD",
+            object="chat.completion.chunk",
+            created=1677825464,
+            model="gpt-3.5-turbo-0301",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(role="assistant"), finish_reason=None, index=0
+                )
+            ],
+        ),
+        ChatCompletionChunk(
+            id="chatcmpl-6ptKyqKOGXZT6iQnqiXAH8adNLUzD",
+            object="chat.completion.chunk",
+            created=1677825464,
+            model="gpt-3.5-turbo-0301",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="Hello from\n"),
+                    finish_reason=None,
+                    index=0,
+                )
+            ],
+        ),
+        ChatCompletionChunk(
+            id="chatcmpl-6ptKyqKOGXZT6iQnqiXAH8adNLUzD",
+            object="chat.completion.chunk",
+            created=1677825464,
+            model="gpt-3.5-turbo-0301",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="Azure"), finish_reason=None, index=0
+                )
+            ],
+        ),
+        ChatCompletionChunk(
+            id="chatcmpl-6ptKyqKOGXZT6iQnqiXAH8adNLUzD",
+            object="chat.completion.chunk",
+            created=1677825464,
+            model="gpt-3.5-turbo-0301",
+            choices=[ChunkChoice(delta=ChoiceDelta(), finish_reason="stop", index=0)],
+        ),
+    ]
+    yield from responses
+
+
+async def mock_async_chat_completion_stream_with_filter_results(
+    *args: Any, **kwargs: Any
+) -> AsyncGenerator[ChatCompletionChunk, None]:
+    async def gen() -> AsyncGenerator[ChatCompletionChunk, None]:
+        for response in mock_chat_completion_stream_with_filter_results(
+            *args, **kwargs
+        ):
+            yield response
+
+    return gen()
+
+
+@patch("llama_index.llms.azure_openai.base.SyncAzureOpenAI")
+def test_chat_completion_with_filter_results(sync_azure_openai_mock: MagicMock) -> None:
+    """Tests that synchronous chat completions work correctly if first chunk contains prompt
+    filter results (empty `choices` list).
+    """
+    mock_instance = MagicMock(spec=SyncAzureOpenAI)
+    sync_azure_openai_mock.return_value = mock_instance
+
+    chat_mock = MagicMock()
+    chat_mock.completions.create.return_value = (
+        mock_chat_completion_stream_with_filter_results()
+    )
+    mock_instance.chat = chat_mock
+
+    llm = AzureOpenAI(engine="foo bar", api_key="mock")
+    prompt = "test prompt"
+    message = ChatMessage(role="user", content="test message")
+
+    response_gen = llm.stream_complete(prompt)
+    responses = list(response_gen)
+    assert responses[-1].text == "Hello from\nAzure"
+
+    mock_instance.chat.completions.create.return_value = (
+        mock_chat_completion_stream_with_filter_results()
+    )
+    chat_response_gen = llm.stream_chat([message])
+    chat_responses = list(chat_response_gen)
+    assert chat_responses[-1].message.content == "Hello from\nAzure"
+    assert chat_responses[-1].message.role == "assistant"
+
+
+@pytest.mark.asyncio()
+@patch("llama_index.llms.azure_openai.base.AsyncAzureOpenAI")
+async def test_async_chat_completion_with_filter_results(
+    async_azure_openai_mock: MagicMock,
+) -> None:
+    """Tests that asynchronous chat completions work correctly if first chunk contains prompt
+    filter results (empty `choices` list).
+    """
+    mock_instance = MagicMock(spec=AsyncAzureOpenAI)
+    async_azure_openai_mock.return_value = mock_instance
+    create_fn = AsyncMock()
+    create_fn.side_effect = mock_async_chat_completion_stream_with_filter_results
+    chat_mock = MagicMock()
+    chat_mock.completions.create = create_fn
+    mock_instance.chat = chat_mock
+
+    llm = AzureOpenAI(engine="foo bar", api_key="mock")
+    prompt = "test prompt"
+    message = ChatMessage(role="user", content="test message")
+
+    response_gen = await llm.astream_complete(prompt)
+    responses = [item async for item in response_gen]
+    assert responses[-1].text == "Hello from\nAzure"
+
+    chat_response_gen = await llm.astream_chat([message])
+    chat_responses = [item async for item in chat_response_gen]
+    assert chat_responses[-1].message.content == "Hello from\nAzure"

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -78,7 +78,7 @@ from llama_index.llms.openai.utils import (
     to_openai_message_dicts,
     update_tool_calls,
 )
-from openai import AsyncOpenAI, AzureOpenAI
+from openai import AsyncOpenAI, AzureOpenAI, AsyncAzureOpenAI
 from openai import OpenAI as SyncOpenAI
 from openai.types.chat.chat_completion_chunk import (
     ChatCompletionChunk,
@@ -341,9 +341,6 @@ class OpenAI(FunctionCallingLLM):
             model_name = model_name.split(":")[1]
         return model_name
 
-    def _is_azure_client(self) -> bool:
-        return isinstance(self._get_client(), AzureOpenAI)
-
     @classmethod
     def class_name(cls) -> str:
         return "openai_llm"
@@ -531,7 +528,7 @@ class OpenAI(FunctionCallingLLM):
                 if len(response.choices) > 0:
                     delta = response.choices[0].delta
                 else:
-                    if self._is_azure_client():
+                    if isinstance(client, AzureOpenAI):
                         continue
                     else:
                         delta = ChoiceDelta()
@@ -800,7 +797,7 @@ class OpenAI(FunctionCallingLLM):
                         continue
                     delta = response.choices[0].delta
                 else:
-                    if self._is_azure_client():
+                    if isinstance(aclient, AsyncAzureOpenAI):
                         continue
                     else:
                         delta = ChoiceDelta()

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.36"
+version = "0.3.37"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.35"
+version = "0.3.36"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Azure has a special behaviour that in the chat streaming results, the first chunk will come with an empty `choices` list, it only contains `prompt_filter_results` (these are content filtering check results - hate, jailbreak, etc.).

For that reason, there is a special condition in the handling of these results that depends on if Azure is being used or not. In the old code, to find out if Azure is being used, in the method `_is_azure_client()`,  always the sync `_get_client()` was called, also if executed from the async `_astream_chat()` method. 

The synchronous openai client is normally not required if the user only calls async methods. So the old implementation was inefficient in this place, also it is not expected that a synchronous client is created when using async methods. Furthermore, at least in our application/environment, there seems to be a memory leak in `create_ssl_context()` (called when creating a new openai client).

With this proposed change, no unnecessary creation of openai clients will take place anymore.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests
