### PR TITLE
Milvus Vector Store: Update metadata filtering demo

### DIFF
--- a/docs/docs/examples/vector_stores/MilvusOperatorFunctionDemo.ipynb
+++ b/docs/docs/examples/vector_stores/MilvusOperatorFunctionDemo.ipynb
@@ -4,50 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Milvus Vector Store with Metadata Filtering\n",
-    "\n",
-    "The goal of this guide is to walk through the basics of how to utilize the LlamaIndex FilterOperatorFunctions to leverage the power of Milvus's advanced query cabability against hosted vector databases. For context on how these work, see Milvus's documentation:\n",
-    "1. [Basic operators](https://docs.zilliz.com/docs/get-and-scalar-query#basic-operators)\n",
-    "2. [JSON filtering](https://docs.zilliz.com/docs/use-json-fields)\n",
-    "3. [Array filtering](https://docs.zilliz.com/docs/use-array-fields)\n",
-    "\n",
-    "This guide assumes a few things:\n",
-    "1. You have a provisioned Milvus collection loaded into and hosted on a vector database\n",
-    "2. You are running this example locally and have access to environment variables"
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/docs/examples/vector_stores/MilvusOperatorFunctionDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Install Milvus and LlamaIndex dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%pip install llama-index-vector-stores-milvus"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! pip install llama-index"
+    "# Milvus Vector Store - Metadata Filter\n",
+    "\n",
+    "This notebook illustrates the use of the Milvus vector store in LlamaIndex, focusing on metadata filtering capabilities. You will learn how to index documents with metadata, perform vector searches with LlamaIndex's built-in metadata filters, and apply Milvus's native filtering expressions to the vector store.\n",
+    "\n",
+    "By the end of this notebook, you will understand how to utilize Milvus's filtering features to narrow down search results based on document metadata."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Build reused code\n",
-    "- constants\n",
-    "- function to demonstrate outputs"
+    "## Prerequisites\n",
+    "\n",
+    "**Install dependencies**\n",
+    "\n",
+    "Before getting started, make sure you have the following dependencies installed:"
    ]
   },
   {
@@ -56,32 +35,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core.schema import QueryBundle\n",
-    "\n",
-    "top_k = 5\n",
-    "key = \"product_codes\"\n",
-    "\n",
-    "\n",
-    "def retrieve_and_print_results(retriever):\n",
-    "    query_result = retriever.retrieve(\n",
-    "        QueryBundle(\n",
-    "            query_str=\"Explain non-refoulement.\", embedding=[0.0] * 3072\n",
-    "        )\n",
-    "    )\n",
-    "    for node in query_result:\n",
-    "        print(\n",
-    "            f\"node id_: {node.id_}\\nmetadata: \\n\\tchapter id: {node.metadata['chapter_id']}\\n\\t{key}: {node.metadata[key]}\\n\"\n",
-    "        )"
+    "! pip install llama-index-vector-stores-milvus llama-index"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load .env variables and build the VectorStore/Index\n",
+    "> If you're using Google Colab, you may need to **restart the runtime** (Navigate to the \"Runtime\" menu at the top of the interface, and select \"Restart session\" from the dropdown menu.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Set up accounts**\n",
     "\n",
-    "Provide the path to the variables if necessary (i.e. if running in a forked local repository)\n",
-    "- If you'd rather provide the uri, token and collection info manually, do that in the next step and ignore the load_dotenv"
+    "This tutorial uses OpenAI for text embeddings and answer generation. You need to prepare the [OpenAI API key](https://platform.openai.com/api-keys). "
    ]
   },
   {
@@ -90,9 +60,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dotenv import load_dotenv\n",
+    "import openai\n",
     "\n",
-    "load_dotenv(\"/path/to/your/.env\")"
+    "openai.api_key = \"sk-\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use the Milvus vector store, specify your Milvus server `URI` (and optionally with the `TOKEN`). To start a Milvus server, you can set up a Milvus server by following the [Milvus installation guide](https://milvus.io/docs/install-overview.md) or simply trying [Zilliz Cloud](https://docs.zilliz.com/docs/register-with-zilliz-cloud) for free."
    ]
   },
   {
@@ -101,111 +78,115 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "URI = \"./milvus_filter_demo.db\"  # Use Milvus-Lite for demo purpose\n",
+    "# TOKEN = \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Prepare data**\n",
+    "\n",
+    "For this example, we'll use a few books with similar or identical titles but different metadata (author, genre, and publication year) as the sample data. This will help demonstrate how Milvus can filter and retrieve documents based on both vector similarity and metadata attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.schema import TextNode\n",
+    "\n",
+    "nodes = [\n",
+    "    TextNode(\n",
+    "        text=\"Life: A User's Manual\",\n",
+    "        metadata={\n",
+    "            \"author\": \"Georges Perec\",\n",
+    "            \"genre\": \"Postmodern Fiction\",\n",
+    "            \"year\": 1978,\n",
+    "        },\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"Life and Fate\",\n",
+    "        metadata={\n",
+    "            \"author\": \"Vasily Grossman\",\n",
+    "            \"genre\": \"Historical Fiction\",\n",
+    "            \"year\": 1980,\n",
+    "        },\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"Life\",\n",
+    "        metadata={\n",
+    "            \"author\": \"Keith Richards\",\n",
+    "            \"genre\": \"Memoir\",\n",
+    "            \"year\": 2010,\n",
+    "        },\n",
+    "    ),\n",
+    "    TextNode(\n",
+    "        text=\"The Life\",\n",
+    "        metadata={\n",
+    "            \"author\": \"Malcolm Knox\",\n",
+    "            \"genre\": \"Literary Fiction\",\n",
+    "            \"year\": 2011,\n",
+    "        },\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build Index\n",
+    "\n",
+    "In this section, we will store sample data in Milvus using the default embedding model (OpenAI's `text-embedding-ada-002`). Titles will be converted into text embeddings and stored in a dense embedding field, while all metadata will be stored in scalar fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-04-22 08:31:09,871 [DEBUG][_create_connection]: Created new connection using: 19675caa8f894772b3db175b65d0063a (async_milvus_client.py:547)\n"
+     ]
+    }
+   ],
+   "source": [
     "from llama_index.vector_stores.milvus import MilvusVectorStore\n",
-    "from llama_index.core import VectorStoreIndex\n",
+    "from llama_index.core import StorageContext, VectorStoreIndex\n",
+    "\n",
     "\n",
     "vector_store = MilvusVectorStore(\n",
-    "    overwrite=False,\n",
-    "    uri=os.getenv(\"MILVUS_URI\", \"xxx\"),\n",
-    "    token=os.getenv(\"MILVUS_TOKEN\", \"yyy\"),\n",
-    "    collection_name=os.getenv(\"MILVUS_COLLECTION\", \"zzz\"),\n",
+    "    uri=URI,\n",
+    "    # token=TOKEN,\n",
+    "    collection_name=\"test_filter_collection\",  # Change collection name here\n",
+    "    dim=1536,  # Vector dimension depends on the embedding model\n",
+    "    overwrite=True,  # Drop collection if exists\n",
     ")\n",
-    "\n",
-    "index = VectorStoreIndex.from_vector_store(vector_store=vector_store)"
+    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+    "index = VectorStoreIndex(nodes, storage_context=storage_context)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run Queries\n",
+    "## Metadata Filters\n",
     "\n",
-    "#### Using a FilterOperatorFunction\n",
-    "Assume that there is a metadata field called \"product_codes\" that contains an array of strings detailing certain product information. To filter the vector results down to only those tagged with \"code4\", use the `ARRAY_CONTAINS` function\n",
-    "\n",
-    "Build the `ScalarMetadataFilter` and `ScalarMetadataFilters` objects"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from llama_index.vector_stores.milvus.utils import (\n",
-    "    ScalarMetadataFilters,\n",
-    "    ScalarMetadataFilter,\n",
-    "    FilterOperatorFunction,\n",
-    ")\n",
-    "\n",
-    "array_contains_scalar_filter = ScalarMetadataFilter(\n",
-    "    key=key, value=\"code4\", operator=FilterOperatorFunction.ARRAY_CONTAINS\n",
-    ")\n",
-    "\n",
-    "scalar_filters = ScalarMetadataFilters(filters=[array_contains_scalar_filter])\n",
-    "\n",
-    "retriever = index.as_retriever(\n",
-    "    vector_store_kwargs={\"milvus_scalar_filters\": scalar_filters.to_dict()},\n",
-    "    similarity_top_k=top_k,\n",
-    ")\n",
-    "\n",
-    "retrieve_and_print_results(retriever)"
+    "In this section, we will apply LlamaIndex's built-in metadata filters and conditions to Milvus search."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Execute the query and print the relevant information\n",
-    "\n",
-    "\n",
-    "`ARRAY_CONTAINS(product_codes, \"code4\")`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Example output:\n",
-    "- Only contains nodes with metadata that matches the ARRAY_CONTAINS restriction\n",
-    "\n",
-    "```\n",
-    "node id_: c_142236555_s_291254779-291254817\n",
-    "metadata: \n",
-    "\tchapter id: 142236555\n",
-    "\tproduct_codes: ['code2', 'code9', 'code5', 'code4', 'code6']\n",
-    "\n",
-    "node id_: c_440696406_s_440696822-440696847\n",
-    "metadata: \n",
-    "\tchapter id: 440696406\n",
-    "\tproduct_codes: ['code3', 'code2', 'code1', 'code4', 'code9', 'code5']\n",
-    "\n",
-    "node id_: c_440700190_s_440700206-440700218 \n",
-    "metadata: \n",
-    "\tchapter id: 440700190\n",
-    "\tproduct_codes: ['code9', 'code7', 'code4', 'code2', 'code6']\n",
-    "\n",
-    "node id_: c_440763876_s_440763935-440763942\n",
-    "metadata: \n",
-    "\tchapter id: 440763876\n",
-    "\tproduct_codes: ['code4', 'code8', 'code10']\n",
-    "\n",
-    "node id_: c_440885466_s_440885620-440885631\n",
-    "metadata: \n",
-    "\tchapter id: 440885466\n",
-    "\tproduct_codes: ['code9', 'code5', 'code2', 'code4', 'code1']\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Run a query using the FilterOperator.NIN enum to exclude some previous results\n",
-    "\n",
-    "\n",
-    "`chapter_id not in [440885466, 440763876]`"
+    "**Define metadata filters**"
    ]
   },
   {
@@ -215,118 +196,220 @@
    "outputs": [],
    "source": [
     "from llama_index.core.vector_stores import (\n",
-    "    MetadataFilters,\n",
     "    MetadataFilter,\n",
+    "    MetadataFilters,\n",
     "    FilterOperator,\n",
     ")\n",
     "\n",
-    "not_in_metadata_filter = MetadataFilter(\n",
-    "    key=\"chapter_id\", value=[440885466, 440763876], operator=FilterOperator.NIN\n",
-    ")\n",
-    "\n",
-    "metadata_filters = MetadataFilters(filters=[not_in_metadata_filter])\n",
-    "\n",
-    "retriever = index.as_retriever(\n",
-    "    filters=metadata_filters, similarity_top_k=top_k\n",
-    ")\n",
-    "\n",
-    "retrieve_and_print_results(retriever)"
+    "filters = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(\n",
+    "            key=\"year\", value=2000, operator=FilterOperator.GT\n",
+    "        )  # year > 2000\n",
+    "    ]\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Example output:\n",
-    "- Doesn't contain chapter ids 440885466 or 440763876\n",
-    "- Contains results with product codes we would've excluded in the first query\n",
-    "\n",
-    "```\n",
-    "node id_: c_440769025_s_440769040-440769053\n",
-    "metadata: \n",
-    "\tchapter id: 440769025\n",
-    "\tproduct_codes: ['code3']\n",
-    "\n",
-    "node id_: c_441155692_s_441155856-441155752\n",
-    "metadata: \n",
-    "\tchapter id: 441155692\n",
-    "\tproduct_codes: ['code9', 'code1']\n",
-    "\n",
-    "node id_: c_142236555_s_291254779-291254817\n",
-    "metadata: \n",
-    "\tchapter id: 142236555\n",
-    "\tproduct_codes: ['code2', 'code9', 'code5', 'code4', 'code6']\n",
-    "\n",
-    "node id_: c_441156096_s_441156098-441156102\n",
-    "metadata: \n",
-    "\tchapter id: 441156096\n",
-    "\tproduct_codes: ['code3', 'code8', 'code5']\n",
-    "\n",
-    "node id_: c_444354779_s_444354787-444354792\n",
-    "metadata: \n",
-    "\tchapter id: 444354779\n",
-    "\tproduct_codes: ['code3', 'code5', 'code10', 'code1']\n",
-    "```\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Combine the two query conditions into a single query call\n",
-    "\n",
-    "`ARRAY_CONTAINS(product_codes, \"code4\") and chapter_id not in [440885466, 440763876]`"
+    "**Retrieve from vector store with filters**"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Life\n",
+      "{'author': 'Malcolm Knox', 'genre': 'Literary Fiction', 'year': 2011}\n",
+      "\n",
+      "\n",
+      "Life\n",
+      "{'author': 'Keith Richards', 'genre': 'Memoir', 'year': 2010}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "retriever = index.as_retriever(\n",
-    "    filters=metadata_filters,\n",
-    "    vector_store_kwargs={\"milvus_scalar_filters\": scalar_filters.to_dict()},\n",
-    "    similarity_top_k=top_k,\n",
-    ")\n",
-    "\n",
-    "retrieve_and_print_results(retriever)"
+    "retriever = index.as_retriever(filters=filters, similarity_top_k=5)\n",
+    "result_nodes = retriever.retrieve(\"Books about life\")\n",
+    "for node in result_nodes:\n",
+    "    print(node.text)\n",
+    "    print(node.metadata)\n",
+    "    print(\"\\n\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Example output:\n",
-    "- Doesn't contain chapter ids 440885466 or 440763876\n",
-    "- Only contains results that match the ARRAY_CONTAINS restriction\n",
+    "### Multiple Metdata Filters\n",
     "\n",
-    "```\n",
-    "node id_: c_142236555_s_291254779-291254817\n",
-    "metadata: \n",
-    "\tchapter id: 142236555\n",
-    "\tproduct_codes['code2', 'code9', 'code5', 'code4', 'code6']\n",
+    "You can also combine multiple metadata filters to create more complex queries. LlamaIndex supports both `AND` and `OR` conditions to combine filters. This allows for more precise and flexible retrieval of documents based on their metadata attributes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Condition `AND`**\n",
     "\n",
-    "node id_: c_361386932_s_361386982-361387025\n",
-    "metadata: \n",
-    "\tchapter id: 361386932\n",
-    "\tproduct_codes['code4']\n",
+    "Try an example filtering for books published between 1979 and 2010 (specifically, where 1979 < year ≤ 2010):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Life and Fate\n",
+      "{'author': 'Vasily Grossman', 'genre': 'Historical Fiction', 'year': 1980}\n",
+      "\n",
+      "\n",
+      "Life\n",
+      "{'author': 'Keith Richards', 'genre': 'Memoir', 'year': 2010}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.core.vector_stores import FilterCondition\n",
     "\n",
-    "node id_: c_361386932_s_361387000-361387179\n",
-    "metadata: \n",
-    "\tchapter id: 361386932\n",
-    "\tproduct_codes['code4']\n",
+    "filters = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(\n",
+    "            key=\"year\", value=1979, operator=FilterOperator.GT\n",
+    "        ),  # year > 1979\n",
+    "        MetadataFilter(\n",
+    "            key=\"year\", value=2010, operator=FilterOperator.LTE\n",
+    "        ),  # year <= 2010\n",
+    "    ],\n",
+    "    condition=FilterCondition.AND,\n",
+    ")\n",
     "\n",
-    "node id_: c_361386932_s_361387026-361387053\n",
-    "metadata: \n",
-    "\tchapter id: 361386932\n",
-    "\tproduct_codes['code4']\n",
+    "retriever = index.as_retriever(filters=filters, similarity_top_k=5)\n",
+    "result_nodes = retriever.retrieve(\"Books about life\")\n",
+    "for node in result_nodes:\n",
+    "    print(node.text)\n",
+    "    print(node.metadata)\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Condition `OR`**\n",
     "\n",
-    "node id_: c_361384286_s_361384359-361384367\n",
-    "metadata: \n",
-    "\tchapter id: 361384286\n",
-    "\tproduct_codes['code4', 'code2', 'code9']"
+    "Try another example that filters books written by either Georges Perec or Keith Richards:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Life\n",
+      "{'author': 'Keith Richards', 'genre': 'Memoir', 'year': 2010}\n",
+      "\n",
+      "\n",
+      "Life: A User's Manual\n",
+      "{'author': 'Georges Perec', 'genre': 'Postmodern Fiction', 'year': 1978}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "filters = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(\n",
+    "            key=\"author\", value=\"Georges Perec\", operator=FilterOperator.EQ\n",
+    "        ),  # author is Georges Perec\n",
+    "        MetadataFilter(\n",
+    "            key=\"author\", value=\"Keith Richards\", operator=FilterOperator.EQ\n",
+    "        ),  # author is Keith Richards\n",
+    "    ],\n",
+    "    condition=FilterCondition.OR,\n",
+    ")\n",
+    "\n",
+    "retriever = index.as_retriever(filters=filters, similarity_top_k=5)\n",
+    "result_nodes = retriever.retrieve(\"Books about life\")\n",
+    "for node in result_nodes:\n",
+    "    print(node.text)\n",
+    "    print(node.metadata)\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Milvus's Keyword Arguments\n",
+    "\n",
+    "In addition to the built-in filtering capabilities, you can use Milvus's native filtering expressions by the `string_expr` keyword argument. This allows you to pass specific filter expressions directly to Milvus during search operations, extending beyond the standard metadata filtering to access Milvus's advanced filtering capabilities.\n",
+    "\n",
+    "Milvus provides powerful and flexible filtering options that enable precise querying of your vector data:\n",
+    "\n",
+    "- Basic Operators: Comparison operators, range filters, arithmetic operators, and logical operators\n",
+    "- Filter Expression Templates: Predefined patterns for common filtering scenarios\n",
+    "- Specialized Operators: Data type-specific operators for JSON or array fields\n",
+    "\n",
+    "For comprehensive documentation and examples of Milvus filtering expressions, refer to the official documentation of [Milvus Filtering](https://milvus.io/docs/boolean.md)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The Life\n",
+      "{'author': 'Malcolm Knox', 'genre': 'Literary Fiction', 'year': 2011}\n",
+      "\n",
+      "\n",
+      "Life and Fate\n",
+      "{'author': 'Vasily Grossman', 'genre': 'Historical Fiction', 'year': 1980}\n",
+      "\n",
+      "\n",
+      "Life: A User's Manual\n",
+      "{'author': 'Georges Perec', 'genre': 'Postmodern Fiction', 'year': 1978}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "retriever = index.as_retriever(\n",
+    "    vector_store_kwargs={\n",
+    "        \"string_expr\": \"genre like '%Fiction'\",\n",
+    "    },\n",
+    "    similarity_top_k=5,\n",
+    ")\n",
+    "result_nodes = retriever.retrieve(\"Books about life\")\n",
+    "for node in result_nodes:\n",
+    "    print(node.text)\n",
+    "    print(node.metadata)\n",
+    "    print(\"\\n\")"
    ]
   }
  ],

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -719,7 +719,16 @@ class MilvusVectorStore(BasePydanticVectorStore):
         else:
             raise ValueError(f"Milvus does not support {query.mode} yet.")
 
-        string_expr, output_fields = self._prepare_before_search(query, **kwargs)
+        filter_string_expr, output_fields = self._prepare_before_search(query, **kwargs)
+        custom_string_expr = kwargs.pop("string_expr", "")
+        if len(filter_string_expr) != 0:
+            if len(custom_string_expr) != 0:
+                logger.warning(
+                    "string_expr in vector_store_kwargs is ignored because filters are provided."
+                )
+            string_expr = filter_string_expr
+        else:
+            string_expr = custom_string_expr
 
         # Perform the search
         if query.mode == VectorStoreQueryMode.MMR:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-milvus"
 readme = "README.md"
-version = "0.8.0"
+version = "0.8.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

- Refine the demo for Milvus Vector Store - Metadata Filtering: examples of LlamaIndex's built-in Metadata filters and the keyword arguments specific to Milvus.
- Allow to pass `string_expr` as a keyword argument of vector store enabling Milvus native filtering.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
