### PR TITLE
[instrumentation] fix: let wrapped exceptions bubble up

### DIFF
--- a/llama-index-instrumentation/pyproject.toml
+++ b/llama-index-instrumentation/pyproject.toml
@@ -7,7 +7,7 @@ dev = ["pytest>=8.4.0", "pytest-asyncio>=1.0.0", "pytest-cov>=6.1.1"]
 
 [project]
 name = "llama-index-instrumentation"
-version = "0.3.0"
+version = "0.3.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [{name = "Massimiliano Pippi", email = "mpippi@gmail.com"}]

--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -287,14 +287,7 @@ class Dispatcher(BaseModel):
                 context: Context,
             ) -> None:
                 try:
-                    exception = future.exception()
-                    if exception is not None:
-                        if exception.__class__.__name__ == "WorkflowCancelledByUser":
-                            result = None
-                        else:
-                            raise exception
-                    else:
-                        result = future.result()
+                    result = None if future.exception() else future.result()
 
                     self.span_exit(
                         id_=span_id,


### PR DESCRIPTION
# Description

Currently the instrumentation wrapper re-raises the exception from the inner function `handle_future_result`, causing the duplication of the entire stacktrace that's been wrapped. This is not needed because if we let the exception bubble up, the wrapper decorator will take care of re-raising.

This fixes the overly verbose stacktraces in the code using this library, particularly annoying in Workflows where stacktraces are already deep by nature.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update