### PR TITLE
Allow `ctx` in BaseToolSpec functions, other ctx + tool calling overhauls

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -288,10 +288,10 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
     ) -> ToolOutput:
         """Call the given tool with the given input."""
         try:
-            if isinstance(tool, FunctionTool) and tool.requires_context:
-                tool_output = await tool.acall(ctx=ctx, **tool_input)
-            else:
-                tool_output = await tool.acall(**tool_input)
+            if isinstance(tool, FunctionTool) and tool.requires_context and tool.ctx_param_name is not None:
+                tool_input[tool.ctx_param_name] = ctx
+
+            tool_output = await tool.acall(**tool_input)
         except Exception as e:
             tool_output = ToolOutput(
                 content=str(e),

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -289,9 +289,11 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         """Call the given tool with the given input."""
         try:
             if isinstance(tool, FunctionTool) and tool.requires_context and tool.ctx_param_name is not None:
-                tool_input[tool.ctx_param_name] = ctx
-
-            tool_output = await tool.acall(**tool_input)
+                new_tool_input = {**tool_input}
+                new_tool_input[tool.ctx_param_name] = ctx
+                tool_output = await tool.acall(**new_tool_input)
+            else:
+                tool_output = await tool.acall(**tool_input)
         except Exception as e:
             tool_output = ToolOutput(
                 content=str(e),

--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -243,16 +243,15 @@ class FunctionTool(AsyncBaseTool):
         return self.call(*args, **all_kwargs)
 
     def call(
-        self, *args: Any, ctx: Optional[Context] = None, **kwargs: Any
+        self, *args: Any, **kwargs: Any
     ) -> ToolOutput:
         """Sync Call."""
         all_kwargs = {**self.partial_params, **kwargs}
-        if self.requires_context:
-            if ctx is None:
+        if self.requires_context and self.ctx_param_name is not None:
+            if self.ctx_param_name not in all_kwargs:
                 raise ValueError("Context is required for this tool")
-            raw_output = self._fn(ctx, *args, **all_kwargs)
-        else:
-            raw_output = self._fn(*args, **all_kwargs)
+
+        raw_output = self._fn(*args, **all_kwargs)
         # Default ToolOutput based on the raw output
         default_output = ToolOutput(
             content=str(raw_output),
@@ -276,16 +275,15 @@ class FunctionTool(AsyncBaseTool):
         return default_output
 
     async def acall(
-        self, *args: Any, ctx: Optional[Context] = None, **kwargs: Any
+        self, *args: Any, **kwargs: Any
     ) -> ToolOutput:
         """Async Call."""
         all_kwargs = {**self.partial_params, **kwargs}
-        if self.requires_context:
-            if ctx is None:
+        if self.requires_context and self.ctx_param_name is not None:
+            if self.ctx_param_name not in all_kwargs:
                 raise ValueError("Context is required for this tool")
-            raw_output = await self._async_fn(ctx, *args, **all_kwargs)
-        else:
-            raw_output = await self._async_fn(*args, **all_kwargs)
+
+        raw_output = await self._async_fn(*args, **all_kwargs)
         # Default ToolOutput based on the raw output
         default_output = ToolOutput(
             content=str(raw_output),

--- a/llama-index-core/llama_index/core/tools/tool_spec/base.py
+++ b/llama-index-core/llama_index/core/tools/tool_spec/base.py
@@ -8,7 +8,6 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Type, 
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.tools.types import ToolMetadata
-from llama_index.core.tools.utils import create_schema_from_function
 
 AsyncCallable = Callable[..., Awaitable[Any]]
 
@@ -27,33 +26,33 @@ class BaseToolSpec:
         self, fn_name: str, spec_functions: Optional[List[SPEC_FUNCTION_TYPE]] = None
     ) -> Optional[Type[BaseModel]]:
         """
+        NOTE: This function is deprecated and kept only for backwards compatibility.
+
         Return map from function name.
 
         Return type is Optional, meaning that the schema can be None.
         In this case, it's up to the downstream tool implementation to infer the schema.
 
         """
-        spec_functions = spec_functions or self.spec_functions
-        for fn in spec_functions:
-            if fn == fn_name:
-                return create_schema_from_function(fn_name, getattr(self, fn_name))
-
-        raise ValueError(f"Invalid function name: {fn_name}")
+        return None
 
     def get_metadata_from_fn_name(
         self, fn_name: str, spec_functions: Optional[List[SPEC_FUNCTION_TYPE]] = None
     ) -> Optional[ToolMetadata]:
         """
+        NOTE: This function is deprecated and kept only for backwards compatibility.
+
         Return map from function name.
 
         Return type is Optional, meaning that the schema can be None.
         In this case, it's up to the downstream tool implementation to infer the schema.
 
         """
-        try:
-            func = getattr(self, fn_name)
-        except AttributeError:
+        schema = self.get_fn_schema_from_fn_name(fn_name, spec_functions=spec_functions)
+        if schema is None:
             return None
+
+        func = getattr(self, fn_name)
         name = fn_name
         docstring = func.__doc__ or ""
         description = f"{name}{signature(func)}\n{docstring}"
@@ -117,7 +116,11 @@ def patch_sync(func_async: AsyncCallable) -> Callable:
     """Patch sync function from async function."""
 
     def patched_sync(*args: Any, **kwargs: Any) -> Any:
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         return loop.run_until_complete(func_async(*args, **kwargs))
 
     return patched_sync

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -325,10 +325,10 @@ async def test_invalid_handoff():
 async def test_workflow_with_state():
     """Test workflow with state management."""
 
-    async def modify_state(ctx: Context):
-        state = await ctx.get("state")
+    async def modify_state(random_arg: str, ctx_val: Context):
+        state = await ctx_val.get("state")
         state["counter"] += 1
-        await ctx.set("state", state)
+        await ctx_val.set("state", state)
         return f"State updated to {state}"
 
     agent = FunctionAgent(
@@ -345,7 +345,7 @@ async def test_workflow_with_state():
                             ToolSelection(
                                 tool_id="one",
                                 tool_name="modify_state",
-                                tool_kwargs={},
+                                tool_kwargs={"random_arg": "hello"},
                             )
                         ]
                     },
@@ -373,3 +373,6 @@ async def test_workflow_with_state():
 
     response = await handler
     assert response is not None
+
+    state = await handler.ctx.get("state")
+    assert state["counter"] == 1

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.core.workflow import Context
 
 try:
     import langchain  # pants: no-infer-dep
@@ -44,6 +45,10 @@ def test_function_tool() -> None:
     assert function_tool.metadata.fn_schema is not None
     actual_schema = function_tool.metadata.fn_schema.model_json_schema()
     assert actual_schema["properties"]["x"]["type"] == "integer"
+
+    # should not have ctx param requirements
+    assert function_tool.ctx_param_name is None
+    assert not function_tool.requires_context
 
 
 @pytest.mark.skipif(langchain is None, reason="langchain not installed")
@@ -225,3 +230,32 @@ async def test_function_tool_partial_params_async() -> None:
     assert (await tool.acall(x=1)).raw_input == {"args": (), "kwargs": {"x": 1, "y": 2}}
     assert (await tool.acall(x=1, y=3)).raw_output == "x: 1, y: 3"
     assert (await tool.acall(x=1, y=3)).raw_input == {"args": (), "kwargs": {"x": 1, "y": 3}}
+
+def test_function_tool_ctx_param() -> None:
+    def test_function(x: int, ctx: Context) -> str:
+        return f"x: {x}, ctx: {ctx}"
+
+    tool = FunctionTool.from_defaults(test_function)
+    assert tool.metadata.fn_schema is not None
+    assert tool.ctx_param_name == "ctx"
+    assert tool.requires_context
+
+    actual_schema = tool.metadata.fn_schema.model_json_schema()
+    assert "ctx" not in actual_schema["properties"]
+    assert len(actual_schema["properties"]) == 1
+    assert actual_schema["properties"]["x"]["type"] == "integer"
+
+def test_function_tool_self_param() -> None:
+    class FunctionHolder:
+        def test_function(self, x: int, ctx: Context) -> str:
+            return f"x: {x}, ctx: {ctx}"
+
+    tool = FunctionTool.from_defaults(FunctionHolder.test_function)
+    assert tool.metadata.fn_schema is not None
+    assert tool.ctx_param_name == "ctx"
+    assert tool.requires_context
+
+    actual_schema = tool.metadata.fn_schema.model_json_schema()
+    assert "self" not in actual_schema["properties"]
+    assert "ctx" not in actual_schema["properties"]
+    assert "x" in actual_schema["properties"]

--- a/llama-index-core/tests/tools/tool_spec/test_base.py
+++ b/llama-index-core/tests/tools/tool_spec/test_base.py
@@ -1,11 +1,12 @@
 """Test tool spec."""
 
-from typing import List, Optional, Tuple, Type, Union
+from typing import List, Tuple, Union
 
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.core.tools.types import ToolMetadata
+from llama_index.core.workflow import Context
 
 
 class FooSchema(BaseModel):
@@ -22,7 +23,7 @@ class AbcSchema(BaseModel):
 
 
 class TestToolSpec(BaseToolSpec):
-    spec_functions: List[Union[str, Tuple[str, str]]] = ["foo", "bar", "abc"]
+    spec_functions: List[Union[str, Tuple[str, str]]] = ["foo", "bar", "abc", "abc_with_ctx"]
 
     def foo(self, arg1: str, arg2: int) -> str:
         """Foo."""
@@ -44,23 +45,11 @@ class TestToolSpec(BaseToolSpec):
         # NOTE: no docstring
         return f"bar {arg1}"
 
-    def get_fn_schema_from_fn_name(
-        self,
-        fn_name: str,
-        spec_functions: Optional[List[Union[str, Tuple[str, str]]]] = None,
-    ) -> Type[BaseModel]:
-        """Return map from function name."""
-        spec_functions = spec_functions or self.spec_functions
-        if fn_name == "foo":
-            return FooSchema
-        elif fn_name == "afoo":
-            return FooSchema
-        elif fn_name == "bar":
-            return BarSchema
-        elif fn_name == "abc":
-            return AbcSchema
-        else:
-            raise ValueError(f"Invalid function name: {fn_name}")
+    def abc_with_ctx(self, arg1: str, ctx: Context) -> str:
+        return f"bar {arg1}"
+
+    def unused_function(self, arg1: str) -> str:
+        return f"unused {arg1}"
 
 
 def test_tool_spec() -> None:
@@ -68,16 +57,30 @@ def test_tool_spec() -> None:
     tool_spec = TestToolSpec()
     # first is foo, second is bar
     tools = tool_spec.to_tool_list()
-    assert len(tools) == 3
+    assert len(tools) == 4
     assert tools[0].metadata.name == "foo"
     assert tools[0].metadata.description == "foo(arg1: str, arg2: int) -> str\nFoo."
     assert tools[0].fn("hello", 1) == "foo hello 1"
+    assert tools[0].ctx_param_name is None
+    assert not tools[0].requires_context
+
     assert tools[1].metadata.name == "bar"
     assert tools[1].metadata.description == "bar(arg1: bool) -> str\nBar."
     assert str(tools[1](True)) == "bar True"
+    assert tools[1].ctx_param_name is None
+    assert not tools[1].requires_context
+
     assert tools[2].metadata.name == "abc"
     assert tools[2].metadata.description == "abc(arg1: str) -> str\n"
-    assert tools[2].metadata.fn_schema == AbcSchema
+    assert tools[2].metadata.fn_schema.model_json_schema()["properties"] == AbcSchema.model_json_schema()["properties"]
+    assert tools[2].ctx_param_name is None
+    assert not tools[2].requires_context
+
+    assert tools[3].metadata.name == "abc_with_ctx"
+    assert tools[3].metadata.description == "abc_with_ctx(arg1: str) -> str\n"
+    assert tools[3].metadata.fn_schema.model_json_schema()["properties"] == AbcSchema.model_json_schema()["properties"]
+    assert tools[3].ctx_param_name == "ctx"
+    assert tools[3].requires_context
 
     # test metadata mapping
     tools = tool_spec.to_tool_list(
@@ -87,7 +90,7 @@ def test_tool_spec() -> None:
             ),
         }
     )
-    assert len(tools) == 3
+    assert len(tools) == 4
     assert tools[0].metadata.name == "foo_name"
     assert tools[0].metadata.description == "foo_description"
     assert tools[0].metadata.fn_schema is not None
@@ -107,7 +110,7 @@ async def test_tool_spec_async() -> None:
     """Test async_fn of tool spec."""
     tool_spec = TestToolSpec()
     tools = tool_spec.to_tool_list()
-    assert len(tools) == 3
+    assert len(tools) == 4
     assert await tools[0].async_fn("hello", 1) == "foo hello 1"
     assert str(await tools[1].acall(True)) == "bar True"
 
@@ -121,16 +124,6 @@ def test_async_patching() -> None:
     assert tools[0].fn("hello", 1) == "foo hello 1"
 
 
-def test_tool_spec_schema() -> None:
-    """Test tool spec schemas match."""
-    tool_spec = TestToolSpec()
-    # first is foo, second is bar
-    schema1 = tool_spec.get_fn_schema_from_fn_name("foo")
-    assert schema1 == FooSchema
-    schema2 = tool_spec.get_fn_schema_from_fn_name("bar")
-    assert schema2 == BarSchema
-
-
 def test_tool_spec_subset() -> None:
     """Test tool spec subset."""
     tool_spec = TestToolSpec()
@@ -138,4 +131,4 @@ def test_tool_spec_subset() -> None:
     assert len(tools) == 1
     assert tools[0].metadata.name == "abc"
     assert tools[0].metadata.description == "abc(arg1: str) -> str\n"
-    assert tools[0].metadata.fn_schema == AbcSchema
+    assert tools[0].metadata.fn_schema.model_json_schema()["properties"] == AbcSchema.model_json_schema()["properties"]


### PR DESCRIPTION
Overhauled a bit how `ctx` injection handling works
1. Updated `FunctionTool` to allow the `ctx` param to be any name and any location (not just the first param)
2. Updated `BaseToolSpec` to use `FunctionTool` as a single source of truth for creating the tool list
3. Kept it backwards compatible since the functions I wanted to remove were technically public
4. Updated how the `ctx` is injected in `AgentWorkflow`
5. Added tests for all

Fixes https://github.com/run-llama/llama_index/issues/18758