### PR TITLE
Added Feature: Async methods for BaseIndex

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -9,7 +9,7 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.chat_engine.types import BaseChatEngine, ChatMode
 from llama_index.core.data_structs.data_structs import IndexStruct
-from llama_index.core.ingestion import run_transformations
+from llama_index.core.ingestion import run_transformations, arun_transformations
 from llama_index.core.llms.utils import LLMType, resolve_llm
 from llama_index.core.schema import BaseNode, Document, IndexNode, TransformComponent
 from llama_index.core.settings import Settings
@@ -99,7 +99,7 @@ class BaseIndex(Generic[IS], ABC):
         Create index from documents.
 
         Args:
-            documents (Optional[Sequence[BaseDocument]]): List of documents to
+            documents (Sequence[Document]]): List of documents to
                 build the index from.
 
         """
@@ -207,6 +207,21 @@ class BaseIndex(Generic[IS], ABC):
             self._insert(nodes, **insert_kwargs)
             self._storage_context.index_store.add_index_struct(self._index_struct)
 
+    async def ainsert_nodes(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:
+        """Asynchronously insert nodes."""
+        for node in nodes:
+            if isinstance(node, IndexNode):
+                try:
+                    node.dict()
+                except ValueError:
+                    self._object_map[node.index_id] = node.obj
+                    node.obj = None
+
+        with self._callback_manager.as_trace("ainsert_nodes"):
+            await self.docstore.async_add_documents(nodes, allow_update=True)
+            self._insert(nodes=nodes)
+            await self._storage_context.index_store.async_add_index_struct(self._index_struct)
+
     def insert(self, document: Document, **insert_kwargs: Any) -> None:
         """Insert a document."""
         with self._callback_manager.as_trace("insert"):
@@ -219,6 +234,19 @@ class BaseIndex(Generic[IS], ABC):
 
             self.insert_nodes(nodes, **insert_kwargs)
             self.docstore.set_document_hash(document.get_doc_id(), document.hash)
+
+    async def ainsert(self, document: Document, **insert_kwargs: Any) -> None:
+        """Asynchronously insert a document."""
+        with self._callback_manager.as_trace("ainsert"):
+            nodes = await arun_transformations(
+                [document],
+                self._transformations,
+                show_progress=self._show_progress,
+                **insert_kwargs,
+            )
+
+            await self.ainsert_nodes(nodes, **insert_kwargs)
+            await self.docstore.aset_document_hash(document.get_doc_id(), document.hash)
 
     @abstractmethod
     def _delete_node(self, node_id: str, **delete_kwargs: Any) -> None:
@@ -244,6 +272,26 @@ class BaseIndex(Generic[IS], ABC):
 
         self._storage_context.index_store.add_index_struct(self._index_struct)
 
+    async def adelete_nodes(
+        self,
+        node_ids: List[str],
+        delete_from_docstore: bool = False,
+        **delete_kwargs: Any,
+    ) -> None:
+        """
+        Asynchronously delete a list of nodes from the index.
+
+        Args:
+            doc_ids (List[str]): A list of doc_ids from the nodes to delete
+
+        """
+        for node_id in node_ids:
+            self._delete_node(node_id, **delete_kwargs)
+            if delete_from_docstore:
+                await self.docstore.adelete_document(node_id, raise_error=False)
+
+        await self._storage_context.index_store.async_add_index_struct(self._index_struct)
+
     def delete(self, doc_id: str, **delete_kwargs: Any) -> None:
         """
         Delete a document from the index.
@@ -256,6 +304,7 @@ class BaseIndex(Generic[IS], ABC):
         logger.warning(
             "delete() is now deprecated, please refer to delete_ref_doc() to delete "
             "ingested documents+nodes or delete_nodes to delete a list of nodes."
+            "Use adelete_ref_docs() for an asynchronous implementation"
         )
         self.delete_ref_doc(doc_id)
 
@@ -277,6 +326,24 @@ class BaseIndex(Generic[IS], ABC):
         if delete_from_docstore:
             self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
 
+    async def adelete_ref_doc(
+        self, ref_doc_id: str, delete_from_docstore: bool = False, **delete_kwargs: Any
+    ) -> None:
+        """Delete a document and it's nodes by using ref_doc_id."""
+        ref_doc_info = await self.docstore.aget_ref_doc_info(ref_doc_id)
+        if ref_doc_info is None:
+            logger.warning(f"ref_doc_id {ref_doc_id} not found, nothing deleted.")
+            return
+
+        await self.adelete_nodes(
+            ref_doc_info.node_ids,
+            delete_from_docstore=False,
+            **delete_kwargs,
+        )
+
+        if delete_from_docstore:
+            await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
+
     def update(self, document: Document, **update_kwargs: Any) -> None:
         """
         Update a document and it's corresponding nodes.
@@ -292,6 +359,7 @@ class BaseIndex(Generic[IS], ABC):
         logger.warning(
             "update() is now deprecated, please refer to update_ref_doc() to update "
             "ingested documents+nodes."
+            "Use aupdate_ref_docs() for an asynchronous implementation"
         )
         self.update_ref_doc(document, **update_kwargs)
 
@@ -307,13 +375,33 @@ class BaseIndex(Generic[IS], ABC):
             delete_kwargs (Dict): kwargs to pass to delete
 
         """
-        with self._callback_manager.as_trace("update"):
+        with self._callback_manager.as_trace("update_ref_doc"):
             self.delete_ref_doc(
                 document.get_doc_id(),
                 delete_from_docstore=True,
                 **update_kwargs.pop("delete_kwargs", {}),
             )
             self.insert(document, **update_kwargs.pop("insert_kwargs", {}))
+
+    async def aupdate_ref_doc(self, document: Document, **update_kwargs: Any) -> None:
+        """
+        Asynchronously update a document and it's corresponding nodes.
+
+        This is equivalent to deleting the document and then inserting it again.
+
+        Args:
+            document (Union[BaseDocument, BaseIndex]): document to update
+            insert_kwargs (Dict): kwargs to pass to insert
+            delete_kwargs (Dict): kwargs to pass to delete
+
+        """
+        with self._callback_manager.as_trace("aupdate_ref_doc"):
+            await self.adelete_ref_doc(
+                document.get_doc_id(),
+                delete_from_docstore=True,
+                **update_kwargs.pop("delete_kwargs", {}),
+            )
+            await self.ainsert(document, **update_kwargs.pop("insert_kwargs", {}))
 
     def refresh(
         self, documents: Sequence[Document], **update_kwargs: Any
@@ -328,6 +416,7 @@ class BaseIndex(Generic[IS], ABC):
         logger.warning(
             "refresh() is now deprecated, please refer to refresh_ref_docs() to "
             "refresh ingested documents+nodes with an updated list of documents."
+            "Use arefresh_ref_docs() for an asynchronous implementation"
         )
         return self.refresh_ref_docs(documents, **update_kwargs)
 
@@ -341,7 +430,7 @@ class BaseIndex(Generic[IS], ABC):
         updating documents that have any changes in text or metadata. It
         will also insert any documents that previously were not stored.
         """
-        with self._callback_manager.as_trace("refresh"):
+        with self._callback_manager.as_trace("refresh_ref_docs"):
             refreshed_documents = [False] * len(documents)
             for i, document in enumerate(documents):
                 existing_doc_hash = self._docstore.get_document_hash(
@@ -356,6 +445,32 @@ class BaseIndex(Generic[IS], ABC):
                     )
                     refreshed_documents[i] = True
 
+            return refreshed_documents
+
+    async def arefresh_ref_docs(
+        self, documents: Sequence[Document], **update_kwargs: Any
+    ) -> List[bool]:
+        """
+        Asynchronously refresh an index with documents that have changed.
+
+        This allows users to save LLM and Embedding model calls, while only
+        updating documents that have any changes in text or metadata. It
+        will also insert any documents that previously were not stored.
+        """
+        with self._callback_manager.as_trace("arefresh_ref_docs"):
+            refreshed_documents = [False] * len(documents)
+            for i, document in enumerate(documents):
+                existing_doc_hash = await self._docstore.aget_document_hash(
+                    document.get_doc_id()
+                )
+                if existing_doc_hash is None:
+                    await self.ainsert(document, **update_kwargs.pop("insert_kwargs", {}))
+                    refreshed_documents[i] = True
+                elif existing_doc_hash != document.hash:
+                    await self.aupdate_ref_doc(
+                        document, **update_kwargs.pop("update_kwargs", {})
+                    )
+                    refreshed_documents[i] = True
             return refreshed_documents
 
     @property

--- a/llama-index-core/llama_index/core/storage/index_store/keyval_index_store.py
+++ b/llama-index-core/llama_index/core/storage/index_store/keyval_index_store.py
@@ -87,3 +87,56 @@ class KVIndexStore(BaseIndexStore):
         """
         jsons = self._kvstore.get_all(collection=self._collection)
         return [json_to_index_struct(json) for json in jsons.values()]
+
+    async def async_add_index_struct(self, index_struct: IndexStruct) -> None:
+        """
+        Asynchronously add an index struct.
+
+        Args:
+            index_struct (IndexStruct): index struct
+
+        """
+        key = index_struct.index_id
+        data = index_struct_to_json(index_struct)
+        await self._kvstore.aput(key, data, collection=self._collection)
+
+    async def adelete_index_struct(self, key: str) -> None:
+        """
+        Asynchronously delete an index struct.
+
+        Args:
+            key (str): index struct key
+
+        """
+        await self._kvstore.adelete(key, collection=self._collection)
+
+    async def aget_index_struct(
+        self, struct_id: Optional[str] = None
+    ) -> Optional[IndexStruct]:
+        """
+        Asynchronously get an index struct.
+
+        Args:
+            struct_id (Optional[str]): index struct id
+
+        """
+        if struct_id is None:
+            structs = await self.async_index_structs()
+            assert len(structs) == 1
+            return structs[0]
+        else:
+            json = await self._kvstore.aget(struct_id, collection=self._collection)
+            if json is None:
+                return None
+            return json_to_index_struct(json)
+
+    async def async_index_structs(self) -> List[IndexStruct]:
+        """
+        Asynchronously get all index structs.
+
+        Returns:
+            List[IndexStruct]: index structs
+
+        """
+        jsons = await self._kvstore.aget_all(collection=self._collection)
+        return [json_to_index_struct(json) for json in jsons.values()]

--- a/llama-index-core/llama_index/core/storage/index_store/types.py
+++ b/llama-index-core/llama_index/core/storage/index_store/types.py
@@ -16,7 +16,15 @@ class BaseIndexStore(ABC):
         pass
 
     @abstractmethod
+    async def async_index_structs(self) -> List[IndexStruct]:
+        pass
+
+    @abstractmethod
     def add_index_struct(self, index_struct: IndexStruct) -> None:
+        pass
+
+    @abstractmethod
+    async def async_add_index_struct(self, index_struct: IndexStruct) -> None:
         pass
 
     @abstractmethod
@@ -24,7 +32,17 @@ class BaseIndexStore(ABC):
         pass
 
     @abstractmethod
+    async def adelete_index_struct(self, key: str) -> None:
+        pass
+
+    @abstractmethod
     def get_index_struct(
+        self, struct_id: Optional[str] = None
+    ) -> Optional[IndexStruct]:
+        pass
+
+    @abstractmethod
+    async def aget_index_struct(
         self, struct_id: Optional[str] = None
     ) -> Optional[IndexStruct]:
         pass

--- a/llama-index-core/tests/indices/vector_store/test_simple_async.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple_async.py
@@ -1,0 +1,131 @@
+import pytest
+from typing import List
+from llama_index.core.indices.vector_store.base import VectorStoreIndex
+from llama_index.core.schema import Document
+from llama_index.core.vector_stores.simple import SimpleVectorStore
+
+@pytest.mark.asyncio
+async def test_simple_insertion(
+    documents: List[Document],
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    mock_embed_model,
+):
+    index = VectorStoreIndex.from_documents(
+        documents=documents, embed_model=mock_embed_model
+    )
+    assert isinstance(index, VectorStoreIndex)
+    # insert into index
+    await index.ainsert(Document(text="This is a test v3."))
+
+    # insert empty document to test empty document handling
+    await index.ainsert(Document(text=""))
+
+    # check contenst of nodes
+    actual_node_tups = [
+        ("Hello world.", [1, 0, 0, 0, 0]),
+        ("This is a test.", [0, 1, 0, 0, 0]),
+        ("This is another test.", [0, 0, 1, 0, 0]),
+        ("This is a test v2.", [0, 0, 0, 1, 0]),
+        ("This is a test v3.", [0, 0, 0, 0, 1]),
+    ]
+    for text_id in index.index_struct.nodes_dict:
+        node_id = index.index_struct.nodes_dict[text_id]
+        node = index.docstore.get_node(node_id)
+        # NOTE: this test breaks abstraction
+        assert isinstance(index._vector_store, SimpleVectorStore)
+        embedding = index._vector_store.get(text_id)
+        assert (node.get_content(), embedding) in actual_node_tups
+
+@pytest.mark.asyncio
+async def test_simple_deletion(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    """Test delete VectorStoreIndex."""
+    new_documents = [
+        Document(text="Hello world.", id_="test_id_0"),
+        Document(text="This is a test.", id_="test_id_1"),
+        Document(text="This is another test.", id_="test_id_2"),
+        Document(text="This is a test v2.", id_="test_id_3"),
+    ]
+    index = VectorStoreIndex.from_documents(
+        documents=new_documents, embed_model=mock_embed_model
+    )
+    assert isinstance(index, VectorStoreIndex)
+
+    await index.adelete_ref_doc("test_id_0")
+    assert len(index.index_struct.nodes_dict) == 3
+    actual_node_tups = [
+        ("This is a test.", [0, 1, 0, 0, 0], "test_id_1"),
+        ("This is another test.", [0, 0, 1, 0, 0], "test_id_2"),
+        ("This is a test v2.", [0, 0, 0, 1, 0], "test_id_3"),
+    ]
+    for text_id in index.index_struct.nodes_dict:
+        node_id = index.index_struct.nodes_dict[text_id]
+        node = index.docstore.get_node(node_id)
+        # NOTE: this test breaks abstraction
+        assert isinstance(index._vector_store, SimpleVectorStore)
+        embedding = index._vector_store.get(text_id)
+        assert (node.get_content(), embedding, node.ref_doc_id) in actual_node_tups
+
+    # test insert
+    await index.ainsert(Document(text="Hello world backup.", id_="test_id_0"))
+
+    assert len(index.index_struct.nodes_dict) == 4
+    actual_node_tups = [
+        ("Hello world backup.", [1, 0, 0, 0, 0], "test_id_0"),
+        ("This is a test.", [0, 1, 0, 0, 0], "test_id_1"),
+        ("This is another test.", [0, 0, 1, 0, 0], "test_id_2"),
+        ("This is a test v2.", [0, 0, 0, 1, 0], "test_id_3"),
+    ]
+    for text_id in index.index_struct.nodes_dict:
+        node_id = index.index_struct.nodes_dict[text_id]
+        node = index.docstore.get_node(node_id)
+        # NOTE: this test breaks abstraction
+        assert isinstance(index._vector_store, SimpleVectorStore)
+        embedding = index._vector_store.get(text_id)
+        assert (node.get_content(), embedding, node.ref_doc_id) in actual_node_tups
+
+@pytest.mark.asyncio
+async def test_simple_update(
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    mock_embed_model,
+):
+    new_docs = [Document(id_="1", text="Hello World"), Document(id_="2", text="This is a test")]
+    index = VectorStoreIndex.from_documents(
+        documents=new_docs, embed_model=mock_embed_model
+    )
+    assert isinstance(index, VectorStoreIndex)
+    actual_node_tups = [
+        ("Hello World v1", "1"),
+        ("This is a test", "2"),
+    ]
+    await index.aupdate_ref_doc(Document(id_="1", text="Hello World v1"))
+    for text_id in index.index_struct.nodes_dict:
+        node_id = index.index_struct.nodes_dict[text_id]
+        node = index.docstore.get_node(node_id)
+        # NOTE: this test breaks abstraction
+        assert (node.get_content(), node.ref_doc_id) in actual_node_tups
+
+@pytest.mark.asyncio
+async def test_simple_refresh(
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    mock_embed_model,
+):
+    new_docs = [Document(id_="1", text="Hello World"), Document(id_="2", text="This is a test")]
+    index = VectorStoreIndex.from_documents(
+        documents=new_docs, embed_model=mock_embed_model
+    )
+    assert isinstance(index, VectorStoreIndex)
+    await index.arefresh_ref_docs([Document(id_="1", text="Hello World v1"), Document(id_="2", text="This is a test v1")])
+    actual_node_tups = [
+        ("Hello World v1", "1"),
+        ("This is a test v1", "2"),
+    ]
+    for text_id in index.index_struct.nodes_dict:
+        node_id = index.index_struct.nodes_dict[text_id]
+        node = index.docstore.get_node(node_id)
+        # NOTE: this test breaks abstraction
+        assert (node.get_content(), node.ref_doc_id) in actual_node_tups


### PR DESCRIPTION
# Description

Added several async methods to the BaseIndex class (which are then extended to all the subclasses) and added tests to test that they work properly. Namely, I added:

- `ainsert`
- `adelete`
- `aupdate_ref_doc`
- `arefresh_ref_docs`

And the corresponding async operations on nodes

Fixes #14940 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
