### PR TITLE
Fix event colors of draw_all_possible_flows

### DIFF
--- a/llama-index-utils/llama-index-utils-workflow/llama_index/utils/workflow/draw.py
+++ b/llama-index-utils/llama-index-utils-workflow/llama_index/utils/workflow/draw.py
@@ -64,9 +64,9 @@ def draw_all_possible_flows(
             net.add_node(
                 event_type.__name__,
                 label=event_type.__name__,
-                color="#90EE90" if event_type != StartEvent else "#E27AFF",
+                color=determine_event_color(event_type),
                 shape="ellipse",
-            )  # Light green for events
+            )
 
         for return_type in step_config.return_types:
             if return_type is type(None):
@@ -75,9 +75,9 @@ def draw_all_possible_flows(
             net.add_node(
                 return_type.__name__,
                 label=return_type.__name__,
-                color="#90EE90",
+                color=determine_event_color(return_type),
                 shape="ellipse",
-            )  # Light green for events
+            )
 
             if issubclass(return_type, InputRequiredEvent):
                 # add node for conceptual external step
@@ -115,6 +115,19 @@ def draw_all_possible_flows(
                 )
 
     net.show(filename, notebook=notebook)
+
+
+def determine_event_color(event_type):
+    if issubclass(event_type, StartEvent):
+        # Pink for start events
+        event_color = "#E27AFF"
+    elif issubclass(event_type, StopEvent):
+        # Orange for stop events
+        event_color = "#FFA07A"
+    else:
+        # Light green for other events
+        event_color = "#90EE90"
+    return event_color
 
 
 def draw_most_recent_execution(

--- a/llama-index-utils/llama-index-utils-workflow/pyproject.toml
+++ b/llama-index-utils/llama-index-utils-workflow/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-utils-workflow"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index utils for workflows"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

The StopEvent was not colored orange in the visualisation created by the `draw_all_possible_flows` method. (see [documentation](https://docs.llamaindex.ai/en/stable/understanding/workflows/basic_flow/#visualizing-a-workflow)).
Custom start and stop events were also not colored.
This pull request fixes thoses problems, and thereby makes it easier to understand the graphs.

## Examples:

Basic Workflow
_Before:_
![image](https://github.com/user-attachments/assets/304af9be-2e84-4f3c-b753-82f508089645)

_After:_
![image](https://github.com/user-attachments/assets/46d463af-9538-44b9-bb9b-1eb9b111c619)

Special Workflow 
_Before:_
![image](https://github.com/user-attachments/assets/8c6f8619-0358-4145-8305-b7d7ad42a54f)

_After:_
![image](https://github.com/user-attachments/assets/ad4f7da6-3e0b-4f4f-addf-064fa144b277)

Code:
```
from llama_index.core.workflow import (
    StartEvent,
    StopEvent,
    Workflow,
    step,
    Event,
)
from llama_index.utils.workflow import draw_all_possible_flows


class FirstEvent(Event):
    first_output: str


class SecondEvent(Event):
    second_output: str


class MyWorkflow(Workflow):
    @step
    async def step_one(self, ev: StartEvent) -> FirstEvent:
        print(ev.first_input)
        return FirstEvent(first_output="First step complete.")

    @step
    async def step_two(self, ev: FirstEvent) -> SecondEvent:
        print(ev.first_output)
        return SecondEvent(second_output="Second step complete.")

    @step
    async def step_three(self, ev: SecondEvent) -> StopEvent:
        print(ev.second_output)
        return StopEvent(result="Workflow complete.")


class SpecialStartEvent(StartEvent):
    first_input: str


class SpecialStopEvent(StopEvent):
    first_input: str


class SpecialWorkflow(Workflow):
    @step
    async def step_one(self, ev: SpecialStartEvent) -> FirstEvent:
        print(ev.first_input)
        return FirstEvent(first_output="First step complete.")

    @step
    async def step_two(self, ev: FirstEvent) -> SecondEvent:
        print(ev.first_output)
        return SecondEvent(second_output="Second step complete.")

    @step
    async def step_three(self, ev: SecondEvent) -> SpecialStopEvent:
        print(ev.second_output)
        return StopEvent(result="Workflow complete.")


draw_all_possible_flows(MyWorkflow, filename="basic_workflow.html")
draw_all_possible_flows(SpecialWorkflow, filename="special_workflow.html")
```

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
