### PR TITLE
Setting up System instruction properly for google genai client 

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -292,13 +292,12 @@ def prepare_chat_params(
 
     """
 
-    # Get the system message from the messages
-    system_message = None
-    # If first message is a system message, take it as a system instruction message for genai
-    for i, message in enumerate(messages):
-        if i == 0 and message.role == MessageRole.SYSTEM:
-            system_message = message.content
-            break
+    # Extract system message if present
+    system_message: str | None = None
+    if messages and messages[0].role == MessageRole.SYSTEM:
+        sys_msg = messages.pop(0)
+        system_message = sys_msg.content
+    # Now messages contains the rest of the chat history
 
     # Merge messages with the same role
     merged_messages = merge_neighboring_same_role_messages(messages)

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -291,7 +291,6 @@ def prepare_chat_params(
         - chat_kwargs: processed keyword arguments for chat creation
 
     """
-
     # Extract system message if present
     system_message: str | None = None
     if messages and messages[0].role == MessageRole.SYSTEM:

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -291,6 +291,16 @@ def prepare_chat_params(
         - chat_kwargs: processed keyword arguments for chat creation
 
     """
+
+    # Get the system message from the messages
+    system_message = None
+    # If first message is a system message, take it as a system instruction message for genai
+    for i, message in enumerate(messages):
+        if i == 0 and message.role == MessageRole.SYSTEM:
+            system_message = message.content
+            break
+
+    # Merge messages with the same role
     merged_messages = merge_neighboring_same_role_messages(messages)
     initial_history = list(map(chat_message_to_gemini, merged_messages))
 
@@ -338,6 +348,10 @@ def prepare_chat_params(
     )
     if not isinstance(config, dict):
         config = config.model_dump()
+
+    # Add system message as system_instruction if present
+    if system_message:
+        config["system_instruction"] = system_message
 
     chat_kwargs: ChatParams = {"model": model, "history": history}
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.2.1"
+version = "0.2.2"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -736,7 +736,6 @@ def test_prepare_chat_params_more_than_2_tool_calls():
     ]
 
 
-# New test for system message forwarding
 def test_prepare_chat_params_with_system_message():
     # Setup a conversation starting with a SYSTEM message
     model_name = "models/gemini-test"
@@ -759,7 +758,7 @@ def test_prepare_chat_params_with_system_message():
     assert isinstance(cfg, GenerateContentConfig)
     assert cfg.system_instruction == system_prompt
 
-    # Verify history only contains the system instruction block
+    # Verify history only contains the user messages and the assistant message
     assert chat_kwargs["history"] == [
         types.Content(
             parts=[types.Part(text=user_message_1)],

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -734,3 +734,44 @@ def test_prepare_chat_params_more_than_2_tool_calls():
             role=MessageRole.USER,
         ),
     ]
+
+# New test for system message forwarding
+def test_prepare_chat_params_with_system_message():
+    # Setup a conversation starting with a SYSTEM message
+    model_name = "models/gemini-test"
+    system_prompt = "You are a test system."
+    user_message_1 = "Hello from user 1."
+    assistant_message_1 = "Hello from assistant 1."
+    user_message_2 = "Hello from user 2."
+    messages = [
+        ChatMessage(content=system_prompt, role=MessageRole.SYSTEM),
+        ChatMessage(content=user_message_1, role=MessageRole.USER),
+        ChatMessage(content=assistant_message_1, role=MessageRole.ASSISTANT),
+        ChatMessage(content=user_message_2, role=MessageRole.USER),
+    ]
+
+    # Execute prepare_chat_params
+    next_msg, chat_kwargs = prepare_chat_params(model_name, messages)
+
+    # Verify system_prompt is forwarded to system_instruction
+    cfg = chat_kwargs["config"]
+    assert isinstance(cfg, GenerateContentConfig)
+    assert cfg.system_instruction == system_prompt
+
+    # Verify history only contains the system instruction block
+    assert chat_kwargs["history"] == [
+        types.Content(
+            parts=[types.Part(text=user_message_1)],
+            role=MessageRole.USER,
+        ),
+        types.Content(
+            parts=[types.Part(text=assistant_message_1)],
+            role=MessageRole.MODEL,
+        )
+    ]
+
+    # Verify next_msg is the user message
+    assert next_msg == types.Content(
+        parts=[types.Part(text=user_message_2)],
+        role=MessageRole.USER,
+    )

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -735,6 +735,7 @@ def test_prepare_chat_params_more_than_2_tool_calls():
         ),
     ]
 
+
 # New test for system message forwarding
 def test_prepare_chat_params_with_system_message():
     # Setup a conversation starting with a SYSTEM message
@@ -767,7 +768,7 @@ def test_prepare_chat_params_with_system_message():
         types.Content(
             parts=[types.Part(text=assistant_message_1)],
             role=MessageRole.MODEL,
-        )
+        ),
     ]
 
     # Verify next_msg is the user message


### PR DESCRIPTION
…sages/prompt templates

# Description

This pull request fixes a bug in the Google GenAI integration where `ChatMessage` objects with role `SYSTEM` were being treated as normal user messages instead of true system prompts. Now, all leading `SYSTEM` messages are extracted in `prepare_chat_params` and passed into the GenAI client’s `GenerateContentConfig.system_instruction` field, as documented by Google GenAI.

Check this offical documentation of Llamaindex genai client which states the usage of system prompt which is misleading according to actual implementation
https://docs.llamaindex.ai/en/stable/examples/llm/google_genai/

Closes [#19185](https://github.com/run-llama/llama_index/issues/19185)

**Changes**  
- In `llama_index/llms/google_genai/utils.py`:
  - Updated `prepare_chat_params` to:
    - Collect the first `MessageRole.SYSTEM` messages at the start of the conversation.
    - Store their contents into one string.
    - Set `config.system_instruction` to that string before instantiating `GenerateContentConfig`.
- Added unit tests in `tests/test_google_genai_utils.py` to verify:
  - A single `SYSTEM` message is forwarded correctly.
  - Absence of `SYSTEM` messages leaves `system_instruction` unset.

Fixes # (issue)

Checkout this issue reported here also https://github.com/run-llama/llama_index/issues/19185

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
