### PR TITLE
Adding a very simple implementation of an embeddings cache

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -7,7 +7,6 @@ from enum import Enum
 from typing import Any, Callable, Coroutine, List, Optional, Sequence, Tuple
 from typing_extensions import Self
 
-from llama_index.core.storage.kvstore import SimpleKVStore
 import numpy as np
 from llama_index.core.bridge.pydantic import (
     Field,
@@ -87,15 +86,18 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
         default=None,
         description="The number of workers to use for async embedding calls.",
     )
-    embeddings_cache: Optional[SimpleKVStore] = Field(
-        default=None,
+    embeddings_cache: Optional[Any] = Field(
+        default = None,
         description="Cache for the embeddings: if None, the embeddings are not cached"
     )
 
     @model_validator(mode="after")
     def check_base_embeddings_class(self) -> Self:
+        from llama_index.core.storage.kvstore.simple_kvstore import SimpleKVStore
         if self.callback_manager is None:
             self.callback_manager = CallbackManager([])
+        if not isinstance(self.embeddings_cache, SimpleKVStore):
+            raise TypeError("embeddings_cache must be of type SimpleKVStore")
         return self
 
     @abstractmethod

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -88,28 +88,15 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
         default=None,
         description="The number of workers to use for async embedding calls.",
     )
-    cache_embeddings: bool = Field(
-        default=False,
-        description="Whether to cache embeddings or not"
-    )
     embeddings_cache: Optional[SimpleKVStore] = Field(
         default=None,
         description="Cache for the embeddings"
-    )
-    maximum_cached_embeddings: Optional[int] = Field(
-        default = None,
-        description="Maximum number of embeddings to cache"
     )
 
     @model_validator(mode="after")
     def check_base_embeddings_class(self) -> Self:
         if self.callback_manager is None:
             self.callback_manager = CallbackManager([])
-        if self.cache_embeddings and not self.embeddings_cache:
-            if not self.maximum_cached_embeddings:
-                self.maximum_cached_embeddings = 1000
-            self.cache_embeddings = SimpleKVStore(maximum_data_points = self.maximum_cached_embeddings)
-        return self
 
     @abstractmethod
     def _get_query_embedding(self, query: str) -> Embedding:

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -97,6 +97,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
     def check_base_embeddings_class(self) -> Self:
         if self.callback_manager is None:
             self.callback_manager = CallbackManager([])
+        return self
 
     @abstractmethod
     def _get_query_embedding(self, query: str) -> Embedding:

--- a/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
@@ -20,18 +20,29 @@ class SimpleKVStore(BaseInMemoryKVStore):
 
     Args:
         data (Optional[DATA_TYPE]): data to initialize the store with
+        maximum_data_points (Optional[int]): maximum number of data points that can be stored within a collection in the KVStore
+        size_strict (Optional[bool]): whether to throw an error or not when the maximum size is exceeded
 
     """
 
     def __init__(
         self,
         data: Optional[DATA_TYPE] = None,
+        maximum_data_points: Optional[int] = None,
+        size_strict: Optional[bool] = None,
     ) -> None:
         """Init a SimpleKVStore."""
         self._data: DATA_TYPE = data or {}
+        self._maximum_data_point = maximum_data_points or 1000
+        self._strict = size_strict or False
 
     def put(self, key: str, val: dict, collection: str = DEFAULT_COLLECTION) -> None:
         """Put a key-value pair into the store."""
+        if collection in self._data and len(collection) > self._maximum_data_point:
+            if self._strict:
+                raise ValueError(f"Exceeded the maximum number of data points that can be uploaded to collection {collection}")
+            first_key = next(iter(self._data[collection].keys()))
+            self._data[collection].pop(first_key)
         if collection not in self._data:
             self._data[collection] = {}
         self._data[collection][key] = val.copy()

--- a/llama-index-core/tests/embeddings/test_with_cache.py
+++ b/llama-index-core/tests/embeddings/test_with_cache.py
@@ -1,0 +1,44 @@
+import pytest
+from llama_index.core import MockEmbedding
+from llama_index.core.storage.kvstore import SimpleKVStore
+from typing import List, Any
+
+@pytest.fixture()
+def expected_embeddings() -> List[Any]:
+    return [[0.5, 0.5, 0.5, 0.5], [[0.5, 0.5, 0.5, 0.5]]]
+
+
+def test_sync_methods_with_cache(expected_embeddings: List[Any]):
+    kwargs_dict = {"embeddings_cache": SimpleKVStore()}
+    embed_model = MockEmbedding(embed_dim=4, **kwargs_dict)
+    text = "Hello"
+    texts = ["Hello"]
+    text_embedding = embed_model.get_text_embedding(text)
+    assert text_embedding == expected_embeddings[0]
+    assert embed_model.embeddings_cache.get(key="Hello", collection="embeddings") is not None
+    embd_dict = embed_model.embeddings_cache.get(key="Hello", collection="embeddings")
+    first_key = next(iter(embd_dict.keys()))
+    assert embd_dict[first_key] == expected_embeddings[0]
+    text_embeddings = embed_model.get_text_embedding_batch(texts)
+    assert text_embeddings == expected_embeddings[1]
+    embd_dict = embed_model.embeddings_cache.get(key="Hello", collection="embeddings")
+    first_key = next(iter(embd_dict.keys()))
+    assert embd_dict[first_key] == expected_embeddings[0]
+
+@pytest.mark.asyncio
+async def test_async_methods_with_cache(expected_embeddings: List[Any]):
+    kwargs_dict = {"embeddings_cache": SimpleKVStore()}
+    embed_model = MockEmbedding(embed_dim=4, **kwargs_dict)
+    text = "Hello"
+    texts = ["Hello"]
+    text_embedding = await embed_model.aget_text_embedding(text)
+    assert text_embedding == expected_embeddings[0]
+    assert embed_model.embeddings_cache.get(key="Hello", collection="embeddings") is not None
+    embd_dict = embed_model.embeddings_cache.get(key="Hello", collection="embeddings")
+    first_key = next(iter(embd_dict.keys()))
+    assert embd_dict[first_key] == expected_embeddings[0]
+    text_embeddings = await embed_model.aget_text_embedding_batch(texts)
+    assert text_embeddings == expected_embeddings[1]
+    embd_dict = embed_model.embeddings_cache.get(key="Hello", collection="embeddings")
+    first_key = next(iter(embd_dict.keys()))
+    assert embd_dict[first_key] == expected_embeddings[0]


### PR DESCRIPTION
# Description

Added a very simple implementation of an embeddings cache that:

- Extends the `BaseEmbedding` class with an `embeddings_cache`, that is a `SimpleKVStore`
- `SimpleKVStore `has now a maximum of data points that can be uploaded to it, to avoid the cache swamping the memory (since the cache is never cleared at runtime). 
-  The clearing of the cache when it overflows the max number of data points (default is 1000) follows a FIFO logic
- If caching is enabled, prior to the embedding we will have a search within the cache: the search within the cache **will not be semantic**, but it will be exact key-value match as the embeddings will be stored with the text to be embedded as the key and the embeddings vector as a the value. If there is a match within the cache, then the corresponding embeddings are returned, else we compute the embeddings, cache them and return them.

Example of a cache:

```json
{
   "embeddings": {
        "text-to-be-embedded": {
              "uuid": [0, 0, 1, 0.3]
         },
        "text-to-be-embedded-2": {
              "uuid": [0, 0, 1, 0.3]
         },
    }
}
```

Fixes #18849

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
