### PR TITLE
Fix MarkItDown Reader bugs

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-markitdown/llama_index/readers/markitdown/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-markitdown/llama_index/readers/markitdown/base.py
@@ -62,11 +62,12 @@ class MarkItDownReader(BaseReader):
     """
     MarkItDownReader is a document reader that utilizes the MarkItDown parser to convert files or collections of files into Document objects.
 
-    Methods:
+    Methods
     -------
     load_data(file_path: str | Path | Iterable[str] | Iterable[Path]) -> List[Document]
         Loads and parses a directory (if `file_path` is `str` or `Path`) or a list of files specified by `file_path` using the MarkItDown parser.
         Returns a list of Document objects, each containing the text content and metadata such as file path, file type, and content length.
+
     """
 
     _reader: MarkItDown = MarkItDown()

--- a/llama-index-integrations/readers/llama-index-readers-markitdown/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-markitdown/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-markitdown"
-version = "0.1.0"
+version = "0.1.1"
 description = "llama-index readers MarkItDown integration"
 authors = [{name = "Clelia Astra Bertelli", email = "astraberte9@gmail.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

With this PR, we would fix the bugs in MarkItDown reader to allow users to employ it as a file extractor also within a high-level data loader like SimpleDirectoryReader

Fixes #18609 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `make format; make lint` to appease the lint gods
