### PR TITLE
feat: add OpenAI JSON Schema structured output support

### DIFF
--- a/llama-index-core/llama_index/core/program/streaming_utils.py
+++ b/llama-index-core/llama_index/core/program/streaming_utils.py
@@ -1,0 +1,159 @@
+"""
+Simplified streaming utilities for processing structured outputs from message content.
+
+This module provides utilities for processing streaming responses that contain
+structured data directly in the message content (not in function calls).
+"""
+
+from typing import Optional, Type, Union
+
+from pydantic import ValidationError
+
+from llama_index.core.base.llms.types import ChatResponse
+from llama_index.core.program.utils import (
+    FlexibleModel,
+    _repair_incomplete_json,
+    create_flexible_model,
+)
+from llama_index.core.types import Model
+
+
+def process_streaming_content_incremental(
+    chat_response: ChatResponse,
+    output_cls: Type[Model],
+    cur_object: Optional[Union[Model, FlexibleModel]] = None,
+) -> Union[Model, FlexibleModel]:
+    """
+    Process streaming response content with true incremental list handling.
+
+    This version can extract partial progress from incomplete JSON and build
+    lists incrementally (e.g., 1 joke → 2 jokes → 3 jokes) rather than
+    jumping from empty to complete lists.
+
+    Args:
+        chat_response (ChatResponse): The chat response to process
+        output_cls (Type[BaseModel]): The target output class
+        cur_object (Optional[BaseModel]): Current best object (for comparison)
+        flexible_mode (bool): Whether to use flexible schema during parsing
+
+    Returns:
+        Union[BaseModel, FlexibleModel]: Processed object with incremental updates
+
+    """
+    partial_output_cls = create_flexible_model(output_cls)
+
+    # Get content from message
+    content = chat_response.message.content
+    if not content:
+        return cur_object if cur_object is not None else partial_output_cls()
+    try:
+        parsed_obj = partial_output_cls.model_validate_json(content)
+    except (ValidationError, ValueError):
+        try:
+            repaired_json = _repair_incomplete_json(content)
+            parsed_obj = partial_output_cls.model_validate_json(repaired_json)
+        except (ValidationError, ValueError):
+            extracted_obj = _extract_partial_list_progress(
+                content, output_cls, cur_object, partial_output_cls
+            )
+            parsed_obj = (
+                extracted_obj if extracted_obj is not None else partial_output_cls()
+            )
+
+    # If we still couldn't parse anything, use previous object
+    if parsed_obj is None:
+        if cur_object is not None:
+            return cur_object
+        else:
+            return partial_output_cls()
+
+    # Use incremental comparison that considers list progress
+    try:
+        return output_cls.model_validate(parsed_obj.model_dump(exclude_unset=True))
+    except ValidationError:
+        return parsed_obj
+
+
+def _extract_partial_list_progress(
+    content: str,
+    output_cls: Type[Model],
+    cur_object: Optional[Union[Model, FlexibleModel]],
+    partial_output_cls: Type[FlexibleModel],
+) -> Optional[FlexibleModel]:
+    """
+    Try to extract partial list progress from incomplete JSON.
+
+    This attempts to build upon the current object by detecting partial
+    list additions even when JSON is malformed.
+    """
+    if not isinstance(content, str) or cur_object is None:
+        return None
+
+    try:
+        import re
+
+        # Try to extract list patterns from incomplete JSON
+        # Look for patterns like: "jokes": [{"setup": "...", "punchline": "..."}
+        list_pattern = r'"(\w+)":\s*\[([^\]]*)'
+        matches = re.findall(list_pattern, content)
+
+        if not matches:
+            return None
+
+        # Start with current object data
+        current_data = (
+            cur_object.model_dump() if hasattr(cur_object, "model_dump") else {}
+        )
+
+        for field_name, list_content in matches:
+            if (
+                hasattr(output_cls, "model_fields")
+                and field_name in output_cls.model_fields
+            ):
+                # Try to parse individual items from the list content
+                items = _parse_partial_list_items(list_content, field_name, output_cls)
+                if items:
+                    current_data[field_name] = items
+
+        # Try to create object with updated data
+        return partial_output_cls.model_validate(current_data)
+
+    except Exception:
+        return None
+
+
+def _parse_partial_list_items(
+    list_content: str, field_name: str, output_cls: Type[Model]
+) -> list:
+    """
+    Parse individual items from partial list content.
+    """
+    try:
+        import json
+        import re
+
+        items = []
+
+        # Look for complete object patterns within the list
+        # Pattern: {"key": "value", "key2": "value2"}
+        object_pattern = r"\{[^{}]*\}"
+        object_matches = re.findall(object_pattern, list_content)
+
+        for obj_str in object_matches:
+            try:
+                # Try to parse as complete JSON object
+                obj_data = json.loads(obj_str)
+                items.append(obj_data)
+            except (json.JSONDecodeError, SyntaxError):
+                # Try to repair and parse
+                try:
+                    repaired = _repair_incomplete_json(obj_str)
+                    obj_data = json.loads(repaired)
+                    items.append(obj_data)
+                except (json.JSONDecodeError, SyntaxError):
+                    continue
+
+        return items
+
+    except Exception:
+        return []

--- a/llama-index-core/tests/program/test_streaming_utils.py
+++ b/llama-index-core/tests/program/test_streaming_utils.py
@@ -1,0 +1,289 @@
+"""Test streaming utilities."""
+
+from typing import List, Optional
+from llama_index.core.bridge.pydantic import BaseModel, Field
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse, MessageRole
+from llama_index.core.program.streaming_utils import (
+    process_streaming_content_incremental,
+    _extract_partial_list_progress,
+    _parse_partial_list_items,
+)
+
+
+class Joke(BaseModel):
+    """Test joke model."""
+
+    setup: str
+    punchline: Optional[str] = None
+
+
+class Show(BaseModel):
+    """Test show model with jokes list."""
+
+    title: str = ""
+    jokes: List[Joke] = Field(default_factory=list)
+
+
+class Person(BaseModel):
+    """Test person model."""
+
+    name: str
+    age: Optional[int] = None
+    hobbies: List[str] = Field(default_factory=list)
+
+
+def test_process_streaming_content_incremental_complete_json():
+    """Test processing complete JSON content."""
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"name": "John", "age": 30, "hobbies": ["reading", "coding"]}',
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Person)
+    assert isinstance(result, Person)
+    assert result.name == "John"
+    assert result.age == 30
+    assert result.hobbies == ["reading", "coding"]
+
+
+def test_process_streaming_content_incremental_incomplete_json():
+    """Test processing incomplete JSON content."""
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"name": "John", "age": 30',
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Person)
+    # Should handle incomplete JSON gracefully
+    assert hasattr(result, "name")
+
+
+def test_process_streaming_content_incremental_with_current_object():
+    """Test processing with existing current object."""
+    current_person = Person(name="Jane", age=25)
+
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"name": "John", "age": 30}',
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Person, current_person)
+    assert isinstance(result, Person)
+    assert result.name == "John"
+    assert result.age == 30
+
+
+def test_process_streaming_content_incremental_empty_content():
+    """Test processing empty content."""
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Person)
+    # Should return FlexibleModel instance when no content
+    assert hasattr(result, "__dict__")
+
+
+def test_process_streaming_content_incremental_with_list():
+    """Test processing content with list structures."""
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"title": "Comedy Show", "jokes": [{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side!"}]}',
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Show)
+    assert isinstance(result, Show)
+    assert result.title == "Comedy Show"
+    assert len(result.jokes) == 1
+    assert result.jokes[0].setup == "Why did the chicken cross the road?"
+    assert result.jokes[0].punchline == "To get to the other side!"
+
+
+def test_process_streaming_content_incremental_malformed_json():
+    """Test processing malformed JSON with current object."""
+    current_show = Show(
+        title="Comedy Show",
+        jokes=[Joke(setup="First joke", punchline="First punchline")],
+    )
+
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"jokes": [{"setup": "Second joke", "punchline": "Second punchline"}',
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Show, current_show)
+    # Should attempt to extract partial progress
+    assert hasattr(result, "jokes")
+
+
+def test_extract_partial_list_progress_valid():
+    """Test extracting partial list progress with valid content."""
+    content = '{"jokes": [{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side!"}]'
+    current_show = Show(title="Comedy Show")
+
+    from llama_index.core.program.utils import create_flexible_model
+
+    partial_cls = create_flexible_model(Show)
+
+    result = _extract_partial_list_progress(content, Show, current_show, partial_cls)
+
+    if result is not None:
+        assert hasattr(result, "jokes")
+
+
+def test_extract_partial_list_progress_no_current():
+    """Test extracting partial list progress without current object."""
+    content = '{"jokes": [{"setup": "Why did the chicken cross the road?"}]'
+
+    from llama_index.core.program.utils import create_flexible_model
+
+    partial_cls = create_flexible_model(Show)
+
+    result = _extract_partial_list_progress(content, Show, None, partial_cls)
+    assert result is None
+
+
+def test_extract_partial_list_progress_invalid_content():
+    """Test extracting partial list progress with invalid content."""
+    content = "invalid json content"
+    current_show = Show(title="Comedy Show")
+
+    from llama_index.core.program.utils import create_flexible_model
+
+    partial_cls = create_flexible_model(Show)
+
+    result = _extract_partial_list_progress(content, Show, current_show, partial_cls)
+    assert result is None
+
+
+def test_parse_partial_list_items_complete_objects():
+    """Test parsing complete objects from list content."""
+    list_content = '{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side!"}, {"setup": "Second joke", "punchline": "Second punchline"}'
+
+    result = _parse_partial_list_items(list_content, "jokes", Show)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert result[0]["setup"] == "Why did the chicken cross the road?"
+    assert result[0]["punchline"] == "To get to the other side!"
+    assert result[1]["setup"] == "Second joke"
+    assert result[1]["punchline"] == "Second punchline"
+
+
+def test_parse_partial_list_items_incomplete_objects():
+    """Test parsing incomplete objects from list content."""
+    list_content = '{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side!"}, {"setup": "Second joke"'
+
+    result = _parse_partial_list_items(list_content, "jokes", Show)
+
+    assert isinstance(result, list)
+    # Should get at least the complete object
+    assert len(result) >= 1
+    assert result[0]["setup"] == "Why did the chicken cross the road?"
+
+
+def test_parse_partial_list_items_invalid_content():
+    """Test parsing invalid content returns empty list."""
+    list_content = "completely invalid content"
+
+    result = _parse_partial_list_items(list_content, "jokes", Show)
+
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+
+def test_parse_partial_list_items_empty_content():
+    """Test parsing empty content returns empty list."""
+    list_content = ""
+
+    result = _parse_partial_list_items(list_content, "jokes", Show)
+
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+
+def test_parse_partial_list_items_malformed_json():
+    """Test parsing malformed JSON objects."""
+    list_content = '{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side!"}, {"setup": "Second joke", invalid'
+
+    result = _parse_partial_list_items(list_content, "jokes", Show)
+
+    assert isinstance(result, list)
+    # Should get the complete object, ignore the malformed one
+    assert len(result) >= 1
+    assert result[0]["setup"] == "Why did the chicken cross the road?"
+
+
+def test_process_streaming_content_incremental_none_message():
+    """Test processing when message content is None."""
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content=None,
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Person)
+    # Should return FlexibleModel instance when no content
+    assert hasattr(result, "__dict__")
+
+
+def test_process_streaming_content_incremental_progressive_list_building():
+    """Test progressive list building with incremental updates."""
+    # Start with empty show
+    current_show = Show(title="Comedy Show", jokes=[])
+
+    # First update - add one joke
+    response1 = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"title": "Comedy Show", "jokes": [{"setup": "First joke", "punchline": "First punchline"}]}',
+        )
+    )
+
+    result1 = process_streaming_content_incremental(response1, Show, current_show)
+    assert len(result1.jokes) == 1
+    assert result1.jokes[0].setup == "First joke"
+
+    # Second update - add another joke
+    response2 = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"title": "Comedy Show", "jokes": [{"setup": "First joke", "punchline": "First punchline"}, {"setup": "Second joke", "punchline": "Second punchline"}]}',
+        )
+    )
+
+    result2 = process_streaming_content_incremental(response2, Show, result1)
+    assert len(result2.jokes) == 2
+    assert result2.jokes[1].setup == "Second joke"
+
+
+def test_process_streaming_content_incremental_validation_error_fallback():
+    """Test fallback when validation to target class fails."""
+    # Create content that validates to FlexibleModel but not to strict Person
+    response = ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content='{"name": "John", "unknown_field": "value"}',
+        )
+    )
+
+    result = process_streaming_content_incremental(response, Person)
+    # Should return the flexible model instance when strict validation fails
+    assert hasattr(result, "name")
+    # Should still have the name field
+    if hasattr(result, "name"):
+        assert result.name == "John"

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -77,6 +77,7 @@ from llama_index.llms.openai.utils import (
     resolve_tool_choice,
     to_openai_message_dicts,
     update_tool_calls,
+    is_json_schema_supported,
 )
 from openai import AsyncOpenAI, AzureOpenAI, AsyncAzureOpenAI
 from openai import OpenAI as SyncOpenAI
@@ -1000,6 +1001,23 @@ class OpenAI(FunctionCallingLLM):
 
         return tool_selections
 
+    def _prepare_schema(
+        self, llm_kwargs: Optional[Dict[str, Any]], output_cls: Type[Model]
+    ) -> Dict[str, Any]:
+        from openai.resources.beta.chat.completions import _type_to_response_format
+
+        llm_kwargs = llm_kwargs or {}
+        llm_kwargs["response_format"] = _type_to_response_format(output_cls)
+        if "tool_choice" in llm_kwargs:
+            del llm_kwargs["tool_choice"]
+        return llm_kwargs
+
+    def _should_use_structure_outputs(self):
+        return (
+            self.pydantic_program_mode == PydanticProgramMode.DEFAULT
+            and is_json_schema_supported(self.model)
+        )
+
     @dispatcher.span
     def structured_predict(
         self,
@@ -1011,11 +1029,17 @@ class OpenAI(FunctionCallingLLM):
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
 
+        if self._should_use_structure_outputs():
+            messages = self._extend_messages(prompt.format_messages(**prompt_args))
+            llm_kwargs = self._prepare_schema(llm_kwargs, output_cls)
+            response = self.chat(messages, **llm_kwargs)
+            return output_cls.model_validate_json(str(response.message.content))
+
+        # when uses function calling to extract structured outputs
+        # here we force tool_choice to be required
         llm_kwargs["tool_choice"] = (
             "required" if "tool_choice" not in llm_kwargs else llm_kwargs["tool_choice"]
         )
-        # by default structured prediction uses function calling to extract structured outputs
-        # here we force tool_choice to be required
         return super().structured_predict(
             output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
@@ -1031,14 +1055,90 @@ class OpenAI(FunctionCallingLLM):
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
 
+        if self._should_use_structure_outputs():
+            messages = self._extend_messages(prompt.format_messages(**prompt_args))
+            llm_kwargs = self._prepare_schema(llm_kwargs, output_cls)
+            response = await self.achat(messages, **llm_kwargs)
+            return output_cls.model_validate_json(str(response.message.content))
+
+        # when uses function calling to extract structured outputs
+        # here we force tool_choice to be required
         llm_kwargs["tool_choice"] = (
             "required" if "tool_choice" not in llm_kwargs else llm_kwargs["tool_choice"]
         )
-        # by default structured prediction uses function calling to extract structured outputs
-        # here we force tool_choice to be required
         return await super().astructured_predict(
             output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
+
+    def _structured_stream_call(
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Generator[
+        Union[Model, List[Model], "FlexibleModel", List["FlexibleModel"]], None, None
+    ]:
+        if self._should_use_structure_outputs():
+            from llama_index.core.program.streaming_utils import (
+                process_streaming_content_incremental,
+            )
+
+            messages = self._extend_messages(prompt.format_messages(**prompt_args))
+            llm_kwargs = self._prepare_schema(llm_kwargs, output_cls)
+            curr = None
+            for response in self.stream_chat(messages, **llm_kwargs):
+                curr = process_streaming_content_incremental(response, output_cls, curr)
+                yield curr
+        else:
+            llm_kwargs["tool_choice"] = (
+                "required"
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
+            )
+            yield from super()._structured_stream_call(
+                output_cls, prompt, llm_kwargs, **prompt_args
+            )
+
+    async def _structured_astream_call(
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> AsyncGenerator[
+        Union[Model, List[Model], "FlexibleModel", List["FlexibleModel"]], None
+    ]:
+        if self._should_use_structure_outputs():
+
+            async def gen(
+                llm_kwargs=llm_kwargs,
+            ) -> AsyncGenerator[
+                Union[Model, List[Model], FlexibleModel, List[FlexibleModel]], None
+            ]:
+                from llama_index.core.program.streaming_utils import (
+                    process_streaming_content_incremental,
+                )
+
+                messages = self._extend_messages(prompt.format_messages(**prompt_args))
+                llm_kwargs = self._prepare_schema(llm_kwargs, output_cls)
+                curr = None
+                async for response in await self.astream_chat(messages, **llm_kwargs):
+                    curr = process_streaming_content_incremental(
+                        response, output_cls, curr
+                    )
+                    yield curr
+
+            return gen()
+        else:
+            llm_kwargs["tool_choice"] = (
+                "required"
+                if "tool_choice" not in llm_kwargs
+                else llm_kwargs["tool_choice"]
+            )
+            return await super()._structured_astream_call(
+                output_cls, prompt, llm_kwargs, **prompt_args
+            )
 
     @dispatcher.span
     def stream_structured_predict(
@@ -1051,11 +1151,6 @@ class OpenAI(FunctionCallingLLM):
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
 
-        llm_kwargs["tool_choice"] = (
-            "required" if "tool_choice" not in llm_kwargs else llm_kwargs["tool_choice"]
-        )
-        # by default structured prediction uses function calling to extract structured outputs
-        # here we force tool_choice to be required
         return super().stream_structured_predict(
             output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )
@@ -1070,12 +1165,6 @@ class OpenAI(FunctionCallingLLM):
     ) -> AsyncGenerator[Union[Model, FlexibleModel], None]:
         """Stream structured predict."""
         llm_kwargs = llm_kwargs or {}
-
-        llm_kwargs["tool_choice"] = (
-            "required" if "tool_choice" not in llm_kwargs else llm_kwargs["tool_choice"]
-        )
-        # by default structured prediction uses function calling to extract structured outputs
-        # here we force tool_choice to be required
         return await super().astream_structured_predict(
             output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
         )

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -180,6 +180,32 @@ DISCONTINUED_MODELS = {
     "code-cushman-001": 2048,
 }
 
+JSON_SCHEMA_MODELS = [
+    "o4-mini",
+    "o1",
+    "o1-pro",
+    "o3",
+    "o3-mini",
+    "gpt-4.1",
+    "gpt-4o",
+    "gpt-4.1",
+]
+
+
+def is_json_schema_supported(model: str) -> bool:
+    try:
+        from openai.resources.beta.chat import completions
+
+        if not hasattr(completions, "_type_to_response_format"):
+            return False
+
+        return not model.startswith("o1-mini") and any(
+            model.startswith(m) for m in JSON_SCHEMA_MODELS
+        )
+    except ImportError:
+        return False
+
+
 MISSING_API_KEY_ERROR_MESSAGE = """No API key found for OpenAI.
 Please set either the OPENAI_API_KEY environment variable or \
 openai.api_key prior to initialization.

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -29,6 +29,7 @@ from llama_index.llms.openai.utils import (
     from_openai_messages,
     from_openai_token_logprob,
     from_openai_token_logprobs,
+    is_json_schema_supported,
     to_openai_message_dicts,
     to_openai_tool,
 )
@@ -362,3 +363,46 @@ def test_get_tool_calls_from_response_returns_arguments_with_dict_json_input() -
     tools = OpenAI().get_tool_calls_from_response(response)
     assert len(tools) == 1
     assert tools[0].tool_kwargs == arguments
+
+
+def test_is_json_schema_supported_supported_models() -> None:
+    """Test that supported models return True."""
+    supported_models = [
+        "gpt-4o",
+        "gpt-4o-2024-05-13",
+        "gpt-4.1",
+    ]
+
+    for model in supported_models:
+        assert is_json_schema_supported(model) is True, (
+            f"Model {model} should be supported"
+        )
+
+
+def test_is_json_schema_supported_o1_mini_excluded() -> None:
+    """Test that o1-mini models are explicitly excluded."""
+    o1_mini_models = [
+        "o1-mini",
+        "o1-mini-2024-09-12",
+    ]
+
+    for model in o1_mini_models:
+        assert is_json_schema_supported(model) is False, (
+            f"Model {model} should be excluded"
+        )
+
+
+def test_is_json_schema_supported_unsupported_models() -> None:
+    """Test that unsupported models return False."""
+    unsupported_models = [
+        "gpt-3.5-turbo-0613",
+        "gpt-4-0613",
+        "text-davinci-003",
+        "babbage-002",
+        "unknown-model",
+    ]
+
+    for model in unsupported_models:
+        assert is_json_schema_supported(model) is False, (
+            f"Model {model} should not be supported"
+        )


### PR DESCRIPTION

- Add automatic model detection for JSON schema support
- Implement graceful fallback to function calling for unsupported models
- Maintain full backward compatibility with existing APIs

# Description
## Overview
This PR implements support for OpenAI's native JSON Schema structured output capabilities while maintaining minimal architectural changes and leveraging the existing program pattern.

## Approach

### 1. Minimal Integration Changes
- Leverages existing `structured_predict()` and `astructured_predict()` methods
- No changes to public APIs - fully backward compatible

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
