### PR TITLE
DuckDB: Deadlocks-b-gone

### DIFF
--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/llama_index/storage/kvstore/duckdb/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/llama_index/storage/kvstore/duckdb/base.py
@@ -230,11 +230,10 @@ class DuckDBKVStore(BaseKVStore):
         ]
         arrow_table = pyarrow.Table.from_pylist(rows)
 
-        _ = self.client.from_arrow(arrow_table).query(
-            "put_all",
-            sql_query=f"""
+        _ = self.client.sql(
+            query=f"""
             INSERT OR REPLACE INTO {self.table.alias}
-            SELECT * from put_all;
+            SELECT * from arrow_table;
             """,
         )
 

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-storage-kvstore-duckdb"
-version = "0.1.2"
+version = "0.1.3"
 description = "llama-index kvstore duckdb integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
@@ -66,3 +66,6 @@ disallow_untyped_defs = true
 exclude = ["_static", "build", "examples", "notebooks", "venv"]
 ignore_missing_imports = true
 python_version = "3.9"
+
+[tool.pytest.ini_options]
+addopts = "-s"  # disable captures

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/tests/test_storage_kvstore_duckdb.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/tests/test_storage_kvstore_duckdb.py
@@ -1,3 +1,4 @@
+import os
 from llama_index.core.storage.kvstore.types import BaseKVStore
 from llama_index.storage.kvstore.duckdb import DuckDBKVStore
 from llama_index.vector_stores.duckdb.base import DuckDBVectorStore
@@ -32,123 +33,131 @@ def test_from_vector_store():
     assert results["id_1"] == {"name": "John Doe", "text": "Hello, world!"}
 
 
-@pytest.fixture
-def kv_store():
-    return DuckDBKVStore()
+def memory_store():
+    return DuckDBVectorStore(embed_dim=3)
 
 
-def test_put(kv_store: DuckDBKVStore):
-    key = "id_1"
-    value = {"name": "John Doe", "text": "Hello, world!"}
+def disk_store():
+    if os.path.exists("./storage/persisted.duckdb"):
+        os.remove("./storage/persisted.duckdb")
 
-    _ = kv_store.put(key, value)
-
-
-def test_put_all(kv_store: DuckDBKVStore):
-    kv_pairs = [
-        ("id_1", {"name": "John Doe", "text": "Hello, world!"}),
-        ("id_2", {"name": "Jane Doe", "text": "Hello, world!"}),
-    ]
-
-    _ = kv_store.put_all(kv_pairs)
+    return DuckDBVectorStore(
+        database_name="persisted.duckdb", embed_dim=3, persist_dir="./storage"
+    )
 
 
-def test_put_all_empty(kv_store: DuckDBKVStore):
-    kv_pairs = []
+@pytest.mark.parametrize("persistent", ["memory", "disk"])
+class TestStore:
+    @pytest.fixture
+    def kv_store(self, persistent: str) -> DuckDBVectorStore:
+        if persistent == "memory":
+            return memory_store()
 
-    _ = kv_store.put_all(kv_pairs)
+        return disk_store()
 
+    def test_put(self, kv_store: DuckDBKVStore):
+        key = "id_1"
+        value = {"name": "John Doe", "text": "Hello, world!"}
 
-def test_put_twice(kv_store: DuckDBKVStore):
-    key = "id_1"
-    value = {"name": "John Doe", "text": "Hello, world!"}
-    value_updated = {"name": "Jane Doe", "text": "Hello, world!"}
+        _ = kv_store.put(key, value)
 
-    _ = kv_store.put(key, value)
+    def test_put_all(self, kv_store: DuckDBKVStore):
+        kv_pairs = [
+            ("id_1", {"name": "John Doe", "text": "Hello, world!"}),
+            ("id_2", {"name": "Jane Doe", "text": "Hello, world!"}),
+        ]
 
-    _ = kv_store.put(key, value_updated)
+        _ = kv_store.put_all(kv_pairs)
 
-    assert kv_store.get(key) == value_updated
+    def test_put_all_empty(self, kv_store: DuckDBKVStore):
+        kv_pairs = []
 
+        _ = kv_store.put_all(kv_pairs)
 
-def test_put_get(kv_store: DuckDBKVStore):
-    key = "id_1"
-    value = {"name": "John Doe", "text": "Hello, world!"}
+    def test_put_twice(self, kv_store: DuckDBKVStore):
+        key = "id_1"
+        value = {"name": "John Doe", "text": "Hello, world!"}
+        value_updated = {"name": "Jane Doe", "text": "Hello, world!"}
 
-    _ = kv_store.put(key, value)
+        _ = kv_store.put(key, value)
 
-    assert kv_store.get(key) == value
+        _ = kv_store.put(key, value_updated)
 
+        assert kv_store.get(key) == value_updated
 
-def test_put_get_collection(kv_store: DuckDBKVStore):
-    key = "id_1"
-    value = {"name": "John Doe", "text": "Hello, world!"}
+    def test_put_get(self, kv_store: DuckDBKVStore):
+        key = "id_1"
+        value = {"name": "John Doe", "text": "Hello, world!"}
 
-    _ = kv_store.put(key, value, collection="collection_1")
+        _ = kv_store.put(key, value)
 
-    assert kv_store.get(key, collection="collection_1") == value
+        assert kv_store.get(key) == value
 
+    def test_put_get_collection(self, kv_store: DuckDBKVStore):
+        key = "id_1"
+        value = {"name": "John Doe", "text": "Hello, world!"}
 
-def test_put_get_all(kv_store: DuckDBKVStore):
-    key_1 = "id_1"
-    value_1 = {"name": "John Doe", "text": "Hello, world!"}
+        _ = kv_store.put(key, value, collection="collection_1")
 
-    key_2 = "id_2"
-    value_2 = {"name": "Jane Doe", "text": "Hello, world!"}
+        assert kv_store.get(key, collection="collection_1") == value
 
-    _ = kv_store.put(key_1, value_1)
-    _ = kv_store.put(key_2, value_2)
+    def test_put_get_all(self, kv_store: DuckDBKVStore):
+        key_1 = "id_1"
+        value_1 = {"name": "John Doe", "text": "Hello, world!"}
 
-    results = kv_store.get_all()
+        key_2 = "id_2"
+        value_2 = {"name": "Jane Doe", "text": "Hello, world!"}
 
-    assert results[key_1] == value_1
-    assert results[key_2] == value_2
+        _ = kv_store.put(key_1, value_1)
+        _ = kv_store.put(key_2, value_2)
 
+        results = kv_store.get_all()
 
-def test_delete(kv_store: DuckDBKVStore):
-    key = "id_1"
-    value = {"name": "John Doe", "text": "Hello, world!"}
+        assert results[key_1] == value_1
+        assert results[key_2] == value_2
 
-    _ = kv_store.put(key, value)
+    def test_delete(self, kv_store: DuckDBKVStore):
+        key = "id_1"
+        value = {"name": "John Doe", "text": "Hello, world!"}
 
-    assert kv_store.get(key) == value
+        _ = kv_store.put(key, value)
 
-    _ = kv_store.delete(key)
+        assert kv_store.get(key) == value
 
-    assert kv_store.get(key) is None
+        _ = kv_store.delete(key)
 
+        assert kv_store.get(key) is None
 
-def test_delete_collection(kv_store: DuckDBKVStore):
-    key = "id_1"
-    value = {"name": "John Doe", "text": "Hello, world!"}
+    def test_delete_collection(self, kv_store: DuckDBKVStore):
+        key = "id_1"
+        value = {"name": "John Doe", "text": "Hello, world!"}
 
-    _ = kv_store.put(key, value, collection="collection_1")
+        _ = kv_store.put(key, value, collection="collection_1")
 
-    assert kv_store.get(key, collection="collection_1") == value
+        assert kv_store.get(key, collection="collection_1") == value
 
-    _ = kv_store.delete(key, collection="collection_1")
+        _ = kv_store.delete(key, collection="collection_1")
 
-    assert kv_store.get(key, collection="collection_1") is None
+        assert kv_store.get(key, collection="collection_1") is None
 
+    @pytest.mark.asyncio
+    async def test_async(self, kv_store: DuckDBKVStore):
+        key = "id_1"
+        value = {"name": "John Doe", "text": "Hello, world!"}
 
-@pytest.mark.asyncio
-async def test_async(kv_store: DuckDBKVStore):
-    key = "id_1"
-    value = {"name": "John Doe", "text": "Hello, world!"}
+        _ = await kv_store.aput(key, value)
 
-    _ = await kv_store.aput(key, value)
+        assert await kv_store.aget(key) == value
 
-    assert await kv_store.aget(key) == value
+        new_key = "id_2"
+        new_value = {"name": "Jane Doe", "text": "Hello, world!"}
 
-    new_key = "id_2"
-    new_value = {"name": "Jane Doe", "text": "Hello, world!"}
+        _ = await kv_store.aput_all([(new_key, new_value), (new_key, new_value)])
 
-    _ = await kv_store.aput_all([(new_key, new_value), (new_key, new_value)])
+        assert await kv_store.aget_all() == {key: value, new_key: new_value}
 
-    assert await kv_store.aget_all() == {key: value, new_key: new_value}
+        _ = await kv_store.adelete(key)
 
-    _ = await kv_store.adelete(key)
+        assert await kv_store.aget(key) is None
 
-    assert await kv_store.aget(key) is None
-
-    assert await kv_store.aget_all() == {new_key: new_value}
+        assert await kv_store.aget_all() == {new_key: new_value}

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/tests/test_storage_kvstore_duckdb.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-duckdb/tests/test_storage_kvstore_duckdb.py
@@ -34,22 +34,20 @@ def test_from_vector_store():
 
 
 def memory_store():
-    return DuckDBVectorStore(embed_dim=3)
+    return DuckDBKVStore()
 
 
 def disk_store():
     if os.path.exists("./storage/persisted.duckdb"):
         os.remove("./storage/persisted.duckdb")
 
-    return DuckDBVectorStore(
-        database_name="persisted.duckdb", embed_dim=3, persist_dir="./storage"
-    )
+    return DuckDBKVStore(database_name="persisted.duckdb", persist_dir="./storage")
 
 
 @pytest.mark.parametrize("persistent", ["memory", "disk"])
 class TestStore:
     @pytest.fixture
-    def kv_store(self, persistent: str) -> DuckDBVectorStore:
+    def kv_store(self, persistent: str) -> DuckDBKVStore:
         if persistent == "memory":
             return memory_store()
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/llama_index/vector_stores/duckdb/base.py
@@ -259,7 +259,7 @@ class DuckDBVectorStore(BasePydanticVectorStore):
 
         conn.begin().execute(f"""
             CREATE TABLE IF NOT EXISTS {table_name}  (
-                node_id VARCHAR,
+                node_id VARCHAR PRIMARY KEY,
                 text TEXT,
                 embedding {embedding_type},
                 metadata_ JSON

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-duckdb"
-version = "0.4.5"
+version = "0.4.6"
 description = "llama-index vector_stores duckdb integration"
 authors = [
     {name = "Adithya Krishnan", email = "me@krishadi.com"},

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import os
 from typing import List
 import importlib.util
 import duckdb
@@ -108,16 +109,6 @@ def text_node_list() -> List[TextNode]:
     ]
 
 
-@pytest.fixture(scope="module")
-def vector_store() -> DuckDBVectorStore:
-    return DuckDBVectorStore(embed_dim=3)
-
-
-@pytest.fixture(scope="module")
-def vector_store_async() -> DuckDBVectorStore:
-    return DuckDBVectorStore(embed_dim=3)
-
-
 def test_instance_creation_from_memory(
     vector_store: DuckDBVectorStore,
 ) -> None:
@@ -136,48 +127,6 @@ def test_instance_creation_from_client(
     assert len(nodes) == 1
 
 
-def test_duckdb_add_and_query(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-) -> None:
-    vector_store.add(text_node_list)
-
-    nodes = vector_store.get_nodes(node_ids=["c330d77f-90bd-4c51-9ed2-57d8d693b3b0"])
-    assert len(nodes) == 1
-
-    res = vector_store.query(
-        VectorStoreQuery(query_embedding=[1.1, 0.0, 0.0], similarity_top_k=1)
-    )
-    assert res.nodes
-    assert res.nodes[0].node_id == "c330d77f-90bd-4c51-9ed2-57d8d693b3b0"
-    assert res.nodes[0].get_content() == "lorem ipsum"
-    assert res.nodes[0].metadata.get("author") == "Stephen King"
-    assert res.nodes[0].metadata.get("theme") == "Friendship"
-
-    assert res.nodes[0].excluded_embed_metadata_keys == []
-    assert res.nodes[0].excluded_llm_metadata_keys == []
-    assert res.nodes[0].source_node is not None
-    assert res.nodes[0].source_node.node_id == "test-0"
-
-    res = vector_store.query(
-        VectorStoreQuery(query_embedding=[0.9, 0.3, 0.3], similarity_top_k=1)
-    )
-    assert res.nodes
-    assert res.nodes[0].node_id == "e8f0c6cb-8d35-4240-a60a-b57070b3960f"
-    assert (
-        res.nodes[0].get_content()
-        == "Vector stores contain embedding vectors of ingested document chunks (and sometimes the document chunks as well)."
-    )
-    assert res.nodes[0].metadata.get("author") == "Emma Johnson"
-    assert res.nodes[0].excluded_embed_metadata_keys == ["excluded_embed"]
-    assert res.nodes[0].excluded_llm_metadata_keys == [
-        "excluded_llm",
-        "metadata",
-        "keys",
-    ]
-    assert res.nodes[0].source_node is not None
-    assert res.nodes[0].source_node.node_id == "test-7"
-
-
 def test_duckdb_from_local_and_params():
     store1 = DuckDBVectorStore.from_local(database_path=":memory:", embed_dim=3)
     assert isinstance(store1, DuckDBVectorStore)
@@ -185,379 +134,430 @@ def test_duckdb_from_local_and_params():
     assert isinstance(store2, DuckDBVectorStore)
 
 
-def test_delete_nodes(vector_store: DuckDBVectorStore, text_node_list: List[TextNode]):
-    vector_store.clear()
-    vector_store.add(text_node_list[:2])
-    node_ids = [n.node_id for n in text_node_list[:2]]
-    assert len(vector_store.get_nodes(node_ids=node_ids)) == 2
-    vector_store.delete_nodes(node_ids=[node_ids[0]])
-    nodes = vector_store.get_nodes(node_ids=node_ids)
-    assert len(nodes) == 1
-    assert nodes[0].node_id == node_ids[1]
+def memory_store():
+    return DuckDBVectorStore(embed_dim=3)
 
 
-def test_clear(vector_store: DuckDBVectorStore, text_node_list: List[TextNode]):
-    vector_store.add(text_node_list[:2])
-    assert len(vector_store.get_nodes()) >= 2
-    vector_store.clear()
-    assert len(vector_store.get_nodes()) == 0
+def disk_store():
+    if os.path.exists("./storage/persisted.duckdb"):
+        os.remove("./storage/persisted.duckdb")
 
-
-def test_delete_by_ref_doc_id(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    test_node = text_node_list[0]
-    test_node_id = test_node.node_id
-    assert test_node.source_node is not None
-
-    test_node_source_document = test_node.source_node
-    test_node_source_document_id = test_node_source_document.node_id
-
-    vector_store.add([test_node])
-    nodes = vector_store.get_nodes()
-    assert vector_store.get_nodes(node_ids=[test_node_id])
-    vector_store.delete(ref_doc_id=test_node_source_document_id)
-    assert not vector_store.get_nodes(node_ids=[test_node_id])
-
-
-def test_get_nodes(vector_store: DuckDBVectorStore, text_node_list: List[TextNode]):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    nodes = vector_store.get_nodes()
-    assert len(nodes) == len(text_node_list)
-    assert all(n.node_id in [n.node_id for n in text_node_list] for n in nodes)
-    assert all(n.embedding is not None for n in nodes)
-
-
-def test_get_nodes_with_metadata_filters(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list[:2])
-
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value="Stephen King", operator=FilterOperator.EQ
-            ),
-        ],
+    return DuckDBVectorStore(
+        database_name="persisted.duckdb", embed_dim=3, persist_dir="./storage"
     )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 1
-    assert nodes[0].metadata.get("author") == "Stephen King"
 
 
-def test_lazy_table_initialization():
-    store = DuckDBVectorStore(embed_dim=3)
+@pytest.mark.parametrize("persistent", ["memory", "disk"])
+class TestStore:
+    @pytest.fixture
+    def vector_store(self, persistent: str) -> DuckDBVectorStore:
+        if persistent == "memory":
+            return memory_store()
 
-    nodes = store.get_nodes(node_ids=["any"])
-    assert len(nodes) == 0
+        return disk_store()
 
+    def test_duckdb_add_and_query(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ) -> None:
+        vector_store.add(text_node_list)
 
-def test_filter_operator_ne(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value="Stephen King", operator=FilterOperator.NE
-            )
+        nodes = vector_store.get_nodes(
+            node_ids=["c330d77f-90bd-4c51-9ed2-57d8d693b3b0"]
+        )
+        assert len(nodes) == 1
+
+        res = vector_store.query(
+            VectorStoreQuery(query_embedding=[1.1, 0.0, 0.0], similarity_top_k=1)
+        )
+        assert res.nodes
+        assert res.nodes[0].node_id == "c330d77f-90bd-4c51-9ed2-57d8d693b3b0"
+        assert res.nodes[0].get_content() == "lorem ipsum"
+        assert res.nodes[0].metadata.get("author") == "Stephen King"
+        assert res.nodes[0].metadata.get("theme") == "Friendship"
+
+        assert res.nodes[0].excluded_embed_metadata_keys == []
+        assert res.nodes[0].excluded_llm_metadata_keys == []
+        assert res.nodes[0].source_node is not None
+        assert res.nodes[0].source_node.node_id == "test-0"
+
+        res = vector_store.query(
+            VectorStoreQuery(query_embedding=[0.9, 0.3, 0.3], similarity_top_k=1)
+        )
+        assert res.nodes
+        assert res.nodes[0].node_id == "e8f0c6cb-8d35-4240-a60a-b57070b3960f"
+        assert (
+            res.nodes[0].get_content()
+            == "Vector stores contain embedding vectors of ingested document chunks (and sometimes the document chunks as well)."
+        )
+        assert res.nodes[0].metadata.get("author") == "Emma Johnson"
+        assert res.nodes[0].excluded_embed_metadata_keys == ["excluded_embed"]
+        assert res.nodes[0].excluded_llm_metadata_keys == [
+            "excluded_llm",
+            "metadata",
+            "keys",
         ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 5
-    # Only the second node has a different author
-    assert all(n.metadata.get("author") != "Stephen King" for n in nodes)
+        assert res.nodes[0].source_node is not None
+        assert res.nodes[0].source_node.node_id == "test-7"
 
+    def test_delete_nodes(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list[:2])
+        node_ids = [n.node_id for n in text_node_list[:2]]
+        assert len(vector_store.get_nodes(node_ids=node_ids)) == 2
+        vector_store.delete_nodes(node_ids=[node_ids[0]])
+        nodes = vector_store.get_nodes(node_ids=node_ids)
+        assert len(nodes) == 1
+        assert nodes[0].node_id == node_ids[1]
 
-def test_filter_operator_in(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
+    def test_clear(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.add(text_node_list[:2])
+        assert len(vector_store.get_nodes()) >= 2
+        vector_store.clear()
+        assert len(vector_store.get_nodes()) == 0
 
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author",
-                value=["Marie Curie", "Stephen King"],
-                operator=FilterOperator.IN,
-            )
+    def test_delete_by_ref_doc_id(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        test_node = text_node_list[0]
+        test_node_id = test_node.node_id
+        assert test_node.source_node is not None
+
+        test_node_source_document = test_node.source_node
+        test_node_source_document_id = test_node_source_document.node_id
+
+        vector_store.add([test_node])
+        nodes = vector_store.get_nodes()
+        assert vector_store.get_nodes(node_ids=[test_node_id])
+        vector_store.delete(ref_doc_id=test_node_source_document_id)
+        assert not vector_store.get_nodes(node_ids=[test_node_id])
+
+    def test_get_nodes(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        nodes = vector_store.get_nodes()
+        assert len(nodes) == len(text_node_list)
+        assert all(n.node_id in [n.node_id for n in text_node_list] for n in nodes)
+        assert all(n.embedding is not None for n in nodes)
+
+    def test_get_nodes_with_metadata_filters(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list[:2])
+
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value="Stephen King", operator=FilterOperator.EQ
+                ),
+            ],
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 1
+        assert nodes[0].metadata.get("author") == "Stephen King"
+
+    def test_filter_operator_ne(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value="Stephen King", operator=FilterOperator.NE
+                )
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 5
+        # Only the second node has a different author
+        assert all(n.metadata.get("author") != "Stephen King" for n in nodes)
+
+    def test_filter_operator_in(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author",
+                    value=["Marie Curie", "Stephen King"],
+                    operator=FilterOperator.IN,
+                )
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 2
+        assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
+        assert any(n.metadata.get("author") == "Marie Curie" for n in nodes)
+
+    def test_filter_operator_nin(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value=["Stephen King"], operator=FilterOperator.NIN
+                )
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 5
+        assert all(n.metadata.get("author") != "Stephen King" for n in nodes)
+
+    def test_filter_text_match(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="theme", value="Friend", operator=FilterOperator.TEXT_MATCH
+                )
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 1
+        assert any("Friend" in n.metadata.get("theme", "") for n in nodes)
+
+    def test_filter_text_match_insensitive(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="theme",
+                    value="friendship",
+                    operator=FilterOperator.TEXT_MATCH_INSENSITIVE,
+                )
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 1
+        assert any(n.metadata.get("theme", "").lower() == "friendship" for n in nodes)
+
+    def test_filter_is_empty_on_none(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        # Add a node with an empty field
+        node = TextNode(
+            text="empty test",
+            id_="empty-node",
+            relationships={},
+            metadata={"empty_field": None},
+            embedding=[0.1, 0.2, 0.3],
+        )
+        vector_store.add([node])
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="empty_field", value=None, operator=FilterOperator.IS_EMPTY
+                )
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 1
+        assert any(n.node_id == "empty-node" for n in nodes)
+
+    def test_filter_is_empty_on_missing_key(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        # Add a node with an empty field
+        node = TextNode(
+            text="empty test",
+            id_="empty-node",
+            relationships={},
+            metadata={},
+            embedding=[0.1, 0.2, 0.3],
+        )
+        vector_store.add([node])
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="empty_field", value=None, operator=FilterOperator.IS_EMPTY
+                )
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 1
+        assert any(n.node_id == "empty-node" for n in nodes)
+
+    def test_filter_and_condition(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value="Stephen King", operator=FilterOperator.EQ
+                ),
+                MetadataFilter(
+                    key="theme", value="Friendship", operator=FilterOperator.EQ
+                ),
+            ],
+            condition=FilterCondition.AND,
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 1
+        assert nodes[0].metadata.get("author") == "Stephen King"
+        assert nodes[0].metadata.get("theme") == "Friendship"
+
+    def test_filter_or_condition(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value="Stephen King", operator=FilterOperator.EQ
+                ),
+                MetadataFilter(key="theme", value="Mafia", operator=FilterOperator.EQ),
+            ],
+            condition=FilterCondition.OR,
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 2
+        # Should match either author or theme
+        assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
+        assert any(n.metadata.get("theme") == "Mafia" for n in nodes)
+
+    def test_filter_not_condition_excludes_null(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        # Based on our list, this doesn't exclude any values except where author is null
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value="Stephen King", operator=FilterOperator.EQ
+                ),
+                MetadataFilter(key="theme", value="Mafia", operator=FilterOperator.EQ),
+            ],
+            condition=FilterCondition.NOT,
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+
+        assert len(nodes) == 6
+
+        assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
+        assert all(n.metadata.get("director") is None for n in nodes)
+
+    def test_filter_not_condition(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value="Stephen King", operator=FilterOperator.EQ
+                ),
+                MetadataFilter(
+                    key="theme", value="Friendship", operator=FilterOperator.EQ
+                ),
+            ],
+            condition=FilterCondition.NOT,
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 6
+
+        assert all(n.metadata.get("theme") != "Friendship" for n in nodes)
+
+    def test_filter_nested_and_or_condition(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="author", value="Stephen King", operator=FilterOperator.EQ
+                ),
+                MetadataFilters(
+                    filters=[
+                        MetadataFilter(
+                            key="theme", value="Mafia", operator=FilterOperator.EQ
+                        ),
+                        MetadataFilter(
+                            key="theme", value="Friendship", operator=FilterOperator.EQ
+                        ),
+                    ],
+                    condition=FilterCondition.OR,
+                ),
+            ],
+            condition=FilterCondition.AND,
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 1
+        # Should match either author or theme
+        assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
+        assert any(n.metadata.get("theme") == "Friendship" for n in nodes)
+
+    def test_filter_missing_key(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        vector_store.clear()
+        vector_store.add(text_node_list)
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilter(key="not_a_key", value="foo", operator=FilterOperator.EQ)
+            ]
+        )
+        nodes = vector_store.get_nodes(filters=filters)
+        assert len(nodes) == 0
+
+    async def test_async(
+        self, vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
+    ):
+        await vector_store.async_add(text_node_list)
+        nodes = await vector_store.aget_nodes()
+        assert len(nodes) == len(text_node_list)
+
+        await vector_store.adelete_nodes(node_ids=[nodes[0].node_id])
+        nodes = await vector_store.aget_nodes()
+        assert len(nodes) == len(text_node_list) - 1
+
+        await vector_store.aclear()
+        assert len(vector_store.get_nodes()) == 0
+
+        def generate_large_node_list(num_nodes: int, prefix: str) -> List[TextNode]:
+            return [
+                TextNode(
+                    text=f"Node {'i' * 10000}",
+                    id_=f"{prefix}_{i}",
+                    embedding=[0.5, 0.5, 0.5],
+                )
+                for i in range(num_nodes)
+            ]
+
+        tasks = [
+            vector_store.async_add(generate_large_node_list(100, "1")),
+            vector_store.async_add(generate_large_node_list(100, "2")),
+            vector_store.async_add(generate_large_node_list(100, "3")),
+            vector_store.async_add(generate_large_node_list(100, "4")),
+            vector_store.aget_nodes(),
+            vector_store.aget_nodes(),
         ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 2
-    assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
-    assert any(n.metadata.get("author") == "Marie Curie" for n in nodes)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
 
-
-def test_filter_operator_nin(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value=["Stephen King"], operator=FilterOperator.NIN
-            )
-        ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 5
-    assert all(n.metadata.get("author") != "Stephen King" for n in nodes)
-
-
-def test_filter_text_match(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="theme", value="Friend", operator=FilterOperator.TEXT_MATCH
-            )
-        ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 1
-    assert any("Friend" in n.metadata.get("theme", "") for n in nodes)
-
-
-def test_filter_text_match_insensitive(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="theme",
-                value="friendship",
-                operator=FilterOperator.TEXT_MATCH_INSENSITIVE,
-            )
-        ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 1
-    assert any(n.metadata.get("theme", "").lower() == "friendship" for n in nodes)
-
-
-def test_filter_is_empty_on_none(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    # Add a node with an empty field
-    node = TextNode(
-        text="empty test",
-        id_="empty-node",
-        relationships={},
-        metadata={"empty_field": None},
-        embedding=[0.1, 0.2, 0.3],
-    )
-    vector_store.add([node])
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="empty_field", value=None, operator=FilterOperator.IS_EMPTY
-            )
-        ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 1
-    assert any(n.node_id == "empty-node" for n in nodes)
-
-
-def test_filter_is_empty_on_missing_key(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    # Add a node with an empty field
-    node = TextNode(
-        text="empty test",
-        id_="empty-node",
-        relationships={},
-        metadata={},
-        embedding=[0.1, 0.2, 0.3],
-    )
-    vector_store.add([node])
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="empty_field", value=None, operator=FilterOperator.IS_EMPTY
-            )
-        ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 1
-    assert any(n.node_id == "empty-node" for n in nodes)
-
-
-def test_filter_and_condition(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value="Stephen King", operator=FilterOperator.EQ
-            ),
-            MetadataFilter(key="theme", value="Friendship", operator=FilterOperator.EQ),
-        ],
-        condition=FilterCondition.AND,
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 1
-    assert nodes[0].metadata.get("author") == "Stephen King"
-    assert nodes[0].metadata.get("theme") == "Friendship"
-
-
-def test_filter_or_condition(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value="Stephen King", operator=FilterOperator.EQ
-            ),
-            MetadataFilter(key="theme", value="Mafia", operator=FilterOperator.EQ),
-        ],
-        condition=FilterCondition.OR,
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 2
-    # Should match either author or theme
-    assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
-    assert any(n.metadata.get("theme") == "Mafia" for n in nodes)
-
-
-def test_filter_not_condition_excludes_null(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    # Based on our list, this doesn't exclude any values except where author is null
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value="Stephen King", operator=FilterOperator.EQ
-            ),
-            MetadataFilter(key="theme", value="Mafia", operator=FilterOperator.EQ),
-        ],
-        condition=FilterCondition.NOT,
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-
-    assert len(nodes) == 6
-
-    assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
-    assert all(n.metadata.get("director") is None for n in nodes)
-
-
-def test_filter_not_condition(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value="Stephen King", operator=FilterOperator.EQ
-            ),
-            MetadataFilter(key="theme", value="Friendship", operator=FilterOperator.EQ),
-        ],
-        condition=FilterCondition.NOT,
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 6
-
-    assert all(n.metadata.get("theme") != "Friendship" for n in nodes)
-
-
-def test_filter_nested_and_or_condition(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(
-                key="author", value="Stephen King", operator=FilterOperator.EQ
-            ),
-            MetadataFilters(
-                filters=[
-                    MetadataFilter(
-                        key="theme", value="Mafia", operator=FilterOperator.EQ
-                    ),
-                    MetadataFilter(
-                        key="theme", value="Friendship", operator=FilterOperator.EQ
-                    ),
-                ],
-                condition=FilterCondition.OR,
-            ),
-        ],
-        condition=FilterCondition.AND,
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 1
-    # Should match either author or theme
-    assert any(n.metadata.get("author") == "Stephen King" for n in nodes)
-    assert any(n.metadata.get("theme") == "Friendship" for n in nodes)
-
-
-def test_filter_missing_key(
-    vector_store: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    vector_store.clear()
-    vector_store.add(text_node_list)
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilter(key="not_a_key", value="foo", operator=FilterOperator.EQ)
-        ]
-    )
-    nodes = vector_store.get_nodes(filters=filters)
-    assert len(nodes) == 0
-
-
-async def test_async(
-    vector_store_async: DuckDBVectorStore, text_node_list: List[TextNode]
-):
-    await vector_store_async.async_add(text_node_list)
-    nodes = await vector_store_async.aget_nodes()
-    assert len(nodes) == len(text_node_list)
-
-    await vector_store_async.adelete_nodes(node_ids=[nodes[0].node_id])
-    nodes = await vector_store_async.aget_nodes()
-    assert len(nodes) == len(text_node_list) - 1
-
-    await vector_store_async.aclear()
-    assert len(vector_store_async.get_nodes()) == 0
-
-    def generate_large_node_list(num_nodes: int) -> List[TextNode]:
-        return [
-            TextNode(
-                text=f"Node {'i' * 10000}", id_=f"node_{i}", embedding=[0.5, 0.5, 0.5]
-            )
-            for i in range(num_nodes)
-        ]
-
-    large_node_list = generate_large_node_list(100)
-    tasks = [
-        vector_store_async.async_add(large_node_list),
-        vector_store_async.async_add(large_node_list),
-        vector_store_async.async_add(large_node_list),
-        vector_store_async.async_add(large_node_list),
-        vector_store_async.aget_nodes(),
-        vector_store_async.aget_nodes(),
-    ]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-
-    exceptions = [result for result in results if isinstance(result, Exception)]
-    assert len(exceptions) == 0
-    assert len(results) == 6
+        exceptions = [result for result in results if isinstance(result, Exception)]
+        assert len(exceptions) == 0
+        assert len(results) == 6

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-duckdb/tests/test_duckdb.py
@@ -109,13 +109,6 @@ def text_node_list() -> List[TextNode]:
     ]
 
 
-def test_instance_creation_from_memory(
-    vector_store: DuckDBVectorStore,
-) -> None:
-    assert isinstance(vector_store, DuckDBVectorStore)
-    assert vector_store.database_name == ":memory:"
-
-
 def test_instance_creation_from_client(
     text_node_list: List[TextNode],
 ) -> None:


### PR DESCRIPTION
# Description

There's either 1) [something funky with how DuckDB is handling arrow tables](https://github.com/duckdb/duckdb/issues/18225) or 2) something wrong with my understanding of how DuckDB handles arrow tables.

In either case, with this PR, the async code path no longer deadlocks under load. I've also adjusted all of the tests to run against an in-memory and a persisted duckdb store.

This PR also adds a primary key constraint to the vector store

Fixes # https://github.com/run-llama/llama_index/issues/19400

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
