### PR TITLE
Fixed special character bug in PGVectorStore query

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -873,11 +873,15 @@ class PGVectorStore(BasePydanticVectorStore):
         if query_str is None:
             raise ValueError("query_str must be specified for a sparse vector query.")
 
-        # Spaces get converted to "&", so replace them with "|" to perform an OR search for higher recall
-        config_type_coerce = type_coerce(self.text_search_config, REGCONFIG)
+        # Remove "&", "|" and collapse multiple spaces ("&" and "|" are used by ts_query)
+        query_str = re.sub(r"\s*(?:[|&]|\s)\s*", " ", query_str).strip()
+
+        # Replace space with "|" to perform an OR search for higher recall
+        query_str = query_str.replace(" ", "|")
+
         ts_query = func.to_tsquery(
             type_coerce(self.text_search_config, REGCONFIG),
-            query_str.replace(" ", "|"),
+            query_str,
         )
         stmt = (
             select(  # type: ignore

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-postgres"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index vector_stores postgres integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Searching a `PGVectorStore` with a query containing special characters (such as "&" or "|") produces a ts_query syntax error. `ts_query` [uses special operators](https://www.postgresql.org/docs/current/textsearch-controls.html) as syntax. With the way `PGVectorStore` currently works, nothing prevents the queries to have these special characters and produce a syntax error.

This PR adds some steps to clean special characters from the input query and collapse multiple spaces.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
