### PR TITLE
Fix IntelEmbedding base.py

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-optimum-intel/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-optimum-intel/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-huggingface-optimum-intel"
-version = "0.3.0"
+version = "0.3.1"
 description = "llama-index embeddings Optimum Intel integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
1. Changed `normalize` from str to bool
2. Set default for `cache_folder` to `None`
3. Added `cache_folder` to `__init__` args.
4. Used `device` by moving model and model inputs to device providing speedup by using "xpu" as device.
5. Changed `torch.cpu.amp.autocast()` to `torch.autocast(device_type=self._device)` due to depreciation, and to use set device.

# Description

Fixes [issue](https://github.com/run-llama/llama_index/issues/19327), provides performance speedup by using the device set in arguments. XPU provided a 6x speedup, CUDA should also work.

Fixes #19327

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
