### PR TITLE
fix: Handle possible OverflowError when getting Neptune node properties

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/neptune.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/neptune.py
@@ -272,7 +272,7 @@ def _get_node_properties(query: str, n_labels: List[str], types: Dict) -> List:
                             data_type = "DATETIME"
                         else:
                             data_type = "STRING"
-                    except ValueError:
+                    except (ValueError, OverflowError):
                         data_type = "STRING"
                 s.add((k, data_type))
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-graph-stores-neptune"
-version = "0.3.2"
+version = "0.3.3"
 description = "llama-index graph stores amazon neptune integration"
 authors = [{name = "Dave Bechberger", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

When using `dateutil.parser.parse`, the following two errors can be raised:
- **`ParserError`**
  - Raised for invalid or unknown string formats, if the provided tzinfo is not in a valid format, or if an invalid date would be created.
- **`OverflowError`**
  - Raised if the parsed date exceeds the largest valid C integer on your system.

Currently, LlamaIndex only handles `ValueError` when calling `dateutil.parser.parse` while getting the Neptune node properties. While `ValueError` satisfies handling `ParseError`, it does _not_ satisfy `OverflowError`. As a result, invalid parsing due to an OverflowError causes the error to go uncaught, thus causing the calling functions to also fail (e.g., `get_schema()` -> `refresh_scema()` -> `_get_node_properties()`).

As a user, I'd expected an OverflowError to be treated in the same way as a `ParserError` (ValueError). That is, I'd expect the node `data_type` to be treated as a `"STRING"`.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
