### PR TITLE
feat: Prefer 'BedrockRerank' over 'AWSBedrockRerank'

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/README.md
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/README.md
@@ -4,14 +4,14 @@
 
 ```python
 from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
-from llama_index.postprocessor.bedrock_rerank import AWSBedrockRerank
+from llama_index.postprocessor.bedrock_rerank import BedrockRerank
 
 
 documents = SimpleDirectoryReader("./data/paul_graham/").load_data()
 index = VectorStoreIndex.from_documents(documents=documents)
-reranker = AWSBedrockRerank(
+reranker = BedrockRerank(
     top_n=3,
-    model_id="cohere.rerank-v3-5:0",
+    rerank_model_name="cohere.rerank-v3-5:0",
     region_name="us-west-2",
 )
 query_engine = index.as_query_engine(

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/llama_index/postprocessor/bedrock_rerank/__init__.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/llama_index/postprocessor/bedrock_rerank/__init__.py
@@ -1,3 +1,6 @@
-from llama_index.postprocessor.bedrock_rerank.base import AWSBedrockRerank
+from llama_index.postprocessor.bedrock_rerank.base import (
+    AWSBedrockRerank,
+    BedrockRerank,
+)
 
-__all__ = ["AWSBedrockRerank"]
+__all__ = ["AWSBedrockRerank", "BedrockRerank"]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-bedrock-rerank"
-version = "0.3.2"
+version = "0.3.3"
 description = "llama-index postprocessor bedrock rerank integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/tests/test_postprocessor_bedrock_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/tests/test_postprocessor_bedrock_rerank.py
@@ -8,12 +8,12 @@ from llama_index.core.postprocessor.types import (
 )
 from llama_index.core.schema import TextNode
 
-from llama_index.postprocessor.bedrock_rerank import AWSBedrockRerank
+from llama_index.postprocessor.bedrock_rerank import BedrockRerank
 
 
-class TestAWSBedrockRerank(TestCase):
+class TestBedrockRerank(TestCase):
     def test_class(self):
-        names_of_base_classes = [b.__name__ for b in AWSBedrockRerank.__mro__]
+        names_of_base_classes = [b.__name__ for b in BedrockRerank.__mro__]
         self.assertIn(BaseNodePostprocessor.__name__, names_of_base_classes)
 
     def test_bedrock_rerank(self):
@@ -43,7 +43,7 @@ class TestAWSBedrockRerank(TestCase):
         ]
 
         bedrock_client = boto3.client("bedrock-agent-runtime", region_name="us-west-2")
-        reranker = AWSBedrockRerank(client=bedrock_client, num_results=2)
+        reranker = BedrockRerank(client=bedrock_client, num_results=2)
 
         with mock.patch.object(
             bedrock_client, "rerank", return_value=exp_rerank_response


### PR DESCRIPTION
# Description

Updates the usage of `AWSBedrockRerank` to just `BedrockRerank` in an effort to stay consistent with the other Amazon Bedrock "offerings" ([BedrockMultimodal](https://docs.llamaindex.ai/en/stable/api_reference/multi_modal_llms/bedrock/), [BedrockConverse](https://docs.llamaindex.ai/en/stable/examples/llm/bedrock_converse/), etc.).

I also included a small fix in the README.md as the previously mentioned `model_id` kwarg is non-existent in this implementation.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
