### PR TITLE
ImageDocument path and url checking to ensure that the input is really an image

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -32,6 +32,7 @@ import requests
 from dataclasses_json import DataClassJsonMixin
 from deprecated import deprecated
 from typing_extensions import Self
+from PIL import Image
 
 from llama_index.core.bridge.pydantic import (
     AnyUrl,
@@ -1220,6 +1221,27 @@ class Document(Node):
         )
 
 
+def is_image_pil(file_path: str) -> bool:
+    try:
+        with Image.open(file_path) as img:
+            img.verify()  # Verify it's a valid image
+        return True
+    except (IOError, SyntaxError):
+        return False
+
+
+def is_image_url_pil(url: str) -> bool:
+    try:
+        response = requests.get(url, stream=True)
+        response.raise_for_status()  # Raise an exception for bad status codes
+        # Open image from the response content
+        img = Image.open(BytesIO(response.content))
+        img.verify()
+        return True
+    except (requests.RequestException, IOError, SyntaxError):
+        return False
+
+
 class ImageDocument(Document):
     """Backward compatible wrapper around Document containing an image."""
 
@@ -1235,10 +1257,14 @@ class ImageDocument(Document):
                 data=image, mimetype=image_mimetype
             )
         elif image_path:
+            if not is_image_pil(image_path):
+                raise ValueError("The specified file path is not an accessible image")
             kwargs["image_resource"] = MediaResource(
                 path=image_path, mimetype=image_mimetype
             )
         elif image_url:
+            if not is_image_url_pil(image_url):
+                raise ValueError("The specified URL is not an accessible image")
             kwargs["image_resource"] = MediaResource(
                 url=image_url, mimetype=image_mimetype
             )

--- a/llama-index-core/tests/schema/test_image_document.py
+++ b/llama-index-core/tests/schema/test_image_document.py
@@ -1,0 +1,36 @@
+import httpx
+import pytest
+
+from pathlib import Path
+from llama_index.core.schema import ImageDocument
+
+
+@pytest.fixture()
+def image_url() -> str:
+    return "https://astrabert.github.io/hophop-science/images/whale_doing_science.png"
+
+
+def test_real_image_path(tmp_path: Path, image_url: str) -> None:
+    content = httpx.get(image_url).content
+    fl_path = tmp_path / "test_image.png"
+    fl_path.write_bytes(content)
+    doc = ImageDocument(image_path=fl_path.__str__())
+    assert isinstance(doc, ImageDocument)
+
+
+def test_real_image_url(image_url: str) -> None:
+    doc = ImageDocument(image_url=image_url)
+    assert isinstance(doc, ImageDocument)
+
+
+def test_non_image_path(tmp_path: Path) -> None:
+    fl_path = tmp_path / "test_file.txt"
+    fl_path.write_text("Hello world!")
+    with pytest.raises(expected_exception=ValueError):
+        doc = ImageDocument(image_path=fl_path.__str__())
+
+
+def test_non_image_url(image_url: str) -> None:
+    image_url = image_url.replace("png", "txt")
+    with pytest.raises(expected_exception=ValueError):
+        doc = ImageDocument(image_url=image_url)


### PR DESCRIPTION
# Description

I included two functions to check whether or not an image path or an image url are actually images. It uses PIL so it should be covered by `llama-index-core` dependencies without needing to install anything extra.

Should fix [This Huntr issue](https://huntr.com/bounties/e89d14f8-bfe8-4c9a-bb2a-656c01cc9a68)

I also added tests to prove the effectiveness of the fix
