### PR TITLE
Throw error if resolve methods yield empty bytes

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -124,17 +124,15 @@ class ImageBlock(BaseModel):
             url=str(self.url) if self.url else None,
             as_base64=as_base64,
         )
-        with data_buffer as r:
-            rb = r.read()
-        if len(rb) == 0:
-            raise ValueError("resolve_image returned zero bytes")
-        return resolve_binary(
-            raw_bytes=self.image,
-            path=self.path,
-            url=str(self.url) if self.url else None,
-            as_base64=as_base64,
-        )
 
+        # Check size by seeking to end and getting position
+        data_buffer.seek(0, 2)  # Seek to end
+        size = data_buffer.tell()
+        data_buffer.seek(0)     # Reset to beginning
+
+        if size == 0:
+            raise ValueError("resolve_image returned zero bytes")
+        return data_buffer
 
 class AudioBlock(BaseModel):
     block_type: Literal["audio"] = "audio"
@@ -194,16 +192,15 @@ class AudioBlock(BaseModel):
             url=str(self.url) if self.url else None,
             as_base64=as_base64,
         )
-        with data_buffer as r:
-            rb = r.read()
-        if len(rb) == 0:
-            raise ValueError("resolve_audio returned zero bytes")
-        return resolve_binary(
-            raw_bytes=self.audio,
-            path=self.path,
-            url=str(self.url) if self.url else None,
-            as_base64=as_base64,
-        )
+        # Check size by seeking to end and getting position
+        data_buffer.seek(0, 2)  # Seek to end
+        size = data_buffer.tell()
+        data_buffer.seek(0)     # Reset to beginning
+
+        if size == 0:
+            raise ValueError("resolve_image returned zero bytes")
+        return data_buffer
+
 
 class DocumentBlock(BaseModel):
     block_type: Literal["document"] = "document"
@@ -241,16 +238,15 @@ class DocumentBlock(BaseModel):
             url=str(self.url) if self.url else None,
             as_base64=False,
         )
-        with data_buffer as r:
-            rb = r.read()
-        if len(rb) == 0:
-            raise ValueError("resolve_document returned zero bytes")
-        return resolve_binary(
-                raw_bytes=self.data,
-                path=self.path,
-                url=str(self.url) if self.url else None,
-                as_base64=False,
-            )
+        # Check size by seeking to end and getting position
+        data_buffer.seek(0, 2)  # Seek to end
+        size = data_buffer.tell()
+        data_buffer.seek(0)     # Reset to beginning
+
+        if size == 0:
+            raise ValueError("resolve_image returned zero bytes")
+        return data_buffer
+
 
     def _get_b64_string(self, data_buffer: BytesIO) -> str:
         """

--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -118,6 +118,16 @@ class ImageBlock(BaseModel):
             as_base64 (bool): whether the resolved image should be returned as base64-encoded bytes
 
         """
+        data_buffer = resolve_binary(
+            raw_bytes=self.image,
+            path=self.path,
+            url=str(self.url) if self.url else None,
+            as_base64=as_base64,
+        )
+        with data_buffer as r:
+            rb = r.read()
+        if len(rb) == 0:
+            raise ValueError("resolve_image returned zero bytes")
         return resolve_binary(
             raw_bytes=self.image,
             path=self.path,
@@ -178,6 +188,16 @@ class AudioBlock(BaseModel):
             as_base64 (bool): whether the resolved audio should be returned as base64-encoded bytes
 
         """
+        data_buffer = resolve_binary(
+            raw_bytes=self.audio,
+            path=self.path,
+            url=str(self.url) if self.url else None,
+            as_base64=as_base64,
+        )
+        with data_buffer as r:
+            rb = r.read()
+        if len(rb) == 0:
+            raise ValueError("resolve_audio returned zero bytes")
         return resolve_binary(
             raw_bytes=self.audio,
             path=self.path,
@@ -215,12 +235,22 @@ class DocumentBlock(BaseModel):
         """
         Resolve a document such that it is represented by a BufferIO object.
         """
-        return resolve_binary(
+        data_buffer = resolve_binary(
             raw_bytes=self.data,
             path=self.path,
             url=str(self.url) if self.url else None,
             as_base64=False,
         )
+        with data_buffer as r:
+            rb = r.read()
+        if len(rb) == 0:
+            raise ValueError("resolve_document returned zero bytes")
+        return resolve_binary(
+                raw_bytes=self.data,
+                path=self.path,
+                url=str(self.url) if self.url else None,
+                as_base64=False,
+            )
 
     def _get_b64_string(self, data_buffer: BytesIO) -> str:
         """

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -13,16 +13,19 @@ from llama_index.core.base.llms.types import (
     MessageRole,
     TextBlock,
     DocumentBlock,
+    AudioBlock,
 )
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.schema import ImageDocument
 from pydantic import AnyUrl
 
+@pytest.fixture()
+def empty_bytes() -> bytes:
+    return b""
 
 @pytest.fixture()
 def png_1px_b64() -> bytes:
     return b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
-
 
 @pytest.fixture()
 def png_1px(png_1px_b64) -> bytes:
@@ -278,3 +281,27 @@ def test_document_block_from_url(pdf_url: str):
         bytes_base64_encoded = False
     assert bytes_base64_encoded
     assert document.title == "dummy_pdf"
+
+def test_empty_bytes(empty_bytes: bytes, png_1px: bytes):
+    errors = []
+    try:
+        DocumentBlock(data=empty_bytes).resolve_document()
+        errors.append(0)
+    except ValueError:
+        errors.append(1)
+    try:
+        AudioBlock(audio=empty_bytes).resolve_audio()
+        errors.append(0)
+    except ValueError:
+        errors.append(1)
+    try:
+        ImageBlock(image=empty_bytes).resolve_image()
+        errors.append(0)
+    except ValueError:
+        errors.append(1)
+    try:
+        ImageBlock(image=png_1px).resolve_image()
+        errors.append(0)
+    except ValueError:
+        errors.append(1)
+    assert sum(errors) == 3


### PR DESCRIPTION
# Description

The `resolve` methods for all the classes belonging to ContentBlock is now equipped with a checking mechanism that throws an error if the operation yielded zero bytes.

Fixes #18813 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
