### PR TITLE
[google genai] merge tool messages properly

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -14,16 +14,75 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
     ImageBlock,
+    MessageRole,
     TextBlock,
-)
-from llama_index.core.utilities.gemini_utils import (
-    ROLES_FROM_GEMINI,
-    ROLES_TO_GEMINI,
-    merge_neighboring_same_role_messages,
 )
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
+
+
+ROLES_TO_GEMINI: dict[MessageRole, MessageRole] = {
+    MessageRole.USER: MessageRole.USER,
+    MessageRole.ASSISTANT: MessageRole.MODEL,
+    ## Gemini chat mode only has user and model roles. Put the rest in user role.
+    MessageRole.SYSTEM: MessageRole.USER,
+    MessageRole.MODEL: MessageRole.MODEL,
+    ## Gemini has function role, but chat mode only accepts user and model roles.
+    ## https://medium.com/@smallufo/openai-vs-gemini-function-calling-a664f7f2b29f
+    ## Agent response's 'tool/function' role is converted to 'user' role.
+    MessageRole.TOOL: MessageRole.USER,
+    MessageRole.FUNCTION: MessageRole.USER,
+}
+
+ROLES_FROM_GEMINI: dict[str, MessageRole] = {
+    ## Gemini has user, model and function roles.
+    "user": MessageRole.USER,
+    "model": MessageRole.ASSISTANT,
+    "function": MessageRole.TOOL,
+}
+
+
+def merge_neighboring_same_role_messages(
+    messages: Sequence[ChatMessage],
+) -> Sequence[ChatMessage]:
+    if len(messages) < 2:
+        # Nothing to merge
+        return messages
+
+    # Gemini does not support multiple messages of the same role in a row, so we merge them
+    # However, tool messages are not merged, so that we can keep the tool names
+    # (merging them would destroy the tool name)
+    merged_messages = []
+    i = 0
+
+    while i < len(messages):
+        current_message = messages[i]
+        # Initialize merged content with current message content
+        merged_content = current_message.blocks
+
+        # Check if the next message exists and has the same role
+        while (
+            i + 1 < len(messages)
+            and ROLES_TO_GEMINI[messages[i + 1].role]
+            == ROLES_TO_GEMINI[current_message.role]
+            and current_message.role != MessageRole.TOOL
+        ):
+            i += 1
+            next_message = messages[i]
+            merged_content.extend(next_message.blocks)
+
+        # Create a new ChatMessage or similar object with merged content
+        merged_message = ChatMessage(
+            role=ROLES_TO_GEMINI[current_message.role],
+            blocks=merged_content,
+            additional_kwargs=current_message.additional_kwargs,
+        )
+
+        merged_messages.append(merged_message)
+        i += 1
+
+    return merged_messages
 
 
 def _error_if_finished_early(candidate: types.Candidate) -> None:
@@ -206,8 +265,44 @@ def prepare_chat_params(
         - next_msg: the next message to send
         - chat_kwargs: processed keyword arguments for chat creation
     """
+    breakpoint()
     merged_messages = merge_neighboring_same_role_messages(messages)
-    *history, next_msg = map(chat_message_to_gemini, merged_messages)
+    initial_history = list(map(chat_message_to_gemini, merged_messages))
+
+    # merge tool messages into a single tool message
+    # while maintaining the tool names
+    history = []
+    for idx, msg in enumerate(initial_history):
+        if idx < 1:
+            history.append(msg)
+            continue
+
+        # Skip if the role is different or not a tool message
+        if msg.parts and not any(
+            part.function_response is not None for part in msg.parts
+        ):
+            history.append(msg)
+            continue
+
+        last_msg = history[idx - 1]
+
+        # Skip if the last message is not a tool message
+        if last_msg.parts and not any(
+            part.function_response is not None for part in last_msg.parts
+        ):
+            history.append(msg)
+            continue
+
+        # Skip if the role is different
+        if last_msg.role != msg.role:
+            history.append(msg)
+            continue
+
+        # Merge the tool messages
+        last_msg.parts.extend(msg.parts or [])
+
+    # Separate the next message from the history
+    next_msg = history.pop()
 
     tools: types.Tool | list[types.Tool] | None = kwargs.pop("tools", None)
     if tools and not isinstance(tools, list):

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -265,7 +265,6 @@ def prepare_chat_params(
         - next_msg: the next message to send
         - chat_kwargs: processed keyword arguments for chat creation
     """
-    breakpoint()
     merged_messages = merge_neighboring_same_role_messages(messages)
     initial_history = list(map(chat_message_to_gemini, merged_messages))
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-google-genai"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
The way tool messages got merged in the `GoogleGenAI` llm class caused sequential tool messages to get concatenated together, causing issues in the API like

```
{'error': {'code': 400, 'message': 'Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.', 'status': 'INVALID_ARGUMENT'}}
```

This PR
1. Stops using the logic from core (this technically is no longer needed when genai does not need to share these utils)
2. Updates the merge logic to skip merging tool messages
3. Inserts custom tool merging logic to maintain distinct `Part` objects per function response