### PR TITLE
fix ensuring structured output

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -27,7 +27,7 @@ class AgentStream(Event):
     response: str
     current_agent_name: str
     tool_calls: list[ToolSelection]
-    raw: Any = Field(exclude=True)
+    raw: Any = Field(default=None, exclude=True)
 
 
 class AgentOutput(Event):

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from llama_index.core.bridge.pydantic import Field, model_serializer
 from llama_index.core.tools import ToolSelection, ToolOutput
@@ -27,7 +27,7 @@ class AgentStream(Event):
     response: str
     current_agent_name: str
     tool_calls: list[ToolSelection]
-    raw: Any = Field(default=None, exclude=True)
+    raw: Optional[Any] = Field(default=None, exclude=True)
 
 
 class AgentOutput(Event):
@@ -35,7 +35,7 @@ class AgentOutput(Event):
 
     response: ChatMessage
     tool_calls: list[ToolSelection]
-    raw: Any
+    raw: Optional[Any] = Field(default=None, exclude=True)
     current_agent_name: str
 
     def __str__(self) -> str:


### PR DESCRIPTION
Now that `FunctionCallingLLM` supports the `tool_required` kwarg, all LLMs should use this and default to `True` in `FunctionCallingProgram`