### PR TITLE
Mark older agent architectures in core as deprecated

### DIFF
--- a/docs/docs/examples/agent/react_agent.ipynb
+++ b/docs/docs/examples/agent/react_agent.ipynb
@@ -13,7 +13,7 @@
    "id": "1fb3144c-99b8-482d-a205-0f50877653aa",
    "metadata": {},
    "source": [
-    "# ReAct Agent - A Simple Intro with Calculator Tools\n",
+    "# ReActAgent - A Simple Intro with Calculator Tools\n",
     "\n",
     "This is a notebook that showcases the ReAct agent over very simple calculator tools (no fancy RAG pipelines or API calls).\n",
     "\n",

--- a/docs/docs/module_guides/deploying/agents/index.md
+++ b/docs/docs/module_guides/deploying/agents/index.md
@@ -44,6 +44,8 @@ Calling this agent kicks off a specific loop of actions:
     - The tool call results are added to the chat history
     - The Agent is invoked again with updated history, and either responds directly or selects more calls
 
+The `FunctionAgent` is a type of agent that uses an LLM provider's function/tool calling capabilities to execute tools. Other types of agents, such as [`ReActAgent`](../../../examples/agent/react_agent.ipynb) and [`CodeActAgent`](../../../examples/agent/code_act_agent.ipynb), use different prompting strategies to execute tools.
+
 ## Tools
 
 Tools can be defined simply as python functions, or further customized using classes like `FunctionTool` and `QueryEngineTool`. LlamaIndex also provides sets of pre-defined tools for common APIs using something called `Tool Specs`.

--- a/docs/docs/understanding/agent/index.md
+++ b/docs/docs/understanding/agent/index.md
@@ -91,6 +91,8 @@ workflow = FunctionAgent(
 
 GPT-4o-mini is actually smart enough to not need tools to do such simple math, which is why we specified that it should use tools in the prompt.
 
+Beyond `FunctionAgent`, there are other agents available in LlamaIndex, such as [`ReActAgent`](../../examples/agent/react_agent.ipynb) and [`CodeActAgent`](../../examples/agent/code_act_agent.ipynb), which use different prompting strategies to execute tools.
+
 ## Ask a question
 
 Now we can ask the agent to do some math:

--- a/llama-index-core/llama_index/core/agent/function_calling/base.py
+++ b/llama-index-core/llama_index/core/agent/function_calling/base.py
@@ -1,5 +1,6 @@
 """Function calling agent."""
 
+import deprecated
 from typing import Any, List, Optional
 
 from llama_index.core.agent.runner.base import AgentRunner, AgentState
@@ -16,8 +17,20 @@ from llama_index.core.settings import Settings
 from llama_index.core.tools.types import BaseTool
 
 
+@deprecated.deprecated(
+    reason=(
+        "FunctionCallingAgent has been rewritten and replaced by newer agents based on llama_index.core.agent.workflow.FunctionAgent.\n\n"
+        "This implementation will be removed in a v0.13.0.\n\n"
+        "See the docs for more information on updated usage: https://docs.llamaindex.ai/en/stable/understanding/agent/"
+    ),
+    action="once",
+)
 class FunctionCallingAgent(AgentRunner):
     """
+    DEPRECATED: FunctionCallingAgent has been deprecated and is not maintained.
+    This implementation will be removed in a v0.13.0.
+    See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/
+
     Function calling agent.
 
     Light wrapper around AgentRunner.

--- a/llama-index-core/llama_index/core/agent/legacy/react/base.py
+++ b/llama-index-core/llama_index/core/agent/legacy/react/base.py
@@ -1,4 +1,5 @@
 import asyncio
+import deprecated
 from itertools import chain
 from typing import (
     Any,
@@ -45,8 +46,21 @@ from llama_index.core.types import Thread
 from llama_index.core.utils import print_text, unit_generator
 
 
+@deprecated.deprecated(
+    reason=(
+        "ReActAgent has been rewritten and replaced by llama_index.core.agent.workflow.ReActAgent.\n\n"
+        "This implementation will be removed in a v0.13.0 and the new implementation will be "
+        "promoted to the `from llama_index.core.agent import ReActAgent` path.\n\n"
+        "See the docs for more information: https://docs.llamaindex.ai/en/stable/understanding/agent/"
+    ),
+    action="once",
+)
 class ReActAgent(BaseAgent):
     """
+    DEPRECATED: ReActAgent has been deprecated and is not maintained.
+    This implementation will be removed in a v0.13.0.
+    See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/
+
     ReAct agent.
 
     Uses a ReAct prompt that can be used in both chat and text

--- a/llama-index-core/llama_index/core/agent/react/base.py
+++ b/llama-index-core/llama_index/core/agent/react/base.py
@@ -10,6 +10,7 @@ from llama_index.core.agent.legacy.react.base import ReActAgent
 
 """
 
+import deprecated
 from typing import (
     Any,
     List,
@@ -36,8 +37,21 @@ from llama_index.core.tools import BaseTool, ToolOutput
 from llama_index.core.prompts.mixin import PromptMixinType
 
 
+@deprecated.deprecated(
+    reason=(
+        "ReActAgent has been rewritten and replaced by llama_index.core.agent.workflow.ReActAgent.\n\n"
+        "This implementation will be removed in a v0.13.0 and the new implementation will be "
+        "promoted to the `from llama_index.core.agent import ReActAgent` path.\n\n"
+        "See the docs for more information: https://docs.llamaindex.ai/en/stable/understanding/agent/"
+    ),
+    action="once",
+)
 class ReActAgent(AgentRunner):
     """
+    DEPRECATED: ReActAgent has been deprecated and is not maintained.
+    This implementation will be removed in a v0.13.0.
+    See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/
+
     ReAct agent.
 
     Subclasses AgentRunner with a ReActAgentWorker.

--- a/llama-index-core/llama_index/core/agent/runner/base.py
+++ b/llama-index-core/llama_index/core/agent/runner/base.py
@@ -1,3 +1,4 @@
+import deprecated
 import os
 from abc import abstractmethod
 from collections import deque
@@ -206,8 +207,20 @@ class AgentState(BaseModel):
         self.task_dict = {}
 
 
+@deprecated.deprecated(
+    reason=(
+        "AgentRunner has been deprecated and is not maintained.\n\n"
+        "This implementation will be removed in a v0.13.0.\n\n"
+        "See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/"
+    ),
+    action="once",
+)
 class AgentRunner(BaseAgentRunner):
     """
+    DEPRECATED: AgentRunner has been deprecated and is not maintained.
+    This implementation will be removed in a v0.13.0.
+    See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/
+
     Agent runner.
 
     Top-level agent orchestrator that can create tasks, run each step in a task,

--- a/llama-index-core/llama_index/core/agent/runner/parallel.py
+++ b/llama-index-core/llama_index/core/agent/runner/parallel.py
@@ -1,6 +1,7 @@
 """Agent executor."""
 
 import asyncio
+import deprecated
 from collections import deque
 from typing import Any, Deque, Dict, List, Optional, Union, cast
 
@@ -69,8 +70,20 @@ class DAGAgentState(BaseModel):
         return self.task_dict[task_id].step_queue
 
 
+@deprecated.deprecated(
+    reason=(
+        "ParallelAgentRunner has been deprecated and is not maintained.\n\n"
+        "This implementation will be removed in a v0.13.0.\n\n"
+        "See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/"
+    ),
+    action="once",
+)
 class ParallelAgentRunner(BaseAgentRunner):
     """
+    DEPRECATED: ParallelAgentRunner has been deprecated and is not maintained.
+    This implementation will be removed in a v0.13.0.
+    See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/
+
     Parallel agent runner.
 
     Executes steps in queue in parallel. Requires async support.

--- a/llama-index-core/llama_index/core/agent/runner/planner.py
+++ b/llama-index-core/llama_index/core/agent/runner/planner.py
@@ -1,3 +1,4 @@
+import deprecated
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -135,8 +136,19 @@ Overall Task: {task}
 """
 
 
+@deprecated.deprecated(
+    reason=(
+        "StructuredPlannerAgent has been deprecated and is not maintained.\n\n"
+        "This implementation will be removed in a v0.13.0.\n\n"
+        "See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/"
+    ),
+)
 class StructuredPlannerAgent(BasePlanningAgentRunner):
     """
+    DEPRECATED: StructuredPlannerAgent has been deprecated and is not maintained.
+    This implementation will be removed in a v0.13.0.
+    See the docs for more information on updated agent usage: https://docs.llamaindex.ai/en/stable/understanding/agent/
+
     Structured Planner Agent runner.
 
     Top-level agent orchestrator that can create tasks, run each step in a task,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ target-version = "py312"
 lint.ignore = [
     "COM812",  # Too aggressive
     "D212",  # Using D213
+    "D400",  # Too annoying/buggy
+    "D415",  # Too annoying/buggy
     "D417",  # Too aggressive
     "F541",  # Messes with prompts.py
     "RUF100",  # Allow blanket noqa


### PR DESCRIPTION
All the older non-workflow based agents are deprecated. This PR marks them and links to updated usage.

Also tweaked the agent docs to explicitly mention and link to react and codeact agents