### PR TITLE
aextract_table_summaries cause unwanted output when showprogress is False

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -225,20 +225,21 @@ class BaseElementNodeParser(NodeParser):
         llm = self.llm or Settings.llm
 
         table_context_list = []
-        for idx, element in tqdm(enumerate(elements)):
-            if element.type not in ("table", "table_text"):
-                continue
-            table_context = str(element.element)
-            if idx > 0 and str(elements[idx - 1].element).lower().strip().startswith(
-                "table"
-            ):
-                table_context = str(elements[idx - 1].element) + "\n" + table_context
-            if idx < len(elements) + 1 and str(
-                elements[idx - 1].element
-            ).lower().strip().startswith("table"):
-                table_context += "\n" + str(elements[idx + 1].element)
+        if elements:
+            for idx, element in tqdm(enumerate(elements)):
+                if element.type not in ("table", "table_text"):
+                    continue
+                table_context = str(element.element)
+                if idx > 0 and str(elements[idx - 1].element).lower().strip().startswith(
+                    "table"
+                ):
+                    table_context = str(elements[idx - 1].element) + "\n" + table_context
+                if idx < len(elements) + 1 and str(
+                    elements[idx - 1].element
+                ).lower().strip().startswith("table"):
+                    table_context += "\n" + str(elements[idx + 1].element)
 
-            table_context_list.append(table_context)
+                table_context_list.append(table_context)
 
         async def _get_table_output(table_context: str, summary_query_str: str) -> Any:
             index = SummaryIndex.from_documents(

--- a/llama-index-core/llama_index/core/node_parser/relational/base_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/base_element.py
@@ -230,10 +230,12 @@ class BaseElementNodeParser(NodeParser):
                 if element.type not in ("table", "table_text"):
                     continue
                 table_context = str(element.element)
-                if idx > 0 and str(elements[idx - 1].element).lower().strip().startswith(
-                    "table"
-                ):
-                    table_context = str(elements[idx - 1].element) + "\n" + table_context
+                if idx > 0 and str(
+                    elements[idx - 1].element
+                ).lower().strip().startswith("table"):
+                    table_context = (
+                        str(elements[idx - 1].element) + "\n" + table_context
+                    )
                 if idx < len(elements) + 1 and str(
                     elements[idx - 1].element
                 ).lower().strip().startswith("table"):


### PR DESCRIPTION
# Description

Looping through `elements` with `tqdm` when `elements` is empty causes unwanted printing of `0it [00:00, ?it/s]`

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
