### PR TITLE
nvidia-llm : Adding support to use llm models outside default list

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-nvidia/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/README.md
@@ -76,6 +76,17 @@ messages = [
 llm.chat(messages)
 ```
 
+For models that are not included in the default model table (see [`llama_index/llms/nvidia/utils.py`](llama_index/llms/nvidia/utils.py)), you need to explicitly specify whether the model supports chat endpoints using the `is_chat_model` parameter:
+- `is_chat_model=False` (default): Uses the `/completions` endpoint
+- `is_chat_model=True`: Uses the `/chat/completions` endpoint
+
+```python
+llm = NVIDIA(
+    model="nvidia/llama-3.3-nemotron-super-49b-v1",
+    is_chat_model=True  
+)
+```
+
 ## Working with NVIDIA NIMs
 
 When ready to deploy, you can self-host models with NVIDIA NIM—which is included with the NVIDIA AI Enterprise software license—and run them anywhere, giving you ownership of your customizations and full control of your intellectual property (IP) and AI applications.

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/README.md
@@ -77,13 +77,13 @@ llm.chat(messages)
 ```
 
 For models that are not included in the default model table (see [`llama_index/llms/nvidia/utils.py`](llama_index/llms/nvidia/utils.py)), you need to explicitly specify whether the model supports chat endpoints using the `is_chat_model` parameter:
+
 - `is_chat_model=False` (default): Uses the `/completions` endpoint
 - `is_chat_model=True`: Uses the `/chat/completions` endpoint
 
 ```python
 llm = NVIDIA(
-    model="nvidia/llama-3.3-nemotron-super-49b-v1",
-    is_chat_model=True  
+    model="nvidia/llama-3.3-nemotron-super-49b-v1", is_chat_model=True
 )
 ```
 

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
@@ -106,7 +106,18 @@ class NVIDIA(OpenAILike, FunctionCallingLLM):
             self._validate_model(self.model)  ## validate model
 
         self.is_chat_model = self._is_chat_model() or self.is_chat_model
-        self.is_function_calling_model = self._is_function_calling_model() or self.is_function_calling_model
+        self.is_function_calling_model = (
+            self._is_function_calling_model() or self.is_function_calling_model
+        )
+
+        # Warn if unknown model is set to is_chat_model=False
+        if not self._is_chat_model() and not self.is_chat_model and self.model:
+            warnings.warn(
+                f"Unknown model '{self.model}' with is_chat_model=False. "
+                "This may cause 404 errors if the model only supports chat endpoints. "
+                "Set is_chat_model=True if this is a chat model.",
+                UserWarning,
+            )
 
     def __get_default_model(self):
         """Set default model."""
@@ -191,6 +202,11 @@ class NVIDIA(OpenAILike, FunctionCallingLLM):
             }
             models = [model for model in models if model.id not in exclude]
         return models
+
+    @property
+    def base_url(self) -> str:
+        """Get the base URL for backward compatibility."""
+        return self.api_base
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
@@ -110,15 +110,6 @@ class NVIDIA(OpenAILike, FunctionCallingLLM):
             self._is_function_calling_model() or self.is_function_calling_model
         )
 
-        # Warn if unknown model is set to is_chat_model=False
-        if not self._is_chat_model() and not self.is_chat_model and self.model:
-            warnings.warn(
-                f"Unknown model '{self.model}' with is_chat_model=False. "
-                "This may cause 404 errors if the model only supports chat endpoints. "
-                "Set is_chat_model=True if this is a chat model.",
-                UserWarning,
-            )
-
     def __get_default_model(self):
         """Set default model."""
         if not self._is_hosted:
@@ -202,11 +193,6 @@ class NVIDIA(OpenAILike, FunctionCallingLLM):
             }
             models = [model for model in models if model.id not in exclude]
         return models
-
-    @property
-    def base_url(self) -> str:
-        """Get the base URL for backward compatibility."""
-        return self.api_base
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/base.py
@@ -104,8 +104,9 @@ class NVIDIA(OpenAILike, FunctionCallingLLM):
 
         if not self.model.startswith("nvdev/"):
             self._validate_model(self.model)  ## validate model
-        self.is_chat_model = self._is_chat_model()
-        self.is_function_calling_model = self._is_function_calling_model()
+
+        self.is_chat_model = self._is_chat_model() or self.is_chat_model
+        self.is_function_calling_model = self._is_function_calling_model() or self.is_function_calling_model
 
     def __get_default_model(self):
         """Set default model."""

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/pyproject.toml
@@ -34,7 +34,7 @@ test_integration = [
 
 [project]
 name = "llama-index-llms-nvidia"
-version = "0.3.4"
+version = "0.3.5"
 description = "llama-index llms nvidia api catalog integration"
 authors = [{name = "Chris Alexiuk", email = "calexiuk@nvidia.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
@@ -91,12 +91,12 @@ def test_exclude_models(mode: dict, excluded: str) -> None:
 def test_unknown_model_functionality(mode: dict, is_chat_model) -> None:
     """Test that unknown chat model works correctly if using chat endpoint and not completion endpoint."""
     unknown_model = "nvidia/llama-3.3-nemotron-super-49b-v1"
-    
+
     kwargs = {"model": unknown_model, **mode}
     if is_chat_model is not None:
         kwargs["is_chat_model"] = is_chat_model
     llm = NVIDIA(**kwargs)
-    
+
     if is_chat_model is True:
         # the model should work for a chat or complete method
         message = ChatMessage(role="user", content="Hello")
@@ -106,5 +106,6 @@ def test_unknown_model_functionality(mode: dict, is_chat_model) -> None:
     else:
         # Completion mode should fail for a chat model (404 error) - both None and False default to False
         import openai
+
         with pytest.raises(openai.NotFoundError, match="404 page not found"):
             llm.complete("Hello")

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
@@ -84,28 +84,3 @@ async def test_astream_complete(chat_model: str, mode: dict) -> None:
 )
 def test_exclude_models(mode: dict, excluded: str) -> None:
     assert excluded not in [model.id for model in NVIDIA(**mode).available_models]
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("is_chat_model", [None, True, False])
-def test_unknown_model_functionality(mode: dict, is_chat_model) -> None:
-    """Test that unknown chat model works correctly if using chat endpoint and not completion endpoint."""
-    unknown_model = "nvidia/llama-3.3-nemotron-super-49b-v1"
-
-    kwargs = {"model": unknown_model, **mode}
-    if is_chat_model is not None:
-        kwargs["is_chat_model"] = is_chat_model
-    llm = NVIDIA(**kwargs)
-
-    if is_chat_model is True:
-        # the model should work for a chat or complete method
-        message = ChatMessage(role="user", content="Hello")
-        response = llm.chat([message])
-        assert isinstance(response, ChatResponse)
-        assert isinstance(response.message.content, str)
-    else:
-        # Completion mode should fail for a chat model (404 error) - both None and False default to False
-        import openai
-
-        with pytest.raises(openai.NotFoundError, match="404 page not found"):
-            llm.complete("Hello")

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_integration.py
@@ -84,3 +84,27 @@ async def test_astream_complete(chat_model: str, mode: dict) -> None:
 )
 def test_exclude_models(mode: dict, excluded: str) -> None:
     assert excluded not in [model.id for model in NVIDIA(**mode).available_models]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("is_chat_model", [None, True, False])
+def test_unknown_model_functionality(mode: dict, is_chat_model) -> None:
+    """Test that unknown chat model works correctly if using chat endpoint and not completion endpoint."""
+    unknown_model = "nvidia/llama-3.3-nemotron-super-49b-v1"
+    
+    kwargs = {"model": unknown_model, **mode}
+    if is_chat_model is not None:
+        kwargs["is_chat_model"] = is_chat_model
+    llm = NVIDIA(**kwargs)
+    
+    if is_chat_model is True:
+        # the model should work for a chat or complete method
+        message = ChatMessage(role="user", content="Hello")
+        response = llm.chat([message])
+        assert isinstance(response, ChatResponse)
+        assert isinstance(response.message.content, str)
+    else:
+        # Completion mode should fail for a chat model (404 error) - both None and False default to False
+        import openai
+        with pytest.raises(openai.NotFoundError, match="404 page not found"):
+            llm.complete("Hello")

--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_unknown_models.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_unknown_models.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from llama_index.llms.nvidia import NVIDIA
+
+
+@pytest.mark.parametrize("is_chat_model", [True, False])
+def test_unknown_model_is_chat_model_parameter(is_chat_model) -> None:
+    """Test that is_chat_model parameter is respected for unknown models."""
+    mock_model = MagicMock()
+    mock_model.id = "nvidia/llama-3.3-nemotron-super-49b-v1"
+
+    with patch.object(NVIDIA, "available_models", [mock_model]):
+        llm = NVIDIA(
+            model="nvidia/llama-3.3-nemotron-super-49b-v1",
+            is_chat_model=is_chat_model,
+            api_key="fake-key",
+        )
+        assert llm.is_chat_model is is_chat_model
+
+
+def test_unknown_model_default_is_chat_model() -> None:
+    """Test that default (no parameter) defaults to False for unknown models."""
+    mock_model = MagicMock()
+    mock_model.id = "nvidia/llama-3.3-nemotron-super-49b-v1"
+
+    with patch.object(NVIDIA, "available_models", [mock_model]):
+        llm = NVIDIA(model="nvidia/llama-3.3-nemotron-super-49b-v1", api_key="fake-key")
+        # Should default to False for unknown models
+        assert llm.is_chat_model is False
+
+
+def test_known_model_not_overridden() -> None:
+    """Test that known models are not overridden by user-provided is_chat_model parameter."""
+    mock_model = MagicMock()
+    mock_model.id = "mistralai/mistral-7b-instruct-v0.2"
+
+    with patch.object(NVIDIA, "available_models", [mock_model]):
+        llm = NVIDIA(
+            model="mistralai/mistral-7b-instruct-v0.2",
+            is_chat_model=False,
+            api_key="fake-key",
+        )
+        # Should not be overridden - known models keep their original setting
+        assert llm.is_chat_model is True


### PR DESCRIPTION
# Description
This PR fixes the NVIDIA LLM integration to properly handle custom models not included in the static [MODEL_TABLE](https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/llms/llama-index-llms-nvidia/llama_index/llms/nvidia/utils.py). Previously, the NVIDIA class would override user-provided `is_chat_model` and `is_function_calling_model` parameters after initialization, ignoring user preferences for unknown models.

Fixes #19243

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit test to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
