### PR TITLE
Fix error getting metadata file IDs in google drive reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -271,9 +271,9 @@ class GoogleDriveReader(
         """
         from googleapiclient.discovery import build
 
+        fileids_meta = []
         try:
             service = build("drive", "v3", credentials=self._creds)
-            fileids_meta = []
 
             if folder_id and not file_id:
                 try:
@@ -427,6 +427,7 @@ class GoogleDriveReader(
             logger.error(
                 f"An error occurred while getting fileids metadata: {e}", exc_info=True
             )
+            return fileids_meta
 
     def _download_file(self, fileid: str, filename: str) -> str:
         """

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-google"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index readers google integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
We log an error, but return nothing, which implicitly returns `None` -- this will cause errors later on when we try to deconstruct the returned list from the function