### PR TITLE
llama-dev: run tests locally passing package name

### DIFF
--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -50,8 +50,9 @@ NO_TESTS_INDICATOR = "no tests ran"
     default=0,
     help="Compute test coverage",
 )
-@click.option("--base-ref", required=True)
+@click.option("--base-ref", required=False)
 @click.option("--workers", default=8)
+@click.argument("package_names", required=False, nargs=-1)
 @click.pass_obj
 def test(
     obj: dict,
@@ -60,6 +61,7 @@ def test(
     cov_fail_under: int,
     base_ref: str,
     workers: int,
+    package_names: tuple,
 ):
     # Fail on incompatible configurations
     if cov_fail_under and not cov:
@@ -67,22 +69,26 @@ def test(
             "You have to pass --cov in order to use --cov-fail-under"
         )
 
-    if not base_ref:
+    if base_ref is not None and not base_ref:
         raise click.UsageError("Option '--base-ref' cannot be empty.")
 
     console = obj["console"]
     repo_root = obj["repo_root"]
-
-    # Collect the packages to test
+    packages_to_test: set[Path] = set()
     all_packages = find_all_packages(repo_root)
-    # Get the files that changed from the base branch
-    changed_files = get_changed_files(repo_root, base_ref)
-    # Get the packages containing the changed files
-    changed_packages = get_changed_packages(changed_files, all_packages)
+
+    if package_names:
+        changed_packages: set[Path] = {repo_root / Path(pn) for pn in package_names}
+    else:
+        # Get the files that changed from the base branch
+        changed_files = get_changed_files(repo_root, base_ref)
+        # Get the packages containing the changed files
+        changed_packages = get_changed_packages(changed_files, all_packages)
+
     # Find the dependants of the changed packages
     dependants = get_dependants_packages(changed_packages, all_packages)
     # Test the packages directly affected and their dependants
-    packages_to_test: set[Path] = changed_packages | dependants
+    packages_to_test = changed_packages | dependants
 
     # Test the packages using a process pool
     results = []
@@ -211,16 +217,19 @@ def _pytest(
 def _diff_cover(
     package_path: Path, env: dict[str, str], cov_fail_under: int, base_ref: str
 ) -> subprocess.CompletedProcess:  # pragma: no cover
+    diff_cover_cmd = [
+        "uv",
+        "run",
+        "--",
+        "diff-cover",
+        "coverage.xml",
+        f"--fail-under={cov_fail_under}",
+    ]
+    if base_ref:
+        diff_cover_cmd.append(f"--compare-branch={base_ref}")
+
     return subprocess.run(
-        [
-            "uv",
-            "run",
-            "--",
-            "diff-cover",
-            "coverage.xml",
-            f"--fail-under={cov_fail_under}",
-            f"--compare-branch={base_ref}",
-        ],
+        diff_cover_cmd,
         cwd=package_path,
         text=True,
         capture_output=True,

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -69,10 +69,6 @@ def package_data():
 def test_test_command_requires_base_ref():
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["test"])
-    assert result.exit_code != 0
-    assert "Error: Missing option '--base-ref'" in result.output
-
     result = runner.invoke(cli, ["test", "--base-ref"])
     assert result.exit_code != 0
     assert "Error: Option '--base-ref' requires an argument." in result.output
@@ -244,6 +240,41 @@ def test_success(
     # Check console output
     assert result.exit_code == 0
     assert "✅ test_integration succeeded in 0.1s" in result.stdout
+
+
+@mock.patch("llama_dev.test.find_all_packages")
+@mock.patch("llama_dev.test.get_changed_files")
+@mock.patch("llama_dev.test.get_changed_packages")
+@mock.patch("llama_dev.test.get_dependants_packages")
+def test_package_parameter(
+    mock_get_dependants,
+    mock_get_changed_packages,
+    mock_get_changed_files,
+    mock_find_all_packages,
+    data_path,
+):
+    # Setup minimal test data
+    mock_find_all_packages.return_value = set()
+    mock_get_changed_files.return_value = set()
+    mock_get_changed_packages.return_value = set()
+    mock_get_dependants.return_value = set()
+
+    runner = CliRunner()
+    runner.invoke(
+        cli,
+        [
+            "--repo-root",
+            data_path,
+            "test",
+            "--base-ref",
+            "main",
+            "package_1",
+            "package_2",
+        ],
+    )
+    mock_get_dependants.assert_called_with(
+        {data_path / "package_1", data_path / "package_2"}, set()
+    )
 
 
 #


### PR DESCRIPTION
# Description

`llama-dev test` only run tests for packages that changed between two commits. In order to allow debugging the CI locally, now `llama-dev test` can optionally take a path to a local package and run the tests, like:
```
llama-dev test --cov --cov-fail-under 100 llama-index-integrations/embeddings/llama-index-embeddings-ibm
```
