### PR TITLE
allow content blocks in openai assistant messages

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -488,7 +488,7 @@ def to_openai_responses_message_dict(
             "role": message.role.value,
             "content": (
                 content_txt
-                if message.role.value in ("assistant", "system", "developer")
+                if message.role.value in ("system", "developer")
                 or all(isinstance(block, TextBlock) for block in message.blocks)
                 else content
             ),

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.37"
+version = "0.3.38"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/18478

Contrary to openai's api docs, Assistant messages CAN have images and other block types