### PR TITLE
reset next_agent in multi agent workflows

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -502,6 +502,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         next_agent_name = await ctx.get("next_agent", default=None)
         if next_agent_name:
             await ctx.set("current_agent_name", next_agent_name)
+            await ctx.set("next_agent", None)
 
         if any(
             tool_call_result.return_direct for tool_call_result in tool_call_results


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/18767

`next_agent` should be reset so that on subsequent runs it does not force an agent to run