### PR TITLE
Fix evaluate crash when no images provided

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/multi_modal/faithfulness.py
+++ b/llama-index-core/llama_index/core/evaluation/multi_modal/faithfulness.py
@@ -150,12 +150,14 @@ class MultiModalFaithfulnessEvaluator(BaseEvaluator):
             context_str=context_str, query_str=response
         )
 
+        image_nodes: List[Union[ImageBlock, TextBlock]] = []
+
         if image_paths:
-            image_nodes: List[Any] = [
-                ImageBlock(path=Path(image_path)) for image_path in image_paths
-            ]
+            image_nodes.extend(
+                [ImageBlock(path=Path(image_path)) for image_path in image_paths]
+            )
         if image_urls:
-            image_nodes = [ImageBlock(url=image_url) for image_url in image_urls]
+            image_nodes.extend([ImageBlock(url=image_url) for image_url in image_urls])
 
         image_nodes.append(TextBlock(text=fmt_prompt))
 


### PR DESCRIPTION
# Description

Currently, the evaluate function raises an UnboundLocalError when neither image_paths nor image_urls are passed, since image_nodes is only defined inside conditional blocks.

This PR ensures image_nodes is always initialized to an empty list, preventing crashes and allowing evaluation to proceed with text-only input.

Changes:
- Initialize image_nodes as an empty list at the start.
- Use .extend() instead of reassigning inside conditionals.
