### PR TITLE
Fixing crashing when retrieving from empty vector store index

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -51,20 +51,31 @@ def log_vector_store_query_result(
     logger = logger or _logger
 
     assert result.ids is not None
-    assert result.nodes is not None
+
     similarities = (
         result.similarities
         if result.similarities is not None and len(result.similarities) > 0
         else [1.0 for _ in result.ids]
     )
 
-    fmt_txts = []
-    for node_idx, node_similarity, node in zip(result.ids, similarities, result.nodes):
-        fmt_txt = f"> [Node {node_idx}] [Similarity score: \
-            {float(node_similarity):.6}] {truncate_text(node.get_content(), 100)}"
-        fmt_txts.append(fmt_txt)
-    top_k_node_text = "\n".join(fmt_txts)
-    logger.debug(f"> Top {len(result.nodes)} nodes:\n{top_k_node_text}")
+    if result.nodes is not None:
+        fmt_txts = []
+        for node_idx, node_similarity, node in zip(
+            result.ids, similarities, result.nodes
+        ):
+            fmt_txt = f"> [Node {node_idx}] [Similarity score: \
+                {float(node_similarity):.6}] {truncate_text(node.get_content(), 100)}"
+            fmt_txts.append(fmt_txt)
+        top_k_node_text = "\n".join(fmt_txts)
+        logger.debug(f"> Top {len(result.nodes)} nodes:\n{top_k_node_text}")
+    else:
+        fmt_txts = []
+        for node_idx, node_similarity in zip(result.ids, similarities):
+            fmt_txt = f"> [Node {node_idx}] [Similarity score: \
+                {float(node_similarity):.6}]"
+            fmt_txts.append(fmt_txt)
+        top_k_node_text = "\n".join(fmt_txts)
+        logger.debug(f"> Top {len(result.ids)} nodes:\n{top_k_node_text}")
 
 
 def default_format_node_batch_fn(

--- a/llama-index-core/llama_index/core/vector_stores/simple.py
+++ b/llama-index-core/llama_index/core/vector_stores/simple.py
@@ -310,7 +310,8 @@ class SimpleVectorStore(BasePydanticVectorStore):
             raise ValueError(f"Invalid query mode: {query.mode}")
 
         return VectorStoreQueryResult(
-            similarities=top_similarities, ids=top_ids, nodes=[]
+            similarities=top_similarities,
+            ids=top_ids,
         )
 
     def persist(


### PR DESCRIPTION
# Description

When we retrieve from empty vector store index, `VectorStoreQueryResult.nodes = None` by default. This `VectorStoreQueryResult` crashes later at `assert result.nodes is not None` at [`log_vector_store_query_result`](https://github.com/ondraz/llama_index/blob/76ce60660b1bd51ff20fb5f62144a2e0b9b03f78/llama-index-core/llama_index/core/indices/utils.py#L54)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
-  [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
