### PR TITLE
Implement aget_nodes and adelete in PGVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-vector-stores-postgres"
 readme = "README.md"
-version = "0.5.0"
+version = "0.5.1"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
Implements aget_nodes in PGVectorStore, previously this redirected to get_nodes causing a hidden sync operation in async paths.

Also implements adelete(), along with an index for ref_doc_id