### PR TITLE
Remove tool-length check in openai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Optional, Sequence, Union
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -9,7 +9,6 @@ from llama_index.core.base.llms.types import (
     CompletionResponseAsyncGen,
     CompletionResponseGen,
     LLMMetadata,
-    MessageRole,
 )
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.constants import DEFAULT_CONTEXT_WINDOW
@@ -18,8 +17,7 @@ from llama_index.core.base.llms.generic_utils import (
     completion_response_to_chat_response,
     stream_completion_response_to_chat_response,
 )
-from llama_index.core.tools import BaseTool
-from llama_index.llms.openai.base import OpenAI, Tokenizer, resolve_tool_choice
+from llama_index.llms.openai.base import OpenAI, Tokenizer
 from transformers import AutoTokenizer
 
 
@@ -218,44 +216,3 @@ class OpenAILike(OpenAI):
             )
 
         return await super().astream_chat(messages, **kwargs)
-
-    def _prepare_chat_with_tools(
-        self,
-        tools: Sequence["BaseTool"],
-        user_msg: Optional[Union[str, ChatMessage]] = None,
-        chat_history: Optional[List[ChatMessage]] = None,
-        verbose: bool = False,
-        allow_parallel_tool_calls: bool = False,
-        tool_choice: Union[str, dict] = "auto",
-        strict: Optional[bool] = None,
-        **kwargs: Any,
-    ) -> Dict[str, Any]:
-        """Format the chat with tools."""
-        tool_specs = [tool.metadata.to_openai_tool(skip_length_check=True) for tool in tools]
-
-        # if strict is passed in, use, else default to the class-level attribute, else default to True`
-        if strict is not None:
-            strict = strict
-        else:
-            strict = self.strict
-
-        if self.metadata.is_function_calling_model:
-            for tool_spec in tool_specs:
-                if tool_spec["type"] == "function":
-                    tool_spec["function"]["strict"] = strict
-                    # in current openai 1.40.0 it is always false.
-                    tool_spec["function"]["parameters"]["additionalProperties"] = False
-
-        if isinstance(user_msg, str):
-            user_msg = ChatMessage(role=MessageRole.USER, content=user_msg)
-
-        messages = chat_history or []
-        if user_msg:
-            messages.append(user_msg)
-
-        return {
-            "messages": messages,
-            "tools": tool_specs or None,
-            "tool_choice": resolve_tool_choice(tool_choice) if tool_specs else None,
-            **kwargs,
-        }

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "llama-index-llms-openai>=0.3.9,<0.4",
+    "llama-index-llms-openai>=0.3.42,<0.4",
     "transformers>=4.37.0,<5",
     "llama-index-core>=0.12.0,<0.13",
 ]

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai-like"
-version = "0.3.4"
+version = "0.3.5"
 description = "llama-index llms openai like integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -909,7 +909,7 @@ class OpenAI(FunctionCallingLLM):
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Predict and call the tool."""
-        tool_specs = [tool.metadata.to_openai_tool() for tool in tools]
+        tool_specs = [tool.metadata.to_openai_tool(skip_length_check=True) for tool in tools]
 
         # if strict is passed in, use, else default to the class-level attribute, else default to True`
         if strict is not None:

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.3.41"
+version = "0.3.42"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
It seems openai has removed this length limit.

Tested with the following code after disabling the check

```python
from llama_index.core.tools import FunctionTool
from llama_index.llms.openai import OpenAI

llm = OpenAI(model="gpt-4.1-mini", api_key="sk-...")

tool = FunctionTool.from_defaults(
    fn=lambda x: x,
    name="test",
    description="test tool" * 4000,
)

response = llm.chat_with_tools([tool], user_msg="test")
print(response.message.additional_kwargs)
```