### PR TITLE
make prefix and response non-required for hitl events

### DIFF
--- a/llama-index-core/llama_index/core/workflow/events.py
+++ b/llama-index-core/llama_index/core/workflow/events.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Type
 from llama_index.core.bridge.pydantic import (
     BaseModel,
     ConfigDict,
-    Field,
     PrivateAttr,
     model_serializer,
 )
@@ -165,15 +164,9 @@ class StopEvent(Event):
 class InputRequiredEvent(Event):
     """InputRequiredEvent is sent when an input is required for a step."""
 
-    prefix: str = Field(
-        description="The prefix and description of the input that is required."
-    )
-
 
 class HumanResponseEvent(Event):
     """HumanResponseEvent is sent when a human response is required for a step."""
-
-    response: str = Field(description="The response from the human.")
 
 
 EventType = Type[Event]


### PR DESCRIPTION
This (should be) a non-breaking change to remove the required fields on InputRequiredEvent and HumanResponseEvent

Since the base event class already does arbitrary attribute storage, and serializes those attributes, this will be non-breaking (and likely only affect type-checkers)