### PR TITLE
Fix media resource serialization

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -566,7 +566,7 @@ class MediaResource(BaseModel):
 
         return v
 
-    @field_serializer("path")
+    @field_serializer("path")  # type: ignore
     def serialize_path(
         self, path: Optional[Path], _info: ValidationInfo
     ) -> Optional[str]:

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -1024,7 +1024,7 @@ class Document(Node):
             else:
                 data["metadata"] = value
 
-        if "text" in data:
+        if data.get("text"):
             text = data.pop("text")
             if "text_resource" in data:
                 text_resource = (

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -45,6 +45,7 @@ from llama_index.core.bridge.pydantic import (
     SerializeAsAny,
     SerializerFunctionWrapHandler,
     ValidationInfo,
+    field_serializer,
     field_validator,
     model_serializer,
 )
@@ -564,6 +565,14 @@ class MediaResource(BaseModel):
                 return ftype.mime
 
         return v
+
+    @field_serializer("path")
+    def serialize_path(
+        self, path: Optional[Path], _info: ValidationInfo
+    ) -> Optional[str]:
+        if path is None:
+            return path
+        return str(path)
 
     @property
     def hash(self) -> str:

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -281,6 +281,11 @@ def test_image_document_embeddings():
     assert doc.text_resource.embeddings == {"dense": [1.0, 2.0, 3.0]}
 
 
+def test_image_document_path_serialization():
+    doc = ImageDocument(image_path=Path("test.png"))
+    assert doc.model_dump()["image_resource"]["path"] == "test.png"
+
+
 def test_image_block_resolve_image(png_1px: bytes, png_1px_b64: bytes):
     doc = ImageDocument()
     assert doc.resolve_image().read() == b""

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -285,6 +285,9 @@ def test_image_document_path_serialization():
     doc = ImageDocument(image_path=Path("test.png"))
     assert doc.model_dump()["image_resource"]["path"] == "test.png"
 
+    new_doc = ImageDocument(**doc.model_dump())
+    assert new_doc.image_resource.path == Path("test.png")
+
 
 def test_image_block_resolve_image(png_1px: bytes, png_1px_b64: bytes):
     doc = ImageDocument()

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -488,7 +488,7 @@ def to_openai_responses_message_dict(
             "role": message.role.value,
             "content": (
                 content_txt
-                if message.role.value in ("assistant", "system", "developer")
+                if message.role.value in ("system", "developer")
                 or all(isinstance(block, TextBlock) for block in message.blocks)
                 else content
             ),

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -28,7 +28,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-openai"
 readme = "README.md"
-version = "0.3.37"
+version = "0.3.38"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/18492

Pydantic needs a way to serialize the `Path` object