### PR TITLE
Automate inserting current CHANGELOG segment into release

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Build and publish to pypi
         run: uv build && uv publish --token ${{ secrets.LLAMA_INDEX_PYPI_TOKEN }}
 
+      - uses: CSchoel/release-notes-from-changelog@v1
+        with:
+          version: "$(date +'%Y-%m-%d')"
+
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
@@ -39,6 +43,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
+          body_path: "RELEASE.md"
           draft: false
           prerelease: false
 

--- a/RELEASE_HEAD.md
+++ b/RELEASE_HEAD.md
@@ -1,0 +1,1 @@
+# Release Notes


### PR DESCRIPTION
# Description
Implements latest `CHANGELOG` segment insertion into release publication by current date - utilizing [CSchoel/release-notes-from-changelog@v1](https://github.com/marketplace/actions/create-release-notes-from-changelog) within [.github/publish_release.yml](https://github.com/run-llama/llama_index/blob/main/.github/workflows/publish_release.yml)

Fixes #18640 

## Type of Change
New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

These instructions document the local testing of the changelog release notes functionality using [`nektos/act`](https://github.com/nektos/act). The test workflow verifies that the action correctly extracts and formats release notes from the root `CHANGELOG.md`.

### Prerequisites
Install [nektos/act](https://nektosact.com/installation/index.html)

### Test Setup

Create a mock GitHub Actions workflow file at `./.github/workflows/test-changelog.yml`:
```yaml
name: Test Changelog Release Notes

on: push

jobs:
  test-changelog:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: CSchoel/release-notes-from-changelog@v1
        with:
          version: "2025-04-30"  # Use "$(date +'%Y-%m-%d')" for actual releases
      - run: 'cat RELEASE.md'
```

### Running the Test

Execute the test workflow using act:
```bash
act -W '.github/workflows/test-changelog.yml'
```

### Expected Result
The workflow will:
1. Generate release notes from the `CHANGELOG.md` file
2. Match the section corresponding to the specified version (e.g., provided date in `YYYY-MM-DD` format)
3. Prepend the contents of this `RELEASE_HEAD.md` file
4. Output the combined content to `RELEASE.md`

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
