### PR TITLE
Fix bugs in tool calling for OCI generative AI Llama models

### DIFF
--- a/docs/docs/examples/llm/oci_genai.ipynb
+++ b/docs/docs/examples/llm/oci_genai.ipynb
@@ -413,6 +413,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ea4b58c3",
+   "metadata": {},
+   "source": [
+    "Use chat_with_tools for tool calling."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "5546c661",
@@ -445,6 +453,59 @@
     "response = llm.chat_with_tools(\n",
     "    tools=[add_tool, multiply_tool],\n",
     "    user_msg=\"What is 3 * 12? Also, what is 11 + 49?\",\n",
+    "    allow_parallel_tool_calls=True,\n",
+    ")\n",
+    "\n",
+    "print(response)\n",
+    "tool_calls = response.message.additional_kwargs.get(\"tool_calls\", [])\n",
+    "print(tool_calls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63702c0e",
+   "metadata": {},
+   "source": [
+    "Use chat for tool calling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "637eaeef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms.oci_genai import OCIGenAI\n",
+    "from llama_index.core.llms import ChatMessage, MessageRole\n",
+    "\n",
+    "llm = OCIGenAI(\n",
+    "    model=\"MY_MODEL\",\n",
+    "    service_endpoint=\"https://inference.generativeai.us-chicago-1.oci.oraclecloud.com\",\n",
+    "    compartment_id=\"MY_OCID\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiple two integers and returns the result integer\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "def add(a: int, b: int) -> int:\n",
+    "    \"\"\"Addition function on two integers.\"\"\"\n",
+    "    return a + b\n",
+    "\n",
+    "\n",
+    "add_tool = FunctionTool.from_defaults(fn=add)\n",
+    "multiply_tool = FunctionTool.from_defaults(fn=multiply)\n",
+    "\n",
+    "user_msg = ChatMessage(\n",
+    "    role=MessageRole.USER, content=\"What is 3 * 12? Also, what is 11 + 49?\"\n",
+    ")\n",
+    "\n",
+    "response = llm.chat(\n",
+    "    messages=[user_msg],\n",
+    "    tools=[multiply_tool, add_tool],\n",
     ")\n",
     "\n",
     "print(response)\n",

--- a/llama-index-integrations/llms/llama-index-llms-oci-genai/llama_index/llms/oci_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-genai/llama_index/llms/oci_genai/base.py
@@ -228,6 +228,7 @@ class OCIGenAI(FunctionCallingLLM):
         tools = kwargs.pop("tools", None)
         all_kwargs = self._get_all_kwargs(**kwargs)
         chat_params = {**all_kwargs, **oci_params}
+
         if tools:
             chat_params["tools"] = [
                 self._provider.convert_to_oci_tool(tool) for tool in tools
@@ -383,7 +384,7 @@ class OCIGenAI(FunctionCallingLLM):
         tool_required: bool = False,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        tool_specs = [self._provider.convert_to_oci_tool(tool) for tool in tools]
+        tool_specs = tools
 
         if isinstance(user_msg, str):
             user_msg = ChatMessage(role=MessageRole.USER, content=user_msg)

--- a/llama-index-integrations/llms/llama-index-llms-oci-genai/llama_index/llms/oci_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-genai/llama_index/llms/oci_genai/utils.py
@@ -600,6 +600,7 @@ class MetaProvider(Provider):
         }
 
     def chat_stream_generation_info(self, event_data: Dict) -> Dict[str, Any]:
+        """Extract generation metadata from Meta chat stream event."""
         return {
             "finish_reason": event_data["finishReason"],
         }

--- a/llama-index-integrations/llms/llama-index-llms-oci-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-oci-genai/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-oci-genai"
-version = "0.5.1"
+version = "0.5.2"
 description = "llama-index llms OCI GenAI integration"
 authors = [
     {name = "Arthur Cheng", email = "arthur.cheng@oracle.com"},

--- a/llama-index-integrations/llms/llama-index-llms-oci-genai/tests/test_llms_oci_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-genai/tests/test_llms_oci_genai.py
@@ -39,8 +39,8 @@ def test_prepare_chat_with_tools_tool_required():
 
     assert result["tool_choice"] == "REQUIRED"
     assert len(result["tools"]) == 1
-    # CohereTool objects have a `name` attribute directly
-    assert result["tools"][0].name == "search_tool"
+    # FunctionTool objects don't have a name attribute directly
+    assert result["tools"][0].metadata.name == "search_tool"
 
 
 def test_prepare_chat_with_tools_tool_not_required():
@@ -64,5 +64,5 @@ def test_prepare_chat_with_tools_tool_not_required():
     # When tool_required is False, tool_choice should not be included
     assert "tool_choice" not in result
     assert len(result["tools"]) == 1
-    # CohereTool objects have a `name` attribute directly
-    assert result["tools"][0].name == "search_tool"
+    # FunctionTool objects don't have a name attribute directly
+    assert result["tools"][0].metadata.name == "search_tool"


### PR DESCRIPTION
# Description

Oracle Cloud Infrastructure (OCI) Generative AI is a fully managed service that provides a set of state-of-the-art large language models (LLMs) which are available through a single API. This PR fixes bugs in tool calling to Cohere provider for using OCI Generative AI services with Llama Index and add new example for tool calling.

Fixes # (issue)
chat_with_tool API not work with Cohere provider for using OCI Generative AI services with Llama Index.

## New Package?
NA

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
