### PR TITLE
Allow PGVectorStore to allow passing in engines

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.4.2"
+version = "0.5.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
To allow better control or engine instances and lifetimes, allow the user to pass them in.

They must both be provided (async and sync)

Added new tests, and confirmed all existing tests pass on my local pgvector db