### PR TITLE
Add other special characters in ts_query normalization

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -873,8 +873,11 @@ class PGVectorStore(BasePydanticVectorStore):
         if query_str is None:
             raise ValueError("query_str must be specified for a sparse vector query.")
 
-        # Remove "&", "|" and collapse multiple spaces ("&" and "|" are used by ts_query)
-        query_str = re.sub(r"\s*(?:[|&]|\s)\s*", " ", query_str).strip()
+        # Remove special characters used by ts_query
+        query_str = re.sub(r"[&|!:*()'<>]", " ", query_str)
+
+        # Collapse multiple spaces
+        query_str = re.sub(r"\s+", " ", query_str).strip()
 
         # Replace space with "|" to perform an OR search for higher recall
         query_str = query_str.replace(" ", "|")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-postgres"
-version = "0.6.2"
+version = "0.6.3"
 description = "llama-index vector_stores postgres integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -742,7 +742,7 @@ async def test_sparse_query_with_special_characters(
     assert isinstance(pg_hybrid, PGVectorStore)
     assert hasattr(pg_hybrid, "_engine")
 
-    # text search should work when query is a sentence and not just a single word
+    # text search should work with special characters
     q = VectorStoreQuery(
         query_embedding=_get_sample_vector(0.1),
         query_str="   who' & s |     (the): <-> **fox**?!!!  ",
@@ -884,7 +884,7 @@ async def test_hybrid_query_with_special_characters(
     assert res.nodes[2].node_id == "ccc"
     assert res.nodes[3].node_id == "ddd"
 
-    # text search should work when query is a sentence and not just a single word
+    # text search should work with special characters
     q = VectorStoreQuery(
         query_embedding=_get_sample_vector(0.1),
         query_str="   who' & s |     (the): <-> **fox**?!!!  ",

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -730,6 +730,39 @@ async def test_sparse_query(
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])
+async def test_sparse_query_with_special_characters(
+    pg_hybrid: PGVectorStore,
+    hybrid_node_embeddings: List[TextNode],
+    use_async: bool,
+) -> None:
+    if use_async:
+        await pg_hybrid.async_add(hybrid_node_embeddings)
+    else:
+        pg_hybrid.add(hybrid_node_embeddings)
+    assert isinstance(pg_hybrid, PGVectorStore)
+    assert hasattr(pg_hybrid, "_engine")
+
+    # text search should work when query is a sentence and not just a single word
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.1),
+        query_str="   who' & s |     (the): <-> **fox**?!!!  ",
+        sparse_top_k=2,
+        mode=VectorStoreQueryMode.SPARSE,
+    )
+
+    if use_async:
+        res = await pg_hybrid.aquery(q)
+    else:
+        res = pg_hybrid.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 2
+    assert res.nodes[0].node_id == "ccc"
+    assert res.nodes[1].node_id == "ddd"
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [True, False])
 async def test_hybrid_query(
     pg_hybrid: PGVectorStore,
     hybrid_node_embeddings: List[TextNode],
@@ -783,6 +816,78 @@ async def test_hybrid_query(
     q = VectorStoreQuery(
         query_embedding=_get_sample_vector(0.1),
         query_str="who is the fox?",
+        similarity_top_k=2,
+        mode=VectorStoreQueryMode.HYBRID,
+    )
+
+    if use_async:
+        res = await pg_hybrid.aquery(q)
+    else:
+        res = pg_hybrid.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 4
+    assert res.nodes[0].node_id == "aaa"
+    assert res.nodes[1].node_id == "bbb"
+    assert res.nodes[2].node_id == "ccc"
+    assert res.nodes[3].node_id == "ddd"
+
+
+@pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [True, False])
+async def test_hybrid_query_with_special_characters(
+    pg_hybrid: PGVectorStore,
+    hybrid_node_embeddings: List[TextNode],
+    use_async: bool,
+) -> None:
+    if use_async:
+        await pg_hybrid.async_add(hybrid_node_embeddings)
+    else:
+        pg_hybrid.add(hybrid_node_embeddings)
+    assert isinstance(pg_hybrid, PGVectorStore)
+    assert hasattr(pg_hybrid, "_engine")
+
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.1),
+        query_str="fox",
+        similarity_top_k=2,
+        mode=VectorStoreQueryMode.HYBRID,
+        sparse_top_k=1,
+    )
+
+    if use_async:
+        res = await pg_hybrid.aquery(q)
+    else:
+        res = pg_hybrid.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 3
+    assert res.nodes[0].node_id == "aaa"
+    assert res.nodes[1].node_id == "bbb"
+    assert res.nodes[2].node_id == "ccc"
+
+    # if sparse_top_k is not specified, it should default to similarity_top_k
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.1),
+        query_str="fox",
+        similarity_top_k=2,
+        mode=VectorStoreQueryMode.HYBRID,
+    )
+
+    if use_async:
+        res = await pg_hybrid.aquery(q)
+    else:
+        res = pg_hybrid.query(q)
+    assert res.nodes
+    assert len(res.nodes) == 4
+    assert res.nodes[0].node_id == "aaa"
+    assert res.nodes[1].node_id == "bbb"
+    assert res.nodes[2].node_id == "ccc"
+    assert res.nodes[3].node_id == "ddd"
+
+    # text search should work when query is a sentence and not just a single word
+    q = VectorStoreQuery(
+        query_embedding=_get_sample_vector(0.1),
+        query_str="   who' & s |     (the): <-> **fox**?!!!  ",
         similarity_top_k=2,
         mode=VectorStoreQueryMode.HYBRID,
     )


### PR DESCRIPTION
# Description

Following PR #19621, which fixed a `ts_query` syntax error in `PGVectorStore` involving the & and | characters, additional special characters — such as ! : * ( ) ' < > — must also be removed from the query to prevent syntax errors.
This PR add these special characters removal from the `PGVectorStore` query.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
