### PR TITLE
fix: change ts_query definition to avoid double-stemming

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -873,15 +873,11 @@ class PGVectorStore(BasePydanticVectorStore):
         if query_str is None:
             raise ValueError("query_str must be specified for a sparse vector query.")
 
-        # Replace '&' with '|' to perform an OR search for higher recall
+        # Spaces get converted to "&", so replace them with "|" to perform an OR search for higher recall
         config_type_coerce = type_coerce(self.text_search_config, REGCONFIG)
         ts_query = func.to_tsquery(
-            config_type_coerce,
-            func.replace(
-                func.text(func.plainto_tsquery(config_type_coerce, query_str)),
-                "&",
-                "|",
-            ),
+            type_coerce(self.text_search_config, REGCONFIG),
+            query_str.replace(" ", "|")
         )
         stmt = (
             select(  # type: ignore

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -877,7 +877,7 @@ class PGVectorStore(BasePydanticVectorStore):
         config_type_coerce = type_coerce(self.text_search_config, REGCONFIG)
         ts_query = func.to_tsquery(
             type_coerce(self.text_search_config, REGCONFIG),
-            query_str.replace(" ", "|")
+            query_str.replace(" ", "|"),
         )
         stmt = (
             select(  # type: ignore

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-postgres"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index vector_stores postgres integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Fixes #19580 

When performing sparse queries with words ending in double-E's (such as refugee), relevant database entries would not be returned. This is because the Snowball stemmer is not idempotent on double-E words (i.e. `stem(stem('refugee')) 'refug' != stem('refugee') = 'refugee'`, and the query was being stemmed twice while the database entries were stemmed only once.

This is a consequence of the definition of ts_query, which first transformed the string into a ts query, then to text so the AND operators could be replaced with OR operators, and finally back into a ts query.

Instead, we can replace the spaces with "|"'s in the initial query string, so that the to_tsquery transformation need only be applied once. This will ensure an OR query while stemming only one time.

Note: this assumes English stemming and may have unintended consequences for other languages/encodings, depending on how spaces work in the corresponding Snowball stemmers.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
