### PR TITLE
Strip code block backticks from QueryFusionRetriever llm response

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -87,8 +87,8 @@ class QueryFusionRetriever(BaseRetriever):
         )
         response = self._llm.complete(prompt_str)
 
-        # assume LLM proper put each query on a newline
-        queries = response.text.split("\n")
+        # Strip code block and assume LLM properly put each query on a newline
+        queries = response.text.strip("`").split("\n")
         queries = [q.strip() for q in queries if q.strip()]
         if self._verbose:
             queries_str = "\n".join(queries)


### PR DESCRIPTION
# Description

We've observed cases where the response to the QueryFusionRetriever's "get queries" call to gemini-1.5-pro-001 will be wrapped with a code block. So instead of:

```
"first query\nsecond query"
```
it returns:

```
"```\nfirst query\nsecond query\n```"
```

Instead of parsing `["first query", "second query"]`, we get `["```", "first query"]` as the two related queries. Obviously, the `"```"` query ends up retrieving poor quality nodes.

This may not be a widespread issue, but I thought this change was small and safe enough to be worth implementing to guard against this problem.

(I did not add a unit test because I do not see existing tests for the QueryFusionRetriever).

## New Package? - No

## Version Bump? - No

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
