### PR TITLE
Updates to ClickHouse integration based on new vector search capabilities in ClickHouse

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
@@ -214,7 +214,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             index_type=index_type,
             metric=metric,
             batch_size=batch_size,
-            dimension = dimension,
+            dimension=dimension,
             index_params=index_params,
             search_params=search_params,
             **kwargs,
@@ -282,12 +282,24 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
         ef_c = 128
 
         if self._config.index_type.lower() == "hnsw":
-            if self._config.index_params and "quantization" in self._config.index_params:
+            if (
+                self._config.index_params
+                and "quantization" in self._config.index_params
+            ):
                 quantization = self._config.index_params["quantization"]
-            if self._config.index_params and "hnsw_max_connections_per_layer" in self._config.index_params:
+            if (
+                self._config.index_params
+                and "hnsw_max_connections_per_layer" in self._config.index_params
+            ):
                 M = self._config.index_params["hnsw_max_connections_per_layer"]
-            if self._config.index_params and "hnsw_candidate_list_size_for_construction" in self._config.index_params:
-                ef_c = self._config.index_params["hnsw_candidate_list_size_for_construction"]
+            if (
+                self._config.index_params
+                and "hnsw_candidate_list_size_for_construction"
+                in self._config.index_params
+            ):
+                ef_c = self._config.index_params[
+                    "hnsw_candidate_list_size_for_construction"
+                ]
             index = f"INDEX vector_index vector TYPE vector_similarity('hnsw', '{DISTANCE_MAPPING[self._config.metric]}', {dimension}, '{quantization}', {M}, {ef_c})"
         schema_ = f"""
             CREATE TABLE IF NOT EXISTS {self._config.database}.{self._config.table}(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/llama_index/vector_stores/clickhouse/base.py
@@ -2,6 +2,7 @@
 ClickHouse vector store.
 
 An index that is built on top of an existing ClickHouse cluster.
+For current documentation, refer to : https://clickhouse.com/docs/engines/table-engines/mergetree-family/annindexes
 """
 
 import importlib
@@ -56,7 +57,6 @@ def format_list_to_string(lst: List) -> str:
 DISTANCE_MAPPING = {
     "l2": "L2Distance",
     "cosine": "cosineDistance",
-    "dot": "dotProduct",
 }
 
 
@@ -69,7 +69,7 @@ class ClickHouseSettings:
         database (str): Database name to find the table.
         engine (str): Engine. Options are "MergeTree" and "Memory". Default is "MergeTree".
         index_type (str): Index type string.
-        metric (str): Metric type to compute distance e.g., cosine, l3, or dot.
+        metric (str): Metric type to compute distance e.g., cosine or l2
         batch_size (int): The size of documents to insert.
         index_params (dict, optional): Index build parameter.
         search_params (dict, optional): Index search parameters for ClickHouse query.
@@ -84,6 +84,7 @@ class ClickHouseSettings:
         index_type: str,
         metric: str,
         batch_size: int,
+        dimension: Optional[int] = None,
         index_params: Optional[dict] = None,
         search_params: Optional[dict] = None,
         **kwargs: Any,
@@ -94,6 +95,7 @@ class ClickHouseSettings:
         self.index_type = index_type
         self.metric = metric
         self.batch_size = batch_size
+        self.dimension = dimension
         self.index_params = index_params
         self.search_params = search_params
 
@@ -131,12 +133,15 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
         database (str, optional): The name of the ClickHouse database
             where data will be stored. Defaults to "default".
         index_type (str, optional): The type of the ClickHouse vector index.
-            Defaults to "NONE", supported are ("NONE", "HNSW", "ANNOY")
+            Defaults to "HNSW", supported are ("NONE", "HNSW"). Use NONE for brute-force KNN search.
         metric (str, optional): The metric type of the ClickHouse vector index.
-            Defaults to "cosine".
+            Defaults to "cosine". Alternate metric type is "l2".
         batch_size (int, optional): the size of documents to insert. Defaults to 1000.
         index_params (dict, optional): The index parameters for ClickHouse.
-            Defaults to None.
+            Defaults to None. For HNSW, following parameters are supported :-
+            "quantization" : One of 'f64','f32', 'f16', 'bf16', 'i8', 'b1'. Default is 'bf16'.
+            "hnsw_max_connections_per_layer": Default is 32.
+            "hnsw_candidate_list_size_for_construction" : Default is 128.
         search_params (dict, optional): The search parameters for a ClickHouse query.
             Defaults to None.
 
@@ -180,9 +185,10 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
         table: str = "llama_index",
         database: str = "default",
         engine: str = "MergeTree",
-        index_type: str = "NONE",
+        index_type: str = "HNSW",
         metric: str = "cosine",
         batch_size: int = 1000,
+        dimension: Optional[int] = None,
         index_params: Optional[dict] = None,
         search_params: Optional[dict] = None,
         **kwargs: Any,
@@ -208,6 +214,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             index_type=index_type,
             metric=metric,
             batch_size=batch_size,
+            dimension = dimension,
             index_params=index_params,
             search_params=search_params,
             **kwargs,
@@ -249,6 +256,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             index_type=index_type,
             metric=metric,
             batch_size=batch_size,
+            dimension=dimension,
             index_params=index_params,
             search_params=search_params,
         )
@@ -257,7 +265,8 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
         self._column_config = column_config
         self._column_names = column_names
         self._column_type_names = column_type_names
-        dimension = len(Settings.embed_model.get_query_embedding("try this out"))
+        if dimension is None:
+            dimension = len(Settings.embed_model.get_query_embedding("try this out"))
         self.create_table(dimension)
 
     @property
@@ -267,19 +276,19 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
 
     def create_table(self, dimension: int) -> None:
         index = ""
-        settings = {"allow_experimental_object_type": "1"}
+        settings = {"allow_experimental_vector_similarity_index": "1"}
+        quantization = "bf16"
+        M = 32
+        ef_c = 128
+
         if self._config.index_type.lower() == "hnsw":
-            scalarKind = "f32"
-            if self._config.index_params and "ScalarKind" in self._config.index_params:
-                scalarKind = self._config.index_params["ScalarKind"]
-            index = f"INDEX hnsw_indx vector TYPE usearch('{DISTANCE_MAPPING[self._config.metric]}', '{scalarKind}')"
-            settings["allow_experimental_usearch_index"] = "1"
-        elif self._config.index_type.lower() == "annoy":
-            numTrees = 100
-            if self._config.index_params and "NumTrees" in self._config.index_params:
-                numTrees = self._config.index_params["NumTrees"]
-            index = f"INDEX annoy_indx vector TYPE annoy('{DISTANCE_MAPPING[self._config.metric]}', {numTrees})"
-            settings["allow_experimental_annoy_index"] = "1"
+            if self._config.index_params and "quantization" in self._config.index_params:
+                quantization = self._config.index_params["quantization"]
+            if self._config.index_params and "hnsw_max_connections_per_layer" in self._config.index_params:
+                M = self._config.index_params["hnsw_max_connections_per_layer"]
+            if self._config.index_params and "hnsw_candidate_list_size_for_construction" in self._config.index_params:
+                ef_c = self._config.index_params["hnsw_candidate_list_size_for_construction"]
+            index = f"INDEX vector_index vector TYPE vector_similarity('hnsw', '{DISTANCE_MAPPING[self._config.metric]}', {dimension}, '{quantization}', {M}, {ef_c})"
         schema_ = f"""
             CREATE TABLE IF NOT EXISTS {self._config.database}.{self._config.table}(
                 {",".join([f"{k} {v['type']}" for k, v in self._column_config.items()])},
@@ -288,6 +297,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             ) ENGINE = MergeTree ORDER BY id
             """
         self._dim = dimension
+        self.drop()
         self._client.command(schema_, settings=settings)
         self._table_existed = True
 
@@ -321,7 +331,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             sql_escaped = escape_str(regex_escaped)
             safe_tokens.append(sql_escaped)
 
-        terms_pattern = [f"\\\\b(?i){token}\\\\b" for token in safe_tokens]
+        terms_pattern = [f"\\b(?i){token}\\b" for token in safe_tokens]
         joined_tokens_pattern = escape_str("|".join(safe_tokens))
         column_keys = [k for k in self._column_config if k != "vector"]
         column_list = ",".join(column_keys)
@@ -330,7 +340,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             f"FROM {self._config.database}.{self._config.table} WHERE score > 0 "
             f"ORDER BY length(multiMatchAllIndices(text, {terms_pattern})) "
             f"AS score DESC, "
-            f"log(1 + countMatches(text, '\\\\b(?i)({joined_tokens_pattern})\\\\b')) "
+            f"log(1 + countMatches(text, '\\b(?i)({joined_tokens_pattern})\\b')) "
             f"AS d2 DESC limit {similarity_top_k}"
         )
 
@@ -345,7 +355,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             sql_escaped = escape_str(regex_escaped)
             safe_tokens.append(sql_escaped)
 
-        terms_pattern = [f"\\\\b(?i){token}\\\\b" for token in safe_tokens]
+        terms_pattern = [f"\\b(?i){token}\\b" for token in safe_tokens]
         joined_tokens_pattern = escape_str("|".join(safe_tokens))
         column_keys = [k for k in self._column_config if k != "vector"]
         column_list = ",".join(column_keys)
@@ -354,7 +364,7 @@ class ClickHouseVectorStore(BasePydanticVectorStore):
             f"FROM ({stage_one_sql}) tempt "
             f"ORDER BY length(multiMatchAllIndices(text, {terms_pattern})) "
             f"AS d1 DESC, "
-            f"log(1 + countMatches(text, '\\\\\\\\b(?i)({joined_tokens_pattern})\\\\\\\\b')) "
+            f"log(1 + countMatches(text, '\\b(?i)({joined_tokens_pattern})\\b')) "
             f"AS d2 DESC limit {similarity_top_k}"
         )
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-clickhouse"
-version = "0.5.0"
+version = "0.6.0"
 description = "llama-index vector_stores clickhouse integration"
 authors = [{name = "ClickHouse", email = "info@clickhouse.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "clickhouse-connect>=0.7.0,<0.8",
+    "clickhouse-connect>=0.7.0",
     "llama-index-core>=0.13.0,<0.14",
 ]
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/tests/test_clickhouse.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/tests/test_clickhouse.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import uuid
 from typing import Any, Generator, List
 import clickhouse_connect
@@ -299,7 +298,9 @@ def test_add_to_ch_query_and_delete(
 
     clickhouse_store.delete("test-0")
 
-    clickhouse_client.command(f"OPTIMIZE TABLE {TEST_DB}.{table_name} FINAL SETTINGS mutations_sync=2")
+    clickhouse_client.command(
+        f"OPTIMIZE TABLE {TEST_DB}.{table_name} FINAL SETTINGS mutations_sync=2"
+    )
 
     res = clickhouse_store.query(q)
     assert res.nodes

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/tests/test_clickhouse.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-clickhouse/tests/test_clickhouse.py
@@ -74,6 +74,7 @@ def clickhouse_store(table_name: str, clickhouse_client: Any) -> ClickHouseVecto
         database=TEST_DB,
         table=table_name,
         metric="l2",
+        dimension=3,
     )
 
 
@@ -151,6 +152,7 @@ def test_instance_creation(table_name: str, clickhouse_client: Any) -> None:
         clickhouse_client,
         database=TEST_DB,
         table=table_name,
+        dimension=3,
     )
     assert isinstance(ch_store, ClickHouseVectorStore)
 
@@ -161,6 +163,7 @@ def test_table_creation(table_name: str, clickhouse_client: Any) -> None:
         clickhouse_client,
         database=TEST_DB,
         table=table_name,
+        dimension=3,
     )
     ch_store.create_table(3)
     ch_store.drop()
@@ -197,33 +200,6 @@ def test_add_to_ch_and_text_query(
 
 
 @pytest.mark.skipif(clickhouse_not_available, reason="clickhouse is not available")
-@pytest.mark.skipif(sys.platform == "darwin", reason="annoy not supported on osx")
-def test_add_to_ch_and_text_query_annoy(
-    clickhouse_client: Any,
-    table_name: str,
-    node_embeddings: List[TextNode],
-) -> None:
-    clickhouse_store = ClickHouseVectorStore(
-        clickhouse_client,
-        database=TEST_DB,
-        table=table_name,
-        metric="l2",
-        index_type="ANNOY",
-        index_params={"NumTrees": 100},
-    )
-    clickhouse_store.add(node_embeddings)
-    res = clickhouse_store.query(
-        VectorStoreQuery(
-            query_str="lorem",
-            mode=VectorStoreQueryMode.TEXT_SEARCH,
-            similarity_top_k=1,
-        )
-    )
-    assert res.nodes
-    assert res.nodes[0].get_content() == "lorem ipsum"
-
-
-@pytest.mark.skipif(clickhouse_not_available, reason="clickhouse is not available")
 def test_add_to_ch_and_text_query_hnsw(
     clickhouse_client: Any,
     table_name: str,
@@ -235,7 +211,8 @@ def test_add_to_ch_and_text_query_hnsw(
         table=table_name,
         metric="l2",
         index_type="HNSW",
-        index_params={"ScalarKind": "f16"},
+        index_params={"quantization": "f16"},
+        dimension=3,
     )
     clickhouse_store.add(node_embeddings)
     res = clickhouse_store.query(
@@ -307,6 +284,8 @@ def test_add_to_ch_query_with_where_filters(
 
 @pytest.mark.skipif(clickhouse_not_available, reason="clickhouse is not available")
 def test_add_to_ch_query_and_delete(
+    clickhouse_client: Any,
+    table_name: str,
     clickhouse_store: ClickHouseVectorStore,
     node_embeddings: List[TextNode],
 ) -> None:
@@ -319,6 +298,9 @@ def test_add_to_ch_query_and_delete(
     assert res.nodes[0].node_id == "c330d77f-90bd-4c51-9ed2-57d8d693b3b0"
 
     clickhouse_store.delete("test-0")
+
+    clickhouse_client.command(f"OPTIMIZE TABLE {TEST_DB}.{table_name} FINAL SETTINGS mutations_sync=2")
+
     res = clickhouse_store.query(q)
     assert res.nodes
     assert len(res.nodes) == 1


### PR DESCRIPTION
# Description

ClickHouse has updated and revamped it's vector search features in the `25.x `release series. The earlier vector index implementation based on `Annoy` / `FAISS` libraries have been made obsolete. This PR is to make the corresponding updates to `LLamaIndex` integration.

Please let me know if the documentation get auto-updated from the comments in the Python code? https://docs.llamaindex.ai/en/stable/api_reference/storage/vector_store/clickhouse/

I have tested using the existing ClickHouse unit-tests and using the "paul_graham" samples.

More info on current ClickHouse status -
Documentation : https://clickhouse.com/docs/engines/table-engines/mergetree-family/annindexes
Recent PRs : [Link](https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Apr+author%3Ashankar-iyer+is%3Aclosed+vector)

## New Package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
