### PR TITLE
mcp client upgrade

### DIFF
--- a/docs/docs/examples/tools/mcp.ipynb
+++ b/docs/docs/examples/tools/mcp.ipynb
@@ -161,6 +161,147 @@
     "- `start_event_model`: The event model to use for the start event. You can either use a custom `StartEvent` class in your workflow or pass in your own pydantic model here to define the inputs to the workflow.\n",
     "- `**fastmcp_init_kwargs`: Any extra arguments to pass to the `FastMCP()` server constructor."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MCP Client Usage\n",
+    "\n",
+    "The `BasicMCPClient` provides comprehensive access to MCP server capabilities beyond just tools.\n",
+    "\n",
+    "### Basic Client Operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import BasicMCPClient\n",
+    "\n",
+    "# Connect to an MCP server using different transports\n",
+    "http_client = BasicMCPClient(\"https://example.com/mcp\")  # Streamable HTTP\n",
+    "sse_client = BasicMCPClient(\"https://example.com/sse\")  # Server-Sent Events\n",
+    "local_client = BasicMCPClient(\"python\", args=[\"server.py\"])  # stdio\n",
+    "\n",
+    "# List available tools\n",
+    "tools = await http_client.list_tools()\n",
+    "\n",
+    "# Call a tool\n",
+    "result = await http_client.call_tool(\"calculate\", {\"x\": 5, \"y\": 10})\n",
+    "\n",
+    "# List available resources\n",
+    "resources = await http_client.list_resources()\n",
+    "\n",
+    "# Read a resource\n",
+    "content, mime_type = await http_client.read_resource(\"config://app\")\n",
+    "\n",
+    "# List available prompts\n",
+    "prompts = await http_client.list_prompts()\n",
+    "\n",
+    "# Get a prompt\n",
+    "prompt_result = await http_client.get_prompt(\"greet\", {\"name\": \"World\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### OAuth Authentication\n",
+    "\n",
+    "The client supports OAuth 2.0 authentication for connecting to protected MCP servers.\n",
+    "\n",
+    "You can see the [MCP docs](https://github.com/modelcontextprotocol/python-sdk/blob/main/README.md) for full details on configuring the various aspects of OAuth for both [clients](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#oauth-authentication-for-clients) and [servers](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#authentication)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import BasicMCPClient\n",
+    "\n",
+    "# Simple authentication with in-memory token storage\n",
+    "client = BasicMCPClient.with_oauth(\n",
+    "    \"https://api.example.com/mcp\",\n",
+    "    client_name=\"My App\",\n",
+    "    redirect_uris=[\"http://localhost:3000/callback\"],\n",
+    "    # Function to handle the redirect URL (e.g., open a browser)\n",
+    "    redirect_handler=lambda url: print(f\"Please visit: {url}\"),\n",
+    "    # Function to get the authorization code from the user\n",
+    "    callback_handler=lambda: (input(\"Enter the code: \"), None),\n",
+    ")\n",
+    "\n",
+    "# Use the authenticated client\n",
+    "tools = await client.list_tools()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, the client will use an in-memory token storage if no `token_storage` is provided. You can pass in a custom `TokenStorage` instance to use a different storage.\n",
+    "\n",
+    "Below is an example showing the default in-memory token storage implementation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import BasicMCPClient\n",
+    "from mcp.client.auth import TokenStorage\n",
+    "from mcp.shared.auth import OAuthToken, OAuthClientInformationFull\n",
+    "from typing import Optional\n",
+    "\n",
+    "\n",
+    "class DefaultInMemoryTokenStorage(TokenStorage):\n",
+    "    \"\"\"\n",
+    "    Simple in-memory token storage implementation for OAuth authentication.\n",
+    "\n",
+    "    This is the default storage used when none is provided to with_oauth().\n",
+    "    Not suitable for production use across restarts as tokens are only stored\n",
+    "    in memory.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self._tokens: Optional[OAuthToken] = None\n",
+    "        self._client_info: Optional[OAuthClientInformationFull] = None\n",
+    "\n",
+    "    async def get_tokens(self) -> Optional[OAuthToken]:\n",
+    "        \"\"\"Get the stored OAuth tokens.\"\"\"\n",
+    "        return self._tokens\n",
+    "\n",
+    "    async def set_tokens(self, tokens: OAuthToken) -> None:\n",
+    "        \"\"\"Store OAuth tokens.\"\"\"\n",
+    "        self._tokens = tokens\n",
+    "\n",
+    "    async def get_client_info(self) -> Optional[OAuthClientInformationFull]:\n",
+    "        \"\"\"Get the stored client information.\"\"\"\n",
+    "        return self._client_info\n",
+    "\n",
+    "    async def set_client_info(\n",
+    "        self, client_info: OAuthClientInformationFull\n",
+    "    ) -> None:\n",
+    "        \"\"\"Store client information.\"\"\"\n",
+    "        self._client_info = client_info\n",
+    "\n",
+    "\n",
+    "# Use custom storage\n",
+    "client = BasicMCPClient.with_oauth(\n",
+    "    \"https://api.example.com/mcp\",\n",
+    "    client_name=\"My App\",\n",
+    "    redirect_uris=[\"http://localhost:3000/callback\"],\n",
+    "    redirect_handler=lambda url: print(f\"Please visit: {url}\"),\n",
+    "    callback_handler=lambda: (input(\"Enter the code: \"), None),\n",
+    "    token_storage=DefaultInMemoryTokenStorage(),\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -23,6 +23,8 @@ mcp_tool_spec = McpToolSpec(
     client=mcp_client,
     # Optional: Filter the tools by name
     # allowed_tools=["tool1", "tool2"],
+    # Optional: Include resources in the tool list
+    # include_resources=True,
 )
 
 # sync
@@ -112,6 +114,141 @@ tools = get_tools_from_mcp_url("http://127.0.0.1:8000/sse")
 
 # async
 tools = await get_tools_from_mcp_url("http://127.0.0.1:8000/sse")
+```
+
+## MCP Client Usage
+
+The `BasicMCPClient` provides comprehensive access to MCP server capabilities beyond just tools.
+
+### Basic Client Operations
+
+```python
+from llama_index.tools.mcp import BasicMCPClient
+
+# Connect to an MCP server using different transports
+http_client = BasicMCPClient("https://example.com/mcp")  # Streamable HTTP
+sse_client = BasicMCPClient("https://example.com/sse")  # Server-Sent Events
+local_client = BasicMCPClient("python", args=["server.py"])  # stdio
+
+# List available tools
+tools = await http_client.list_tools()
+
+# Call a tool
+result = await http_client.call_tool("calculate", {"x": 5, "y": 10})
+
+# List available resources
+resources = await http_client.list_resources()
+
+# Read a resource
+content, mime_type = await http_client.read_resource("config://app")
+
+# List available prompts
+prompts = await http_client.list_prompts()
+
+# Get a prompt
+prompt_result = await http_client.get_prompt("greet", {"name": "World"})
+```
+
+### Resource Subscriptions
+
+For real-time updates to resources, you can use persistent sessions with callbacks:
+
+```python
+client = BasicMCPClient("https://example.com/mcp")
+
+
+# Define a callback to handle resource updates
+async def handle_profile_update(resource_name, content, mime_type):
+    print(f"Profile updated: {content.decode()}")
+    # Update your application state with the new data
+
+
+# Start a persistent session
+await client.start_persistent_session()
+
+try:
+    # Subscribe to a resource with callback
+    await client.subscribe_resource_with_callback(
+        "users://123/profile", handle_profile_update
+    )
+
+    # Your application continues running...
+    # The callback will be triggered whenever the resource changes
+
+    # When you no longer need updates
+    await client.unsubscribe_resource("users://123/profile")
+
+finally:
+    # Always clean up the persistent session
+    await client.stop_persistent_session()
+```
+
+### OAuth Authentication
+
+The client supports OAuth 2.0 authentication for connecting to protected MCP servers:
+
+```python
+from llama_index.tools.mcp import BasicMCPClient
+
+# Simple authentication with in-memory token storage
+client = BasicMCPClient.with_oauth(
+    "https://api.example.com/mcp",
+    client_name="My App",
+    redirect_uris=["http://localhost:3000/callback"],
+    # Function to handle the redirect URL (e.g., open a browser)
+    redirect_handler=lambda url: print(f"Please visit: {url}"),
+    # Function to get the authorization code from the user
+    callback_handler=lambda: (input("Enter the code: "), None),
+)
+
+# Use the authenticated client
+tools = await client.list_tools()
+```
+
+For production use, you can implement a custom token storage:
+
+```python
+from llama_index.tools.mcp import BasicMCPClient
+from mcp.client.auth import TokenStorage
+from mcp.shared.auth import OAuthToken, OAuthClientInformationFull
+import json
+import os
+
+
+class FileTokenStorage(TokenStorage):
+    """Store OAuth tokens in a file."""
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+
+    async def get_tokens(self):
+        if not os.path.exists(self.file_path):
+            return None
+        with open(self.file_path, "r") as f:
+            data = json.load(f)
+            return OAuthToken(**data.get("tokens", {}))
+
+    async def set_tokens(self, tokens):
+        data = {}
+        if os.path.exists(self.file_path):
+            with open(self.file_path, "r") as f:
+                data = json.load(f)
+        data["tokens"] = tokens.__dict__
+        with open(self.file_path, "w") as f:
+            json.dump(data, f)
+
+    # Implement remaining methods...
+
+
+# Use custom storage
+client = BasicMCPClient.with_oauth(
+    "https://api.example.com/mcp",
+    client_name="My App",
+    redirect_uris=["http://localhost:3000/callback"],
+    redirect_handler=lambda url: print(f"Please visit: {url}"),
+    callback_handler=lambda: (input("Enter the code: "), None),
+    token_storage=FileTokenStorage("tokens.json"),
+)
 ```
 
 ## Notebook Example

--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -184,8 +184,9 @@ import os
 class FileTokenStorage(TokenStorage):
     """Store OAuth tokens in a file."""
 
-    def __init__(self, file_path):
+    def __init__(self, file_path: str):
         self.file_path = file_path
+        self._client_info: Optional[OAuthClientInformationFull] = None
 
     async def get_tokens(self):
         if not os.path.exists(self.file_path):
@@ -203,7 +204,15 @@ class FileTokenStorage(TokenStorage):
         with open(self.file_path, "w") as f:
             json.dump(data, f)
 
-    # Implement remaining methods...
+    async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
+        """Get the stored client information."""
+        return self._client_info
+
+    async def set_client_info(
+        self, client_info: OAuthClientInformationFull
+    ) -> None:
+        """Store client information."""
+        self._client_info = client_info
 
 
 # Use custom storage

--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -149,40 +149,6 @@ prompts = await http_client.list_prompts()
 prompt_result = await http_client.get_prompt("greet", {"name": "World"})
 ```
 
-### Resource Subscriptions
-
-For real-time updates to resources, you can use persistent sessions with callbacks:
-
-```python
-client = BasicMCPClient("https://example.com/mcp")
-
-
-# Define a callback to handle resource updates
-async def handle_profile_update(resource_name, content, mime_type):
-    print(f"Profile updated: {content.decode()}")
-    # Update your application state with the new data
-
-
-# Start a persistent session
-await client.start_persistent_session()
-
-try:
-    # Subscribe to a resource with callback
-    await client.subscribe_resource_with_callback(
-        "users://123/profile", handle_profile_update
-    )
-
-    # Your application continues running...
-    # The callback will be triggered whenever the resource changes
-
-    # When you no longer need updates
-    await client.unsubscribe_resource("users://123/profile")
-
-finally:
-    # Always clean up the persistent session
-    await client.stop_persistent_session()
-```
-
 ### OAuth Authentication
 
 The client supports OAuth 2.0 authentication for connecting to protected MCP servers:

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
@@ -1,11 +1,15 @@
 from llama_index.tools.mcp.base import McpToolSpec
 from llama_index.tools.mcp.client import BasicMCPClient
-from llama_index.tools.mcp.utils import workflow_as_mcp, get_tools_from_mcp_url, aget_tools_from_mcp_url
+from llama_index.tools.mcp.utils import (
+    workflow_as_mcp,
+    get_tools_from_mcp_url,
+    aget_tools_from_mcp_url,
+)
 
 __all__ = [
     "McpToolSpec",
     "BasicMCPClient",
     "workflow_as_mcp",
     "get_tools_from_mcp_url",
-    "aget_tools_from_mcp_url"
+    "aget_tools_from_mcp_url",
 ]

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from typing import Optional, List, Dict, Tuple, Callable, AsyncIterator, Awaitable, Dict
 from urllib.parse import urlparse
 
-from mcp.client.session import ClientSession
+from mcp.client.session import ClientSession, ProgressFnT
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client, StdioServerParameters
 from mcp.client.streamable_http import streamablehttp_client
@@ -173,10 +173,11 @@ class BasicMCPClient(ClientSession):
                     yield session
 
     # Tool methods
-    async def call_tool(self, tool_name: str, arguments: dict) -> types.CallToolResult:
+    async def call_tool(self, tool_name: str, arguments: Optional[dict] = None, progress_callback: Optional[ProgressFnT] = None) -> types.CallToolResult:
         """Call a tool on the MCP server."""
         async with self._run_session() as session:
-            return await session.call_tool(tool_name, arguments)
+            return await session.call_tool(tool_name, arguments=arguments, progress_callback=progress_callback)
+
 
     async def list_tools(self) -> types.ListToolsResult:
         """List all available tools on the MCP server."""

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Optional, List, Dict, Tuple, Callable, AsyncIterator, Awaitable, Dict
@@ -111,6 +112,7 @@ class BasicMCPClient(ClientSession):
         # Use default in-memory storage if none provided
         if token_storage is None:
             token_storage = DefaultInMemoryTokenStorage()
+            warnings.warn("Using default in-memory token storage. Tokens will be lost on restart.", UserWarning)
 
         oauth_auth = OAuthClientProvider(
             server_url=command_or_url if urlparse(command_or_url).scheme else None,

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,24 +1,62 @@
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple, Callable, AsyncIterator, Awaitable, Dict
 from urllib.parse import urlparse
 
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client, StdioServerParameters
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthClientInformationFull
+from mcp import types
+
+from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+
+
+class DefaultInMemoryTokenStorage(TokenStorage):
+    """
+    Simple in-memory token storage implementation for OAuth authentication.
+
+    This is the default storage used when none is provided to with_oauth().
+    Not suitable for production use across restarts as tokens are only stored
+    in memory.
+    """
+
+    def __init__(self):
+        self._tokens: Optional[OAuthToken] = None
+        self._client_info: Optional[OAuthClientInformationFull] = None
+
+    async def get_tokens(self) -> Optional[OAuthToken]:
+        """Get the stored OAuth tokens."""
+        return self._tokens
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        """Store OAuth tokens."""
+        self._tokens = tokens
+
+    async def get_client_info(self) -> Optional[OAuthClientInformationFull]:
+        """Get the stored client information."""
+        return self._client_info
+
+    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        """Store client information."""
+        self._client_info = client_info
 
 
 class BasicMCPClient(ClientSession):
     """
     Basic MCP client that can be used to connect to an MCP server.
 
-    This is useful for verifying that the MCP server which implements `FastMCP` is working.
+    This is useful for connecting to any MCP server.
 
     Args:
         command_or_url: The command to run or the URL to connect to.
         args: The arguments to pass to StdioServerParameters.
         env: The environment variables to set for StdioServerParameters.
         timeout: The timeout for the command in seconds.
+        auth: Optional OAuth client provider for authentication.
+        sampling_callback: Optional callback for handling sampling messages.
 
     """
 
@@ -28,36 +66,191 @@ class BasicMCPClient(ClientSession):
         args: Optional[List[str]] = None,
         env: Optional[Dict[str, str]] = None,
         timeout: int = 30,
+        auth: Optional[OAuthClientProvider] = None,
+        sampling_callback: Optional[
+            Callable[
+                [types.CreateMessageRequestParams], Awaitable[types.CreateMessageResult]
+            ]
+        ] = None,
     ):
         self.command_or_url = command_or_url
         self.args = args or []
         self.env = env or {}
         self.timeout = timeout
+        self.auth = auth
+        self.sampling_callback = sampling_callback
+
+    @classmethod
+    def with_oauth(
+        cls,
+        command_or_url: str,
+        client_name: str,
+        redirect_uris: List[str],
+        redirect_handler: Callable[[str], None],
+        callback_handler: Callable[[], Tuple[str, Optional[str]]],
+        token_storage: Optional[TokenStorage] = None,
+        **kwargs,
+    ) -> "BasicMCPClient":
+        """
+        Create a client with OAuth authentication.
+
+        Args:
+            command_or_url: The command to run or the URL to connect to
+            client_name: The name of the OAuth client
+            redirect_uris: The redirect URIs for the OAuth flow
+            redirect_handler: Function that handles the redirect URL
+            callback_handler: Function that returns the auth code and state
+            token_storage: Optional token storage for OAuth client. If not provided,
+                           a default in-memory storage is used (tokens will be lost on restart).
+            **kwargs: Additional arguments to pass to the client constructor
+
+        Returns:
+            An authenticated MCP client
+
+        """
+        # Use default in-memory storage if none provided
+        if token_storage is None:
+            token_storage = DefaultInMemoryTokenStorage()
+
+        oauth_auth = OAuthClientProvider(
+            server_url=command_or_url if urlparse(command_or_url).scheme else None,
+            client_metadata=OAuthClientMetadata(
+                client_name=client_name,
+                redirect_uris=redirect_uris,
+                grant_types=["authorization_code", "refresh_token"],
+                response_types=["code"],
+            ),
+            redirect_handler=redirect_handler,
+            callback_handler=callback_handler,
+            storage=token_storage,
+        )
+
+        return cls(command_or_url, auth=oauth_auth, **kwargs)
 
     @asynccontextmanager
-    async def _run_session(self):
-        if urlparse(self.command_or_url).scheme in ("http", "https"):
-            async with sse_client(self.command_or_url) as streams:
-                async with ClientSession(
-                    *streams, read_timeout_seconds=timedelta(seconds=self.timeout)
-                ) as session:
-                    await session.initialize()
-                    yield session
+    async def _run_session(self) -> AsyncIterator[ClientSession]:
+        """Create and initialize a session with the MCP server."""
+        url = urlparse(self.command_or_url)
+        scheme = url.scheme
+
+        if scheme in ("http", "https"):
+            # Check if this is a streamable HTTP endpoint (default) or SSE
+            if url.path.endswith("/sse"):
+                # SSE transport
+                async with sse_client(self.command_or_url, auth=self.auth) as streams:
+                    async with ClientSession(
+                        *streams,
+                        read_timeout_seconds=timedelta(seconds=self.timeout),
+                        sampling_callback=self.sampling_callback,
+                    ) as session:
+                        await session.initialize()
+                        yield session
+            else:
+                # Streamable HTTP transport (recommended)
+                async with streamablehttp_client(
+                    self.command_or_url, auth=self.auth
+                ) as (read, write, _):
+                    async with ClientSession(
+                        read,
+                        write,
+                        read_timeout_seconds=timedelta(seconds=self.timeout),
+                        sampling_callback=self.sampling_callback,
+                    ) as session:
+                        await session.initialize()
+                        yield session
         else:
+            # stdio transport
             server_parameters = StdioServerParameters(
                 command=self.command_or_url, args=self.args, env=self.env
             )
             async with stdio_client(server_parameters) as streams:
                 async with ClientSession(
-                    *streams, read_timeout_seconds=timedelta(seconds=self.timeout)
+                    *streams,
+                    read_timeout_seconds=timedelta(seconds=self.timeout),
+                    sampling_callback=self.sampling_callback,
                 ) as session:
                     await session.initialize()
                     yield session
 
-    async def call_tool(self, tool_name: str, arguments: dict):
+    # Tool methods
+    async def call_tool(self, tool_name: str, arguments: dict) -> types.CallToolResult:
+        """Call a tool on the MCP server."""
         async with self._run_session() as session:
             return await session.call_tool(tool_name, arguments)
 
-    async def list_tools(self):
+    async def list_tools(self) -> types.ListToolsResult:
+        """List all available tools on the MCP server."""
         async with self._run_session() as session:
             return await session.list_tools()
+
+    # Resource methods
+    async def list_resources(self) -> types.ListToolsRequest:
+        """List all available resources on the MCP server."""
+        async with self._run_session() as session:
+            return await session.list_resources()
+
+    async def read_resource(self, resource_name: str) -> types.ReadResourceResult:
+        """
+        Read a resource from the MCP server.
+
+        Returns:
+            Tuple containing the resource content as bytes and the MIME type
+
+        """
+        async with self._run_session() as session:
+            return await session.read_resource(resource_name)
+
+    ## ----- Prompt methods -----
+
+    async def list_prompts(self) -> List[types.Prompt]:
+        """List all available prompts on the MCP server."""
+        async with self._run_session() as session:
+            return await session.list_prompts()
+
+    async def get_prompt(
+        self, prompt_name: str, arguments: Optional[Dict[str, str]] = None
+    ) -> List[ChatMessage]:
+        """
+        Get a prompt from the MCP server.
+
+        Args:
+            prompt_name: The name of the prompt to get
+            arguments: Optional arguments to pass to the prompt
+
+        Returns:
+            The prompt as a list of llama-index ChatMessage objects
+
+        """
+        async with self._run_session() as session:
+            prompt = await session.get_prompt(prompt_name, arguments)
+            llama_messages = []
+            for message in prompt.messages:
+                if isinstance(message.content, types.TextContent):
+                    llama_messages.append(
+                        ChatMessage(
+                            role=message.role,
+                            blocks=[TextBlock(text=message.content.text)],
+                        )
+                    )
+                elif isinstance(message.content, types.ImageContent):
+                    llama_messages.append(
+                        ChatMessage(
+                            role=message.role,
+                            blocks=[
+                                ImageBlock(
+                                    image=message.content.data,
+                                    image_mimetype=message.content.mimeType,
+                                )
+                            ],
+                        )
+                    )
+                elif isinstance(message.content, types.EmbeddedResource):
+                    raise NotImplementedError(
+                        "Embedded resources are not supported yet"
+                    )
+                else:
+                    raise ValueError(
+                        f"Unsupported content type: {type(message.content)}"
+                    )
+
+            return llama_messages

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.1.3"
+version = "0.2.0"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "codespell[toml]>=v2.2.6",
     "diff-cover>=9.2.4",
     "pytest-cov>=6.1.1",
+    "pytest-asyncio>=0.23.8",
 ]
 
 [project]
@@ -40,8 +41,8 @@ keywords = [
     "tools",
 ]
 dependencies = [
-    "mcp>=1.2.0,<2",
-    "llama-index-core>=0.12.0,<0.13",
+    "mcp>=1.9.1,<2",
+    "llama-index-core>=0.12.37,<0.13",
     "pydantic>=2.0.0,<3",
 ]
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
@@ -127,10 +127,8 @@ def update_user(
 @mcp.tool(description="Long running task with progress updates")
 async def long_task(steps: int, ctx: Context) -> str:
     """Long-running task to test progress reporting."""
-    for i in range(steps):
-        ctx.info(f"Processing step {i + 1}/{steps}")
-        await ctx.report_progress(i, steps)
-        await asyncio.sleep(1)  # Simulate work
+    for i in range(1, steps + 1):
+        await ctx.report_progress(i, steps, f"Processing step {i}/{steps}")
     return f"Completed {steps} steps"
 
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
@@ -1,0 +1,252 @@
+import asyncio
+import random
+import time
+from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Dict, Optional
+
+from mcp.server.fastmcp import FastMCP, Context, Image
+from mcp.server.fastmcp.prompts import base
+from PIL import Image as PILImage
+import numpy as np
+import io
+
+
+@asynccontextmanager
+async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
+    """
+    Context manager for the MCP server lifetime.
+    """
+    task = asyncio.create_task(periodic_updates())
+    try:
+        yield
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+# Create the MCP server
+mcp = FastMCP(
+    "TestAllFeatures",
+    description="A test server that demonstrates all MCP features",
+    dependencies=["pillow", "numpy"],
+    lifespan=app_lifespan,
+)
+
+# --- In-memory data store for testing ---
+users = {
+    "123": {
+        "name": "Test User",
+        "email": "test@example.com",
+        "last_updated": time.time(),
+    },
+    "456": {
+        "name": "Another User",
+        "email": "another@example.com",
+        "last_updated": time.time(),
+    },
+}
+
+# Resource that changes periodically for subscription testing
+counter = 0
+last_weather = {"temperature": 22, "condition": "sunny"}
+
+# --- Tools ---
+
+
+@mcp.tool(description="Echo back the input message")
+def echo(message: str) -> str:
+    """Simple echo tool to test basic tool functionality."""
+    return f"Echo: {message}"
+
+
+@mcp.tool(description="Add two numbers together")
+def add(a: float, b: float) -> float:
+    """Add two numbers to test numeric tool arguments."""
+    return a + b
+
+
+@mcp.tool(description="Get current server time")
+def get_time() -> str:
+    """Get the current server time to test tools without arguments."""
+    return datetime.now().isoformat()
+
+
+@mcp.tool(description="Generate a random image")
+def generate_image(width: int = 100, height: int = 100, color: str = "random") -> Image:
+    """Generate an image to test image return values."""
+    # Create a random color image
+    if color == "random":
+        img_array = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+    elif color == "red":
+        img_array = np.zeros((height, width, 3), dtype=np.uint8)
+        img_array[:, :, 0] = 255
+    elif color == "green":
+        img_array = np.zeros((height, width, 3), dtype=np.uint8)
+        img_array[:, :, 1] = 255
+    elif color == "blue":
+        img_array = np.zeros((height, width, 3), dtype=np.uint8)
+        img_array[:, :, 2] = 255
+    else:
+        img_array = np.zeros((height, width, 3), dtype=np.uint8)
+
+    # Convert numpy array to PIL Image
+    pil_img = PILImage.fromarray(img_array)
+
+    # Save to bytes
+    img_byte_arr = io.BytesIO()
+    pil_img.save(img_byte_arr, format="PNG")
+    img_byte_arr = img_byte_arr.getvalue()
+
+    return Image(data=img_byte_arr, format="png")
+
+
+@mcp.tool(description="Update user information")
+def update_user(
+    user_id: str, name: Optional[str] = None, email: Optional[str] = None
+) -> Dict:
+    """Update a user to test triggering resource changes."""
+    global users
+
+    if user_id not in users:
+        raise ValueError(f"User {user_id} not found")
+
+    if name is not None:
+        users[user_id]["name"] = name
+    if email is not None:
+        users[user_id]["email"] = email
+
+    users[user_id]["last_updated"] = time.time()
+    return users[user_id]
+
+
+@mcp.tool(description="Long running task with progress updates")
+async def long_task(steps: int, ctx: Context) -> str:
+    """Long-running task to test progress reporting."""
+    for i in range(steps):
+        ctx.info(f"Processing step {i + 1}/{steps}")
+        await ctx.report_progress(i, steps)
+        await asyncio.sleep(1)  # Simulate work
+    return f"Completed {steps} steps"
+
+
+@mcp.tool(description="Update weather data")
+def update_weather(temperature: float, condition: str) -> Dict:
+    """Update weather data to test resource change notifications."""
+    global last_weather
+    last_weather = {"temperature": temperature, "condition": condition}
+    return last_weather
+
+
+# --- Static Resources ---
+
+
+@mcp.resource("config://app")
+def get_app_config() -> str:
+    """Static configuration resource."""
+    return """
+    {
+        "app_name": "MCP Test Server",
+        "version": "1.0.0",
+        "environment": "testing"
+    }
+    """
+
+
+@mcp.resource("help://usage")
+def get_help() -> str:
+    """Static help text resource."""
+    return """
+    This server lets you test all MCP client features:
+
+    - Call tools with various argument types
+    - Read static and dynamic resources
+    - Subscribe to changing resources
+    - Use prompts with templates
+    """
+
+
+# --- Dynamic Resources ---
+
+
+@mcp.resource("users://{user_id}/profile")
+def get_user_profile(user_id: str) -> str:
+    """Dynamic user profile resource."""
+    if user_id not in users:
+        return f"User {user_id} not found"
+
+    user = users[user_id]
+    return f"""
+    Name: {user["name"]}
+    Email: {user["email"]}
+    Last Updated: {datetime.fromtimestamp(user["last_updated"]).isoformat()}
+    """
+
+
+@mcp.resource("counter://value")
+def get_counter() -> str:
+    """Resource that changes on every access for testing subscriptions."""
+    global counter
+    counter += 1
+    return f"Current counter value: {counter}"
+
+
+@mcp.resource("weather://current")
+def get_weather() -> str:
+    """Weather resource that can be updated via a tool."""
+    global last_weather
+    return f"""
+    Current Weather:
+    Temperature: {last_weather["temperature"]}°C
+    Condition: {last_weather["condition"]}
+    Last Updated: {datetime.now().isoformat()}
+    """
+
+
+# --- Prompts ---
+
+
+@mcp.prompt()
+def simple_greeting() -> str:
+    """Simple prompt without arguments."""
+    return "Hello! How can I help you today?"
+
+
+@mcp.prompt()
+def personalized_greeting(name: str) -> str:
+    """Prompt with arguments."""
+    return f"Hello, {name}! How can I assist you today?"
+
+
+@mcp.prompt()
+def analyze_data(data: str) -> list[base.Message]:
+    """Multi-message prompt template."""
+    return [
+        base.UserMessage("Please analyze this data:"),
+        base.UserMessage(data),
+        base.AssistantMessage("I'll analyze this data for you. Let me break it down:"),
+    ]
+
+
+# --- Start periodic resource updater ---
+# This simulates resources changing on their own for subscription testing
+
+
+async def periodic_updates():
+    """Task that periodically updates resources to test subscriptions."""
+    while True:
+        await asyncio.sleep(10)
+        # Update weather randomly
+        new_temp = last_weather["temperature"] + random.uniform(-2, 2)
+        conditions = ["sunny", "cloudy", "rainy", "windy", "snowy"]
+        new_condition = random.choice(conditions)
+        update_weather(new_temp, new_condition)
+
+
+# --- Run the server ---
+if __name__ == "__main__":
+    mcp.run()

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,0 +1,172 @@
+import os
+import pytest
+
+from llama_index.tools.mcp import BasicMCPClient
+from mcp import types
+
+
+# Path to the test server script - adjust as needed
+SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "server.py")
+
+
+@pytest.fixture(scope="session")
+def client():
+    """Create a basic MCP client connected to the test server."""
+    return BasicMCPClient("python", args=[SERVER_SCRIPT], timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_list_tools(client):
+    """Test listing tools from the server."""
+    tools = await client.list_tools()
+
+    # Check that we got a list of tools
+    assert isinstance(tools, types.ListToolsResult)
+    assert len(tools.tools) > 0
+
+    # Verify some expected tools are present
+    tool_names = [tool.name for tool in tools.tools]
+    assert "echo" in tool_names
+    assert "add" in tool_names
+    assert "get_time" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_call_tools(client):
+    """Test calling various tools."""
+    # Test echo tool
+    result = await client.call_tool("echo", {"message": "Hello, World!"})
+    assert result.content[0].text == "Echo: Hello, World!"
+
+    # Test add tool
+    result = await client.call_tool("add", {"a": 5, "b": 7})
+    assert result.content[0].text == "12.0"
+
+    # Test get_time tool (just verify it returns something)
+    result = await client.call_tool("get_time", {})
+    assert isinstance(result.content[0].text, str)
+    assert len(result.content[0].text) > 0
+
+
+@pytest.mark.asyncio
+async def test_list_resources(client):
+    """Test listing resources from the server."""
+    resources = await client.list_resources()
+
+    # Check that we got a list of resources
+    assert isinstance(resources, types.ListResourcesResult)
+    assert len(resources.resources) > 0
+
+    # Verify some expected resources are present
+    resource_names = [str(resource.uri) for resource in resources.resources]
+    assert "config://app" in resource_names
+    assert "help://usage" in resource_names
+    assert "counter://value" in resource_names
+    assert "weather://current" in resource_names
+
+
+@pytest.mark.asyncio
+async def test_read_resources(client):
+    """Test reading various resources."""
+    # Test static resource
+    resource = await client.read_resource("config://app")
+    assert isinstance(resource, types.ReadResourceResult)
+    assert resource.contents[0].mimeType == "text/plain"
+    config_text = resource.contents[0].text
+    assert "app_name" in config_text
+    assert "MCP Test Server" in config_text
+
+    # Test parametrized resource
+    resource = await client.read_resource("users://123/profile")
+    profile_text = resource.contents[0].text
+    assert "Test User" in profile_text
+    assert "test@example.com" in profile_text
+
+
+@pytest.mark.asyncio
+async def test_list_prompts(client):
+    """Test listing prompts from the server."""
+    prompts = await client.list_prompts()
+
+    # Check that we got a list of prompts
+    assert isinstance(prompts, types.ListPromptsResult)
+    assert len(prompts.prompts) > 0
+
+    # Verify some expected prompts are present
+    prompt_names = [prompt.name for prompt in prompts.prompts]
+    assert "simple_greeting" in prompt_names
+    assert "personalized_greeting" in prompt_names
+    assert "analyze_data" in prompt_names
+
+
+@pytest.mark.asyncio
+async def test_get_prompts(client):
+    """Test getting various prompts."""
+    # Test simple prompt
+    result = await client.get_prompt("simple_greeting")
+    assert len(result) > 0
+
+    # Test prompt with arguments
+    result = await client.get_prompt("personalized_greeting", {"name": "Tester"})
+    assert len(result) > 0
+    assert "Tester" in result[0].content
+
+    # Test multi-message prompt
+    result = await client.get_prompt("analyze_data", {"data": "1,2,3,4,5"})
+    assert len(result) > 1
+    assert any("1,2,3,4,5" in msg.content for msg in result)
+
+
+@pytest.mark.asyncio
+async def test_resource_updates_via_tool(client):
+    """Test updating a resource via a tool and reading the changes."""
+    # First read the initial user profile
+    resource = await client.read_resource("users://123/profile")
+    profile1 = resource.contents[0].text
+    assert "Test User" in profile1
+
+    # Update the user via the tool
+    result = await client.call_tool(
+        "update_user", {"user_id": "123", "name": "Updated User"}
+    )
+
+    profile2 = result.content[0].text
+    assert "Updated User" in profile2
+    assert "Test User" not in profile2
+
+
+@pytest.mark.asyncio
+async def test_default_in_memory_storage():
+    """Test the default in-memory token storage."""
+    # Create client with OAuth using default storage
+    client = BasicMCPClient.with_oauth(
+        "python",
+        args=[SERVER_SCRIPT],
+        client_name="Test Client",
+        redirect_uris=["http://localhost:3000/callback"],
+        redirect_handler=lambda url: None,  # Do nothing in test
+        callback_handler=lambda: ("fake_code", None),  # Return fake code
+    )
+
+    # Just verify initialization works
+    assert client.auth is not None
+
+
+@pytest.mark.asyncio
+async def test_long_running_task(client):
+    """Test a long-running task with progress updates."""
+    # This will run a task that takes a few seconds and reports progress
+    result = await client.call_tool("long_task", {"steps": 3})
+    assert "Completed 3 steps" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_image_return_value(client):
+    """Test tools that return images."""
+    result = await client.call_tool(
+        "generate_image", {"width": 50, "height": 50, "color": "blue"}
+    )
+
+    # Check that we got image data back
+    assert isinstance(result, types.CallToolResult)
+    assert len(result.content[0].data) > 0

--- a/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
@@ -1511,7 +1511,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-tools-mcp"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },

--- a/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
@@ -110,6 +110,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload_time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload_time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1464,10 +1476,11 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.12.33.post1"
+version = "0.12.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiosqlite" },
     { name = "banks" },
     { name = "dataclasses-json" },
     { name = "deprecated" },
@@ -1491,14 +1504,14 @@ dependencies = [
     { name = "typing-inspect" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/51/e99358e80b0d80777c84081159d351f51feaa6c7d7054486bbbb49f6c9c0/llama_index_core-0.12.33.post1.tar.gz", hash = "sha256:d257f6f594dfd9cf6435af02761a3d21f1427df5347f0e5e9fffe4024db6a724", size = 7282200, upload_time = "2025-04-23T18:48:42.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/96/cb236b066184c5154b391d5028a56d6ca1f9aec69edf6cbef6c9a6ff1eff/llama_index_core-0.12.37.tar.gz", hash = "sha256:c2c13c36229bc9cfffc7bf1daca888e382d5ae484af96273c53f001ed84dc253", size = 7289254, upload_time = "2025-05-19T22:14:39.022Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/01/6fcf557a72ad25734327515db506744f8f8ba95846a0f7e055c8fa95a54d/llama_index_core-0.12.33.post1-py3-none-any.whl", hash = "sha256:2c4a316a1ae9ec86c817d44961d1058691632acb3a7021e6af56fcfb8735fd3d", size = 7650733, upload_time = "2025-04-23T18:48:33.433Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e8/1a2c5ca5d2af0f1741964259f09d1c8b7ce27b0e913f39c894038088d430/llama_index_core-0.12.37-py3-none-any.whl", hash = "sha256:1a841db0dcdace161d2fcecfee0ab94d28e50196973974c5142f0d18d3f7663f", size = 7661867, upload_time = "2025-05-19T22:14:30.121Z" },
 ]
 
 [[package]]
 name = "llama-index-tools-mcp"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1519,6 +1532,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pylint" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -1532,8 +1546,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "llama-index-core", specifier = ">=0.12.0,<0.13" },
-    { name = "mcp", specifier = ">=1.2.0,<2" },
+    { name = "llama-index-core", specifier = ">=0.12.37,<0.13" },
+    { name = "mcp", specifier = ">=1.9.1,<2" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
 ]
 
@@ -1550,6 +1564,7 @@ dev = [
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
     { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = "==3.11.1" },
     { name = "ruff", specifier = "==0.0.292" },
@@ -1654,7 +1669,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.6.0"
+version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1662,13 +1677,14 @@ dependencies = [
     { name = "httpx-sse" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/d2/f587cb965a56e992634bebc8611c5b579af912b74e04eb9164bd49527d21/mcp-1.6.0.tar.gz", hash = "sha256:d9324876de2c5637369f43161cd71eebfd803df5a95e46225cab8d280e366723", size = 200031, upload_time = "2025-03-27T16:46:32.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/bc/54aec2c334698cc575ca3b3481eed627125fb66544152fa1af927b1a495c/mcp-1.9.1.tar.gz", hash = "sha256:19879cd6dde3d763297617242888c2f695a95dfa854386a6a68676a646ce75e4", size = 316247, upload_time = "2025-05-22T15:52:21.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/30/20a7f33b0b884a9d14dd3aa94ff1ac9da1479fe2ad66dd9e2736075d2506/mcp-1.6.0-py3-none-any.whl", hash = "sha256:7bd24c6ea042dbec44c754f100984d186620d8b841ec30f1b19eda9b93a634d0", size = 76077, upload_time = "2025-03-27T16:46:29.919Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c0/4ac795585a22a0a2d09cd2b1187b0252d2afcdebd01e10a68bbac4d34890/mcp-1.9.1-py3-none-any.whl", hash = "sha256:2900ded8ffafc3c8a7bfcfe8bc5204037e988e753ec398f371663e6a06ecd9a9", size = 130261, upload_time = "2025-05-22T15:52:19.702Z" },
 ]
 
 [[package]]
@@ -2494,6 +2510,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.23.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/b4/0b378b7bf26a8ae161c3890c0b48a91a04106c5713ce81b4b080ea2f4f18/pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3", size = 46920, upload_time = "2024-07-17T17:39:34.617Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/82/62e2d63639ecb0fbe8a7ee59ef0bc69a4669ec50f6d3459f74ad4e4189a2/pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2", size = 17663, upload_time = "2024-07-17T17:39:32.478Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2546,6 +2574,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642, upload_time = "2025-03-07T07:08:27.301Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163, upload_time = "2025-03-07T07:08:25.627Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload_time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload_time = "2024-12-16T19:45:44.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
HUGE update to our `BasicMCPClient`

- support `sse` and `Streamable HTTP transport` protocols
- added OAuth support (not able to fully test this yet though)
- methods for nearly every feature MCP offers
- update the toolspec to optionally include resources as readonly tools
- added many tests

Some notes:
- Have not tested oauth yet. Need to find some public server
- I made made `get_prompt()` return llama-index chat messages. This is a little debatable (should we just return the raw mcp types? Or are there more endpoints that can be converted into more use llama-index objects?)
- MCP kind of supports notifications for when resources change, but there's no docs on this, so left it out for now