### PR TITLE
Fix retriever KeyError when using FAISS

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
@@ -178,6 +178,8 @@ class VectorIndexRetriever(BaseRetriever):
                     new_nodes.append(node)
         elif query_result.ids:
             for node_id in query_result.ids:
+                if node_id not in self._index.index_struct.nodes_dict:
+                    raise KeyError(f"Node ID {node_id} not found in index. ")
                 node_id_str = str(self._index.index_struct.nodes_dict[node_id])
                 if node_id_str in fetched_nodes_by_id:
                     new_nodes.append(fetched_nodes_by_id[node_id_str])

--- a/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
@@ -177,9 +177,14 @@ class VectorIndexRetriever(BaseRetriever):
                 else:
                     new_nodes.append(node)
         elif query_result.ids:
-            for idx in query_result.ids:
-                str_node_id = self._index.index_struct.nodes_dict[idx]
-                new_nodes.append(fetched_nodes_by_id[str_node_id])
+            for node_id in query_result.ids:
+                node_id_str = str(self._index.index_struct.nodes_dict[node_id])
+                if node_id_str in fetched_nodes_by_id:
+                    new_nodes.append(fetched_nodes_by_id[node_id_str])
+                else:
+                    raise KeyError(
+                        f"Node ID {node_id_str} not found in fetched nodes. "
+                    )
         elif query_result.ids is None and query_result.nodes is None:
             raise ValueError(
                 "Vector store query result should return at least one of nodes or ids."
@@ -229,13 +234,15 @@ class VectorIndexRetriever(BaseRetriever):
         query_result = await self._vector_store.aquery(query, **self._kwargs)
 
         # Async fetch any missing nodes from the docstore and insert them into the query result
-        fetched_nodes: List[BaseNode] = await self._docstore.aget_nodes(
-            node_ids=self._determine_nodes_to_fetch(query_result), raise_error=False
-        )
+        nodes_to_fetch = self._determine_nodes_to_fetch(query_result)
+        if nodes_to_fetch:
+            fetched_nodes: List[BaseNode] = await self._docstore.aget_nodes(
+                node_ids=nodes_to_fetch, raise_error=False
+            )
 
-        query_result.nodes = self._insert_fetched_nodes_into_query_result(
-            query_result, fetched_nodes
-        )
+            query_result.nodes = self._insert_fetched_nodes_into_query_result(
+                query_result, fetched_nodes
+            )
 
         log_vector_store_query_result(query_result)
 

--- a/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
@@ -177,14 +177,9 @@ class VectorIndexRetriever(BaseRetriever):
                 else:
                     new_nodes.append(node)
         elif query_result.ids:
-            for node_id in query_result.ids:
-                node_id_str = str(node_id)
-                if node_id_str in fetched_nodes_by_id:
-                    new_nodes.append(fetched_nodes_by_id[node_id_str])
-                else:
-                    raise KeyError(
-                        f"Node ID {node_id_str} not found in fetched nodes. "
-                    )
+            for idx in query_result.ids:
+                str_node_id = self._index.index_struct.nodes_dict[idx]
+                new_nodes.append(fetched_nodes_by_id[str_node_id])
         elif query_result.ids is None and query_result.nodes is None:
             raise ValueError(
                 "Vector store query result should return at least one of nodes or ids."

--- a/llama-index-core/tests/indices/vector_store/test_retrievers.py
+++ b/llama-index-core/tests/indices/vector_store/test_retrievers.py
@@ -136,7 +136,7 @@ def test_insert_fetched_nodes_handles_all_branches():
     with pytest.raises(KeyError) as exc_info:
         retriever._insert_fetched_nodes_into_query_result(query_result, fetched_nodes)
 
-    assert "Node ID unknown not found" in str(exc_info.value)
+    assert "Node ID 0 not found in index." in str(exc_info.value)
 
 
 def test_insert_fetched_nodes_with_nodes_present():


### PR DESCRIPTION
# Description

When testing locally, this change fixes the KeyError issue I was experiencing when using FAISS, however, I am unaware if this will have negative impact to any other functions outside of FAISS usage. Please review this aspect prior to accepting.

I don't believe the original fix worked, because the FAISS integers need to be mapped back to the correct node id. Casting to a string wouldn't achieve this.

Fixes #19475

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests