### PR TITLE
simplify citation block

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -336,9 +336,6 @@ class CitationBlock(BaseModel):
     ]
     source: str
     title: str
-    cited_block_index: int
-    inner_start_block_index: int
-    inner_end_block_index: int
     additional_location_info: Dict[str, int]
 
     @field_validator("cited_content", mode="before")


### PR DESCRIPTION
I'm actually not convinced yet the best way to link back to the cited source beyond the cited text. Going to remove the index-specific fields until we decide the best official way to do this.

For now, its still easy to trace back the source block using the cited content 