### PR TITLE
Add StopEvent step validation

### DIFF
--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -952,3 +952,23 @@ def test__ensure_stop_event_class_multiple_types():
         match="Only one type of StopEvent is allowed per workflow, found 2",
     ):
         wf = DummyWorkflow()
+
+
+@pytest.mark.asyncio
+async def test_workflow_validation_steps_cannot_accept_stop_event():
+    # Test single step that incorrectly accepts StopEvent
+    class InvalidWorkflowSingleStep(Workflow):
+        @step
+        async def start_step(self, ev: StartEvent) -> StopEvent:
+            return StopEvent()
+
+        @step
+        async def bad_step(self, ev: StopEvent) -> StopEvent:
+            return StopEvent()
+
+    workflow = InvalidWorkflowSingleStep()
+    with pytest.raises(
+        WorkflowValidationError,
+        match="Step 'bad_step' cannot accept StopEvent. StopEvent signals the end of the workflow. Use a different Event type instead.",
+    ):
+        await workflow.run()


### PR DESCRIPTION
# Description

I was helping a colleague with a workflow. It was acting very strange, the workflow step would run up until the first call to an `await`, and then it would stop. No exception, just wouldn't continue. Then I realized that their workflow `@step` was accepting a `StopEvent` as the event, causing only the synchronous parts of their step to run (and the workflow to otherwise complete)

This doesn't seem like something one should ever do in a step, so this adds validation to prevent accepting `StopEvent` within a step handler.


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
