### PR TITLE
fix: add structured output to multi agent also from secondary constructor + tests

### DIFF
--- a/docs/docs/understanding/agent/multi_agent.md
+++ b/docs/docs/understanding/agent/multi_agent.md
@@ -405,3 +405,5 @@ This approach means *you* own the orchestration loop, so you can insert whatever
 | Custom planner | ⭐⭐⭐ | ★★★★★ | Yes (via sub-agents). Top-level is up to you. |
 
 If you are prototyping quickly, start with `AgentWorkflow`.  Move to an *Orchestrator agent* when you need more control over the sequence.  Reach for a *Custom planner* only when the first two patterns cannot express the flow you need.
+
+Next you will learn how to use [structured output in single and multi-agent workflows](./structured_output.md)

--- a/docs/docs/understanding/agent/structured_output.md
+++ b/docs/docs/understanding/agent/structured_output.md
@@ -1,0 +1,185 @@
+# Using Structured Output
+
+Agents are knowingly unreliable in their outputs, as most of the times we would like them to answer in a specific format but they do not follow the rules due to their internal complexity.
+
+To tackle this challenge, we added the possibility of specifying a structured output format within single and multi-agent workflows so that you can have a more fine-grained control over the data structure that your agent returns.
+
+You can do it by adding an `output_cls` argument to the initialization options of your agent/multi-agent workflows:
+
+```python
+from llama_index.core.agent.workflow import FunctionAgent, AgentWorkflow
+from llama_index.llms.openai import OpenAI
+from pydantic import BaseModel, Field
+
+llm = OpenAI(model="gpt-4.1")
+
+# single agent
+
+
+## define structured output format  and tools
+class MathResult(BaseModel):
+    operation: str = Field(description="the performed operation")
+    result: int = Field(description="the result of the operation")
+
+
+def multiply(x: int, y: int):
+    """Multiply two numbers"""
+    return x * y
+
+
+## define agent
+agent = FunctionAgent(
+    tools=[multiply],
+    name="calculator",
+    system_prompt="You are a calculator agent who can multiply two numbers using the `multiply` tool.",
+    output_cls=MathResult,
+    llm=llm,
+)
+
+# multi agent
+
+
+## define structured output format  and tools
+class Weather(BaseModel):
+    location: str = Field(description="The location")
+    weather: str = Field(description="The weather")
+
+
+def get_weather(location: str):
+    """Get the weather for a given location"""
+    return f"The weather in {location} is sunny"
+
+
+## define single agents
+agent = FunctionAgent(
+    llm=llm,
+    tools=[get_weather],
+    system_prompt="You are a weather agent that can get the weather for a given location",
+    name="WeatherAgent",
+    description="The weather forecaster agent.",
+)
+main_agent = FunctionAgent(
+    name="MainAgent",
+    tools=[],
+    description="The main agent",
+    system_prompt="You are the main agent, your task is to dispatch tasks to secondary agents, specifically to WeatherAgent",
+    can_handoff_to=["WeatherAgent"],
+    llm=llm,
+)
+
+## define multi-agent workflow
+workflow = AgentWorkflow(
+    agents=[main_agent, agent],
+    root_agent=main_agent.name,
+    output_cls=Weather,
+)
+
+# multi agent from tools or functions
+
+## define multi-agent workflow
+workflow = AgentWorkflow.from_tools_or_functions(
+    tools_or_functions=[get_weather],
+    system_prompt="You are a weather agent that can get the weather for a given location",
+    output_cls=Weather,
+    llm=llm,
+)
+```
+
+Or you can define a custom function that takes as input a sequence of ChatMessages produced by the agent workflow and returns a dictionary (that can be turned into a BaseModel subclass):
+
+```python
+import json
+from llama_index.core.llms import ChatMessage
+from typing import List, Dict, Any
+
+
+class Flavor(BaseModel):
+    flavor: str
+    with_sugar: bool
+
+
+# define it sync
+def structured_output_parsing(messages: List[ChatMessage]) -> Dict[str, Any]:
+    sllm = llm.as_structured_llm(Flavor)
+    messages.append(
+        ChatMessage(
+            role="user",
+            content="Given the previous message history, structure the output based on the provided format.",
+        )
+    )
+    response = sllm.chat(messages)
+    return json.loads(response.message.content)
+
+
+# define it async
+async def astructured_output_parsing(
+    messages: List[ChatMessage],
+) -> Dict[str, Any]:
+    sllm = llm.as_structured_llm(Flavor)
+    messages.append(
+        ChatMessage(
+            role="user",
+            content="Given the previous message history, structure the output based on the provided format.",
+        )
+    )
+    response = await sllm.achat(messages)
+    return json.loads(response.message.content)
+
+
+def get_flavor(ice_cream_shop: str):
+    return "Strawberry with no extra sugar"
+
+
+agent_sync = FunctionAgent(
+    tools=[get_flavor],
+    name="ice_cream_shopper",
+    system_prompt="You are an agent that knows the ice cream flavors in various shops.",
+    structured_output_fn=structured_output_parsing,
+    llm=llm,
+)
+agent_async = FunctionAgent(
+    tools=[get_flavor],
+    name="ice_cream_shopper",
+    system_prompt="You are an agent that knows the ice cream flavors in various shops.",
+    structured_output_fn=astructured_output_parsing,
+    llm=llm,
+)
+```
+
+Now you can get the structured output while the workflow by using the `AgentStreamStructuredOutput` event:
+
+```python
+from llama_index.core.agent.workflow import (
+    AgentInput,
+    AgentOutput,
+    ToolCall,
+    ToolCallResult,
+    AgentStreamStructuredOutput,
+)
+
+handler = agent.run("What strawberry flavor is available at Gelato Italia?")
+
+async for event in handler.stream_events():
+    if isinstance(event, AgentInput):
+        print(event)
+    elif isinstance(event, AgentStreamStructuredOutput):
+        print(event.output)
+        print(event.get_pydantic_model(Weather))
+    elif isinstance(event, ToolCallResult):
+        print(event)
+    elif isinstance(event, ToolCall):
+        print(event)
+    elif isinstance(event, AgentOutput):
+        print(event)
+    else:
+        pass
+
+response = await handler
+```
+
+And you can parse the structured output in the agent's response accessing it directly as a dictionary or loading it as a BaseModel subclass by using the `get_pydantic_model` method:
+
+```python
+print(response.structured_response)
+print(response.get_pydantic_model(Flavor))
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
           - Streaming output and events: ./understanding/agent/streaming.md
           - Human in the loop: ./understanding/agent/human_in_the_loop.md
           - Multi-agent workflows: ./understanding/agent/multi_agent.md
+          - Using structured output: ./understanding/agent/structured_output.md
       - Building Workflows:
           - Introduction to workflows: ./understanding/workflows/index.md
           - A basic workflow: ./understanding/workflows/basic_flow.md

--- a/llama-index-core/llama_index/core/agent/workflow/__init__.py
+++ b/llama-index-core/llama_index/core/agent/workflow/__init__.py
@@ -10,6 +10,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentOutput,
     ToolCall,
     ToolCallResult,
+    AgentStreamStructuredOutput,
 )
 
 
@@ -25,4 +26,5 @@ __all__ = [
     "ReActAgent",
     "ToolCall",
     "ToolCallResult",
+    "AgentStreamStructuredOutput",
 ]

--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -10,6 +10,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentInput,
     AgentSetup,
     AgentWorkflowStartEvent,
+    AgentStreamStructuredOutput,
     ToolCall,
     ToolCallResult,
 )
@@ -438,6 +439,9 @@ class BaseWorkflowAgent(
                         output.structured_response = cast(
                             Dict[str, Any], self.structured_output_fn(messages)
                         )
+                    ctx.write_event_to_stream(
+                        AgentStreamStructuredOutput(output=output.structured_response)
+                    )
                 except Exception as e:
                     warnings.warn(
                         f"There was a problem with the generation of the structured output: {e}"
@@ -446,6 +450,9 @@ class BaseWorkflowAgent(
                 try:
                     output.structured_response = await generate_structured_response(
                         messages=messages, llm=self.llm, output_cls=self.output_cls
+                    )
+                    ctx.write_event_to_stream(
+                        AgentStreamStructuredOutput(output=output.structured_response)
                     )
                 except Exception as e:
                     warnings.warn(

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -25,6 +25,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentSetup,
     AgentOutput,
     AgentWorkflowStartEvent,
+    AgentStreamStructuredOutput,
 )
 from llama_index.core.llms import ChatMessage, TextBlock
 from llama_index.core.llms.llm import LLM
@@ -469,6 +470,9 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                         output.structured_response = cast(
                             Dict[str, Any], self.structured_output_fn(messages)
                         )
+                    ctx.write_event_to_stream(
+                        AgentStreamStructuredOutput(output=output.structured_response)
+                    )
                 except Exception as e:
                     warnings.warn(
                         f"There was a problem with the generation of the structured output: {e}"
@@ -477,6 +481,9 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 try:
                     output.structured_response = await generate_structured_response(
                         messages=messages, llm=agent.llm, output_cls=self.output_cls
+                    )
+                    ctx.write_event_to_stream(
+                        AgentStreamStructuredOutput(output=output.structured_response)
                     )
                 except Exception as e:
                     warnings.warn(

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -655,6 +655,10 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         system_prompt: Optional[str] = None,
         state_prompt: Optional[Union[str, BasePromptTemplate]] = None,
         initial_state: Optional[dict] = None,
+        output_cls: Optional[Type[BaseModel]] = None,
+        structured_output_fn: Optional[
+            Callable[[List[ChatMessage]], Dict[str, Any]]
+        ] = None,
         timeout: Optional[float] = None,
         verbose: bool = False,
     ) -> "AgentWorkflow":
@@ -687,6 +691,8 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                     system_prompt=system_prompt,
                 )
             ],
+            output_cls=output_cls,
+            structured_output_fn=structured_output_fn,
             state_prompt=state_prompt,
             initial_state=initial_state,
             timeout=timeout,

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -62,7 +62,7 @@ class AgentStreamStructuredOutput(Event):
             )
             return None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(self.output, indent=4)
 
 

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+import json
 from typing import Any, Optional, Dict, Type
 
 from llama_index.core.bridge.pydantic import (
@@ -42,6 +43,27 @@ class AgentStream(Event):
     current_agent_name: str
     tool_calls: list[ToolSelection] = Field(default_factory=list)
     raw: Optional[Any] = Field(default=None, exclude=True)
+
+
+class AgentStreamStructuredOutput(Event):
+    """Stream the structured output"""
+
+    output: Dict[str, Any]
+
+    def get_pydantic_model(self, model: Type[BaseModel]) -> Optional[BaseModel]:
+        if self.output is None:
+            return self.output
+        try:
+            return model.model_validate(self.output)
+        except ValidationError as e:
+            warnings.warn(
+                f"Conversion of structured response to Pydantic model failed because:\n\n{e.title}\n\nPlease check the model you provided.",
+                PydanticConversionWarning,
+            )
+            return None
+
+    def __str__(self):
+        return json.dumps(self.output, indent=4)
 
 
 class AgentOutput(Event):


### PR DESCRIPTION
# Description

We do not support structured output when calling `AgentWorkflow.from_tools_or_functions`, in this PR I try to fix that

We also allow user to capture the structured output from streamed events adding the `AgentStreamStructuredOutput` event.