### PR TITLE
fix docstring typo

### DIFF
--- a/llama-index-core/llama_index/core/base/response/schema.py
+++ b/llama-index-core/llama_index/core/base/response/schema.py
@@ -80,7 +80,7 @@ class PydanticResponse:
 
         However, it appears that in that automatic conversion, this method
         is left as NoneType, which raises an error. To safeguard against that,
-        we are expilcitly defining this method as something that can be called.
+        we are explicitly defining this method as something that can be called.
 
         Sources:
             - https://docs.pydantic.dev/1.10/usage/dataclasses/#use-of-stdlib-dataclasses-with-basemodel


### PR DESCRIPTION
# Description

Simple typo fix in PydanticResponse dunder docstring

No relevant issues.

## New Package?

No.

## Version Bump?

Not needed.

## Type of Change

Typo

## How Has This Been Tested?

No code changes.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
