### PR TITLE
Fixing DocumentBlock usage within Bedrock Converse

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
@@ -182,14 +183,13 @@ def _content_block_to_bedrock_format(
     elif isinstance(block, DocumentBlock):
         if not block.data:
             file_buffer = block.resolve_document()
-            data = block._get_b64_bytes(file_buffer)
+            with file_buffer as f:
+                data = f.read()
         else:
-            data = block.data
-
-        format = block.guess_format() or "pdf"
+            data = base64.b64decode(block.data)
         title = block.title
         return {
-            "document": {"format": format, "name": title, "source": {"bytes": data}}
+            "document": {"format": "txt", "name": title, "source": {"bytes": data}}
         }
     elif isinstance(block, ImageBlock):
         if role != MessageRole.USER:

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -188,6 +188,8 @@ def _content_block_to_bedrock_format(
         else:
             data = base64.b64decode(block.data)
         title = block.title
+        # NOTE: At the time of writing, "txt" format works for all file types
+        # The API then infers the format from the file type based on the bytes
         return {
             "document": {"format": "txt", "name": title, "source": {"bytes": data}}
         }

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.5.4"
+version = "0.5.6"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
@@ -38,7 +38,7 @@ license = "MIT"
 dependencies = [
     "boto3>=1.34.122,<2",
     "aioboto3>=13.1.1,<14",
-    "llama-index-core>=0.12.36,<0.13",
+    "llama-index-core>=0.12.37,<0.13",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.5.6"
+version = "0.5.5"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

We now use `txt` as enforced document type, since that is the only type that seems to be inferred by Bedrock and using a different one causes a validation error.
We are also using decoded bytes instead of b64-encoded bytes, since Bedrock seems to be working only with them.

Fixes #18789 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
