### PR TITLE
Add reasoning support to mistralai LLM + magistral

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/utils.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict
 
 MISTRALAI_MODELS: Dict[str, int] = {
@@ -18,6 +19,10 @@ MISTRALAI_MODELS: Dict[str, int] = {
     "ministral-3b-latest": 131000,
     "pixtral-large-latest": 131000,
     "pixtral-12b-2409": 131000,
+    "magistral-medium-2506": 40000,
+    "magistral-small-2506": 40000,
+    "magistral-medium-latest": 40000,
+    "magistral-small-latest": 40000,
 }
 
 MISTRALAI_FUNCTION_CALLING_MODELS = (
@@ -30,9 +35,23 @@ MISTRALAI_FUNCTION_CALLING_MODELS = (
     "open-mistral-nemo-latest",
     "pixtral-large-latest",
     "pixtral-12b-2409",
+    "magistral-medium-2506",
+    "magistral-small-2506",
+    "magistral-medium-latest",
+    "magistral-small-latest",
+)
+
+MISTRAL_AI_REASONING_MODELS = (
+    "magistral-medium-2506",
+    "magistral-small-2506",
+    "magistral-medium-latest",
+    "magistral-small-latest",
 )
 
 MISTRALAI_CODE_MODELS = "codestral-latest"
+
+THINKING_REGEX = re.compile(r"^<think>\n(.*?)\n</think>\n")
+THINKING_START_REGEX = re.compile(r"^<think>\n")
 
 
 def mistralai_modelname_to_contextsize(modelname: str) -> int:

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
@@ -26,14 +26,14 @@ dev = [
 
 [project]
 name = "llama-index-llms-mistralai"
-version = "0.5.0"
+version = "0.6.0"
 description = "llama-index llms mistral ai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "mistralai>=1.0.0",
+    "mistralai>=1.8.2",
     "llama-index-core>=0.12.0,<0.13",
 ]
 

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/tests/test_llms_mistral.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/tests/test_llms_mistral.py
@@ -5,11 +5,12 @@ from mistralai import ToolCall
 import pytest
 
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.llms import ChatMessage
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.mistralai import MistralAI
 
 
-def test_embedding_class():
+def test_llm_class():
     names_of_base_classes = [b.__name__ for b in MistralAI.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
 
@@ -80,3 +81,72 @@ def test_prepare_chat_with_tools_tool_not_required(mock_mistral_client):
         assert len(result["tools"]) == 1
         assert result["tools"][0]["type"] == "function"
         assert result["tools"][0]["function"]["name"] == "search_tool"
+
+
+@pytest.mark.skipif(
+    os.environ.get("MISTRAL_API_KEY") is None, reason="MISTRAL_API_KEY not set"
+)
+def test_thinking():
+    llm = MistralAI(model="magistral-small-latest", show_thinking=True)
+
+    # It will sometimes not think, so we need to guard
+    result = llm.complete("What is the capital of France?")
+    if "thinking" in result.additional_kwargs:
+        assert result.additional_kwargs["thinking"] is not None
+        assert result.additional_kwargs["thinking"] != ""
+        assert "<think>" in result.text
+
+    result = llm.chat(
+        [ChatMessage(role="user", content="What is the capital of France?")]
+    )
+    if "thinking" in result.message.additional_kwargs:
+        assert result.message.additional_kwargs["thinking"] is not None
+        assert result.message.additional_kwargs["thinking"] != ""
+        assert "<think>" in result.message.content
+
+    result = llm.stream_complete("What is the capital of France?")
+    resp = None
+    for resp in result:
+        pass
+
+    assert resp is not None
+    if "thinking" in resp.additional_kwargs:
+        assert resp.additional_kwargs["thinking"] is not None
+        assert resp.additional_kwargs["thinking"] != ""
+        assert "<think>" in resp.text
+
+    result = llm.stream_chat(
+        [ChatMessage(role="user", content="What is the capital of France?")]
+    )
+    resp = None
+    for resp in result:
+        pass
+
+    assert resp is not None
+    if "thinking" in resp.message.additional_kwargs:
+        assert resp.message.additional_kwargs["thinking"] is not None
+        assert resp.message.additional_kwargs["thinking"] != ""
+        assert "<think>" in resp.message.content
+
+
+@pytest.mark.skipif(
+    os.environ.get("MISTRAL_API_KEY") is None, reason="MISTRAL_API_KEY not set"
+)
+def test_thinking_not_shown():
+    llm = MistralAI(model="magistral-small-latest", show_thinking=False)
+
+    result = llm.complete("What is the capital of France?")
+
+    if "thinking" in result.additional_kwargs:
+        assert result.additional_kwargs["thinking"] is None
+        assert result.additional_kwargs["thinking"] is None
+        assert "<think>" not in result.text
+
+    response_gen = llm.stream_complete("What is the capital of France?")
+    resp = None
+    for resp in response_gen:
+        assert "<think>" not in resp.text
+
+    if "thinking" in resp.additional_kwargs:
+        assert resp.additional_kwargs["thinking"] is None
+        assert "<think>" not in resp.text


### PR DESCRIPTION
Added option to show/hide thinking in final response. But always throw the thinking if its there into additional_kwargs

Added magistral to the supported model names.

Added tests (that run locally anyways) for this, and they pass.