### PR TITLE
Support concurrent use of multiple ConfluenceReader instances

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import uuid
+import tempfile
 from typing import Callable, Dict, List, Optional
 from urllib.parse import unquote
 
@@ -567,22 +568,29 @@ class ConfluenceReader(BaseReader, DispatcherSpanMixin):
             attachment_texts = []
         if FileType.HTML in self.custom_parsers and self.custom_folder:
             html_text = page["body"]["export_view"]["value"]
-            # save in file
-            file_location = os.path.join(self.custom_folder, "output.html")
-            with open(file_location, "w", encoding="utf-8") as f:
+            # save in temporary file
+            file_location = None
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".html", encoding="utf-8", dir=self.custom_folder, delete=False) as f:
                 f.write(html_text)
-            text = (
-                page["title"]
-                + "\n"
-                + "\n".join(
-                    doc.text
-                    for doc in self.custom_parsers[FileType.HTML].load_data(
-                        file_path=file_location
+                file_location = f.name
+            try:
+                text = (
+                    page["title"]
+                    + "\n"
+                    + "\n".join(
+                        doc.text
+                        for doc in self.custom_parsers[FileType.HTML].load_data(
+                            file_path=file_location
+                        )
                     )
+                    + "\n"
+                    + "\n".join(attachment_texts)
                 )
-                + "\n"
-                + "\n".join(attachment_texts)
-            )
+            finally:
+                try:
+                    os.unlink(file_location)
+                except OSError:
+                    pass
         else:
             text = text_maker.handle(page["body"]["export_view"]["value"]) + "".join(
                 attachment_texts

--- a/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
@@ -570,7 +570,13 @@ class ConfluenceReader(BaseReader, DispatcherSpanMixin):
             html_text = page["body"]["export_view"]["value"]
             # save in temporary file
             file_location = None
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".html", encoding="utf-8", dir=self.custom_folder, delete=False) as f:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".html",
+                encoding="utf-8",
+                dir=self.custom_folder,
+                delete=False,
+            ) as f:
                 f.write(html_text)
                 file_location = f.name
             try:

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-confluence"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index readers confluence integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/tests/test_readers_confluence.py
@@ -319,7 +319,7 @@ def test_confluence_reader_process_page_with_callbacks(mock_html2text_class):
     result = reader.process_page(page_data, False, mock_text_maker)
     assert result is not None
     assert result.doc_id == "normal_page"
-    assert result.extra_info["title"] == "Test Page"
+    assert result.metadata["title"] == "Test Page"
 
     # Test page that should be skipped
     page_data_skip = {

--- a/llama-index-integrations/readers/llama-index-readers-confluence/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1690,7 +1690,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-confluence"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "atlassian-python-api" },


### PR DESCRIPTION
# Description

Support concurrent use of multiple ConfluenceReader instances when a custom HTML parser is provided. A uniquely named temporary file will be created in the system’s temporary directory and passed to the custom parser.

Update tests to use the result’s metadata field instead of the deprecated extra_info attribute.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
