### PR TITLE
dont pass in both extra_info and metadata in vector stores

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lindorm/llama_index/vector_stores/lindorm/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lindorm/llama_index/vector_stores/lindorm/base.py
@@ -751,7 +751,6 @@ class LindormVectorClient:
                     start_char_idx=start_char_idx,
                     end_char_idx=end_char_idx,
                     relationships=relationships,
-                    extra_info=source,
                 )
             ids.append(node_id)
             nodes.append(node)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lindorm/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lindorm/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-lindorm"
-version = "0.3.0"
+version = "0.3.1"
 description = "llama-index vector_stores lindorm integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -901,7 +901,6 @@ class OpensearchVectorClient:
                     start_char_idx=start_char_idx,
                     end_char_idx=end_char_idx,
                     relationships=relationships,
-                    extra_info=source,
                 )
             ids.append(node_id)
             nodes.append(node)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-opensearch"
-version = "0.5.3"
+version = "0.5.4"
 description = "llama-index vector_stores opensearch integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/18804

Passing both extra_info and metadata is not correct (extra_info is an alias for metadata, and will override it)