### PR TITLE
fix resuming AgentWorkflow from ctx during hitl

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -559,17 +559,26 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         checkpoint_callback: Optional[CheckpointCallback] = None,
         **kwargs: Any,
     ) -> WorkflowHandler:
-        return super().run(
-            start_event=AgentWorkflowStartEvent(
-                user_msg=user_msg,
-                chat_history=chat_history,
-                memory=memory,
+        # Detect if hitl is needed
+        if ctx is not None and ctx.is_running:
+            return super().run(
+                ctx=ctx,
+                stepwise=stepwise,
+                checkpoint_callback=checkpoint_callback,
                 **kwargs,
-            ),
-            ctx=ctx,
-            stepwise=stepwise,
-            checkpoint_callback=checkpoint_callback,
-        )
+            )
+        else:
+            return super().run(
+                start_event=AgentWorkflowStartEvent(
+                    user_msg=user_msg,
+                    chat_history=chat_history,
+                    memory=memory,
+                    **kwargs,
+                ),
+                ctx=ctx,
+                stepwise=stepwise,
+                checkpoint_callback=checkpoint_callback,
+            )
 
     @classmethod
     def from_tools_or_functions(

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -15,7 +15,7 @@ from llama_index.core.llms import (
 )
 from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.core.tools import FunctionTool, ToolSelection
-from llama_index.core.workflow import Context, WorkflowRuntimeError
+from llama_index.core.workflow import Context, WorkflowRuntimeError, HumanResponseEvent, InputRequiredEvent
 
 
 class MockLLM(MockLLM):
@@ -376,3 +376,62 @@ async def test_workflow_with_state():
 
     state = await handler.ctx.get("state")
     assert state["counter"] == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_with_hitl():
+    """Test agent with hitl."""
+    async def hitl(ctx: Context):
+        resp = await ctx.wait_for_event(
+            HumanResponseEvent,
+            waiter_event=InputRequiredEvent(prefix="What is your name?")
+        )
+        return f"Your name is {resp.response}"
+
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[hitl],
+        llm=MockLLM(
+            responses=[
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content="handing off",
+                    additional_kwargs={
+                        "tool_calls": [
+                            ToolSelection(
+                                tool_id="one",
+                                tool_name="hitl",
+                                tool_kwargs={},
+                            )
+                        ]
+                    },
+                ),
+                ChatMessage(
+                    role=MessageRole.ASSISTANT, content="HITL successful"
+                ),
+            ],
+        ),
+    )
+
+    workflow = AgentWorkflow(
+        agents=[agent],
+        root_agent="agent",
+    )
+
+    handler = workflow.run(user_msg="test")
+    ctx_dict = None
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            ctx_dict = handler.ctx.to_dict()
+            await handler.cancel_run()
+            break
+
+    new_ctx = Context.from_dict(workflow, ctx_dict)
+    handler = workflow.run(user_msg="test", ctx=new_ctx)
+    handler.ctx.send_event(HumanResponseEvent(response="John Doe"))
+
+    response = await handler
+
+    assert response is not None
+    assert "HITL successful" in str(response)


### PR DESCRIPTION
If we are resuming a ctx, do not pass start event

FIxes https://github.com/run-llama/llama_index/issues/18842