### PR TITLE
Fix Typo in Environment Variable Name in README

### DIFF
--- a/llama-index-networks/examples/privacy_safe_retrieval/README.md
+++ b/llama-index-networks/examples/privacy_safe_retrieval/README.md
@@ -80,7 +80,7 @@ fill in your openai-api-key and then save it as `.env.contributor.service`
 (you can also save it simply as `.env` as the `ContributorRetrieverServiceSettings`
 class will look for `.env` file if it can't find `.env.contributor.service`).
 
-Additionally, we need to define the `SIMILIARITY_TOP_K` environment variable
+Additionally, we need to define the `SIMILARITY_TOP_K` environment variable
 for each of the retrievers. To do this, you can use `template.env.retriever` file
 and fill in your desired top-k value and then save it as `.env.retriever`. You
 must do this for both contributors.


### PR DESCRIPTION
# Description

This pull request corrects a typo in the environment variable name from SIMILIARITY_TOP_K to SIMILARITY_TOP_K in the README file for the privacy_safe_retrieval example. This change ensures consistency and prevents potential configuration errors for users following the documentation. No other files were modified.