### PR TITLE
feat(baiduvectordb): add wait logic for critical operations

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/llama_index/vector_stores/baiduvectordb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/llama_index/vector_stores/baiduvectordb/base.py
@@ -432,7 +432,6 @@ class BaiduVectorDB(BasePydanticVectorStore):
         except (pymochow.exception.ServerError, AttributeError):
             # Table doesn't exist or _table not properly initialized, nothing to delete
             logger.debug("Table does not exist, nothing to clear.")
-            pass
 
     def add(
         self,
@@ -454,6 +453,7 @@ class BaiduVectorDB(BasePydanticVectorStore):
 
         Returns:
             List of node IDs that were added to the table.
+
         """
         return asyncio.get_event_loop().run_until_complete(
             self.async_add(
@@ -484,6 +484,7 @@ class BaiduVectorDB(BasePydanticVectorStore):
 
         Returns:
             List of node IDs that were added to the table.
+
         """
         if len(nodes) == 0:
             return []
@@ -569,6 +570,7 @@ class BaiduVectorDB(BasePydanticVectorStore):
 
         Returns:
             VectorStoreQueryResult: Query result containing nodes, similarities, and ids.
+
         """
         return asyncio.get_event_loop().run_until_complete(self.aquery(query, **kwargs))
 
@@ -586,6 +588,7 @@ class BaiduVectorDB(BasePydanticVectorStore):
 
         Returns:
             VectorStoreQueryResult: Query result containing nodes, similarities, and ids.
+
         """
         from pymochow.model.table import AnnSearch, HNSWSearchParams
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/llama_index/vector_stores/baiduvectordb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/llama_index/vector_stores/baiduvectordb/base.py
@@ -2,6 +2,8 @@
 
 import json
 import time
+import asyncio
+import logging
 from typing import Any, Dict, List, Optional
 
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
@@ -19,10 +21,13 @@ from llama_index.core.vector_stores.types import (
 )
 from llama_index.core.vector_stores.utils import DEFAULT_DOC_ID_KEY, DEFAULT_TEXT_KEY
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_ACCOUNT = "root"
 DEFAULT_DATABASE_NAME = "llama_default_database"
 DEFAULT_TABLE_NAME = "llama_default_table"
 DEFAULT_TIMEOUT_IN_MILLS: int = 30 * 1000
+DEFAULT_WAIT_TIMEOUT: int = 30  # 30 seconds for operations
 
 DEFAULT_PARTITION = 1
 DEFAULT_REPLICA = 3
@@ -199,20 +204,25 @@ class BaiduVectorDB(BasePydanticVectorStore):
         from pymochow.configuration import Configuration
         from pymochow.auth.bce_credentials import BceCredentials
 
+        logger.debug("Connecting to Baidu VectorDB...")
         config = Configuration(
             credentials=BceCredentials(account, api_key),
             endpoint=endpoint,
             connection_timeout_in_mills=DEFAULT_TIMEOUT_IN_MILLS,
         )
         self._vdb_client = pymochow.MochowClient(config)
+        logger.debug("Baidu VectorDB client initialized.")
 
     def _create_database_if_not_exists(self, database_name: str) -> None:
         db_list = self._vdb_client.list_databases()
 
         if database_name in [db.database_name for db in db_list]:
+            logger.debug(f"Database '{database_name}' already exists.")
             self._database = self._vdb_client.database(database_name)
         else:
+            logger.debug(f"Creating database '{database_name}'.")
             self._database = self._vdb_client.create_database(database_name)
+            logger.debug(f"Database '{database_name}' created.")
 
     def _create_table(self, table_params: TableParams) -> None:
         import pymochow
@@ -222,10 +232,30 @@ class BaiduVectorDB(BasePydanticVectorStore):
 
         try:
             self._table = self._database.describe_table(table_params.table_name)
+            logger.debug(f"Table '{table_params.table_name}' already exists.")
             if table_params.drop_exists:
+                logger.debug(f"Dropping table '{table_params.table_name}'.")
                 self._database.drop_table(table_params.table_name)
-                # wait db release resource
-                time.sleep(5)
+                # wait for table to be fully dropped
+                start_time = time.time()
+                loop_count = 0
+                while time.time() - start_time < DEFAULT_WAIT_TIMEOUT:
+                    loop_count += 1
+                    logger.debug(
+                        f"Waiting for table {table_params.table_name} to be dropped,"
+                        f" attempt {loop_count}"
+                    )
+                    time.sleep(1)
+                    tables = self._database.list_table()
+                    table_names = {table.table_name for table in tables}
+                    if table_params.table_name not in table_names:
+                        logger.debug(f"Table '{table_params.table_name}' dropped.")
+                        break
+                else:
+                    raise TimeoutError(
+                        f"Table {table_params.table_name} was not dropped within"
+                        f" {DEFAULT_WAIT_TIMEOUT} seconds"
+                    )
                 self._create_table_in_db(table_params)
         except pymochow.exception.ServerError:
             self._create_table_in_db(table_params)
@@ -234,10 +264,11 @@ class BaiduVectorDB(BasePydanticVectorStore):
         self,
         table_params: TableParams,
     ) -> None:
-        from pymochow.model.enum import FieldType
+        from pymochow.model.enum import FieldType, TableState
         from pymochow.model.schema import Field, Schema, SecondaryIndex, VectorIndex
         from pymochow.model.table import Partition
 
+        logger.debug(f"Creating table '{table_params.table_name}'.")
         index_type = self._get_index_type(table_params.index_type)
         metric_type = self._get_metric_type(table_params.metric_type)
         vector_params = self._get_index_params(index_type, table_params)
@@ -282,11 +313,28 @@ class BaiduVectorDB(BasePydanticVectorStore):
             table_name=table_params.table_name,
             replication=table_params.replication,
             partition=Partition(partition_num=table_params.partition),
-            schema=Schema(fields=fields, indexes=indexes),
+            schema=schema,
             enable_dynamic_field=True,
         )
-        # need wait 10s to wait proxy sync meta
-        time.sleep(10)
+        # wait for table to be ready
+        start_time = time.time()
+        loop_count = 0
+        while time.time() - start_time < DEFAULT_WAIT_TIMEOUT:
+            loop_count += 1
+            logger.debug(
+                f"Waiting for table {table_params.table_name} to become ready,"
+                f" attempt {loop_count}"
+            )
+            time.sleep(1)
+            table = self._database.describe_table(table_params.table_name)
+            if table.state == TableState.NORMAL:
+                logger.debug(f"Table '{table_params.table_name}' is ready.")
+                break
+        else:
+            raise TimeoutError(
+                f"Table {table_params.table_name} did not become ready within"
+                f" {DEFAULT_WAIT_TIMEOUT} seconds"
+            )
 
     @staticmethod
     def _get_index_params(index_type: Any, table_params: TableParams) -> None:
@@ -339,26 +387,114 @@ class BaiduVectorDB(BasePydanticVectorStore):
     @property
     def client(self) -> Any:
         """Get client."""
-        return self.tencent_client
+        return self._vdb_client
+
+    def clear(self) -> None:
+        """
+        Clear all nodes from Baidu VectorDB table.
+        This method deletes the table.
+        """
+        return asyncio.get_event_loop().run_until_complete(self.aclear())
+
+    async def aclear(self) -> None:
+        """
+        Asynchronously clear all nodes from Baidu VectorDB table.
+        This method deletes the table.
+        """
+        import pymochow
+
+        try:
+            # Check if table exists
+            table_name = self._table.table_name
+            self._database.describe_table(table_name)
+            # Table exists, drop it
+            logger.debug(f"Dropping table '{table_name}'.")
+            self._database.drop_table(table_name)
+            # Wait for table to be fully dropped
+            start_time = time.time()
+            loop_count = 0
+            while time.time() - start_time < DEFAULT_WAIT_TIMEOUT:
+                loop_count += 1
+                logger.debug(
+                    f"Waiting for table {table_name} to be dropped, attempt {loop_count}"
+                )
+                await asyncio.sleep(1)
+                tables = self._database.list_table()
+                table_names = {table.table_name for table in tables}
+                if table_name not in table_names:
+                    logger.debug(f"Table '{table_name}' dropped.")
+                    break
+            else:
+                raise TimeoutError(
+                    f"Table {table_name} was not dropped within {DEFAULT_WAIT_TIMEOUT}"
+                    " seconds"
+                )
+        except (pymochow.exception.ServerError, AttributeError):
+            # Table doesn't exist or _table not properly initialized, nothing to delete
+            logger.debug("Table does not exist, nothing to clear.")
+            pass
 
     def add(
         self,
         nodes: List[BaseNode],
+        *,
+        rebuild_index: bool = True,
+        rebuild_timeout: Optional[int] = None,
         **add_kwargs: Any,
     ) -> List[str]:
         """
-        Add nodes to index.
+        Add nodes to Baidu VectorDB table.
 
         Args:
-            nodes: List[BaseNode]: list of nodes with embeddings
+            nodes: List of nodes with embeddings.
+            rebuild_index: Optional. Whether to rebuild the vector index
+                          after adding nodes. Defaults to True.
+            rebuild_timeout: Optional. Timeout for rebuilding the index in seconds.
+                             If None, it will wait indefinitely. Defaults to None.
 
+        Returns:
+            List of node IDs that were added to the table.
         """
+        return asyncio.get_event_loop().run_until_complete(
+            self.async_add(
+                nodes,
+                rebuild_index=rebuild_index,
+                rebuild_timeout=rebuild_timeout,
+                **add_kwargs,
+            )
+        )
+
+    async def async_add(
+        self,
+        nodes: List[BaseNode],
+        *,
+        rebuild_index: bool = True,
+        rebuild_timeout: Optional[int] = None,
+        **add_kwargs: Any,
+    ) -> List[str]:
+        """
+        Asynchronous method to add nodes to Baidu VectorDB table.
+
+        Args:
+            nodes: List of nodes with embeddings.
+            rebuild_index: Optional. Whether to rebuild the vector index
+                          after adding nodes. Defaults to True.
+            rebuild_timeout: Optional. Timeout for rebuilding the index in seconds.
+                             If None, it will wait indefinitely. Defaults to None.
+
+        Returns:
+            List of node IDs that were added to the table.
+        """
+        if len(nodes) == 0:
+            return []
+
         from pymochow.model.table import Row
         from pymochow.model.enum import IndexState
 
         ids = []
         rows = []
-        for node in nodes:
+        for i, node in enumerate(nodes):
+            logger.debug(f"Processing node {i + 1}/{len(nodes)}, id: {node.node_id}")
             row = Row(id=node.node_id, vector=node.get_embedding())
             if node.ref_doc_id is not None:
                 row._data[DEFAULT_DOC_ID_KEY] = node.ref_doc_id
@@ -375,18 +511,38 @@ class BaiduVectorDB(BasePydanticVectorStore):
             ids.append(node.node_id)
 
             if len(rows) >= self.batch_size:
-                self.collection.upsert(rows=rows)
+                logger.debug(f"Upserting {len(rows)} rows to the table.")
+                self._table.upsert(rows=rows)
                 rows = []
 
         if len(rows) > 0:
+            logger.debug(f"Upserting remaining {len(rows)} rows to the table.")
             self._table.upsert(rows=rows)
 
-        self._table.rebuild_index(INDEX_VECTOR)
-        while True:
-            time.sleep(2)
-            index = self._table.describe_index(INDEX_VECTOR)
-            if index.state == IndexState.NORMAL:
-                break
+        if rebuild_index:
+            logger.debug(f"Rebuilding index '{INDEX_VECTOR}'.")
+            self._table.rebuild_index(INDEX_VECTOR)
+            start_time = time.time()
+            loop_count = 0
+            while True:
+                loop_count += 1
+                logger.debug(
+                    f"Waiting for index {INDEX_VECTOR} to be ready, attempt"
+                    f" {loop_count}"
+                )
+                await asyncio.sleep(1)
+                index = self._table.describe_index(INDEX_VECTOR)
+                if index.state == IndexState.NORMAL:
+                    logger.debug(f"Index '{INDEX_VECTOR}' is ready.")
+                    break
+                if (
+                    rebuild_timeout is not None
+                    and time.time() - start_time > rebuild_timeout
+                ):
+                    raise TimeoutError(
+                        f"Index {INDEX_VECTOR} did not become ready within"
+                        f" {rebuild_timeout} seconds"
+                    )
 
         return ids
 
@@ -411,12 +567,34 @@ class BaiduVectorDB(BasePydanticVectorStore):
                 similarity_top_k (int): top k most similar nodes
                 filters (Optional[MetadataFilters]): filter result
 
+        Returns:
+            VectorStoreQueryResult: Query result containing nodes, similarities, and ids.
+        """
+        return asyncio.get_event_loop().run_until_complete(self.aquery(query, **kwargs))
+
+    async def aquery(
+        self, query: VectorStoreQuery, **kwargs: Any
+    ) -> VectorStoreQueryResult:
+        """
+        Asynchronously query index for top k most similar nodes.
+
+        Args:
+            query (VectorStoreQuery): contains
+                query_embedding (List[float]): query embedding
+                similarity_top_k (int): top k most similar nodes
+                filters (Optional[MetadataFilters]): filter result
+
+        Returns:
+            VectorStoreQueryResult: Query result containing nodes, similarities, and ids.
         """
         from pymochow.model.table import AnnSearch, HNSWSearchParams
 
         search_filter = None
         if query.filters is not None:
             search_filter = self._build_filter_condition(query.filters, **kwargs)
+        logger.debug(
+            f"Querying with top_k={query.similarity_top_k} and filter='{search_filter}'"
+        )
         anns = AnnSearch(
             vector_field=FIELD_VECTOR,
             vector_floats=query.query_embedding,
@@ -426,8 +604,10 @@ class BaiduVectorDB(BasePydanticVectorStore):
         res = self._table.search(anns=anns, retrieve_vector=True)
         rows = res.rows
         if rows is None or len(rows) == 0:
+            logger.debug("Query returned no results.")
             return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
 
+        logger.debug(f"Query returned {len(rows)} results.")
         nodes = []
         similarities = []
         ids = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/pyproject.toml
@@ -26,16 +26,13 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-baiduvectordb"
-version = "0.4.0"
+version = "0.5.0"
 description = "llama-index vector_stores baiduvectordb integration"
-authors = [{name = "Your Name", email = "you@example.com"}]
+authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
-dependencies = [
-    "pymochow>=1.0.2,<2",
-    "llama-index-core>=0.13.0,<0.14",
-]
+dependencies = ["pymochow>=1.0.2,<2", "llama-index-core>=0.13.0,<0.14"]
 
 [tool.codespell]
 check-filenames = true

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-baiduvectordb/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 name = "llama-index-vector-stores-baiduvectordb"
 version = "0.5.0"
 description = "llama-index vector_stores baiduvectordb integration"
-authors = [{ name = "Your Name", email = "you@example.com" }]
+authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This commit introduces polling mechanisms with timeouts to ensure that long-running operations, such as table creation, deletion, and index rebuilding, complete reliably.

This improves the robustness of the integration by preventing race conditions that can occur due to the asynchronous nature of the Baidu VectorDB backend. It adds waiting loops after these critical operations and centralizes the timeout configuration.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
