### PR TITLE
[Fix #19447]: MediaResource and Node hashing semantics

### DIFF
--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 
 [project]
 name = "llama-index-core"
-version = "0.13.2"
+version = "0.13.3"
 description = "Interface between LLMs and your data"
 authors = [{name = "Jerry Liu", email = "jerry@llamaindex.ai"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-core/tests/schema/test_media_resource.py
+++ b/llama-index-core/tests/schema/test_media_resource.py
@@ -52,4 +52,63 @@ def test_hash():
         ).hash
         == "04414a5f03ad7fa055229b4d3690d47427cb0b65bc7eb8f770d1ecbd54ab4909"
     )
-    assert MediaResource().hash == ""
+    # Test that empty MediaResource returns None
+    assert MediaResource().hash is None
+
+    # Test that MediaResource with empty content still generates a hash
+    assert MediaResource(text="").hash is not None
+    assert MediaResource(text="").hash != ""
+
+    # Test that MediaResource with None values but some content generates a hash
+    assert MediaResource(text="", data=b"").hash is not None
+    assert MediaResource(text="", data=b"").hash != ""
+
+
+def test_hash_edge_cases():
+    """Test various edge cases for hash generation."""
+    # Test with only text (empty string)
+    empty_text = MediaResource(text="")
+    assert empty_text.hash is not None
+    assert empty_text.hash != ""
+
+    # Test with only data (empty bytes)
+    empty_data = MediaResource(data=b"")
+    assert empty_data.hash is not None
+    assert empty_data.hash != ""
+
+    # Test with only path
+    path_only = MediaResource(path=Path("test.txt"))
+    assert path_only.hash is not None
+    assert path_only.hash != ""
+
+    # Test with only URL
+    url_only = MediaResource(url=AnyUrl("http://example.com"))
+    assert url_only.hash is not None
+    assert url_only.hash != ""
+
+    # Test with mixed None and empty values
+    mixed_empty = MediaResource(text="", data=None, path=None, url=None)
+    assert mixed_empty.hash is not None
+    assert mixed_empty.hash != ""
+
+    # Test with all None values
+    all_none = MediaResource(text=None, data=None, path=None, url=None)
+    assert all_none.hash is None
+
+
+def test_hash_consistency():
+    """Test that hash values are consistent for the same content."""
+    # Same content should produce same hash
+    resource1 = MediaResource(text="hello", data=b"world")
+    resource2 = MediaResource(text="hello", data=b"world")
+    assert resource1.hash == resource2.hash
+
+    # Different content should produce different hashes
+    resource3 = MediaResource(text="hello", data=b"different")
+    assert resource1.hash != resource3.hash
+
+    # Empty resources should all return None
+    empty1 = MediaResource()
+    empty2 = MediaResource()
+    assert empty1.hash is None
+    assert empty2.hash is None


### PR DESCRIPTION
# Description

Fix MediaResource.hash to return None when no content available, improving semantic distinction between no content and empty content while maintaining backward compatibility.

Fixes #19447


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods