### PR TITLE
Add headers handling to BasicMCPClient

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -99,7 +99,7 @@ class BasicMCPClient(ClientSession):
                 [types.CreateMessageRequestParams], Awaitable[types.CreateMessageResult]
             ]
         ] = None,
-        headers: dict[str, Any] | None = None,
+        headers: Optional[Dict[str, Any]] = None,
     ):
         self.command_or_url = command_or_url
         self.args = args or []

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,7 +1,17 @@
 import warnings
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import Optional, List, Dict, Tuple, Callable, AsyncIterator, Awaitable, Dict
+from typing import (
+    Optional,
+    List,
+    Dict,
+    Tuple,
+    Callable,
+    AsyncIterator,
+    Awaitable,
+    Dict,
+    Any,
+)
 from urllib.parse import urlparse, parse_qs
 from mcp.client.session import ClientSession, ProgressFnT
 from mcp.client.sse import sse_client
@@ -74,6 +84,7 @@ class BasicMCPClient(ClientSession):
         auth: Optional OAuth client provider for authentication.
         sampling_callback: Optional callback for handling sampling messages.
         headers: Optional headers to pass by sse client or streamable http client
+
     """
 
     def __init__(
@@ -163,7 +174,9 @@ class BasicMCPClient(ClientSession):
             # Check if this is a streamable HTTP endpoint (default) or SSE
             if enable_sse(self.command_or_url):
                 # SSE transport
-                async with sse_client(self.command_or_url, auth=self.auth, headers=self.headers) as streams:
+                async with sse_client(
+                    self.command_or_url, auth=self.auth, headers=self.headers
+                ) as streams:
                     async with ClientSession(
                         *streams,
                         read_timeout_seconds=timedelta(seconds=self.timeout),

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Both sse and streamable http clients allow to add custom headers when using them. BasicMCPClient do not allow to pass them. This PR is adding new optional `headers` parameter to this class.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
