### PR TITLE
add message separator in VectorMemoryBlock._get_text_from_messages

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory_blocks/vector.py
+++ b/llama-index-core/llama_index/core/memory/memory_blocks/vector.py
@@ -89,11 +89,12 @@ class VectorMemoryBlock(BaseMemoryBlock[str]):
     def _get_text_from_messages(self, messages: List[ChatMessage]) -> str:
         """Get the text from the messages."""
         text = ""
-        for message in messages:
+        for i, message in enumerate(messages):
             for block in message.blocks:
                 if isinstance(block, TextBlock):
                     text += block.text
-
+            if len(messages) > 1 and i != len(messages)-1:
+                text += " "
         return text
 
     async def _aget(


### PR DESCRIPTION
# Description

before this change, if you have more than one message in the list ChatMessages, the concatenated output text does not have a separator between message. For example, two of my message is: ["hello", "good morning"], the output text will be: "hellogood morning"

I added a separator to make the output separated, above example would become: "hello good morning"

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
