### PR TITLE
Using httpx instead of urllib in llama-index-readers-web

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/sitemap/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/sitemap/base.py
@@ -1,4 +1,4 @@
-import urllib.request
+import httpx
 from typing import List
 
 from defusedxml.ElementTree import fromstring
@@ -30,9 +30,9 @@ class SitemapReader(BaseReader):
         self._limit = limit
 
     def _load_sitemap(self, sitemap_url: str) -> str:
-        sitemap_url_request = urllib.request.urlopen(sitemap_url)
+        sitemap_url_request = httpx.get(sitemap_url)
 
-        return sitemap_url_request.read()
+        return sitemap_url_request.content
 
     def _parse_sitemap(self, raw_sitemap: str, filter_locs: str = None) -> list:
         sitemap = fromstring(raw_sitemap)

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-web"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index readers web integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Using `httpx.get` instead of `urllib.request.urlopen` in `llama-index-readers-web` should solve the vulnerability detailed [in this Huntr issue](https://huntr.com/bounties/5621160b-9171-4e18-a96a-d0e73a67a68d)

This vulnerability does not seem to affect the Joplin reader integration.