### PR TITLE
ollama embed fix

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-ollama/llama_index/embeddings/ollama/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ollama/llama_index/embeddings/ollama/base.py
@@ -87,14 +87,14 @@ class OllamaEmbedding(BaseEmbedding):
 
     def get_general_text_embedding(self, texts: str) -> List[float]:
         """Get Ollama embedding."""
-        result = self._client.embeddings(
-            model=self.model_name, prompt=texts, options=self.ollama_additional_kwargs
+        result = self._client.embed(
+            model=self.model_name, input=texts, options=self.ollama_additional_kwargs
         )
         return result["embedding"]
 
     async def aget_general_text_embedding(self, prompt: str) -> List[float]:
         """Asynchronously get Ollama embedding."""
-        result = await self._async_client.embeddings(
-            model=self.model_name, prompt=prompt, options=self.ollama_additional_kwargs
+        result = await self._async_client.embed(
+            model=self.model_name, input=prompt, options=self.ollama_additional_kwargs
         )
         return result["embedding"]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ollama/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ollama/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-ollama"
-version = "0.7.1"
+version = "0.8.0"
 description = "llama-index embeddings ollama integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ollama/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ollama/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-ollama"
-version = "0.7.0"
+version = "0.7.1"
 description = "llama-index embeddings ollama integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
/embeddings returns non-normalized embeddings (apparently?)

/embed should be used in a majority of cases 