### PR TITLE
fix assert error in tests

### DIFF
--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -41,7 +41,7 @@ except Exception:
 def test_number_of_returned_nodes() -> None:
     nodes = splitter.get_nodes_from_documents([doc])
 
-    assert len(nodes) == 4
+    assert len(nodes) == 2
 
 
 @pytest.mark.skipif(not spacy_available, reason="Spacy model not available")
@@ -50,7 +50,7 @@ def test_creating_initial_chunks() -> None:
     sentences = splitter.sentence_splitter(text)
     initial_chunks = splitter._create_initial_chunks(sentences)
 
-    assert len(initial_chunks) == 9
+    assert len(initial_chunks) == 4
 
 
 @pytest.mark.skipif(not spacy_available, reason="Spacy model not available")


### PR DESCRIPTION
# Description

There are two tests failure in tests/node_parser/test_semantic_double_merging_splitter.py. From the selected sample document, splitter config and similarity threshold, the document would be processed in the following pipeline:

1. create 13 sentences;
2. merge 13 sentences to 4 chunks;
3. merge 4 chunks to 2 chunks.

I have used spacy's similarity function to verify above. Two of the test cases assert wrong node number which caused test failure.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
