### PR TITLE
fix: respect the value of NLTK_DATA env var if present

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -52,11 +52,10 @@ class GlobalsHelper:
 
         # Set up NLTK data directory
         if "NLTK_DATA" in os.environ:
-            path = Path(os.environ["NLTK_DATA"])
+            self._nltk_data_dir = str(Path(os.environ["NLTK_DATA"]))
         else:
             path = Path(platformdirs.user_cache_dir("llama_index"))
-
-        self._nltk_data_dir = str(path / "_static/nltk_cache")
+            self._nltk_data_dir = str(path / "_static/nltk_cache")
 
         # Ensure the directory exists
         os.makedirs(self._nltk_data_dir, exist_ok=True)


### PR DESCRIPTION
# Description

Fixes #19661 

The original PR was supposed to respect the value of `$NLTK_DATA` if present, but it wasn't.
