### PR TITLE
Prevent MCP Connections Hang

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,7 +1,7 @@
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client, StdioServerParameters
-
+from datetime import timedelta
 from urllib.parse import urlparse
 from contextlib import asynccontextmanager
 
@@ -22,9 +22,10 @@ class BasicMCPClient(ClientSession):
 
     @asynccontextmanager
     async def _run_session(self):
+        timeout = timedelta(seconds=30)
         if urlparse(self.command_or_url).scheme in ("http", "https"):
             async with sse_client(self.command_or_url) as streams:
-                async with ClientSession(*streams) as session:
+                async with ClientSession(*streams, read_timeout_seconds=timeout) as session:
                     await session.initialize()
                     yield session
         else:
@@ -32,7 +33,7 @@ class BasicMCPClient(ClientSession):
                 command=self.command_or_url, args=self.args, env=self.env
             )
             async with stdio_client(server_parameters) as streams:
-                async with ClientSession(*streams) as session:
+                async with ClientSession(*stream, read_timeout_seconds=timeouts) as session:
                     await session.initialize()
                     yield session
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -21,11 +21,10 @@ class BasicMCPClient(ClientSession):
         self.env = env
 
     @asynccontextmanager
-    async def _run_session(self):
-        timeout = timedelta(seconds=30)
+    async def _run_session(self, timeout: int=30):
         if urlparse(self.command_or_url).scheme in ("http", "https"):
             async with sse_client(self.command_or_url) as streams:
-                async with ClientSession(*streams, read_timeout_seconds=timeout) as session:
+                async with ClientSession(*streams, read_timeout_seconds=timedelta(seconds=timeout) as session:
                     await session.initialize()
                     yield session
         else:
@@ -33,7 +32,7 @@ class BasicMCPClient(ClientSession):
                 command=self.command_or_url, args=self.args, env=self.env
             )
             async with stdio_client(server_parameters) as streams:
-                async with ClientSession(*stream, read_timeout_seconds=timeouts) as session:
+                async with ClientSession(*stream, read_timeout_seconds=timedelta(seconds=timeout)) as session:
                     await session.initialize()
                     yield session
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,9 +1,11 @@
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Optional, List, Dict
+from urllib.parse import urlparse
+
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client, StdioServerParameters
-from datetime import timedelta
-from urllib.parse import urlparse
-from contextlib import asynccontextmanager
 
 
 class BasicMCPClient(ClientSession):
@@ -11,20 +13,33 @@ class BasicMCPClient(ClientSession):
     Basic MCP client that can be used to connect to an MCP server.
 
     This is useful for verifying that the MCP server which implements `FastMCP` is working.
+
+    Args:
+        command_or_url: The command to run or the URL to connect to.
+        args: The arguments to pass to StdioServerParameters.
+        env: The environment variables to set for StdioServerParameters.
+        timeout: The timeout for the command in seconds.
     """
 
     def __init__(
-        self, command_or_url: str, args: list[str] = [], env: dict[str, str] = {}
+        self,
+        command_or_url: str,
+        args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout: int = 30,
     ):
         self.command_or_url = command_or_url
-        self.args = args
-        self.env = env
+        self.args = args or []
+        self.env = env or {}
+        self.timeout = timeout
 
     @asynccontextmanager
-    async def _run_session(self, timeout: int=30):
+    async def _run_session(self):
         if urlparse(self.command_or_url).scheme in ("http", "https"):
             async with sse_client(self.command_or_url) as streams:
-                async with ClientSession(*streams, read_timeout_seconds=timedelta(seconds=timeout) as session:
+                async with ClientSession(
+                    *streams, read_timeout_seconds=timedelta(seconds=self.timeout)
+                ) as session:
                     await session.initialize()
                     yield session
         else:
@@ -32,7 +47,9 @@ class BasicMCPClient(ClientSession):
                 command=self.command_or_url, args=self.args, env=self.env
             )
             async with stdio_client(server_parameters) as streams:
-                async with ClientSession(*stream, read_timeout_seconds=timedelta(seconds=timeout)) as session:
+                async with ClientSession(
+                    *streams, read_timeout_seconds=timedelta(seconds=self.timeout)
+                ) as session:
                     await session.initialize()
                     yield session
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["psiace"]
 name = "llama-index-tools-mcp"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
I don't expect this to be the final implementation, but this seems like the most efficient way to get the conversation started.


# Description

Per https://modelcontextprotocol.io/specification/draft/basic/lifecycle#timeouts

"Implementations SHOULD establish timeouts for all sent requests, to prevent hung connections and resource exhaustion. When the request has not received a success or error response within the timeout period, the sender SHOULD issue a cancellation notification for that request and stop waiting for a response.

SDKs and other middleware SHOULD allow these timeouts to be configured on a per-request basis."

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
