### PR TITLE
fix: do not checkout any branch on repo fetch

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
# Description

Make the script detecting changed files work on PRs coming from branches called `main`

