### PR TITLE
fix: Ensure CallbackManager is applied to default embed_model

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -67,10 +67,8 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         """Initialize params."""
         self._use_async = use_async
         self._store_nodes_override = store_nodes_override
-        self._embed_model = (
-            resolve_embed_model(embed_model, callback_manager=callback_manager)
-            if embed_model
-            else Settings.embed_model
+        self._embed_model = resolve_embed_model(
+            embed_model or Settings.embed_model, callback_manager=callback_manager
         )
 
         self._insert_batch_size = insert_batch_size


### PR DESCRIPTION
# Description

This PR corrects the initialization logic in VectorStoreIndex to ensure that a callback_manager provided during index creation is correctly propagated to the embedding model. This applies even when the embed_model is not explicitly specified and falls back to the default from Settings.embed_model.
The previous implementation had a conditional check that bypassed resolve_embed_model when using the default model, preventing the callback_manager from being attached.

Fixes #19336 

# Change

The logic in VectorStoreIndex.__init__ has been modified from:

```python
self._embed_model = (
    resolve_embed_model(embed_model, callback_manager=callback_manager)
    if embed_model
    else Settings.embed_model
)
```

to:

```python
self._embed_model = resolve_embed_model(
    embed_model or Settings.embed_model, callback_manager=callback_manager
)
```

This change ensures that resolve_embed_model is always called with the selected embedding model (either user-provided or the default) and the provided callback_manager, guaranteeing consistent behavior.



## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
