### PR TITLE
Upsert Entities supported in Milvus

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -137,6 +137,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
             stored. Defaults to "llamalection".
         overwrite (bool, optional): Whether to overwrite existing collection with same
             name. Defaults to False.
+        upsert_mode (bool, optional): Whether to upsert documents into existing collection. Defaults to False.
         doc_id_field (str, optional): The name of the doc_id field for the collection,
             defaults to DEFAULT_DOC_ID_KEY.
         text_key (str, optional): What key text is stored in in the passed collection.
@@ -230,6 +231,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
     similarity_metric: str = "IP"
     consistency_level: str = "Session"
     overwrite: bool = False
+    upsert_mode: bool = False
     text_key: str = DEFAULT_TEXT_KEY
     output_fields: List[str] = Field(default_factory=list)
     index_config: Optional[dict]
@@ -259,6 +261,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         token: str = "",
         collection_name: str = "llamacollection",
         overwrite: bool = False,
+        upsert_mode: bool = False,
         collection_properties: Optional[dict] = None,
         doc_id_field: str = DEFAULT_DOC_ID_KEY,
         text_key: str = DEFAULT_TEXT_KEY,
@@ -291,6 +294,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
             doc_id_field=doc_id_field,
             consistency_level=consistency_level,
             overwrite=overwrite,
+            upsert_mode=upsert_mode,
             text_key=text_key,
             output_fields=output_fields or [],
             index_config=index_config if index_config else {},
@@ -448,9 +452,14 @@ class MilvusVectorStore(BasePydanticVectorStore):
             insert_ids.append(node.node_id)
             insert_list.append(entry)
 
-        # Insert the data into milvus
+        if self.upsert_mode:
+            executor_wrapper = self.client.upsert
+        else:
+            executor_wrapper = self.client.insert
+
+        # Insert or Upsert the data into milvus
         for insert_batch in iter_batch(insert_list, self.batch_size):
-            self.client.insert(self.collection_name, insert_batch)
+            executor_wrapper(self.collection_name, insert_batch)
         if add_kwargs.get("force_flush", False):
             self.client.flush(self.collection_name)
         logger.debug(
@@ -495,9 +504,14 @@ class MilvusVectorStore(BasePydanticVectorStore):
             insert_ids.append(node.node_id)
             insert_list.append(entry)
 
-        # Insert the data into milvus
+        if self.upsert_mode:
+            executor_wrapper = self.aclient.upsert
+        else:
+            executor_wrapper = self.aclient.insert
+
+        # Insert or Upsert the data into milvus
         for insert_batch in iter_batch(insert_list, self.batch_size):
-            await self.aclient.insert(self.collection_name, insert_batch)
+            await executor_wrapper(self.collection_name, insert_batch)
         if add_kwargs.get("force_flush", False):
             raise NotImplementedError("force_flush is not supported in async mode.")
             # await self.aclient.flush(self.collection_name)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -137,7 +137,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
             stored. Defaults to "llamalection".
         overwrite (bool, optional): Whether to overwrite existing collection with same
             name. Defaults to False.
-        upsert_mode (bool, optional): Whether to upsert documents into existing collection. Defaults to False.
+        upsert_mode (bool, optional): Whether to upsert documents into existing collection with same node id. Defaults to False.
         doc_id_field (str, optional): The name of the doc_id field for the collection,
             defaults to DEFAULT_DOC_ID_KEY.
         text_key (str, optional): What key text is stored in in the passed collection.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-milvus"
-version = "0.8.3"
+version = "0.8.4"
 description = "llama-index vector_stores milvus integration"
 authors = []
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Add support for `upsert_mode` within `MilvusVectorStore` so that you can use [Upsert Entities](https://milvus.io/docs/upsert-entities.md)  Mode with same node id.
(this is my first pull request within web, and my bad at english, so commit many times 😆 )

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [√] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [√] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [√] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [√] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [√] I have performed a self-review of my own code
- [√] I have commented my code, particularly in hard-to-understand areas
- [√] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
