### PR TITLE
fix: fix structured output

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -443,8 +443,11 @@ class BaseWorkflowAgent(
                             messages
                         )
                     else:
-                        output.structured_response = self.structured_output_fn(messages)
+                        output.structured_response = cast(
+                            Dict[str, Any], self.structured_output_fn(messages)
+                        )
                 except Exception as e:
+                    error = e
                     if (
                         isinstance(output.response.content, str)
                         and messages[-1].role.value == "user"
@@ -458,8 +461,8 @@ class BaseWorkflowAgent(
                                     await self.structured_output_fn(messages)
                                 )
                             else:
-                                output.structured_response = self.structured_output_fn(
-                                    messages
+                                output.structured_response = cast(
+                                    Dict[str, Any], self.structured_output_fn(messages)
                                 )
                         except Exception as e:
                             warnings.warn(
@@ -467,7 +470,7 @@ class BaseWorkflowAgent(
                             )
                     else:
                         warnings.warn(
-                            f"There was a problem with the generation of the structured output: {e}"
+                            f"There was a problem with the generation of the structured output: {error}"
                         )
             if self.output_cls is not None:
                 try:
@@ -475,6 +478,7 @@ class BaseWorkflowAgent(
                         messages=messages, llm=self.llm, output_cls=self.output_cls
                     )
                 except Exception as e:
+                    error = e
                     if (
                         isinstance(output.response.content, str)
                         and messages[-1].role.value == "user"
@@ -496,7 +500,7 @@ class BaseWorkflowAgent(
                             )
                     else:
                         warnings.warn(
-                            f"There was a problem with the generation of the structured output: {e}"
+                            f"There was a problem with the generation of the structured output: {error}"
                         )
 
             await ctx.store.set("current_tool_calls", [])

--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -420,6 +420,7 @@ class BaseWorkflowAgent(
             )
 
         if not ev.tool_calls:
+            # important: messages should always be fetched after calling finalize, otherwise they do not contain the agent's response
             output = await self.finalize(ctx, ev, memory)
             messages = await memory.aget()
             cur_tool_calls: List[ToolCallResult] = await ctx.store.get(

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -449,6 +449,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         if not ev.tool_calls:
             agent = self.agents[ev.current_agent_name]
             memory = await ctx.store.get("memory")
+            # important: messages should always be fetched after calling finalize, otherwise they do not contain the agent's response
             output = await agent.finalize(ctx, ev, memory)
             messages = await memory.aget()
 

--- a/llama-index-core/tests/agent/utils/test_agent_utils.py
+++ b/llama-index-core/tests/agent/utils/test_agent_utils.py
@@ -1,8 +1,125 @@
 import pytest
+from typing import Any, List, Type, Optional, Dict
+from typing_extensions import override
 
+from pydantic import BaseModel
 from llama_index.core.llms import ChatMessage, TextBlock
-from llama_index.core.agent.utils import messages_to_xml_format
-from typing import List
+from llama_index.core.types import Model
+from llama_index.core.llms import (
+    LLMMetadata,
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    LLM,
+)
+from llama_index.core.prompts.base import PromptTemplate
+from llama_index.core.tools import ToolSelection
+from llama_index.core.agent.utils import (
+    messages_to_xml_format,
+    generate_structured_response,
+)
+
+
+class Structure(BaseModel):
+    hello: str
+    world: int
+
+
+class TestLLM(LLM):
+    def __init__(self, responses: List[ChatMessage], structured_response: str):
+        super().__init__()
+        self._responses = responses
+        self._structured_response = structured_response
+        self._response_index = 0
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(is_function_calling_model=True)
+
+    async def astream_chat(
+        self, messages: List[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        response_msg = None
+        if self._responses:
+            response_msg = self._responses[self._response_index]
+            self._response_index = (self._response_index + 1) % len(self._responses)
+
+        async def _gen():
+            if response_msg:
+                yield ChatResponse(
+                    message=response_msg,
+                    delta=response_msg.content,
+                    raw={"content": response_msg.content},
+                )
+
+        return _gen()
+
+    async def astream_chat_with_tools(
+        self, tools: List[Any], chat_history: List[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        response_msg = None
+        if self._responses:
+            response_msg = self._responses[self._response_index]
+            self._response_index = (self._response_index + 1) % len(self._responses)
+
+        async def _gen():
+            if response_msg:
+                yield ChatResponse(
+                    message=response_msg,
+                    delta=response_msg.content,
+                    raw={"content": response_msg.content},
+                )
+
+        return _gen()
+
+    def get_tool_calls_from_response(
+        self, response: ChatResponse, **kwargs: Any
+    ) -> List[ToolSelection]:
+        return response.message.additional_kwargs.get("tool_calls", [])
+
+    @override
+    async def astructured_predict(
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Model:
+        return output_cls.model_validate_json(self._structured_response)
+
+    @override
+    async def structured_predict(
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Model:
+        return output_cls.model_validate_json(self._structured_response)
+
+    async def achat(self, *args, **kwargs):
+        pass
+
+    def chat(self, *args, **kwargs):
+        pass
+
+    def stream_chat(self, *args, **kwargs):
+        pass
+
+    def complete(self, *args, **kwargs):
+        pass
+
+    async def acomplete(self, *args, **kwargs):
+        pass
+
+    def stream_complete(self, *args, **kwargs):
+        pass
+
+    async def astream_complete(self, *args, **kwargs):
+        pass
+
+    def _prepare_chat_with_tools(self, *args, **kwargs):
+        return {}
 
 
 @pytest.fixture
@@ -20,10 +137,31 @@ def xml_string() -> str:
     return "<current_conversation>\n\t<user>\n\t\t<message>hello</message>\n\t</user>\n\t<assistant>\n\t\t<message>hello back</message>\n\t</assistant>\n\t<user>\n\t\t<message>how are you?</message>\n\t</user>\n\t<assistant>\n\t\t<message>I am good, thank you.</message>\n\t</assistant>\n</current_conversation>\n\nGiven the conversation, format the output according to the provided schema."
 
 
-def test_messages_to_xml(chat_messages: List[ChatMessage], xml_string: str):
+@pytest.fixture
+def structured_response() -> str:
+    return Structure(hello="test", world=1).model_dump_json()
+
+
+def test_messages_to_xml(chat_messages: List[ChatMessage], xml_string: str) -> None:
     msg = messages_to_xml_format(chat_messages)
     assert isinstance(msg, ChatMessage)
     s = ""
     for block in msg.blocks:
         s += block.text
     assert s == xml_string
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_response(
+    chat_messages: List[ChatMessage], structured_response: str
+) -> None:
+    llm = TestLLM(
+        responses=[ChatMessage(role="assistant", content="Hello World!")],
+        structured_response=structured_response,
+    )
+    generated_response = await generate_structured_response(
+        messages=chat_messages, llm=llm, output_cls=Structure
+    )
+    assert Structure.model_validate(
+        generated_response
+    ) == Structure.model_validate_json(structured_response)


### PR DESCRIPTION
# Description

Structured generation breaks when there is not assistant message in memory with the result - this fixes it by using the agent output response to as the final answer of the assistant, adding it to the messages that serve as input for the structured output generation.

I also removed `tool_required = True` which seems to hinder/slow down the generation of structured output, at least in the code below:

```python
from llama_index.llms.openai import OpenAI  
from llama_index.core.agent.workflow import FunctionAgent, AgentWorkflow
from pydantic import BaseModel, Field

class MathResult(BaseModel):
    operation: str = Field(description="The operation that has been performed")
    result: int = Field(description="Result of the operation")   


llm = OpenAI(model="gpt-4.1", api_key="***")         

def add(x: int, y: int):
    """Add two numbers"""
    return x+y

def multiply(x: int, y: int):
    """Multiply two numbers"""
    return x*y

agent = FunctionAgent(llm=llm, tools=[add, multiply], system_prompt="You are a calculator agent that can add or multiply two numbers by calling tools. You must call tools.", name="calculator", description="An agent", output_cls=MathResult) 

async def main():
    response = await agent.run("What is the result of 10 multiplied by 4?")
    return response

if __name__ == "__main__":
    import asyncio
    asyncio.run(main())
    a = asyncio.run(main())
    print(a.get_pydantic_model(MathResult))
    # Returns: MathResult(operation='10 multiplied by 4', result=40)
```