### PR TITLE
Update tools.md: FunctionAgent seems to be moved.

### DIFF
--- a/docs/docs/understanding/agent/tools.md
+++ b/docs/docs/understanding/agent/tools.md
@@ -33,14 +33,11 @@ finance_tools.extend([multiply, add])
 And we'll ask a different question than last time, necessitating the use of the new tools:
 
 ```python
-workflow = FunctionAgent(
-    name="Agent",
-    description="Useful for performing financial operations.",
-    llm=OpenAI(model="gpt-4o-mini"),
-    tools=finance_tools,
-    system_prompt="You are a helpful assistant.",
+workflow = AgentWorkflow.from_tools_or_functions(
+    finance_tools,
+    llm=llm,
+    system_prompt="You are an agent that can perform basic mathematical operations and fetch financial data using tools."
 )
-
 
 async def main():
     response = await workflow.run(


### PR DESCRIPTION
# Description

`FunctionAgent` does not seem to exist in  `llama_index.core.agent.workflow`.

# Fixes:

- Added the `AgentWorkflow.from_tools_or_functions` function instead which is already present in the [notebook repo](https://github.com/run-llama/python-agents-tutorial/tree/main) for these tutorials.
- Also removed invalid attributes.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
