### PR TITLE
Fix SemanticDoubleMergingSplitterNodeParser not respecting max_chunk_size

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -281,8 +281,8 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
                     self.language_config.nlp(self._clean_text_advanced(sentence))
                 )
                 > self.appending_threshold
-                and len(last_sentences) + len(sentence) + 1 <= self.max_chunk_size
-                # and not len(chunk) > self.max_chunk_size
+                # and len(last_sentences) + len(sentence) + 1 <= self.max_chunk_size
+                and len(chunk) + len(sentence) + 1 <= self.max_chunk_size
             ):
                 # elif nlp(last_sentences).similarity(nlp(sentence)) > self.threshold:
                 chunk_sentences.append(sentence)

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -19,6 +19,10 @@ doc = Document(
     "Its branches include algebra, calculus, geometry, and statistics."
 )
 
+doc_same = Document(
+    text="Krakow is one of the oldest and largest cities in Poland, located in the southern part of the country on the Vistula River. " * 20
+)
+
 try:
     splitter = SemanticDoubleMergingSplitterNodeParser(
         initial_threshold=0.7,
@@ -91,13 +95,12 @@ def test_chunk_size_1() -> None:
 def test_chunk_size_2() -> None:
     splitter.max_chunk_size = 200
     nodes = splitter.get_nodes_from_documents([doc])
-    assert len(nodes) == 9
-    assert len(nodes[0].get_content()) < 200
-    assert len(nodes[1].get_content()) < 200
-    assert len(nodes[2].get_content()) < 200
-    assert len(nodes[3].get_content()) < 200
-    assert len(nodes[4].get_content()) < 200
-    assert len(nodes[5].get_content()) < 200
-    assert len(nodes[6].get_content()) < 200
-    assert len(nodes[7].get_content()) < 200
-    assert len(nodes[8].get_content()) < 200
+    for node in nodes:
+        assert len(node.get_content()) < 200
+
+@pytest.mark.skipif(not spacy_available, reason="Spacy model not available")
+def test_chunk_size_3() -> None:
+    splitter.max_chunk_size = 500
+    nodes = splitter.get_nodes_from_documents([doc_same])
+    for node in nodes:
+        assert len(node.get_content()) < 500


### PR DESCRIPTION
When text is similliar enought to create bigger block in some cases it
was not respecting the max_chunk_size
