### PR TITLE
Pass agent workflow kwargs into start event

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -561,11 +561,11 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 user_msg=user_msg,
                 chat_history=chat_history,
                 memory=memory,
+                **kwargs,
             ),
             ctx=ctx,
             stepwise=stepwise,
             checkpoint_callback=checkpoint_callback,
-            **kwargs,
         )
 
     @classmethod


### PR DESCRIPTION
Pass extra kwargs into the start event, which are accessible  later on with `ev.get(...)`

Useful for users who want to subclass and pass through extra info

Fixes https://github.com/run-llama/llama_index/issues/18733

