### PR TITLE
Avoid hash collision in XML parsing

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-docugami/llama_index/readers/docugami/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-docugami/llama_index/readers/docugami/base.py
@@ -160,8 +160,9 @@ class DocugamiReader(BaseReader):
             )
 
         def _build_framework_chunk(dg_chunk: Chunk) -> Document:
-            # Stable IDs for chunks with the same text.
-            _hashed_id = hashlib.md5(dg_chunk.text.encode()).hexdigest()
+            # Adding dg_chunk.text + dg_chunk.xpath should prevent hash collision between two chunks that have the same text but a different xpath
+            text = dg_chunk.xpath + "\n" + dg_chunk.text
+            _hashed_id = hashlib.md5(text.encode()).hexdigest()
             metadata = {
                 XPATH_KEY: dg_chunk.xpath,
                 ID_KEY: _hashed_id,

--- a/llama-index-integrations/readers/llama-index-readers-docugami/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-docugami/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-docugami"
-version = "0.3.0"
+version = "0.3.1"
 description = "llama-index readers docugami integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR avoids hash collision in XML parsing within `llama-index-readers-docugami` by hashing both the text and the xpath of an element, under the assumption that unique elements always have different xpaths but they might not always have different text.