### PR TITLE
Enable forwarding of arbitrary Azure Search SDK parameters in AzureAISearchVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -1223,7 +1223,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                     odata_filter,
                     self._search_client,
                     self._async_search_client,
-                    **kwargs
+                    **kwargs,
                 )
             )
         if query.mode == VectorStoreQueryMode.SPARSE:
@@ -1233,7 +1233,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
-                **kwargs
+                **kwargs,
             )
         elif query.mode == VectorStoreQueryMode.HYBRID:
             azure_query_result_search = AzureQueryResultSearchHybrid(
@@ -1242,7 +1242,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
-                **kwargs
+                **kwargs,
             )
         elif query.mode == VectorStoreQueryMode.SEMANTIC_HYBRID:
             azure_query_result_search = AzureQueryResultSearchSemanticHybrid(
@@ -1252,7 +1252,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._search_client,
                 self._async_search_client,
                 self._semantic_configuration_name or "mySemanticConfig",
-                **kwargs
+                **kwargs,
             )
         return azure_query_result_search.search()
 
@@ -1276,7 +1276,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
-                **kwargs
+                **kwargs,
             )
         )
         if query.mode == VectorStoreQueryMode.SPARSE:
@@ -1286,7 +1286,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
-                **kwargs
+                **kwargs,
             )
         elif query.mode == VectorStoreQueryMode.HYBRID:
             azure_query_result_search = AzureQueryResultSearchHybrid(
@@ -1295,7 +1295,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
-                **kwargs
+                **kwargs,
             )
         elif query.mode == VectorStoreQueryMode.SEMANTIC_HYBRID:
             azure_query_result_search = AzureQueryResultSearchSemanticHybrid(
@@ -1305,7 +1305,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._search_client,
                 self._async_search_client,
                 self._semantic_configuration_name or "mySemanticConfig",
-                **kwargs
+                **kwargs,
             )
         return await azure_query_result_search.asearch()
 
@@ -1475,7 +1475,6 @@ class AzureQueryResultSearchBase:
     def _create_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
-        
         params = {
             "search_text": search_query,
             "vector_queries": vectors,
@@ -1484,12 +1483,10 @@ class AzureQueryResultSearchBase:
             "filter": self._odata_filter,
             "semantic_configuration_name": self._semantic_configuration_name,
         }
-        
+
         params.update(self._search_kwargs)
-        
-        results = self._search_client.search(
-            **params
-        )
+
+        results = self._search_client.search(**params)
 
         id_result = []
         node_result = []
@@ -1536,7 +1533,6 @@ class AzureQueryResultSearchBase:
     async def _acreate_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
-        
         params = {
             "search_text": search_query,
             "vector_queries": vectors,
@@ -1545,12 +1541,10 @@ class AzureQueryResultSearchBase:
             "filter": self._odata_filter,
             "semantic_configuration_name": self._semantic_configuration_name,
         }
-        
+
         params.update(self._search_kwargs)
-        
-        results = await self._async_search_client.search(
-            **params
-        )
+
+        results = await self._async_search_client.search(**params)
 
         id_result = []
         node_result = []
@@ -1667,7 +1661,6 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
     def _create_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
-        
         params = {
             "search_text": search_query,
             "vector_queries": vectors,
@@ -1677,12 +1670,10 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
             "semantic_configuration_name": self._semantic_configuration_name,
             "query_type": "semantic",
         }
-        
+
         params.update(self._search_kwargs)
-        
-        results = self._search_client.search(
-            **params
-        )
+
+        results = self._search_client.search(**params)
 
         id_result = []
         node_result = []
@@ -1730,7 +1721,6 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
     async def _acreate_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
-        
         params = {
             "search_text": search_query,
             "vector_queries": vectors,
@@ -1740,12 +1730,10 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
             "semantic_configuration_name": self._semantic_configuration_name,
             "query_type": "semantic",
         }
-        
+
         params.update(self._search_kwargs)
-        
-        results = await self._async_search_client.search(
-            **params
-        )
+
+        results = await self._async_search_client.search(**params)
         id_result = []
         node_result = []
         score_result = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -1205,7 +1205,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         odata_filter = None
         semantic_configuration_name = None
 
-        # NOTE: users can provide odata_filters directly to the query
+        # NOTE: users can provide odata_filters directly to the query and any other search parameters like scoring_profile etc .
         odata_filters = kwargs.get("odata_filters")
         if odata_filters is not None:
             odata_filter = odata_filters
@@ -1223,6 +1223,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                     odata_filter,
                     self._search_client,
                     self._async_search_client,
+                    **kwargs
                 )
             )
         if query.mode == VectorStoreQueryMode.SPARSE:
@@ -1232,6 +1233,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                **kwargs
             )
         elif query.mode == VectorStoreQueryMode.HYBRID:
             azure_query_result_search = AzureQueryResultSearchHybrid(
@@ -1240,6 +1242,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                **kwargs
             )
         elif query.mode == VectorStoreQueryMode.SEMANTIC_HYBRID:
             azure_query_result_search = AzureQueryResultSearchSemanticHybrid(
@@ -1249,6 +1252,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._search_client,
                 self._async_search_client,
                 self._semantic_configuration_name or "mySemanticConfig",
+                **kwargs
             )
         return azure_query_result_search.search()
 
@@ -1272,6 +1276,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                **kwargs
             )
         )
         if query.mode == VectorStoreQueryMode.SPARSE:
@@ -1281,6 +1286,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                **kwargs
             )
         elif query.mode == VectorStoreQueryMode.HYBRID:
             azure_query_result_search = AzureQueryResultSearchHybrid(
@@ -1289,6 +1295,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 odata_filter,
                 self._search_client,
                 self._async_search_client,
+                **kwargs
             )
         elif query.mode == VectorStoreQueryMode.SEMANTIC_HYBRID:
             azure_query_result_search = AzureQueryResultSearchSemanticHybrid(
@@ -1298,6 +1305,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._search_client,
                 self._async_search_client,
                 self._semantic_configuration_name or "mySemanticConfig",
+                **kwargs
             )
         return await azure_query_result_search.asearch()
 
@@ -1439,6 +1447,7 @@ class AzureQueryResultSearchBase:
         search_client: SearchClient,
         async_search_client: AsyncSearchClient,
         semantic_configuration_name: Optional[str] = None,
+        **search_kwargs: Any,
     ) -> None:
         self._query = query
         self._field_mapping = field_mapping
@@ -1446,6 +1455,7 @@ class AzureQueryResultSearchBase:
         self._search_client = search_client
         self._async_search_client = async_search_client
         self._semantic_configuration_name = semantic_configuration_name
+        self._search_kwargs = search_kwargs
 
     @property
     def _select_fields(self) -> List[str]:
@@ -1465,13 +1475,20 @@ class AzureQueryResultSearchBase:
     def _create_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
+        
+        params = {
+            "search_text": search_query,
+            "vector_queries": vectors,
+            "top": self._query.similarity_top_k,
+            "select": self._select_fields,
+            "filter": self._odata_filter,
+            "semantic_configuration_name": self._semantic_configuration_name,
+        }
+        
+        params.update(self._search_kwargs)
+        
         results = self._search_client.search(
-            search_text=search_query,
-            vector_queries=vectors,
-            top=self._query.similarity_top_k,
-            select=self._select_fields,
-            filter=self._odata_filter,
-            semantic_configuration_name=self._semantic_configuration_name,
+            **params
         )
 
         id_result = []
@@ -1519,13 +1536,20 @@ class AzureQueryResultSearchBase:
     async def _acreate_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
+        
+        params = {
+            "search_text": search_query,
+            "vector_queries": vectors,
+            "top": self._query.similarity_top_k,
+            "select": self._select_fields,
+            "filter": self._odata_filter,
+            "semantic_configuration_name": self._semantic_configuration_name,
+        }
+        
+        params.update(self._search_kwargs)
+        
         results = await self._async_search_client.search(
-            search_text=search_query,
-            vector_queries=vectors,
-            top=self._query.similarity_top_k,
-            select=self._select_fields,
-            filter=self._odata_filter,
-            semantic_configuration_name=self._semantic_configuration_name,
+            **params
         )
 
         id_result = []
@@ -1643,14 +1667,21 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
     def _create_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
+        
+        params = {
+            "search_text": search_query,
+            "vector_queries": vectors,
+            "top": self._query.similarity_top_k,
+            "select": self._select_fields,
+            "filter": self._odata_filter,
+            "semantic_configuration_name": self._semantic_configuration_name,
+            "query_type": "semantic",
+        }
+        
+        params.update(self._search_kwargs)
+        
         results = self._search_client.search(
-            search_text=search_query,
-            vector_queries=vectors,
-            top=self._query.similarity_top_k,
-            select=self._select_fields,
-            filter=self._odata_filter,
-            query_type="semantic",
-            semantic_configuration_name=self._semantic_configuration_name,
+            **params
         )
 
         id_result = []
@@ -1699,16 +1730,22 @@ class AzureQueryResultSearchSemanticHybrid(AzureQueryResultSearchHybrid):
     async def _acreate_query_result(
         self, search_query: str, vectors: Optional[List[Any]]
     ) -> VectorStoreQueryResult:
+        
+        params = {
+            "search_text": search_query,
+            "vector_queries": vectors,
+            "top": self._query.similarity_top_k,
+            "select": self._select_fields,
+            "filter": self._odata_filter,
+            "semantic_configuration_name": self._semantic_configuration_name,
+            "query_type": "semantic",
+        }
+        
+        params.update(self._search_kwargs)
+        
         results = await self._async_search_client.search(
-            search_text=search_query,
-            vector_queries=vectors,
-            top=self._query.similarity_top_k,
-            select=self._select_fields,
-            filter=self._odata_filter,
-            query_type="semantic",
-            semantic_configuration_name=self._semantic_configuration_name,
+            **params
         )
-
         id_result = []
         node_result = []
         score_result = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -329,3 +329,34 @@ def test_azureaisearch_semantic_query() -> None:
     assert len(result.nodes) == 2
     assert len(result.ids) == 2
     assert len(result.similarities) == 2
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
+def test_azureaisearch_query_forwards_extra_kwargs() -> None:
+    """Ensure any extra kwargs (e.g. scoring_profile, order_by) get forwarded."""
+    search_client = mock_client_with_user_agent("search")
+
+    search_client.search.return_value = []
+    vector_store = create_mock_vector_store(search_client)
+
+    query = VectorStoreQuery(
+        query_embedding=[0.1, 0.2],
+        similarity_top_k=1,
+        mode=VectorStoreQueryMode.DEFAULT,
+    )
+
+    # Pass two arbitrary params supported by Azure AI Search
+    vector_store.query(
+        query,
+        scoring_profile="myCustomProfile",
+        order_by=["title asc"],
+    )
+
+    called_kwargs = search_client.search.call_args[1]
+    # existing defaults still there
+    assert called_kwargs["search_text"] == "*"
+    # plus our extras
+    assert called_kwargs["scoring_profile"] == "myCustomProfile"
+    assert called_kwargs["order_by"] == ["title asc"]


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

_This change lets users pass any valid Azure Search SDK argument (e.g. scoring_profile, order_by, minimum_coverage, etc.) through AzureAISearchVectorStore for retrieval, when searching for documents_ 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
