### PR TITLE
Fix token counting bug

### DIFF
--- a/llama-index-core/llama_index/core/utilities/token_counting.py
+++ b/llama-index-core/llama_index/core/utilities/token_counting.py
@@ -30,7 +30,7 @@ class TokenCounter:
             int: The token count.
 
         """
-        return len(self.tokenizer(string))
+        return len(self.tokenizer(string.replace("\n", " ")))
 
     def estimate_tokens_in_messages(self, messages: List[ChatMessage]) -> int:
         """


### PR DESCRIPTION
# Description

Fixes a minor bug in embedding token-counting within `TokenCountingHandler`.  
The current implementation replaces `\n` with spaces (`" "`) before sending the prompt to the model (e.g., OpenAI), but this replacement is **not** applied when counting tokens locally.  
This causes a mismatch between actual usage reported by the provider and what LlamaIndex estimates.

### Fix

Added `.replace("\n", " ")` before counting tokens to align local counting with what is actually sent.

**Fixes:** No associated issue number (happy to file one if needed).


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes  
- [x] No


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes  
- [x] No


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- [x] Manually compared OpenAI API usage reports with `TokenCountingHandler` output after the fix


## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
