### PR TITLE
log deprecation warning for TextGenerationInference

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/README.md
@@ -1,24 +1,22 @@
 # LlamaIndex Llms Integration: Text Generation Inference
 
-Integration with [Text Generation Inference](https://huggingface.co/docs/text-generation-inference) from Hugging Face to generate text.
+⚠️ This integration has been deprecated!
 
-## Installation
+The `TextGenerationInference` is no longer maintained. Instead, you can use [`HuggingFaceInferenceAPI`](https://github.com/run-llama/llama_index/tree/main/llama-index-integrations/llms/llama-index-llms-huggingface-api). The underlying Text Generation Inference SDK (`tgi`) [has been deprecated](https://github.com/huggingface/text-generation-inference/tree/main/clients/python) in favor of `huggingface_hub`, which `HuggingFaceInferenceAPI` is built on top of.
+
+Instead, use `llama-index-llms-huggingface-api`:
 
 ```shell
-pip install llama-index-llms-text-generation-inference
+pip install llama-index-llms-huggingface-api
 ```
 
-## Usage
+Usage:
 
-```python
-from llama_index.llms.text_generation_inference import TextGenerationInference
+```py
+from llama_index.llms.huggingface_api import HuggingFaceInferenceAPI
 
-llm = TextGenerationInference(
-    model_name="openai-community/gpt2",
-    temperature=0.7,
-    max_tokens=100,
-    token="<your-token>",  # Optional
-)
-
-response = llm.complete("Hello, how are you?")
+# access hugging face inference
+hub_llm = HuggingFaceInferenceAPI(model="openai-community/gpt2")
+# or with a local TGI server
+tgi_llm = HuggingFaceInferenceAPI(model="http://localhost:8080")
 ```

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/__init__.py
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/__init__.py
@@ -1,5 +1,20 @@
+import logging
+
 from llama_index.llms.text_generation_inference.base import (
     TextGenerationInference,
 )
+
+logger = logging.getLogger(__name__)
+
+logger.warning("""
+===============================================================================
+                         ⚠️ DEPRECATION WARNING ⚠️
+===============================================================================
+The llama-index-llms-text-generation-inference package is NO LONGER MAINTAINED!
+Please use HuggingFaceInferenceAPI instead, which can call either TGI servers
+or huggingface inference API.
+To install: pip install llama-index-llms-huggingface-api
+===============================================================================
+""".strip())
 
 __all__ = ["TextGenerationInference"]

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/llama_index/llms/text_generation_inference/base.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
+from deprecated import deprecated
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
@@ -50,6 +51,7 @@ from tgi import (
 logger = logging.getLogger(__name__)
 
 
+@deprecated(reason="use HuggingFaceInferenceAPI from llama-index-llms-huggingface-api instead")
 class TextGenerationInference(FunctionCallingLLM):
     model_name: Optional[str] = Field(
         default=None,

--- a/llama-index-integrations/llms/llama-index-llms-text-generation-inference/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-text-generation-inference/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-text-generation-inference"
-version = "0.3.2"
+version = "0.3.3"
 description = "llama-index llms huggingface text generation inference integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description
Ahead of full code removal, https://github.com/run-llama/llama_index/pull/18656, this version will log warnings about its status.


Looks like this:
<img width="583" alt="image" src="https://github.com/user-attachments/assets/2b499076-d8dd-419d-b9f1-1f4d6db799aa" />

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
