### PR TITLE
Add support for AWS Bedrock Application Inference Profiles

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/README.md
@@ -105,6 +105,33 @@ resp = llm.complete("Paul Graham is ")
 print(resp)
 ```
 
+### Use an Application Inference Profile
+
+AWS Bedrock supports Application Inference Profiles which are a sort of provisioned proxy to Bedrock LLMs.
+
+Since these profile ARNs are account-specific, they must be handled specially in BedrockConverse.
+
+When an application inference profile is created as an AWS resource, it references an existing Bedrock foundation model or a cross-region inference profile. The referenced model must be provided to the BedrockConverse initializer as the `model` argument, and the ARN of the application inference profile must be provided as the `application_inference_profile_arn` argument.
+
+**Important:** BedrockConverse does not validate that the `model` argument in fact matches the underlying model referenced by the application inference profile provided. The caller is responsible for making sure they match. Behavior when they do not match is undefined.
+
+```py
+# Assumes the existence of a provisioned application inference profile
+# that references a foundation model or cross-region inference profile.
+
+from llama_index.llms.bedrock_converse import BedrockConverse
+
+
+# Instantiate the BedrockConverse model
+# with the model and application inference profile
+# Make sure the model is the one that the
+# application inference profile refers to in AWS
+llm = BedrockConverse(
+    model="us.anthropic.claude-3-5-sonnet-20240620-v1:0",  # this is the referenced model/profile
+    application_inference_profile_arn="arn:aws:bedrock:us-east-1:012345678901:application-inference-profile/fake-profile-name",
+)
+```
+
 ### Function Calling
 
 ```py

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -124,6 +124,9 @@ class BedrockConverse(FunctionCallingLLM):
             description="The version number for the guardrail. The value can also be DRAFT"
         ),
     )
+    application_inference_profile_arn: Optional[str] = Field(
+        description="The ARN of an application inference profile to invoke in place of the model. If provided, make sure the model argument refers to the same one underlying the application inference profile."
+    )
     trace: Optional[str] = (
         Field(
             description="Specifies whether to enable or disable the Bedrock trace. If enabled, you can see the full Bedrock trace."
@@ -162,6 +165,7 @@ class BedrockConverse(FunctionCallingLLM):
         output_parser: Optional[BaseOutputParser] = None,
         guardrail_identifier: Optional[str] = None,
         guardrail_version: Optional[str] = None,
+        application_inference_profile_arn: Optional[str] = None,
         trace: Optional[str] = None,
     ) -> None:
         additional_kwargs = additional_kwargs or {}
@@ -198,6 +202,7 @@ class BedrockConverse(FunctionCallingLLM):
             botocore_config=botocore_config,
             guardrail_identifier=guardrail_identifier,
             guardrail_version=guardrail_version,
+            application_inference_profile_arn=application_inference_profile_arn,
             trace=trace,
         )
 
@@ -252,7 +257,7 @@ class BedrockConverse(FunctionCallingLLM):
     @property
     def _model_kwargs(self) -> Dict[str, Any]:
         base_kwargs = {
-            "model": self.model,
+            "model": self.application_inference_profile_arn or self.model,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
         }

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -27,7 +27,7 @@ exclude = ["**/BUILD"]
 license = "MIT"
 name = "llama-index-llms-bedrock-converse"
 readme = "README.md"
-version = "0.4.15"
+version = "0.5.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

AWS Bedrock recently added support for Application Inference Profiles, a type of provisioned resource that serves as a proxy for a Bedrock foundation model or cross-region inference profile, and that can be used to track costs and usage on a per-application basis rather than per-account.

AWS documentation on application inference profiles may be found at https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html.

This PR adds support for application inference profiles to BedrockConverse.

- Adds new optional keyword argument `application_inference_profile_arn` to BedrockConverse initializer
- Modifies logic to use profile ARN instead of model when invoking LLM
- Adds new fixture and unit test to verify changed logic
- Updates README with instructions on using the new feature
- Bumps minor version to 0.5.0 to reflect backwards-compatible feature addition

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

**NOTE:** Because this feature is for a specialized use of Bedrock and relies on a previously provisioned resource in the target account, an integration test is not provided in this PR. I have, however, tested this in a live AWS account on a provisioned application inference profile, and it behaved as expected.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
