### PR TITLE
Fix parameter name in NotionDemo.ipynb: database_id → database_ids

### DIFF
--- a/docs/docs/examples/data_connectors/NotionDemo.ipynb
+++ b/docs/docs/examples/data_connectors/NotionDemo.ipynb
@@ -133,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "database_ids = \"<database-id>\"\n",
+    "database_ids = [\"<database-id>\"]\n",
     "\n",
     "# https://developers.notion.com/docs/working-with-databases for how to find your database id\n",
     "\n",


### PR DESCRIPTION
# Description

This PR fixes an incorrect parameter name in NotionDemo.ipynb.

The parameter should be `database_ids` (plural) , not `database_id` (singular).

see: 
https://github.com/run-llama/llama_index/blob/a58926c3d08a02802811a603732287aa58163f33/llama-index-integrations/readers/llama-index-readers-notion/llama_index/readers/notion/base.py#L193-L198


## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

No testing required.


## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
