### PR TITLE
Obsidian reader checks and skips hardlinks

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-obsidian/llama_index/readers/obsidian/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/llama_index/readers/obsidian/base.py
@@ -30,6 +30,18 @@ from llama_index.core.schema import Document
 from llama_index.readers.file import MarkdownReader
 
 
+def is_hardlink(filepath: Path) -> bool:
+    """
+    Check if a file is a hardlink by checking the number of links to/from it.
+
+    Args:
+        filepath (Path): path to the file.
+
+    """
+    stat_info = os.stat(filepath)
+    return stat_info.st_nlink > 1
+
+
 class ObsidianReader(BaseReader):
     """
     input_dir (str): Path to the Obsidian vault.
@@ -68,6 +80,11 @@ class ObsidianReader(BaseReader):
                     filepath = os.path.join(dirpath, filename)
                     file_path_obj = Path(filepath).resolve()
                     try:
+                        if is_hardlink(filepath=file_path_obj):
+                            print(
+                                f"Warning: Skipping file because it is a hardlink (potential malicious exploit): {filepath}"
+                            )
+                            continue
                         if not str(file_path_obj).startswith(str(input_dir_abs)):
                             print(
                                 f"Warning: Skipping file outside input directory: {filepath}"

--- a/llama-index-integrations/readers/llama-index-readers-obsidian/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-obsidian/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-obsidian"
-version = "0.5.1"
+version = "0.5.2"
 description = "llama-index readers obsidian integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Implemented hardlink checking before proceeding with reading files: hardlinks are recognized and skipped now. 

Should fix [this Huntr issue](https://huntr.com/bounties/a654b322-a509-4448-a1f5-0f22850b4687)