### PR TITLE
doc: fix the wrong environement variable name in the azure openai llm example

### DIFF
--- a/docs/docs/examples/llm/azure_openai.ipynb
+++ b/docs/docs/examples/llm/azure_openai.ipynb
@@ -171,7 +171,7 @@
     "    This may change in the future.\n",
     "- `AZURE_OPENAI_ENDPOINT`: your endpoint should look like the following\n",
     "    https://YOUR_RESOURCE_NAME.openai.azure.com/\n",
-    "- `OPENAI_API_KEY`: your API key"
+    "- `AZURE_OPENAI_API_KEY`: your API key"
    ]
   },
   {
@@ -183,7 +183,7 @@
    "source": [
     "import os\n",
     "\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"<your-api-key>\"\n",
+    "os.environ[\"AZURE_OPENAI_API_KEY\"] = \"<your-api-key>\"\n",
     "os.environ[\n",
     "    \"AZURE_OPENAI_ENDPOINT\"\n",
     "] = \"https://<your-resource-name>.openai.azure.com/\"\n",


### PR DESCRIPTION
… example

# Description

Fix the wrong environment variable name OPENAI_API_KEY in the azure openai llm example. It should be AZURE_OPENAI_API_KEY for azure openai.
reference: /llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/base.py

Fixes #19214 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested locally. The fixed version AZURE_OPENAI_API_KEY can go through.


Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
