### PR TITLE
Payload indexes support to QdrantVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -949,7 +949,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 )
 
             if self._payload_indexes:
-                self._create_payload_indexes()
+                await self._acreate_payload_indexes()
         except (RpcError, ValueError, UnexpectedResponse) as exc:
             if "already exists" not in str(exc):
                 raise exc  # noqa: TRY201
@@ -974,7 +974,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                         )
                         continue
             if self._payload_indexes:
-                self._create_payload_indexes()
+                await self._acreate_payload_indexes()
 
         self._collection_initialized = True
 
@@ -987,6 +987,17 @@ class QdrantVectorStore(BasePydanticVectorStore):
         return await self._aclient.collection_exists(collection_name)
 
     def _create_payload_indexes(self) -> None:
+        """Create payload indexes in Qdrant collection."""
+        if not self._payload_indexes:
+            return
+        for payload_index in self._payload_indexes:
+            self._client.create_payload_index(
+                collection_name=self.collection_name,
+                field_name=payload_index["field_name"],
+                field_schema=payload_index["field_schema"],
+            )
+
+    async def _acreate_payload_indexes(self) -> None:
         """Create payload indexes in Qdrant collection."""
         if not self._payload_indexes:
             return

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -103,6 +103,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         write_consistency_factor (Optional[int]): Write consistency factor for the collection
         shard_key_selector_fn (Optional[Callable[..., rest.ShardKeySelector]]): Function to select shard keys
         shard_keys (Optional[list[rest.ShardKey]]): List of shard keys
+        payload_indexes: Optional[list[dict[str, rest.PayloadSchemaType]]]: List of payload field indexes
 
     Notes:
         For backward compatibility, the vector store will automatically detect the vector format
@@ -163,6 +164,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
     _sharding_method: Optional[rest.ShardingMethod] = PrivateAttr()
     _replication_factor: Optional[int] = PrivateAttr()
     _write_consistency_factor: Optional[int] = PrivateAttr()
+    _payload_indexes: Optional[list[dict[str, rest.PayloadSchemaType]]] = PrivateAttr()
 
     def __init__(
         self,
@@ -193,6 +195,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         shard_keys: Optional[list[rest.ShardKey]] = None,
         replication_factor: Optional[int] = None,
         write_consistency_factor: Optional[int] = None,
+        payload_indexes: Optional[list[dict[str, rest.PayloadSchemaType]]] = None,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -250,12 +253,16 @@ class QdrantVectorStore(BasePydanticVectorStore):
             self._client = client
             self._aclient = aclient
 
+        self._payload_indexes = payload_indexes
+
         # Check if collection exists and detect vector format
         self._legacy_vector_format = None
         if self._client is not None:
             self._collection_initialized = self._collection_exists(collection_name)
             if self._collection_initialized:
                 self._detect_vector_format(collection_name)
+                if self._payload_indexes:
+                    self._create_payload_indexes()
         else:
             # Need to do lazy init for async clients
             self._collection_initialized = False
@@ -851,6 +858,9 @@ class QdrantVectorStore(BasePydanticVectorStore):
                     field_name=DOCUMENT_ID_KEY,
                     field_schema=rest.PayloadSchemaType.KEYWORD,
                 )
+
+            if self._payload_indexes:
+                self._create_payload_indexes()
         except (RpcError, ValueError, UnexpectedResponse) as exc:
             if "already exists" not in str(exc):
                 raise exc  # noqa: TRY201
@@ -874,6 +884,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
                             shard_key,
                         )
                         continue
+            if self._payload_indexes:
+                self._create_payload_indexes()
 
         self._collection_initialized = True
 
@@ -935,6 +947,9 @@ class QdrantVectorStore(BasePydanticVectorStore):
                     field_name=DOCUMENT_ID_KEY,
                     field_schema=rest.PayloadSchemaType.KEYWORD,
                 )
+
+            if self._payload_indexes:
+                self._create_payload_indexes()
         except (RpcError, ValueError, UnexpectedResponse) as exc:
             if "already exists" not in str(exc):
                 raise exc  # noqa: TRY201
@@ -958,6 +973,8 @@ class QdrantVectorStore(BasePydanticVectorStore):
                             shard_key,
                         )
                         continue
+            if self._payload_indexes:
+                self._create_payload_indexes()
 
         self._collection_initialized = True
 
@@ -968,6 +985,17 @@ class QdrantVectorStore(BasePydanticVectorStore):
     async def _acollection_exists(self, collection_name: str) -> bool:
         """Asynchronous method to check if a collection exists."""
         return await self._aclient.collection_exists(collection_name)
+
+    def _create_payload_indexes(self) -> None:
+        """Create payload indexes in Qdrant collection."""
+        if not self._payload_indexes:
+            return
+        for payload_index in self._payload_indexes:
+            self._client.create_payload_index(
+                collection_name=self.collection_name,
+                field_name=payload_index["field_name"],
+                field_schema=payload_index["field_schema"],
+            )
 
     def query(
         self,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1002,7 +1002,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         if not self._payload_indexes:
             return
         for payload_index in self._payload_indexes:
-            self._client.create_payload_index(
+            self._aclient.create_payload_index(
                 collection_name=self.collection_name,
                 field_name=payload_index["field_name"],
                 field_schema=payload_index["field_schema"],

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1002,7 +1002,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
         if not self._payload_indexes:
             return
         for payload_index in self._payload_indexes:
-            self._aclient.create_payload_index(
+            await self._aclient.create_payload_index(
                 collection_name=self.collection_name,
                 field_name=payload_index["field_name"],
                 field_schema=payload_index["field_schema"],

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-qdrant"
-version = "0.8.1"
+version = "0.8.2"
 description = "llama-index vector_stores qdrant integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<3.14"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/conftest.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/conftest.py
@@ -176,52 +176,142 @@ async def payload_indexed_vector_store() -> AsyncGenerator[QdrantVectorStore, No
     aclient = qdrant_client.AsyncQdrantClient(url)
     collection_name = "test"
 
-    vector_store = QdrantVectorStore(
-        collection_name,
-        client=client,
-        aclient=aclient,
-        payload_indexes=[
-            {
-                "field_name": "tenant_id",
-                "field_schema": models.PayloadSchemaType.KEYWORD,
-            },
-            {
-                "field_name": "some_key",
-                "field_schema": models.PayloadSchemaType.INTEGER,
-            },
-        ],
-        index_doc_id=False,
-    )
+    try:
+        vector_store = QdrantVectorStore(
+            collection_name,
+            client=client,
+            aclient=aclient,
+            payload_indexes=[
+                {
+                    "field_name": "tenant_id",
+                    "field_schema": models.PayloadSchemaType.KEYWORD,
+                },
+                {
+                    "field_name": "some_key",
+                    "field_schema": models.PayloadSchemaType.INTEGER,
+                },
+            ],
+            index_doc_id=False,
+        )
 
-    nodes = [
-        TextNode(
-            text="test1",
-            id_="11111111-1111-1111-1111-111111111111",
-            embedding=[1.0, 0.0],
-            metadata={"some_key": 1, "tenant_id": "A"},
-            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
-        ),
-        TextNode(
-            text="test2",
-            id_="22222222-2222-2222-2222-222222222222",
-            embedding=[0.0, 1.0],
-            metadata={"some_key": 2, "tenant_id": "B"},
-            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
-        ),
-        TextNode(
-            text="test3",
-            id_="33333333-3333-3333-3333-333333333333",
-            embedding=[1.0, 1.0],
-            metadata={"some_key": "3", "tenant_id": "A"},
-        ),
-    ]
+        nodes = [
+            TextNode(
+                text="test1",
+                id_="11111111-1111-1111-1111-111111111111",
+                embedding=[1.0, 0.0],
+                metadata={"some_key": 1, "tenant_id": "A"},
+                relationships={
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
+                },
+            ),
+            TextNode(
+                text="test2",
+                id_="22222222-2222-2222-2222-222222222222",
+                embedding=[0.0, 1.0],
+                metadata={"some_key": 2, "tenant_id": "B"},
+                relationships={
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
+                },
+            ),
+            TextNode(
+                text="test3",
+                id_="33333333-3333-3333-3333-333333333333",
+                embedding=[1.0, 1.0],
+                metadata={"some_key": "3", "tenant_id": "A"},
+            ),
+        ]
 
-    vector_store.add(nodes)
+        vector_store.add(nodes)
 
-    # in-memory client does not share data between instances
-    await vector_store.async_add(nodes)
+        # in-memory client does not share data between instances
+        await vector_store.async_add(nodes)
+
+        yield vector_store
+    finally:
+        try:
+            await aclient.delete_collection(collection_name=collection_name)
+        except Exception:
+            pass
+        try:
+            await aclient.close()
+        except Exception:
+            pass
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def collection_initialized_payload_indexed_vector_store() -> AsyncGenerator[
+    QdrantVectorStore, None
+]:
+    url = os.getenv("QDRANT_URL") or os.getenv("QDRANT_CLUSTER_URL")
+    assert url, "QDRANT_URL must be set for payload indexes, not supported in memory"
+
+    client = qdrant_client.QdrantClient(url)
+    aclient = qdrant_client.AsyncQdrantClient(url)
+    collection_name = "test"
 
     try:
+        await aclient.create_collection(
+            collection_name,
+            vectors_config={
+                "text-dense": models.VectorParams(
+                    size=2, distance=models.Distance.COSINE
+                )
+            },
+        )
+
+        vector_store = QdrantVectorStore(
+            collection_name,
+            client=client,
+            aclient=aclient,
+            payload_indexes=[
+                {
+                    "field_name": "tenant_id",
+                    "field_schema": models.PayloadSchemaType.KEYWORD,
+                },
+                {
+                    "field_name": "some_key",
+                    "field_schema": models.PayloadSchemaType.INTEGER,
+                },
+            ],
+            index_doc_id=False,
+        )
+
+        nodes = [
+            TextNode(
+                text="test1",
+                id_="11111111-1111-1111-1111-111111111111",
+                embedding=[1.0, 0.0],
+                metadata={"some_key": 1, "tenant_id": "A"},
+                relationships={
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
+                },
+            ),
+            TextNode(
+                text="test2",
+                id_="22222222-2222-2222-2222-222222222222",
+                embedding=[0.0, 1.0],
+                metadata={"some_key": 2, "tenant_id": "B"},
+                relationships={
+                    NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")
+                },
+            ),
+            TextNode(
+                text="test3",
+                id_="33333333-3333-3333-3333-333333333333",
+                embedding=[1.0, 1.0],
+                metadata={"some_key": "3", "tenant_id": "A"},
+            ),
+        ]
+
+        vector_store.add(nodes)
+
+        # in-memory client does not share data between instances
+        await vector_store.async_add(nodes)
+
         yield vector_store
     finally:
         try:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/conftest.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from typing import AsyncGenerator
 
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.vector_stores.qdrant import QdrantVectorStore
@@ -85,7 +86,7 @@ async def hybrid_vector_store() -> QdrantVectorStore:
 
 
 @pytest_asyncio.fixture
-async def shard_vector_store() -> QdrantVectorStore:
+async def shard_vector_store() -> AsyncGenerator[QdrantVectorStore, None]:
     """
     Build a QdrantVectorStore configured for *custom sharding* and seed it with three nodes.
 
@@ -99,9 +100,10 @@ async def shard_vector_store() -> QdrantVectorStore:
 
     client = qdrant_client.QdrantClient(url)
     aclient = qdrant_client.AsyncQdrantClient(url)
+    collection_name = "test"
 
     vector_store = QdrantVectorStore(
-        "test",
+        collection_name,
         client=client,
         aclient=aclient,
         sharding_method=models.ShardingMethod.CUSTOM,
@@ -148,4 +150,89 @@ async def shard_vector_store() -> QdrantVectorStore:
     # in-memory client does not share data between instances
     await vector_store.async_add([node_3], shard_identifier=3)
 
-    return vector_store
+    try:
+        yield vector_store
+    finally:
+        try:
+            await aclient.delete_collection(collection_name=collection_name)
+        except Exception:
+            pass
+        try:
+            await aclient.close()
+        except Exception:
+            pass
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def payload_indexed_vector_store() -> AsyncGenerator[QdrantVectorStore, None]:
+    url = os.getenv("QDRANT_URL") or os.getenv("QDRANT_CLUSTER_URL")
+    assert url, "QDRANT_URL must be set for payload indexes, not supported in memory"
+
+    client = qdrant_client.QdrantClient(url)
+    aclient = qdrant_client.AsyncQdrantClient(url)
+    collection_name = "test"
+
+    vector_store = QdrantVectorStore(
+        collection_name,
+        client=client,
+        aclient=aclient,
+        payload_indexes=[
+            {
+                "field_name": "tenant_id",
+                "field_schema": models.PayloadSchemaType.KEYWORD,
+            },
+            {
+                "field_name": "some_key",
+                "field_schema": models.PayloadSchemaType.INTEGER,
+            },
+        ],
+        index_doc_id=False,
+    )
+
+    nodes = [
+        TextNode(
+            text="test1",
+            id_="11111111-1111-1111-1111-111111111111",
+            embedding=[1.0, 0.0],
+            metadata={"some_key": 1, "tenant_id": "A"},
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
+        ),
+        TextNode(
+            text="test2",
+            id_="22222222-2222-2222-2222-222222222222",
+            embedding=[0.0, 1.0],
+            metadata={"some_key": 2, "tenant_id": "B"},
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="test-0")},
+        ),
+        TextNode(
+            text="test3",
+            id_="33333333-3333-3333-3333-333333333333",
+            embedding=[1.0, 1.0],
+            metadata={"some_key": "3", "tenant_id": "A"},
+        ),
+    ]
+
+    vector_store.add(nodes)
+
+    # in-memory client does not share data between instances
+    await vector_store.async_add(nodes)
+
+    try:
+        yield vector_store
+    finally:
+        try:
+            await aclient.delete_collection(collection_name=collection_name)
+        except Exception:
+            pass
+        try:
+            await aclient.close()
+        except Exception:
+            pass
+        try:
+            client.close()
+        except Exception:
+            pass

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -581,3 +581,79 @@ def test_payload_indexes_created_sync(
         missing = schema_keys - payload_keys
         extra = payload_keys - schema_keys
         assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"
+
+
+@pytest.mark.asyncio
+@requires_qdrant_server
+async def test_payload_indexes_created_on_existing_collection(
+    collection_initialized_payload_indexed_vector_store: QdrantVectorStore,
+):
+    collection_info = (
+        collection_initialized_payload_indexed_vector_store._client.get_collection(
+            collection_initialized_payload_indexed_vector_store.collection_name
+        )
+    )
+    if collection_initialized_payload_indexed_vector_store._payload_indexes:
+        payload_keys = {
+            d["field_name"]
+            for d in collection_initialized_payload_indexed_vector_store._payload_indexes
+        }
+        schema_keys = set(collection_info.payload_schema)
+        missing = schema_keys - payload_keys
+        extra = payload_keys - schema_keys
+        assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"
+    await collection_initialized_payload_indexed_vector_store._acreate_collection(
+        collection_initialized_payload_indexed_vector_store.collection_name, 2
+    )
+    collection_info = (
+        collection_initialized_payload_indexed_vector_store._client.get_collection(
+            collection_initialized_payload_indexed_vector_store.collection_name
+        )
+    )
+    if collection_initialized_payload_indexed_vector_store._payload_indexes:
+        payload_keys = {
+            d["field_name"]
+            for d in collection_initialized_payload_indexed_vector_store._payload_indexes
+        }
+        schema_keys = set(collection_info.payload_schema)
+        missing = schema_keys - payload_keys
+        extra = payload_keys - schema_keys
+        assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"
+
+
+@requires_qdrant_server
+def test_payload_indexes_created_on_existing_collection_sync(
+    collection_initialized_payload_indexed_vector_store: QdrantVectorStore,
+):
+    collection_info = (
+        collection_initialized_payload_indexed_vector_store._client.get_collection(
+            collection_initialized_payload_indexed_vector_store.collection_name
+        )
+    )
+    if collection_initialized_payload_indexed_vector_store._payload_indexes:
+        payload_keys = {
+            d["field_name"]
+            for d in collection_initialized_payload_indexed_vector_store._payload_indexes
+        }
+        schema_keys = set(collection_info.payload_schema)
+        missing = schema_keys - payload_keys
+        extra = payload_keys - schema_keys
+        assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"
+
+    collection_initialized_payload_indexed_vector_store._create_collection(
+        collection_initialized_payload_indexed_vector_store.collection_name, 2
+    )
+    collection_info = (
+        collection_initialized_payload_indexed_vector_store._client.get_collection(
+            collection_initialized_payload_indexed_vector_store.collection_name
+        )
+    )
+    if collection_initialized_payload_indexed_vector_store._payload_indexes:
+        payload_keys = {
+            d["field_name"]
+            for d in collection_initialized_payload_indexed_vector_store._payload_indexes
+        }
+        schema_keys = set(collection_info.payload_schema)
+        missing = schema_keys - payload_keys
+        extra = payload_keys - schema_keys
+        assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -556,9 +556,7 @@ async def test_payload_indexes_created(
         payload_keys = {
             d["field_name"] for d in payload_indexed_vector_store._payload_indexes
         }
-        print(collection_info)
         schema_keys = set(collection_info.payload_schema)
-        print(schema_keys)
         missing = schema_keys - payload_keys
         extra = payload_keys - schema_keys
         assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"
@@ -575,9 +573,7 @@ def test_payload_indexes_created_sync(
         payload_keys = {
             d["field_name"] for d in payload_indexed_vector_store._payload_indexes
         }
-        print(collection_info)
         schema_keys = set(collection_info.payload_schema)
-        print(schema_keys)
         missing = schema_keys - payload_keys
         extra = payload_keys - schema_keys
         assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"


### PR DESCRIPTION
# Description
This pull request adds support for defining and creating custom payload field indexes in Qdrant collections within the `QdrantVectorStore` integration. It introduces a new parameter for specifying payload indexes, ensures these indexes are created when initializing or creating collections (both synchronously and asynchronously), and adds comprehensive tests to verify this functionality. The changes also improve test resource management and update the package version.

**QdrantVectorStore payload index support:**

* Added a new `payload_indexes` parameter to the `QdrantVectorStore` class, allowing users to specify a list of payload field indexes to be created in the Qdrant collection. This is stored as a private attribute and handled in both sync and async collection creation flows. [[1]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R106) [[2]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R167) [[3]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R198) [[4]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R256-R265)
* Implemented the `_create_payload_indexes` method to create the specified payload indexes in the Qdrant collection, and invoked it during collection initialization and creation (sync and async paths). [[1]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R861-R863) [[2]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R887-R888) [[3]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R950-R952) [[4]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R976-R977) [[5]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R989-R999)

**Testing improvements:**

* Added a new pytest fixture `payload_indexed_vector_store` that sets up a vector store with payload indexes and provides proper cleanup of resources after tests. [[1]](diffhunk://#diff-0130860de866f4dc00ddf9b82a9ec2f01309781a21f29feb269deec2075775f3L88-R89) [[2]](diffhunk://#diff-0130860de866f4dc00ddf9b82a9ec2f01309781a21f29feb269deec2075775f3L151-R238)
* Updated the `shard_vector_store` fixture to use an async generator for better resource cleanup. [[1]](diffhunk://#diff-0130860de866f4dc00ddf9b82a9ec2f01309781a21f29feb269deec2075775f3L88-R89) [[2]](diffhunk://#diff-0130860de866f4dc00ddf9b82a9ec2f01309781a21f29feb269deec2075775f3L151-R238)
* Added new tests (`test_payload_indexes_created` and `test_payload_indexes_created_sync`) to verify that the specified payload indexes are correctly created in the Qdrant collection.

**Other changes:**

* Updated the package version to `0.8.2` in `pyproject.toml`.
* Improved test skipping logic to handle cases when Qdrant server or cluster is not available in CI.

## Version Bump?
Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
- [x] Yes

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.
- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
