### PR TITLE
MCP one-liners

### DIFF
--- a/docs/docs/examples/tools/mcp.ipynb
+++ b/docs/docs/examples/tools/mcp.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LlamaIndex + MCP Usage\n",
+    "\n",
+    "The `llama-index-tools-mcp` package provides several tools for using MCP with LlamaIndex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-tools-mcp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Tools from an MCP Server\n",
+    "\n",
+    "Using the `get_tools_from_mcp_url` or `aget_tools_from_mcp_url` function, you can get a list of `FunctionTool`s from an MCP server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import (\n",
+    "    get_tools_from_mcp_url,\n",
+    "    aget_tools_from_mcp_url,\n",
+    ")\n",
+    "\n",
+    "# async\n",
+    "tools = await aget_tools_from_mcp_url(\"http://127.0.0.1:8000/sse\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, this will use our `BasicMCPClient`, which will run a command or connect to the URL and return the tools.\n",
+    "\n",
+    "You can also pass in a custom `ClientSession` to use a different client.\n",
+    "\n",
+    "You can also specify a list of allowed tools to filter the tools that are returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import BasicMCPClient\n",
+    "\n",
+    "client = BasicMCPClient(\"http://127.0.0.1:8000/sse\")\n",
+    "\n",
+    "tools = await aget_tools_from_mcp_url(\n",
+    "    \"http://127.0.0.1:8000/sse\",\n",
+    "    client=client,\n",
+    "    allowed_tools=[\"tool1\", \"tool2\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Converting a Workflow to an MCP App\n",
+    "\n",
+    "If you have a custom `Workflow`, you can convert it to an MCP app using the `workflow_as_mcp` function.\n",
+    "\n",
+    "For example, let's use the following workflow that will make a string loud:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.workflow import (\n",
+    "    Context,\n",
+    "    Workflow,\n",
+    "    Event,\n",
+    "    StartEvent,\n",
+    "    StopEvent,\n",
+    "    step,\n",
+    ")\n",
+    "from llama_index.tools.mcp.utils import workflow_as_mcp\n",
+    "\n",
+    "\n",
+    "class RunEvent(StartEvent):\n",
+    "    msg: str\n",
+    "\n",
+    "\n",
+    "class InfoEvent(Event):\n",
+    "    msg: str\n",
+    "\n",
+    "\n",
+    "class LoudWorkflow(Workflow):\n",
+    "    \"\"\"Useful for converting strings to uppercase and making them louder.\"\"\"\n",
+    "\n",
+    "    @step\n",
+    "    def step_one(self, ctx: Context, ev: RunEvent) -> StopEvent:\n",
+    "        ctx.write_event_to_stream(InfoEvent(msg=\"Hello, world!\"))\n",
+    "\n",
+    "        return StopEvent(result=ev.msg.upper() + \"!\")\n",
+    "\n",
+    "\n",
+    "workflow = LoudWorkflow()\n",
+    "\n",
+    "mcp = workflow_as_mcp(workflow)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code will automatically generate a `FastMCP` server that will\n",
+    "- Use the workflow class name as the tool name\n",
+    "- Use our custom `RunEvent` as the typed inputs to the tool\n",
+    "- Automatically use the SSE stream for streaming json dumps of the workflow event stream"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If this code was in a script called `script.py`, you could launch the MCP server with:\n",
+    "\n",
+    "```bash\n",
+    "mcp dev script.py\n",
+    "```\n",
+    "\n",
+    "Or the other commands documented in the [MCP CLI README](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#quickstart).\n",
+    "\n",
+    "Note that to launch from the CLI, you may need to install the MCP CLI:\n",
+    "\n",
+    "```bash\n",
+    "pip install \"mcp[cli]\"\n",
+    "```\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can further customize the `FastMCP` server by passing in additional arguments to the `workflow_as_mcp` function:\n",
+    "- `workflow_name`: The name of the workflow. Defaults to the class name.\n",
+    "- `workflow_description`: The description of the workflow. Defaults to the class docstring.\n",
+    "- `start_event_model`: The event model to use for the start event. You can either use a custom `StartEvent` class in your workflow or pass in your own pydantic model here to define the inputs to the workflow.\n",
+    "- `**fastmcp_init_kwargs`: Any extra arguments to pass to the `FastMCP()` server constructor."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -49,6 +49,71 @@ agent = FunctionAgent(
 resp = await agent.run("What is the weather in Tokyo?")
 ```
 
+## Helper Functions
+
+This package also includes several helper functions for working with MCP Servers.
+
+### `workflow_as_mcp`
+
+This function converts a `Workflow` to an MCP app.
+
+```python
+from llama_index.core.workflow import (
+    Context,
+    Workflow,
+    Event,
+    StartEvent,
+    StopEvent,
+    step,
+)
+from llama_index.tools.mcp import workflow_as_mcp
+
+
+class RunEvent(StartEvent):
+    msg: str
+
+
+class InfoEvent(Event):
+    msg: str
+
+
+class LoudWorkflow(Workflow):
+    """Useful for converting strings to uppercase and making them louder."""
+
+    @step
+    def step_one(self, ctx: Context, ev: RunEvent) -> StopEvent:
+        ctx.write_event_to_stream(InfoEvent(msg="Hello, world!"))
+
+        return StopEvent(result=ev.msg.upper() + "!")
+
+
+workflow = LoudWorkflow()
+
+mcp = workflow_as_mcp(workflow, start_event_model=RunEvent)
+```
+
+Then, you can launch the MCP server (assuming you have the `mcp[cli]` extra installed):
+
+```bash
+mcp dev script.py
+```
+
+### `get_tools_from_mcp_url` / `aget_tools_from_mcp_url`
+
+This function get a list of `FunctionTool`s from an MCP server or command.
+
+```python
+from llama_index.tools.mcp import (
+    get_tools_from_mcp_url,
+    aget_tools_from_mcp_url,
+)
+
+tools = get_tools_from_mcp_url("http://127.0.0.1:8000/sse")
+
+# async
+tools = await get_tools_from_mcp_url("http://127.0.0.1:8000/sse")
+```
+
 ## Notebook Example
 
 This tool has a more extensive example usage documented in a Jupyter notebook [here](https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/tools/llama-index-tools-mcp/examples/mcp.ipynb).

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
@@ -1,4 +1,11 @@
 from llama_index.tools.mcp.base import McpToolSpec
 from llama_index.tools.mcp.client import BasicMCPClient
+from llama_index.tools.mcp.utils import workflow_as_mcp, get_tools_from_mcp_url, aget_tools_from_mcp_url
 
-__all__ = ["McpToolSpec", "BasicMCPClient"]
+__all__ = [
+    "McpToolSpec",
+    "BasicMCPClient",
+    "workflow_as_mcp",
+    "get_tools_from_mcp_url",
+    "aget_tools_from_mcp_url"
+]

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
@@ -1,0 +1,112 @@
+from typing import Any, List, Optional
+
+from mcp.client.session import ClientSession
+from mcp.server.fastmcp import FastMCP, Context
+from pydantic import BaseModel
+
+from llama_index.core.tools import FunctionTool
+from llama_index.core.workflow import Event, StartEvent, StopEvent, Workflow
+from llama_index.tools.mcp.base import McpToolSpec
+from llama_index.tools.mcp.client import BasicMCPClient
+
+def get_tools_from_mcp_url(
+    command_or_url: str,
+    client: Optional[ClientSession] = None,
+    allowed_tools: Optional[List[str]] = None
+) -> List[FunctionTool]:
+    """
+    Get tools from an MCP server or command.
+
+    Args:
+        command_or_url: The command to run or the URL to connect to.
+        client (optional): The client to use to connect to the MCP server.
+        allowed_tools (optional): The tool names to allow from the MCP server.
+
+    """
+    client = client or BasicMCPClient(command_or_url)
+    tool_spec = McpToolSpec(client, allowed_tools=allowed_tools)
+    return tool_spec.to_tool_list()
+
+async def aget_tools_from_mcp_url(
+    command_or_url: str,
+    client: Optional[ClientSession] = None,
+    allowed_tools: Optional[List[str]] = None
+) -> List[FunctionTool]:
+    """
+    Get tools from an MCP server or command.
+
+    Args:
+        command_or_url: The command to run or the URL to connect to.
+        client (optional): The client to use to connect to the MCP server.
+        allowed_tools (optional): The tool names to allow from the MCP server.
+
+    """
+    client = client or BasicMCPClient(command_or_url)
+    tool_spec = McpToolSpec(client, allowed_tools=allowed_tools)
+    return await tool_spec.to_tool_list_async()
+
+def workflow_as_mcp(
+    workflow: Workflow,
+    workflow_name: Optional[str] = None,
+    workflow_description: Optional[str] = None,
+    start_event_model: Optional[BaseModel] = None,
+    **fastmcp_init_kwargs: Any
+) -> FastMCP:
+    """
+    Convert a workflow to an MCP app.
+
+    This will convert any `Workflow` to an MCP app. It will expose the workflow as a tool
+    within MCP, which will
+
+    Args:
+        workflow:
+            The workflow to convert.
+        workflow_name (optional):
+            The name of the workflow. Defaults to the workflow class name.
+        workflow_description (optional):
+            The description of the workflow. Defaults to the workflow docstring.
+        start_event_model (optional):
+            The start event model of the workflow. Can be a `BaseModel` or a `StartEvent` class.
+            Defaults to the workflow's custom `StartEvent` class.
+        **fastmcp_init_kwargs:
+            Additional keyword arguments to pass to the FastMCP constructor.
+
+    Returns:
+        The MCP app object.
+
+    """
+    app = FastMCP(**fastmcp_init_kwargs)
+
+    # Dynamically get the start event class -- this is a bit of a hack
+    StartEventCLS = start_event_model or workflow._start_event_class
+    if StartEventCLS == StartEvent:
+        raise ValueError(
+            "Must declare a custom StartEvent class in your workflow or provide a start_event_model."
+        )
+
+    # Get the workflow name and description
+    workflow_name = workflow_name or workflow.__class__.__name__
+    workflow_description = workflow_description or workflow.__doc__
+
+    @app.tool(
+        name=workflow_name,
+        description=workflow_description
+    )
+    async def _workflow_tool(run_args: StartEventCLS, context: Context) -> Any:
+
+        # Handle edge cases where the start event is an Event or a BaseModel
+        # If the workflow does not have a custom StartEvent class, then we need to handle the event differently
+        if isinstance(run_args, Event) and workflow._start_event_class != StartEvent:
+            handler = workflow.run(start_event=run_args)
+        elif isinstance(run_args, BaseModel):
+            handler = workflow.run(**run_args.model_dump())
+        else:
+            raise ValueError(f"Invalid start event type: {type(run_args)}")
+
+        async for event in handler.stream_events():
+            if not isinstance(event, StopEvent):
+                await context.log("info", message=event.model_dump_json())
+
+        return await handler
+
+    return app

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.1.2"
+version = "0.1.3"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
This PR adds some more helpful utils to our MCP integration
1. One-liners to get FunctionTools from an MCP server
2. One-liner to construct a `FastMCP` server

