### PR TITLE
Enhance DatabaseReader with new features and improved documentation

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-database/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-database/CHANGELOG.md
@@ -3,3 +3,28 @@
 ## [0.1.2] - 2024-02-13
 
 - Add maintainers and keywords from library.json (llamahub)
+
+## [x.x.x] - 2025-04-27
+
+### Added
+
+- **Extended `DatabaseReader`**
+  - `schema` parameter supported for all connection patterns except when passing an existing `SQLDatabase`.
+  - `metadata_cols` for per-column metadata extraction and optional key-renaming.
+  - `exclude_text_cols` to omit selected columns from the `Document.text_resource` (replaces the deprecated `Document.text`).
+  - `resource_id` callback for deterministic `id_` generation.
+  - `lazy_load_data` generator for memory-efficient row streaming.
+  - `aload_data` async wrapper (runs sync work in a thread with `asyncio.to_thread`).
+- **Test suite**
+  - New pytest module (`tests/test_database_reader.py`) covering:
+    - basic loading,
+    - metadata/exclusion behaviour,
+    - custom `id_` callback,
+    - lazy generator,
+    - async wrapper.
+
+### Changed
+
+- Improved docstrings, adopting new standards for `Document`, noting the deprecated fields.
+- `load_data` now delegates to `lazy_load_data`, reducing duplicate logic.
+- Improved logging; warnings are emitted once per missing/duplicate column.

--- a/llama-index-integrations/readers/llama-index-readers-database/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-database/README.md
@@ -4,6 +4,14 @@
 
 Database Reader is a tool designed to query and load data from databases efficiently.
 
+### Key features
+
+- Accepts connection via `SQLDatabase`, SQLAlchemy `Engine`, full URI, or discrete credentials
+- Optional `schema` selection (namespace)
+- Column-level metadata mapping (`metadata_cols`) and text exclusion (`excluded_text_cols`)
+- Custom `id_` generation function (`document_id`)
+- Supports streaming (`lazy_load_data`) and async (`aload_data`)
+
 ### Installation
 
 You can install Database Reader via pip:
@@ -15,7 +23,6 @@ pip install llama-index-readers-database
 ## Usage
 
 ```python
-from llama_index.core.schema import Document
 from llama_index.readers.database import DatabaseReader
 
 # Initialize DatabaseReader with the SQL database connection details
@@ -34,6 +41,46 @@ reader = DatabaseReader(
 # Load data from the database using a query
 documents = reader.load_data(
     query="<SQL Query>"  # SQL query parameter to filter tables and rows
+)
+```
+
+```python
+# Initialize DatabaseReader with the SQL connection string and custom database schema
+from llama_index.readers.database import DatabaseReader
+
+reader = DatabaseReader(
+    uri="postgresql+psycopg2://user:pass@localhost:5432/mydb",
+    schema="warehouse",  # optional namespace
+)
+# Streaming variant, excluded id from text_resource
+for doc in reader.lazy_load_data(
+    query="SELECT * FROM warehouse.big_table", excluded_text_cols={"id"}
+):
+    process(doc)
+
+# Async variant, added region to metadata
+docs_async = await reader.aload_data(
+    query="SELECT * FROM warehouse.big_table", metadata_cols=["region"]
+)
+```
+
+```python
+# Advanced usage with custom named metadata columns, columns excluded from the `Document.text_resource`, and a dynamic `Document.id_` generated from row data and a fstring template
+from llama_index.readers.database import DatabaseReader
+
+reader_media = DatabaseReader(
+    uri="postgresql+psycopg2://user:pass@localhost:5432/mydb",
+    schema="media",  # optional namespace
+)
+
+docs = reader_media.load_data(
+    query="SELECT id, title, body, updated_at FROM media.articles",
+    metadata_cols=[
+        ("id", "article_id"),
+        "updated_at",
+    ],  # map / include in metadata
+    excluded_text_cols=["updated_at"],  # omit from text
+    document_id=lambda row: f"media-articles-{row['id']}",  # custom document id
 )
 ```
 

--- a/llama-index-integrations/readers/llama-index-readers-database/llama_index/readers/database/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-database/llama_index/readers/database/base.py
@@ -1,18 +1,40 @@
 """Database Reader."""
 
-from typing import Any, List, Optional
+import logging
+import asyncio
+import functools
+from typing import (
+    Any,
+    List,
+    Optional,
+    Dict,
+    Iterable,
+    Set,
+    Union,
+    Callable,
+    Tuple,
+    Generator,
+)
 
 from llama_index.core.readers.base import BaseReader
-from llama_index.core.schema import Document
+from llama_index.core.schema import Document, MediaResource
 from llama_index.core.utilities.sql_wrapper import SQLDatabase
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseReader(BaseReader):
     """Simple Database reader.
 
-    Concatenates each row into Document used by LlamaIndex.
+    Reads data from a database via a query and returns LlamaIndex Documents.
+    Allows specifying columns for metadata (with optional renaming) and
+    excluding columns from text content. Can also generate custom Document IDs
+    from row data.
+
+    Note: The `schema` parameter is not supported when passed with `sql_database`.
+        If the `sql_database` object was created with a schema, it will be used.
 
     Args:
         sql_database (Optional[SQLDatabase]): SQL database to use,
@@ -38,6 +60,33 @@ class DatabaseReader(BaseReader):
 
     Returns:
         DatabaseReader: A DatabaseReader object.
+
+    Note:
+        schema (Optional[str]):
+            Database schema **only honored when a connection object is created
+            inside this class** (i.e. when you pass `engine`, `uri`, or individual
+            connection parameters).
+            If you supply an already-built `SQLDatabase`, its internal schema (if
+            any) is used and this argument is ignored.
+
+    Connection patterns
+    -------------------
+    +----------------------------+-----------+---------------------------------------+
+    | Pattern                    | Supports  | Notes                                 |
+    +============================+===========+=======================================+
+    | ``sql_database``           | ✖         | Pass a pre-configured ``SQLDatabase`` |
+    |                            |           | if you need schema handling here.     |
+    +----------------------------+-----------+---------------------------------------+
+    | ``engine`` + ``schema``    | ✔         |                                       |
+    +----------------------------+-----------+---------------------------------------+
+    | ``uri`` + ``schema``       | ✔         |                                       |
+    +----------------------------+-----------+---------------------------------------+
+    | ``scheme/host/…`` +        | ✔         |                                       |
+    | ``schema``                 |           |                                       |
+    +----------------------------+-----------+---------------------------------------+
+
+    (*schema* = database namespace; *scheme* = driver/dialect, e.g. ``postgresql+psycopg``)
+
     """
 
     def __init__(
@@ -51,21 +100,29 @@ class DatabaseReader(BaseReader):
         user: Optional[str] = None,
         password: Optional[str] = None,
         dbname: Optional[str] = None,
+        schema: Optional[str] = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         """Initialize with parameters."""
+        db_kwargs = kwargs.copy()
+        if schema and not sql_database:
+            db_kwargs["schema"] = schema
+            self.schema = schema if schema else db_kwargs.get("schema", None)
+        else:
+            self.schema = None
+
         if sql_database:
             self.sql_database = sql_database
         elif engine:
-            self.sql_database = SQLDatabase(engine, *args, **kwargs)
+            self.sql_database = SQLDatabase(engine, *args, **db_kwargs)
         elif uri:
             self.uri = uri
-            self.sql_database = SQLDatabase.from_uri(uri, *args, **kwargs)
+            self.sql_database = SQLDatabase.from_uri(uri, *args, **db_kwargs)
         elif scheme and host and port and user and password and dbname:
             uri = f"{scheme}://{user}:{password}@{host}:{port}/{dbname}"
             self.uri = uri
-            self.sql_database = SQLDatabase.from_uri(uri, *args, **kwargs)
+            self.sql_database = SQLDatabase.from_uri(uri, *args, **db_kwargs)
         else:
             raise ValueError(
                 "You must provide either a SQLDatabase, "
@@ -73,26 +130,196 @@ class DatabaseReader(BaseReader):
                 "set of credentials."
             )
 
-    def load_data(self, query: str) -> List[Document]:
-        """Query and load data from the Database, returning a list of Documents.
+    def lazy_load_data(
+        self,
+        query: str,
+        metadata_cols: Optional[Iterable[Union[str, Tuple[str, str]]]] = None,
+        excluded_text_cols: Optional[Iterable[str]] = None,
+        document_id: Optional[Callable[[Dict[str, Any]], str]] = None,
+        **load_kwargs: Any,
+    ) -> Generator[Document, Any, None]:
+        """Lazily query and load data from the Database.
 
         Args:
-            query (str): Query parameter to filter tables and rows.
+            query (str): SQL query to execute.
+            metadata_cols (Optional[Iterable[Union[str, Tuple[str, str]]]]):
+                Iterable of column names or (db_col, meta_key) tuples to include
+                in Document metadata. If str, the column name is used as key.
+                If tuple, uses first element as DB column and second as metadata key.
+                If two entries map to the same metadata key, the latter will silently
+                overwrite the former - **avoid duplicates**.
+            excluded_text_cols (Optional[Iterable[str]]): Iterable of column names to be
+                excluded from Document text. Useful for metadata-only columns.
+            document_id (Optional[Callable[[Dict[str, Any]], str]]): A function
+                that takes a row (as a dict) and returns a string to be used as the
+                Document's `id_`, this replaces the deprecated `doc_id` field.
+                **MUST** return a string, falling back to auto-generated UUID.
+            **load_kwargs: Additional keyword arguments (ignored).
+
+        Yields:
+            Document: A Document object for each row fetched.
+
+        Usage Pattern for Metadata-Only Columns:
+            To include `my_col` ONLY in metadata (not text), specify it in
+            `metadata_cols=['my_col']` and `excluded_text_cols=['my_col']`.
+
+        Usage Pattern for Renaming Metadata Keys:
+            To include DB column `db_col_name` in metadata with the key `meta_key_name`,
+            use `metadata_cols=[('db_col_name', 'meta_key_name')]`.
+        """
+        exclude_set: Set[str] = set(excluded_text_cols or [])
+        missing_columns: Set[str] = set()
+        invalid_columns: Set[str] = set()
+
+        with self.sql_database.engine.connect() as connection:
+            if not query:
+                raise ValueError("A query parameter is necessary.")
+
+            result = connection.execute(text(query))
+            column_names = list(result.keys())
+
+            for row in result:
+                row_values: Dict[str, Any] = dict(zip(column_names, row))
+                doc_metadata: Dict[str, Any] = {}
+
+                # Process metadata_cols based on Union type
+                if metadata_cols:
+                    for item in metadata_cols:
+                        db_col: str
+                        meta_key: str
+                        if isinstance(item, str):
+                            db_col = item
+                            meta_key = item
+                        elif (
+                            isinstance(item, tuple)
+                            and len(item) == 2
+                            and all(isinstance(s, str) for s in item)
+                        ):
+                            db_col, meta_key = item
+                        elif f"{item!r}" not in invalid_columns:
+                            invalid_columns.add(f"{item!r}")
+                            logger.warning(
+                                f"Skipping invalid item in metadata_cols: {item!r}"
+                            )
+                            continue
+                        else:
+                            continue
+
+                        if db_col in row_values:
+                            doc_metadata[meta_key] = row_values[db_col]
+                        elif db_col not in row_values and db_col not in missing_columns:
+                            missing_columns.add(db_col)
+                            logger.warning(
+                                f"Column '{db_col}' specified in metadata_cols not found in query result."
+                            )
+
+                # Prepare text content
+                text_parts: List[str] = [
+                    f"{col}: {val}"
+                    for col, val in row_values.items()
+                    if col not in exclude_set
+                ]
+                text_resource = MediaResource(text=", ".join(text_parts))
+                params = {
+                    "text_resource": text_resource,
+                    "metadata": doc_metadata,
+                }
+
+                if document_id:
+                    try:
+                        # Ensure function receives the row data
+                        id_: Optional[str] = document_id(row_values)
+                        if not isinstance(id_, str):
+                            logger.warning(
+                                f"document_id did not return a string for row {row_values}. Got: {type(id_)}"
+                            )
+                        if id_ is not None:
+                            params["id_"] = id_
+                    except Exception as e:
+                        logger.warning(
+                            f"document_id failed for row {row_values}: {e}",
+                            exc_info=True,
+                        )
+
+                yield Document(**params)
+
+    def load_data(
+        self,
+        query: str,
+        metadata_cols: Optional[Iterable[Union[str, Tuple[str, str]]]] = None,
+        excluded_text_cols: Optional[Iterable[str]] = None,
+        document_id: Optional[Callable[[Dict[str, Any]], str]] = None,
+        **load_kwargs: Any,
+    ) -> List[Document]:
+        """Query and load data from the Database into a list of Documents.
+
+        Args:
+            query (str): SQL query to execute.
+            metadata_cols (Optional[Iterable[Union[str, Tuple[str, str]]]]):
+                Iterable of column names or (db_col, meta_key) tuples to include
+                in Document metadata. If str, the column name is used as key.
+                If tuple, uses first element as DB column and second as metadata key.
+                If two entries map to the same metadata key, the latter will silently
+                overwrite the former - **avoid duplicates**.
+            excluded_text_cols (Optional[Iterable[str]]): Iterable of column names to be
+                excluded from Document text. Useful for metadata-only columns.
+            document_id (Optional[Callable[[Dict[str, Any]], str]]): A function
+                that takes a row (as a dict) and returns a string to be used as the
+                Document's `id_`, this replaces the deprecated `doc_id` field.
+                **MUST** return a string, falling back to auto-generated UUID.
+            **load_kwargs: Additional arguments passed to lazy_load_data.
 
         Returns:
             List[Document]: A list of Document objects.
         """
-        documents = []
-        with self.sql_database.engine.connect() as connection:
-            if query is None:
-                raise ValueError("A query parameter is necessary to filter the data")
-            else:
-                result = connection.execute(text(query))
+        return list(
+            self.lazy_load_data(
+                query=query,
+                metadata_cols=metadata_cols,
+                excluded_text_cols=excluded_text_cols,
+                document_id=document_id,
+                **load_kwargs,
+            )
+        )
 
-            for item in result.fetchall():
-                # fetch each item
-                doc_str = ", ".join(
-                    [f"{col}: {entry}" for col, entry in zip(result.keys(), item)]
-                )
-                documents.append(Document(text=doc_str))
-        return documents
+    async def aload_data(
+        self,
+        query: str,
+        metadata_cols: Optional[Iterable[Union[str, Tuple[str, str]]]] = None,
+        excluded_text_cols: Optional[Iterable[str]] = None,
+        document_id: Optional[Callable[[Dict[str, Any]], str]] = None,
+        **load_kwargs: Any,
+    ) -> List[Document]:
+        """Asynchronously query and load data from the Database into a list.
+
+        Note: Implementation uses `asyncio.to_thread`; database I/O still
+            runs in a worker thread, not an async driver.
+
+        Args:
+            query (str): SQL query to execute.
+            metadata_cols (Optional[Iterable[Union[str, Tuple[str, str]]]]):
+                Iterable of column names or (db_col, meta_key) tuples to include
+                in Document metadata. If str, the column name is used as key.
+                If tuple, uses first element as DB column and second as metadata key.
+                If two entries map to the same metadata key, the latter will silently
+                overwrite the former - **avoid duplicates**.
+            excluded_text_cols (Optional[Iterable[str]]): Iterable of column names to be
+                excluded from Document text. Useful for metadata-only columns.
+            document_id (Optional[Callable[[Dict[str, Any]], str]]): A function
+                that takes a row (as a dict) and returns a string to be used as the
+                Document's `id_`, this replaces the deprecated `doc_id` field.
+                **MUST** return a string, falling back to auto-generated UUID.
+            **load_kwargs: Additional arguments passed to underlying load methods.
+
+        Returns:
+            List[Document]: A list of Document objects.
+        """
+        func = functools.partial(
+            self.load_data,  # Target the sync load_data
+            query=query,
+            metadata_cols=metadata_cols,
+            excluded_text_cols=excluded_text_cols,
+            document_id=document_id,
+            **load_kwargs,
+        )
+        return await asyncio.to_thread(func)

--- a/llama-index-integrations/readers/llama-index-readers-database/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-database/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 maintainers = ["kevinqz"]
 name = "llama-index-readers-database"
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-database/tests/test_readers_database.py
+++ b/llama-index-integrations/readers/llama-index-readers-database/tests/test_readers_database.py
@@ -1,7 +1,144 @@
-from llama_index.core.readers.base import BaseReader
+from typing import List
+
+import pytest
+from sqlalchemy import create_engine, text
+
 from llama_index.readers.database import DatabaseReader
+from llama_index.core.schema import Document
 
 
-def test_class():
-    names_of_base_classes = [b.__name__ for b in DatabaseReader.__mro__]
-    assert BaseReader.__name__ in names_of_base_classes
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def sqlite_engine():
+    """
+    Return an in-memory SQLite engine using a URI that allows sharing
+    the database across connections within the same process.
+    """
+    # This URI creates a named in-memory database that persists
+    # as long as at least one connection is open, and is shareable.
+    db_uri = (
+        "sqlite:///file:llamaindex_reader_test_db?mode=memory&cache=shared&uri=true"
+    )
+    engine = create_engine(db_uri, future=True)
+
+    # Set up schema + sample data (ensure clean state first)
+    with engine.begin() as conn:
+        # Drop table if it exists from a previous potentially failed run
+        conn.execute(text("DROP TABLE IF EXISTS items"))
+        # Create table (no schema prefix)
+        conn.execute(
+            text(
+                """
+                CREATE TABLE items (
+                    id      INTEGER PRIMARY KEY,
+                    name    TEXT,
+                    value   INTEGER
+                )
+                """
+            )
+        )
+        # Insert data (no schema prefix)
+        conn.execute(
+            text(
+                """
+                INSERT INTO items (name, value)
+                VALUES ('foo', 10), ('bar', 20)
+                """
+            )
+        )
+    # The engine is now configured with a persistent in-memory DB
+    # containing the 'items' table.
+    return engine
+
+    # Optional teardown: dispose engine if needed, though usually not required
+    # engine.dispose()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _create_reader(engine):
+    """Utility to build a DatabaseReader for the given engine."""
+    return DatabaseReader(engine=engine)
+
+
+def _get_all_docs(reader: DatabaseReader, **kwargs) -> List[Document]:
+    """Convenience wrapper that returns a list of Documents."""
+    return reader.load_data(
+        query="SELECT id, name, value FROM items ORDER BY id",
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_load_data_basic(sqlite_engine):
+    """It should return two Document objects with concatenated text."""
+    reader = _create_reader(sqlite_engine)
+    docs = _get_all_docs(reader)
+
+    assert len(docs) == 2
+    assert docs[0].text_resource and docs[0].text_resource.text
+    assert docs[0].text_resource.text.startswith("id: 1")
+    assert docs[0].text_resource.text.endswith("value: 10")
+
+
+def test_metadata_and_exclusion(sqlite_engine):
+    """
+    `metadata_cols` should be promoted to metadata and
+    `excluded_text_cols` should remove columns from text.
+    """
+    reader = _create_reader(sqlite_engine)
+    docs = _get_all_docs(
+        reader,
+        metadata_cols=[("id", "item_id"), "value"],
+        excluded_text_cols=["value"],
+    )
+
+    doc = docs[0]
+    # `value` excluded from text, included as metadata
+    assert "value:" not in doc.text
+    assert doc.metadata == {"item_id": 1, "value": 10}
+
+
+def test_resource_id_fn(sqlite_engine):
+    """Custom `document_id` should drive `doc_id`."""
+    reader = _create_reader(sqlite_engine)
+    docs = _get_all_docs(
+        reader,
+        document_id=lambda row: f"custom-{row['id']}",
+    )
+
+    assert docs[0].id_ == "custom-1"
+    assert docs[1].id_ == "custom-2"
+
+
+def test_lazy_load_data_generator(sqlite_engine):
+    """`lazy_load_data` should yield Documents lazily."""
+    reader = _create_reader(sqlite_engine)
+    gen = reader.lazy_load_data(query="SELECT * FROM items")
+    docs = list(gen)
+
+    assert len(docs) == 2
+    assert all(hasattr(d, "text_resource") for d in docs)
+    assert all(hasattr(d.text_resource, "text") for d in docs)
+
+
+@pytest.mark.asyncio()
+async def test_aload_data_async(sqlite_engine):
+    """`aload_data` wraps the sync loader via asyncio.to_thread()."""
+    reader = _create_reader(sqlite_engine)
+    docs = await reader.aload_data(query="SELECT * FROM items")
+
+    assert len(docs) == 2
+    assert docs[0].text_resource and docs[0].text_resource.text
+    assert docs[0].text_resource.text.startswith("id: 1")


### PR DESCRIPTION
- Added support for `metadata_cols`, `excluded_text_cols`, and custom `document_id`, in all loading functions.
- Introduced `aload_data` for asynchronous data loading, and streaming with `lazy_load_data`.
- Updated README and CHANGELOG with new usage examples and features.
- Improved docstrings and logging for better clarity and maintainability.
- Added pytest tests

# Description

This PR significantly enhances the `DatabaseReader` (`llama-index-readers-database`) to provide more flexibility and control over how database rows are converted into LlamaIndex `Document` objects.

**Motivation:**

The previous `DatabaseReader` was fairly simple, loading all queried columns into the `Document.text` and offering no control over metadata population or document IDs. This made it difficult to:
-   Exclude large or irrelevant columns from the text content used for indexing/LLMs.
-   Populate `Document.metadata` with specific structured information from the database row.
-   Assign meaningful, potentially persistent `Document.id_` values based on database primary keys or other columns.
-   Handle database schemas easily when not providing a pre-configured `SQLDatabase` object.

**Enhancements:**

This PR introduces the following improvements:

1.  **Lazy Loading:** Implements `lazy_load_data` using a generator to efficiently stream rows from the database without loading the entire result set into memory first. `load_data` now uses this internally.
2.  **Metadata Control (`metadata_cols`):** Adds a `metadata_cols` parameter to `load_data`, `lazy_load_data`, and `aload_data`. This parameter accepts an iterable of:
    * `str`: Includes the specified database column in `Document.metadata` using the column name as the key.
    * `Tuple[str, str]`: Includes the database column (first element) in `Document.metadata` using the second element as the custom key (allowing renaming).
3.  **Text Exclusion (`excluded_text_cols`):** Adds an `excluded_text_cols` parameter (accepting an iterable of strings) to exclude specific database columns from the generated `Document.text_resource`. This is useful for removing noisy data or for columns intended only for metadata.
4.  **Custom Document IDs (`document_id`):** Adds a `document_id` parameter that accepts a `Callable`. This function receives the database row data (as a dict) and should return a string to be used as the `Document.id_`, providing full control over ID generation.
5.  **Schema Handling (`__init__`):** Clarified the `schema` parameter handling in the `__init__` docstring, explaining when it's used (only when connection details are passed directly, not when a `SQLDatabase` object is provided).


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update *

* I updated the relevant documentation, `README.md` and `CHANGELOG.md`.

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works *
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods

* The tests use Sqlite and I could test everything except the custom schema functionality, however I tested this locally, each of the 3 supported initialization options (engine, uri, connection parameters), against a local postgres instance running in Docker and a remote Supabase instance, all without issue.




**Usage Examples:**

```python
from llama_index.readers.database import DatabaseReader
from sqlalchemy import create_engine

# This URI creates a named in-memory database that persists
# as long as at least one connection is open, and is shareable.
db_uri = (
    "sqlite:///file:llamaindex_reader_test_db?mode=memory&cache=shared&uri=true"
)
engine = create_engine(db_uri, future=True)
with engine.begin() as conn:
    # Drop table if it exists from previous run
    conn.execute(text("DROP TABLE IF EXISTS users"))
    # Create table
    conn.execute(
        text(
            """
            CREATE TABLE users (
                id INTEGER PRIMARY KEY,
                name TEXT NOT NULL,
                email TEXT,
                bio TEXT
            )
            """
        )
    )
    # Insert data
    conn.execute(
        text(
            """
            INSERT INTO users (id, name, email, bio) VALUES
            (1, 'Alice', 'alice@example.com', 'Software engineer and avid reader.'),
            (2, 'Bob', 'bob@example.com', 'Data scientist passionate about AI.')
            """
        )
     )
# --- End Setup ---

reader = DatabaseReader(engine=engine)
query = "SELECT id, name, email, bio FROM users"

# Example 1: Basic load (all columns in text)
docs = reader.load_data(query=query)

# Example 2: Put 'id' and 'email' in metadata, exclude 'bio' from text
docs_meta_exclude = reader.load_data(
    query=query,
    metadata_cols=['id', 'email'],
    excluded_text_cols=['bio']
)
print(docs_meta_exclude)
# doc.text -> "id: 1, name: Alice, email: alice@example.com"
# doc.metadata -> {'id': 1, 'email': 'alice@example.com'}
assert "id" in docs_meta_exclude[0].metadata
assert "email" in docs_meta_exclude[0].metadata

# Example 3: Put 'id' in metadata ONLY (not in text)
docs_meta_only = reader.load_data(
    query=query,
    metadata_cols=['id'],
    excluded_text_cols=['id'] # Exclude from text
)
print(docs_meta_only)
# doc.text -> "name: Alice, email: alice@example.com, bio: ..."
# doc.metadata -> {'id': 1}
assert "id" in docs_meta_only[0].metadata
assert docs_meta_only[0].text_resource and docs_meta_only[0].text_resource.text
assert not docs_meta_only[0].text_resource.text.startswith("id:")
assert docs_meta_only[0].text_resource.text.startswith("name: Alice")


# Example 4: Rename 'email' key in metadata
docs_rename = reader.load_data(
    query=query,
    metadata_cols=['id', ('email', 'contact_email')]
)
print(docs_rename)
# doc.metadata -> {'id': 1, 'contact_email': 'alice@example.com'}
assert 'id' in docs_rename[0].metadata
assert docs_rename[0].metadata['id'] == 1
assert 'contact_email' in docs_rename[0].metadata

# Example 5: Custom Document ID using user 'id' column
def generate_doc_id(row_dict):
    return f"user_{row_dict['id']}"

docs_custom_id = reader.load_data(
    query=query,
    document_id=generate_doc_id
)
print(docs_custom_id)
assert docs_custom_id[0].id_.startswith("user_")
# doc.id_ -> "user_1"

engine.dispose()
```
