### PR TITLE
feat(llama-index-llms-google-genai): 2.5-flash-preview tests

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -40,12 +40,14 @@ from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_ca
 from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.prompts import PromptTemplate
-from llama_index.core.program.utils import FlexibleModel
+from llama_index.core.program.utils import FlexibleModel, create_flexible_model
+from llama_index.core.types import PydanticProgramMode
 from llama_index.llms.google_genai.utils import (
     chat_from_gemini_response,
     chat_message_to_gemini,
     convert_schema_to_function_declaration,
     prepare_chat_params,
+    handle_streaming_flexible_model,
 )
 
 import google.genai
@@ -466,16 +468,33 @@ class GoogleGenAI(FunctionCallingLLM):
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
 
-        if self.is_function_calling_model:
-            llm_kwargs["tool_choice"] = (
-                "required"
-                if "tool_choice" not in llm_kwargs
-                else llm_kwargs["tool_choice"]
+        if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
+            generation_config = {
+                **(self._generation_config or {}),
+                **llm_kwargs.pop("generation_config", {}),
+            }
+
+            # set the specific types needed for the response
+            generation_config["response_mime_type"] = "application/json"
+            generation_config["response_schema"] = output_cls
+
+            messages = prompt.format_messages(**prompt_args)
+            contents = list(map(chat_message_to_gemini, messages))
+            response = self._client.models.generate_content(
+                model=self.model,
+                contents=contents,
+                config=generation_config,
             )
 
-        return super().structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
-        )
+            if isinstance(response.parsed, BaseModel):
+                return response.parsed
+            else:
+                raise ValueError("Response is not a BaseModel")
+
+        else:
+            return super().structured_predict(
+                output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
+            )
 
     @dispatcher.span
     async def astructured_predict(
@@ -488,16 +507,33 @@ class GoogleGenAI(FunctionCallingLLM):
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
 
-        if self.is_function_calling_model:
-            llm_kwargs["tool_choice"] = (
-                "required"
-                if "tool_choice" not in llm_kwargs
-                else llm_kwargs["tool_choice"]
+        if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
+            generation_config = {
+                **(self._generation_config or {}),
+                **llm_kwargs.pop("generation_config", {}),
+            }
+
+            # set the specific types needed for the response
+            generation_config["response_mime_type"] = "application/json"
+            generation_config["response_schema"] = output_cls
+
+            messages = prompt.format_messages(**prompt_args)
+            contents = list(map(chat_message_to_gemini, messages))
+            response = await self._client.aio.models.generate_content(
+                model=self.model,
+                contents=contents,
+                config=generation_config,
             )
 
-        return await super().astructured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
-        )
+            if isinstance(response.parsed, BaseModel):
+                return response.parsed
+            else:
+                raise ValueError("Response is not a BaseModel")
+
+        else:
+            return super().structured_predict(
+                output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
+            )
 
     @dispatcher.span
     def stream_structured_predict(
@@ -510,15 +546,43 @@ class GoogleGenAI(FunctionCallingLLM):
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 
-        if self.is_function_calling_model:
-            llm_kwargs["tool_choice"] = (
-                "required"
-                if "tool_choice" not in llm_kwargs
-                else llm_kwargs["tool_choice"]
+        if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
+            generation_config = {
+                **(self._generation_config or {}),
+                **llm_kwargs.pop("generation_config", {}),
+            }
+
+            # set the specific types needed for the response
+            generation_config["response_mime_type"] = "application/json"
+            generation_config["response_schema"] = output_cls
+
+            messages = prompt.format_messages(**prompt_args)
+            contents = list(map(chat_message_to_gemini, messages))
+
+            def gen() -> Generator[Union[Model, FlexibleModel], None, None]:
+                flexible_model = create_flexible_model(output_cls)
+                response_gen = self._client.models.generate_content_stream(
+                    model=self.model,
+                    contents=contents,
+                    config=generation_config,
+                )
+
+                current_json = ""
+                for chunk in response_gen:
+                    if chunk.parsed:
+                        yield chunk.parsed
+                    elif chunk.candidates:
+                        streaming_model, current_json = handle_streaming_flexible_model(
+                            current_json, chunk.candidates[0], output_cls, flexible_model
+                        )
+                        if streaming_model:
+                            yield streaming_model
+
+            return gen()
+        else:
+            return super().stream_structured_predict(
+                output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
             )
-        return super().stream_structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
-        )
 
     @dispatcher.span
     async def astream_structured_predict(
@@ -531,12 +595,40 @@ class GoogleGenAI(FunctionCallingLLM):
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 
-        if self.is_function_calling_model:
-            llm_kwargs["tool_choice"] = (
-                "required"
-                if "tool_choice" not in llm_kwargs
-                else llm_kwargs["tool_choice"]
+        if self.pydantic_program_mode == PydanticProgramMode.DEFAULT:
+            generation_config = {
+                **(self._generation_config or {}),
+                **llm_kwargs.pop("generation_config", {}),
+            }
+
+            # set the specific types needed for the response
+            generation_config["response_mime_type"] = "application/json"
+            generation_config["response_schema"] = output_cls
+
+            messages = prompt.format_messages(**prompt_args)
+            contents = list(map(chat_message_to_gemini, messages))
+
+            async def gen() -> AsyncGenerator[Union[Model, FlexibleModel], None]:
+                flexible_model = create_flexible_model(output_cls)
+                response_gen = await self._client.aio.models.generate_content_stream(
+                    model=self.model,
+                    contents=contents,
+                    config=generation_config,
+                )
+
+                current_json = ""
+                async for chunk in response_gen:
+                    if chunk.parsed:
+                        yield chunk.parsed
+                    elif chunk.candidates:
+                        streaming_model, current_json = handle_streaming_flexible_model(
+                            current_json, chunk.candidates[0], output_cls, flexible_model
+                        )
+                        if streaming_model:
+                            yield streaming_model
+
+            return gen()
+        else:
+            return await super().astream_structured_predict(
+                output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
             )
-        return await super().astream_structured_predict(
-            output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
-        )

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -11,6 +11,7 @@ dev = [
     "pylint==2.15.10",
     "pytest==7.2.1",
     "pytest-mock==3.11.1",
+    "pytest-asyncio==0.21.0",
     "ruff==0.0.292",
     "tree-sitter-languages>=1.8.0,<2",
     "types-Deprecated>=0.1.0",
@@ -25,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.1.9"
+version = "0.1.10"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -244,6 +244,19 @@ def test_anyof_optional_structured_predict(llm: GoogleGenAI) -> None:
     assert isinstance(response.last_name, str)
     assert isinstance(response.first_name, None | str)
 
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
+def test_as_structured_llm_native_genai(llm: GoogleGenAI) -> None:
+    schema_response = llm._client.models.generate_content(
+        model=llm.model,
+        contents="Generate a simple database structure with at least one table called 'experiments'",
+        config=GenerateContentConfig(
+            response_mime_type="application/json",
+            response_schema=Schema,
+        ),
+    ).parsed
+    assert isinstance(schema_response, Schema)
+    assert len(schema_response.schema_name) > 0
+    assert len(schema_response.tables) > 0
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
 def test_as_structured_llm(llm: GoogleGenAI) -> None:
@@ -258,8 +271,9 @@ def test_as_structured_llm(llm: GoogleGenAI) -> None:
 
     # Test with complex schema
     schema_response = llm.as_structured_llm(output_cls=Schema, prompt=prompt).complete(
-        "Generate a simple database structure"
+        "Generate a simple database structure with at least one table called 'experiments'"
     )
+
     assert isinstance(schema_response.raw, Schema)
     assert len(schema_response.raw.schema_name) > 0
     assert len(schema_response.raw.tables) > 0

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import pytest
 from google.genai import types
@@ -50,7 +50,7 @@ class Schema(BaseModel):
 
 # Define the models to test against
 GEMINI_MODELS_TO_TEST = [
-    # {"model": "models/gemini-2.0-flash-001", "config": {}},
+    {"model": "models/gemini-2.0-flash-001", "config": {}},
     {"model": "models/gemini-2.5-flash-preview-04-17", "config": {
          "generation_config": GenerateContentConfig(
             thinking_config=ThinkingConfig(thinking_budget=0)
@@ -87,13 +87,8 @@ def test_complete_and_acomplete(llm: GoogleGenAI) -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_chat_and_achat() -> None:
+def test_chat_and_achat(llm: GoogleGenAI) -> None:
     """Test both sync and async chat methods."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     message = ChatMessage(content="Write a poem about a magic backpack")
 
     # Test synchronous chat
@@ -108,13 +103,8 @@ def test_chat_and_achat() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_stream_chat_and_astream_chat() -> None:
+def test_stream_chat_and_astream_chat(llm: GoogleGenAI) -> None:
     """Test both sync and async stream chat methods."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     message = ChatMessage(content="Write a poem about a magic backpack")
 
     # Test synchronous stream chat
@@ -135,13 +125,8 @@ def test_stream_chat_and_astream_chat() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_stream_complete_and_astream_complete() -> None:
+def test_stream_complete_and_astream_complete(llm: GoogleGenAI) -> None:
     """Test both sync and async stream complete methods."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     prompt = "Write a poem about a magic backpack"
 
     # Test synchronous stream complete
@@ -162,13 +147,8 @@ def test_stream_complete_and_astream_complete() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_simple_astructured_predict() -> None:
+def test_simple_astructured_predict(llm: GoogleGenAI) -> None:
     """Test async structured prediction with a simple schema."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     response = asyncio.run(
         llm.astructured_predict(
             output_cls=Poem,
@@ -183,13 +163,8 @@ def test_simple_astructured_predict() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_simple_stream_structured_predict() -> None:
+def test_simple_stream_structured_predict(llm: GoogleGenAI) -> None:
     """Test stream structured prediction with a simple schema."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     response = llm.stream_structured_predict(
         output_cls=Poem,
         prompt=PromptTemplate("Write a poem about a magic backpack"),
@@ -206,13 +181,8 @@ def test_simple_stream_structured_predict() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_simple_astream_structured_predict() -> None:
+def test_simple_astream_structured_predict(llm: GoogleGenAI) -> None:
     """Test async stream structured prediction with a simple schema."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     response = llm.astream_structured_predict(
         output_cls=Poem,
         prompt=PromptTemplate("Write a poem about a magic backpack"),
@@ -232,13 +202,8 @@ def test_simple_astream_structured_predict() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_simple_structured_predict() -> None:
+def test_simple_structured_predict(llm: GoogleGenAI) -> None:
     """Test structured prediction with a simple schema."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     response = llm.structured_predict(
         output_cls=Poem,
         prompt=PromptTemplate("Write a poem about a magic backpack"),
@@ -251,13 +216,8 @@ def test_simple_structured_predict() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_complex_structured_predict() -> None:
+def test_complex_structured_predict(llm: GoogleGenAI) -> None:
     """Test structured prediction with a complex nested schema."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
     prompt = PromptTemplate("Generate a simple database structure")
     response = llm.structured_predict(output_cls=Schema, prompt=prompt)
 
@@ -271,12 +231,7 @@ def test_complex_structured_predict() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_anyof_optional_structured_predict() -> None:
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
+def test_anyof_optional_structured_predict(llm: GoogleGenAI) -> None:
     class Person(BaseModel):
         last_name: str = Field(description="Last name")
         first_name: Optional[str] = Field(None, description="Optional first name")
@@ -291,12 +246,7 @@ def test_anyof_optional_structured_predict() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_as_structured_llm() -> None:
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
+def test_as_structured_llm(llm: GoogleGenAI) -> None:
     prompt = PromptTemplate("Generate content")
 
     # Test with simple schema
@@ -316,12 +266,7 @@ def test_as_structured_llm() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_as_structured_llm_async() -> None:
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
+def test_as_structured_llm_async(llm: GoogleGenAI) -> None:
     prompt = PromptTemplate("Generate content")
 
     # Test with simple schema
@@ -345,12 +290,7 @@ def test_as_structured_llm_async() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_as_structure_llm_with_config() -> None:
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-
+def test_as_structure_llm_with_config(llm: GoogleGenAI) -> None:
     response = (
         llm.as_structured_llm(output_cls=Poem)
         .complete(
@@ -375,7 +315,7 @@ def test_as_structure_llm_with_config() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_structured_predict_multiple_block() -> None:
+def test_structured_predict_multiple_block(llm: GoogleGenAI) -> None:
     chat_messages = [
         ChatMessage(
             content=[
@@ -391,10 +331,6 @@ def test_structured_predict_multiple_block() -> None:
     class Response(BaseModel):
         answer: str
 
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
     support = llm.structured_predict(
         output_cls=Response, prompt=ChatPromptTemplate(message_templates=chat_messages)
     )
@@ -403,15 +339,11 @@ def test_structured_predict_multiple_block() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_get_tool_calls_from_response() -> None:
+def test_get_tool_calls_from_response(llm: GoogleGenAI) -> None:
     def add(a: int, b: int) -> int:
         """Add two integers and returns the result integer."""
         return a + b
 
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
 
     add_tool = FunctionTool.from_defaults(fn=add)
     msg = ChatMessage("What is the result of adding 2 and 3?")
@@ -427,23 +359,17 @@ def test_get_tool_calls_from_response() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_convert_llama_index_schema_to_gemini_function_declaration() -> None:
+def test_convert_llama_index_schema_to_gemini_function_declaration(llm: GoogleGenAI) -> None:
     """Test conversion of a llama_index schema to a gemini function declaration."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
     function_tool = get_function_tool(Poem)
     # this is our baseline, which is not working because:
     # 1. the descriptions are missing
-    # 2. the required fields are not set
     google_openai_function = types.FunctionDeclaration.from_callable(
         client=llm._client,
         callable=function_tool.metadata.fn_schema,  # type: ignore
     )
 
     assert google_openai_function.description is None
-    assert google_openai_function.parameters.required is None
 
     # this is our custom conversion that can take a llama index: fn_schema and convert it to a gemini compatible
     # function declaration (subset of OpenAPI v3)
@@ -457,14 +383,10 @@ def test_convert_llama_index_schema_to_gemini_function_declaration() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_convert_llama_index_schema_to_gemini_function_declaration_nested_case() -> (
+def test_convert_llama_index_schema_to_gemini_function_declaration_nested_case(llm: GoogleGenAI) -> (
     None
 ):
     """Test conversion of a llama_index fn_schema to a gemini function declaration."""
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
     function_tool = get_function_tool(Schema)
 
     llama_index_model_json_schema = function_tool.metadata.fn_schema.model_json_schema()
@@ -485,47 +407,11 @@ def test_convert_llama_index_schema_to_gemini_function_declaration_nested_case()
 
     assert converted.parameters.required == ["schema_name", "tables"]
 
-
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_anyof_not_supported_gemini() -> None:
-    class Content(BaseModel):
-        content: Union[int, str]
-
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-    with pytest.raises(ValueError):
-        function_tool = get_function_tool(Content)
-        _ = convert_schema_to_function_declaration(llm._client, function_tool)
-
-
-
-
-@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_default_value_not_supported_gemini() -> None:
-    class ContentWithDefaultValue(BaseModel):
-        content: str = Field(default="default_value")
-
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
-    with pytest.raises(ValueError):
-        function_tool = get_function_tool(ContentWithDefaultValue)
-        _ = convert_schema_to_function_declaration(llm._client, function_tool)
-
-
-@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_optional_value_gemini() -> None:
+def test_optional_value_gemini(llm: GoogleGenAI) -> None:
     class OptionalContent(BaseModel):
         content: Optional[str] = Field(default=None)
         content2: str | None
-
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
 
     function_tool = get_function_tool(OptionalContent)
     decl = convert_schema_to_function_declaration(llm._client, function_tool)
@@ -538,7 +424,7 @@ def test_optional_value_gemini() -> None:
 
 
 @pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
-def test_optional_lists_nested_gemini() -> None:
+def test_optional_lists_nested_gemini(llm: GoogleGenAI) -> None:
     class TextContent(BaseModel):
         text: str
         language: str
@@ -569,10 +455,6 @@ def test_optional_lists_nested_gemini() -> None:
         contents: List[Content]
         category: Optional[str]
 
-    llm = GoogleGenAI(
-        model="models/gemini-2.0-flash-001",
-        api_key=os.environ["GOOGLE_API_KEY"],
-    )
     function_tool = get_function_tool(BlogPost)
 
     llama_index_model_json_schema = function_tool.metadata.fn_schema.model_json_schema()

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai_vertex.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai_vertex.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+from enum import Enum
+import os
+from typing import List, Optional, Union
+
+import pytest
+from llama_index.core.program.function_program import get_function_tool
+from pydantic import BaseModel, Field
+
+from llama_index.llms.google_genai import GoogleGenAI
+from llama_index.llms.google_genai.utils import convert_schema_to_function_declaration
+
+SKIP_VERTEXAI = os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "false") == "false"
+
+@pytest.mark.skipif(
+    SKIP_VERTEXAI,
+    reason="GOOGLE_GENAI_USE_VERTEXAI not set",
+)
+def test_anyof_supported_vertexai() -> None:
+    class Content(BaseModel):
+        content: Union[int, str]
+
+    llm = GoogleGenAI(
+        model="gemini-2.0-flash-001",
+    )
+    function_tool = get_function_tool(Content)
+    _ = convert_schema_to_function_declaration(llm._client, function_tool)
+
+    content = (
+        llm.as_structured_llm(output_cls=Content)
+        .complete(prompt="Generate a small content")
+        .raw
+    )
+    assert isinstance(content, Content)
+    assert isinstance(content.content, int | str)
+
+@pytest.mark.skipif(
+    SKIP_VERTEXAI,
+    reason="GOOGLE_GENAI_USE_VERTEXAI not set",
+)
+def test_optional_lists_nested_vertexai() -> None:
+    class Address(BaseModel):
+        street: str
+        city: str
+        country: str = Field(default="USA")
+
+    class ContactInfo(BaseModel):
+        email: str
+        phone: Optional[str] = None
+        address: Address
+
+    class Department(Enum):
+        ENGINEERING = "engineering"
+        MARKETING = "marketing"
+        SALES = "sales"
+        HR = "human_resources"
+
+    class Employee(BaseModel):
+        name: str
+        contact: ContactInfo
+        department: Department
+        hire_date: datetime
+
+    class Company(BaseModel):
+        name: str
+        founded_year: int
+        website: str
+        employees: List[Employee]
+        headquarters: Address
+
+    llm = GoogleGenAI(
+        model="gemini-2.0-flash-001",
+    )
+
+    function_tool = get_function_tool(Company)
+    converted = convert_schema_to_function_declaration(llm._client, function_tool)
+
+    assert converted.name == "Company"
+    assert converted.description is not None
+    assert converted.parameters.required is not None
+
+    assert list(converted.parameters.properties) == [
+        "name",
+        "founded_year",
+        "website",
+        "employees",
+        "headquarters",
+    ]
+
+    assert "name" in converted.parameters.required
+    assert "founded_year" in converted.parameters.required
+    assert "website" in converted.parameters.required
+    assert "employees" in converted.parameters.required
+    assert "headquarters" in converted.parameters.required
+
+    # call the model and check the output
+    company = (
+        llm.as_structured_llm(output_cls=Company)
+        .complete(prompt="Create a fake company with at least 3 employees")
+        .raw
+    )
+    assert isinstance(company, Company)
+
+    assert len(company.employees) >= 3
+    assert all(
+        employee.department in Department.__members__.values()
+        for employee in company.employees
+    )

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai_vertex.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai_vertex.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from llama_index.llms.google_genai import GoogleGenAI
 from llama_index.llms.google_genai.utils import convert_schema_to_function_declaration
 
+# Don't forget to export GOOGLE_CLOUD_LOCATION and GOOGLE_CLOUD_PROJECT when testing with VertexAI
 SKIP_VERTEXAI = os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "false") == "false"
 
 @pytest.mark.skipif(

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
@@ -1545,6 +1545,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pylint" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "tree-sitter-languages" },
@@ -1573,6 +1574,7 @@ dev = [
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
     { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest-asyncio", specifier = "==0.21.0" },
     { name = "pytest-mock", specifier = "==3.11.1" },
     { name = "ruff", specifier = "==0.0.292" },
     { name = "tree-sitter-languages", specifier = ">=1.8.0,<2" },
@@ -2661,6 +2663,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload_time = "2023-01-14T12:17:33.798Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload_time = "2023-01-14T12:17:32.206Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/c7/9db0c6215f12f26b590c24acc96d048e03989315f198454540dff95109cd/pytest-asyncio-0.21.0.tar.gz", hash = "sha256:2b38a496aef56f56b0e87557ec313e11e1ab9276fc3863f6a7be0f1d0e415e1b", size = 29898, upload_time = "2023-03-19T10:27:25.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/73/817ddb37c627338ecbb96486c03fe69a19bef72de1b6bd641aa06fed13f4/pytest_asyncio-0.21.0-py3-none-any.whl", hash = "sha256:f2b3366b7cd501a4056858bd39349d5af19742aed2d81660b7998b6341c7eb9c", size = 13131, upload_time = "2023-03-19T10:27:23.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

I tried to use Gemini 2.5 flash preview in my current workload an notice some very odd behavior with llama index.
This aims to open the discussion and find a solution as I don't have one for now, and as one of the contributor to the llama-index-llms-google-genai package I feel like we should prepare to the release of those models, and maybe raise issue upstream if needed.

I added a way to run the test on multiple models with multiple configurations, this make it easier to compare 2.0 flash and 2.5 flash.

Here is the current outcome of the tests:

```
FAILED tests/test_llms_google_genai.py::test_complex_structured_predict[llm1] - AssertionError: assert 0 > 0
FAILED tests/test_llms_google_genai.py::test_anyof_optional_structured_predict[llm1] - google.genai.errors.ServerError: 500 INTERNAL. {'error': {'code': 500, 'message': 'An internal error has occurred. Please retry or report in https://developers.generativeai.google/guide/troubleshooting', 'status':...
FAILED tests/test_llms_google_genai.py::test_as_structured_llm[llm1] - assert 0 > 0
FAILED tests/test_llms_google_genai.py::test_as_structured_llm_async[llm0] - RuntimeError: Event loop is closed
FAILED tests/test_llms_google_genai.py::test_as_structured_llm_async[llm1] - RuntimeError: Event loop is closed
FAILED tests/test_llms_google_genai.py::test_optional_lists_nested_gemini[llm1] - AssertionError: assert 0 >= 3
```

`llm0` is 2.0 flash and `llm1` is the newest 2.5-preview.
Something (that I believe to be unrelated) is happening with the event loop, I don't know where it's coming from yet but what I want to discuss about is the other test failures:
- test_complex_structured_predict 
- test_as_structured_llm
- test_optional_lists_nested_gemini

All failed to generate a valid object (or they did but the object was empty). The case of `test_as_structured_llm[llm1] - assert 0 > 0` is very intersting because it's failing at this line:

```
assert len(schema_response.raw.tables) > 0
```

There is nothing that explicitly ask the LLM to generate a table, so I changed the prompt to `  "Generate a simple database structure with at least one table called 'experiments'"` which lead to a 500 instead of an empty table.

I am pretty confident that this is due to the way llama index is doing structured generation through function calling, even though I was not able to pinpoint the exact issue (even on simple schema). I added the following test as a "baseline" to show that this is working as expected using the native structure generation from genai:

```python
@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
def test_as_structured_llm_native_genai(llm: GoogleGenAI) -> None:
    schema_response = llm._client.models.generate_content(
        model=llm.model,
        contents="Generate a simple database structure with at least one table called 'experiments'",
        config=GenerateContentConfig(
            response_mime_type="application/json",
            response_schema=Schema,
        ),
    ).parsed
    assert isinstance(schema_response, Schema)
    assert len(schema_response.schema_name) > 0
    assert len(schema_response.tables) > 0
 ```
 And this is working exactly as expected.
 
 
**I understand that llama index need to work that way in order to integrate with the rest of the ecosystem, and support models that don't have structure generation out of the box, but I think that (in particular with Gemini) making this work reliably is quite hard.**
 
**I spend a few hours trying to debug the exact root cause of this, and why this was only happening with 2.5-preview but could not figure anything out.**

Current workaround: in most of my cases, setting `model.pydantic_program_mode = PydanticProgramMode.LLM` works fine (because the function calling part is not called).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No
- [x] Not yet

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

