### PR TITLE
Adding warning in the docstring of JsonPickleSerializer for the user to deserialize only safe things

### DIFF
--- a/llama-index-core/llama_index/core/workflow/context_serializers.py
+++ b/llama-index-core/llama_index/core/workflow/context_serializers.py
@@ -73,7 +73,11 @@ class JsonPickleSerializer(JsonSerializer):
             return base64.b64encode(pickle.dumps(value)).decode("utf-8")
 
     def deserialize(self, value: str) -> Any:
-        """Deserialize while prioritizing Pickle, falling back to JSON."""
+        """
+        Deserialize while prioritizing Pickle, falling back to JSON.
+        To avoid malicious exploits of the deserialization, deserialize objects
+        only when you deem it safe to do so.
+        """
         try:
             return pickle.loads(base64.b64decode(value))
         except Exception:

--- a/llama-index-core/llama_index/core/workflow/context_serializers.py
+++ b/llama-index-core/llama_index/core/workflow/context_serializers.py
@@ -64,7 +64,7 @@ class JsonSerializer(BaseSerializer):
         return self._deserialize_value(data)
 
 
-class JsonPickleSerializer(JsonSerializer):
+class PickleSerializer(JsonSerializer):
     def serialize(self, value: Any) -> str:
         """Serialize while prioritizing JSON, falling back to Pickle."""
         try:
@@ -82,3 +82,6 @@ class JsonPickleSerializer(JsonSerializer):
             return pickle.loads(base64.b64decode(value))
         except Exception:
             return super().deserialize(value)
+
+
+JsonPickleSerializer = PickleSerializer

--- a/llama-index-core/tests/workflow/test_workflow.py
+++ b/llama-index-core/tests/workflow/test_workflow.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 from llama_index.core import MockEmbedding
 from llama_index.core.llms.mock import MockLLM
-from llama_index.core.workflow.context_serializers import JsonPickleSerializer
+from llama_index.core.workflow.context_serializers import PickleSerializer
 from llama_index.core.workflow.decorators import step
 from llama_index.core.workflow.events import (
     Event,
@@ -534,9 +534,9 @@ async def test_workflow_pickle():
         state_dict = handler.ctx.to_dict()
 
     # if we allow pickle, then we can pickle the LLM/embedding object
-    state_dict = handler.ctx.to_dict(serializer=JsonPickleSerializer())
+    state_dict = handler.ctx.to_dict(serializer=PickleSerializer())
     new_handler = WorkflowHandler(
-        ctx=Context.from_dict(wf, state_dict, serializer=JsonPickleSerializer())
+        ctx=Context.from_dict(wf, state_dict, serializer=PickleSerializer())
     )
     assert new_handler.ctx
 


### PR DESCRIPTION
# Description

We add a warning in the docstring of the `JsonPickleSerializer` so that the user is told not to use it to deserialize things that they deem unsafe. Should fix the [related Huntr issue](https://huntr.com/bounties/9b55a5e8-74e6-4241-b323-e360dc8b110a).
