### PR TITLE
Adding Resource to perform dependency injection in Workflows

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -604,12 +604,8 @@ class Context:
                 )
                 kwargs[service_definition.name] = service
             for resource in config.resources:
-                if resource.resource._cache:
-                    await resource.resource.call()
-                    kwargs[resource.name] = resource.resource._cached_value
-                else:
-                    resource_val = await resource.resource.call()
-                    kwargs[resource.name] = resource_val
+                resource_val = await resource.resource.call()
+                kwargs[resource.name] = resource_val
             kwargs[config.event_name] = ev
 
             # wrap the step with instrumentation

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import functools
 import json
 import time
@@ -604,7 +605,12 @@ class Context:
                 )
                 kwargs[service_definition.name] = service
             for resource in config.resources:
-                kwargs[resource.name] = resource.callable()
+                if not resource.initialized_resource:
+                    if inspect.iscoroutinefunction(resource.callable):
+                        resource.initialized_resource = await resource.callable()
+                    else:
+                        resource.initialized_resource = resource.callable()
+                kwargs[resource.name] = resource.initialized_resource
             kwargs[config.event_name] = ev
 
             # wrap the step with instrumentation

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -1,5 +1,4 @@
 import asyncio
-import inspect
 import functools
 import json
 import time
@@ -605,12 +604,12 @@ class Context:
                 )
                 kwargs[service_definition.name] = service
             for resource in config.resources:
-                if not resource.initialized_resource:
-                    if inspect.iscoroutinefunction(resource.callable):
-                        resource.initialized_resource = await resource.callable()
-                    else:
-                        resource.initialized_resource = resource.callable()
-                kwargs[resource.name] = resource.initialized_resource
+                if resource.resource._cache:
+                    await resource.resource.call()
+                    kwargs[resource.name] = resource.resource._cached_value
+                else:
+                    resource_val = await resource.resource.call()
+                    kwargs[resource.name] = resource_val
             kwargs[config.event_name] = ev
 
             # wrap the step with instrumentation

--- a/llama-index-core/llama_index/core/workflow/context.py
+++ b/llama-index-core/llama_index/core/workflow/context.py
@@ -39,9 +39,11 @@ if TYPE_CHECKING:  # pragma: no cover
 T = TypeVar("T", bound=Event)
 EventBuffer = Dict[str, List[Event]]
 
+
 # Only warn once about unserializable keys
 class UnserializableKeyWarning(Warning):
     pass
+
 
 warnings.simplefilter("once", UnserializableKeyWarning)
 
@@ -60,7 +62,7 @@ class Context:
 
     # These keys are set by pre-built workflows and
     # are known to be unserializable in some cases.
-    known_unserializable_keys = ("memory", )
+    known_unserializable_keys = ("memory",)
 
     def __init__(
         self,
@@ -601,6 +603,8 @@ class Context:
                     service_definition.name, service_definition.default_value
                 )
                 kwargs[service_definition.name] = service
+            for resource in config.resources:
+                kwargs[resource.name] = resource.callable()
             kwargs[config.event_name] = ev
 
             # wrap the step with instrumentation

--- a/llama-index-core/llama_index/core/workflow/decorators.py
+++ b/llama-index-core/llama_index/core/workflow/decorators.py
@@ -4,10 +4,11 @@ from llama_index.core.bridge.pydantic import BaseModel, ConfigDict
 
 from .errors import WorkflowValidationError
 from .utils import (
+    ResourceDefinition,
+    ServiceDefinition,
+    inspect_signature,
     is_free_function,
     validate_step_signature,
-    inspect_signature,
-    ServiceDefinition,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -25,6 +26,7 @@ class StepConfig(BaseModel):
     num_workers: int
     requested_services: List[ServiceDefinition]
     retry_policy: Optional[RetryPolicy]
+    resources: List[ResourceDefinition]
 
 
 def step(
@@ -71,6 +73,7 @@ def step(
             num_workers=num_workers,
             requested_services=spec.requested_services or [],
             retry_policy=retry_policy,
+            resources=spec.resources,
         )
 
         # If this is a free function, call add_step() explicitly.

--- a/llama-index-core/llama_index/core/workflow/types.py
+++ b/llama-index-core/llama_index/core/workflow/types.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar, Union
+from typing import Annotated, Any, Generic, TypeVar, Union
 
 from .events import StopEvent
 
@@ -6,3 +6,16 @@ StopEventT = TypeVar("StopEventT", bound=StopEvent)
 # TODO: When releasing 1.0, remove support for Any
 # and enforce usage of StopEventT
 RunResultT = Union[StopEventT, Any]
+
+T = TypeVar("T")
+
+
+class _ResourceMeta(Generic[T]):
+    def __class_getitem__(cls, item):
+        if not isinstance(item, tuple) or len(item) != 2:
+            raise TypeError("Resource must be used as Resource[type, factory_function]")
+        t_type, factory = item
+        return Annotated[t_type, factory]
+
+
+Resource = _ResourceMeta

--- a/llama-index-core/llama_index/core/workflow/types.py
+++ b/llama-index-core/llama_index/core/workflow/types.py
@@ -15,6 +15,8 @@ class _ResourceMeta(Generic[T]):
         if not(isinstance, tuple) or len(item) > 2:
             return TypeError("A resource should be defined as: Resource[type, factory]")
         type_t, factory = item
+        if not callable(factory):
+            raise TypeError(f"factory must be a callable, got {type(factory)}")
         return Annotated[type_t, factory]
 
 Resource = _ResourceMeta

--- a/llama-index-core/llama_index/core/workflow/types.py
+++ b/llama-index-core/llama_index/core/workflow/types.py
@@ -11,11 +11,10 @@ T = TypeVar("T")
 
 
 class _ResourceMeta(Generic[T]):
-    def __class_getitem__(cls, item):
-        if not isinstance(item, tuple) or len(item) != 2:
-            raise TypeError("Resource must be used as Resource[type, factory_function]")
-        t_type, factory = item
-        return Annotated[t_type, factory]
-
+    def __class_getitem__(cls, item: tuple) -> Annotated[Any, Any]:
+        if not(isinstance, tuple) or len(item) > 2:
+            return TypeError("A resource should be defined as: Resource[type, factory]")
+        type_t, factory = item
+        return Annotated[type_t, factory]
 
 Resource = _ResourceMeta

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -50,6 +50,7 @@ class ServiceDefinition(BaseModel):
 
 
 class ResourceDefinition(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str
     callable: Callable
     initialized_resource: Any = Field(

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -19,8 +19,9 @@ try:
 except ImportError:  # pragma: no cover
     from typing import Union as UnionType  # type: ignore[assignment]
 
-from llama_index.core.bridge.pydantic import BaseModel, ConfigDict, Field
+from llama_index.core.bridge.pydantic import BaseModel, ConfigDict
 
+from .types import _Resource
 from .errors import WorkflowValidationError
 from .events import Event, EventType
 
@@ -52,11 +53,7 @@ class ServiceDefinition(BaseModel):
 class ResourceDefinition(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str
-    callable: Callable
-    initialized_resource: Any = Field(
-        description="Initialized resource that would derive from callable()",
-        default = None,
-    )
+    resource: _Resource
 
 class StepSignatureSpec(BaseModel):
     """A Pydantic model representing the signature of a step function or method."""
@@ -105,11 +102,11 @@ def inspect_signature(fn: Callable) -> StepSignatureSpec:
 
         annotation = type_hints.get(name, t.annotation)
         if get_origin(annotation) is Annotated:
-            base_type, factory = get_args(annotation)
+            base_type, resource = get_args(annotation)
             resources.append(
                 ResourceDefinition(
                     name=name,
-                    callable=factory,
+                    resource = resource,
                 )
             )
             continue

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -112,7 +112,6 @@ def inspect_signature(fn: Callable) -> StepSignatureSpec:
                     callable=factory,
                 )
             )
-            print(f"Base type: {base_type}, Factory: {factory}")
             continue
 
         # Get name and type of the Context param

--- a/llama-index-core/llama_index/core/workflow/utils.py
+++ b/llama-index-core/llama_index/core/workflow/utils.py
@@ -19,7 +19,7 @@ try:
 except ImportError:  # pragma: no cover
     from typing import Union as UnionType  # type: ignore[assignment]
 
-from llama_index.core.bridge.pydantic import BaseModel, ConfigDict
+from llama_index.core.bridge.pydantic import BaseModel, ConfigDict, Field
 
 from .errors import WorkflowValidationError
 from .events import Event, EventType
@@ -50,10 +50,12 @@ class ServiceDefinition(BaseModel):
 
 
 class ResourceDefinition(BaseModel):
-    model_config = ConfigDict(frozen=True)
     name: str
     callable: Callable
-
+    initialized_resource: Any = Field(
+        description="Initialized resource that would derive from callable()",
+        default = None,
+    )
 
 class StepSignatureSpec(BaseModel):
     """A Pydantic model representing the signature of a step function or method."""

--- a/llama-index-core/tests/workflow/test_types.py
+++ b/llama-index-core/tests/workflow/test_types.py
@@ -1,27 +1,136 @@
-import queue
-
 import pytest
+import random
+from typing import List, Optional
 from llama_index.core.workflow.decorators import step
-from llama_index.core.workflow.events import StartEvent, StopEvent
+from pydantic import Field, BaseModel
+from llama_index.core.workflow.events import StartEvent, StopEvent, Event
 from llama_index.core.workflow.types import Resource
 from llama_index.core.workflow.workflow import Workflow
+from llama_index.core.memory import Memory
+from llama_index.core.llms import ChatMessage, MockLLM
 
+class SecondEvent(Event):
+    msg: str = Field(
+        description="A message"
+    )
+
+class ThirdEvent(Event):
+    msg: str = Field(
+        description="A message"
+    )
+
+class MessageHistory(BaseModel):
+    messages: List[ChatMessage] = Field(
+        default_factory=list,
+        description="Messages",
+    )
+    def put(self, message: ChatMessage):
+        self.messages.append(message)
+    def get(self):
+        return self.messages
+
+class MessageStopEvent(StopEvent):
+    llm_response: Optional[str] = Field(
+        default=None
+    )
 
 @pytest.mark.asyncio
 async def test_resource():
-    q = queue.Queue()
 
-    def get_memory(*args, **kwargs) -> queue.Queue:
-        return q
+    def get_memory(*args, **kwargs) -> Memory:
+        return Memory.from_defaults("user_id_123", token_limit=60000)
 
     class TestWorkflow(Workflow):
         @step
-        def f1(
-            self, ev: StartEvent, memory: Resource[queue.Queue, get_memory]
-        ) -> StopEvent:
-            memory.put("test data")
+        def start_step(
+            self, ev: StartEvent
+        ) -> SecondEvent:
+            print("Start step is done", flush=True)
+            return SecondEvent(msg="Hello")
+        @step
+        def second_step(
+            self, ev: SecondEvent
+        ) -> ThirdEvent | StopEvent:
+            if ev.msg == "Hello":
+                return ThirdEvent(msg="Hello 2")
             return StopEvent()
+        @step
+        def f1(
+            self, ev: ThirdEvent, memory: Resource[Memory, get_memory]
+        ) -> SecondEvent:
+            global m
+            memory.put(ChatMessage.from_str(role="user", content=ev.msg))
+            m = memory
+            if random.randint(0,1) == 0:
+                return SecondEvent(msg="Hello")
+            else:
+                return SecondEvent(msg="Hello 3")
 
     wf = TestWorkflow(disable_validation=True)
     await wf.run()
-    assert q.get() == "test data"
+    mem = m.get()
+    assert len(mem) >= 1
+    assert all(el.blocks[0].text=="Hello 2" for el in mem)
+
+@pytest.mark.asyncio
+async def test_resource_async():
+
+    async def hello_world():
+        return "Hello world!"
+
+    async def create_message_history(*args, **kwargs) -> MessageHistory:
+        first_message = await hello_world()
+        return MessageHistory(messages=[ChatMessage.from_str(content=first_message, role="user")])
+
+    class TestWorkflow(Workflow):
+        @step
+        def start_step(
+            self, ev: StartEvent
+        ) -> SecondEvent:
+            print("Start step is done", flush=True)
+            return SecondEvent(msg="Hello")
+        @step
+        def second_step(
+            self, ev: SecondEvent
+        ) -> ThirdEvent | StopEvent:
+            if ev.msg == "Hello":
+                return ThirdEvent(msg="Hello world!")
+            return StopEvent()
+        @step
+        def f1(
+            self, ev: ThirdEvent, history: Resource[MessageHistory, create_message_history]
+        ) -> SecondEvent:
+            global m
+            history.put(ChatMessage.from_str(role="user", content=ev.msg))
+            m = history
+            if random.randint(0,1) == 0:
+                return SecondEvent(msg="Hello")
+            else:
+                return SecondEvent(msg="Hello back!")
+
+    wf = TestWorkflow(disable_validation=True)
+    await wf.run()
+    mem = m.get()
+    assert len(mem) >= 2
+    assert all(el.blocks[0].text=="Hello world!" for el in mem)
+
+@pytest.mark.asyncio
+async def test_resource_with_llm():
+
+    def get_llm(*args, **kwargs) -> MockLLM:
+        return MockLLM()
+
+    class TestWorkflow(Workflow):
+        @step
+        def test_step(
+            self, ev: StartEvent, llm: Resource[MockLLM, get_llm]
+        ) -> MessageStopEvent:
+            response = llm.complete("Hey there, who are you?")
+            res = response.text or None
+            return MessageStopEvent(llm_response=res)
+
+    wf = TestWorkflow(disable_validation=True)
+    handler = await wf.run()
+    response = handler.llm_response
+    assert response is not None
+    assert isinstance(response, str)

--- a/llama-index-core/tests/workflow/test_types.py
+++ b/llama-index-core/tests/workflow/test_types.py
@@ -1,67 +1,66 @@
-import pytest
 import random
-from typing import List, Optional
+from typing import Annotated, List, Optional
+
+import pytest
+from llama_index.core.llms import ChatMessage, MockLLM
+from llama_index.core.memory import Memory
 from llama_index.core.workflow.decorators import step
-from pydantic import Field, BaseModel
-from llama_index.core.workflow.events import StartEvent, StopEvent, Event
+from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.core.workflow.types import Resource
 from llama_index.core.workflow.workflow import Workflow
-from llama_index.core.memory import Memory
-from llama_index.core.llms import ChatMessage, MockLLM
+from pydantic import BaseModel, Field
+
 
 class SecondEvent(Event):
-    msg: str = Field(
-        description="A message"
-    )
+    msg: str = Field(description="A message")
+
 
 class ThirdEvent(Event):
-    msg: str = Field(
-        description="A message"
-    )
+    msg: str = Field(description="A message")
+
 
 class MessageHistory(BaseModel):
     messages: List[ChatMessage] = Field(
         default_factory=list,
         description="Messages",
     )
+
     def put(self, message: ChatMessage):
         self.messages.append(message)
+
     def get(self):
         return self.messages
 
+
 class MessageStopEvent(StopEvent):
-    llm_response: Optional[str] = Field(
-        default=None
-    )
+    llm_response: Optional[str] = Field(default=None)
+
 
 @pytest.mark.asyncio
 async def test_resource():
+    m = Memory.from_defaults("user_id_123", token_limit=60000)
 
     def get_memory(*args, **kwargs) -> Memory:
-        return Memory.from_defaults("user_id_123", token_limit=60000)
+        return m
 
     class TestWorkflow(Workflow):
         @step
-        def start_step(
-            self, ev: StartEvent
-        ) -> SecondEvent:
+        def start_step(self, ev: StartEvent) -> SecondEvent:
             print("Start step is done", flush=True)
             return SecondEvent(msg="Hello")
+
         @step
-        def second_step(
-            self, ev: SecondEvent
-        ) -> ThirdEvent | StopEvent:
+        def second_step(self, ev: SecondEvent) -> ThirdEvent | StopEvent:
             if ev.msg == "Hello":
                 return ThirdEvent(msg="Hello 2")
             return StopEvent()
+
         @step
         def f1(
-            self, ev: ThirdEvent, memory: Resource[Memory, get_memory]
+            self, ev: ThirdEvent, memory: Annotated[Memory, Resource(get_memory)]
         ) -> SecondEvent:
-            global m
             memory.put(ChatMessage.from_str(role="user", content=ev.msg))
-            m = memory
-            if random.randint(0,1) == 0:
+            if random.randint(0, 1) == 0:
                 return SecondEvent(msg="Hello")
             else:
                 return SecondEvent(msg="Hello 3")
@@ -70,40 +69,42 @@ async def test_resource():
     await wf.run()
     mem = m.get()
     assert len(mem) >= 1
-    assert all(el.blocks[0].text=="Hello 2" for el in mem)
+    assert all(el.blocks[0].text == "Hello 2" for el in mem)
+
 
 @pytest.mark.asyncio
 async def test_resource_async():
-
     async def hello_world():
         return "Hello world!"
 
     async def create_message_history(*args, **kwargs) -> MessageHistory:
         first_message = await hello_world()
-        return MessageHistory(messages=[ChatMessage.from_str(content=first_message, role="user")])
+        return MessageHistory(
+            messages=[ChatMessage.from_str(content=first_message, role="user")]
+        )
 
     class TestWorkflow(Workflow):
         @step
-        def start_step(
-            self, ev: StartEvent
-        ) -> SecondEvent:
+        def start_step(self, ev: StartEvent) -> SecondEvent:
             print("Start step is done", flush=True)
             return SecondEvent(msg="Hello")
+
         @step
-        def second_step(
-            self, ev: SecondEvent
-        ) -> ThirdEvent | StopEvent:
+        def second_step(self, ev: SecondEvent) -> ThirdEvent | StopEvent:
             if ev.msg == "Hello":
                 return ThirdEvent(msg="Hello world!")
             return StopEvent()
+
         @step
         def f1(
-            self, ev: ThirdEvent, history: Resource[MessageHistory, create_message_history]
+            self,
+            ev: ThirdEvent,
+            history: Annotated[MessageHistory, create_message_history],
         ) -> SecondEvent:
             global m
             history.put(ChatMessage.from_str(role="user", content=ev.msg))
             m = history
-            if random.randint(0,1) == 0:
+            if random.randint(0, 1) == 0:
                 return SecondEvent(msg="Hello")
             else:
                 return SecondEvent(msg="Hello back!")
@@ -112,18 +113,18 @@ async def test_resource_async():
     await wf.run()
     mem = m.get()
     assert len(mem) >= 2
-    assert all(el.blocks[0].text=="Hello world!" for el in mem)
+    assert all(el.blocks[0].text == "Hello world!" for el in mem)
+
 
 @pytest.mark.asyncio
 async def test_resource_with_llm():
-
     def get_llm(*args, **kwargs) -> MockLLM:
         return MockLLM()
 
     class TestWorkflow(Workflow):
         @step
         def test_step(
-            self, ev: StartEvent, llm: Resource[MockLLM, get_llm]
+            self, ev: StartEvent, llm: Annotated[MockLLM, get_llm]
         ) -> MessageStopEvent:
             response = llm.complete("Hey there, who are you?")
             res = response.text or None

--- a/llama-index-core/tests/workflow/test_types.py
+++ b/llama-index-core/tests/workflow/test_types.py
@@ -99,7 +99,7 @@ async def test_resource_async():
         def f1(
             self,
             ev: ThirdEvent,
-            history: Annotated[MessageHistory, create_message_history],
+            history: Annotated[MessageHistory, Resource(create_message_history)],
         ) -> SecondEvent:
             global m
             history.put(ChatMessage.from_str(role="user", content=ev.msg))
@@ -124,7 +124,7 @@ async def test_resource_with_llm():
     class TestWorkflow(Workflow):
         @step
         def test_step(
-            self, ev: StartEvent, llm: Annotated[MockLLM, get_llm]
+            self, ev: StartEvent, llm: Annotated[MockLLM, Resource(get_llm, cache=False)]
         ) -> MessageStopEvent:
             response = llm.complete("Hey there, who are you?")
             res = response.text or None

--- a/llama-index-core/tests/workflow/test_types.py
+++ b/llama-index-core/tests/workflow/test_types.py
@@ -1,0 +1,27 @@
+import queue
+
+import pytest
+from llama_index.core.workflow.decorators import step
+from llama_index.core.workflow.events import StartEvent, StopEvent
+from llama_index.core.workflow.types import Resource
+from llama_index.core.workflow.workflow import Workflow
+
+
+@pytest.mark.asyncio
+async def test_resource():
+    q = queue.Queue()
+
+    def get_memory(*args, **kwargs) -> queue.Queue:
+        return q
+
+    class TestWorkflow(Workflow):
+        @step
+        def f1(
+            self, ev: StartEvent, memory: Resource[queue.Queue, get_memory]
+        ) -> StopEvent:
+            memory.put("test data")
+            return StopEvent()
+
+    wf = TestWorkflow(disable_validation=True)
+    await wf.run()
+    assert q.get() == "test data"


### PR DESCRIPTION
# Description

Adding `Resource`, a way to expose certain kind of resources (memory, chat history, LLM...) to workflow steps through FastAPI-style dependency injection.

Usage example:

```python
def get_llm(*args, **kwargs) -> MockLLM:
        return MockLLM()

class MessageStopEvent(StopEvent):
    llm_response: Optional[str] = Field(default=None)

class TestWorkflow(Workflow):
    @step
    def test_step(
        self, ev: StartEvent, llm: Annotated[MockLLM, Resource(get_llm, cache=False)]
     ) -> MessageStopEvent:
        response = llm.complete("Hey there, who are you?")
        res = response.text or None
        return MessageStopEvent(llm_response=res)
```
