### PR TITLE
bump openai-like to match openai version

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/pyproject.toml
@@ -26,14 +26,14 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai-like"
-version = "0.3.5"
+version = "0.4.0"
 description = "llama-index llms openai like integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "llama-index-llms-openai>=0.3.42,<0.4",
+    "llama-index-llms-openai>=0.4.0,<0.5",
     "transformers>=4.37.0,<5",
     "llama-index-core>=0.12.0,<0.13",
 ]


### PR DESCRIPTION
# Description

This bumps openai-like, to match openai version and keep consistency. This is for the `tool_required` change, which version bumped a minor version for the new feature (with the 0.x version, that should have probably been a patch, but oops, here we are)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No