### PR TITLE
Added cache dir to Sentence Transformers post processor

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-sbert-rerank/llama_index/postprocessor/sbert_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-sbert-rerank/llama_index/postprocessor/sbert_rerank/base.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
+from pathlib import Path
 
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CBEventType, EventPayload
@@ -35,6 +36,7 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
         model: str = "cross-encoder/stsb-distilroberta-base",
         device: Optional[str] = None,
         keep_retrieval_score: Optional[bool] = False,
+        cache_dir: Optional[Union[str, Path]] = None,
     ):
         try:
             from sentence_transformers import CrossEncoder
@@ -52,7 +54,10 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
         )
         device = infer_torch_device() if device is None else device
         self._model = CrossEncoder(
-            model, max_length=DEFAULT_SENTENCE_TRANSFORMER_MAX_LENGTH, device=device
+            model,
+            max_length=DEFAULT_SENTENCE_TRANSFORMER_MAX_LENGTH,
+            device=device,
+            cache_dir=cache_dir,
         )
 
     @classmethod

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-sbert-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-sbert-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-sbert-rerank"
-version = "0.3.0"
+version = "0.3.1"
 description = "llama-index postprocessor sbert rerank integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Adding `cache_dir` to `SentenceTransformerReranker` in `llama-index-postprocessor-sbert`.

Fixes #19093 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
