### PR TITLE
[DO NOT MERGE] force spiltter tests to fail with big metadata

### DIFF
--- a/llama-index-core/tests/text_splitter/test_sentence_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_sentence_splitter.py
@@ -139,7 +139,7 @@ def test_split_texts_multiple() -> None:
 def test_split_texts_with_metadata(english_text: str) -> None:
     """Test case for a list of texts with metadata."""
     chunk_size = 100
-    metadata_str = "word " * 50
+    metadata_str = "word " * 50 * 10000
     tokenizer = tiktoken.get_encoding("cl100k_base")
     splitter = SentenceSplitter(
         chunk_size=chunk_size, chunk_overlap=0, tokenizer=tokenizer.encode

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -74,7 +74,7 @@ def test_contiguous_text(contiguous_text: str) -> None:
 
 def test_split_with_metadata(english_text: str) -> None:
     chunk_size = 100
-    metadata_str = "word " * 50
+    metadata_str = "word " * 50 *10000
     tokenizer = tiktoken.get_encoding("gpt2")
     splitter = TokenTextSplitter(
         chunk_size=chunk_size, chunk_overlap=0, tokenizer=tokenizer.encode


### PR DESCRIPTION
Investigation branch:

Force `spiltter`s to fail due to large metadata to reproduce what we're seeing for Cemex. Error from the test reproduces errors seen by Cemex.

![Screenshot 2025-04-28 at 2 28 58 PM](https://github.com/user-attachments/assets/3da5cc87-0fa5-4fa0-9119-c99e6875bb53)

Linear: https://linear.app/llamaindex/issue/LI-2528/review-cemex-sharepoint-indexing-metadata-issues
Related `platform` PR: https://github.com/run-llama/platform/pull/6013

 @Georgehe4 