### PR TITLE
avoid DoS on image URL verification by adding a timeout

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -1232,7 +1232,7 @@ def is_image_pil(file_path: str) -> bool:
 
 def is_image_url_pil(url: str) -> bool:
     try:
-        response = requests.get(url, stream=True, timeout=(60,60))
+        response = requests.get(url, stream=True, timeout=(60, 60))
         response.raise_for_status()  # Raise an exception for bad status codes
         # Open image from the response content
         img = Image.open(BytesIO(response.content))


### PR DESCRIPTION
Avoids potential DoS on image URL verification by adding a connection timeout of 60s and a read timeout of 60s (arbitrary, but I think this is reasonable)