### PR TITLE
feat: Add framework name into UserAgent header for bedrock integration

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -147,6 +147,7 @@ class BedrockEmbedding(BaseEmbedding):
                     retries={"max_attempts": max_retries, "mode": "standard"},
                     connect_timeout=timeout,
                     read_timeout=timeout,
+                    user_agent_extra="x-client-framework:llama_index",
                 )
                 if botocore_config is None
                 else botocore_config
@@ -239,6 +240,7 @@ class BedrockEmbedding(BaseEmbedding):
 
         try:
             import boto3
+            from botocore.config import Config
 
             session = boto3.Session(**session_kwargs)
         except ImportError:
@@ -247,7 +249,8 @@ class BedrockEmbedding(BaseEmbedding):
             )
 
         if "bedrock-runtime" in session.get_available_services():
-            self._client = session.client("bedrock-runtime")
+            config = Config(user_agent_extra="x-client-framework:llama_index")
+            self._client = session.client("bedrock-runtime", config=config)
         else:
             self._client = session.client("bedrock")
 
@@ -311,6 +314,7 @@ class BedrockEmbedding(BaseEmbedding):
 
         try:
             import boto3
+            from botocore.config import Config
 
             session = boto3.Session(**session_kwargs)
         except ImportError:
@@ -319,7 +323,8 @@ class BedrockEmbedding(BaseEmbedding):
             )
 
         if "bedrock-runtime" in session.get_available_services():
-            client = session.client("bedrock-runtime")
+            config = Config(user_agent_extra="x-client-framework:llama_index")
+            client = session.client("bedrock-runtime", config=config)
         else:
             client = session.client("bedrock")
         return cls(

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -252,6 +252,7 @@ class BedrockConverse(FunctionCallingLLM):
                     retries={"max_attempts": max_retries, "mode": "standard"},
                     connect_timeout=timeout,
                     read_timeout=timeout,
+                    user_agent_extra="x-client-framework:llama_index",
                 )
                 if botocore_config is None
                 else botocore_config

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/base.py
@@ -182,6 +182,7 @@ class Bedrock(LLM):
                     retries={"max_attempts": max_retries, "mode": "standard"},
                     connect_timeout=timeout,
                     read_timeout=timeout,
+                    user_agent_extra="x-client-framework:llama_index",
                 )
                 if botocore_config is None
                 else botocore_config


### PR DESCRIPTION
# Description

This PR adds the framework name into User-Agent header of Bedrock API call. It only append the framework name haystack into the User-Agent header field for Bedrock API call, which can be used to collect the usage.

## New Package?

- [ ] Yes
- [x ] No

## Version Bump?

- [ ] Yes
- [ x] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
