### PR TITLE
fix: Pass http_client & async_http_client to parent for OpenAILikeEmbedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/llama_index/embeddings/openai_like/base.py
@@ -91,6 +91,8 @@ class OpenAILikeEmbedding(OpenAIEmbedding):
             reuse_client=reuse_client,
             timeout=timeout,
             default_headers=default_headers,
+            http_client=http_client,
+            async_http_client=async_http_client,
             num_workers=num_workers,
             **kwargs,
         )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai-like/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-openai-like"
-version = "0.1.0"
+version = "0.1.1"
 description = "llama-index embeddings openai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

The current implementation of `OpenAILikeEmbedding` does not pass the `http_client` and `async_http_client` parameters to its parent upon instantiation, and thus these two parameters are not being honoured. This PR fixes this issue.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
