### PR TITLE
Return empty list when argument raw_figure_nodes is None type in page_figure_nodes_to_node_with_score

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/api_utils.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/api_utils.py
@@ -297,12 +297,14 @@ def page_screenshot_nodes_to_node_with_score(
 
 def image_nodes_to_node_with_score(
     client: LlamaCloud,
-    raw_image_nodes: List[PageScreenshotNodeWithScore],
+    raw_image_nodes: Optional[List[PageScreenshotNodeWithScore]],
     project_id: str,
 ) -> List[NodeWithScore]:
     """
     Legacy method to alias page_screenshot_nodes_to_node_with_score.
     """
+    if not raw_image_nodes:  # None o list
+        return []
     return page_screenshot_nodes_to_node_with_score(
         client=client, raw_image_nodes=raw_image_nodes, project_id=project_id
     )
@@ -310,9 +312,12 @@ def image_nodes_to_node_with_score(
 
 def page_figure_nodes_to_node_with_score(
     client: LlamaCloud,
-    raw_figure_nodes: List[PageFigureNodeWithScore],
+    raw_figure_nodes: Optional[List[PageFigureNodeWithScore]],
     project_id: str,
 ) -> List[NodeWithScore]:
+    if not raw_figure_nodes:  # None o list
+        return []
+
     figure_nodes = []
     for raw_figure_node in raw_figure_nodes:
         figure_bytes = get_page_figure(

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/api_utils.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/api_utils.py
@@ -1,17 +1,21 @@
-from typing import Any, Optional, Tuple, Union, Dict, Callable
+import base64
 import urllib.parse
 import uuid
 from httpx import Request, HTTPStatusError
-
 from tenacity import (
     retry,
     wait_exponential_jitter,
     stop_after_attempt,
     retry_if_exception,
 )
+from typing import Any, Optional, Tuple, List, Union, Dict, Callable
+
 from llama_index.core.async_utils import run_jobs
+from llama_index.core.schema import NodeWithScore, ImageNode
 from llama_cloud import (
     AutoTransformConfig,
+    PageFigureNodeWithScore,
+    PageScreenshotNodeWithScore,
     Pipeline,
     PipelineCreateEmbeddingConfig,
     PipelineCreateEmbeddingConfig_OpenaiEmbedding,
@@ -261,18 +265,14 @@ async def aget_page_figure(
         raise ApiError(status_code=_response.status_code, body=_response.text)
 
 
-from typing import List
-import base64
-from llama_cloud import PageScreenshotNodeWithScore, PageFigureNodeWithScore
-from llama_index.core.schema import NodeWithScore, ImageNode
-from llama_cloud.client import LlamaCloud, AsyncLlamaCloud
-
-
 def page_screenshot_nodes_to_node_with_score(
     client: LlamaCloud,
-    raw_image_nodes: List[PageScreenshotNodeWithScore],
+    raw_image_nodes: Optional[List[PageScreenshotNodeWithScore]],
     project_id: str,
 ) -> List[NodeWithScore]:
+    if not raw_image_nodes:
+        return []
+
     image_nodes = []
     for raw_image_node in raw_image_nodes:
         image_bytes = get_page_screenshot(
@@ -292,6 +292,7 @@ def page_screenshot_nodes_to_node_with_score(
             score=raw_image_node.score,
         )
         image_nodes.append(image_node_with_score)
+
     return image_nodes
 
 
@@ -303,8 +304,9 @@ def image_nodes_to_node_with_score(
     """
     Legacy method to alias page_screenshot_nodes_to_node_with_score.
     """
-    if not raw_image_nodes:  # None o list
+    if not raw_image_nodes:
         return []
+
     return page_screenshot_nodes_to_node_with_score(
         client=client, raw_image_nodes=raw_image_nodes, project_id=project_id
     )
@@ -315,7 +317,7 @@ def page_figure_nodes_to_node_with_score(
     raw_figure_nodes: Optional[List[PageFigureNodeWithScore]],
     project_id: str,
 ) -> List[NodeWithScore]:
-    if not raw_figure_nodes:  # None o list
+    if not raw_figure_nodes:
         return []
 
     figure_nodes = []
@@ -344,9 +346,12 @@ def page_figure_nodes_to_node_with_score(
 
 async def apage_screenshot_nodes_to_node_with_score(
     client: AsyncLlamaCloud,
-    raw_image_nodes: List[PageScreenshotNodeWithScore],
+    raw_image_nodes: Optional[List[PageScreenshotNodeWithScore]],
     project_id: str,
 ) -> List[NodeWithScore]:
+    if not raw_image_nodes:
+        return []
+
     image_nodes = []
     tasks = [
         aget_page_screenshot(
@@ -376,12 +381,15 @@ async def apage_screenshot_nodes_to_node_with_score(
 
 async def aimage_nodes_to_node_with_score(
     client: AsyncLlamaCloud,
-    raw_image_nodes: List[PageScreenshotNodeWithScore],
+    raw_image_nodes: Optional[List[PageScreenshotNodeWithScore]],
     project_id: str,
 ) -> List[NodeWithScore]:
     """
     Legacy method to alias apage_screenshot_nodes_to_node_with_score.
     """
+    if not raw_image_nodes:
+        return []
+
     return await apage_screenshot_nodes_to_node_with_score(
         client=client, raw_image_nodes=raw_image_nodes, project_id=project_id
     )
@@ -389,9 +397,12 @@ async def aimage_nodes_to_node_with_score(
 
 async def apage_figure_nodes_to_node_with_score(
     client: AsyncLlamaCloud,
-    raw_figure_nodes: List[PageFigureNodeWithScore],
+    raw_figure_nodes: Optional[List[PageFigureNodeWithScore]],
     project_id: str,
 ) -> List[NodeWithScore]:
+    if not raw_figure_nodes:
+        return []
+
     figure_nodes = []
     tasks = [
         aget_page_figure(
@@ -418,4 +429,5 @@ async def apage_figure_nodes_to_node_with_score(
             score=raw_figure_node.score,
         )
         figure_nodes.append(figure_node_with_score)
+
     return figure_nodes

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
@@ -661,8 +661,8 @@ class LlamaCloudIndex(BaseManagedIndex):
         )
 
         doc_ids = [doc.id for doc in upserted_documents]
-        index._wait_for_documents_ingestion(
-            doc_ids, verbose=verbose, raise_on_error=raise_on_error
+        index.wait_for_completion(
+            doc_ids=doc_ids, verbose=verbose, raise_on_error=raise_on_error
         )
 
         print(

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-indices-managed-llama-cloud"
-version = "0.7.6"
+version = "0.7.7"
 description = "llama-index indices llama-cloud integration"
 authors = [{name = "Logan Markewich", email = "logan@llamaindex.ai"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/uv.lock
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/uv.lock
@@ -1652,16 +1652,16 @@ wheels = [
 
 [[package]]
 name = "llama-cloud"
-version = "0.1.25"
+version = "0.1.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/f5/f8a4a01a1c05ef5e6f9a24a08226a464f9ba9552fc5ce47a1413297b329b/llama_cloud-0.1.25.tar.gz", hash = "sha256:8c835b6404a5ccd095cff967f2c4a57a0d24395f35bd3e7f9ec6bb306546a163", size = 101793, upload_time = "2025-06-10T18:49:24.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/02/c6428db51ec5dfcadc9a29e16fcb3829a10d82f6deebf71db0412fc80ef0/llama_cloud-0.1.26.tar.gz", hash = "sha256:b307f91b1ad97189b5278119ac4ad665931b65f240fb643b3e384d0a1fc81f56", size = 92788, upload_time = "2025-06-10T23:35:09.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/22/959e5cb1454cc8757365f52fc1db374acbc8b0adc19c1a28206970b13be6/llama_cloud-0.1.25-py3-none-any.whl", hash = "sha256:5ed47aecc4bf61dec2410299d97ac4b2542d125188a2692bf7118cae61bd5673", size = 266771, upload_time = "2025-06-10T18:49:23.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2a/80864124d649ef06a3cbc93adb0b236dcc3d95348a36e65b852e3ccc9bb4/llama_cloud-0.1.26-py3-none-any.whl", hash = "sha256:2c0b2663e619b71c0645885ef622d6443725ab37bdc6ae5fb723e097f3af9459", size = 266775, upload_time = "2025-06-10T23:35:08.205Z" },
 ]
 
 [[package]]
@@ -1716,7 +1716,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-indices-managed-llama-cloud"
-version = "0.7.5"
+version = "0.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "llama-cloud" },
@@ -1750,7 +1750,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "llama-cloud", specifier = "==0.1.25" },
+    { name = "llama-cloud", specifier = "==0.1.26" },
     { name = "llama-index-core", specifier = ">=0.12.0,<0.13" },
 ]
 


### PR DESCRIPTION


# Description

When creating a LlamaCloudIndex the method page_figure_nodes_to_node_with_score in api_utils.py can receive a None type instead of an interator in argument raw_figure_nodes. This makes the process to crash.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
