### PR TITLE
CI: make dependabot update all the packages in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-python-packages:
+        patterns:
+          - "**"


### PR DESCRIPTION
# Description

- Configure dependabot to use the `uv` ecosystem for package updates
- Configure dependabot to deliver all the updates for the same dependency in one PR

This is still to be proven effective, if it's not practical we can remove the lockfiles.
