### PR TITLE
Fix Typo in Method Name and Update Example Query in README

### DIFF
--- a/llama-index-cli/llama_index/cli/rag/base.py
+++ b/llama-index-cli/llama_index/cli/rag/base.py
@@ -61,7 +61,7 @@ class QueryPipelineQueryEngine(CustomQueryEngine):
     def custom_query(self, query_str: str) -> RESPONSE_TYPE:
         return self.query_pipeline.run(query_str=query_str)
 
-    async def accustom_query(self, query_str: str) -> RESPONSE_TYPE:
+    async def acustom_query(self, query_str: str) -> RESPONSE_TYPE:
         return await self.query_pipeline.arun(query_str=query_str)
 
 


### PR DESCRIPTION


Description:  
This pull request addresses two minor issues:
1. Corrects a typo in the method name from acustom_query to accustom_query in llama_index/cli/rag/base.py, ensuring consistency and proper async usage.
2. Updates the example query in llama-index-packs/llama-index-packs-deeplake-multimodal-retrieval/README.md by fixing the word "celebrity" to "celebriy" for accuracy.

These changes improve code readability and documentation accuracy. No breaking changes are introduced.