### PR TITLE
Fix heading level for `DynamicLLMPathExtractor` in Property Graph docs

### DIFF
--- a/docs/docs/module_guides/indexing/lpg_index_guide.md
+++ b/docs/docs/module_guides/indexing/lpg_index_guide.md
@@ -123,7 +123,7 @@ from llama_index.core.indices.property_graph import ImplicitPathExtractor
 kg_extractor = ImplicitPathExtractor()
 ```
 
-### `DynamicLLMPathExtractor`
+#### `DynamicLLMPathExtractor`
 
 Will extract paths (including entity types!) according to optional list of allowed entity types and relation types. If none are provided, then the LLM will assign types as it sees fit. If they are provided, it will help guide the LLM, but will not enforce exactly those types.
 


### PR DESCRIPTION
# Description

Fixed the heading level for `DynamicLLMPathExtractor` to be consistent with other extractors in the Property Graph docs.

## Type of Change

- [x] Documentation update