### PR TITLE
Fix: Change tool output types (Bright Data tool)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-brightdata/llama_index/tools/brightdata/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-brightdata/llama_index/tools/brightdata/base.py
@@ -1,7 +1,6 @@
 """Bright Data tool spec for LlamaIndex."""
 
 from typing import Dict, Optional
-from llama_index.core.schema import Document
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 
 
@@ -67,7 +66,7 @@ class BrightDataToolSpec(BaseToolSpec):
 
         return response.text
 
-    def scrape_as_markdown(self, url: str, zone: Optional[str] = None) -> Document:
+    def scrape_as_markdown(self, url: str, zone: Optional[str] = None) -> Dict:
         """
         Scrape a webpage and return content in Markdown format.
 
@@ -76,7 +75,7 @@ class BrightDataToolSpec(BaseToolSpec):
             zone (Optional[str]): Override default zone
 
         Returns:
-            Document: Scraped content as Markdown
+            Dict: Scraped content as Markdown
 
         """
         payload = {
@@ -87,7 +86,7 @@ class BrightDataToolSpec(BaseToolSpec):
         }
 
         content = self._make_request(payload)
-        return Document(text=content, metadata={"url": url})
+        return {"content": content, "url": url}
 
     def get_screenshot(
         self, url: str, output_path: str, zone: Optional[str] = None
@@ -143,7 +142,7 @@ class BrightDataToolSpec(BaseToolSpec):
         return_json: bool = False,  # parse results as JSON
         hotel_dates: Optional[str] = None,  # check-in and check-out dates
         hotel_occupancy: Optional[int] = None,  # number of guests
-    ) -> Document:
+    ) -> Dict:
         """
         Search using Google, Bing, or Yandex with advanced parameters and return results in Markdown.
 
@@ -167,7 +166,7 @@ class BrightDataToolSpec(BaseToolSpec):
             hotel_occupancy (Optional[int]): Number of guests (1-4)
 
         Returns:
-            Document: Search results as Markdown or JSON
+            Dict: Search results as Markdown or JSON
 
         """
         encoded_query = self._encode_query(query)
@@ -245,9 +244,7 @@ class BrightDataToolSpec(BaseToolSpec):
         }
 
         content = self._make_request(payload)
-        return Document(
-            text=content, metadata={"query": query, "engine": engine, "url": search_url}
-        )
+        return {"content": content, "query": query, "engine": engine, "url": search_url}
 
     def web_data_feed(
         self,


### PR DESCRIPTION
# Description
Fix BrightData tool integration with latest LlamaIndex version by changing return types from Document to Dict. The latest version of LlamaIndex truncates Document objects when converting them to strings for agent consumption, causing tools to return minimal data. This change ensures all tool functions return Dict objects with full content, maintaining compatibility with the current LlamaIndex architecture.

Fixes # (no specific issue number - bug discovered during testing)

## New Package?
Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?
- [ ] Yes  
- [x] No

## Version Bump?
Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
- [ ] Yes
- [x] No

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.
- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
