### PR TITLE
check thinking is non-null in anthropic messages

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -186,7 +186,7 @@ def messages_to_anthropic_messages(
             content: list[TextBlockParam | ImageBlockParam | DocumentBlockParam] = []
             for block in message.blocks:
                 if isinstance(block, TextBlock):
-                    if block.text or "thinking" in message.additional_kwargs:
+                    if block.text or message.additional_kwargs.get("thinking"):
                         content.append(
                             _text_block_to_anthropic_message(
                                 block, message.additional_kwargs

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-anthropic"
-version = "0.6.18"
+version = "0.6.19"
 description = "llama-index llms anthropic integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

extended thinking was mostly fixed by #18834, though claude 4 will also occasionally issue tool calls with no accompanying text, and null 'thinking' in additional_kwargs, as seen below:
```
DEBUG:    Empty response full structure: {
  "role": "assistant",
  "additional_kwargs": {
    "tool_calls": [
      {
        #[redacted]
      }
    ],
    "thinking": null
  },
  "blocks": [
    {
      "block_type": "text",
      "text": ""
    }
  ]
}
```

this causes a downstream exception:
`anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages: text content blocks must be non-empty'}}`


Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I tested locally and checked that this resolved the bug I was encountering.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
