### PR TITLE
fix: use a private folder to store NTLK cache

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -51,13 +51,12 @@ class GlobalsHelper:
         from nltk.data import path as nltk_path
 
         # Set up NLTK data directory
-        self._nltk_data_dir = os.environ.get(
-            "NLTK_DATA",
-            os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                "_static/nltk_cache",
-            ),
-        )
+        if "NLTK_DATA" in os.environ:
+            path = Path(os.environ["NLTK_DATA"])
+        else:
+            path = Path(platformdirs.user_cache_dir("llama_index"))
+
+        self._nltk_data_dir = str(path / "_static/nltk_cache")
 
         # Ensure the directory exists
         os.makedirs(self._nltk_data_dir, exist_ok=True)


### PR DESCRIPTION
# Description

Similar to #19415 - avoid storing data in a folder potentially accessible by others. Update is safe, worst case scenario NLTK will download again its assets upon a llama_index update.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update