### PR TITLE
Add MutableMappingKVStore

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/simple_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/simple_docstore.py
@@ -10,7 +10,7 @@ from llama_index.core.storage.docstore.types import (
     DEFAULT_PERSIST_PATH,
 )
 from llama_index.core.storage.kvstore.simple_kvstore import SimpleKVStore
-from llama_index.core.storage.kvstore.types import MutableMappingKVStore
+from llama_index.core.storage.kvstore.types import MutableMappingKVStore, BaseInMemoryKVStore
 from llama_index.core.utils import concat_dirs
 
 
@@ -71,7 +71,8 @@ class SimpleDocumentStore(KVDocumentStore):
         Args:
             persist_path (str): Path to persist the store
             namespace (Optional[str]): namespace for the docstore
-            fs (Optional[fsspec.AbstractFileSystem]): filesystem to use
+            fs (
+            Optional[fsspec.AbstractFileSystem]): filesystem to use
 
         """
         simple_kvstore = SimpleKVStore.from_persist_path(persist_path, fs=fs)
@@ -83,7 +84,7 @@ class SimpleDocumentStore(KVDocumentStore):
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Persist the store."""
-        if isinstance(self._kvstore, MutableMappingKVStore):
+        if isinstance(self._kvstore, (MutableMappingKVStore, BaseInMemoryKVStore)):
             self._kvstore.persist(persist_path, fs=fs)
 
     @classmethod

--- a/llama-index-core/llama_index/core/storage/docstore/simple_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/simple_docstore.py
@@ -10,7 +10,7 @@ from llama_index.core.storage.docstore.types import (
     DEFAULT_PERSIST_PATH,
 )
 from llama_index.core.storage.kvstore.simple_kvstore import SimpleKVStore
-from llama_index.core.storage.kvstore.types import BaseInMemoryKVStore
+from llama_index.core.storage.kvstore.types import MutableMappingKVStore
 from llama_index.core.utils import concat_dirs
 
 
@@ -83,7 +83,7 @@ class SimpleDocumentStore(KVDocumentStore):
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Persist the store."""
-        if isinstance(self._kvstore, BaseInMemoryKVStore):
+        if isinstance(self._kvstore, MutableMappingKVStore):
             self._kvstore.persist(persist_path, fs=fs)
 
     @classmethod

--- a/llama-index-core/llama_index/core/storage/index_store/simple_index_store.py
+++ b/llama-index-core/llama_index/core/storage/index_store/simple_index_store.py
@@ -9,7 +9,7 @@ from llama_index.core.storage.index_store.types import (
     DEFAULT_PERSIST_PATH,
 )
 from llama_index.core.storage.kvstore.simple_kvstore import SimpleKVStore
-from llama_index.core.storage.kvstore.types import BaseInMemoryKVStore
+from llama_index.core.storage.kvstore.types import MutableMappingKVStore
 from llama_index.core.utils import concat_dirs
 
 
@@ -60,7 +60,7 @@ class SimpleIndexStore(KVIndexStore):
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Persist the store."""
-        if isinstance(self._kvstore, BaseInMemoryKVStore):
+        if isinstance(self._kvstore, MutableMappingKVStore):
             self._kvstore.persist(persist_path, fs=fs)
 
     @classmethod

--- a/llama-index-core/llama_index/core/storage/index_store/simple_index_store.py
+++ b/llama-index-core/llama_index/core/storage/index_store/simple_index_store.py
@@ -9,7 +9,10 @@ from llama_index.core.storage.index_store.types import (
     DEFAULT_PERSIST_PATH,
 )
 from llama_index.core.storage.kvstore.simple_kvstore import SimpleKVStore
-from llama_index.core.storage.kvstore.types import MutableMappingKVStore
+from llama_index.core.storage.kvstore.types import (
+    MutableMappingKVStore,
+    BaseInMemoryKVStore,
+)
 from llama_index.core.utils import concat_dirs
 
 
@@ -60,7 +63,7 @@ class SimpleIndexStore(KVIndexStore):
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> None:
         """Persist the store."""
-        if isinstance(self._kvstore, MutableMappingKVStore):
+        if isinstance(self._kvstore, (MutableMappingKVStore, BaseInMemoryKVStore)):
             self._kvstore.persist(persist_path, fs=fs)
 
     @classmethod

--- a/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
@@ -51,6 +51,7 @@ class SimpleKVStore(MutableMappingKVStore[dict]):
         """Load a SimpleKVStore from a persist path and filesystem."""
         fs = fs or fsspec.filesystem("file")
         logger.debug(f"Loading {__name__} from {persist_path}.")
+        print(f"Loading {__name__} from {persist_path}.")
         with fs.open(persist_path, "rb") as f:
             data = json.load(f)
         return cls(data)

--- a/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
@@ -5,8 +5,8 @@ from typing import Dict, Optional
 
 import fsspec
 from llama_index.core.storage.kvstore.types import (
-    DEFAULT_COLLECTION,
     BaseInMemoryKVStore,
+    MutableMappingKVStore,
 )
 
 logger = logging.getLogger(__name__)
@@ -14,14 +14,12 @@ logger = logging.getLogger(__name__)
 DATA_TYPE = Dict[str, Dict[str, dict]]
 
 
-class SimpleKVStore(BaseInMemoryKVStore):
+class SimpleKVStore(MutableMappingKVStore[dict], BaseInMemoryKVStore):
     """
     Simple in-memory Key-Value store.
 
     Args:
         data (Optional[DATA_TYPE]): data to initialize the store with
-        maximum_data_points (Optional[int]): maximum number of data points that can be stored within a collection in the KVStore
-        size_strict (Optional[bool]): whether to throw an error or not when the maximum size is exceeded
 
     """
 
@@ -30,54 +28,10 @@ class SimpleKVStore(BaseInMemoryKVStore):
         data: Optional[DATA_TYPE] = None,
     ) -> None:
         """Init a SimpleKVStore."""
-        self._data: DATA_TYPE = data or {}
+        super().__init__(mapping_factory=dict)
 
-    def put(self, key: str, val: dict, collection: str = DEFAULT_COLLECTION) -> None:
-        """Put a key-value pair into the store."""
-        if collection not in self._data:
-            self._data[collection] = {}
-        self._data[collection][key] = val.copy()
-
-    async def aput(
-        self, key: str, val: dict, collection: str = DEFAULT_COLLECTION
-    ) -> None:
-        """Put a key-value pair into the store."""
-        self.put(key, val, collection)
-
-    def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:
-        """Get a value from the store."""
-        collection_data = self._data.get(collection, None)
-        if not collection_data:
-            return None
-        if key not in collection_data:
-            return None
-        return collection_data[key].copy()
-
-    async def aget(
-        self, key: str, collection: str = DEFAULT_COLLECTION
-    ) -> Optional[dict]:
-        """Get a value from the store."""
-        return self.get(key, collection)
-
-    def get_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
-        """Get all values from the store."""
-        return self._data.get(collection, {}).copy()
-
-    async def aget_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
-        """Get all values from the store."""
-        return self.get_all(collection)
-
-    def delete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
-        """Delete a value from the store."""
-        try:
-            self._data[collection].pop(key)
-            return True
-        except KeyError:
-            return False
-
-    async def adelete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
-        """Delete a value from the store."""
-        return self.delete(key, collection)
+        if data is not None:
+            self._collections_mappings = data.copy()
 
     def persist(
         self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
@@ -89,7 +43,7 @@ class SimpleKVStore(BaseInMemoryKVStore):
             fs.makedirs(dirpath)
 
         with fs.open(persist_path, "w") as f:
-            f.write(json.dumps(self._data))
+            f.write(json.dumps(self._collections_mappings))
 
     @classmethod
     def from_persist_path(
@@ -104,7 +58,7 @@ class SimpleKVStore(BaseInMemoryKVStore):
 
     def to_dict(self) -> dict:
         """Save the store as dict."""
-        return self._data
+        return self._collections_mappings.copy()
 
     @classmethod
     def from_dict(cls, save_dict: dict) -> "SimpleKVStore":

--- a/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
@@ -5,7 +5,6 @@ from typing import Dict, Optional
 
 import fsspec
 from llama_index.core.storage.kvstore.types import (
-    BaseInMemoryKVStore,
     MutableMappingKVStore,
 )
 
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 DATA_TYPE = Dict[str, Dict[str, dict]]
 
 
-class SimpleKVStore(MutableMappingKVStore[dict], BaseInMemoryKVStore):
+class SimpleKVStore(MutableMappingKVStore[dict]):
     """
     Simple in-memory Key-Value store.
 

--- a/llama-index-core/llama_index/core/storage/kvstore/types.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/types.py
@@ -106,13 +106,13 @@ class MutableMappingKVStore(Generic[MutableMappingT], BaseKVStore):
         self._collections_mappings: Dict[str, MutableMappingT] = {}
         self._mapping_factory = mapping_factory
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         state = self.__dict__.copy()
         state["factory_fn"] = {"fn": self._mapping_factory}
         del state["_mapping_factory"]
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict) -> None:
         self._collections_mappings = state["_collections_mappings"]
         self._mapping_factory = state["factory_fn"]["fn"]
 

--- a/llama-index-core/llama_index/core/storage/kvstore/types.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/types.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from collections.abc import MutableMapping, Callable
+from typing import Dict, List, Optional, Tuple, TypeVar, Generic
 
 import fsspec
 
@@ -86,3 +87,71 @@ class BaseInMemoryKVStore(BaseKVStore):
     @abstractmethod
     def from_persist_path(cls, persist_path: str) -> "BaseInMemoryKVStore":
         """Create a BaseInMemoryKVStore from a persist directory."""
+
+
+MutableMappingT = TypeVar("MutableMappingT", bound=MutableMapping[str, dict])
+
+
+class MutableMappingKVStore(BaseKVStore, Generic[MutableMappingT]):
+    """
+    MutableMapping Key-Value store.
+
+    Args:
+        mapping_factory (Callable[[], MutableMapping[str, dict]): the mutable mapping factory
+
+    """
+
+    def __init__(self, mapping_factory: Callable[[], MutableMappingT]) -> None:
+        """Initialize a MutableMappingKVStore."""
+        self._collections_mappings = {}
+        self._mapping_factory = mapping_factory
+
+    def _get_collection_mapping(self, collection: str) -> MutableMappingT:
+        """Get a collection mapping. Create one if it does not exist."""
+        if collection not in self._collections_mappings:
+            self._collections_mappings[collection] = self._mapping_factory()
+        return self._collections_mappings[collection]
+
+    def put(self, key: str, val: dict, collection: str = DEFAULT_COLLECTION) -> None:
+        """Put a key-value pair into the store."""
+        self._get_collection_mapping(collection)[key] = val.copy()
+
+    async def aput(
+        self, key: str, val: dict, collection: str = DEFAULT_COLLECTION
+    ) -> None:
+        """Put a key-value pair into the store."""
+        self.put(key, val, collection=collection)
+
+    def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> Optional[dict]:
+        """Get a value from the store."""
+        mapping = self._get_collection_mapping(collection)
+
+        if key not in mapping:
+            return None
+        return mapping[key].copy()
+
+    async def aget(
+        self, key: str, collection: str = DEFAULT_COLLECTION
+    ) -> Optional[dict]:
+        """Get a value from the store."""
+        return self.get(key, collection=collection)
+
+    def get_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
+        """Get all values from the store."""
+        return dict(self._get_collection_mapping(collection))
+
+    async def aget_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
+        """Get all values from the store."""
+        return self.get_all(collection=collection)
+
+    def delete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
+        """Delete a value from the store."""
+        try:
+            self._get_collection_mapping(collection).pop(key)
+            return True
+        except KeyError:
+            return False
+
+    async def adelete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
+        """Delete a value from the store."""
+        return self.delete(key, collection=collection)

--- a/llama-index-core/llama_index/core/storage/kvstore/types.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/types.py
@@ -92,7 +92,7 @@ class BaseInMemoryKVStore(BaseKVStore):
 MutableMappingT = TypeVar("MutableMappingT", bound=MutableMapping[str, dict])
 
 
-class MutableMappingKVStore(BaseKVStore, Generic[MutableMappingT]):
+class MutableMappingKVStore(Generic[MutableMappingT], BaseKVStore):
     """
     MutableMapping Key-Value store.
 
@@ -103,7 +103,7 @@ class MutableMappingKVStore(BaseKVStore, Generic[MutableMappingT]):
 
     def __init__(self, mapping_factory: Callable[[], MutableMappingT]) -> None:
         """Initialize a MutableMappingKVStore."""
-        self._collections_mappings = {}
+        self._collections_mappings: Dict[str, MutableMappingT] = {}
         self._mapping_factory = mapping_factory
 
     def _get_collection_mapping(self, collection: str) -> MutableMappingT:

--- a/llama-index-core/llama_index/core/storage/kvstore/types.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/types.py
@@ -155,3 +155,14 @@ class MutableMappingKVStore(Generic[MutableMappingT], BaseKVStore):
     async def adelete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
         """Delete a value from the store."""
         return self.delete(key, collection=collection)
+
+    @abstractmethod
+    def persist(
+        self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
+    ) -> None:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_persist_path(cls, persist_path: str) -> "MutableMappingKVStore":
+        """Create a MutableMappingKVStore from a persist directory."""

--- a/llama-index-core/llama_index/core/storage/kvstore/types.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/types.py
@@ -156,13 +156,18 @@ class MutableMappingKVStore(Generic[MutableMappingT], BaseKVStore):
         """Delete a value from the store."""
         return self.delete(key, collection=collection)
 
-    @abstractmethod
+    # this method is here to avoid TypeChecker shows an error
     def persist(
         self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
     ) -> None:
-        pass
+        """Persist the store."""
+        raise NotImplementedError(
+            "Use subclasses of MutableMappingKVStore (such as SimpleKVStore) to call this method"
+        )
 
-    @classmethod
-    @abstractmethod
+    # this method is here to avoid TypeChecker shows an error
     def from_persist_path(cls, persist_path: str) -> "MutableMappingKVStore":
         """Create a MutableMappingKVStore from a persist directory."""
+        raise NotImplementedError(
+            "Use subclasses of MutableMappingKVStore (such as SimpleKVStore) to call this method"
+        )

--- a/llama-index-core/llama_index/core/storage/kvstore/types.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/types.py
@@ -106,6 +106,16 @@ class MutableMappingKVStore(Generic[MutableMappingT], BaseKVStore):
         self._collections_mappings: Dict[str, MutableMappingT] = {}
         self._mapping_factory = mapping_factory
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["factory_fn"] = {"fn": self._mapping_factory}
+        del state["_mapping_factory"]
+        return state
+
+    def __setstate__(self, state):
+        self._collections_mappings = state["_collections_mappings"]
+        self._mapping_factory = state["factory_fn"]["fn"]
+
     def _get_collection_mapping(self, collection: str) -> MutableMappingT:
         """Get a collection mapping. Create one if it does not exist."""
         if collection not in self._collections_mappings:

--- a/llama-index-core/tests/node_parser/sentence_window.py
+++ b/llama-index-core/tests/node_parser/sentence_window.py
@@ -12,12 +12,12 @@ def test_split_and_window() -> None:
     nodes = node_parser.get_nodes_from_documents([document])
 
     assert len(nodes) == 3
-    assert nodes[0].get_content() == "This is a test 1."
-    assert nodes[1].get_content() == "This is a test 2."
+    assert nodes[0].get_content() == "This is a test 1. "
+    assert nodes[1].get_content() == "This is a test 2. "
     assert nodes[2].get_content() == "This is a test 3."
 
     assert (
-        " ".join(nodes[0].metadata["window"])
-        == "This is a test 1. This is a test 2. Thius is a test 3."
+        "".join(nodes[0].metadata["window"])
+        == "This is a test 1.  This is a test 2.  This is a test 3."
     )
-    assert nodes[0].metadata["original_text"] == "This is a test 1."
+    assert nodes[0].metadata["original_text"] == "This is a test 1. "

--- a/llama-index-core/tests/storage/kvstore/test_mutable_mapping_kvstore.py
+++ b/llama-index-core/tests/storage/kvstore/test_mutable_mapping_kvstore.py
@@ -1,0 +1,37 @@
+import pytest
+
+from llama_index.core.storage.kvstore.types import MutableMappingKVStore
+from llama_index.core.storage.kvstore.simple_kvstore import SimpleKVStore
+
+
+def test_simple_kvstore():
+    kv_store = SimpleKVStore()
+    assert isinstance(kv_store, MutableMappingKVStore)
+    kv_store.put(key="foo", val={"foo": "bar"})
+    assert kv_store.get_all() == {"foo": {"foo": "bar"}}
+
+
+def test_sync_methods():
+    mut_mapping = MutableMappingKVStore(dict)
+    mut_mapping.put(key="foo", val={"foo": "bar"})
+    assert mut_mapping.get("foo") == {"foo": "bar"}
+    assert mut_mapping.get("bar") is None
+    mut_mapping.put(key="bar", val={"bar": "foo"})
+    assert mut_mapping.get_all() == {"foo": {"foo": "bar"}, "bar": {"bar": "foo"}}
+    mut_mapping.delete(key="bar")
+    assert mut_mapping.get_all() == {"foo": {"foo": "bar"}}
+
+
+@pytest.mark.asyncio
+async def test_async_methods():
+    mut_mapping = MutableMappingKVStore(dict)
+    await mut_mapping.aput(key="foo", val={"foo": "bar"})
+    assert await mut_mapping.aget("foo") == {"foo": "bar"}
+    assert await mut_mapping.aget("bar") is None
+    await mut_mapping.aput(key="bar", val={"bar": "foo"})
+    assert await mut_mapping.aget_all() == {
+        "foo": {"foo": "bar"},
+        "bar": {"bar": "foo"},
+    }
+    await mut_mapping.adelete(key="bar")
+    assert await mut_mapping.aget_all() == {"foo": {"foo": "bar"}}


### PR DESCRIPTION
# Description

Following the discussion in #18883 regarding the integration of a `KVStore` for cachetools, I propose an alternative solution that is more generic than the one previously proposed. A new `MutableMappingKVStore` class has been added to the core package, which wraps generic MutableMapping collections and implements basic operations such as `get`, `put`, and `delete`. This makes it much simpler to create new KV stores using different underlying storage systems.

For example:

```python
# Create a dictionary store
dict_store = MutableMappingKVStore(mapping_factory=dict)

# Create a cache with cachetools
cache_store = MutableMappingKVStore(mapping_factory=lambda: cachetools.LRUCache(maxsize=2))

# Create a cache with redis
redis_cache_store = MutableMappingKVStore(mapping_factory=lambda: CacheToolsUtils.RedisCache(redis.Redis(host="localhost")))
```

The `SimpleKVStore` now inherits from both `MutableMappingKVStore[dict]` and `BaseInMemoryKVStore`, making the changes non-breaking.


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
