### PR TITLE
fix(cohere-embedding): add batch size validation with 96 limit for Cohere API

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/llama_index/embeddings/cohere/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/llama_index/embeddings/cohere/base.py
@@ -117,6 +117,9 @@ VALID_TRUNCATE_OPTIONS = [CAT.START, CAT.END, CAT.NONE]
 # supported image formats
 SUPPORTED_IMAGE_FORMATS = {"png", "jpeg", "jpg", "webp", "gif"}
 
+# Maximum batch size for Cohere API
+MAX_EMBED_BATCH_SIZE = 96
+
 
 # Assuming BaseEmbedding is a Pydantic model and handles its own initializations
 class CohereEmbedding(MultiModalEmbedding):
@@ -171,6 +174,8 @@ class CohereEmbedding(MultiModalEmbedding):
                                     'search_document', 'classification', or 'clustering'.
             model_name (str): The name of the model to be used for generating embeddings. The class ensures that
                           this model is supported and that the input type provided is compatible with the model.
+            embed_batch_size (int): The batch size for embedding generation. Maximum allowed value is 96 (MAX_EMBED_BATCH_SIZE)
+                                   due to Cohere API limitations. Defaults to DEFAULT_EMBED_BATCH_SIZE.
 
         """
         # Validate model_name and input_type
@@ -188,6 +193,12 @@ class CohereEmbedding(MultiModalEmbedding):
 
         if truncate not in VALID_TRUNCATE_OPTIONS:
             raise ValueError(f"truncate must be one of {VALID_TRUNCATE_OPTIONS}")
+
+        # Validate embed_batch_size
+        if embed_batch_size > MAX_EMBED_BATCH_SIZE:
+            raise ValueError(
+                f"embed_batch_size {embed_batch_size} exceeds the maximum allowed value of {MAX_EMBED_BATCH_SIZE} for Cohere API"
+            )
 
         super().__init__(
             api_key=api_key or cohere_api_key,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-cohere"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index embeddings cohere integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/test_embeddings.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/test_embeddings.py
@@ -32,6 +32,25 @@ def test_sync_embedding():
 @pytest.mark.skipif(
     os.environ.get("CO_API_KEY") is None, reason="Cohere API key required"
 )
+def test_batch_size_validation():
+    """Test that batch size validation works correctly."""
+    # Test batch size exceeding the limit
+    with pytest.raises(ValueError) as exc_info:
+        CohereEmbedding(api_key=os.environ["CO_API_KEY"], embed_batch_size=97)
+    assert "exceeds the maximum allowed value of 96" in str(exc_info.value)
+
+    # Test batch size at the limit (should not raise)
+    emb = CohereEmbedding(api_key=os.environ["CO_API_KEY"], embed_batch_size=96)
+    assert emb.embed_batch_size == 96
+
+    # Test batch size below the limit (should not raise)
+    emb = CohereEmbedding(api_key=os.environ["CO_API_KEY"], embed_batch_size=50)
+    assert emb.embed_batch_size == 50
+
+
+@pytest.mark.skipif(
+    os.environ.get("CO_API_KEY") is None, reason="Cohere API key required"
+)
 @pytest.mark.asyncio
 async def test_async_embedding():
     emb = CohereEmbedding(


### PR DESCRIPTION
# Description

Add batch size validation for Cohere Embedding API to enforce the 96 batch size limit imposed by Cohere's API. This prevents runtime errors by catching invalid batch sizes during initialization, providing better error messages and preventing unnecessary API calls that would fail.

The change adds:
- MAX_EMBED_BATCH_SIZE constant set to 96
- Validation in __init__ method to check embed_batch_size parameter
- Clear error message when batch size exceeds the limit
- Updated docstring to document the limitation
- Unit tests to verify the validation works correctly

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods