### PR TITLE
Fix metadata serialization issue in AzStorageBlobReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
@@ -31,7 +31,6 @@ from llama_index.core.readers.base import (
 from llama_index.core.schema import Document
 
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -39,6 +38,7 @@ FileMetadataCallable = Annotated[
     Callable[[str], Dict],
     WithJsonSchema({"type": "string"}),
 ]
+
 
 class SanitizedJSONEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -186,17 +186,20 @@ class AzStorageBlobReader(
     ) -> List[Document]:
         """Load documents from a directory and extract metadata."""
 
-        
         def get_metadata(file_name: str) -> Dict[str, Any]:
             sanitized_file_name = os.path.basename(file_name)
             metadata_sanitized = files_metadata.get(sanitized_file_name, {})
             if not isinstance(metadata_sanitized, dict):
-                raise ValueError(f"Expected metadata to be a dict, got {type(metadata_sanitized)}")
+                raise ValueError(
+                    f"Expected metadata to be a dict, got {type(metadata_sanitized)}"
+                )
             try:
                 json_str = json.dumps(metadata_sanitized, cls=SanitizedJSONEncoder)
                 clean_metadata = json.loads(json_str)
             except (TypeError, ValueError) as e:
-                logger.error(f"Failed to serialize/deserialize metadata for '{sanitized_file_name}': {e}")
+                logger.error(
+                    f"Failed to serialize/deserialize metadata for '{sanitized_file_name}': {e}"
+                )
                 clean_metadata = {}
             return dict(**clean_metadata)
 
@@ -282,5 +285,3 @@ class AzStorageBlobReader(
             logger.info("Document creation starting")
 
             return self._load_documents_with_metadata(files_metadata, temp_dir)
-        
-

--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
@@ -186,10 +186,6 @@ class AzStorageBlobReader(
     ) -> List[Document]:
         """Load documents from a directory and extract metadata."""
 
-        def get_metadata(file_name: str) -> Dict[str, Any]:
-            sanitized_file_name = os.path.basename(file_name)
-            metadata = files_metadata.get(sanitized_file_name, {})
-            return dict(**metadata)
         
         def get_metadata(file_name: str) -> Dict[str, Any]:
             sanitized_file_name = os.path.basename(file_name)

--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-azstorage-blob"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index readers azstorage_blob integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

fixes https://github.com/run-llama/llama_index/issues/19486

The problem was that in previous versions (<=0.3.0), in the get_metadata, was always passed the filename (full route) so as result the key was not founded in files_metadata and always return an empty object. After the fix in 0.3.1, when was added the metadata_sanitized, the filename was without route and as result is founded in files_metadata, and pass as a returned dict. The main problem is that dictionary have the raw metadata object from Azure, including some types that are not supported by some json storages as MongoDB, and also some types not supported by json format. 

That is why MongoDB rejected  and crush on ingestion. The way to fix is add a "parser" , to map datetime to isodate for,and bytearray to base64, between others.

Fixes # (issue)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.
- [ x ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
