### PR TITLE
Add retry capability to workflow agents

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -137,19 +137,22 @@ class ReActAgent(BaseWorkflowAgent):
             reasoning_step = output_parser.parse(message_content, is_streaming=False)
         except ValueError as e:
             error_msg = f"Error: Could not parse output. Please follow the thought-action-input format. Try again. Details: {e!s}"
-            await memory.aput(last_chat_response.message)
-            await memory.aput(ChatMessage(role="user", content=error_msg))
 
             raw = (
                 last_chat_response.raw.model_dump()
                 if isinstance(last_chat_response.raw, BaseModel)
                 else last_chat_response.raw
             )
+            # Return with retry messages to let the LLM fix the error
             return AgentOutput(
                 response=last_chat_response.message,
                 tool_calls=[],
                 raw=raw,
                 current_agent_name=self.name,
+                retry_messages=[
+                    last_chat_response.message,
+                    ChatMessage(role="user", content=error_msg),
+                ],
             )
 
         # add to reasoning if not a handoff

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -122,7 +122,6 @@ class ReActAgent(BaseWorkflowAgent):
                 AgentStream(
                     delta=last_chat_response.delta or "",
                     response=last_chat_response.message.content or "",
-                    tool_calls=[],
                     raw=raw,
                     current_agent_name=self.name,
                 )
@@ -146,7 +145,6 @@ class ReActAgent(BaseWorkflowAgent):
             # Return with retry messages to let the LLM fix the error
             return AgentOutput(
                 response=last_chat_response.message,
-                tool_calls=[],
                 raw=raw,
                 current_agent_name=self.name,
                 retry_messages=[
@@ -168,7 +166,6 @@ class ReActAgent(BaseWorkflowAgent):
         if reasoning_step.is_done:
             return AgentOutput(
                 response=last_chat_response.message,
-                tool_calls=[],
                 raw=raw,
                 current_agent_name=self.name,
             )

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -38,9 +38,10 @@ class AgentOutput(Event):
     """LLM output."""
 
     response: ChatMessage
-    tool_calls: list[ToolSelection]
-    raw: Optional[Any] = Field(default=None, exclude=True)
     current_agent_name: str
+    raw: Optional[Any] = Field(default=None, exclude=True)
+    tool_calls: list[ToolSelection] = Field(default_factory=list)
+    retry_messages: list[ChatMessage] = Field(default_factory=list)
 
     def __str__(self) -> str:
         return self.response.content or ""

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -30,7 +30,7 @@ class AgentStream(Event):
     delta: str
     response: str
     current_agent_name: str
-    tool_calls: list[ToolSelection]
+    tool_calls: list[ToolSelection] = Field(default_factory=list)
     raw: Optional[Any] = Field(default=None, exclude=True)
 
 

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -482,3 +482,57 @@ async def test_max_iterations():
 
     # Set max iterations to 101 to avoid error
     _ = workflow.run(user_msg="test", max_iterations=101)
+
+
+@pytest.mark.asyncio
+async def test_retry():
+    """Test retry."""
+
+    def add_tool(a: int, b: int) -> int:
+        return a + b
+
+    agent = ReActAgent(
+        name="agent",
+        description="test",
+        tools=[add_tool],
+        llm=MockLLM(
+            responses=[
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content='Thought: I need to add these numbers\nAction: add\n{"a": 5 "b": 3}\n',
+                ),
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content='Thought: I need to add these numbers\nAction: add\nAction Input: {"a": 5, "b": 3}\n',
+                ),
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content=r"Thought: The result is 8\Answer: The sum is 8",
+                ),
+            ]
+        ),
+    )
+
+    workflow = AgentWorkflow(
+        agents=[agent],
+    )
+
+    memory = ChatMemoryBuffer.from_defaults()
+    handler = workflow.run(user_msg="Can you add 5 and 3?", memory=memory)
+
+    events = []
+    contains_error_message = False
+    async for event in handler.stream_events():
+        events.append(event)
+        if isinstance(event, AgentInput):
+            if (
+                "Please follow the thought-action-input format."
+                in event.input[-1].content
+            ):
+                contains_error_message = True
+
+    assert contains_error_message
+
+    response = await handler
+
+    assert "8" in str(response.response)

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -2,7 +2,7 @@ from typing import List, Any
 
 import pytest
 
-from llama_index.core.agent.workflow import FunctionAgent, ReActAgent
+from llama_index.core.agent.workflow import FunctionAgent, ReActAgent, AgentInput
 from llama_index.core.base.llms.types import (
     ChatMessage,
     LLMMetadata,
@@ -120,6 +120,35 @@ def calculator_agent():
     )
 
 
+@pytest.fixture()
+def retry_calculator_agent():
+    return ReActAgent(
+        name="calculator",
+        description="Performs basic arithmetic operations",
+        system_prompt="You are a calculator assistant.",
+        tools=[
+            FunctionTool.from_defaults(fn=add),
+            FunctionTool.from_defaults(fn=subtract),
+        ],
+        llm=MockLLM(
+            responses=[
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content='Thought: I need to add these numbers\nAction: add\n{"a": 5 "b": 3}\n',
+                ),
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content='Thought: I need to add these numbers\nAction: add\nAction Input: {"a": 5, "b": 3}\n',
+                ),
+                ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    content=r"Thought: The result is 8\Answer: The sum is 8",
+                ),
+            ]
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_single_function_agent(function_agent):
     """Test single agent with state management."""
@@ -140,6 +169,30 @@ async def test_single_react_agent(calculator_agent):
     events = []
     async for event in handler.stream_events():
         events.append(event)
+
+    response = await handler
+
+    assert "8" in str(response.response)
+
+
+@pytest.mark.asyncio
+async def test_single_react_agent_retry(retry_calculator_agent):
+    """Verify execution of basic ReAct single agent with retry du to a output parsing error."""
+    memory = ChatMemoryBuffer.from_defaults()
+    handler = retry_calculator_agent.run(user_msg="Can you add 5 and 3?", memory=memory)
+
+    events = []
+    contains_error_message = False
+    async for event in handler.stream_events():
+        events.append(event)
+        if isinstance(event, AgentInput):
+            if (
+                "Please follow the thought-action-input format."
+                in event.input[-1].content
+            ):
+                contains_error_message = True
+
+    assert contains_error_message
 
     response = await handler
 


### PR DESCRIPTION
# Description

Add retry capability to the `BaseWorkflowAgent` and `AgentWorkflow`. Some agents (such as `ReActAgent`) requires retrying when the output parser fails to parse the LLM response. The `AgentOutput` event now contains a `retry_messages` field that triggers a new `AgentInput` in `parse_agent_output`.

Fixes #19392

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
