### PR TITLE
Remove breakpoints from CoA code

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-coa/llama_index/agent/coa/output_parser.py
+++ b/llama-index-integrations/agent/llama-index-agent-coa/llama_index/agent/coa/output_parser.py
@@ -2,11 +2,11 @@
 
 import asyncio
 import json
-import networkx as nx
 import re
 from collections import defaultdict
 from typing import Dict, Tuple
 
+import networkx as nx
 from llama_index.core.tools import AsyncBaseTool, ToolOutput
 from llama_index.core.types import BaseOutputParser
 
@@ -84,7 +84,6 @@ class ChainOfAbstractionParser(BaseOutputParser):
                 )
 
                 # loop up any inputs that depend on other functions
-                breakpoint()
                 input_values = [results.get(inp, inp) for inp in inputs]
                 if self._verbose:
                     print(

--- a/llama-index-integrations/agent/llama-index-agent-coa/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-coa/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-agent-coa"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index agent coa integration"
 authors = [{name = "Logan Markewich", email = "logan@runllama.ai"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-packs/llama-index-packs-agents-coa/llama_index/packs/agents_coa/output_parser.py
+++ b/llama-index-packs/llama-index-packs-agents-coa/llama_index/packs/agents_coa/output_parser.py
@@ -84,7 +84,6 @@ class ChainOfAbstractionParser(BaseOutputParser):
                 )
 
                 # loop up any inputs that depend on other functions
-                breakpoint()
                 input_values = [results.get(inp, inp) for inp in inputs]
                 if self._verbose:
                     print(

--- a/llama-index-packs/llama-index-packs-agents-coa/pyproject.toml
+++ b/llama-index-packs/llama-index-packs-agents-coa/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-packs-agents-coa"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index packs for chain-of-abstraction"
 authors = [{name = "Logan Markewich", email = "logan@runllama.ai"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

- Removes breakpoints from CoA code which were introduced in https://github.com/run-llama/llama_index/pull/19137
- Modifies CoA function call parsing to handle placeholders better.
- Also my editor moved the networkx import to the proper location so I kept that change as well.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
