### PR TITLE
fix: Replace `ctx.get/set` with `ctx.store.get/set` in Context

### DIFF
--- a/docs/docs/examples/agent/custom_multi_agent.ipynb
+++ b/docs/docs/examples/agent/custom_multi_agent.ipynb
@@ -585,7 +585,7 @@
     }
    ],
    "source": [
-    "state = await handler.ctx.get(\"state\")\n",
+    "state = await handler.ctx.store.get(\"state\")\n",
     "print(state[\"report_content\"])"
    ]
   },

--- a/docs/docs/examples/agent/multi_agent_workflow_with_weaviate_queryagent.ipynb
+++ b/docs/docs/examples/agent/multi_agent_workflow_with_weaviate_queryagent.ipynb
@@ -807,7 +807,7 @@
     "async def run_docs_agent(query: str):\n",
     "    handler = everything_docs_agent.run(start_event=StartEvent(query=query))\n",
     "    result = await handler\n",
-    "    for response in await handler.ctx.get(\"results\"):\n",
+    "    for response in await handler.ctx.store.get(\"results\"):\n",
     "        print(response)"
    ]
   },

--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -229,14 +229,14 @@ class BaseWorkflowAgent(
         if not await ctx.store.get("state", default=None):
             await ctx.store.set("state", self.initial_state.copy())
 
-        if not await ctx.get("max_iterations", default=None):
+        if not await ctx.store.get("max_iterations", default=None):
             max_iterations = (
                 ev.get("max_iterations", default=None) or DEFAULT_MAX_ITERATIONS
             )
-            await ctx.set("max_iterations", max_iterations)
+            await ctx.store.set("max_iterations", max_iterations)
 
         # Reset the number of iterations
-        await ctx.set("num_iterations", 0)
+        await ctx.store.set("num_iterations", 0)
 
         # always set to false initially
         await ctx.store.set("formatted_input_with_state", False)
@@ -368,10 +368,10 @@ class BaseWorkflowAgent(
     async def parse_agent_output(
         self, ctx: Context, ev: AgentOutput
     ) -> Union[StopEvent, ToolCall, None]:
-        max_iterations = await ctx.get("max_iterations", default=DEFAULT_MAX_ITERATIONS)
-        num_iterations = await ctx.get("num_iterations", default=0)
+        max_iterations = await ctx.store.get("max_iterations", default=DEFAULT_MAX_ITERATIONS)
+        num_iterations = await ctx.store.get("num_iterations", default=0)
         num_iterations += 1
-        await ctx.set("num_iterations", num_iterations)
+        await ctx.store.set("num_iterations", num_iterations)
 
         if num_iterations >= max_iterations:
             raise WorkflowRuntimeError(

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -260,14 +260,14 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             await ctx.store.set(
                 "handoff_output_prompt", self.handoff_output_prompt.get_template()
             )
-        if not await ctx.get("max_iterations", default=None):
+        if not await ctx.store.get("max_iterations", default=None):
             max_iterations = (
                 ev.get("max_iterations", default=None) or DEFAULT_MAX_ITERATIONS
             )
-            await ctx.set("max_iterations", max_iterations)
+            await ctx.store.set("max_iterations", max_iterations)
 
         # Reset the number of iterations
-        await ctx.set("num_iterations", 0)
+        await ctx.store.set("num_iterations", 0)
 
         # always set to false initially
         await ctx.store.set("formatted_input_with_state", False)
@@ -403,10 +403,10 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
     async def parse_agent_output(
         self, ctx: Context, ev: AgentOutput
     ) -> Union[StopEvent, ToolCall, None]:
-        max_iterations = await ctx.get("max_iterations", default=DEFAULT_MAX_ITERATIONS)
-        num_iterations = await ctx.get("num_iterations", default=0)
+        max_iterations = await ctx.store.get("max_iterations", default=DEFAULT_MAX_ITERATIONS)
+        num_iterations = await ctx.store.get("num_iterations", default=0)
         num_iterations += 1
-        await ctx.set("num_iterations", num_iterations)
+        await ctx.store.set("num_iterations", num_iterations)
 
         if num_iterations >= max_iterations:
             raise WorkflowRuntimeError(

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -379,7 +379,7 @@ async def test_workflow_with_state():
     response = await handler
     assert response is not None
 
-    state = await handler.ctx.get("state")
+    state = await handler.ctx.store.get("state")
     assert state["counter"] == 1
 
 

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -133,7 +133,7 @@ class AGUIChatWorkflow(Workflow):
                 state = self.initial_state.copy()
 
             # Save state to context for tools to use
-            await ctx.set("state", state)
+            await ctx.store.set("state", state)
 
             if state:
                 for msg in chat_history[::-1]:
@@ -151,9 +151,9 @@ class AGUIChatWorkflow(Workflow):
                         0, ChatMessage(role="system", content=self.system_prompt)
                     )
 
-            await ctx.set("chat_history", chat_history)
+            await ctx.store.set("chat_history", chat_history)
         else:
-            chat_history = await ctx.get("chat_history")
+            chat_history = await ctx.store.get("chat_history")
 
         tools = list(self.frontend_tools.values())
         tools.extend(list(self.backend_tools.values()))
@@ -180,13 +180,13 @@ class AGUIChatWorkflow(Workflow):
 
         chat_history.append(resp.message)
         self._snapshot_messages(ctx, [*chat_history])
-        await ctx.set("chat_history", chat_history)
+        await ctx.store.set("chat_history", chat_history)
 
         tool_calls = self.llm.get_tool_calls_from_response(
             resp, error_on_no_tool_call=False
         )
         if tool_calls:
-            await ctx.set("num_tool_calls", len(tool_calls))
+            await ctx.store.set("num_tool_calls", len(tool_calls))
             frontend_tool_calls = [
                 tool_call
                 for tool_call in tool_calls
@@ -274,7 +274,7 @@ class AGUIChatWorkflow(Workflow):
     async def aggregate_tool_calls(
         self, ctx: Context, ev: ToolCallResultEvent
     ) -> Optional[Union[StopEvent, LoopEvent]]:
-        num_tool_calls = await ctx.get("num_tool_calls")
+        num_tool_calls = await ctx.store.get("num_tool_calls")
         tool_call_results: List[ToolCallResultEvent] = ctx.collect_events(
             ev, [ToolCallResultEvent] * num_tool_calls
         )
@@ -307,11 +307,11 @@ class AGUIChatWorkflow(Workflow):
             )
 
         # emit a messages snapshot event if there are new messages
-        chat_history = await ctx.get("chat_history")
+        chat_history = await ctx.store.get("chat_history")
         if new_tool_messages:
             chat_history.extend(new_tool_messages)
             self._snapshot_messages(ctx, [*chat_history])
-            await ctx.set("chat_history", chat_history)
+            await ctx.store.set("chat_history", chat_history)
 
         if len(frontend_tool_calls) > 0:
             # Expect frontend tool calls to call back to the agent

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
@@ -78,7 +78,7 @@ class AGUIWorkflowRouter:
                 _ = await handler
 
                 # Update the state
-                state = await handler.ctx.get("state", default={})
+                state = await handler.ctx.store.get("state", default={})
                 yield workflow_event_to_sse(StateSnapshotWorkflowEvent(snapshot=state))
 
                 yield workflow_event_to_sse(


### PR DESCRIPTION
# Description

This pull request standardizes the usage of the new `ctx.store` for accessing and modifying context data across multiple files and functions. The changes replace calls to `ctx.get` and `ctx.set` with `ctx.store.get` and `ctx.store.set`, ensuring consistency and improving maintainability.

### Standardization of Context Data Access (`ctx.store`):

#### Updates in Agent Workflow:
* [`llama-index-core/llama_index/core/agent/workflow/base_agent.py`](diffhunk://#diff-22a8ddae7bca9f9625b3ab18d213b0961a84660a0a575f61d79d193fe1cf829bL232-R239): Replaced `ctx.get` and `ctx.set` with `ctx.store.get` and `ctx.store.set` for managing `state`, `max_iterations`, and `num_iterations` in `_init_context` and `run_agent_step`. [[1]](diffhunk://#diff-22a8ddae7bca9f9625b3ab18d213b0961a84660a0a575f61d79d193fe1cf829bL232-R239) [[2]](diffhunk://#diff-22a8ddae7bca9f9625b3ab18d213b0961a84660a0a575f61d79d193fe1cf829bL371-R374)

* [`llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py`](diffhunk://#diff-9206dc1ca1e8d6e03d53c68d7b17677e392860c8ae5c315693ca9cec7a4a3151L263-R270): Applied the same replacements for `max_iterations`, `num_iterations`, and other context properties in `_init_context` and `run_agent_step`. [[1]](diffhunk://#diff-9206dc1ca1e8d6e03d53c68d7b17677e392860c8ae5c315693ca9cec7a4a3151L263-R270) [[2]](diffhunk://#diff-9206dc1ca1e8d6e03d53c68d7b17677e392860c8ae5c315693ca9cec7a4a3151L406-R409)

#### Updates in Protocols:
* [`llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py`](diffhunk://#diff-5a8122c46605845c4c82c8b4759ddbb5819f79b733344bd556a7ac96c4ba681bL136-R136): Standardized context access for `state`, `chat_history`, and `num_tool_calls` in `chat`, `handle_tool_call`, and `aggregate_tool_calls`. [[1]](diffhunk://#diff-5a8122c46605845c4c82c8b4759ddbb5819f79b733344bd556a7ac96c4ba681bL136-R136) [[2]](diffhunk://#diff-5a8122c46605845c4c82c8b4759ddbb5819f79b733344bd556a7ac96c4ba681bL154-R156) [[3]](diffhunk://#diff-5a8122c46605845c4c82c8b4759ddbb5819f79b733344bd556a7ac96c4ba681bL183-R189) [[4]](diffhunk://#diff-5a8122c46605845c4c82c8b4759ddbb5819f79b733344bd556a7ac96c4ba681bL277-R277) [[5]](diffhunk://#diff-5a8122c46605845c4c82c8b4759ddbb5819f79b733344bd556a7ac96c4ba681bL310-R314)

* [`llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py`](diffhunk://#diff-d7f501c1ebfe5d7d4acaa37e56877c5dea48aba2af29983202a4d7c6d74a7f05L81-R81): Updated `stream_response` to use `ctx.store.get` for retrieving the state snapshot.

#### Updates in Documentation and Testing:
* `docs/docs/examples/agent/custom_multi_agent.ipynb` and `docs/docs/examples/agent/multi_agent_workflow_with_weaviate_queryagent.ipynb`: Adjusted example code to use `ctx.store.get` for fetching `state` and `results`. [[1]](diffhunk://#diff-2ee61deb8babcd8fda6d9ba163f42bcae6f1cc4680fbec1e6e10af497d90db2aL588-R588) [[2]](diffhunk://#diff-3dae23a166e2dc91c5e13cdc5cff6c6add711a2e8f36262b93c0572b2d08985aL810-R810)

* [`llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py`](diffhunk://#diff-0273f905161d6c1501e6bd0a124708ea5d39ccebd08f81c7d9ae57bf6b0139c6L382-R382): Modified test cases to use `ctx.store.get` for validating `state` updates.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
