### PR TITLE
fix: McpToolSpec fetch all tools given the empty allowed_tools list

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -1,7 +1,70 @@
+import os
+import pytest
+
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
-from llama_index.tools.mcp import McpToolSpec
+from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
+
+# Path to the test server script - adjust as needed
+SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "server.py")
+
+
+@pytest.fixture(scope="session")
+def client() -> BasicMCPClient:
+    """Create a basic MCP client connected to the test server."""
+    return BasicMCPClient("python", args=[SERVER_SCRIPT], timeout=5)
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in McpToolSpec.__mro__]
     assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_get_tools(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client)
+    tools = tool_spec.to_tool_list()
+    assert len(tools) > 0
+
+    tool_spec = McpToolSpec(client, include_resources=True)
+    tools_plus_resources = tool_spec.to_tool_list()
+    assert len(tools_plus_resources) > len(tools)
+
+
+@pytest.mark.asyncio
+async def test_get_tools_async(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client)
+    tools = await tool_spec.to_tool_list_async()
+    assert len(tools) > 0
+
+    tool_spec = McpToolSpec(client, include_resources=True)
+    tools_plus_resources = await tool_spec.to_tool_list_async()
+    assert len(tools_plus_resources) > len(tools)
+
+
+def test_get_single_tool(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client, allowed_tools=["echo"])
+
+    tools = tool_spec.to_tool_list()
+    assert len(tools) == 1
+    assert tools[0].metadata.name == "echo"
+
+
+@pytest.mark.asyncio
+async def test_get_single_tool_async(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client, allowed_tools=["echo"])
+
+    tools = await tool_spec.to_tool_list_async()
+    assert len(tools) == 1
+    assert tools[0].metadata.name == "echo"
+
+
+def test_get_zero_tools(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client, allowed_tools=[])
+    tools = tool_spec.to_tool_list()
+    assert len(tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_zero_tools_async(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client, allowed_tools=[])
+    tools = await tool_spec.to_tool_list_async()
+    assert len(tools) == 0


### PR DESCRIPTION
# Description

Adjusted `McpToolSpec.fetch_tools()` method to handle empty `allowed_tools` filtering list. As a result, it returns an empty list of tools as no tools are allowed.

Fixes https://github.com/run-llama/llama_index/issues/18878 issue

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
