### PR TITLE
(temp) pin llama-index-readers-file pandas for now

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-file"
-version = "0.4.8"
+version = "0.4.9"
 description = "llama-index readers file integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
@@ -72,7 +72,8 @@ dependencies = [
     "beautifulsoup4>=4.12.3,<5",
     "pypdf>=5.1.0,<6",
     "striprtf>=0.0.26,<0.0.27",
-    "pandas",
+    # note: pandas 2.3.0 changed build requirements, unpin when resolved
+    "pandas<2.3.0",
     "llama-index-core>=0.12.0,<0.13",
 ]
 

--- a/llama-index-integrations/readers/llama-index-readers-file/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-file/uv.lock
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-file"
-version = "0.4.7"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1717,7 +1717,7 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.3,<5" },
     { name = "llama-index-core", specifier = ">=0.12.0,<0.13" },
-    { name = "pandas" },
+    { name = "pandas", specifier = "<2.3.0" },
     { name = "pymupdf", marker = "extra == 'pymupdf'", specifier = ">=1.23.21,<2" },
     { name = "pypdf", specifier = ">=5.1.0,<6" },
     { name = "striprtf", specifier = ">=0.0.26,<0.0.27" },


### PR DESCRIPTION
This pins the pandas version for the llama-index-readers-file package

I only pinned this package because its part of the umbrella `llama-index` package. We should unpin this once they figure out their build requirements 

Fixes https://github.com/run-llama/llama_index/issues/18974