### PR TITLE
fix(setup_agent): Don't duplicate `system_prompt` message.

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -352,12 +352,6 @@ class BaseWorkflowAgent(
         """Main agent handling logic."""
         llm_input = [*ev.input]
 
-        if self.system_prompt:
-            llm_input = [
-                ChatMessage(role="system", content=self.system_prompt),
-                *llm_input,
-            ]
-
         state = await ctx.store.get("state", default=None)
         formatted_input_with_state = await ctx.store.get(
             "formatted_input_with_state", default=False

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -153,8 +153,11 @@ def retry_calculator_agent():
 async def test_single_function_agent(function_agent):
     """Test single agent with state management."""
     handler = function_agent.run(user_msg="test")
-    async for _ in handler.stream_events():
-        pass
+    async for event in handler.stream_events():
+        if isinstance(event, AgentInput):
+            assert (
+                sum(message.role == MessageRole.SYSTEM for message in event.input) == 1
+            )
 
     response = await handler
     assert "Success with the FunctionAgent" in str(response.response)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/run-llama/llama_index/pull/19490 .

In that PR, `AgentWorkflowStartEvent` was already including a ChatMessage for the system_prompt before reaching `setup_agent`, which was then inserting a duplicate.

Fixes https://github.com/run-llama/llama_index/issues/19509
