### PR TITLE
Enabled partially formatted system prompt for ReAct agent

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -74,7 +74,7 @@ class ReActAgent(BaseWorkflowAgent):
             react_header = prompts["react_header"]
             if isinstance(react_header, str):
                 react_header = PromptTemplate(react_header)
-            self.formatter.system_header = react_header.get_template()
+            self.formatter.system_header = react_header.format()
 
     async def take_step(
         self,

--- a/llama-index-core/tests/agent/react/test_prompt_customization.py
+++ b/llama-index-core/tests/agent/react/test_prompt_customization.py
@@ -1,0 +1,27 @@
+from llama_index.core import PromptTemplate
+from llama_index.core.agent.workflow import ReActAgent
+
+from textwrap import dedent
+
+
+def test_partial_formatted_system_prompt():
+    """Partially formatted context should be preserved."""
+    agent = ReActAgent()
+
+    prompt = PromptTemplate(
+        dedent(
+            """\
+            Required template variables:
+            {tool_desc}
+            {tool_names}
+
+            Additional variables:
+            {dummy_var}
+            """
+        )
+    )
+
+    dummy_var = "dummy_context"
+    agent.update_prompts({"react_header": prompt.partial_format(dummy_var=dummy_var)})
+
+    assert dummy_var in agent.formatter.system_header


### PR DESCRIPTION
# Description

The pull request enables setting the system prompt for the ReAct agent with a partially formatted prompt template.
For example, we want to let the agent know the personal information of the logged-in user:

```python
from textwrap import dedent

from llama_index.core import PromptTemplate
from llama_index.core.agent.workflow import ReActAgent

# Define the system prompt and ReAct agent
react_system_prompt = PromptTemplate(
    dedent(
        """\
        ... (omitted)

        ## User Information

        Here is the personal information of the currently logged-in user:
        User name: {user_name}

        ## Current Conversation

        Below is the current conversation consisting of interleaving human and assistant messages.
        """
    )
)

agent = ReActAgent(...)

# After a user is logged in, we update the system prompt with their name.
agent.update_prompts(
    {"react_header": react_system_prompt.partial_format(user_name="James Lai")}
)

# Run the agent
response = agent.run(...)
```

Without any modification, the agent is failing with a `KeyError` exception:
<img width="946" height="616" alt="image" src="https://github.com/user-attachments/assets/f70f3675-2ba8-460d-8d46-57b191aaa52b" />

With this modification, the agent can successfully answer "Who am I?":
<img width="946" height="107" alt="image" src="https://github.com/user-attachments/assets/0c1cc68a-f7a4-4d2b-928e-e102a2891c07" />

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
