### PR TITLE
Fix: prevent duplicate triplets in SimpleGraphStore.upsert_triplet (#19404)

### DIFF
--- a/llama-index-core/llama_index/core/graph_stores/simple.py
+++ b/llama-index-core/llama_index/core/graph_stores/simple.py
@@ -124,8 +124,9 @@ class SimpleGraphStore(GraphStore):
         """Add triplet."""
         if subj not in self._data.graph_dict:
             self._data.graph_dict[subj] = []
-        if (rel, obj) not in self._data.graph_dict[subj]:
-            self._data.graph_dict[subj].append([rel, obj])
+        existing = self._data.graph_dict[subj]
+        if (rel, obj) not in map(tuple, existing):
+            existing.append([rel, obj])
 
     def delete(self, subj: str, rel: str, obj: str) -> None:
         """Delete triplet."""


### PR DESCRIPTION
## Summary

Fixes [#19404](https://github.com/run-llama/llama_index/issues/19404)

This PR resolves a bug in the `SimpleGraphStore.upsert_triplet` method that was allowing duplicate triplets to be inserted. The issue was caused by a type mismatch when checking for duplicates — comparing a tuple `(rel, obj)` against a list `[rel, obj]`.

## Changes Made

- Used `map(tuple, existing)` to compare against existing triplets correctly
- Ensures idempotent upsert behavior: multiple calls with the same triplet do not add duplicates

## Testing

Manually verified that:
```python
store.upsert_triplet("P", "rel", "Q")
store.upsert_triplet("P", "rel", "Q")
assert store.get("P") == [["rel", "Q"]]
