### PR TITLE
add stalebot action

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -9,11 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: "This issue is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 5 days."
           stale-pr-message: "This PR is stale because it has been open 50 days with no activity. Remove stale label or comment or this will be closed in 10 days."
-          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
           close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
-          days-before-issue-stale: 25
           days-before-pr-stale: 50
-          days-before-issue-close: 5
           days-before-pr-close: 10

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -1,0 +1,19 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: "This issue is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          stale-pr-message: "This PR is stale because it has been open 50 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          close-issue-message: "This issue was closed because it has been stalled for 5 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
+          days-before-issue-stale: 25
+          days-before-pr-stale: 50
+          days-before-issue-close: 5
+          days-before-pr-close: 10


### PR DESCRIPTION
This PR adds an action that will close inactive PRs after 60 days and inactive issues after 30 days. It will remind users 5 days before issue closure and 10 days before PR closure.
