### PR TITLE
BUG FIX: DEFAULT_EVAL_TEMPLATE in relevancy.py was missing "Response:…

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/relevancy.py
+++ b/llama-index-core/llama_index/core/evaluation/relevancy.py
@@ -19,7 +19,8 @@ DEFAULT_EVAL_TEMPLATE = PromptTemplate(
     "You have two options to answer. Either YES/ NO.\n"
     "Answer - YES, if the response for the query \
     is in line with context information otherwise NO.\n"
-    "Query and Response: \n {query_str}\n"
+    "Query: \n {query_str}\n"
+    "Response: \n {response_str}\n"
     "Context: \n {context_str}\n"
     "Answer: "
 )


### PR DESCRIPTION
… {response_str}" which causes all calls to RelevancyEvaluator() to return NO (false) as the LLM response to be compared was not included in the prompt.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # Adds "Response: \n {response_str}\n" to DEFAULT_EVAL_TEMPLATE which was otherwise missing.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
