### PR TITLE
Add check for empty tool call delta, bump version

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -761,7 +761,7 @@ def update_tool_calls(
         List[ChoiceDeltaToolCall]: the updated tool calls
     """
     # openai provides chunks consisting of tool_call deltas one tool at a time
-    if tool_calls_delta is None:
+    if tool_calls_delta is None or len(tool_calls_delta) == 0:
         return tool_calls
 
     tc_delta = tool_calls_delta[0]

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,16 +27,13 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.3.39"
+version = "0.3.40"
 description = "llama-index llms openai integration"
-authors = [{name = "llama-index"}]
+authors = [{ name = "llama-index" }]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
-dependencies = [
-    "openai>=1.66.3,<2",
-    "llama-index-core>=0.12.36,<0.13",
-]
+dependencies = ["openai>=1.66.3,<2", "llama-index-core>=0.12.36,<0.13"]
 
 [tool.codespell]
 check-filenames = true

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 name = "llama-index-llms-openai"
 version = "0.3.40"
 description = "llama-index llms openai integration"
-authors = [{ name = "llama-index" }]
+authors = [{name = "llama-index"}]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
# Description

An error occurs in `update_tool_calls` when `tool_calls_delta` is an empty list. This adds an additional check to ensure it is not empty.

## Version Bump?

- [X] Yes
- [ ] No

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
