### PR TITLE
chore: fix lagecy office reader bloated metadata

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-legacy-office/llama_index/readers/legacy_office/reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-legacy-office/llama_index/readers/legacy_office/reader.py
@@ -133,32 +133,33 @@ class LegacyOfficeReader(BaseReader):
             "meta:character-count": "chars",
             "meta:page-count": "pages",
             "xmptpg:npages": "pages",
-
             # Dates
             "dcterms:created": "created",
             "dcterms:modified": "modified",
         }
 
-        for key, value in tika_metadata.items():
+        for key, orig_value in tika_metadata.items():
             # Skip if not an essential key
             normalized_key = essential_keys.get(key.lower())
             if not normalized_key:
                 continue
 
             # Skip empty values
-            if not value:
+            if not orig_value:
                 continue
 
             # Handle lists by joining with semicolon
-            if isinstance(value, list):
-                value = "; ".join(str(v) for v in value)
+            processed_value = orig_value
+            if isinstance(orig_value, list):
+                processed_value = "; ".join(str(v) for v in orig_value)
 
             # Convert to string and clean up
-            value = str(value).strip()
-            if value:
-                if ":" in value:
-                    value = value.split(":", 1)[1].strip()
-                metadata[normalized_key] = value
+            processed_value = str(processed_value).strip()
+            if processed_value and ":" in processed_value:
+                processed_value = processed_value.split(":", 1)[1].strip()
+
+            if processed_value:
+                metadata[normalized_key] = processed_value
 
         return metadata
 

--- a/llama-index-integrations/readers/llama-index-readers-legacy-office/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-legacy-office/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-legacy-office"
-version = "0.1.0"
+version = "0.1.1"
 description = "LlamaIndex Legacy Office Reader, handles .doc files loading with Apache Tika"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

fix metadata too large in text window splitting `split_text_metadata_aware()`

```python
    def split_text_metadata_aware(self, text: str, metadata_str: str) -> List[str]:
        metadata_len = len(self._tokenizer(metadata_str))
        effective_chunk_size = self.chunk_size - metadata_len
        if effective_chunk_size <= 0:
            raise ValueError(
                f"Metadata length ({metadata_len}) is longer than chunk size "
                f"({self.chunk_size}). Consider increasing the chunk size or "
                "decreasing the size of your metadata to avoid this."
            )
        elif effective_chunk_size < 50:
            print(
                f"Metadata length ({metadata_len}) is close to chunk size "
                f"({self.chunk_size}). Resulting chunks are less than 50 tokens. "
                "Consider increasing the chunk size or decreasing the size of "
                "your metadata to avoid this.",
                flush=True,
            )

        return self._split_text(text, chunk_size=effective_chunk_size)
```

## New Package?


- [ ] Yes
- [x] No

## Version Bump?

> `0.1.1`

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
