### PR TITLE
Update concurrent_execution.md with None return

### DIFF
--- a/docs/docs/understanding/workflows/concurrent_execution.md
+++ b/docs/docs/understanding/workflows/concurrent_execution.md
@@ -43,7 +43,9 @@ class ConcurrentFlow(Workflow):
         return StepThreeEvent(result=ev.query)
 
     @step
-    async def step_three(self, ctx: Context, ev: StepThreeEvent) -> StopEvent | None:
+    async def step_three(
+        self, ctx: Context, ev: StepThreeEvent
+    ) -> StopEvent | None:
         # wait until we receive 3 events
         result = ctx.collect_events(ev, [StepThreeEvent] * 3)
         if result is None:
@@ -93,7 +95,7 @@ class ConcurrentFlow(Workflow):
     async def step_three(
         self,
         ctx: Context,
-        ev: StepACompleteEvent | StepBCompleteEvent | StepCCompleteEvent | None,
+        ev: StepACompleteEvent | StepBCompleteEvent | StepCCompleteEvent,
     ) -> StopEvent:
         print("Received event ", ev.result)
 


### PR DESCRIPTION
# Description

Regarding a concurrent example of Workflow, we use context to send an event without return (None), so the return type from the method signature should support None.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
