### PR TITLE
Correcting Redis URL/Client handling

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -183,6 +183,11 @@ class RedisVectorStore(BasePydanticVectorStore):
         )
         self._redis_client_async = redis_client_async
         if redis_client or redis_url:
+            if redis_url and not redis_client:
+                redis_client = Redis(
+                    host=redis_url.split("://")[1].split(":")[0],
+                    port=int(redis_url.split("://")[1].split(":")[1]),
+                )
             self._redis_client = redis_client
             self.create_index()
             if not self._redis_client_async:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -184,10 +184,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         self._redis_client_async = redis_client_async
         if redis_client or redis_url:
             if redis_url and not redis_client:
-                redis_client = Redis(
-                    host=redis_url.split("://")[1].split(":")[0],
-                    port=int(redis_url.split("://")[1].split(":")[1]),
-                )
+                redis_client = Redis.from_url(redis_url)
             self._redis_client = redis_client
             self.create_index()
             if not self._redis_client_async:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-redis"
-version = "0.5.1"
+version = "0.5.2"
 description = "llama-index vector_stores redis integration"
 authors = [{name = "Tyler Hutcherson", email = "tyler.hutcherson@redis.com"}]
 requires-python = ">=3.9,<3.14"


### PR DESCRIPTION
# Description

In `llama-index-vector-store-redis` v0.5.1 we incorrectly check for the `redis_client`, so that the `RedisVectorStore` object cannot be loaded simply from a URL anymore. With this PR, we correct the redis client handling so that the client is instatiated from the URL, if the `redis_client` itself is not passed.

Fixes #18981 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
