### PR TITLE
feat(s3): add support for region_name via client_kwargs in S3Reader (#19530)

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
@@ -53,6 +53,8 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
         Default is None.
     aws_access_id (Optional[str]): provide AWS access key directly.
     aws_access_secret (Optional[str]): provide AWS access key directly.
+    aws_region_name (Optional[str]): AWS region for the S3 bucket. If not provided,
+    the default environment region or AWS config will be used.
     s3_endpoint_url (Optional[str]): provide S3 endpoint URL directly.
 
     """
@@ -73,6 +75,7 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
     aws_access_id: Optional[str] = None
     aws_access_secret: Optional[str] = None
     aws_session_token: Optional[str] = None
+    aws_region_name: Optional[str] = None
     s3_endpoint_url: Optional[str] = None
     custom_reader_path: Optional[str] = None
     invalidate_s3fs_cache: bool = True
@@ -84,11 +87,16 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
     def _get_s3fs(self):
         from s3fs import S3FileSystem
 
+        client_kwargs = {}
+        if isinstance(self.aws_region_name, str) and self.aws_region_name.strip():
+            client_kwargs["region_name"] = self.aws_region_name.strip()
+
         s3fs = S3FileSystem(
             key=self.aws_access_id,
             endpoint_url=self.s3_endpoint_url,
             secret=self.aws_access_secret,
             token=self.aws_session_token,
+            client_kwargs=client_kwargs or None,
         )
         if self.invalidate_s3fs_cache:
             s3fs.invalidate_cache()

--- a/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-s3/llama_index/readers/s3/base.py
@@ -53,7 +53,7 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
         Default is None.
     aws_access_id (Optional[str]): provide AWS access key directly.
     aws_access_secret (Optional[str]): provide AWS access key directly.
-    aws_region_name (Optional[str]): AWS region for the S3 bucket. If not provided,
+    region_name (Optional[str]): AWS region for the S3 bucket. If not provided,
     the default environment region or AWS config will be used.
     s3_endpoint_url (Optional[str]): provide S3 endpoint URL directly.
 
@@ -75,7 +75,7 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
     aws_access_id: Optional[str] = None
     aws_access_secret: Optional[str] = None
     aws_session_token: Optional[str] = None
-    aws_region_name: Optional[str] = None
+    region_name: Optional[str] = None
     s3_endpoint_url: Optional[str] = None
     custom_reader_path: Optional[str] = None
     invalidate_s3fs_cache: bool = True
@@ -88,8 +88,8 @@ class S3Reader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderMixin):
         from s3fs import S3FileSystem
 
         client_kwargs = {}
-        if isinstance(self.aws_region_name, str) and self.aws_region_name.strip():
-            client_kwargs["region_name"] = self.aws_region_name.strip()
+        if isinstance(self.region_name, str) and self.region_name.strip():
+            client_kwargs["region_name"] = self.region_name.strip()
 
         s3fs = S3FileSystem(
             key=self.aws_access_id,

--- a/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-s3/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-s3"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index readers s3 integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR adds support for setting the AWS `region_name` in the `S3Reader` by passing it through the `client_kwargs` dictionary. This provides flexibility for users interacting with S3-compatible services that require a specific region configuration.

### Motivation

Some S3-compatible services (e.g., local stacks, custom endpoints) require explicitly setting the `region_name` in `boto3`/`s3fs` clients. This change enables users to pass the region using:

```python
reader = S3Reader(region="us-east-1")
Internally, this region is mapped to client_kwargs["region_name"], which is picked up by s3fs.

Fixes #19530

New Package?
 No

Version Bump?
 No

Type of Change
 New feature (non-breaking change which adds functionality)

 I used moto to mock an S3 server and verified the correct behavior.

Suggested Checklist:
 I have performed a self-review of my own code

 I have commented my code, particularly in hard-to-understand areas

 I have made corresponding changes to the documentation (if applicable)

 My changes generate no new warnings


 New and existing unit tests pass locally with my changes

 I ran uv run make format; uv run make lint to appease the lint gods
