### PR TITLE
Adapting Mem0 to new framework memory standard

### DIFF
--- a/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional, Union, Any
-from llama_index.core.memory.chat_memory_buffer import ChatMemoryBuffer
 from llama_index.core.memory.types import BaseMemory
+from llama_index.core.memory import Memory as LlamaIndexMemory
 from llama_index.memory.mem0.utils import (
     convert_memory_to_system_message,
     convert_chat_history_to_dict,
@@ -14,6 +14,7 @@ from llama_index.core.bridge.pydantic import (
     model_validator,
     SerializeAsAny,
     PrivateAttr,
+    ConfigDict,
 )
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 
@@ -65,7 +66,8 @@ class Mem0Context(BaseModel):
 
 
 class Mem0Memory(BaseMem0):
-    primary_memory: SerializeAsAny[BaseMemory] = Field(
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    primary_memory: SerializeAsAny[LlamaIndexMemory] = Field(
         description="Primary memory source for chat agent."
     )
     context: Optional[Mem0Context] = None
@@ -99,7 +101,7 @@ class Mem0Memory(BaseMem0):
         search_msg_limit: int = 5,
         **kwargs: Any,
     ):
-        primary_memory = ChatMemoryBuffer.from_defaults()
+        primary_memory = LlamaIndexMemory.from_defaults()
 
         try:
             context = Mem0Context(**context)
@@ -124,7 +126,7 @@ class Mem0Memory(BaseMem0):
         search_msg_limit: int = 5,
         **kwargs: Any,
     ):
-        primary_memory = ChatMemoryBuffer.from_defaults()
+        primary_memory = LlamaIndexMemory.from_defaults()
 
         try:
             context = Mem0Context(**context)

--- a/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-memory-mem0"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index memory mem0 integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = "<4.0,>=3.9"


### PR DESCRIPTION
# Description

Mem0 still used ChatMemoryBuffer (deprecated in favor of Memory) and its primary memory serialized as `BaseMemory`, which caused some problems (see attached issue) and prevented it from being recognized as a unserializable key. Now this should be solved with the modifications introduced in this PR.

Fixes #19228 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
