### PR TITLE
llama-dev: add `--debug` flag and trim tests output to 50 lines

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -35,7 +35,8 @@ jobs:
         working-directory: llama-dev
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
-          uv run -- llama-dev --repo-root ".." test \
+          uv run -- llama-dev \
+            --repo-root ".." ${{ env.ACTIONS_STEP_DEBUG == 'true' && '--debug' || '' }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref ${{ github.event.pull_request.base.ref }}
 
@@ -45,7 +46,8 @@ jobs:
         working-directory: llama-dev
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
-          uv run -- llama-dev --repo-root ".." test \
+          uv run -- llama-dev \
+            --repo-root ".." ${{ env.ACTIONS_STEP_DEBUG == 'true' && '--debug' || '' }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref=${{ github.event.pull_request.base.ref }} \
             --cov \

--- a/llama-dev/llama_dev/cli.py
+++ b/llama-dev/llama_dev/cli.py
@@ -27,12 +27,14 @@ LLAMA_DEV_THEME = Theme(
     default=".",
     help="Path to the llama_index repository, defaults to '.'",
 )
+@click.option("--debug", is_flag=True, help="Enable verbose output.")
 @click.pass_context
-def cli(ctx, repo_root: str):
+def cli(ctx, repo_root: str, debug: bool):
     """The official CLI for development, testing, and automation in the LlamaIndex monorepo."""
     ctx.obj = {
         "console": Console(theme=LLAMA_DEV_THEME, soft_wrap=True),
         "repo_root": Path(repo_root).resolve(),
+        "debug": debug,
     }
 
 

--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -31,6 +31,7 @@ class ResultStatus(Enum):
 
 
 NO_TESTS_INDICATOR = "no tests ran"
+MAX_CONSOLE_PRINT_LINES = 50
 
 
 @click.command(short_help="Run tests across the monorepo")
@@ -80,6 +81,7 @@ def test(
 
     console = obj["console"]
     repo_root = obj["repo_root"]
+    debug: bool = obj["debug"]
     packages_to_test: set[Path] = set()
     all_packages = find_all_packages(repo_root)
 
@@ -117,22 +119,27 @@ def test(
 
             # Print results as they complete
             package: Path = result["package"]
+            package_name = package.relative_to(repo_root)
             if result["status"] == ResultStatus.INSTALL_FAILED:
+                console.print(f"❗ Unable to build package {package_name}")
                 console.print(
-                    f"❗ Unable to build package {package.relative_to(repo_root)}"
+                    _trim(debug, f"Error:\n{result['stderr']}"), style="warning"
                 )
-                console.print(f"Error:\n{result['stderr']}", style="warning")
             elif result["status"] == ResultStatus.TESTS_PASSED:
-                console.print(
-                    f"✅ {package.relative_to(repo_root)} succeeded in {result['time']}"
-                )
+                console.print(f"✅ {package_name} succeeded in {result['time']}")
             elif result["status"] == ResultStatus.SKIPPED:
-                console.print(f"⏭️  {package.relative_to(repo_root)} skipped")
-                console.print(f"Error:\n{result['stderr']}", style="warning")
+                console.print(f"⏭️  {package_name} skipped")
+                console.print(
+                    _trim(debug, f"Error:\n{result['stderr']}"), style="warning"
+                )
             else:
-                console.print(f"❌ {package.relative_to(repo_root)} failed")
-                console.print(f"Error:\n{result['stderr']}", style="error")
-                console.print(f"Output:\n{result['stdout']}", style="info")
+                console.print(f"❌ {package_name} failed")
+                console.print(
+                    _trim(debug, f"Error:\n{result['stderr']}"), style="error"
+                )
+                console.print(
+                    _trim(debug, f"Output:\n{result['stdout']}"), style="info"
+                )
 
     # Print summary
     failed = [
@@ -174,6 +181,16 @@ def test(
         console.print(
             f"\nTests passed for {len(results) - len(skipped)} packages.", style="green"
         )
+
+
+def _trim(debug: bool, msg: str):
+    lines = msg.split("\n")
+    if len(lines) > MAX_CONSOLE_PRINT_LINES and not debug:
+        lines = lines[:MAX_CONSOLE_PRINT_LINES]
+        lines.append(
+            "<-- llama-dev: output truncated, pass '--debug' to see the full log -->"
+        )
+    return "\n".join(lines)
 
 
 def _uv_sync(


### PR DESCRIPTION
# Description

In `llama-dev test` we print the raw output of installation and test failures, and some packages produce incredibly long and useless logs that make it hard browsing the logs in github actions. This PR:
- trims the output of the `test` command to 50 lines
- adds a flag `--debug` that's used to get the previous behaviour, printing the full log
- changes the Github workflow so that `llama-dev` will be called with `--debug` when the user checks the "enable debug logs in github

<img width="628" alt="immagine" src="https://github.com/user-attachments/assets/49d1fd6e-3937-4024-afd4-329fc060d856" />


