### PR TITLE
Support presidio entities

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
@@ -55,7 +55,8 @@ class EntityTypeCountAnonymizer(Operator):
 
 
 class PresidioPIINodePostprocessor(BaseNodePostprocessor):
-    """presidio PII Node processor.
+    """
+    presidio PII Node processor.
     Uses a presidio to analyse PIIs.
     """
 

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict, List, Optional, Tuple
 from copy import deepcopy
 
-from presidio_anonymizer.operators import Operator, OperatorType
+from llama_index.core.bridge.pydantic import Field
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
 
 from presidio_analyzer import AnalyzerEngine
 from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import OperatorConfig
+from presidio_anonymizer.operators import Operator, OperatorType
 
 
 class EntityTypeCountAnonymizer(Operator):
@@ -61,9 +62,9 @@ class PresidioPIINodePostprocessor(BaseNodePostprocessor):
     """
 
     pii_node_info_key: str = "__pii_node_info__"
-    entity_mapping: Dict[str, Dict] = {}
-    mapping: Dict[str, str] = {}
-    presidio_entities: List = []
+    entity_mapping: Dict[str, Dict] = Field(default_factory=dict)
+    mapping: Dict[str, str] = Field(default_factory=dict)
+    presidio_entities: List = Field(default_factory=list)
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
@@ -55,14 +55,14 @@ class EntityTypeCountAnonymizer(Operator):
 
 
 class PresidioPIINodePostprocessor(BaseNodePostprocessor):
-    """
-    presidio PII Node processor.
+    """presidio PII Node processor.
     Uses a presidio to analyse PIIs.
     """
 
     pii_node_info_key: str = "__pii_node_info__"
     entity_mapping: Dict[str, Dict] = {}
     mapping: Dict[str, str] = {}
+    presidio_entities: List = []
 
     @classmethod
     def class_name(cls) -> str:
@@ -70,7 +70,7 @@ class PresidioPIINodePostprocessor(BaseNodePostprocessor):
 
     def mask_pii(self, text: str) -> Tuple[str, Dict]:
         analyzer = AnalyzerEngine()
-        results = analyzer.analyze(text=text, language="en")
+        results = analyzer.analyze(text=text, language="en", entities=self.presidio_entities)
         engine = AnonymizerEngine()
         engine.add_anonymizer(EntityTypeCountAnonymizer)
 

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/llama_index/postprocessor/presidio/base.py
@@ -71,7 +71,9 @@ class PresidioPIINodePostprocessor(BaseNodePostprocessor):
 
     def mask_pii(self, text: str) -> Tuple[str, Dict]:
         analyzer = AnalyzerEngine()
-        results = analyzer.analyze(text=text, language="en", entities=self.presidio_entities)
+        results = analyzer.analyze(
+            text=text, language="en", entities=self.presidio_entities
+        )
         engine = AnonymizerEngine()
         engine.add_anonymizer(EntityTypeCountAnonymizer)
 

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-presidio/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-presidio"
-version = "0.4.0"
+version = "0.5.0"
 description = "llama-index postprocessor presidio integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

By default, all [entities](https://microsoft.github.io/presidio/supported_entities/) are masked. This feature allows specifying only the desired entities to be redacted, for example `["URL, "PERSON"]`

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
