### PR TITLE
fix persist load for bm25

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -82,6 +82,7 @@ class BM25Retriever(BaseRetriever):
         skip_stemming: bool = False,
         token_pattern: str = r"(?u)\b\w\w+\b",
         filters: Optional[MetadataFilters] = None,
+        corpus_weight_mask: Optional[List[int]] = None,
     ) -> None:
         self.stemmer = stemmer or Stemmer.Stemmer("english")
         self.similarity_top_k = similarity_top_k
@@ -124,7 +125,7 @@ class BM25Retriever(BaseRetriever):
             )
             self.similarity_top_k = int(self.bm25.scores["num_docs"])
 
-        self.corpus_weight_mask = None
+        self.corpus_weight_mask = corpus_weight_mask or None
         if filters and self.corpus:
             # Build a weight mask for each corpus to filter out only relevant nodes
             _corpus_dict = {

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-retrievers-bm25"
-version = "0.6.2"
+version = "0.6.3"
 description = "llama-index retrievers bm25 integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 from llama_index.core import Document
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.retrievers.bm25.base import BM25Retriever
@@ -121,3 +124,27 @@ def _count_score_greater_than_zero(nodes):
         print(node.score)
         count = count + (node.score > 0)
     return count
+
+
+def test_persist_and_load():
+    documents = [Document.example()]
+
+    splitter = SentenceSplitter(chunk_size=1024)
+    nodes = splitter.get_nodes_from_documents(documents)
+
+    # Passing a high value of similarity_top_k w.r.t Document example
+    similarity_top_k = 20
+    retriever = BM25Retriever.from_defaults(
+        nodes=nodes, similarity_top_k=similarity_top_k
+    )
+
+    # Persist the retriever
+    try:
+        retriever.persist("test_retriever")
+
+        # Load the retriever
+        _ = BM25Retriever.from_persist_dir("test_retriever")
+    finally:
+        # Clean up the test_retriever directory
+        if os.path.exists("test_retriever"):
+            shutil.rmtree("test_retriever")


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/19656

need to handle persisting the weight mask (which actually was originally computed from filters)