### PR TITLE
fix: BM25 Retriever allow top_k value greater than number of nodes added

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -99,6 +99,21 @@ class BM25Retriever(BaseRetriever):
             )
             self.bm25 = bm25s.BM25()
             self.bm25.index(corpus_tokens, show_progress=verbose)
+
+        if (
+            self.bm25.scores.get("num_docs")
+            and int(self.bm25.scores["num_docs"]) < self.similarity_top_k
+        ):
+            if int(self.bm25.scores["num_docs"]) == 0:
+                raise ValueError(
+                    "No nodes added to the retriever kindly add more data."
+                )
+
+            logger.warning(
+                "As bm25s.BM25 requires k less than or equal to number of nodes added. Overriding the value of similarity_top_k to number of nodes added."
+            )
+            self.similarity_top_k = int(self.bm25.scores["num_docs"])
+
         super().__init__(
             callback_manager=callback_manager,
             object_map=object_map,

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-retrievers-bm25"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index retrievers bm25 integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
@@ -25,3 +25,22 @@ def test_scores():
     for node in result_nodes:
         assert node.score is not None
         assert node.score > 0.0
+
+
+def test_large_value_of_top_k():
+    documents = [Document.example()]
+
+    splitter = SentenceSplitter(chunk_size=1024)
+    nodes = splitter.get_nodes_from_documents(documents)
+
+    # Passing a high value of similarity_top_k w.r.t Document example
+    similarity_top_k = 20
+    retriever = BM25Retriever.from_defaults(
+        nodes=nodes, similarity_top_k=similarity_top_k
+    )
+    result_nodes = retriever.retrieve("What is llama index about?")
+
+    # As we had less nodes then similarity_top_k in the retriever
+    assert len(result_nodes) < similarity_top_k
+    # Retrieved nodes should be all the nodes added in retriever
+    assert len(result_nodes) == len(nodes)


### PR DESCRIPTION
# Description

- Allow BM25 Retriever top_k to be greater than len(nodes) added to the retriever.

Fixes #19568 (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
