### PR TITLE
Skip tool description length check in OpenAI agent

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
+++ b/llama-index-integrations/agent/llama-index-agent-openai/llama_index/agent/openai/step.py
@@ -573,7 +573,7 @@ class OpenAIAgentWorker(BaseAgentWorker):
             )
         # TODO: see if we want to do step-based inputs
         tools = self.get_tools(task.input)
-        openai_tools = [tool.metadata.to_openai_tool() for tool in tools]
+        openai_tools = [tool.metadata.to_openai_tool(skip_length_check=True) for tool in tools]
 
         llm_chat_kwargs = self._get_llm_chat_kwargs(task, openai_tools, tool_choice)
         agent_chat_response = self._get_agent_response(
@@ -665,7 +665,7 @@ class OpenAIAgentWorker(BaseAgentWorker):
             )
 
         tools = self.get_tools(task.input)
-        openai_tools = [tool.metadata.to_openai_tool() for tool in tools]
+        openai_tools = [tool.metadata.to_openai_tool(skip_length_check=True) for tool in tools]
 
         llm_chat_kwargs = self._get_llm_chat_kwargs(task, openai_tools, tool_choice)
         agent_chat_response = await self._get_async_agent_response(

--- a/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-agent-openai"
-version = "0.4.7"
+version = "0.4.8"
 description = "llama-index agent openai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

It seems that the length check on tools description introduced by OpenAI is now removed, you have recently introduced a fix to the function calling LLM but the issue persists with the OpenAI agent

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No new packages were introduced

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests
