### PR TITLE
chore(oci): update list of supported LLMs for OCI integration

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-oci-genai/llama_index/llms/oci_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-genai/llama_index/llms/oci_genai/utils.py
@@ -38,6 +38,9 @@ CHAT_MODELS = {
     "meta.llama-3.1-70b-instruct": 128000,
     "meta.llama-3.1-405b-instruct": 128000,
     "meta.llama-3.2-90b-vision-instruct": 128000,
+    "meta.llama-3.3-70b-instruct": 128000,
+    "meta.llama-4-scout-17b-16e-instruct": 192000,
+    "meta.llama-4-maverick-17b-128e-instruct-fp8": 512000,
 }
 
 OCIGENAI_LLMS = {**COMPLETION_MODELS, **CHAT_MODELS}

--- a/llama-index-integrations/llms/llama-index-llms-oci-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-oci-genai/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-oci-genai"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index llms OCI GenAI integration"
 authors = [
     {name = "Arthur Cheng", email = "arthur.cheng@oracle.com"},


### PR DESCRIPTION
# Description

Added new available OCI LLMs:

* meta.llama-3.3-70b-instruct
* meta.llama-4-scout-17b-16e-instruct
* meta.llama-4-maverick-17b-128e-instruct-fp8

## Type of Change

- Update (non-breaking change which adds functionality)

## How Has This Been Tested?

- I believe this change is already covered by existing unit tests.
- I did not change any core functionality. Only updated a constant dictionary. (Available chat models in OCI)

## Suggested Checklist:

- I have performed a self-review of my own code
