### PR TITLE
Fix get_function_tool in function_program.py when schema doesn't have "title" key

### DIFF
--- a/llama-index-core/llama_index/core/program/function_program.py
+++ b/llama-index-core/llama_index/core/program/function_program.py
@@ -46,6 +46,8 @@ def get_function_tool(output_cls: Type[Model]) -> FunctionTool:
 
     return FunctionTool.from_defaults(
         fn=model_fn,
+        # schema won't always have a title attribute
+        # fallback to using the class name directly
         name=schema.get("title", output_cls.__name__),
         description=schema_description,
         fn_schema=output_cls,

--- a/llama-index-core/llama_index/core/program/function_program.py
+++ b/llama-index-core/llama_index/core/program/function_program.py
@@ -46,7 +46,7 @@ def get_function_tool(output_cls: Type[Model]) -> FunctionTool:
 
     return FunctionTool.from_defaults(
         fn=model_fn,
-        name=schema["title"],
+        name=schema.get("title", output_cls.__name__),
         description=schema_description,
         fn_schema=output_cls,
     )


### PR DESCRIPTION
# Description

Fix case when the pydantic generated JSON schema doesn't have a top level `title` attribute


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
