### PR TITLE
chore: deprecate llama-index-indices-managed-llama-cloud in favor of llama-cloud-services

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/base.py
@@ -7,6 +7,7 @@ interfaces a managed service.
 """
 
 import asyncio
+from deprecated import deprecated
 import httpx
 import os
 import time
@@ -59,6 +60,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    reason="llama-index-indices-managed-llama-cloud has been moved to llama-cloud-services (https://github.com/run-llama/llama_cloud_services) as of llama-cloud-services v0.6.55, thus llama-index-indices-managed-llama-cloud package will be deprecated and no longer maintained. Check out the LlamaCloud documentation for more information: https://docs.cloud.llamaindex.ai",
+    version="0.9.1",
+)
 class LlamaCloudIndex(BaseManagedIndex):
     """
     A managed index that stores documents in LlamaCloud.

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/composite_retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/composite_retriever.py
@@ -1,5 +1,6 @@
 from typing import Any, List, Optional
 
+from deprecated import deprecated
 import httpx
 from llama_cloud import (
     CompositeRetrievalMode,
@@ -24,6 +25,10 @@ from llama_index.indices.managed.llama_cloud.api_utils import (
 )
 
 
+@deprecated(
+    reason="llama-index-indices-managed-llama-cloud has been moved to llama-cloud-services (https://github.com/run-llama/llama_cloud_services) as of llama-cloud-services v0.6.55, thus llama-index-indices-managed-llama-cloud package will be deprecated and no longer maintained. Check out the LlamaCloud documentation for more information: https://docs.cloud.llamaindex.ai",
+    version="0.9.1",
+)
 class LlamaCloudCompositeRetriever(BaseRetriever):
     def __init__(
         self,

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/llama_index/indices/managed/llama_cloud/retriever.py
@@ -1,5 +1,6 @@
 from typing import Any, List, Optional
 
+from deprecated import deprecated
 import httpx
 from llama_cloud import (
     TextNodeWithScore,
@@ -25,6 +26,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    reason="llama-index-indices-managed-llama-cloud has been moved to llama-cloud-services (https://github.com/run-llama/llama_cloud_services) as of llama-cloud-services v0.6.55, thus llama-index-indices-managed-llama-cloud package will be deprecated and no longer maintained. Check out the LlamaCloud documentation for more information: https://docs.cloud.llamaindex.ai",
+    version="0.9.1",
+)
 class LlamaCloudRetriever(BaseRetriever):
     def __init__(
         self,

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-indices-managed-llama-cloud"
-version = "0.9.0"
+version = "0.9.1"
 description = "llama-index indices llama-cloud integration"
 authors = [{name = "Logan Markewich", email = "logan@llamaindex.ai"}]
 requires-python = ">=3.9,<4.0"
@@ -36,6 +36,7 @@ license = "MIT"
 dependencies = [
     "llama-cloud==0.1.35",
     "llama-index-core>=0.13.0,<0.14",
+    "deprecated==1.2.18",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/uv.lock
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/uv.lock
@@ -1639,9 +1639,10 @@ wheels = [
 
 [[package]]
 name = "llama-index-indices-managed-llama-cloud"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
+    { name = "deprecated" },
     { name = "llama-cloud" },
     { name = "llama-index-core" },
 ]
@@ -1672,6 +1673,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "deprecated", specifier = "==1.2.18" },
     { name = "llama-cloud", specifier = "==0.1.35" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.14" },
 ]


### PR DESCRIPTION
As per title, will follow up with a PR to move it to stale_packages :))