### PR TITLE
reduce some metadata keys from S3VectorStore to save space

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-s3/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-s3/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-s3"
-version = "0.1.0"
+version = "0.1.1"
 description = "llama-index vector_stores s3Vectors integration"
 authors = [{name = "Logan Markewich", email = "logan@runllama.ai"}]
 requires-python = ">=3.9,<3.14"


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/19522

This way, users have more room for their own metadata since the max is currently 10 keys