### PR TITLE
Making the progress bar of title extractor unified

### DIFF
--- a/llama-index-core/llama_index/core/extractors/metadata_extractors.py
+++ b/llama-index-core/llama_index/core/extractors/metadata_extractors.py
@@ -137,27 +137,38 @@ class TitleExtractor(BaseExtractor):
         return separated_items
 
     async def extract_titles(self, nodes_by_doc_id: Dict) -> Dict:
-        titles_by_doc_id = {}
-        for key, nodes in nodes_by_doc_id.items():
+        jobs = []
+        final_dict = {}
+
+        async def get_titles_by_doc(nodes: List[BaseNode], key: str) -> Dict:
+            titles_by_doc_id = {}
             title_candidates = await self.get_title_candidates(nodes)
             combined_titles = ", ".join(title_candidates)
             titles_by_doc_id[key] = await self.llm.apredict(
                 PromptTemplate(template=self.combine_template),
                 context_str=combined_titles,
             )
-        return titles_by_doc_id
+            return titles_by_doc_id
+
+        for key, nodes in nodes_by_doc_id.items():
+            jobs.append(get_titles_by_doc(nodes, key))
+        list_dict_titles: List[Dict] = await run_jobs(
+            jobs=jobs,
+            show_progress=self.show_progress,
+        )
+        for d in list_dict_titles:
+            for key, value in d.items():
+                final_dict.update({key: value})
+        return final_dict
 
     async def get_title_candidates(self, nodes: List[BaseNode]) -> List[str]:
-        title_jobs = [
-            self.llm.apredict(
+        return [
+            await self.llm.apredict(
                 PromptTemplate(template=self.node_template),
                 context_str=cast(TextNode, node).text,
             )
             for node in nodes
         ]
-        return await run_jobs(
-            title_jobs, show_progress=self.show_progress, workers=self.num_workers
-        )
 
 
 DEFAULT_KEYWORD_EXTRACT_TEMPLATE = """\


### PR DESCRIPTION
# Description

This PR makes the progress bar of `TitleExtractor` unified for all title extractions jobs instead of one per job.

Fixes #19129 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
