### PR TITLE
memory revamp

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -1,0 +1,628 @@
+import asyncio
+import uuid
+from abc import abstractmethod
+from enum import Enum
+from sqlalchemy.ext.asyncio import AsyncEngine
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TypeVar, Generic, cast
+
+from llama_index.core.async_utils import asyncio_run
+from llama_index.core.base.llms.types import ChatMessage, ContentBlock, TextBlock, AudioBlock, ImageBlock
+from llama_index.core.bridge.pydantic import BaseModel, Field, model_validator, ConfigDict
+from llama_index.core.memory.types import BaseMemory
+from llama_index.core.prompts import RichPromptTemplate
+from llama_index.core.storage.chat_store.sql import SQLAlchemyChatStore, MessageStatus
+from llama_index.core.utils import get_tokenizer
+
+# Define type variable for memory block content
+T = TypeVar("T", str, List[ContentBlock], List[ChatMessage])
+
+DEFAULT_TOKEN_LIMIT = 30000
+DEFAULT_FLUSH_SIZE = int(DEFAULT_TOKEN_LIMIT * 0.7)
+DEFAULT_MEMORY_BLOCKS_TEMPLATE = RichPromptTemplate(
+"""
+<memory>
+{% for (block_name, block_content) in memory_blocks %}
+<{{ block_name }}>
+  {% for block in block_content %}
+    {% if block.block_type == "text" %}
+      {{ block.text }}
+    {% elif block.block_type == "image" %}
+      {% if block.url %}
+        {{ block.url | image }}
+      {% elif block.path %}
+        {{ block.path | image }}
+      {% endif %}
+    {% elif block.block_type == "audio" %}
+      {% if block.url %}
+        {{ block.url | audio }}
+      {% elif block.path %}
+        {{ block.path | audio }}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+</{{ block_name }}>
+{% endfor %}
+</memory>
+"""
+)
+
+class InsertMethod(Enum):
+    SYSTEM = "system"
+    USER = "user"
+
+
+def generate_chat_store_key() -> str:
+    """Generate a unique chat store key."""
+    return str(uuid.uuid4())
+
+
+def get_default_chat_store() -> SQLAlchemyChatStore:
+    """Get the default chat store."""
+    return SQLAlchemyChatStore(table_name="llama_index_memory")
+
+
+class BaseMemoryBlock(BaseModel, Generic[T]):
+    """
+    A base class for memory blocks.
+
+    Subclasses must implement the `aget` and `aput` methods.
+    Optionally, subclasses can implement the `atruncate` method, which is used to reduce the size of the memory block.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str = Field(description="The name/identifier of the memory block.")
+    description: Optional[str] = Field(default=None, description="A description of the memory block.")
+    priority: int = Field(default=0, description="Priority of this memory block (0 = never truncate, 1 = highest priority, etc.).")
+    accept_short_term_memory: bool = Field(default=True, description="Whether to accept puts from messages ejected from the short-term memory.")
+
+    @abstractmethod
+    async def _aget(self, messages: List[ChatMessage], **block_kwargs: Any) -> T:
+        """Pull the memory block (async)."""
+
+    async def aget(self, messages: List[ChatMessage], **block_kwargs: Any) -> T:
+        """
+        Pull the memory block (async).
+
+        Returns:
+            T: The memory block content. One of:
+            - str: A simple text string to be inserted into the template.
+            - List[ContentBlock]: A list of content blocks to be inserted into the template.
+            - List[ChatMessage]: A list of chat messages to be directly appended to the chat history.
+
+        """
+        return await self._aget(messages, **block_kwargs)
+
+    @abstractmethod
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        """Push to the memory block (async)."""
+
+    async def aput(self, messages: List[ChatMessage], from_short_term_memory: bool = False) -> None:
+        """Push to the memory block (async)."""
+        if from_short_term_memory and not self.accept_short_term_memory:
+            return
+
+        await self._aput(messages)
+
+    async def atruncate(self, content: T, tokens_to_truncate: int) -> Optional[T]:
+        """
+        Truncate the memory block content to the given token limit.
+
+        By default, truncation will remove the entire block content.
+
+        Args:
+            content:
+                The content of type T, depending on what the memory block returns.
+            tokens_to_truncate:
+                The number of tokens requested to truncate the content by.
+                Blocks may or may not truncate to the exact number of tokens requested, but it
+                can be used as a hint for the block to truncate.
+
+        Returns:
+            The truncated content of type T, or None if the content is completely truncated.
+
+        """
+        return None
+
+
+class Memory(BaseMemory):
+    """
+    A memory module that waterfalls into memory blocks.
+
+    Works by orchestrating around
+    - a FIFO queue of messages
+    - a list of memory blocks
+    - various parameters (pressure size, token limit, etc.)
+
+    When the FIFO queue reaches the token limit, the oldest messages within the pressure size are ejected from the FIFO queue.
+    The messages are then processed by each memory block.
+
+    When pulling messages from this memory, the memory blocks are processed in order, and the messages are injected into the system message or the latest user message.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    token_limit: int = Field(
+        default=DEFAULT_TOKEN_LIMIT,
+        description="The overall token limit of the memory.",
+    )
+    token_flush_size: int = Field(
+        default=DEFAULT_FLUSH_SIZE,
+        description="The token size to use for flushing the FIFO queue.",
+    )
+    chat_history_min_token_ratio: float = Field(
+        default=0.7,
+        description="Minimum percentage ratio of total token limit reserved for chat history.",
+    )
+    memory_blocks: List[BaseMemoryBlock] = Field(
+        default_factory=list,
+        description="The list of memory blocks to use.",
+    )
+    memory_blocks_template: RichPromptTemplate = Field(
+        default=DEFAULT_MEMORY_BLOCKS_TEMPLATE,
+        description="The template to use for formatting the memory blocks.",
+    )
+    insert_method: InsertMethod = Field(
+        default=InsertMethod.SYSTEM,
+        description="Whether to inject memory blocks into a system message or into the latest user message.",
+    )
+    image_token_size_estimate: int = Field(
+        default=256,
+        description="The token size estimate for images.",
+    )
+    audio_token_size_estimate: int = Field(
+        default=256,
+        description="The token size estimate for audio.",
+    )
+    tokenizer_fn: Callable[[str], List] = Field(
+        default_factory=get_tokenizer,
+        exclude=True,
+        description="The tokenizer function to use for token counting.",
+    )
+    sql_store: SQLAlchemyChatStore = Field(
+        default_factory=get_default_chat_store,
+        exclude=True,
+        description="The chat store to use for storing messages.",
+    )
+    user_id: str = Field(
+        default_factory=generate_chat_store_key,
+        description="The key to use for storing messages in the chat store.",
+    )
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "Memory"
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_memory(cls, values: dict) -> dict:
+        # Validate token limit
+        token_limit = values.get("token_limit", -1)
+        if token_limit < 1:
+            raise ValueError("Token limit must be set and greater than 0.")
+
+        tokenizer_fn = values.get("tokenizer_fn")
+        if tokenizer_fn is None:
+            values["tokenizer_fn"] = get_tokenizer()
+
+        if values.get("token_flush_size", -1) < 1:
+            values["token_flush_size"] = int(token_limit * 0.7)
+        elif values.get("token_flush_size", -1) > token_limit:
+            values["token_flush_size"] = int(token_limit * 0.7)
+
+        return values
+
+    @classmethod
+    def from_defaults(  # type: ignore[override]
+        cls,
+        user_id: str,
+        chat_history: Optional[List[ChatMessage]] = None,
+        token_limit: int = DEFAULT_TOKEN_LIMIT,
+        memory_blocks: Optional[List[BaseMemoryBlock[Any]]] = None,
+        tokenizer_fn: Optional[Callable[[str], List]] = None,
+        chat_history_min_token_ratio: float = 0.7,
+        token_flush_size: int = DEFAULT_FLUSH_SIZE,
+        memory_blocks_template: RichPromptTemplate = DEFAULT_MEMORY_BLOCKS_TEMPLATE,
+        insert_method: InsertMethod = InsertMethod.SYSTEM,
+        image_token_size_estimate: int = 256,
+        audio_token_size_estimate: int = 256,
+        # SQLAlchemyChatStore parameters
+        table_name: str = "llama_index_memory",
+        async_database_uri: Optional[str] = None,
+        async_engine: Optional[AsyncEngine] = None,
+    ) -> "Memory":
+        """Initialize Memory."""
+        # If not using the SQLAlchemyChatStore, provide an error
+        sql_store = SQLAlchemyChatStore(
+            table_name=table_name,
+            async_database_uri=async_database_uri,
+            async_engine=async_engine,
+        )
+
+        if chat_history is not None:
+            asyncio_run(sql_store.set_messages(user_id, chat_history))
+
+        if token_flush_size > token_limit:
+            token_flush_size = int(token_limit * 0.7)
+
+        return cls(
+            token_limit=token_limit,
+            tokenizer_fn=tokenizer_fn or get_tokenizer(),
+            sql_store=sql_store,
+            user_id=user_id,
+            memory_blocks=memory_blocks or [],
+            chat_history_min_token_ratio=chat_history_min_token_ratio,
+            token_flush_size=token_flush_size,
+            memory_blocks_template=memory_blocks_template,
+            insert_method=insert_method,
+            image_token_size_estimate=image_token_size_estimate,
+            audio_token_size_estimate=audio_token_size_estimate,
+        )
+
+    def _estimate_token_count(self, message_or_blocks: Union[str, ChatMessage, List[ChatMessage], List[ContentBlock]]) -> int:
+        """Estimate token count for a message."""
+        token_count = 0
+
+        # Normalize the input to a list of ContentBlocks
+        if isinstance(message_or_blocks, ChatMessage):
+            blocks = message_or_blocks.blocks
+
+            # Estimate the token count for the additional kwargs
+            if message_or_blocks.additional_kwargs:
+                token_count += len(self.tokenizer_fn(str(message_or_blocks.additional_kwargs)))
+        elif isinstance(message_or_blocks, List):
+            # Type narrow the list
+            messages: List[ChatMessage] = []
+            content_blocks: List[Union[TextBlock, ImageBlock, AudioBlock]] = []
+
+            if all(isinstance(item, ChatMessage) for item in message_or_blocks):
+                messages = cast(List[ChatMessage], message_or_blocks)
+
+                blocks = []
+                for msg in messages:
+                    blocks.extend(msg.blocks)
+
+                # Estimate the token count for the additional kwargs
+                token_count += sum(len(self.tokenizer_fn(str(msg.additional_kwargs))) for msg in messages if msg.additional_kwargs)
+            elif all(isinstance(item, (TextBlock, ImageBlock, AudioBlock)) for item in message_or_blocks):
+                content_blocks = cast(List[Union[TextBlock, ImageBlock, AudioBlock]], message_or_blocks)
+                blocks = content_blocks
+            else:
+                raise ValueError(f"Invalid message type: {type(message_or_blocks)}")
+        elif isinstance(message_or_blocks, str):
+            blocks = [TextBlock(text=message_or_blocks)]
+        else:
+            raise ValueError(f"Invalid message type: {type(message_or_blocks)}")
+
+        # Estimate the token count for each block
+        for block in blocks:
+            if isinstance(block, TextBlock):
+                token_count += len(self.tokenizer_fn(block.text))
+            elif isinstance(block, ImageBlock):
+                token_count += self.image_token_size_estimate
+            elif isinstance(block, AudioBlock):
+                token_count += self.audio_token_size_estimate
+
+        return token_count
+
+    async def _get_memory_blocks_content(self, chat_history: List[ChatMessage], **block_kwargs: Any) -> Dict[str, Any]:
+        """Get content from memory blocks in priority order."""
+        content_per_memory_block: Dict[str, Any] = {}
+
+        # Process memory blocks in priority order
+        for memory_block in sorted(self.memory_blocks, key=lambda x: -x.priority):
+            content = await memory_block.aget(chat_history, **block_kwargs)
+
+            # Handle different return types from memory blocks
+            if content and isinstance(content, list):
+                # Memory block returned content blocks
+                content_per_memory_block[memory_block.name] = content
+            elif content and isinstance(content, str):
+                # Memory block returned a string
+                content_per_memory_block[memory_block.name] = content
+            elif not content:
+                continue
+            else:
+                raise ValueError(f"Invalid content type received from memory block {memory_block.name}: {type(content)}")
+
+        return content_per_memory_block
+
+    async def _truncate_memory_blocks(
+        self,
+        content_per_memory_block: Dict[str, Any],
+        memory_blocks_tokens: int,
+        chat_history_tokens: int
+    ) -> Dict[str, Any]:
+        """Truncate memory blocks if total token count exceeds limit."""
+        if memory_blocks_tokens + chat_history_tokens <= self.token_limit:
+            return content_per_memory_block
+
+        tokens_to_truncate = memory_blocks_tokens + chat_history_tokens - self.token_limit
+        truncated_content = content_per_memory_block.copy()
+
+        # Truncate memory blocks based on priority
+        for memory_block in sorted(self.memory_blocks, key=lambda x: x.priority):  # Lower priority first
+            # Skip memory blocks with priority 0, they should never be truncated
+            if memory_block.priority == 0:
+                continue
+
+            if tokens_to_truncate <= 0:
+                break
+
+            # Truncate content and measure tokens saved
+            content = truncated_content.get(memory_block.name, [])
+
+            truncated_block_content = await memory_block.atruncate(content, tokens_to_truncate)
+
+            # Calculate tokens saved
+            original_tokens = self._estimate_token_count(content)
+
+            if truncated_block_content is None:
+                new_tokens = 0
+            else:
+                new_tokens = self._estimate_token_count(truncated_block_content)
+
+            tokens_saved = original_tokens - new_tokens
+            tokens_to_truncate -= tokens_saved
+
+            # Update the content blocks
+            if truncated_block_content is None:
+                truncated_content[memory_block.name] = []
+            else:
+                truncated_content[memory_block.name] = truncated_block_content
+
+        # handle case where we still have tokens to truncate
+        # just remove the blocks starting from the least priority
+        for memory_block in sorted(self.memory_blocks, key=lambda x: x.priority):
+            if memory_block.priority == 0:
+                continue
+
+            if tokens_to_truncate <= 0:
+                break
+
+            # Truncate content and measure tokens saved
+            content = truncated_content.pop(memory_block.name)
+            tokens_to_truncate -= self._estimate_token_count(content)
+
+        return truncated_content
+
+    async def _format_memory_blocks(
+        self,
+        content_per_memory_block: Dict[str, Any]
+    ) -> Tuple[List[Tuple[str, List[ContentBlock]]], List[ChatMessage]]:
+        """Format memory blocks content into template data and chat messages."""
+        memory_blocks_data: List[Tuple[str, List[ContentBlock]]] = []
+        chat_message_data: List[ChatMessage] = []
+
+        for block in self.memory_blocks:
+            if block.name in content_per_memory_block:
+                content = content_per_memory_block[block.name]
+
+                # Skip empty memory blocks
+                if not content:
+                    continue
+
+                if isinstance(content, list) and content and isinstance(content[0], ChatMessage):
+                    chat_message_data.extend(content)
+                elif isinstance(content, str):
+                    memory_blocks_data.append((block.name, [TextBlock(text=content)]))
+                else:
+                    memory_blocks_data.append((block.name, content))
+
+        return memory_blocks_data, chat_message_data
+
+    def _insert_memory_content(
+        self,
+        chat_history: List[ChatMessage],
+        memory_content: List[ContentBlock],
+        chat_message_data: List[ChatMessage]
+    ) -> List[ChatMessage]:
+        """Insert memory content into chat history based on insert method."""
+        result = chat_history.copy()
+
+        # Process chat messages
+        if chat_message_data:
+            result = [*chat_message_data, *result]
+
+        # Process template-based memory blocks
+        if memory_content:
+            if self.insert_method == InsertMethod.SYSTEM:
+                # Find system message or create a new one
+                system_idx = next((i for i, msg in enumerate(result) if msg.role == "system"), None)
+
+                if system_idx is not None:
+                    # Update existing system message
+                    result[system_idx].blocks = [*memory_content, *result[system_idx].blocks]
+                else:
+                    # Create new system message at the beginning
+                    result.insert(0, ChatMessage(role="system", blocks=memory_content))
+            elif self.insert_method == InsertMethod.USER:
+                # Find the latest user message
+                user_idx = next((i for i, msg in enumerate(reversed(result)) if msg.role == "user"), None)
+
+                if user_idx is not None:
+                    # Get actual index (since we enumerated in reverse)
+                    actual_idx = len(result) - 1 - user_idx
+                    # Update existing user message
+                    result[actual_idx].blocks = [*result[actual_idx].blocks, *memory_content]
+                else:
+                    raise ValueError("No user message found in chat history!")
+
+        return result
+
+    async def aget(self, **block_kwargs: Any) -> List[ChatMessage]:  # type: ignore[override]
+        """Get messages with memory blocks included (async)."""
+        # Get chat history efficiently
+        chat_history = await self.sql_store.get_messages(self.user_id, status=MessageStatus.ACTIVE)
+        chat_history_tokens = sum(self._estimate_token_count(message) for message in chat_history)
+
+        # Get memory blocks content
+        content_per_memory_block = await self._get_memory_blocks_content(chat_history, **block_kwargs)
+
+        # Calculate memory blocks tokens
+        memory_blocks_tokens = sum(self._estimate_token_count(content) for content in content_per_memory_block.values())
+
+        # Handle truncation if needed
+        truncated_content = await self._truncate_memory_blocks(
+            content_per_memory_block,
+            memory_blocks_tokens,
+            chat_history_tokens
+        )
+
+        # Format template-based memory blocks
+        memory_blocks_data, chat_message_data = await self._format_memory_blocks(truncated_content)
+
+        # Create messages from template content
+        memory_content = []
+        if memory_blocks_data:
+            memory_block_messages = self.memory_blocks_template.format_messages(memory_blocks=memory_blocks_data)
+            memory_content = memory_block_messages[0].blocks if memory_block_messages else []
+
+        # Insert memory content into chat history
+        return self._insert_memory_content(chat_history, memory_content, chat_message_data)
+
+    async def _manage_queue(self) -> None:
+        """
+        Manage the FIFO queue.
+
+        This function manages the memory queue using a waterfall approach:
+        1. If the queue exceeds the token limit, it removes oldest messages first
+        2. Removed messages are archived and passed to memory blocks
+        3. It ensures conversation integrity by keeping related messages together
+        4. It maintains at least one complete conversation turn
+        """
+        # Calculate if we need to waterfall
+        current_queue = await self.sql_store.get_messages(self.user_id, status=MessageStatus.ACTIVE)
+        tokens_in_current_queue = sum(self._estimate_token_count(message) for message in current_queue)
+
+        # If we're over the token limit, initiate waterfall
+        token_limit = self.token_limit * self.chat_history_min_token_ratio
+        if tokens_in_current_queue > token_limit:
+            # Process from oldest to newest, but efficiently with pop() operations
+            reversed_queue = current_queue[::-1]  # newest first, oldest last
+
+            # Calculate approximate number of messages to remove
+            tokens_to_remove = tokens_in_current_queue - token_limit
+
+            while tokens_to_remove > 0:
+                # Collect messages to flush (up to flush size)
+                messages_to_flush = []
+                flushed_tokens = 0
+
+                # Remove oldest messages (from end of reversed list) until reaching flush size
+                while flushed_tokens < self.token_flush_size and reversed_queue:
+                    message = reversed_queue.pop()
+                    messages_to_flush.append(message)
+                    flushed_tokens += self._estimate_token_count(message)
+
+                # Ensure we keep at least one message
+                if not reversed_queue and messages_to_flush:
+                    reversed_queue.append(messages_to_flush.pop())
+
+                # We need to maintain conversation integrity
+                # Messages should be removed in complete conversation turns
+                chronological_view = reversed_queue[::-1]  # View in chronological order
+
+                # Find the correct conversation boundary
+                # We want the first message in our remaining queue to be a user message
+                # and the last message to be from assistant or tool
+                if chronological_view:
+                    # Keep removing messages until first remaining message is from user
+                    # This ensures we start with a user message
+                    while chronological_view and chronological_view[0].role != "user":
+                        if reversed_queue:
+                            messages_to_flush.append(reversed_queue.pop())
+                            chronological_view = reversed_queue[::-1]
+                        else:
+                            break
+
+                    # If we end up with an empty queue, keep at least one full conversation turn
+                    if not reversed_queue and messages_to_flush:
+                        # Find the most recent complete conversation turn
+                        # (user → assistant/tool sequence) in messages_to_flush
+                        found_user = False
+                        turn_messages: List[ChatMessage] = []
+
+                        # Go through messages_to_flush in reverse (newest first)
+                        for msg in reversed(messages_to_flush):
+                            if msg.role == "user" and not found_user:
+                                found_user = True
+                                turn_messages.insert(0, msg)
+                            elif found_user:
+                                turn_messages.insert(0, msg)
+                            else:
+                                break
+
+                        # If we found a complete turn, keep it
+                        if found_user and turn_messages:
+                            # Remove these messages from messages_to_flush
+                            for msg in turn_messages:
+                                messages_to_flush.remove(msg)
+                            # Add them back to the queue
+                            reversed_queue = turn_messages[::-1] + reversed_queue
+
+                # Archive the flushed messages
+                if messages_to_flush:
+                    await self.sql_store.archive_oldest_messages(self.user_id, n=len(messages_to_flush))
+
+                    # Waterfall the flushed messages to memory blocks
+                    await asyncio.gather(*[block.aput(messages_to_flush, from_short_term_memory=True) for block in self.memory_blocks])
+
+                # Recalculate remaining tokens
+                chronological_view = reversed_queue[::-1]
+                tokens_in_current_queue = sum(self._estimate_token_count(message) for message in chronological_view)
+                tokens_to_remove = tokens_in_current_queue - token_limit
+
+                # Exit if we've flushed everything possible but still over limit
+                if not messages_to_flush:
+                    break
+
+    async def aput(self, message: ChatMessage) -> None:
+        """Add a message to the chat store and process waterfall logic if needed."""
+        # Add the message to the chat store
+        await self.sql_store.add_message(self.user_id, message, status=MessageStatus.ACTIVE)
+
+        # Ensure the active queue is managed
+        await self._manage_queue()
+
+    async def aput_messages(self, messages: List[ChatMessage]) -> None:
+        """Add a list of messages to the chat store and process waterfall logic if needed."""
+        # Add the messages to the chat store
+        await self.sql_store.add_messages(self.user_id, messages, status=MessageStatus.ACTIVE)
+
+        # Ensure the active queue is managed
+        await self._manage_queue()
+
+    async def aset(self, messages: List[ChatMessage]) -> None:
+        """Set the chat history."""
+        await self.sql_store.set_messages(self.user_id, messages, status=MessageStatus.ACTIVE)
+
+    async def aget_all(self, status: Optional[MessageStatus] = None) -> List[ChatMessage]:
+        """Get all messages."""
+        return await self.sql_store.get_messages(self.user_id, status=status)
+
+    async def areset(self, status: Optional[MessageStatus] = None) -> None:
+        """Reset the memory."""
+        await self.sql_store.delete_messages(self.user_id, status=status)
+
+    # ---- Sync method wrappers ----
+
+    def get(self, **block_kwargs: Any) -> List[ChatMessage]:  # type: ignore[override]
+        """Get messages with memory blocks included."""
+        return asyncio_run(self.aget(**block_kwargs))
+
+    def get_all(self, status: Optional[MessageStatus] = None) -> List[ChatMessage]:
+        """Get all messages."""
+        return asyncio_run(self.aget_all(status=status))
+
+    def put(self, message: ChatMessage) -> None:
+        """Add a message to the chat store and process waterfall logic if needed."""
+        return asyncio_run(self.aput(message))
+
+    def set(self, messages: List[ChatMessage]) -> None:
+        """Set the chat history."""
+        return asyncio_run(self.aset(messages))
+
+    def reset(self) -> None:
+        """Reset the memory."""
+        return asyncio_run(self.areset())

--- a/llama-index-core/llama_index/core/storage/chat_store/base_db.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/base_db.py
@@ -1,0 +1,101 @@
+from abc import abstractmethod
+from typing import List, Optional
+from enum import Enum
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.bridge.pydantic import BaseModel
+
+
+class MessageStatus(str, Enum):
+    """Status of a message in the chat store."""
+
+    # Message is in the active FIFO queue
+    ACTIVE = "active"
+
+    # Message has been processed and is archived, removed from the active queue
+    ARCHIVED = "archived"
+
+
+class AsyncDBChatStore(BaseModel):
+    """
+    Base class for DB-based chat stores.
+
+    Meant to implement a FIFO queue to manage short-term memory and
+    general conversation history.
+    """
+
+    @abstractmethod
+    async def get_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[ChatMessage]:
+        """
+        Get all messages for a key with the specified status (async).
+
+        Returns a list of messages.
+        """
+
+    @abstractmethod
+    async def count_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+    ) -> int:
+        """Count messages for a key with the specified status (async)."""
+
+    @abstractmethod
+    async def add_message(
+        self,
+        key: str,
+        message: ChatMessage,
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a message for a key with the specified status (async)."""
+
+    @abstractmethod
+    async def add_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a list of messages in batch for the specified key and status (async)."""
+
+    @abstractmethod
+    async def set_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Set all messages for a key (replacing existing ones) with the specified status (async)."""
+
+    @abstractmethod
+    async def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
+        """Delete a specific message by ID and return it (async)."""
+
+    @abstractmethod
+    async def delete_messages(
+        self, key: str, status: Optional[MessageStatus] = None
+    ) -> None:
+        """Delete all messages for a key with the specified status (async)."""
+
+    @abstractmethod
+    async def delete_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Delete the oldest n messages for a key and return them (async)."""
+
+    @abstractmethod
+    async def archive_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Archive the oldest n messages for a key and return them (async)."""
+
+    @abstractmethod
+    async def get_keys(self) -> List[str]:
+        """Get all unique keys in the store (async)."""
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Return the class name."""
+        return "AsyncDBChatStore"

--- a/llama-index-core/llama_index/core/storage/chat_store/sql.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/sql.py
@@ -1,0 +1,376 @@
+import time
+from typing import List, Optional, Tuple
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    delete,
+    select,
+    insert,
+    update,
+)
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    create_async_engine,
+    async_sessionmaker,
+)
+from sqlalchemy.orm import declarative_base
+
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.storage.chat_store.base_db import AsyncDBChatStore, MessageStatus
+
+
+DEFAULT_ASYNC_DATABASE_URI = "sqlite+aiosqlite:///:memory:"
+Base = declarative_base()
+
+
+class SQLAlchemyChatStore(AsyncDBChatStore):
+    """
+    Base class for SQLAlchemy-based chat stores.
+
+    This class provides a foundation for creating chat stores that use SQLAlchemy
+    to interact with SQL databases. It handles common operations like managing
+    sessions, creating tables, and CRUD operations on chat messages.
+
+    Enhanced with status tracking for better FIFO queue management for short-term memory.
+
+    This class is meant to replace all other chat store classes.
+    """
+
+    table_name: str = Field(description="Name of the table to store messages")
+    async_database_uri: str = Field(
+        default=DEFAULT_ASYNC_DATABASE_URI,
+        description="SQLAlchemy async connection URI",
+    )
+
+    _async_engine: Optional[AsyncEngine] = PrivateAttr(default=None)
+    _async_session_factory: Optional[async_sessionmaker] = PrivateAttr(default=None)
+    _metadata: MetaData = PrivateAttr(default_factory=MetaData)
+    _table: Optional[Table] = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        table_name: str,
+        async_database_uri: Optional[str] = DEFAULT_ASYNC_DATABASE_URI,
+        async_engine: Optional[AsyncEngine] = None,
+    ):
+        """Initialize the SQLAlchemy chat store."""
+        super().__init__(
+            table_name=table_name,
+            async_database_uri=async_database_uri or DEFAULT_ASYNC_DATABASE_URI,
+        )
+        self._async_engine = async_engine
+
+    async def _initialize(self) -> Tuple[async_sessionmaker[AsyncSession], Table]:
+        """Initialize the chat store. Used to avoid HTTP connections in constructor."""
+        if self._async_session_factory is not None and self._table is not None:
+            return self._async_session_factory, self._table
+
+        async_engine, async_session_factory = await self._setup_connections()
+        table = await self._setup_tables(async_engine)
+
+        return async_session_factory, table
+
+    async def _setup_connections(
+        self,
+    ) -> Tuple[AsyncEngine, async_sessionmaker[AsyncSession]]:
+        """Set up database connections and session factories."""
+        # Create async engine and session factory if async URI is provided
+        if self._async_session_factory is not None and self._async_engine is not None:
+            return self._async_engine, self._async_session_factory
+        elif self.async_database_uri or self._async_engine:
+            self._async_engine = self._async_engine or create_async_engine(
+                self.async_database_uri
+            )
+            if self.async_database_uri is None:
+                self.async_database_uri = self._async_engine.url
+
+            self._async_session_factory = async_sessionmaker(
+                bind=self._async_engine, class_=AsyncSession
+            )
+
+            return self._async_engine, self._async_session_factory
+        else:
+            raise ValueError(
+                "No async database URI or engine provided, cannot initialize DB sessionmaker"
+            )
+
+    async def _setup_tables(self, async_engine: AsyncEngine) -> Table:
+        """Set up database tables."""
+        # Create messages table with status column
+        self._table = Table(
+            f"{self.table_name}",
+            self._metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column("key", String, nullable=False, index=True),
+            Column("timestamp", Integer, nullable=False, index=True),
+            Column("role", String, nullable=False),
+            Column(
+                "status",
+                String,
+                nullable=False,
+                default=MessageStatus.ACTIVE.value,
+                index=True,
+            ),
+            Column("data", JSON, nullable=False),
+        )
+
+        # Create tables in the database
+        async with async_engine.begin() as conn:
+            await conn.run_sync(self._metadata.create_all)
+
+        return self._table
+
+    async def get_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[ChatMessage]:
+        """
+        Get all messages for a key with the specified status (async).
+
+        Returns a list of messages.
+        """
+        session_factory, table = await self._initialize()
+
+        query = select(table).where(table.c.key == key)
+
+        if limit is not None:
+            query = query.limit(limit)
+
+        if offset is not None:
+            query = query.offset(offset)
+
+        if status is not None:
+            query = query.where(table.c.status == status.value)
+
+        async with session_factory() as session:
+            result = await session.execute(
+                query.order_by(table.c.timestamp, table.c.id)
+            )
+            rows = result.fetchall()
+
+            return [ChatMessage.model_validate(row.data) for row in rows]
+
+    async def count_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+    ) -> int:
+        """Count messages for a key with the specified status (async)."""
+        session_factory, table = await self._initialize()
+
+        query = select(table.c.id).where(table.c.key == key)
+
+        if status is not None:
+            query = query.where(table.c.status == status.value)
+
+        async with session_factory() as session:
+            result = await session.execute(query)
+            rows = result.fetchall()
+            return len(rows)
+
+    async def add_message(
+        self,
+        key: str,
+        message: ChatMessage,
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a message for a key with the specified status (async)."""
+        session_factory, table = await self._initialize()
+
+        async with session_factory() as session:
+            await session.execute(
+                insert(table).values(
+                    key=key,
+                    timestamp=int(time.time()),
+                    role=message.role,
+                    status=status.value,
+                    data=message.model_dump(mode="json"),
+                )
+            )
+            await session.commit()
+
+    async def add_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Add a list of messages in batch for the specified key and status (async)."""
+        session_factory, table = await self._initialize()
+
+        async with session_factory() as session:
+            await session.execute(
+                insert(table).values(
+                    [
+                        {
+                            "key": key,
+                            "timestamp": int(time.time()),
+                            "role": message.role,
+                            "status": status.value,
+                            "data": message.model_dump(mode="json"),
+                        }
+                        for message in messages
+                    ]
+                )
+            )
+            await session.commit()
+
+    async def set_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        """Set all messages for a key (replacing existing ones) with the specified status (async)."""
+        session_factory, table = await self._initialize()
+
+        # First delete all existing messages
+        await self.delete_messages(key)
+
+        # Then add new messages
+        current_time = int(time.time())
+
+        async with session_factory() as session:
+            for i, message in enumerate(messages):
+                await session.execute(
+                    insert(table).values(
+                        key=key,
+                        timestamp=current_time
+                        + i,  # Preserve order with incremental timestamps
+                        role=message.role,
+                        status=status.value,
+                        data=message.model_dump(mode="json"),
+                    )
+                )
+            await session.commit()
+
+    async def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
+        """Delete a specific message by ID and return it (async)."""
+        session_factory, table = await self._initialize()
+
+        async with session_factory() as session:
+            # First get the message
+            result = await session.execute(
+                select(table).where(table.c.key == key, table.c.id == idx)
+            )
+            row = result.fetchone()
+
+            if not row:
+                return None
+
+            # Store the message we're about to delete
+            message = ChatMessage.model_validate(row.data)
+
+            # Delete the message
+            await session.execute(delete(table).where(table.c.id == idx))
+            await session.commit()
+
+            return message
+
+    async def delete_messages(
+        self, key: str, status: Optional[MessageStatus] = None
+    ) -> None:
+        """Delete all messages for a key with the specified status (async)."""
+        session_factory, table = await self._initialize()
+
+        query = delete(table).where(table.c.key == key)
+
+        if status is not None:
+            query = query.where(table.c.status == status.value)
+
+        async with session_factory() as session:
+            await session.execute(query)
+            await session.commit()
+
+    async def delete_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Delete the oldest n messages for a key and return them (async)."""
+        session_factory, table = await self._initialize()
+
+        oldest_messages = []
+
+        async with session_factory() as session:
+            # First get the oldest n messages
+            result = await session.execute(
+                select(table)
+                .where(
+                    table.c.key == key,
+                    table.c.status == MessageStatus.ACTIVE.value,
+                )
+                .order_by(table.c.timestamp, table.c.id)
+                .limit(n)
+            )
+            rows = result.fetchall()
+
+            if not rows:
+                return []
+
+            # Store the messages we're about to delete
+            oldest_messages = [ChatMessage.model_validate(row.data) for row in rows]
+
+            # Get the IDs to delete
+            ids_to_delete = [row.id for row in rows]
+
+            # Delete the messages
+            await session.execute(delete(table).where(table.c.id.in_(ids_to_delete)))
+            await session.commit()
+
+        return oldest_messages
+
+    async def archive_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        """Archive the oldest n messages for a key and return them (async)."""
+        session_factory, table = await self._initialize()
+
+        async with session_factory() as session:
+            # First get the oldest n messages
+            result = await session.execute(
+                select(table)
+                .where(
+                    table.c.key == key,
+                    table.c.status == MessageStatus.ACTIVE.value,
+                )
+                .order_by(table.c.timestamp, table.c.id)
+                .limit(n)
+            )
+            rows = result.fetchall()
+
+            if not rows:
+                return []
+
+            # Store the messages we're about to archive
+            archived_messages = [ChatMessage.model_validate(row.data) for row in rows]
+
+            # Get the IDs to archive
+            ids_to_archive = [row.id for row in rows]
+
+            # Update message status to archived
+            await session.execute(
+                update(table)
+                .where(table.c.id.in_(ids_to_archive))
+                .values(status=MessageStatus.ARCHIVED.value)
+            )
+            await session.commit()
+
+        return archived_messages
+
+    async def get_keys(self) -> List[str]:
+        """Get all unique keys in the store (async)."""
+        session_factory, table = await self._initialize()
+
+        async with session_factory() as session:
+            result = await session.execute(select(table.c.key).distinct())
+            return [row[0] for row in result.fetchall()]
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Return the class name."""
+        return "SQLAlchemyChatStore"

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -85,6 +85,7 @@ dependencies = [
     "filetype>=1.2.0,<2",
     "eval-type-backport>=0.2.0,<0.3 ; python_version < '3.10'",
     "banks>=2.0.0,<3",
+    "aiosqlite",
 ]
 
 [project.urls]

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -1,59 +1,12 @@
 import pytest
-from typing import List, Any, Optional
 
-from llama_index.core.base.llms.types import ChatMessage, TextBlock, ImageBlock, AudioBlock
-from llama_index.core.memory.memory import Memory, BaseMemoryBlock
+from llama_index.core.base.llms.types import ChatMessage, ImageBlock, AudioBlock
+from llama_index.core.memory.memory import Memory
 from llama_index.core.storage.chat_store.sql import MessageStatus
 
 
-class TestMemoryBlock(BaseMemoryBlock[str]):
-    """Simple memory block for testing."""
-
-    get_result: str = "Test memory content"
-    put_called: bool = False
-
-    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> str:
-        return self.get_result
-
-    async def _aput(self, messages: List[ChatMessage]) -> None:
-        self.put_called = True
-
-
-class TruncatableMemoryBlock(BaseMemoryBlock[str]):
-    """Memory block that supports truncation for testing."""
-
-    get_result: str = "Some truncatable content that can be reduced"
-    truncate_return: Optional[str] = "Truncated content"
-    put_called: bool = False
-
-    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> str:
-        return self.get_result
-
-    async def _aput(self, messages: List[ChatMessage]) -> None:
-        self.put_called = True
-
-    async def atruncate(self, content: str, tokens_to_truncate: int) -> Optional[str]:
-        return self.truncate_return
-
-
-class ChatMessagesMemoryBlock(BaseMemoryBlock[List[ChatMessage]]):
-    """Memory block that returns chat messages."""
-
-    get_result: List[ChatMessage] = [
-        ChatMessage(role="user", content="Test user message from memory block")
-    ]
-    put_called: bool = False
-
-    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> List[ChatMessage]:
-        return self.get_result
-
-    async def _aput(self, messages: List[ChatMessage]) -> None:
-        self.put_called = True
-
-
-
 @pytest.fixture()
-def basic_memory():
+def memory():
     """Create a basic memory instance for testing."""
     return Memory(
         token_limit=1000,
@@ -61,228 +14,120 @@ def basic_memory():
         user_id="test_user",
     )
 
-@pytest.fixture()
-def memory_with_blocks():
-    """Create a memory instance with memory blocks."""
-    return Memory(
-        token_limit=1000,
-        token_flush_size=700,
-        user_id="test_user",
-        memory_blocks=[
-            TestMemoryBlock(name="test_block", priority=0),
-            TruncatableMemoryBlock(name="truncatable_block", priority=1),
-            ChatMessagesMemoryBlock(name="chat_messages_block", priority=2),
-        ],
-    )
 
 @pytest.mark.asyncio
-async def test_initialization(basic_memory):
+async def test_initialization(memory):
     """Test that memory initializes correctly."""
-    assert basic_memory.token_limit == 1000
-    assert basic_memory.token_flush_size == 700
-    assert basic_memory.user_id == "test_user"
+    assert memory.token_limit == 1000
+    assert memory.token_flush_size == 700
+    assert memory.user_id == "test_user"
 
 @pytest.mark.asyncio
-async def test_estimate_token_count_text(basic_memory):
+async def test_estimate_token_count_text(memory):
     """Test token counting for text."""
     message = ChatMessage(role="user", content="Test message")
-    count = basic_memory._estimate_token_count(message)
-    assert count == len(basic_memory.tokenizer_fn("Test message"))
+    count = memory._estimate_token_count(message)
+    assert count == len(memory.tokenizer_fn("Test message"))
 
 @pytest.mark.asyncio
-async def test_estimate_token_count_image(basic_memory):
+async def test_estimate_token_count_image(memory):
     """Test token counting for images."""
     block = ImageBlock(url="http://example.com/image.jpg")
     message = ChatMessage(role="user", blocks=[block])
-    count = basic_memory._estimate_token_count(message)
-    assert count == basic_memory.image_token_size_estimate
+    count = memory._estimate_token_count(message)
+    assert count == memory.image_token_size_estimate
 
 @pytest.mark.asyncio
-async def test_estimate_token_count_audio(basic_memory):
+async def test_estimate_token_count_audio(memory):
     """Test token counting for audio."""
     block = AudioBlock(url="http://example.com/audio.mp3")
     message = ChatMessage(role="user", blocks=[block])
-    count = basic_memory._estimate_token_count(message)
-    assert count == basic_memory.audio_token_size_estimate
-
-@pytest.mark.asyncio
-async def test_get_memory_blocks_content(memory_with_blocks):
-    """Test getting content from memory blocks."""
-    chat_history = [
-        ChatMessage(role="user", content="Test message for blocks")
-    ]
-
-    content = await memory_with_blocks._get_memory_blocks_content(chat_history)
-
-    assert "test_block" in content
-    assert content["test_block"] == "Test memory content"
-    assert "truncatable_block" in content
-    assert "chat_messages_block" in content
-
-@pytest.mark.asyncio
-async def test_truncate_memory_blocks(memory_with_blocks):
-    """Test truncation of memory blocks when token limit is exceeded."""
-    content_per_block = {
-        "test_block": "Test memory content",  # Priority 0 - never truncate
-        "truncatable_block": "Some truncatable content that can be reduced",  # Priority 1
-        "chat_messages_block": [ChatMessage(role="user", content="Test user message from memory block")]  # Priority 2
-    }
-
-    memory_blocks_tokens = 500  # Simulate token count
-    chat_history_tokens = 600  # Simulate token count
-
-    # Total (1100) exceeds token limit (1000), so we need to truncate 100 tokens
-    truncated = await memory_with_blocks._truncate_memory_blocks(
-        content_per_block, memory_blocks_tokens, chat_history_tokens
-    )
-
-    # Priority 0 block should never be truncated
-    assert "test_block" in truncated
-
-    # All other blocks should be truncated
-    assert "truncatable_block" not in truncated
-    assert "chat_messages_block" not in truncated
-
-@pytest.mark.asyncio
-async def test_format_memory_blocks(memory_with_blocks):
-    """Test formatting memory blocks into template data and chat messages."""
-    content_per_block = {
-        "test_block": "Test memory content",
-        "chat_messages_block": [ChatMessage(role="user", content="Test user message from memory block")]
-    }
-
-    formatted_blocks, chat_messages = await memory_with_blocks._format_memory_blocks(content_per_block)
-
-    # Text content should be formatted as text blocks
-    assert len(formatted_blocks) == 1
-    block_name, blocks = formatted_blocks[0]
-    assert block_name == "test_block"
-    assert len(blocks) == 1
-    assert blocks[0].text == "Test memory content"
-
-    # Chat messages should be returned separately
-    assert len(chat_messages) == 1
-    assert chat_messages[0].role == "user"
-    assert chat_messages[0].content == "Test user message from memory block"
-
-@pytest.mark.asyncio
-async def test_insert_memory_content(memory_with_blocks):
-    """Test inserting memory content into chat history."""
-    chat_history = [
-        ChatMessage(role="user", content="Original user message"),
-        ChatMessage(role="assistant", content="Original assistant response"),
-    ]
-
-    blocks = [TextBlock(text="User content1"), TextBlock(text="User content2")]
-    chat_message_data = [ChatMessage(role="user", content="Memory block user message")]
-
-    result = memory_with_blocks._insert_memory_content(
-        chat_history, blocks, chat_message_data
-    )
-
-    # Should have all original messages plus new ones
-    assert len(result) == 4  # 2 original + 1 user content + 1 chat message data
-
-    # Our content should be inserted into the system message
-    assert result[0].role == "system"
-    assert any(block.text == "User content1" for block in result[0].blocks)
-    assert any(block.text == "User content2" for block in result[0].blocks)
-
-@pytest.mark.asyncio
-async def test_aget(memory_with_blocks):
-    """Test getting messages with memory blocks included."""
-    result = await memory_with_blocks.aget()
-
-    # Should have processed messages with memory blocks
-    assert len(result) > 0
-
-    # First message should have memory block content
-    first_msg = result[0]
-    assert first_msg is not None
+    count = memory._estimate_token_count(message)
+    assert count == memory.audio_token_size_estimate
 
 
 @pytest.mark.asyncio
-async def test_manage_queue_under_limit(basic_memory):
+async def test_manage_queue_under_limit(memory):
     """Test queue management when under token limit."""
     # Set up a case where we're under the token limit
     chat_messages = [
         ChatMessage(role="user", content="Short message")
     ]
 
-    await basic_memory.aput_messages(chat_messages)
-    cur_messages = await basic_memory.aget()
+    await memory.aput_messages(chat_messages)
+    cur_messages = await memory.aget()
     assert len(cur_messages) == 1
     assert cur_messages[0].content == "Short message"
 
 @pytest.mark.asyncio
-async def test_manage_queue_over_limit(memory_with_blocks):
+async def test_manage_queue_over_limit(memory):
     """Test queue management when over token limit."""
-    # Create a long message history that exceeds token limit
-    # This will cause manage_queue to run and manage the FIFO queue
-    long_messages = [
-        ChatMessage(role="user", content="x " * 800),
-        ChatMessage(role="assistant", content="y " * 800),
-        ChatMessage(role="user", content="z " * 800),
+    # Set up a case where we're over the token limit
+    chat_messages = [
+        ChatMessage(role="user", content="x " * 500),
+        ChatMessage(role="assistant", content="y " * 500),
+        ChatMessage(role="user", content="z " * 500),
     ]
 
-    await memory_with_blocks.aput_messages(long_messages)
+    # This will exceed the token limit and flush 700 tokens (two messages)
+    await memory.aput_messages(chat_messages)
 
-
-    messages = await memory_with_blocks.aget()
-    assert len(messages) == 3
+    cur_messages = await memory.aget()
+    assert len(cur_messages) == 1
+    assert "z " in cur_messages[0].content
 
 @pytest.mark.asyncio
-async def test_aput(basic_memory):
+async def test_aput(memory):
     """Test adding a message."""
     message = ChatMessage(role="user", content="New message")
 
-    await basic_memory.aput(message)
+    await memory.aput(message)
 
     # Should add the message to the store
-    messages = await basic_memory.aget()
+    messages = await memory.aget()
     assert len(messages) == 1
     assert messages[0].content == "New message"
 
 @pytest.mark.asyncio
-async def test_aput_messages(basic_memory):
+async def test_aput_messages(memory):
     """Test adding multiple messages."""
     messages = [
         ChatMessage(role="user", content="Message 1"),
         ChatMessage(role="assistant", content="Response 1"),
     ]
 
-    await basic_memory.aput_messages(messages)
+    await memory.aput_messages(messages)
 
     # Should add the messages to the store
-    messages = await basic_memory.aget()
+    messages = await memory.aget()
     assert len(messages) == 2
     assert messages[0].content == "Message 1"
     assert messages[1].content == "Response 1"
 
 @pytest.mark.asyncio
-async def test_aset(basic_memory):
+async def test_aset(memory):
     """Test setting the chat history."""
     messages = [
         ChatMessage(role="user", content="Message 1"),
         ChatMessage(role="assistant", content="Response 1"),
     ]
 
-    await basic_memory.aset(messages)
+    await memory.aset(messages)
 
     # Should set the messages in the store
-    messages = await basic_memory.aget()
+    messages = await memory.aget()
     assert len(messages) == 2
     assert messages[0].content == "Message 1"
     assert messages[1].content == "Response 1"
 
 @pytest.mark.asyncio
-async def test_aget_all(basic_memory):
+async def test_aget_all(memory):
     """Test getting all messages."""
-    await basic_memory.aput_messages([
+    await memory.aput_messages([
         ChatMessage(role="user", content="Message 1"),
         ChatMessage(role="assistant", content="Response 1"),
     ])
-    messages = await basic_memory.aget_all(status=MessageStatus.ACTIVE)
+    messages = await memory.aget_all(status=MessageStatus.ACTIVE)
 
     # Should get all messages from the store
     assert len(messages) == 2
@@ -290,11 +135,11 @@ async def test_aget_all(basic_memory):
     assert messages[1].content == "Response 1"
 
 @pytest.mark.asyncio
-async def test_areset(basic_memory):
+async def test_areset(memory):
     """Test resetting the memory."""
-    await basic_memory.aput(ChatMessage(role="user", content="New message"))
-    await basic_memory.areset(status=MessageStatus.ACTIVE)
+    await memory.aput(ChatMessage(role="user", content="New message"))
+    await memory.areset(status=MessageStatus.ACTIVE)
 
     # Should delete messages from the store
-    messages = await basic_memory.aget()
+    messages = await memory.aget()
     assert len(messages) == 0

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -1,0 +1,300 @@
+import pytest
+from typing import List, Any, Optional
+
+from llama_index.core.base.llms.types import ChatMessage, TextBlock, ImageBlock, AudioBlock
+from llama_index.core.memory.memory import Memory, BaseMemoryBlock
+from llama_index.core.storage.chat_store.sql import MessageStatus
+
+
+class TestMemoryBlock(BaseMemoryBlock[str]):
+    """Simple memory block for testing."""
+
+    get_result: str = "Test memory content"
+    put_called: bool = False
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> str:
+        return self.get_result
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        self.put_called = True
+
+
+class TruncatableMemoryBlock(BaseMemoryBlock[str]):
+    """Memory block that supports truncation for testing."""
+
+    get_result: str = "Some truncatable content that can be reduced"
+    truncate_return: Optional[str] = "Truncated content"
+    put_called: bool = False
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> str:
+        return self.get_result
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        self.put_called = True
+
+    async def atruncate(self, content: str, tokens_to_truncate: int) -> Optional[str]:
+        return self.truncate_return
+
+
+class ChatMessagesMemoryBlock(BaseMemoryBlock[List[ChatMessage]]):
+    """Memory block that returns chat messages."""
+
+    get_result: List[ChatMessage] = [
+        ChatMessage(role="user", content="Test user message from memory block")
+    ]
+    put_called: bool = False
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> List[ChatMessage]:
+        return self.get_result
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        self.put_called = True
+
+
+
+@pytest.fixture()
+def basic_memory():
+    """Create a basic memory instance for testing."""
+    return Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        user_id="test_user",
+    )
+
+@pytest.fixture()
+def memory_with_blocks():
+    """Create a memory instance with memory blocks."""
+    return Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        user_id="test_user",
+        memory_blocks=[
+            TestMemoryBlock(name="test_block", priority=0),
+            TruncatableMemoryBlock(name="truncatable_block", priority=1),
+            ChatMessagesMemoryBlock(name="chat_messages_block", priority=2),
+        ],
+    )
+
+@pytest.mark.asyncio
+async def test_initialization(basic_memory):
+    """Test that memory initializes correctly."""
+    assert basic_memory.token_limit == 1000
+    assert basic_memory.token_flush_size == 700
+    assert basic_memory.user_id == "test_user"
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_text(basic_memory):
+    """Test token counting for text."""
+    message = ChatMessage(role="user", content="Test message")
+    count = basic_memory._estimate_token_count(message)
+    assert count == len(basic_memory.tokenizer_fn("Test message"))
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_image(basic_memory):
+    """Test token counting for images."""
+    block = ImageBlock(url="http://example.com/image.jpg")
+    message = ChatMessage(role="user", blocks=[block])
+    count = basic_memory._estimate_token_count(message)
+    assert count == basic_memory.image_token_size_estimate
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_audio(basic_memory):
+    """Test token counting for audio."""
+    block = AudioBlock(url="http://example.com/audio.mp3")
+    message = ChatMessage(role="user", blocks=[block])
+    count = basic_memory._estimate_token_count(message)
+    assert count == basic_memory.audio_token_size_estimate
+
+@pytest.mark.asyncio
+async def test_get_memory_blocks_content(memory_with_blocks):
+    """Test getting content from memory blocks."""
+    chat_history = [
+        ChatMessage(role="user", content="Test message for blocks")
+    ]
+
+    content = await memory_with_blocks._get_memory_blocks_content(chat_history)
+
+    assert "test_block" in content
+    assert content["test_block"] == "Test memory content"
+    assert "truncatable_block" in content
+    assert "chat_messages_block" in content
+
+@pytest.mark.asyncio
+async def test_truncate_memory_blocks(memory_with_blocks):
+    """Test truncation of memory blocks when token limit is exceeded."""
+    content_per_block = {
+        "test_block": "Test memory content",  # Priority 0 - never truncate
+        "truncatable_block": "Some truncatable content that can be reduced",  # Priority 1
+        "chat_messages_block": [ChatMessage(role="user", content="Test user message from memory block")]  # Priority 2
+    }
+
+    memory_blocks_tokens = 500  # Simulate token count
+    chat_history_tokens = 600  # Simulate token count
+
+    # Total (1100) exceeds token limit (1000), so we need to truncate 100 tokens
+    truncated = await memory_with_blocks._truncate_memory_blocks(
+        content_per_block, memory_blocks_tokens, chat_history_tokens
+    )
+
+    # Priority 0 block should never be truncated
+    assert "test_block" in truncated
+
+    # All other blocks should be truncated
+    assert "truncatable_block" not in truncated
+    assert "chat_messages_block" not in truncated
+
+@pytest.mark.asyncio
+async def test_format_memory_blocks(memory_with_blocks):
+    """Test formatting memory blocks into template data and chat messages."""
+    content_per_block = {
+        "test_block": "Test memory content",
+        "chat_messages_block": [ChatMessage(role="user", content="Test user message from memory block")]
+    }
+
+    formatted_blocks, chat_messages = await memory_with_blocks._format_memory_blocks(content_per_block)
+
+    # Text content should be formatted as text blocks
+    assert len(formatted_blocks) == 1
+    block_name, blocks = formatted_blocks[0]
+    assert block_name == "test_block"
+    assert len(blocks) == 1
+    assert blocks[0].text == "Test memory content"
+
+    # Chat messages should be returned separately
+    assert len(chat_messages) == 1
+    assert chat_messages[0].role == "user"
+    assert chat_messages[0].content == "Test user message from memory block"
+
+@pytest.mark.asyncio
+async def test_insert_memory_content(memory_with_blocks):
+    """Test inserting memory content into chat history."""
+    chat_history = [
+        ChatMessage(role="user", content="Original user message"),
+        ChatMessage(role="assistant", content="Original assistant response"),
+    ]
+
+    blocks = [TextBlock(text="User content1"), TextBlock(text="User content2")]
+    chat_message_data = [ChatMessage(role="user", content="Memory block user message")]
+
+    result = memory_with_blocks._insert_memory_content(
+        chat_history, blocks, chat_message_data
+    )
+
+    # Should have all original messages plus new ones
+    assert len(result) == 4  # 2 original + 1 user content + 1 chat message data
+
+    # Our content should be inserted into the system message
+    assert result[0].role == "system"
+    assert any(block.text == "User content1" for block in result[0].blocks)
+    assert any(block.text == "User content2" for block in result[0].blocks)
+
+@pytest.mark.asyncio
+async def test_aget(memory_with_blocks):
+    """Test getting messages with memory blocks included."""
+    result = await memory_with_blocks.aget()
+
+    # Should have processed messages with memory blocks
+    assert len(result) > 0
+
+    # First message should have memory block content
+    first_msg = result[0]
+    assert first_msg is not None
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_under_limit(basic_memory):
+    """Test queue management when under token limit."""
+    # Set up a case where we're under the token limit
+    chat_messages = [
+        ChatMessage(role="user", content="Short message")
+    ]
+
+    await basic_memory.aput_messages(chat_messages)
+    cur_messages = await basic_memory.aget()
+    assert len(cur_messages) == 1
+    assert cur_messages[0].content == "Short message"
+
+@pytest.mark.asyncio
+async def test_manage_queue_over_limit(memory_with_blocks):
+    """Test queue management when over token limit."""
+    # Create a long message history that exceeds token limit
+    # This will cause manage_queue to run and manage the FIFO queue
+    long_messages = [
+        ChatMessage(role="user", content="x " * 800),
+        ChatMessage(role="assistant", content="y " * 800),
+        ChatMessage(role="user", content="z " * 800),
+    ]
+
+    await memory_with_blocks.aput_messages(long_messages)
+
+
+    messages = await memory_with_blocks.aget()
+    assert len(messages) == 3
+
+@pytest.mark.asyncio
+async def test_aput(basic_memory):
+    """Test adding a message."""
+    message = ChatMessage(role="user", content="New message")
+
+    await basic_memory.aput(message)
+
+    # Should add the message to the store
+    messages = await basic_memory.aget()
+    assert len(messages) == 1
+    assert messages[0].content == "New message"
+
+@pytest.mark.asyncio
+async def test_aput_messages(basic_memory):
+    """Test adding multiple messages."""
+    messages = [
+        ChatMessage(role="user", content="Message 1"),
+        ChatMessage(role="assistant", content="Response 1"),
+    ]
+
+    await basic_memory.aput_messages(messages)
+
+    # Should add the messages to the store
+    messages = await basic_memory.aget()
+    assert len(messages) == 2
+    assert messages[0].content == "Message 1"
+    assert messages[1].content == "Response 1"
+
+@pytest.mark.asyncio
+async def test_aset(basic_memory):
+    """Test setting the chat history."""
+    messages = [
+        ChatMessage(role="user", content="Message 1"),
+        ChatMessage(role="assistant", content="Response 1"),
+    ]
+
+    await basic_memory.aset(messages)
+
+    # Should set the messages in the store
+    messages = await basic_memory.aget()
+    assert len(messages) == 2
+    assert messages[0].content == "Message 1"
+    assert messages[1].content == "Response 1"
+
+@pytest.mark.asyncio
+async def test_aget_all(basic_memory):
+    """Test getting all messages."""
+    await basic_memory.aput_messages([
+        ChatMessage(role="user", content="Message 1"),
+        ChatMessage(role="assistant", content="Response 1"),
+    ])
+    messages = await basic_memory.aget_all(status=MessageStatus.ACTIVE)
+
+    # Should get all messages from the store
+    assert len(messages) == 2
+    assert messages[0].content == "Message 1"
+    assert messages[1].content == "Response 1"
+
+@pytest.mark.asyncio
+async def test_areset(basic_memory):
+    """Test resetting the memory."""
+    await basic_memory.aput(ChatMessage(role="user", content="New message"))
+    await basic_memory.areset(status=MessageStatus.ACTIVE)
+
+    # Should delete messages from the store
+    messages = await basic_memory.aget()
+    assert len(messages) == 0

--- a/llama-index-core/tests/memory/test_memory_blocks_base.py
+++ b/llama-index-core/tests/memory/test_memory_blocks_base.py
@@ -1,0 +1,322 @@
+import pytest
+from typing import List, Any, Optional, Union
+
+from llama_index.core.base.llms.types import ChatMessage, TextBlock, ContentBlock
+from llama_index.core.memory.memory import Memory, BaseMemoryBlock, InsertMethod
+
+
+class TextMemoryBlock(BaseMemoryBlock[str]):
+    """Memory block that returns text content."""
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> str:
+        return "Simple text content from TextMemoryBlock"
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        # Just a no-op for testing
+        pass
+
+
+class ContentBlocksMemoryBlock(BaseMemoryBlock[List[ContentBlock]]):
+    """Memory block that returns content blocks."""
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> List[ContentBlock]:
+        return [
+            TextBlock(text="Text block 1"),
+            TextBlock(text="Text block 2"),
+        ]
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        # Just a no-op for testing
+        pass
+
+    async def atruncate(self, content: List[ContentBlock], tokens_to_truncate: int) -> Optional[List[ContentBlock]]:
+        # Simple truncation - remove last block
+        if not content:
+            return None
+        return content[:-1]
+
+
+class ChatMessagesMemoryBlock(BaseMemoryBlock[List[ChatMessage]]):
+    """Memory block that returns chat messages."""
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> List[ChatMessage]:
+        return [
+            ChatMessage(role="user", content="Historical user message"),
+            ChatMessage(role="assistant", content="Historical assistant response"),
+        ]
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        # Just a no-op for testing
+        pass
+
+
+class ComplexMemoryBlock(BaseMemoryBlock[Union[str, List[ContentBlock]]]):
+    """Memory block that can return different types based on input."""
+
+    mode: str = "text"  # Can be "text" or "blocks"
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> Union[str, List[ContentBlock]]:
+        if self.mode == "text":
+            return "Text content from ComplexMemoryBlock"
+        else:
+            return [
+                TextBlock(text="Complex block 1"),
+                TextBlock(text="Complex block 2"),
+            ]
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        # Just a no-op for testing
+        pass
+
+
+class ParameterizedMemoryBlock(BaseMemoryBlock[str]):
+    """Memory block that uses parameters passed to aget."""
+
+    async def _aget(self, messages: List[ChatMessage], **kwargs: Any) -> str:
+        # Use parameters passed to aget
+        parameter = kwargs.get("test_parameter", "default")
+        return f"Parameter value: {parameter}"
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        # Just a no-op for testing
+        pass
+
+
+@pytest.fixture()
+def memory_with_blocks():
+    """Set up memory with different types of memory blocks."""
+    return Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        user_id="test_blocks",
+        memory_blocks=[
+            TextMemoryBlock(name="text_block", priority=1),
+            ContentBlocksMemoryBlock(name="content_blocks", priority=2),
+            ChatMessagesMemoryBlock(name="chat_messages", priority=3),
+            ComplexMemoryBlock(name="complex_block", priority=4),
+            ParameterizedMemoryBlock(name="param_block", priority=5),
+        ],
+    )
+
+@pytest.mark.asyncio
+async def test_text_memory_block(memory_with_blocks):
+    """Test text memory block integration."""
+    # Get the memory block content
+    content = await memory_with_blocks._get_memory_blocks_content([])
+
+    # Verify text block content
+    assert "text_block" in content
+    assert content["text_block"] == "Simple text content from TextMemoryBlock"
+
+    # Format content for insertion
+    formatted_blocks, _ = await memory_with_blocks._format_memory_blocks(
+        {"text_block": content["text_block"]}
+    )
+
+    # Check formatting
+    assert len(formatted_blocks) == 1
+    block_name, content = formatted_blocks[0]
+
+    assert block_name == "text_block"
+    assert len(content) == 1
+    assert content[0].text == "Simple text content from TextMemoryBlock"
+
+@pytest.mark.asyncio
+async def test_content_blocks_memory_block(memory_with_blocks):
+    """Test content blocks memory block integration."""
+    # Get the memory block content
+    content = await memory_with_blocks._get_memory_blocks_content([])
+
+    # Verify content blocks block content
+    assert "content_blocks" in content
+    assert len(content["content_blocks"]) == 2
+    assert content["content_blocks"][0].text == "Text block 1"
+    assert content["content_blocks"][1].text == "Text block 2"
+
+    # Format content for insertion
+    formatted_blocks, _ = await memory_with_blocks._format_memory_blocks(
+        {"content_blocks": content["content_blocks"]}
+    )
+
+    # Check formatting
+    assert len(formatted_blocks) == 1
+    block_name, content = formatted_blocks[0]
+
+    assert block_name == "content_blocks"
+    assert len(content) == 2
+    assert content[0].text == "Text block 1"
+    assert content[1].text == "Text block 2"
+
+@pytest.mark.asyncio
+async def test_chat_messages_memory_block(memory_with_blocks):
+    """Test chat messages memory block integration."""
+    # Get the memory block content
+    content = await memory_with_blocks._get_memory_blocks_content([])
+
+    # Verify chat messages block content
+    assert "chat_messages" in content
+    assert len(content["chat_messages"]) == 2
+    assert content["chat_messages"][0].role == "user"
+    assert content["chat_messages"][0].content == "Historical user message"
+    assert content["chat_messages"][1].role == "assistant"
+    assert content["chat_messages"][1].content == "Historical assistant response"
+
+    # Format content for insertion
+    formatted_blocks, chat_messages = await memory_with_blocks._format_memory_blocks(
+        {"chat_messages": content["chat_messages"]}
+    )
+
+    # Chat messages should be returned directly
+    assert len(chat_messages) == 2
+    assert chat_messages[0].role == "user"
+    assert chat_messages[0].content == "Historical user message"
+    assert chat_messages[1].role == "assistant"
+    assert chat_messages[1].content == "Historical assistant response"
+
+@pytest.mark.asyncio
+async def test_complex_memory_block_text_mode(memory_with_blocks):
+    """Test complex memory block in text mode."""
+    # Set complex block to text mode
+    for block in memory_with_blocks.memory_blocks:
+        if isinstance(block, ComplexMemoryBlock):
+            block.mode = "text"
+            break
+
+    # Get the memory block content
+    content = await memory_with_blocks._get_memory_blocks_content([])
+
+    # Verify complex block content in text mode
+    assert "complex_block" in content
+    assert content["complex_block"] == "Text content from ComplexMemoryBlock"
+
+@pytest.mark.asyncio
+async def test_complex_memory_block_blocks_mode(memory_with_blocks):
+    """Test complex memory block in blocks mode."""
+    # Set complex block to blocks mode
+    for block in memory_with_blocks.memory_blocks:
+        if isinstance(block, ComplexMemoryBlock):
+            block.mode = "blocks"
+            break
+
+    # Get the memory block content
+    content = await memory_with_blocks._get_memory_blocks_content([])
+
+    # Verify complex block content in blocks mode
+    assert "complex_block" in content
+    assert len(content["complex_block"]) == 2
+    assert content["complex_block"][0].text == "Complex block 1"
+    assert content["complex_block"][1].text == "Complex block 2"
+
+@pytest.mark.asyncio
+async def test_parameterized_memory_block(memory_with_blocks):
+    """Test memory block that accepts parameters."""
+    # Get memory block content with parameter
+    content = await memory_with_blocks._get_memory_blocks_content(
+        [], test_parameter="custom_value"
+    )
+
+    # Verify parameter was passed through
+    assert "param_block" in content
+    assert content["param_block"] == "Parameter value: custom_value"
+
+    # Try with default parameter
+    content = await memory_with_blocks._get_memory_blocks_content([])
+    assert content["param_block"] == "Parameter value: default"
+
+@pytest.mark.asyncio
+async def test_truncation_of_content_blocks(memory_with_blocks):
+    """Test truncation of content blocks."""
+    # Get memory blocks content
+    content = await memory_with_blocks._get_memory_blocks_content([])
+    content_blocks = content["content_blocks"]
+
+    # Get the memory block for truncation
+    content_block = next(
+        (block for block in memory_with_blocks.memory_blocks
+            if isinstance(block, ContentBlocksMemoryBlock)),
+        None
+    )
+    assert content_block is not None
+
+    # Test truncation
+    truncated = await content_block.atruncate(content_blocks, 100)
+    assert len(truncated) == 1  # Should have truncated to one block
+    assert truncated[0].text == "Text block 1"
+
+@pytest.mark.asyncio
+async def test_memory_with_all_block_types(memory_with_blocks):
+    """Test getting all memory block types together."""
+    # Set up block content
+    chat_history = [ChatMessage(role="user", content="Current message")]
+
+    # Get final messages with memory blocks included
+    messages = await memory_with_blocks.aget()
+
+    # Should have properly inserted all memory content
+    assert len(messages) > 0
+
+    # Should have a system message with memory blocks
+    system_messages = [msg for msg in messages if msg.role == "system"]
+    assert len(system_messages) > 0
+
+    # The system message should contain content from our blocks
+    system_content = system_messages[0].blocks[0].text
+    assert "Simple text content from TextMemoryBlock" in system_content
+    assert "Text block 1" in system_content
+    assert "Text block 2" in system_content
+
+    # Should also include direct chat messages from ChatMessagesMemoryBlock
+    user_historical = [msg for msg in messages if msg.content == "Historical user message"]
+    assert len(user_historical) > 0
+
+@pytest.mark.asyncio
+async def test_insert_method_setting():
+    """Test that insert_method is respected for blocks."""
+    # Create blocks with different insert methods
+    system_block = TextMemoryBlock(
+        name="system_block", priority=1,
+    )
+    user_block = TextMemoryBlock(
+        name="user_block", priority=2,
+    )
+
+    # Create memory with user insert method
+    memory = Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        user_id="test_insert_methods",
+        insert_method=InsertMethod.USER,
+        memory_blocks=[system_block, user_block],
+    )
+
+    # Insert a user message
+    await memory.aput(ChatMessage(role="user", content="Test message!"))
+
+    # Get messages
+    messages = await memory.aget()
+
+    # Should have both system and user messages with appropriate content
+    system_msgs = [msg for msg in messages if msg.role == "system"]
+    user_msgs = [msg for msg in messages if msg.role == "user"]
+
+    assert len(user_msgs) > 0
+    assert len(system_msgs) == 0
+
+    # Create memory with system insert method
+    memory = Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        user_id="test_insert_methods",
+        insert_method=InsertMethod.SYSTEM,
+        memory_blocks=[system_block, user_block],
+    )
+
+    # Get messages
+    messages = await memory.aget()
+
+    # Should have both system and user messages with appropriate content
+    system_msgs = [msg for msg in messages if msg.role == "system"]
+    user_msgs = [msg for msg in messages if msg.role == "user"]
+
+    assert len(user_msgs) == 0
+    assert len(system_msgs) > 0

--- a/llama-index-core/tests/storage/chat_store/test_sql.py
+++ b/llama-index-core/tests/storage/chat_store/test_sql.py
@@ -1,0 +1,253 @@
+import aiosqlite  # noqa: F401  needed for pants
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.storage.chat_store.sql import (
+    SQLAlchemyChatStore,
+    MessageStatus,
+)
+
+
+@pytest.fixture()
+def chat_store() -> SQLAlchemyChatStore:
+    """Create a SQLAlchemyChatStore for testing."""
+    return SQLAlchemyChatStore(
+        table_name="test_messages",
+        async_database_uri="sqlite+aiosqlite:///:memory:",
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_get_messages(chat_store: SQLAlchemyChatStore):
+    """Test adding and retrieving messages."""
+    # Add messages
+    await chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
+    await chat_store.add_message(
+        "user1", ChatMessage(role="assistant", content="world")
+    )
+
+    # Test getting messages
+    messages = await chat_store.get_messages("user1")
+    assert len(messages) == 2
+    assert messages[0].role == "user"
+    assert messages[0].content == "hello"
+    assert messages[1].role == "assistant"
+    assert messages[1].content == "world"
+
+    # Test with non-existent key
+    empty_messages = await chat_store.get_messages("nonexistent")
+    assert len(empty_messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_add_messages_batch(chat_store: SQLAlchemyChatStore):
+    """Test adding messages in batch."""
+    batch_messages = [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="assistant", content="world"),
+        ChatMessage(role="user", content="how are you?"),
+    ]
+
+    await chat_store.add_messages("batch_user", batch_messages)
+
+    messages = await chat_store.get_messages("batch_user")
+    assert len(messages) == 3
+    assert [m.content for m in messages] == ["hello", "world", "how are you?"]
+
+
+@pytest.mark.asyncio
+async def test_count_messages(chat_store: SQLAlchemyChatStore):
+    """Test counting messages."""
+    batch_messages = [
+        ChatMessage(role="user", content="message1"),
+        ChatMessage(role="assistant", content="message2"),
+        ChatMessage(role="user", content="message3"),
+    ]
+
+    await chat_store.add_messages("count_user", batch_messages)
+
+    count = await chat_store.count_messages("count_user")
+    assert count == 3
+
+    # Test count with non-existent key
+    empty_count = await chat_store.count_messages("nonexistent")
+    assert empty_count == 0
+
+
+@pytest.mark.asyncio
+async def test_set_messages(chat_store: SQLAlchemyChatStore):
+    """Test setting messages (replacing existing ones)."""
+    # Add initial messages
+    await chat_store.add_message(
+        "replace_user", ChatMessage(role="user", content="initial")
+    )
+
+    # Replace with new set
+    new_messages = [
+        ChatMessage(role="user", content="replaced1"),
+        ChatMessage(role="assistant", content="replaced2"),
+    ]
+    await chat_store.set_messages("replace_user", new_messages)
+
+    # Verify replacement
+    messages = await chat_store.get_messages("replace_user")
+    assert len(messages) == 2
+    assert [m.content for m in messages] == ["replaced1", "replaced2"]
+
+
+@pytest.mark.asyncio
+async def test_delete_message(chat_store: SQLAlchemyChatStore):
+    """Test deleting a specific message."""
+    batch_messages = [
+        ChatMessage(role="user", content="message1"),
+        ChatMessage(role="assistant", content="message2"),
+        ChatMessage(role="user", content="message3"),
+    ]
+
+    await chat_store.add_messages("delete_user", batch_messages)
+
+    # Get messages to find their IDs
+    async with chat_store._async_session_factory() as session:
+        result = await session.execute(
+            chat_store._table.select().where(chat_store._table.c.key == "delete_user")
+        )
+        rows = result.fetchall()
+
+    # Delete the middle message
+    middle_id = rows[1].id
+    deleted_message = await chat_store.delete_message("delete_user", middle_id)
+
+    # Verify deletion
+    assert deleted_message.content == "message2"
+
+    remaining_messages = await chat_store.get_messages("delete_user")
+    assert len(remaining_messages) == 2
+    assert [m.content for m in remaining_messages] == ["message1", "message3"]
+
+
+@pytest.mark.asyncio
+async def test_delete_messages(chat_store: SQLAlchemyChatStore):
+    """Test deleting all messages for a key."""
+    # Add messages for multiple users
+    await chat_store.add_message(
+        "delete_all_user1", ChatMessage(role="user", content="user1_message")
+    )
+    await chat_store.add_message(
+        "delete_all_user2", ChatMessage(role="user", content="user2_message")
+    )
+
+    # Delete messages for user1
+    await chat_store.delete_messages("delete_all_user1")
+
+    # Verify deletion
+    user1_messages = await chat_store.get_messages("delete_all_user1")
+    user2_messages = await chat_store.get_messages("delete_all_user2")
+
+    assert len(user1_messages) == 0
+    assert len(user2_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_oldest_messages(chat_store: SQLAlchemyChatStore):
+    """Test deleting oldest messages."""
+    batch_messages = [
+        ChatMessage(role="user", content="oldest"),
+        ChatMessage(role="assistant", content="middle"),
+        ChatMessage(role="user", content="newest"),
+    ]
+
+    await chat_store.add_messages("oldest_test", batch_messages)
+
+    # Delete oldest message
+    deleted = await chat_store.delete_oldest_messages("oldest_test", 1)
+
+    # Verify deleted message
+    assert len(deleted) == 1
+    assert deleted[0].content == "oldest"
+
+    # Verify remaining messages
+    remaining = await chat_store.get_messages("oldest_test")
+    assert len(remaining) == 2
+    assert [m.content for m in remaining] == ["middle", "newest"]
+
+
+@pytest.mark.asyncio
+async def test_archive_oldest_messages(chat_store: SQLAlchemyChatStore):
+    """Test archiving oldest messages."""
+    batch_messages = [
+        ChatMessage(role="user", content="oldest"),
+        ChatMessage(role="assistant", content="middle"),
+        ChatMessage(role="user", content="newest"),
+    ]
+
+    await chat_store.add_messages("archive_test", batch_messages)
+
+    # Archive oldest message
+    archived = await chat_store.archive_oldest_messages("archive_test", 1)
+
+    # Verify archived message
+    assert len(archived) == 1
+    assert archived[0].content == "oldest"
+
+    # Verify active messages
+    active = await chat_store.get_messages("archive_test", status=MessageStatus.ACTIVE)
+    assert len(active) == 2
+    assert [m.content for m in active] == ["middle", "newest"]
+
+    # Verify archived messages
+    archived_msgs = await chat_store.get_messages(
+        "archive_test", status=MessageStatus.ARCHIVED
+    )
+    assert len(archived_msgs) == 1
+    assert archived_msgs[0].content == "oldest"
+
+
+@pytest.mark.asyncio
+async def test_get_messages_with_limit_offset(chat_store: SQLAlchemyChatStore):
+    """Test getting messages with limit and offset."""
+    batch_messages = [
+        ChatMessage(role="user", content="message1"),
+        ChatMessage(role="assistant", content="message2"),
+        ChatMessage(role="user", content="message3"),
+        ChatMessage(role="assistant", content="message4"),
+        ChatMessage(role="user", content="message5"),
+    ]
+
+    await chat_store.add_messages("pagination_test", batch_messages)
+
+    # Test with limit
+    limited = await chat_store.get_messages("pagination_test", limit=2)
+    assert len(limited) == 2
+    assert [m.content for m in limited] == ["message1", "message2"]
+
+    # Test with offset
+    offset = await chat_store.get_messages("pagination_test", offset=2)
+    assert len(offset) == 3
+    assert [m.content for m in offset] == ["message3", "message4", "message5"]
+
+    # Test with both limit and offset
+    paginated = await chat_store.get_messages("pagination_test", limit=2, offset=1)
+    assert len(paginated) == 2
+    assert [m.content for m in paginated] == ["message2", "message3"]
+
+
+@pytest.mark.asyncio
+async def test_get_keys(chat_store: SQLAlchemyChatStore):
+    """Test getting all unique keys."""
+    # Add messages for multiple users
+    await chat_store.add_message(
+        "keys_user1", ChatMessage(role="user", content="user1_message")
+    )
+    await chat_store.add_message(
+        "keys_user2", ChatMessage(role="user", content="user2_message")
+    )
+    await chat_store.add_message(
+        "keys_user3", ChatMessage(role="user", content="user3_message")
+    )
+
+    # Get all keys
+    keys = await chat_store.get_keys()
+
+    # Verify keys (note: other tests may add more keys)
+    expected_keys = {"keys_user1", "keys_user2", "keys_user3"}
+    assert expected_keys.issubset(set(keys))

--- a/llama-index-core/uv.lock
+++ b/llama-index-core/uv.lock
@@ -128,6 +128,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload_time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload_time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -967,10 +979,11 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.12.34"
+version = "0.12.34.post1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiosqlite" },
     { name = "banks" },
     { name = "dataclasses-json" },
     { name = "deprecated" },
@@ -1031,6 +1044,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.6,<4" },
+    { name = "aiosqlite" },
     { name = "banks", specifier = ">=2.0.0,<3" },
     { name = "dataclasses-json" },
     { name = "deprecated", specifier = ">=1.2.9.3" },


### PR DESCRIPTION
This is a redo of a few other PRs, git history got too wacky
1. Adds new SQLAlchemy chat store for managing fifo queue memory on top of a DB
2. Adds a new `Memory` class meant to replace all existing memory modules
3. Tests for everything

Remaining after this merges
1. Prebuilt blocks
2. Docs