### PR TITLE
fix: pass **kwargs to super().__init__ in BaiduVectorDB to ensure pro…

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/llama_index/vector_stores/baiduvectordb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/llama_index/vector_stores/baiduvectordb/base.py
@@ -161,6 +161,7 @@ class BaiduVectorDB(BasePydanticVectorStore):
         super().__init__(
             user_defined_fields=table_params.filter_fields,
             batch_size=batch_size,
+            **kwargs,
         )
 
         self._init_client(endpoint, account, api_key)


### PR DESCRIPTION
…per pydantic initialization

# Description

This PR fixes a pydantic initialization issue in the BaiduVectorDB vector store integration. The `super().__init__()` call in the `BaiduVectorDB.__init__` method was not passing the `**kwargs` parameter to the parent class `BasePydanticVectorStore`, which could cause initialization failures when additional parameters like `stores_text` are required by the base class.

The fix ensures that all keyword arguments are properly forwarded to the parent class constructor, allowing for proper pydantic field initialization.

Fixes pydantic initialization failure in BaiduVectorDB when base class fields are not properly initialized.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
