### PR TITLE
Fix typo: Correct "prediciton" to "prediction" in docstrings

### DIFF
--- a/llama-index-core/llama_index/core/llama_dataset/base.py
+++ b/llama-index-core/llama_index/core/llama_dataset/base.py
@@ -200,7 +200,7 @@ class BaseLlamaDataset(BaseModel, Generic[P]):
         NOTE: Subclasses need to implement this.
 
         Args:
-            predictor (PredictorType): The predictor to make the prediciton with.
+            predictor (PredictorType): The predictor to make the prediction with.
             example (BaseLlamaDataExample): The example to predict on.
 
         Returns:
@@ -263,7 +263,7 @@ class BaseLlamaDataset(BaseModel, Generic[P]):
         NOTE: Subclasses need to implement this.
 
         Args:
-            predictor (PredictorType): The predictor to make the prediciton with.
+            predictor (PredictorType): The predictor to make the prediction with.
             example (BaseLlamaDataExample): The example to predict on.
 
         Returns:


### PR DESCRIPTION
Fix spelling errors in docstring parameters:
- Corrected "prediciton" to "prediction" in _predict_example() method
- Corrected same typo in _apredict_example() method

This improves code documentation quality and consistency.
