### PR TITLE
new sql db chat store

### DIFF
--- a/llama-index-core/.gitignore
+++ b/llama-index-core/.gitignore
@@ -1,4 +1,4 @@
-storage/
+./storage
 .DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/llama-index-core/llama_index/core/storage/chat_store/base_db.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/base_db.py
@@ -1,0 +1,99 @@
+from abc import abstractmethod
+from typing import List, Optional
+from enum import Enum
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.bridge.pydantic import BaseModel
+
+
+class MessageStatus(str, Enum):
+    """Status of a message in the chat store."""
+
+    # Message is in the active FIFO queue
+    ACTIVE = "active"
+
+    # Message has been processed and is archived, removed from the active queue
+    ARCHIVED = "archived"
+
+
+class AsyncDBChatStore(BaseModel):
+    """Base class for DB-based chat stores.
+
+    Meant to implement a FIFO queue to manage short-term memory and
+    general conversation history.
+    """
+
+    @abstractmethod
+    async def get_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[ChatMessage]:
+        """Get all messages for a key with the specified status (async).
+
+        Returns a list of messages.
+        """
+
+    @abstractmethod
+    async def count_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+    ) -> int:
+        """Count messages for a key with the specified status (async)."""
+
+    @abstractmethod
+    async def add_message(
+        self,
+        key: str,
+        message: ChatMessage,
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a message for a key with the specified status (async)."""
+
+    @abstractmethod
+    async def add_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a list of messages in batch for the specified key and status (async)."""
+
+    @abstractmethod
+    async def set_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Set all messages for a key (replacing existing ones) with the specified status (async)."""
+
+    @abstractmethod
+    async def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
+        """Delete a specific message by ID and return it (async)."""
+
+    @abstractmethod
+    async def delete_messages(
+        self, key: str, status: Optional[MessageStatus] = None
+    ) -> None:
+        """Delete all messages for a key with the specified status (async)."""
+
+    @abstractmethod
+    async def delete_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Delete the oldest n messages for a key and return them (async)."""
+
+    @abstractmethod
+    async def archive_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Archive the oldest n messages for a key and return them (async)."""
+
+    @abstractmethod
+    async def get_keys(self) -> List[str]:
+        """Get all unique keys in the store (async)."""
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Return the class name."""
+        return "AsyncDBChatStore"

--- a/llama-index-core/llama_index/core/storage/chat_store/sql.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/sql.py
@@ -132,6 +132,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
         Returns a list of messages.
         """
         await self._initialize()
+        assert self._async_session_factory is not None
 
         query = select(self._table).where(self._table.c.key == key)
 
@@ -159,6 +160,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     ) -> int:
         """Count messages for a key with the specified status (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         query = select(self._table.c.id).where(self._table.c.key == key)
 
@@ -178,6 +180,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     ) -> None:
         """Add a message for a key with the specified status (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         async with self._async_session_factory() as session:
             await session.execute(
@@ -199,6 +202,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     ) -> None:
         """Add a list of messages in batch for the specified key and status (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         async with self._async_session_factory() as session:
             await session.execute(
@@ -225,6 +229,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     ) -> None:
         """Set all messages for a key (replacing existing ones) with the specified status (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         # First delete all existing messages
         await self.delete_messages(key)
@@ -249,6 +254,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     async def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
         """Delete a specific message by ID and return it (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         async with self._async_session_factory() as session:
             # First get the message
@@ -276,6 +282,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     ) -> None:
         """Delete all messages for a key with the specified status (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         query = delete(self._table).where(self._table.c.key == key)
 
@@ -289,6 +296,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     async def delete_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
         """Delete the oldest n messages for a key and return them (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         oldest_messages = []
 
@@ -325,6 +333,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     async def archive_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
         """Archive the oldest n messages for a key and return them (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         async with self._async_session_factory() as session:
             # First get the oldest n messages
@@ -361,6 +370,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     async def get_keys(self) -> List[str]:
         """Get all unique keys in the store (async)."""
         await self._initialize()
+        assert self._async_session_factory is not None
 
         async with self._async_session_factory() as session:
             result = await session.execute(select(self._table.c.key).distinct())

--- a/llama-index-core/llama_index/core/storage/chat_store/sql.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/sql.py
@@ -1,0 +1,372 @@
+import time
+from typing import List, Optional
+from enum import Enum
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    delete,
+    select,
+    insert,
+    update,
+)
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.storage.chat_store.base_db import AsyncDBChatStore
+
+
+DEFAULT_ASYNC_DATABASE_URI = "sqlite+aiosqlite:///:memory:"
+Base = declarative_base()
+
+
+class MessageStatus(str, Enum):
+    """Status of a message in the chat store."""
+
+    # Message is in the active FIFO queue
+    ACTIVE = "active"
+
+    # Message has been processed and is archived, removed from the active queue
+    ARCHIVED = "archived"
+
+
+class SQLAlchemyChatStore(AsyncDBChatStore):
+    """Base class for SQLAlchemy-based chat stores.
+
+    This class provides a foundation for creating chat stores that use SQLAlchemy
+    to interact with SQL databases. It handles common operations like managing
+    sessions, creating tables, and CRUD operations on chat messages.
+
+    Enhanced with status tracking for better FIFO queue management for short-term memory.
+
+    This class is meant to replace all other chat store classes.
+    """
+
+    table_name: str = Field(description="Name of the table to store messages")
+    async_database_uri: str = Field(
+        default=DEFAULT_ASYNC_DATABASE_URI,
+        description="SQLAlchemy async connection URI",
+    )
+
+    _async_engine: Optional[AsyncEngine] = PrivateAttr(default=None)
+    _async_session_factory: Optional[sessionmaker] = PrivateAttr(default=None)
+    _metadata: MetaData = PrivateAttr(default_factory=MetaData)
+    _table: Optional[Table] = PrivateAttr(default=None)
+    _is_initialized: bool = PrivateAttr(default=False)
+
+    def __init__(
+        self,
+        table_name: str,
+        async_database_uri: Optional[str] = DEFAULT_ASYNC_DATABASE_URI,
+        async_engine: Optional[AsyncEngine] = None,
+    ):
+        """Initialize the SQLAlchemy chat store."""
+        super().__init__(
+            table_name=table_name,
+            async_database_uri=async_database_uri or DEFAULT_ASYNC_DATABASE_URI,
+        )
+        self._async_engine = async_engine
+
+    async def _initialize(self) -> None:
+        """Initialize the chat store. Used to avoid HTTP connections in constructor."""
+        if self._is_initialized:
+            return
+
+        await self._setup_connections()
+        await self._setup_tables()
+        self._is_initialized = True
+
+    async def _setup_connections(self) -> None:
+        """Set up database connections and session factories."""
+        # Create async engine and session factory if async URI is provided
+        if self.async_database_uri or self._async_engine:
+            self._async_engine = self._async_engine or create_async_engine(
+                self.async_database_uri
+            )
+            if self.async_database_uri is None:
+                self.async_database_uri = self._async_engine.url
+
+            self._async_session_factory = sessionmaker(
+                bind=self._async_engine, class_=AsyncSession
+            )
+
+    async def _setup_tables(self) -> None:
+        """Set up database tables."""
+        # Create messages table with status column
+        self._table = Table(
+            f"{self.table_name}",
+            self._metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column("key", String, nullable=False, index=True),
+            Column("timestamp", Integer, nullable=False, index=True),
+            Column("role", String, nullable=False),
+            Column(
+                "status",
+                String,
+                nullable=False,
+                default=MessageStatus.ACTIVE.value,
+                index=True,
+            ),
+            Column("data", JSON, nullable=False),
+        )
+
+        # Create tables in the database
+        async with self._async_engine.begin() as conn:
+            await conn.run_sync(self._metadata.create_all)
+
+    async def get_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[ChatMessage]:
+        """Get all messages for a key with the specified status (async).
+
+        Returns a list of messages.
+        """
+        await self._initialize()
+
+        query = select(self._table).where(self._table.c.key == key)
+
+        if limit is not None:
+            query = query.limit(limit)
+
+        if offset is not None:
+            query = query.offset(offset)
+
+        if status is not None:
+            query = query.where(self._table.c.status == status.value)
+
+        async with self._async_session_factory() as session:
+            result = await session.execute(
+                query.order_by(self._table.c.timestamp, self._table.c.id)
+            )
+            rows = result.fetchall()
+
+            return [ChatMessage.model_validate(row.data) for row in rows]
+
+    async def count_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+    ) -> int:
+        """Count messages for a key with the specified status (async)."""
+        await self._initialize()
+
+        query = select(self._table.c.id).where(self._table.c.key == key)
+
+        if status is not None:
+            query = query.where(self._table.c.status == status.value)
+
+        async with self._async_session_factory() as session:
+            result = await session.execute(query)
+            rows = result.fetchall()
+            return len(rows)
+
+    async def add_message(
+        self,
+        key: str,
+        message: ChatMessage,
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a message for a key with the specified status (async)."""
+        await self._initialize()
+
+        async with self._async_session_factory() as session:
+            await session.execute(
+                insert(self._table).values(
+                    key=key,
+                    timestamp=int(time.time()),
+                    role=message.role,
+                    status=status.value,
+                    data=message.model_dump(mode="json"),
+                )
+            )
+            await session.commit()
+
+    async def add_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a list of messages in batch for the specified key and status (async)."""
+        await self._initialize()
+
+        async with self._async_session_factory() as session:
+            await session.execute(
+                insert(self._table).values(
+                    [
+                        {
+                            "key": key,
+                            "timestamp": int(time.time()),
+                            "role": message.role,
+                            "status": status.value,
+                            "data": message.model_dump(mode="json"),
+                        }
+                        for message in messages
+                    ]
+                )
+            )
+            await session.commit()
+
+    async def set_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Set all messages for a key (replacing existing ones) with the specified status (async)."""
+        await self._initialize()
+
+        # First delete all existing messages
+        await self.delete_messages(key)
+
+        # Then add new messages
+        current_time = int(time.time())
+
+        async with self._async_session_factory() as session:
+            for i, message in enumerate(messages):
+                await session.execute(
+                    insert(self._table).values(
+                        key=key,
+                        timestamp=current_time
+                        + i,  # Preserve order with incremental timestamps
+                        role=message.role,
+                        status=status.value,
+                        data=message.model_dump(mode="json"),
+                    )
+                )
+            await session.commit()
+
+    async def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
+        """Delete a specific message by ID and return it (async)."""
+        await self._initialize()
+
+        async with self._async_session_factory() as session:
+            # First get the message
+            result = await session.execute(
+                select(self._table).where(
+                    self._table.c.key == key, self._table.c.id == idx
+                )
+            )
+            row = result.fetchone()
+
+            if not row:
+                return None
+
+            # Store the message we're about to delete
+            message = ChatMessage.model_validate(row.data)
+
+            # Delete the message
+            await session.execute(delete(self._table).where(self._table.c.id == idx))
+            await session.commit()
+
+            return message
+
+    async def delete_messages(
+        self, key: str, status: Optional[MessageStatus] = None
+    ) -> None:
+        """Delete all messages for a key with the specified status (async)."""
+        await self._initialize()
+
+        query = delete(self._table).where(self._table.c.key == key)
+
+        if status is not None:
+            query = query.where(self._table.c.status == status.value)
+
+        async with self._async_session_factory() as session:
+            await session.execute(query)
+            await session.commit()
+
+    async def delete_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Delete the oldest n messages for a key and return them (async)."""
+        await self._initialize()
+
+        oldest_messages = []
+
+        async with self._async_session_factory() as session:
+            # First get the oldest n messages
+            result = await session.execute(
+                select(self._table)
+                .where(
+                    self._table.c.key == key,
+                    self._table.c.status == MessageStatus.ACTIVE.value,
+                )
+                .order_by(self._table.c.timestamp, self._table.c.id)
+                .limit(n)
+            )
+            rows = result.fetchall()
+
+            if not rows:
+                return []
+
+            # Store the messages we're about to delete
+            oldest_messages = [ChatMessage.model_validate(row.data) for row in rows]
+
+            # Get the IDs to delete
+            ids_to_delete = [row.id for row in rows]
+
+            # Delete the messages
+            await session.execute(
+                delete(self._table).where(self._table.c.id.in_(ids_to_delete))
+            )
+            await session.commit()
+
+        return oldest_messages
+
+    async def archive_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Archive the oldest n messages for a key and return them (async)."""
+        await self._initialize()
+
+        async with self._async_session_factory() as session:
+            # First get the oldest n messages
+            result = await session.execute(
+                select(self._table)
+                .where(
+                    self._table.c.key == key,
+                    self._table.c.status == MessageStatus.ACTIVE.value,
+                )
+                .order_by(self._table.c.timestamp, self._table.c.id)
+                .limit(n)
+            )
+            rows = result.fetchall()
+
+            if not rows:
+                return []
+
+            # Store the messages we're about to archive
+            archived_messages = [ChatMessage.model_validate(row.data) for row in rows]
+
+            # Get the IDs to archive
+            ids_to_archive = [row.id for row in rows]
+
+            # Update message status to archived
+            await session.execute(
+                update(self._table)
+                .where(self._table.c.id.in_(ids_to_archive))
+                .values(status=MessageStatus.ARCHIVED.value)
+            )
+            await session.commit()
+
+        return archived_messages
+
+    async def get_keys(self) -> List[str]:
+        """Get all unique keys in the store (async)."""
+        await self._initialize()
+
+        async with self._async_session_factory() as session:
+            result = await session.execute(select(self._table.c.key).distinct())
+            return [row[0] for row in result.fetchall()]
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Return the class name."""
+        return "SQLAlchemyChatStore"

--- a/llama-index-core/poetry.lock
+++ b/llama-index-core/poetry.lock
@@ -132,6 +132,25 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+description = "asyncio bridge to the standard sqlite3 module"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0"},
+    {file = "aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3"},
+]
+
+[package.dependencies]
+typing_extensions = ">=4.0"
+
+[package.extras]
+dev = ["attribution (==1.7.1)", "black (==24.3.0)", "build (>=1.2)", "coverage[toml] (==7.6.10)", "flake8 (==7.0.0)", "flake8-bugbear (==24.12.12)", "flit (==3.10.1)", "mypy (==1.14.1)", "ufmt (==2.5.1)", "usort (==1.0.8.post1)"]
+docs = ["sphinx (==8.1.3)", "sphinx-mdinclude (==0.6.1)"]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -3365,4 +3384,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "93862f54b9fb6ea1977d7b7830455f923c5965bd9cebc1cd12f91a9b2cf6086b"
+content-hash = "6558062471c1c47a198ba35c02372ec89f19fa5f8e758e1f0c8221008147544a"

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -78,6 +78,7 @@ pydantic = ">=2.8.0"
 filetype = "^1.2.0"  # Used for multi-modal MIME utils
 eval-type-backport = {python = "<3.10", version = "^0.2.0"}
 banks = "^2.0.0"
+aiosqlite = "^0.21.0"
 
 [tool.poetry.group.dev.dependencies]
 black = {version = ">=23.7.0,<=24.3.0"}

--- a/llama-index-core/tests/storage/chat_store/test_sql.py
+++ b/llama-index-core/tests/storage/chat_store/test_sql.py
@@ -1,3 +1,4 @@
+import aiosqlite  # noqa: F401  needed for pants
 import pytest
 
 from llama_index.core.base.llms.types import ChatMessage

--- a/llama-index-core/tests/storage/chat_store/test_sql.py
+++ b/llama-index-core/tests/storage/chat_store/test_sql.py
@@ -248,4 +248,5 @@ async def test_get_keys(chat_store: SQLAlchemyChatStore):
     keys = await chat_store.get_keys()
 
     # Verify keys (note: other tests may add more keys)
-    assert set("keys_user1", "keys_user2", "keys_user3").issubset(set(keys))
+    expected_keys = {"keys_user1", "keys_user2", "keys_user3"}
+    assert expected_keys.issubset(set(keys))

--- a/llama-index-core/tests/storage/chat_store/test_sql.py
+++ b/llama-index-core/tests/storage/chat_store/test_sql.py
@@ -1,0 +1,251 @@
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.storage.chat_store.sql import (
+    SQLAlchemyChatStore,
+    MessageStatus,
+)
+
+
+@pytest.fixture()
+def chat_store() -> SQLAlchemyChatStore:
+    """Create a SQLAlchemyChatStore for testing."""
+    return SQLAlchemyChatStore(
+        table_name="test_messages",
+        async_database_uri="sqlite+aiosqlite:///:memory:",
+    )
+
+
+@pytest.mark.asyncio()
+async def test_add_get_messages(chat_store: SQLAlchemyChatStore):
+    """Test adding and retrieving messages."""
+    # Add messages
+    await chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
+    await chat_store.add_message(
+        "user1", ChatMessage(role="assistant", content="world")
+    )
+
+    # Test getting messages
+    messages = await chat_store.get_messages("user1")
+    assert len(messages) == 2
+    assert messages[0].role == "user"
+    assert messages[0].content == "hello"
+    assert messages[1].role == "assistant"
+    assert messages[1].content == "world"
+
+    # Test with non-existent key
+    empty_messages = await chat_store.get_messages("nonexistent")
+    assert len(empty_messages) == 0
+
+
+@pytest.mark.asyncio()
+async def test_add_messages_batch(chat_store: SQLAlchemyChatStore):
+    """Test adding messages in batch."""
+    batch_messages = [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="assistant", content="world"),
+        ChatMessage(role="user", content="how are you?"),
+    ]
+
+    await chat_store.add_messages("batch_user", batch_messages)
+
+    messages = await chat_store.get_messages("batch_user")
+    assert len(messages) == 3
+    assert [m.content for m in messages] == ["hello", "world", "how are you?"]
+
+
+@pytest.mark.asyncio()
+async def test_count_messages(chat_store: SQLAlchemyChatStore):
+    """Test counting messages."""
+    batch_messages = [
+        ChatMessage(role="user", content="message1"),
+        ChatMessage(role="assistant", content="message2"),
+        ChatMessage(role="user", content="message3"),
+    ]
+
+    await chat_store.add_messages("count_user", batch_messages)
+
+    count = await chat_store.count_messages("count_user")
+    assert count == 3
+
+    # Test count with non-existent key
+    empty_count = await chat_store.count_messages("nonexistent")
+    assert empty_count == 0
+
+
+@pytest.mark.asyncio()
+async def test_set_messages(chat_store: SQLAlchemyChatStore):
+    """Test setting messages (replacing existing ones)."""
+    # Add initial messages
+    await chat_store.add_message(
+        "replace_user", ChatMessage(role="user", content="initial")
+    )
+
+    # Replace with new set
+    new_messages = [
+        ChatMessage(role="user", content="replaced1"),
+        ChatMessage(role="assistant", content="replaced2"),
+    ]
+    await chat_store.set_messages("replace_user", new_messages)
+
+    # Verify replacement
+    messages = await chat_store.get_messages("replace_user")
+    assert len(messages) == 2
+    assert [m.content for m in messages] == ["replaced1", "replaced2"]
+
+
+@pytest.mark.asyncio()
+async def test_delete_message(chat_store: SQLAlchemyChatStore):
+    """Test deleting a specific message."""
+    batch_messages = [
+        ChatMessage(role="user", content="message1"),
+        ChatMessage(role="assistant", content="message2"),
+        ChatMessage(role="user", content="message3"),
+    ]
+
+    await chat_store.add_messages("delete_user", batch_messages)
+
+    # Get messages to find their IDs
+    async with chat_store._async_session_factory() as session:
+        result = await session.execute(
+            chat_store._table.select().where(chat_store._table.c.key == "delete_user")
+        )
+        rows = result.fetchall()
+
+    # Delete the middle message
+    middle_id = rows[1].id
+    deleted_message = await chat_store.delete_message("delete_user", middle_id)
+
+    # Verify deletion
+    assert deleted_message.content == "message2"
+
+    remaining_messages = await chat_store.get_messages("delete_user")
+    assert len(remaining_messages) == 2
+    assert [m.content for m in remaining_messages] == ["message1", "message3"]
+
+
+@pytest.mark.asyncio()
+async def test_delete_messages(chat_store: SQLAlchemyChatStore):
+    """Test deleting all messages for a key."""
+    # Add messages for multiple users
+    await chat_store.add_message(
+        "delete_all_user1", ChatMessage(role="user", content="user1_message")
+    )
+    await chat_store.add_message(
+        "delete_all_user2", ChatMessage(role="user", content="user2_message")
+    )
+
+    # Delete messages for user1
+    await chat_store.delete_messages("delete_all_user1")
+
+    # Verify deletion
+    user1_messages = await chat_store.get_messages("delete_all_user1")
+    user2_messages = await chat_store.get_messages("delete_all_user2")
+
+    assert len(user1_messages) == 0
+    assert len(user2_messages) == 1
+
+
+@pytest.mark.asyncio()
+async def test_delete_oldest_messages(chat_store: SQLAlchemyChatStore):
+    """Test deleting oldest messages."""
+    batch_messages = [
+        ChatMessage(role="user", content="oldest"),
+        ChatMessage(role="assistant", content="middle"),
+        ChatMessage(role="user", content="newest"),
+    ]
+
+    await chat_store.add_messages("oldest_test", batch_messages)
+
+    # Delete oldest message
+    deleted = await chat_store.delete_oldest_messages("oldest_test", 1)
+
+    # Verify deleted message
+    assert len(deleted) == 1
+    assert deleted[0].content == "oldest"
+
+    # Verify remaining messages
+    remaining = await chat_store.get_messages("oldest_test")
+    assert len(remaining) == 2
+    assert [m.content for m in remaining] == ["middle", "newest"]
+
+
+@pytest.mark.asyncio()
+async def test_archive_oldest_messages(chat_store: SQLAlchemyChatStore):
+    """Test archiving oldest messages."""
+    batch_messages = [
+        ChatMessage(role="user", content="oldest"),
+        ChatMessage(role="assistant", content="middle"),
+        ChatMessage(role="user", content="newest"),
+    ]
+
+    await chat_store.add_messages("archive_test", batch_messages)
+
+    # Archive oldest message
+    archived = await chat_store.archive_oldest_messages("archive_test", 1)
+
+    # Verify archived message
+    assert len(archived) == 1
+    assert archived[0].content == "oldest"
+
+    # Verify active messages
+    active = await chat_store.get_messages("archive_test", status=MessageStatus.ACTIVE)
+    assert len(active) == 2
+    assert [m.content for m in active] == ["middle", "newest"]
+
+    # Verify archived messages
+    archived_msgs = await chat_store.get_messages(
+        "archive_test", status=MessageStatus.ARCHIVED
+    )
+    assert len(archived_msgs) == 1
+    assert archived_msgs[0].content == "oldest"
+
+
+@pytest.mark.asyncio()
+async def test_get_messages_with_limit_offset(chat_store: SQLAlchemyChatStore):
+    """Test getting messages with limit and offset."""
+    batch_messages = [
+        ChatMessage(role="user", content="message1"),
+        ChatMessage(role="assistant", content="message2"),
+        ChatMessage(role="user", content="message3"),
+        ChatMessage(role="assistant", content="message4"),
+        ChatMessage(role="user", content="message5"),
+    ]
+
+    await chat_store.add_messages("pagination_test", batch_messages)
+
+    # Test with limit
+    limited = await chat_store.get_messages("pagination_test", limit=2)
+    assert len(limited) == 2
+    assert [m.content for m in limited] == ["message1", "message2"]
+
+    # Test with offset
+    offset = await chat_store.get_messages("pagination_test", offset=2)
+    assert len(offset) == 3
+    assert [m.content for m in offset] == ["message3", "message4", "message5"]
+
+    # Test with both limit and offset
+    paginated = await chat_store.get_messages("pagination_test", limit=2, offset=1)
+    assert len(paginated) == 2
+    assert [m.content for m in paginated] == ["message2", "message3"]
+
+
+@pytest.mark.asyncio()
+async def test_get_keys(chat_store: SQLAlchemyChatStore):
+    """Test getting all unique keys."""
+    # Add messages for multiple users
+    await chat_store.add_message(
+        "keys_user1", ChatMessage(role="user", content="user1_message")
+    )
+    await chat_store.add_message(
+        "keys_user2", ChatMessage(role="user", content="user2_message")
+    )
+    await chat_store.add_message(
+        "keys_user3", ChatMessage(role="user", content="user3_message")
+    )
+
+    # Get all keys
+    keys = await chat_store.get_keys()
+
+    # Verify keys (note: other tests may add more keys)
+    assert set("keys_user1", "keys_user2", "keys_user3").issubset(set(keys))


### PR DESCRIPTION
This PR implements a new Async-first DB chat store layer

It essentially is built to manage a FIFO-like queue, helping track which messages are in the current "queue window" and which are archived from the window.

This class is 
1. Brand new, and deviates from the existing chat store classes (this is on purpose, this well help replace/deprecate existing chat stores)
2. Is not user facing. I don't expect users to ever import or configure this class directly. It is meant to be used with new memory modules 