### PR TITLE
feat: Optimize get_biggest_prompt for readability and efficiency

### DIFF
--- a/llama-index-core/llama_index/core/prompts/prompt_utils.py
+++ b/llama-index-core/llama_index/core/prompts/prompt_utils.py
@@ -27,6 +27,4 @@ def get_biggest_prompt(prompts: List[BasePromptTemplate]) -> BasePromptTemplate:
     is a helper utility for that.
 
     """
-    empty_prompt_txts = [get_empty_prompt_txt(prompt) for prompt in prompts]
-    empty_prompt_txt_lens = [len(txt) for txt in empty_prompt_txts]
-    return prompts[empty_prompt_txt_lens.index(max(empty_prompt_txt_lens))]
+    return max(prompts, key=lambda p: len(get_empty_prompt_txt(p)))


### PR DESCRIPTION
# Description

Refactor `get_biggest_prompt` to use `max()` with a key function. This improves code readability and eliminates the creation of intermediate lists, potentially enhancing performance for large prompt sets.
Just spotted it and thought it should be tweaked, so I went ahead and made the change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
