### PR TITLE
ci: fix debug logging

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ vars.RUNNER_DEBUG && '--debug' || '' }} test \
+            --repo-root ".." ${{ vars.RUNNER_DEBUG }} && '--debug' || '' test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref ${{ github.event.pull_request.base.ref }}
 
@@ -47,7 +47,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ env.ACTIONS_STEP_DEBUG == 'true' && '--debug' || '' }} test \
+            --repo-root ".." ${{ vars.RUNNER_DEBUG  }} && '--debug' || '' test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref=${{ github.event.pull_request.base.ref }} \
             --cov \

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -10,8 +10,6 @@ env:
   COV_FAIL_UNDER: 50
   # Which Python from the matrix will be used to run the coverage check
   COV_PYTHON_VERSION: 3.12
-  # Configure debug invocation
-  DEBUG_CMD: ${{ vars.RUNNER_DEBUG && '--debug' || '' }}
 
 jobs:
   test:
@@ -38,7 +36,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ env.DEBUG_CMD }} test \
+            --repo-root ".." ${{ runner.debug && '--debug' || '' }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref ${{ github.event.pull_request.base.ref }}
 
@@ -49,7 +47,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ env.DEBUG_CMD }} test \
+            --repo-root ".." ${{ runner.debug && '--debug' || '' }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref=${{ github.event.pull_request.base.ref }} \
             --cov \

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ env.ACTIONS_STEP_DEBUG == 'true' && '--debug' || '' }} test \
+            --repo-root ".." ${{ vars.RUNNER_DEBUG == '1' && '--debug' || '' }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref ${{ github.event.pull_request.base.ref }}
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -10,6 +10,8 @@ env:
   COV_FAIL_UNDER: 50
   # Which Python from the matrix will be used to run the coverage check
   COV_PYTHON_VERSION: 3.12
+  # Configure debug invocation
+  DEBUG_CMD: ${{ vars.RUNNER_DEBUG && '--debug' || '' }}
 
 jobs:
   test:
@@ -36,7 +38,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ vars.RUNNER_DEBUG }} && '--debug' || '' test \
+            --repo-root ".." ${{ env.DEBUG_CMD }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref ${{ github.event.pull_request.base.ref }}
 
@@ -47,7 +49,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ vars.RUNNER_DEBUG  }} && '--debug' || '' test \
+            --repo-root ".." ${{ env.DEBUG_CMD }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref=${{ github.event.pull_request.base.ref }} \
             --cov \

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
           uv run -- llama-dev \
-            --repo-root ".." ${{ vars.RUNNER_DEBUG == '1' && '--debug' || '' }} test \
+            --repo-root ".." ${{ vars.RUNNER_DEBUG && '--debug' || '' }} test \
             --workers ${{ env.NUM_WORKERS }} \
             --base-ref ${{ github.event.pull_request.base.ref }}
 


### PR DESCRIPTION
# Description

The current approach for enabling debug logging on `llama-dev` based on the global Github actions settings doesn't seem to work.

- With debug enabled: https://github.com/run-llama/llama_index/actions/runs/15303353416/job/43049784986?pr=18882#step:5:141
- Without debug enabled (default behaviour): https://github.com/run-llama/llama_index/actions/runs/15303353416/job/43049784235?pr=18882#step:4:4