### PR TITLE
Avoid changing 'top_n' self attribute at runtime

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/llama_index/postprocessor/bedrock_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/llama_index/postprocessor/bedrock_rerank/base.py
@@ -208,8 +208,7 @@ class BedrockRerank(BaseNodePostprocessor):
                     }
                 )
             # change top_n if the number of nodes is less than top_n
-            if len(nodes) < self.top_n:
-                self.top_n = len(nodes)
+            top_n = min(self.top_n, len(nodes))
 
             queries = [
                 {
@@ -218,10 +217,10 @@ class BedrockRerank(BaseNodePostprocessor):
                 }
             ]
 
-            rerankingConfiguration = {
+            reranking_configuration = {
                 "type": "BEDROCK_RERANKING_MODEL",
                 "bedrockRerankingConfiguration": {
-                    "numberOfResults": self.top_n,
+                    "numberOfResults": top_n,
                     "modelConfiguration": {
                         "modelArn": self._model_package_arn,
                     },
@@ -232,7 +231,7 @@ class BedrockRerank(BaseNodePostprocessor):
                 response = self._client.rerank(
                     queries=queries,
                     sources=text_sources,
-                    rerankingConfiguration=rerankingConfiguration,
+                    rerankingConfiguration=reranking_configuration,
                 )
 
                 results = response["results"]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-bedrock-rerank"
-version = "0.3.3"
+version = "0.4.0"
 description = "llama-index postprocessor bedrock rerank integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/tests/test_postprocessor_bedrock_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/tests/test_postprocessor_bedrock_rerank.py
@@ -1,13 +1,8 @@
 from unittest import TestCase, mock
 
 import boto3
-from llama_index.core.postprocessor.types import (
-    BaseNodePostprocessor,
-    NodeWithScore,
-    QueryBundle,
-)
-from llama_index.core.schema import TextNode
-
+from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 from llama_index.postprocessor.bedrock_rerank import BedrockRerank
 
 
@@ -43,7 +38,7 @@ class TestBedrockRerank(TestCase):
         ]
 
         bedrock_client = boto3.client("bedrock-agent-runtime", region_name="us-west-2")
-        reranker = BedrockRerank(client=bedrock_client, num_results=2)
+        reranker = BedrockRerank(client=bedrock_client, top_n=2)
 
         with mock.patch.object(
             bedrock_client, "rerank", return_value=exp_rerank_response
@@ -65,3 +60,19 @@ class TestBedrockRerank(TestCase):
                 self.assertAlmostEqual(
                     actual_node_with_score.score, expected_node_with_score.score
                 )
+
+    def test_bedrock_rerank_consistent_top_n(self):
+        input_nodes = [NodeWithScore(node=TextNode(id_="4", text="last 1"))]
+
+        bedrock_client = boto3.client("bedrock-agent-runtime", region_name="us-west-2")
+        reranker = BedrockRerank(client=bedrock_client, top_n=4)
+        self.assertEqual(reranker.top_n, 4)
+
+        with mock.patch.object(bedrock_client, "rerank") as patched_rerank:
+            reranker.postprocess_nodes(input_nodes, query_str="last")
+            self.assertTrue(patched_rerank.called)
+            num_results = patched_rerank.call_args.kwargs["rerankingConfiguration"][
+                "bedrockRerankingConfiguration"
+            ]["numberOfResults"]
+            self.assertEqual(num_results, len(input_nodes))
+            self.assertEqual(reranker.top_n, 4)

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/uv.lock
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-postprocessor-bedrock-rerank"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# Description

The current implementation of `_postprocess_nodes` modifies `self.top_n` if the length of the nodes to process is less than the current `self.top_n`. As a result, if the same instance of `BedrockRerank` is then _re-used_ as part of another post-processing "process" (e.g., `node_postprocessors`), BedrockRerank unexpectedly uses the _new_ `self.top_n`, leading to potentially less results than originally expected.

https://github.com/run-llama/llama_index/blob/cc821b2d5a3f297853b5554d7ee169421e8cf698/llama-index-integrations/postprocessor/llama-index-postprocessor-bedrock-rerank/llama_index/postprocessor/bedrock_rerank/base.py#L210-L212

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
