### PR TITLE
llama-index-integrations-neo4j - Patch Neo4jVector Call version

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-neo4jvector/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-neo4jvector/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-neo4jvector"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index vector_stores neo4jvector integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

PR (https://github.com/run-llama/llama_index/pull/19495) resolved deprecated Cypher and fixed issues with the latest version of Neo4j. It introduced a breaking change with older versions (pre v5.23) of Neo4j.

This PR checks the version of Neo4j database and adapts the Cypher call as appropriate.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
