### PR TITLE
fix: Resolve AttributeError in CollectionParams.filter_fields access

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-tencentvectordb/llama_index/vector_stores/tencentvectordb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-tencentvectordb/llama_index/vector_stores/tencentvectordb/base.py
@@ -145,6 +145,11 @@ class CollectionParams:
         self.drop_exists = drop_exists
         self._filter_fields = filter_fields or []
 
+    @property
+    def filter_fields(self) -> List[FilterField]:
+        """Get the filter fields for the collection."""
+        return self._filter_fields
+
 
 class TencentVectorDB(BasePydanticVectorStore):
     """

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-tencentvectordb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-tencentvectordb/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-tencentvectordb"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index vector_stores tencentvectordb integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-tencentvectordb/tests/test_vector_stores_tencentvectordb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-tencentvectordb/tests/test_vector_stores_tencentvectordb.py
@@ -1,7 +1,40 @@
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
-from llama_index.vector_stores.tencentvectordb import TencentVectorDB
+from llama_index.vector_stores.tencentvectordb import TencentVectorDB, CollectionParams, FilterField
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in TencentVectorDB.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+def test_collection_params_filter_fields():
+    """Test that CollectionParams.filter_fields property works correctly.
+    
+    This test verifies the fix for Issue #19675 where filter_fields was not accessible.
+    """
+    # Test with filter fields
+    filter_field = FilterField(name="author", data_type="string")
+    collection_params = CollectionParams(
+        dimension=1536,
+        filter_fields=[filter_field]
+    )
+    
+    # Test that filter_fields property is accessible
+    assert hasattr(collection_params, 'filter_fields')
+    assert len(collection_params.filter_fields) == 1
+    assert collection_params.filter_fields[0].name == "author"
+    assert collection_params.filter_fields[0].data_type == "string"
+    
+    # Test iteration over filter_fields (this was failing before the fix)
+    for field in collection_params.filter_fields:
+        assert field.name == "author"
+        assert field.data_type == "string"
+    
+    # Test with empty filter fields
+    empty_params = CollectionParams(dimension=1536)
+    assert len(empty_params.filter_fields) == 0
+    
+    # Test that empty filter_fields can be iterated over
+    for field in empty_params.filter_fields:
+        # This should not raise an AttributeError
+        pass


### PR DESCRIPTION
## Summary
Fixes Issue #19675 where 'CollectionParams' object has no attribute 'filter_fields'. The filter_fields parameter was stored as private attribute _filter_fields but accessed as public attribute filter_fields, causing AttributeError when iterating over collection_params.filter_fields.

## Motivation and Context
Users were unable to use the Tencent VectorDB integration with filter fields due to this AttributeError. The fix maintains encapsulation while providing necessary public access to filter fields for proper collection creation.

## Dependencies
No new dependencies required. This is a pure Python property addition.

## Changes Made
- Added @property decorator for filter_fields in CollectionParams class
- Bumped version from 0.4.0 to 0.4.1
- Added comprehensive test coverage for filter_fields property
- Test verifies both populated and empty filter_fields scenarios

## Testing
- Added unit test test_collection_params_filter_fields() that covers:
  - Property access with filter fields
  - Iteration over filter_fields (the failing scenario)
  - Empty filter_fields handling
- Test ensures the fix resolves the AttributeError completely

Fixes #19675

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
