### PR TITLE
Fixing ChatMessage to str handling of empty inputs

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -415,7 +415,10 @@ class ChatMessage(BaseModel):
             if isinstance(block, TextBlock):
                 content_strs.append(block.text)
 
-        return "\n".join(content_strs) or None
+        ct = "\n".join(content_strs) or None
+        if ct is None and len(content_strs) == 1:
+            return ""
+        return ct
 
     @content.setter
     def content(self, content: str) -> None:


### PR DESCRIPTION
# Description

As per title, we make sure that str(message) does not return `None` when message.content = "".

Fixes #19290