### PR TITLE
Fix/docling node parser metadata

### DIFF
--- a/llama-index-integrations/node_parser/llama-index-node-parser-docling/llama_index/node_parser/docling/base.py
+++ b/llama-index-integrations/node_parser/llama-index-node-parser-docling/llama_index/node_parser/docling/base.py
@@ -33,8 +33,7 @@ class DoclingNodeParser(NodeParser):
 
     @runtime_checkable
     class NodeIDGenCallable(Protocol):
-        def __call__(self, i: int, node: BaseNode) -> str:
-            ...
+        def __call__(self, i: int, node: BaseNode) -> str: ...
 
     @staticmethod
     def _uuid4_node_id_gen(i: int, node: BaseNode) -> str:
@@ -66,6 +65,21 @@ class DoclingNodeParser(NodeParser):
                     k for k in chunk.meta.excluded_embed if k in metadata
                 ]
                 excl_llm_keys = [k for k in chunk.meta.excluded_llm if k in metadata]
+
+                excl_embed_keys.extend(
+                    [
+                        k
+                        for k in li_doc.excluded_embed_metadata_keys
+                        if k not in excl_embed_keys
+                    ]
+                )
+                excl_llm_keys.extend(
+                    [
+                        k
+                        for k in li_doc.excluded_llm_metadata_keys
+                        if k not in excl_llm_keys
+                    ]
+                )
 
                 node = TextNode(
                     id_=self.id_func(i=i, node=li_doc),

--- a/llama-index-integrations/node_parser/llama-index-node-parser-docling/pyproject.toml
+++ b/llama-index-integrations/node_parser/llama-index-node-parser-docling/pyproject.toml
@@ -26,16 +26,13 @@ dev = [
 
 [project]
 name = "llama-index-node-parser-docling"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index node_parser docling integration"
-authors = [{name = "Panos Vagenas", email = "pva@zurich.ibm.com"}]
+authors = [{ name = "Panos Vagenas", email = "pva@zurich.ibm.com" }]
 requires-python = "~=3.10"
 readme = "README.md"
 license = "MIT"
-dependencies = [
-    "llama-index-core>=0.12.0,<0.13",
-    "docling-core>=2.18.0,<3",
-]
+dependencies = ["llama-index-core>=0.12.0,<0.13", "docling-core>=2.18.0,<3"]
 
 [tool.codespell]
 check-filenames = true

--- a/llama-index-integrations/node_parser/llama-index-node-parser-docling/pyproject.toml
+++ b/llama-index-integrations/node_parser/llama-index-node-parser-docling/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 name = "llama-index-node-parser-docling"
 version = "0.3.2"
 description = "llama-index node_parser docling integration"
-authors = [{ name = "Panos Vagenas", email = "pva@zurich.ibm.com" }]
+authors = [{name = "Panos Vagenas", email = "pva@zurich.ibm.com"}]
 requires-python = "~=3.10"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
# Description

Fixes issue where `DoclingNodeParser` does not include `excluded_embed_metadata_keys` and `excluded_llm_metadata_keys` from the source `Document` in the resulting `TextNode`.

## Version Bump?

- [X] Yes
- [ ] No

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
