### PR TITLE
docs: update docker image and new method to setup in JaguarDB documentation

### DIFF
--- a/docs/docs/examples/vector_stores/JaguarIndexDemo.ipynb
+++ b/docs/docs/examples/vector_stores/JaguarIndexDemo.ipynb
@@ -28,12 +28,20 @@
     "\n",
     "You must install packages llama-index and jaguardb-http-client.\n",
     "\n",
-    "    docker pull jaguardb/jaguardb_with_http\n",
-    "    docker run -d -p 8888:8888 -p 8080:8080 --name jaguardb_with_http jaguardb/jaguardb_with_http\n",
+    "**Method One : Docker**\n",
+    "\n",
+    "    docker pull jaguardb/jaguardb\n",
+    "    docker run -d -p 8888:8888 -p 8080:8080 --name jaguardb jaguardb/jaguardb\n",
     "    pip install -U llama-index\n",
     "    pip install -U jaguardb-http-client\n",
     "\n",
-    "    "
+    "**Method Two: Quick Setup(Linux)**\n",
+    "\n",
+    "    curl -fsSL http://jaguardb.com/install.sh | sh\\n\n",
+    "    pip install -U llama-index\n",
+    "    pip install -U jaguardb-http-client\n",
+    "\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
# Description
Updated the quick setup instructions for JaguarDB in the documentation. Replaced the outdated Docker image `jaguardb/jaguardb_with_http` with the current recommended image `jaguardb/jaguardb` for pulling and running the server.
Added "Method Two: Quick Setup (Linux)" section to prerequisites, providing a curl-based installation method for deploying JaguarDB without Docker. Retained original Docker setup instructions for flexibility.

## Type of Change
- [ ] This change requires a documentation update

