### PR TITLE
Fix missing prompt in async MultiModalLLMProgram calls

### DIFF
--- a/llama-index-core/llama_index/core/program/multi_modal_llm_program.py
+++ b/llama-index-core/llama_index/core/program/multi_modal_llm_program.py
@@ -167,7 +167,7 @@ class MultiModalLLMCompletionProgram(BasePydanticProgram[BaseModel]):
         blocks.append(TextBlock(text=formatted_prompt))
 
         response = await self._multi_modal_llm.achat(
-            messages=[ChatMessage(role="user", blocks=image_docs)],
+            messages=[ChatMessage(role="user", blocks=blocks)],
             **llm_kwargs,
         )
 


### PR DESCRIPTION
# Description

Currently, the async call only passes in the image_docs, but does not append the prompts. When used with vanilla OpenAI llm this call fails. The sync call right above is implemented correctly. This PR addresses that.

First time suggesting a fix, so apologies if I'm doing it wrong.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
