### PR TITLE
Fix: Minor typo fixes in documentation

### DIFF
--- a/llama-index-integrations/memory/llama-index-memory-mem0/README.md
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/README.md
@@ -90,7 +90,7 @@ memory = Mem0Memory.from_config(
 
 Currently, Mem0 Memory is supported in the `SimpleChatEngine`, `FunctionCallingAgent` and `ReActAgent`.
 
-Intilaize the LLM
+Initialize the LLM
 
 ```python
 import os

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/README.md
@@ -19,7 +19,7 @@ To disable: `loader.load_data(recursive = False)`
 
 You can also filter the files by the mimeType e.g.: `mime_types=["application/vnd.openxmlformats-officedocument.wordprocessingml.document"]`
 
-### Authenticaton
+### Authentication
 
 OneDriveReader supports following two **MSAL authentication**:
 


### PR DESCRIPTION


### **Description:**

This pull request addresses two minor typographical errors found in the documentation.

**Changes:**

*   Corrected a typo from "Intilaize" to "Initialize" in `llama-index-integrations/memory/llama-index-memory-mem0/README.md`.
*   Corrected a typo from "Authenticaton" to "Authentication" in `llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/README.md`.

These changes improve the clarity and professionalism of the documentation.