### PR TITLE
Add timeout to webpage readers

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/async_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/async_web/base.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List
+from typing import List, Optional
 
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
@@ -29,6 +29,7 @@ class AsyncWebPageReader(BaseReader):
         limit: int = 10,
         dedupe: bool = True,
         fail_on_error: bool = False,
+        timeout: Optional[int] = None,
     ) -> None:
         """Initialize with parameters."""
         try:
@@ -47,6 +48,7 @@ class AsyncWebPageReader(BaseReader):
         self._html_to_text = html_to_text
         self._dedupe = dedupe
         self._fail_on_error = fail_on_error
+        self._timeout = timeout
 
     async def aload_data(self, urls: List[str]) -> List[Document]:
         """
@@ -76,7 +78,12 @@ class AsyncWebPageReader(BaseReader):
 
         async def fetch_urls(urls: List[str]):
             http_client = chunked_http_client(self._limit)
-            async with aiohttp.ClientSession() as session:
+
+            timeout = (
+                aiohttp.ClientTimeout(total=self._timeout) if self._timeout else None
+            )
+
+            async with aiohttp.ClientSession(timeout=timeout) as session:
                 tasks = [http_client(url, session) for url in urls]
                 return await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -88,17 +95,19 @@ class AsyncWebPageReader(BaseReader):
 
         for i, response_tuple in enumerate(responses):
             if not isinstance(response_tuple, tuple):
-                raise ValueError(f"One of the inputs is not a valid url: {urls[i]}")
+                if self._fail_on_error:
+                    raise ValueError(f"Error fetching {urls[i]}")
+                continue
 
             response, raw_page = response_tuple
 
             if response.status != 200:
-                logger.warning(f"error fetching page from {urls[i]}")
+                logger.warning(f"Error fetching page from {urls[i]}")
                 logger.info(response)
 
                 if self._fail_on_error:
                     raise ValueError(
-                        f"error fetching page from {urls[i]}. server returned status:"
+                        f"Error fetching page from {urls[i]}. server returned status:"
                         f" {response.status} and response {raw_page}"
                     )
 

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/async_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/async_web/base.py
@@ -29,7 +29,7 @@ class AsyncWebPageReader(BaseReader):
         limit: int = 10,
         dedupe: bool = True,
         fail_on_error: bool = False,
-        timeout: Optional[int] = None,
+        timeout: Optional[int] = 60,
     ) -> None:
         """Initialize with parameters."""
         try:

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/simple_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/simple_web/base.py
@@ -35,7 +35,7 @@ class SimpleWebPageReader(BasePydanticReader):
         self,
         html_to_text: bool = False,
         metadata_fn: Optional[Callable[[str], Dict]] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[int] = 60,
         fail_on_error: bool = False,
     ) -> None:
         """Initialize with parameters."""

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/simple_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/simple_web/base.py
@@ -28,11 +28,15 @@ class SimpleWebPageReader(BasePydanticReader):
     html_to_text: bool
 
     _metadata_fn: Optional[Callable[[str], Dict]] = PrivateAttr()
+    _timeout: Optional[int] = PrivateAttr()
+    _fail_on_error: bool = PrivateAttr()
 
     def __init__(
         self,
         html_to_text: bool = False,
         metadata_fn: Optional[Callable[[str], Dict]] = None,
+        timeout: Optional[int] = None,
+        fail_on_error: bool = False,
     ) -> None:
         """Initialize with parameters."""
         try:
@@ -43,6 +47,8 @@ class SimpleWebPageReader(BasePydanticReader):
             )
         super().__init__(html_to_text=html_to_text)
         self._metadata_fn = metadata_fn
+        self._timeout = timeout
+        self._fail_on_error = fail_on_error
 
     @classmethod
     def class_name(cls) -> str:
@@ -63,11 +69,25 @@ class SimpleWebPageReader(BasePydanticReader):
             raise ValueError("urls must be a list of strings.")
         documents = []
         for url in urls:
-            response = requests.get(url, headers=None).text
+            try:
+                response = requests.get(url, headers=None, timeout=self._timeout)
+            except Exception:
+                if self._fail_on_error:
+                    raise
+                continue
+
+            response_text = response.text
+
+            if response.status_code != 200 and self._fail_on_error:
+                raise ValueError(
+                    f"Error fetching page from {url}. server returned status:"
+                    f" {response.status_code} and response {response_text}"
+                )
+
             if self.html_to_text:
                 import html2text
 
-                response = html2text.html2text(response)
+                response_text = html2text.html2text(response_text)
 
             metadata: Dict = {"url": url}
             if self._metadata_fn is not None:
@@ -76,7 +96,7 @@ class SimpleWebPageReader(BasePydanticReader):
                     metadata["url"] = url
 
             documents.append(
-                Document(text=response, id_=str(uuid.uuid4()), metadata=metadata)
+                Document(text=response_text, id_=str(uuid.uuid4()), metadata=metadata)
             )
 
         return documents

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-web"
-version = "0.4.4"
+version = "0.4.5"
 description = "llama-index readers web integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/tests/test_async_web.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/tests/test_async_web.py
@@ -1,0 +1,16 @@
+import pytest
+
+from llama_index.readers.web import AsyncWebPageReader
+
+
+@pytest.fixture()
+def url() -> str:
+    return "https://docs.llamaindex.ai/en/stable/module_guides/workflow/"
+
+
+def test_async_web_reader(url: str) -> None:
+    documents = AsyncWebPageReader().load_data(urls=[url])
+    assert len(documents) > 0
+    assert isinstance(documents[0].id_, str)
+    assert documents[0].id_ != url
+    assert len(documents[0].id_) == 36

--- a/llama-index-integrations/readers/llama-index-readers-web/tests/test_simple_webreader.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/tests/test_simple_webreader.py
@@ -5,11 +5,11 @@ from llama_index.readers.web import SimpleWebPageReader
 
 @pytest.fixture()
 def url() -> str:
-    return "https://www.pringles.com"
+    return "https://docs.llamaindex.ai/en/stable/module_guides/workflow/"
 
 
 def test_simple_web_reader(url: str) -> None:
-    documents = SimpleWebPageReader(timeout=1).load_data(urls=[url])
+    documents = SimpleWebPageReader().load_data(urls=[url])
     assert len(documents) > 0
     assert isinstance(documents[0].id_, str)
     assert documents[0].id_ != url

--- a/llama-index-integrations/readers/llama-index-readers-web/tests/test_simple_webreader.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/tests/test_simple_webreader.py
@@ -5,11 +5,11 @@ from llama_index.readers.web import SimpleWebPageReader
 
 @pytest.fixture()
 def url() -> str:
-    return "https://docs.llamaindex.ai/en/stable/module_guides/workflow/"
+    return "https://www.pringles.com"
 
 
 def test_simple_web_reader(url: str) -> None:
-    documents = SimpleWebPageReader().load_data(urls=[url])
+    documents = SimpleWebPageReader(timeout=1).load_data(urls=[url])
     assert len(documents) > 0
     assert isinstance(documents[0].id_, str)
     assert documents[0].id_ != url

--- a/llama-index-integrations/readers/llama-index-readers-web/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-web/uv.lock
@@ -1667,7 +1667,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-web"
-version = "0.4.2"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/llama-index-integrations/readers/llama-index-readers-web/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-web/uv.lock
@@ -1667,7 +1667,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-web"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# Description

Add a `timeout` argument to `SimpleWebPageReader` and `AsyncWebPageReader`.
Add missing `fail_on_error` to  `SimpleWebPageReader` (it is already present in `AsyncWebPageReader`).
Add missing test for `AsyncWebPageReader`.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
