### PR TITLE
fix issue#19116: Connections.connect() got multiple values for argume…

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -318,7 +318,8 @@ class MilvusVectorStore(BasePydanticVectorStore):
             **kwargs,  # pass additional arguments such as server_pem_path
         )
 
-        # https://github.com/run-llama/llama_index/issues/19116
+        # As of writing, milvus sets alias internally in the async client.
+        # This will cause an error if not removed.
         kwargs.pop("alias", None)
 
         self._async_milvusclient = AsyncMilvusClient(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-milvus"
-version = "0.8.4"
+version = "0.8.5"
 description = "llama-index vector_stores milvus integration"
 authors = []
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Fixes issue 19116 which causes the error "Connections.connect() got multiple values for argument 'alias' when instantiating the MilvusVectorStore class with the "alias" parameter. The synchronous MilvusClient uses this parameter to name and reuse connections, but the AsyncMilvusClient (also instantiated in the MilvusVectorStore.__init__) throws this error.

Fixes #19116

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X ] No

## Type of Change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested with local build.

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X ] I believe this change is already covered by existing unit tests