### PR TITLE
feat: Update aioboto3 dependency

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-bedrock"
-version = "0.5.1"
+version = "0.5.2"
 description = "llama-index embeddings bedrock integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
@@ -35,7 +35,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "boto3>=1.34.23,<2",
-    "aioboto3>=13.1.1,<15",
+    "aioboto3>=13.1.1,<16",
     "llama-index-core>=0.12.0,<0.13",
 ]
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
@@ -1706,7 +1706,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-bedrock"
-version = "0.5.0"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -1740,7 +1740,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=13.1.1,<14" },
+    { name = "aioboto3", specifier = ">=13.1.1,<16" },
     { name = "boto3", specifier = ">=1.34.23,<2" },
     { name = "llama-index-core", specifier = ">=0.12.0,<0.13" },
 ]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.7.3"
+version = "0.7.4"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
@@ -37,7 +37,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "boto3>=1.34.122,<2",
-    "aioboto3>=13.1.1,<15",
+    "aioboto3>=13.1.1,<16",
     "llama-index-core>=0.12.44,<0.13",
 ]
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -1707,7 +1707,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.12.37"
+version = "0.12.44"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1744,7 +1744,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.7.1"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -1780,9 +1780,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=13.1.1,<15" },
+    { name = "aioboto3", specifier = ">=13.1.1,<16" },
     { name = "boto3", specifier = ">=1.34.122,<2" },
-    { name = "llama-index-core", specifier = ">=0.12.37,<0.13" },
+    { name = "llama-index-core", specifier = ">=0.12.44,<0.13" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
# Description

Update aioboto3 dependency restrictions within `llama-index-embeddings-bedrock` and `llama-index-llms-bedrock-converse`  to allow for the latest version, `15.0.0`.

Per the [aioboto3 changelog](https://github.com/terricain/aioboto3/blob/27c73fa9029795a026bd7224489d7032e07f2752/CHANGELOG.rst#1500-2025-06-26), version 15.0.0:
* Bumped aiobotocore to to 2.23.0
* Dropped Python 3.8 support.

This should also help out with #17895 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
