### PR TITLE
fix: update reasoning_effort key to reasoning in OpenAIResponses class

### DIFF
--- a/docs/docs/examples/llm/openai_responses.ipynb
+++ b/docs/docs/examples/llm/openai_responses.ipynb
@@ -357,7 +357,7 @@
     "\n",
     "For O-series models, you can set the reasoning effort to control the amount of time the model will spend reasoning.\n",
     "\n",
-    "The possible values are `low`, `medium`, and `high`."
+    "See the [OpenAI API docs](https://platform.openai.com/docs/guides/reasoning?api-mode=responses) for more information."
    ]
   },
   {
@@ -370,19 +370,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "assistant: The question “What is the meaning of life?” has intrigued humanity for centuries, and there isn’t one universally accepted answer. Different perspectives offer different insights:\n",
+      "assistant: The question “What is the meaning of life?” has been asked by philosophers, theologians, scientists, and countless individuals throughout history—and there isn’t one definitive answer that satisfies everyone. Here are a few perspectives that help illustrate why the answer is so open-ended:\n",
       "\n",
-      "• Religious and Spiritual Views: Many traditions propose that life’s meaning is connected to a divine purpose, spiritual growth, or fulfilling the will of a higher power. For example, some religions teach that life is about serving God, others emphasize enlightenment or unity with the universe.\n",
+      "1. Philosophical and Existential Views:  \n",
+      " • Some existentialist thinkers, such as Jean-Paul Sartre and Albert Camus, argue that life doesn’t come with a preordained meaning. Instead, they suggest that it’s up to each individual to create their own purpose through choices, relationships, and personal projects.  \n",
+      " • Other philosophies, like those in classical philosophy, have emphasized the pursuit of virtue, knowledge, or happiness as key to a meaningful life.\n",
       "\n",
-      "• Philosophical Perspectives: Philosophers have long debated the issue. Existentialists, such as Jean-Paul Sartre or Albert Camus, suggest that life doesn’t come with an inherent meaning—that instead, each person must create their own purpose through choices and actions. Other philosophical traditions, like those found in ancient Greek thought, propose that the pursuit of virtue or wisdom is central to a meaningful life.\n",
+      "2. Religious and Spiritual Perspectives:  \n",
+      " • Many religious traditions offer meanings tied to their spiritual beliefs. In these views, life might be seen as a journey of growth, moral development, or fulfilling a divine plan—whether that means living according to God’s commandments, achieving enlightenment, or learning lessons through reincarnation.  \n",
+      " • Spiritual traditions often encourage adherents to find meaning in love, compassion, and service to others.\n",
       "\n",
-      "• Scientific and Evolutionary Insights: From a scientific standpoint, life can be seen as the product of natural processes like evolution. In this view, the “meaning” is less about cosmic purpose and more about survival, reproduction, and the development of complex societies. Many find purpose in understanding the universe and our place within it.\n",
+      "3. Scientific and Naturalistic Approaches:  \n",
+      " • From a biological standpoint, one might say that the purpose of life is simply to survive and reproduce—the basic mechanisms that drive natural selection and evolution.  \n",
+      " • Some argue that while biology defines life’s mechanics, human consciousness allows us to transcend mere survival and imbue our existence with personal and cultural meaning.\n",
       "\n",
-      "• Personal and Existential Meanings: For many people today, meaning is deeply personal. It might be found in relationships, love, creative expression, learning, or contributing to something larger than oneself—be it community, art, science, or social progress. This view suggests that meaning isn’t handed to us; it’s something we create over the course of our lives.\n",
+      "4. Personal and Cultural Interpretations:  \n",
+      " • For many, meaning is found in everyday connections: love, creativity, learning, and contributing to the community or society at large.  \n",
+      " • Different cultures and individuals may prioritize various values (such as achievement, compassion, or exploration), which means the “meaning” can vary widely based on one’s upbringing, experiences, and personal reflections.\n",
       "\n",
-      "In essence, the meaning of life is a multifaceted question that can lead to introspection about what matters most to you. Whether you lean toward religious faith, philosophical inquiry, scientific curiosity, or personal fulfillment, the idea is that meaning often emerges from how we engage with the world, form connections, and choose to live our lives.\n",
+      "5. A Humorous Take:  \n",
+      " • Popular culture, notably in Douglas Adams’ The Hitchhiker’s Guide to the Galaxy, famously suggests that the answer to the ultimate question of life is “42”—a playful reminder that the real significance often lies in the journey of questioning itself rather than arriving at a single answer.\n",
+      "\n",
+      "In the end, the meaning of life might be considered less of an absolute truth and more of an invitation to explore, question, and define what matters most to you personally. Whether through relationships, creative pursuits, intellectual challenges, or spiritual practices, many believe we have the power to create our own meaning in a vast and complex universe.\n",
       "================\n",
-      "{'built_in_tool_calls': [], 'reasoning': ResponseReasoningItem(id='rs_67e5eb6de5a881918ffb8aabe12eb8da0859b64a1dc4ba8f', summary=[], type='reasoning', status=None), 'annotations': [], 'usage': ResponseUsage(input_tokens=72, output_tokens=828, output_tokens_details=OutputTokensDetails(reasoning_tokens=448), total_tokens=900, input_tokens_details={'cached_tokens': 0})}\n"
+      "{'built_in_tool_calls': [], 'reasoning': ResponseReasoningItem(id='rs_683e2dde0e308198a72c5e7f2e9bf52a0dd2faa5908183b8', summary=[], type='reasoning', encrypted_content=None, status=None), 'annotations': [], 'usage': ResponseUsage(input_tokens=13, input_tokens_details=InputTokensDetails(cached_tokens=0), output_tokens=841, output_tokens_details=OutputTokensDetails(reasoning_tokens=320), total_tokens=854)}\n"
      ]
     }
    ],
@@ -392,7 +403,7 @@
     "\n",
     "llm = OpenAIResponses(\n",
     "    model=\"o3-mini\",\n",
-    "    reasoning=\"high\",\n",
+    "    reasoning_options={\"effort\": \"high\"},\n",
     ")\n",
     "\n",
     "resp = llm.chat(\n",

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -411,7 +411,7 @@ class OpenAIResponses(FunctionCallingLLM):
 
         if self.model in O1_MODELS and self.reasoning_effort is not None:
             # O1 models support reasoning_effort of low, medium, high
-            model_kwargs["reasoning_effort"] = {"effort": self.reasoning_effort}
+            model_kwargs["reasoning"] = {"effort": self.reasoning_effort}
 
         # priority is class args > additional_kwargs > runtime args
         model_kwargs.update(self.additional_kwargs)

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -36,7 +36,6 @@ from typing import (
     Dict,
     Generator,
     List,
-    Literal,
     Optional,
     Protocol,
     Sequence,
@@ -143,6 +142,9 @@ class OpenAIResponses(FunctionCallingLLM):
         model: name of the OpenAI model to use.
         temperature: a float from 0 to 1 controlling randomness in generation; higher will lead to more creative, less deterministic responses.
         max_output_tokens: the maximum number of tokens to generate.
+        reasoning_options: Optional dictionary to configure reasoning for O1 models.
+                    Corresponds to the 'reasoning' parameter in the OpenAI API.
+                    Example: {"effort": "low", "summary": "concise"}
         include: Additional output data to include in the model response.
         instructions: Instructions for the model to follow.
         track_previous_responses: Whether to track previous responses. If true, the LLM class will statefully track previous responses.
@@ -192,6 +194,10 @@ class OpenAIResponses(FunctionCallingLLM):
     max_output_tokens: Optional[int] = Field(
         description="The maximum number of tokens to generate.",
         gt=0,
+    )
+    reasoning_options: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Optional dictionary to configure reasoning for O1 models. Example: {'effort': 'low', 'summary': 'concise'}",
     )
     include: Optional[List[str]] = Field(
         default=None,
@@ -249,10 +255,6 @@ class OpenAIResponses(FunctionCallingLLM):
     api_key: str = Field(default=None, description="The OpenAI API key.")
     api_base: str = Field(description="The base URL for OpenAI API.")
     api_version: str = Field(description="The API version for OpenAI API.")
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = Field(
-        default=None,
-        description="The effort to use for reasoning models.",
-    )
     context_window: Optional[int] = Field(
         default=None,
         description="The context window override for the model.",
@@ -269,7 +271,7 @@ class OpenAIResponses(FunctionCallingLLM):
         model: str = DEFAULT_OPENAI_MODEL,
         temperature: float = DEFAULT_TEMPERATURE,
         max_output_tokens: Optional[int] = None,
-        reasoning_effort: Optional[Literal["low", "medium", "high"]] = None,
+        reasoning_options: Optional[Dict[str, Any]] = None,
         include: Optional[List[str]] = None,
         instructions: Optional[str] = None,
         track_previous_responses: bool = False,
@@ -310,7 +312,7 @@ class OpenAIResponses(FunctionCallingLLM):
             model=model,
             temperature=temperature,
             max_output_tokens=max_output_tokens,
-            reasoning_effort=reasoning_effort,
+            reasoning_options=reasoning_options,
             include=include,
             instructions=instructions,
             track_previous_responses=track_previous_responses,
@@ -409,9 +411,8 @@ class OpenAIResponses(FunctionCallingLLM):
             "user": self.user,
         }
 
-        if self.model in O1_MODELS and self.reasoning_effort is not None:
-            # O1 models support reasoning_effort of low, medium, high
-            model_kwargs["reasoning"] = {"effort": self.reasoning_effort}
+        if self.model in O1_MODELS and self.reasoning_options is not None:
+            model_kwargs["reasoning"] = self.reasoning_options
 
         # priority is class args > additional_kwargs > runtime args
         model_kwargs.update(self.additional_kwargs)

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -408,7 +408,8 @@ def test_stream_chat_with_api():
 
     assert len(responses) > 0
     assert all(r.message.role == MessageRole.ASSISTANT for r in responses)
-    assert responses[-1].message.content is not None
+    accumulated_content = "".join([r.delta for r in responses if r.delta is not None])
+    assert len(accumulated_content) > 0, "Accumulated content should not be empty"
 
 
 @pytest.mark.skipif(SKIP_OPENAI_TESTS, reason="OpenAI API key not available")
@@ -458,7 +459,8 @@ async def test_astream_chat_with_api():
 
     assert len(responses) > 0
     assert all(r.message.role == MessageRole.ASSISTANT for r in responses)
-    assert responses[-1].message.content is not None
+    accumulated_content = "".join([r.delta for r in responses if r.delta is not None])
+    assert len(accumulated_content) > 0, "Accumulated content should not be empty"
 
 
 @pytest.mark.skipif(SKIP_OPENAI_TESTS, reason="OpenAI API key not available")


### PR DESCRIPTION
# Description

This PR addresses a `TypeError` that occurs when utilizing the `reasoning_effort` parameter with O1 models within the `OpenAIResponses` class (specifically when using the OpenAI Responses API).

`TypeError: Responses.create() got an unexpected keyword argument 'reasoning_effort'`

The root cause was that `reasoning_effort` was being passed as a top-level keyword argument (`reasoning_effort={"effort": "low"}`) to the `openai.responses.create()` method. However, the OpenAI Python SDK's `Responses.create()` method expects reasoning configurations to be nested under a single `reasoning` parameter, structured as `reasoning={"effort": "low", ...}`.

This change modifies the `_get_model_kwargs` method in `llama_index.llms.openai.responses.py` to correctly structure the `reasoning_effort` value under the `reasoning` key when `self.model` is an O1 model and `self.reasoning_effort` is set. This ensures compatibility with the OpenAI API and allows users to properly leverage the reasoning effort feature.

This PR also refactors the assertions in `test_stream_chat_with_api` and `test_astream_chat_with_api`. The original tests incorrectly checked the content of the last message in the stream, which can be metadata-only. The updated tests now correctly accumulate all `delta` responses to verify the complete streamed content, ensuring more reliable test outcomes.

*(Self-note: I will be opening a separate issue to discuss broader support for the full `Reasoning` object from the OpenAI API, including parameters like `summary`.)*

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
