### PR TITLE
long tail cicd issues

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-optimum/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-optimum/pyproject.toml
@@ -29,7 +29,7 @@ name = "llama-index-embeddings-huggingface-optimum"
 version = "0.3.0"
 description = "llama-index embeddings huggingface optimum integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
@@ -28,7 +28,7 @@ name = "llama-index-embeddings-ibm"
 version = "0.3.1"
 description = "llama-index embeddings IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ipex-llm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ipex-llm/pyproject.toml
@@ -28,7 +28,7 @@ name = "llama-index-embeddings-ipex-llm"
 version = "0.3.0"
 description = "llama-index embeddings ipex-llm integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/embeddings/llama-index-embeddings-vllm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-vllm/pyproject.toml
@@ -28,7 +28,7 @@ name = "llama-index-embeddings-vllm"
 version = "0.0.1"
 description = "llama-index embeddings vllm integration"
 authors = [{name = "Yuri", email = "yuri@yurinet.blog"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = ["llama-index-core>=0.12.0,<0.13", "vllm"]

--- a/llama-index-integrations/extractors/llama-index-extractors-relik/pyproject.toml
+++ b/llama-index-integrations/extractors/llama-index-extractors-relik/pyproject.toml
@@ -28,7 +28,7 @@ name = "llama-index-extractors-relik"
 version = "0.3.1"
 description = "llama-index extractors relik integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
@@ -28,7 +28,7 @@ name = "llama-index-llms-ibm"
 version = "0.3.5"
 description = "llama-index llms IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/pyproject.toml
@@ -28,7 +28,7 @@ name = "llama-index-llms-ipex-llm"
 version = "0.3.1"
 description = "llama-index llms ipex-llm integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.10,<3.12"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
+++ b/llama-index-integrations/multi_modal_llms/llama-index-multi-modal-llms-huggingface/pyproject.toml
@@ -29,15 +29,15 @@ name = "llama-index-multi-modal-llms-huggingface"
 version = "0.4.2"
 description = "llama-index multi_modal_llms HuggingFace integration by [Cihan Yalçın](https://www.linkedin.com/in/chanyalcin/)"
 authors = [{name = "M.Cihan Yalçın", email = "mcihan.yalcin@outlook.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
     "llama-index-core>=0.12.0,<0.13",
-    "transformers[torch]~=4.45",
+    "transformers[torch]>=4.45",
     "qwen-vl-utils>=0.0.8",
-    "torchvision>=0.19.1,<0.20",
-    "Pillow>=10.0.0,<11",
+    "torchvision>=0.19.1",
+    "Pillow>=10.0.0",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/pyproject.toml
@@ -28,7 +28,7 @@ name = "llama-index-postprocessor-ibm"
 version = "0.1.0"
 description = "llama-index postprocessor IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -27,7 +27,7 @@ name = "llama-index-postprocessor-rankllm-rerank"
 version = "0.4.0"
 description = "llama-index postprocessor rankllm-rerank integration"
 authors = [{name = "Ryan Nguyen", email = "ryan.nguyen@uwaterloo.ca"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/readers/llama-index-readers-chroma/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-chroma/pyproject.toml
@@ -29,7 +29,7 @@ name = "llama-index-readers-chroma"
 version = "0.3.0"
 description = "llama-index readers chroma integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 maintainers = [{name = "atroyn"}]

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -27,7 +27,7 @@ name = "llama-index-readers-google"
 version = "0.6.1"
 description = "llama-index readers google integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 maintainers = [

--- a/llama-index-integrations/readers/llama-index-readers-oxylabs/llama_index/readers/oxylabs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-oxylabs/llama_index/readers/oxylabs/base.py
@@ -1,6 +1,6 @@
 import abc
 from platform import architecture, python_version
-from typing import Any
+from typing import Any, Optional
 from importlib.metadata import version
 
 from llama_index.core.readers.base import BasePydanticReader
@@ -18,7 +18,7 @@ class OxylabsBaseReader(BasePydanticReader, abc.ABC):
     https://developers.oxylabs.io/scraper-apis/web-scraper-api
     """
 
-    top_level_header: str | None = None
+    top_level_header: Optional[str] = None
 
     timeout_s: int = 100
     oxylabs_scraper_url: str = "https://realtime.oxyserps-dev.fun/v1/queries"

--- a/llama-index-integrations/readers/llama-index-readers-oxylabs/llama_index/readers/oxylabs/utils.py
+++ b/llama-index-integrations/readers/llama-index-readers-oxylabs/llama_index/readers/oxylabs/utils.py
@@ -1,7 +1,7 @@
-from typing import Any
+from typing import Any, Optional
 
 
-def json_to_markdown(data: Any, level: int = 0, header: str | None = None) -> str:
+def json_to_markdown(data: Any, level: int = 0, header: Optional[str] = None) -> str:
     """
     Recursively converts a Python object (from JSON) into a Markdown string.
 

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/oxylabs_web/utils.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/oxylabs_web/utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any
+from typing import Any, Optional
 
 from lxml.html import defs, fromstring, tostring
 from lxml.html.clean import Cleaner
@@ -74,7 +74,7 @@ def strip_html(html: str) -> str:
     return re.sub(r"\n{2,}", "", stripped_html)
 
 
-def json_to_markdown(data: Any, level: int = 0, header: str | None = None) -> str:
+def json_to_markdown(data: Any, level: int = 0, header: Optional[str] = None) -> str:
     """
     Recursively converts a Python object (from JSON) into a Markdown string.
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-ApertureDB/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-ApertureDB/pyproject.toml
@@ -31,7 +31,7 @@ name = "llama-index-vector-stores-ApertureDB"
 version = "0.0.2"
 description = "llama-index vector_stores ApertureDB integration"
 authors = [{name = "ApertureData", email = "team@aperturedata.io"}]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/pyproject.toml
@@ -30,7 +30,7 @@ name = "llama-index-vector-stores-chroma"
 version = "0.4.1"
 description = "llama-index vector_stores chroma integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [

--- a/llama-index-packs/llama-index-packs-chroma-autoretrieval/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-chroma-autoretrieval/pyproject.toml
@@ -29,7 +29,7 @@ name = "llama-index-packs-chroma-autoretrieval"
 version = "0.3.0"
 description = "llama-index packs chroma_autoretrieval integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 maintainers = [{name = "logan-markewich"}]

--- a/llama-index-packs/llama-index-packs-rag-cli-local/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-rag-cli-local/pyproject.toml
@@ -29,7 +29,7 @@ name = "llama-index-packs-rag-cli-local"
 version = "0.4.0"
 description = "llama-index packs rag cli local integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 maintainers = [{name = "jerryjliu"}]


### PR DESCRIPTION
Attempt at cleaning up some long-tail CICD issues.

Most of these are just issues with packages that no longer support python 3.9

There are a few other more complex issues. The most bizarre is that `mlx` only supports macos lol might need to special case it in CICD?