### PR TITLE
ci: skip workflow on main

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,9 +1,6 @@
 name: Unit Testing
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 env:


### PR DESCRIPTION
# Description

The workflow tries to use the target branch of a PR to decide which tests to run, and this fails on regular pushes, for example when we merge on `main`, see https://github.com/run-llama/llama_index/actions/runs/14843054645

Since the tests wouldn't run in any case because the `git diff` to detect what changed would be always empty on `main`, we just skip the workflow. Note that this was the same behaviour provided by Pants, see https://github.com/run-llama/llama_index/actions/runs/14646928364/job/41103376799
