### PR TITLE
Multi language analyzer supported in Milvus

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/utils.py
@@ -255,6 +255,7 @@ class BM25BuiltInFunction(BaseMilvusBuiltInFunction):
         function_description: str = "",
         function_params: Optional[Dict] = None,
         analyzer_params: Optional[Dict[Any, Any]] = None,
+        multi_analyzer_params: Optional[Dict[Any, Any]] = None,
         enable_match: bool = False,
     ):
         if not function_name:
@@ -269,6 +270,7 @@ class BM25BuiltInFunction(BaseMilvusBuiltInFunction):
         )
         self.analyzer_params = analyzer_params
         self.enable_match = enable_match
+        self.multi_analyzer_params = multi_analyzer_params
 
     def get_field_kwargs(self) -> dict:
         field_schema_kwargs: Dict[Any, Any] = {
@@ -277,6 +279,8 @@ class BM25BuiltInFunction(BaseMilvusBuiltInFunction):
         }
         if self.analyzer_params is not None:
             field_schema_kwargs["analyzer_params"] = self.analyzer_params
+        if self.multi_analyzer_params is not None:
+            field_schema_kwargs["multi_analyzer_params"] = self.multi_analyzer_params
         return field_schema_kwargs
 
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,14 +27,14 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-milvus"
-version = "0.8.2"
+version = "0.8.3"
 description = "llama-index vector_stores milvus integration"
 authors = []
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "pymilvus>=2.5.2,<3",
+    "pymilvus>=2.5.10,<3",
     "llama-index-core>=0.12.0,<0.13",
 ]
 


### PR DESCRIPTION
# Description

Add support for `multi_analyzer_params` within `BM25BuiltInFunction` so that you can use multi-language analysis within Milvus vector databases (tested with Chinese, seems to work well).

Fixes #18899 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
