### PR TITLE
feat: add configurable allow_parallel_tool_calls to FunctionAgent

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -15,11 +15,15 @@ from llama_index.core.memory import BaseMemory
 from llama_index.core.tools import AsyncBaseTool
 from llama_index.core.workflow import Context
 
+from pydantic import Field
 
 class FunctionAgent(SingleAgentRunnerMixin, BaseWorkflowAgent):
     """Function calling agent implementation."""
 
     scratchpad_key: str = "scratchpad"
+    allow_parallel_tool_calls: bool = Field(
+        default=True, description="If True, the agent will call multiple tools in parallel. If False, the agent will call tools sequentially."
+    )
 
     async def take_step(
         self,
@@ -40,7 +44,9 @@ class FunctionAgent(SingleAgentRunnerMixin, BaseWorkflowAgent):
         )
 
         response = await self.llm.astream_chat_with_tools(  # type: ignore
-            tools, chat_history=current_llm_input, allow_parallel_tool_calls=True
+            tools=tools,
+            chat_history=current_llm_input,
+            allow_parallel_tool_calls=self.allow_parallel_tool_calls,
         )
         # last_chat_response will be used later, after the loop.
         # We initialize it so it's valid even when 'response' is empty

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -9,13 +9,12 @@ from llama_index.core.agent.workflow.workflow_events import (
     ToolCallResult,
 )
 from llama_index.core.base.llms.types import ChatResponse
-from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.llms import ChatMessage
 from llama_index.core.memory import BaseMemory
 from llama_index.core.tools import AsyncBaseTool
 from llama_index.core.workflow import Context
 
-from pydantic import Field
 
 class FunctionAgent(SingleAgentRunnerMixin, BaseWorkflowAgent):
     """Function calling agent implementation."""


### PR DESCRIPTION
# Description

This PR adds a configurable `allow_parallel_tool_calls` parameter to the `FunctionAgent` class. Previously, parallel tool calls were always enabled (hardcoded to `True`), which could cause issues in certain scenarios. This change allows users to disable parallel tool calls when needed while maintaining backward compatibility.

## Motivation

When `allow_parallel_tool_calls` is always set to `True`, it can cause unexpected behavior or errors in some use cases, such as:
- When tools have dependencies on each other's execution order
- When the LLM model doesn't properly handle parallel tool calls
- When debugging tool execution flow

By making this parameter configurable, users can choose the appropriate behavior for their specific use case.

## Changes

- Add `allow_parallel_tool_calls` parameter to FunctionAgent class with Pydantic Field
- Default to `True` for backward compatibility
- Update `astream_chat_with_tools` call to use instance parameter
- Add descriptive documentation for the parameter

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (core package)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Usage Example

```python
# Default behavior (parallel tool calls enabled)
agent = FunctionAgent(
    name="my_agent",
    llm=llm,
    tools=tools
)

# Disable parallel tool calls
agent = FunctionAgent(
    name="my_agent",
    llm=llm,
    tools=tools,
    allow_parallel_tool_calls=False
)
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods