### PR TITLE
fix: add ```base_url``` property to nvidia class to fix test compatibility

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_base_url.py
+++ b/llama-index-integrations/llms/llama-index-llms-nvidia/tests/test_base_url.py
@@ -45,15 +45,15 @@ def test_base_url_valid_not_hosted(base_url: str, mock_local_models: None) -> No
 
 
 @pytest.mark.parametrize("base_url", ["https://integrate.api.nvidia.com/v1/"])
-def test_base_url_valid_hosted_without_api_key(base_url: str) -> None:
+def test_base_url_valid_hosted_with_api_key(base_url: str) -> None:
     Interface(base_url=base_url, api_key="BOGUS")
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize("base_url", ["https://integrate.api.nvidia.com/v1/"])
-def test_base_url_valid_hosted_with_api_key(base_url: str) -> None:
+def test_base_url_valid_hosted_without_api_key(base_url: str) -> None:
     llm = Interface()
-    assert llm.base_url == base_url
+    assert llm.api_base == base_url
 
     llm = Interface(base_url=base_url)
-    assert llm.base_url == base_url
+    assert llm.api_base == base_url


### PR DESCRIPTION
# Description
- Fix the issue that the test case ```test_base_url_valid_hosted_with_api_key``` fails for NVIDIA LLMs.
- Fix the test names to reflect what they are actually testing. 

Fixes #19523 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

NA.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

NA.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
