### PR TITLE
fix: add system prompt to memory and use it also for structured generation

### DIFF
--- a/llama-index-core/llama_index/core/agent/utils.py
+++ b/llama-index-core/llama_index/core/agent/utils.py
@@ -3,7 +3,7 @@
 import json
 
 from llama_index.core.llms import ChatMessage, TextBlock
-from typing import List, Type, Dict, Any, cast
+from typing import List, Type, Dict, Any, Optional, cast
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.agent.types import TaskStep
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
@@ -21,9 +21,12 @@ def add_user_step_to_memory(
         print(f"Added user message to memory: {step.input}")
 
 
-def messages_to_xml_format(messages: List[ChatMessage]) -> ChatMessage:
+def messages_to_xml_format(messages: List[ChatMessage]) -> List[ChatMessage]:
     blocks = [TextBlock(text="<current_conversation>\n")]
+    system_msg: Optional[str] = None
     for message in messages:
+        if message.role.value == "system":
+            system_msg = message.content
         blocks.append(TextBlock(text=f"\t<{message.role.value}>\n"))
         for block in message.blocks:
             if isinstance(block, TextBlock):
@@ -35,7 +38,12 @@ def messages_to_xml_format(messages: List[ChatMessage]) -> ChatMessage:
             text="Given the conversation, format the output according to the provided schema."
         )
     )
-    return ChatMessage(role="user", blocks=blocks)
+    messages = [ChatMessage(role="user", blocks=blocks)]
+    if system_msg:
+        messages.insert(
+            0, ChatMessage(role=MessageRole.SYSTEM, blocks=[TextBlock(text=system_msg)])
+        )
+    return messages
 
 
 async def generate_structured_response(
@@ -44,5 +52,5 @@ async def generate_structured_response(
     xml_message = messages_to_xml_format(messages)
     structured_response = await llm.as_structured_llm(
         output_cls,
-    ).achat(messages=[xml_message])
+    ).achat(messages=xml_message)
     return cast(Dict[str, Any], json.loads(structured_response.message.content))

--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -323,12 +323,17 @@ class BaseWorkflowAgent(
                 ]
             )
             await ctx.store.set("user_msg_str", content_str)
-        elif chat_history:
+        elif chat_history and not all(
+            message.role == "system" for message in chat_history
+        ):
             # If no user message, use the last message from chat history as user_msg_str
+            user_hist: List[ChatMessage] = [
+                msg for msg in chat_history if msg.role == "user"
+            ]
             content_str = "\n".join(
                 [
                     block.text
-                    for block in chat_history[-1].blocks
+                    for block in user_hist[-1].blocks
                     if isinstance(block, TextBlock)
                 ]
             )
@@ -605,6 +610,7 @@ class BaseWorkflowAgent(
                 chat_history=chat_history,
                 memory=memory,
                 max_iterations=max_iterations,
+                system_prompt=self.system_prompt,
                 **kwargs,
             )
             return super().run(

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -345,12 +345,17 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 ]
             )
             await ctx.store.set("user_msg_str", content_str)
-        elif chat_history:
+        elif chat_history and not all(
+            message.role == "system" for message in chat_history
+        ):
             # If no user message, use the last message from chat history as user_msg_str
+            user_hist: List[ChatMessage] = [
+                msg for msg in chat_history if msg.role == "user"
+            ]
             content_str = "\n".join(
                 [
                     block.text
-                    for block in chat_history[-1].blocks
+                    for block in user_hist[-1].blocks
                     if isinstance(block, TextBlock)
                 ]
             )

--- a/llama-index-core/tests/agent/utils/test_agent_utils.py
+++ b/llama-index-core/tests/agent/utils/test_agent_utils.py
@@ -132,9 +132,22 @@ def chat_messages() -> List[ChatMessage]:
     ]
 
 
+@pytest.fixture()
+def chat_messages_sys(chat_messages: List[ChatMessage]) -> List[ChatMessage]:
+    return [
+        ChatMessage(role="system", content="You are a helpful assistant."),
+        *chat_messages,
+    ]
+
+
 @pytest.fixture
 def xml_string() -> str:
     return "<current_conversation>\n\t<user>\n\t\t<message>hello</message>\n\t</user>\n\t<assistant>\n\t\t<message>hello back</message>\n\t</assistant>\n\t<user>\n\t\t<message>how are you?</message>\n\t</user>\n\t<assistant>\n\t\t<message>I am good, thank you.</message>\n\t</assistant>\n</current_conversation>\n\nGiven the conversation, format the output according to the provided schema."
+
+
+@pytest.fixture
+def xml_string_sys() -> str:
+    return "<current_conversation>\n\t<system>\n\t\t<message>You are a helpful assistant.</message>\n\t</system>\n\t<user>\n\t\t<message>hello</message>\n\t</user>\n\t<assistant>\n\t\t<message>hello back</message>\n\t</assistant>\n\t<user>\n\t\t<message>how are you?</message>\n\t</user>\n\t<assistant>\n\t\t<message>I am good, thank you.</message>\n\t</assistant>\n</current_conversation>\n\nGiven the conversation, format the output according to the provided schema."
 
 
 @pytest.fixture
@@ -144,11 +157,26 @@ def structured_response() -> str:
 
 def test_messages_to_xml(chat_messages: List[ChatMessage], xml_string: str) -> None:
     msg = messages_to_xml_format(chat_messages)
-    assert isinstance(msg, ChatMessage)
+    assert len(msg) == 1
+    assert isinstance(msg[0], ChatMessage)
     s = ""
-    for block in msg.blocks:
+    for block in msg[0].blocks:
         s += block.text
     assert s == xml_string
+
+
+def test_messages_to_xml_sys(
+    chat_messages_sys: List[ChatMessage], xml_string_sys: str
+) -> None:
+    msg = messages_to_xml_format(chat_messages_sys)
+    assert len(msg) == 2
+    assert isinstance(msg[0], ChatMessage)
+    assert msg[0].role == "system"
+    assert msg[0].content == "You are a helpful assistant."
+    s = ""
+    for block in msg[1].blocks:
+        s += block.text
+    assert s == xml_string_sys
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

As of now, we do not insert the system prompt of the agent within the chat history and in memory. At the same time, we do not use it in the structured generation, where it could be very important since it could bear information related to the output schema.
With this PR, we fix both these issues by adding the system prompt to the chat history and to the structured generation.

Fixes #19487 (hopefully🤞)
