### PR TITLE
fix(SageMakerLLM): fix constructor region read to not read region_name before is popped from kwargs, and fix assign to super

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/base.py
@@ -161,13 +161,24 @@ class SageMakerLLM(LLM):
         content_handler = content_handler
         callback_manager = callback_manager or CallbackManager([])
 
+        region_name = kwargs.pop("region_name", None)
+
+        if region_name is not None:
+            warnings.warn(
+                "Kwarg `region_name` is deprecated and will be removed in a future version. "
+                "Please use `aws_region_name` instead.",
+                DeprecationWarning,
+            )
+            if not aws_region_name:
+                aws_region_name = region_name
+
         super().__init__(
             endpoint_name=endpoint_name,
             endpoint_kwargs=endpoint_kwargs,
             model_kwargs=model_kwargs,
             content_handler=content_handler,
             profile_name=profile_name,
-            region_name=region_name,
+            region_name=aws_region_name,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
@@ -179,17 +190,8 @@ class SageMakerLLM(LLM):
             pydantic_program_mode=pydantic_program_mode,
             output_parser=output_parser,
         )
-        self._completion_to_prompt = completion_to_prompt
 
-        region_name = kwargs.pop("region_name", None)
-        if region_name is not None:
-            warnings.warn(
-                "Kwarg `region_name` is deprecated and will be removed in a future version. "
-                "Please use `aws_region_name` instead.",
-                DeprecationWarning,
-            )
-            if not aws_region_name:
-                aws_region_name = region_name
+        self._completion_to_prompt = completion_to_prompt
 
         self._client = get_aws_service_client(
             service_name="sagemaker-runtime",

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-sagemaker-endpoint"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index llms sagemaker endpoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
region_name is not defined before, so use it in super will throw an error

# Description

region_name is not defined before, so use it in super will throw an error, already tested in my local project that use that lib for the first time and it is working, without the fix my app was crashing at start (is a super simple fix)

# (issue)
change super constructor call using correct param aws_region_name

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
i tested it in my local project that had the problem before that fix

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods