### PR TITLE
Muhammadk 03/fix llamadev no tests skip

### DIFF
--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -157,17 +157,29 @@ def test(
         for r in results
         if r["status"] == ResultStatus.INSTALL_FAILED
     ]
-    skipped = [
+    skipped_no_tests = [
+        r["package"].relative_to(repo_root)
+        for r in results
+        if r["status"] == ResultStatus.SKIPPED and "package has no tests" in r["stderr"]
+    ]
+    skipped_pyversion_incompatible = [
         r["package"].relative_to(repo_root)
         for r in results
         if r["status"] == ResultStatus.SKIPPED
+        and "Not compatible with Python" in r["stderr"]
     ]
 
-    if skipped:
+    if skipped_pyversion_incompatible:
         console.print(
-            f"\n{len(skipped)} packages were skipped due to Python version incompatibility:"
+            f"\n{len(skipped_pyversion_incompatible)} packages were skipped due to Python version incompatibility:"
         )
-        for p in skipped:
+        for p in skipped_pyversion_incompatible:
+            print(p)
+    if skipped_no_tests:
+        console.print(
+            f"\n{len(skipped_no_tests)} packages were skipped because they have no tests:"
+        )
+        for p in skipped_no_tests:
             print(p)
 
     if install_failed:
@@ -184,7 +196,8 @@ def test(
         exit(1)
     else:
         console.print(
-            f"\nTests passed for {len(results) - len(skipped)} packages.", style="green"
+            f"\nTests passed for {len(results) - len(skipped_no_tests) - len(skipped_pyversion_incompatible)} packages.",
+            style="green",
         )
 
 

--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -26,7 +26,8 @@ class ResultStatus(Enum):
     INSTALL_FAILED = auto()
     TESTS_FAILED = auto()
     TESTS_PASSED = auto()
-    SKIPPED = auto()
+    NO_TESTS = auto()
+    UNSUPPORTED_PYTHON_VERSION = auto()
     COVERAGE_FAILED = auto()
 
 
@@ -132,8 +133,15 @@ def test(
                 )
             elif result["status"] == ResultStatus.TESTS_PASSED:
                 console.print(f"✅ {package_name} succeeded in {result['time']}")
-            elif result["status"] == ResultStatus.SKIPPED:
-                console.print(f"⏭️  {package_name} skipped")
+            elif result["status"] == ResultStatus.UNSUPPORTED_PYTHON_VERSION:
+                console.print(
+                    f"⏭️ {package_name} skipped due to python version incompatibility"
+                )
+                console.print(
+                    _trim(debug, f"Error:\n{result['stderr']}"), style="warning"
+                )
+            elif result["status"] == ResultStatus.NO_TESTS:
+                console.print(f"⏭️ {package_name} skipped due to no tests")
                 console.print(
                     _trim(debug, f"Error:\n{result['stderr']}"), style="warning"
                 )
@@ -160,12 +168,13 @@ def test(
     skipped_no_tests = [
         r["package"].relative_to(repo_root)
         for r in results
-        if r["status"] == ResultStatus.SKIPPED and "package has no tests" in r["stderr"]
+        if r["status"] == ResultStatus.NO_TESTS
+        and "package has no tests" in r["stderr"]
     ]
     skipped_pyversion_incompatible = [
         r["package"].relative_to(repo_root)
         for r in results
-        if r["status"] == ResultStatus.SKIPPED
+        if r["status"] == ResultStatus.UNSUPPORTED_PYTHON_VERSION
         and "Not compatible with Python" in r["stderr"]
     ]
 
@@ -297,7 +306,7 @@ def _run_tests(
     if not is_python_version_compatible(package_data):
         return {
             "package": package_path,
-            "status": ResultStatus.SKIPPED,
+            "status": ResultStatus.UNSUPPORTED_PYTHON_VERSION,
             "stdout": "",
             "stderr": f"Skipped: Not compatible with Python {sys.version_info.major}.{sys.version_info.minor}",
             "time": "0.00s",
@@ -307,7 +316,7 @@ def _run_tests(
     if not package_has_tests(package_path):
         return {
             "package": package_path,
-            "status": ResultStatus.SKIPPED,
+            "status": ResultStatus.NO_TESTS,
             "stdout": "",
             "stderr": f"Skipped: package has no tests",
             "time": "0.00s",

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -202,37 +202,6 @@ def test_install_failures(
     assert "Error:\nInstall failed" in result.stdout
 
 
-# @mock.patch("llama_dev.test.find_all_packages")
-# @mock.patch("llama_dev.test.get_changed_files")
-# @mock.patch("llama_dev.test.get_changed_packages")
-# @mock.patch("llama_dev.test.get_dependants_packages")
-# def test_skip_failures(
-#     mock_get_dependants,
-#     mock_get_changed_packages,
-#     mock_get_changed_files,
-#     mock_find_all_packages,
-#     monkeypatch,
-#     data_path,
-# ):
-#     mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
-#     mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
-#     mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
-#     mock_get_dependants.return_value = set()
-
-#     monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_skip_failed)
-
-#     runner = CliRunner()
-#     result = runner.invoke(
-#         cli,
-#         ["--repo-root", data_path, "test", "--base-ref", "main"],
-#     )
-
-#     # Check console output
-#     assert result.exit_code == 0
-#     assert "⏭️  test_integration skipped" in result.stdout
-#     assert "Error:\nIntegration skipped" in result.stdout
-
-
 @mock.patch("llama_dev.test.find_all_packages")
 @mock.patch("llama_dev.test.get_changed_files")
 @mock.patch("llama_dev.test.get_changed_packages")
@@ -292,11 +261,10 @@ def test_skip_failures_unsupported_python(
 
     # Check console output
     assert result.exit_code == 0
-    # assert "⏭️  test_integration skipped" in result.stdout
     assert (
         "⏭️ test_integration skipped due to python version incompatibility"
         in result.stdout
-    )  # assert "Not compatible with Python" in result.stdout
+    )
 
 
 @mock.patch("llama_dev.test.find_all_packages")

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -28,12 +28,22 @@ def mocked_install_failed(*args, **kwargs):
     }
 
 
-def mocked_skip_failed(*args, **kwargs):
+def mocked_skip_failed_unsupported_python_version(*args, **kwargs):
     return {
         "package": Path(__file__).parent.parent / "data" / "test_integration",
-        "status": ResultStatus.SKIPPED,
+        "status": ResultStatus.UNSUPPORTED_PYTHON_VERSION,
         "stdout": "",
-        "stderr": "Integration skipped",
+        "stderr": "Not compatible with Python",
+        "time": "0.1s",
+    }
+
+
+def mocked_skip_failed_no_tests(*args, **kwargs):
+    return {
+        "package": Path(__file__).parent.parent / "data" / "test_integration",
+        "status": ResultStatus.NO_TESTS,
+        "stdout": "",
+        "stderr": "package has no tests",
         "time": "0.1s",
     }
 
@@ -192,11 +202,42 @@ def test_install_failures(
     assert "Error:\nInstall failed" in result.stdout
 
 
+# @mock.patch("llama_dev.test.find_all_packages")
+# @mock.patch("llama_dev.test.get_changed_files")
+# @mock.patch("llama_dev.test.get_changed_packages")
+# @mock.patch("llama_dev.test.get_dependants_packages")
+# def test_skip_failures(
+#     mock_get_dependants,
+#     mock_get_changed_packages,
+#     mock_get_changed_files,
+#     mock_find_all_packages,
+#     monkeypatch,
+#     data_path,
+# ):
+#     mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
+#     mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
+#     mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
+#     mock_get_dependants.return_value = set()
+
+#     monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_skip_failed)
+
+#     runner = CliRunner()
+#     result = runner.invoke(
+#         cli,
+#         ["--repo-root", data_path, "test", "--base-ref", "main"],
+#     )
+
+#     # Check console output
+#     assert result.exit_code == 0
+#     assert "⏭️  test_integration skipped" in result.stdout
+#     assert "Error:\nIntegration skipped" in result.stdout
+
+
 @mock.patch("llama_dev.test.find_all_packages")
 @mock.patch("llama_dev.test.get_changed_files")
 @mock.patch("llama_dev.test.get_changed_packages")
 @mock.patch("llama_dev.test.get_dependants_packages")
-def test_skip_failures(
+def test_skip_failures_no_tests(
     mock_get_dependants,
     mock_get_changed_packages,
     mock_get_changed_files,
@@ -209,7 +250,7 @@ def test_skip_failures(
     mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
     mock_get_dependants.return_value = set()
 
-    monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_skip_failed)
+    monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_skip_failed_no_tests)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -219,8 +260,43 @@ def test_skip_failures(
 
     # Check console output
     assert result.exit_code == 0
-    assert "⏭️  test_integration skipped" in result.stdout
-    assert "Error:\nIntegration skipped" in result.stdout
+    assert "⏭️ test_integration skipped due to no tests" in result.stdout
+
+
+@mock.patch("llama_dev.test.find_all_packages")
+@mock.patch("llama_dev.test.get_changed_files")
+@mock.patch("llama_dev.test.get_changed_packages")
+@mock.patch("llama_dev.test.get_dependants_packages")
+def test_skip_failures_unsupported_python(
+    mock_get_dependants,
+    mock_get_changed_packages,
+    mock_get_changed_files,
+    mock_find_all_packages,
+    monkeypatch,
+    data_path,
+):
+    mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
+    mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
+    mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
+    mock_get_dependants.return_value = set()
+
+    monkeypatch.setattr(
+        llama_dev_test, "_run_tests", mocked_skip_failed_unsupported_python_version
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--repo-root", data_path, "test", "--base-ref", "main"],
+    )
+
+    # Check console output
+    assert result.exit_code == 0
+    # assert "⏭️  test_integration skipped" in result.stdout
+    assert (
+        "⏭️ test_integration skipped due to python version incompatibility"
+        in result.stdout
+    )  # assert "Not compatible with Python" in result.stdout
 
 
 @mock.patch("llama_dev.test.find_all_packages")
@@ -334,11 +410,29 @@ def test_incompatible_python_version(changed_packages):
             return_value={"project": {"requires-python": ">=3.10"}},
         ),
         mock.patch("llama_dev.test.is_python_version_compatible", return_value=False),
+        mock.patch("llama_dev.test.package_has_tests", return_value=True),
     ):
         result = _run_tests(Path(), changed_packages, "main", False, 0)
 
-        assert result["status"] == ResultStatus.SKIPPED
+        assert result["status"] == ResultStatus.UNSUPPORTED_PYTHON_VERSION
         assert "Not compatible with Python" in result["stderr"]
+        assert "package has no tests" not in result["stderr"]
+
+
+def test_no_package_tests(changed_packages):
+    with (
+        mock.patch(
+            "llama_dev.test.load_pyproject",
+            return_value={"project": {"requires-python": ">=3.8"}},
+        ),
+        mock.patch("llama_dev.test.is_python_version_compatible", return_value=True),
+        mock.patch("llama_dev.test.package_has_tests", return_value=False),
+    ):
+        result = _run_tests(Path(), changed_packages, "main", False, 0)
+
+        assert result["status"] == ResultStatus.NO_TESTS
+        assert "package has no tests" in result["stderr"]
+        assert "Not compatible with Python" not in result["stderr"]
 
 
 def test_install_dependencies_failure(changed_packages, package_data):

--- a/llama-dev/tests/test_cli.py
+++ b/llama-dev/tests/test_cli.py
@@ -1,5 +1,7 @@
 from click.testing import CliRunner
 from llama_dev.cli import cli
+from unittest import mock
+from pathlib import Path
 
 
 def test_version():
@@ -8,3 +10,43 @@ def test_version():
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert result.output.startswith("cli, version ")
+
+
+def test_cli_empty_package_only_skipped_for_no_tests(tmp_path):
+    # Find the repo root
+    repo_root = Path(__file__).parent.parent.parent / "llama-dev"
+    # Temporarily create a directory for testing the empty package output in CLI
+    test_pkg = repo_root / "empty_package"
+    test_pkg.mkdir(exist_ok=True)
+
+    # Create pyproject.toml
+    (test_pkg / "pyproject.toml").write_text("[project]\nrequires-python = '>=3.8'\n")
+
+    try:
+        # Mock all the method return values
+        with (
+            mock.patch("llama_dev.test.find_all_packages", return_value={test_pkg}),
+            mock.patch("llama_dev.test.get_changed_files", return_value={}),
+            mock.patch("llama_dev.test.get_changed_packages", return_value={test_pkg}),
+            mock.patch("llama_dev.test.get_dependants_packages", return_value=set()),
+            mock.patch(
+                "llama_dev.test.load_pyproject",
+                return_value={"project": {"requires-python": ">=3.8"}},
+            ),
+            mock.patch(
+                "llama_dev.test.is_python_version_compatible", return_value=True
+            ),
+            mock.patch("llama_dev.test.package_has_tests", return_value=False),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["--repo-root", str(repo_root), "test", "empty_package"]
+            )
+
+        assert "skipped because they have no tests" in result.output
+        assert "skipped due to Python version incompatibility" not in result.output
+    finally:
+        # Clean up
+        for f in test_pkg.iterdir():
+            f.unlink()
+        test_pkg.rmdir()

--- a/llama-dev/tests/test_cli.py
+++ b/llama-dev/tests/test_cli.py
@@ -1,7 +1,5 @@
 from click.testing import CliRunner
 from llama_dev.cli import cli
-from unittest import mock
-from pathlib import Path
 
 
 def test_version():
@@ -10,43 +8,3 @@ def test_version():
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert result.output.startswith("cli, version ")
-
-
-def test_cli_empty_package_only_skipped_for_no_tests(tmp_path):
-    # Find the repo root
-    repo_root = Path(__file__).parent.parent.parent / "llama-dev"
-    # Temporarily create a directory for testing the empty package output in CLI
-    test_pkg = repo_root / "empty_package"
-    test_pkg.mkdir(exist_ok=True)
-
-    # Create pyproject.toml
-    (test_pkg / "pyproject.toml").write_text("[project]\nrequires-python = '>=3.8'\n")
-
-    try:
-        # Mock all the method return values
-        with (
-            mock.patch("llama_dev.test.find_all_packages", return_value={test_pkg}),
-            mock.patch("llama_dev.test.get_changed_files", return_value={}),
-            mock.patch("llama_dev.test.get_changed_packages", return_value={test_pkg}),
-            mock.patch("llama_dev.test.get_dependants_packages", return_value=set()),
-            mock.patch(
-                "llama_dev.test.load_pyproject",
-                return_value={"project": {"requires-python": ">=3.8"}},
-            ),
-            mock.patch(
-                "llama_dev.test.is_python_version_compatible", return_value=True
-            ),
-            mock.patch("llama_dev.test.package_has_tests", return_value=False),
-        ):
-            runner = CliRunner()
-            result = runner.invoke(
-                cli, ["--repo-root", str(repo_root), "test", "empty_package"]
-            )
-
-        assert "skipped because they have no tests" in result.output
-        assert "skipped due to Python version incompatibility" not in result.output
-    finally:
-        # Clean up
-        for f in test_pkg.iterdir():
-            f.unlink()
-        test_pkg.rmdir()


### PR DESCRIPTION
# Description

This PR is for the wrong error that was being printed in stderr. Specifically, when a package had no tests, llamadev still reported the error "1 packages were skipped due to Python version incompatibility:".
This fix creates two different arrays. One of them keeps track of the packages skipped due to version incompatibility and the other keeps track of packages skipped due to no tests being present and prints the appropriate message to stderr.

Fixes #19420 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
