### PR TITLE
improve empty retrieval check in vector index retriever 

### DIFF
--- a/docs/docs/examples/vector_stores/postgres.ipynb
+++ b/docs/docs/examples/vector_stores/postgres.ipynb
@@ -88,8 +88,7 @@
     "from llama_index.core import SimpleDirectoryReader, StorageContext\n",
     "from llama_index.core import VectorStoreIndex\n",
     "from llama_index.vector_stores.postgres import PGVectorStore\n",
-    "import textwrap\n",
-    "import openai"
+    "import textwrap"
    ]
   },
   {
@@ -110,8 +109,7 @@
    "source": [
     "import os\n",
     "\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"<your key>\"\n",
-    "openai.api_key = os.environ[\"OPENAI_API_KEY\"]"
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\""
    ]
   },
   {
@@ -133,16 +131,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2024-07-29 15:29:26--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
-      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 2606:50c0:8000::154, 2606:50c0:8002::154, 2606:50c0:8003::154, ...\n",
-      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|2606:50c0:8000::154|:443... connected.\n",
+      "--2025-07-18 16:24:08--  https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 75042 (73K) [text/plain]\n",
       "Saving to: ‘data/paul_graham/paul_graham_essay.txt’\n",
       "\n",
       "data/paul_graham/pa 100%[===================>]  73.28K  --.-KB/s    in 0.04s   \n",
       "\n",
-      "2024-07-29 15:29:26 (1.75 MB/s) - ‘data/paul_graham/paul_graham_essay.txt’ saved [75042/75042]\n",
+      "2025-07-18 16:24:09 (1.62 MB/s) - ‘data/paul_graham/paul_graham_essay.txt’ saved [75042/75042]\n",
       "\n"
      ]
     }
@@ -172,7 +170,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Document ID: e9a28a97-73af-42dd-8b40-9c585e222e69\n"
+      "Document ID: 370b5f28-a362-429b-ad6d-a931b30e00a0\n"
      ]
     }
    ],
@@ -223,7 +221,18 @@
    "execution_count": null,
    "id": "8731da62",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/loganmarkewich/giant_change/llama_index/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Parsing nodes: 100%|██████████| 1/1 [00:00<00:00,  7.66it/s]\n",
+      "Generating embeddings: 100%|██████████| 22/22 [00:01<00:00, 18.30it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "from sqlalchemy import make_url\n",
     "\n",
@@ -280,8 +289,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The author worked on writing essays, programming, developing software, giving talks, and starting a\n",
-      "startup.\n"
+      "The author worked on writing essays, programming, creating microcomputers, developing software,\n",
+      "giving talks, and starting a startup.\n"
      ]
     }
    ],
@@ -309,9 +318,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In the mid-1980s, the context mentions the presence of a famous fund manager who was not much older\n",
-      "than the author and was super rich. This sparked a thought in the author's mind about becoming rich\n",
-      "as well to have the freedom to work on whatever he wanted.\n"
+      "AI was in the air in the mid 1980s, and two things that influenced the desire to work on it were a\n",
+      "novel by Heinlein called The Moon is a Harsh Mistress, which featured an intelligent computer called\n",
+      "Mike, and a PBS documentary that showed Terry Winograd using SHRDLU.\n"
      ]
     }
    ],
@@ -374,8 +383,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The author worked on writing essays, programming, developing software, giving talks, and starting a\n",
-      "startup.\n"
+      "The author worked on writing essays, programming, creating microcomputers, developing software,\n",
+      "giving talks, and starting a startup.\n"
      ]
     }
    ],
@@ -520,7 +529,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Paul Graham associates the word \"schtick\" with artists who have a distinctive signature style in their work. This signature style serves as a visual identifier unique to the artist, making their work easily recognizable and attributed to them.\n"
+      "Paul Graham thinks of Roy Lichtenstein when using the word \"schtick\" because Lichtenstein's distinctive signature style in his paintings immediately identifies his work as his own.\n"
      ]
     }
    ],
@@ -1056,7 +1065,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },

--- a/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
@@ -154,9 +154,7 @@ class VectorIndexRetriever(BaseRetriever):
                 self._index.index_struct.nodes_dict[idx] for idx in query_result.ids
             ]
         else:
-            raise ValueError(
-                "Vector store query result should return at least one of nodes or ids."
-            )
+            return []
 
     def _insert_fetched_nodes_into_query_result(
         self, query_result: VectorStoreQueryResult, fetched_nodes: List[BaseNode]
@@ -187,7 +185,7 @@ class VectorIndexRetriever(BaseRetriever):
                     raise KeyError(
                         f"Node ID {node_id_str} not found in fetched nodes. "
                     )
-        else:
+        elif query_result.ids is None and query_result.nodes is None:
             raise ValueError(
                 "Vector store query result should return at least one of nodes or ids."
             )
@@ -215,13 +213,15 @@ class VectorIndexRetriever(BaseRetriever):
         query_result = self._vector_store.query(query, **self._kwargs)
 
         # Fetch any missing nodes from the docstore and insert them into the query result
-        fetched_nodes: List[BaseNode] = self._docstore.get_nodes(
-            node_ids=self._determine_nodes_to_fetch(query_result), raise_error=False
-        )
+        nodes_to_fetch = self._determine_nodes_to_fetch(query_result)
+        if nodes_to_fetch:
+            fetched_nodes: List[BaseNode] = self._docstore.get_nodes(
+                node_ids=nodes_to_fetch, raise_error=False
+            )
 
-        query_result.nodes = self._insert_fetched_nodes_into_query_result(
-            query_result, fetched_nodes
-        )
+            query_result.nodes = self._insert_fetched_nodes_into_query_result(
+                query_result, fetched_nodes
+            )
 
         log_vector_store_query_result(query_result)
 


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/19455

The refactoring here in other PRs had some un-intended consequences. Mainly, checking for `None` v.s. `false-y` 