### PR TITLE
Update ReAct agent parse error message

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -135,7 +135,21 @@ class ReActAgent(BaseWorkflowAgent):
         try:
             reasoning_step = output_parser.parse(message_content, is_streaming=False)
         except ValueError as e:
-            error_msg = f"Error: Could not parse output. Please follow the thought-action-input format. Try again. Details: {e!s}"
+            error_msg = (
+                f"Error while parsing the output: {e!s}\n\n"
+                "The output should be in one of the following formats:\n"
+                "1. To call a tool:\n"
+                "```\n"
+                "Thought: <thought>\n"
+                "Action: <action>\n"
+                "Action Input: <action_input>\n"
+                "```\n"
+                "2. To answer the question:\n"
+                "```\n"
+                "Thought: <thought>\n"
+                "Answer: <answer>\n"
+                "```\n"
+            )
 
             raw = (
                 last_chat_response.raw.model_dump()


### PR DESCRIPTION
# Description

This PR updates the error message sent by the ReAct agent to the retry process when the output parser fails to parse the output. In some situations, the LLM replies in its Thought and does not provide an Answer. The current error message being too vague, the agent can become stuck in a retry loop. The new error message specifies what are the expected formats more clearly to prevent this retry loop.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
