### PR TITLE
replace get_doc_id() with id_

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -110,7 +110,7 @@ class BaseIndex(Generic[IS], ABC):
 
         with callback_manager.as_trace("index_construction"):
             for doc in documents:
-                docstore.set_document_hash(doc.get_doc_id(), doc.hash)
+                docstore.set_document_hash(doc.id_, doc.hash)
 
             nodes = run_transformations(
                 documents,  # type: ignore


### PR DESCRIPTION
# Description

For class Document, replace call of get_doc_id() with id_, according to the following function decorator:

    @deprecated(
        version="0.12.2",
        reason="'get_doc_id' is deprecated, access the 'id_' property instead.",
    )

This would suppress warnings. For running test tests/node_parser/test_markdown_element.py, before change:
6 passed, 74 warnings in 1.68s

After change:
6 passed in 0.87s

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
