### PR TITLE
Bug fix: embedding model with custom endpoints 404 error

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/llama_index/embeddings/nvidia/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/llama_index/embeddings/nvidia/base.py
@@ -126,7 +126,6 @@ class NVIDIAEmbedding(BaseEmbedding):
             if api_key == "NO_API_KEY_PROVIDED":
                 raise ValueError("An API key is required for hosted NIM.")
 
-        # Create clients first
         self._client = OpenAI(
             api_key=api_key,
             base_url=self.base_url,

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/llama_index/embeddings/nvidia/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/llama_index/embeddings/nvidia/base.py
@@ -126,6 +126,7 @@ class NVIDIAEmbedding(BaseEmbedding):
             if api_key == "NO_API_KEY_PROVIDED":
                 raise ValueError("An API key is required for hosted NIM.")
 
+        # Create clients first
         self._client = OpenAI(
             api_key=api_key,
             base_url=self.base_url,
@@ -191,6 +192,9 @@ class NVIDIAEmbedding(BaseEmbedding):
                 warnings.warn(f"Unable to determine validity of {model_name}")
             if model and model.endpoint:
                 self.base_url = model.endpoint
+                # Update client base_url for custom endpoints
+                self._client.base_url = self.base_url
+                self._aclient.base_url = self.base_url
         # TODO: handle locally hosted models
 
     @property

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
@@ -36,7 +36,7 @@ test_integration = [
 
 [project]
 name = "llama-index-embeddings-nvidia"
-version = "0.3.3"
+version = "0.3.4"
 description = "llama-index embeddings nvidia integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/conftest.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/tests/conftest.py
@@ -71,7 +71,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     mode = get_mode(metafunc.config)
 
     if "model" in metafunc.fixturenames:
-        models = [DEFAULT_MODEL]
+        # Default models to test - include both default and custom endpoint models
+        models = [DEFAULT_MODEL, "NV-Embed-QA"]
         if model := metafunc.config.getoption("--model-id"):
             models = [model]
         elif metafunc.config.getoption("--all-models"):


### PR DESCRIPTION
# Description

Fix issue where custom endpoints for NVIDIA embedding models were not properly applied to client objects. 

Custom endpoint models (like `NV-Embed-QA`) had their `base_url` updated during model validation, but client objects 
were already created with the original URL, causing API calls to wrong endpoints.

Fixes #19140

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Added `NV-Embed-QA` to default test coverage in `conftest.py`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
