### PR TITLE
llama-dev: do not print full path on tests reports

### DIFF
--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -135,14 +135,20 @@ def test(
 
     # Print summary
     failed = [
-        r["package"]
+        r["package"].relative_to(repo_root)
         for r in results
         if r["status"] in (ResultStatus.TESTS_FAILED, ResultStatus.COVERAGE_FAILED)
     ]
     install_failed = [
-        r["package"] for r in results if r["status"] == ResultStatus.INSTALL_FAILED
+        r["package"].relative_to(repo_root)
+        for r in results
+        if r["status"] == ResultStatus.INSTALL_FAILED
     ]
-    skipped = [r["package"] for r in results if r["status"] == ResultStatus.SKIPPED]
+    skipped = [
+        r["package"].relative_to(repo_root)
+        for r in results
+        if r["status"] == ResultStatus.SKIPPED
+    ]
 
     if skipped:
         console.print(


### PR DESCRIPTION
# Description

In the tests report, do not print the full path of the integrations, print the relative path to repo root instead. This will allow to copy the list of failed integrations and direclty paste into a terminal and feed `llama-dev`
