### PR TITLE
make memory serialization great again

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -15,6 +15,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentSetup,
     AgentOutput,
 )
+from llama_index.core.bridge.pydantic import model_serializer
 from llama_index.core.llms import ChatMessage, TextBlock
 from llama_index.core.llms.llm import LLM
 from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
@@ -78,6 +79,17 @@ async def handoff(ctx: Context, to_agent: str, reason: str) -> str:
     )
 
     return handoff_output_prompt.format(to_agent=to_agent, reason=reason)
+
+
+class AgentWorkflowStartEvent(StartEvent):
+
+    @model_serializer()
+    def serialize_start_event(self) -> dict:
+        """Serialize the start event and exclude the memory."""
+        return {
+            "user_msg": self.user_msg,
+            "chat_history": self.chat_history,
+        }
 
 
 class AgentWorkflowMeta(WorkflowMeta, ABCMeta):
@@ -292,7 +304,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         return tool_output
 
     @step
-    async def init_run(self, ctx: Context, ev: StartEvent) -> AgentInput:
+    async def init_run(self, ctx: Context, ev: AgentWorkflowStartEvent) -> AgentInput:
         """Sets up the workflow and validates inputs."""
         await self._init_context(ctx, ev)
 
@@ -545,9 +557,11 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         **kwargs: Any,
     ) -> WorkflowHandler:
         return super().run(
-            user_msg=user_msg,
-            chat_history=chat_history,
-            memory=memory,
+            start_event=AgentWorkflowStartEvent(
+                user_msg=user_msg,
+                chat_history=chat_history,
+                memory=memory,
+            ),
             ctx=ctx,
             stepwise=stepwise,
             checkpoint_callback=checkpoint_callback,


### PR DESCRIPTION
This adds some fixes to
1. Make the default chat store serializable
2. Make memory serialization handling in the `Context` and `AgentWorkflow` more manageable (now gives warnings and skips known unserializable keys)

I would consider this a bandaid fix -- we really need to rethink how the heck this should work (which we are already attempting to rethink!)

Re-do of https://github.com/run-llama/llama_index/pull/18621