### PR TITLE
feat[IBM]: Support for additional/external urls, make instance_id deprecated

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/llama_index/embeddings/ibm/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/llama_index/embeddings/ibm/base.py
@@ -39,13 +39,13 @@ class WatsonxEmbeddings(BaseEmbedding):
 
     model_id: str = Field(
         default=DEFAULT_EMBED_MODEL,
-        description="""Type of model to use.""",
+        description="Type of model to use.",
         allow_mutation=False,
     )
 
     truncate_input_tokens: Optional[int] = Field(
         default=None,
-        description="""Represents the maximum number of input tokens accepted.""",
+        description="Represents the maximum number of input tokens accepted.",
     )
 
     project_id: Optional[str] = Field(
@@ -56,42 +56,51 @@ class WatsonxEmbeddings(BaseEmbedding):
 
     space_id: Optional[str] = Field(
         default=None,
-        description="""ID of the Watson Studio space.""",
+        description="ID of the Watson Studio space.",
         allow_mutation=False,
     )
 
     url: Optional[SecretStr] = Field(
         default=None,
-        description="""Url to Watson Machine Learning or CPD instance""",
+        description="Url to the IBM watsonx.ai for IBM Cloud or the IBM watsonx.ai software instance.",
         allow_mutation=False,
     )
 
     apikey: Optional[SecretStr] = Field(
         default=None,
-        description="""Apikey to Watson Machine Learning or CPD instance""",
+        description="API key to the IBM watsonx.ai for IBM Cloud or the IBM watsonx.ai software instance.",
         allow_mutation=False,
     )
 
     token: Optional[SecretStr] = Field(
-        default=None, description="""Token to CPD instance""", allow_mutation=False
+        default=None,
+        description="Token to the IBM watsonx.ai software instance.",
+        allow_mutation=False,
     )
 
     password: Optional[SecretStr] = Field(
-        default=None, description="""Password to CPD instance""", allow_mutation=False
+        default=None,
+        description="Password to the IBM watsonx.ai software instance.",
+        allow_mutation=False,
     )
 
     username: Optional[SecretStr] = Field(
-        default=None, description="""Username to CPD instance""", allow_mutation=False
+        default=None,
+        description="Username to the IBM watsonx.ai software instance.",
+        allow_mutation=False,
     )
 
     instance_id: Optional[SecretStr] = Field(
         default=None,
-        description="""Instance_id of CPD instance""",
+        description="Instance_id of the IBM watsonx.ai software instance.",
         allow_mutation=False,
+        deprecated="The `instance_id` parameter is deprecated and will no longer be utilized for logging to the IBM watsonx.ai software instance.",
     )
 
     version: Optional[SecretStr] = Field(
-        default=None, description="""Version of CPD instance""", allow_mutation=False
+        default=None,
+        description="Version of the IBM watsonx.ai software instance.",
+        allow_mutation=False,
     )
 
     verify: Union[str, bool, None] = Field(
@@ -124,7 +133,6 @@ class WatsonxEmbeddings(BaseEmbedding):
         token: Optional[str] = None,
         password: Optional[str] = None,
         username: Optional[str] = None,
-        instance_id: Optional[str] = None,
         version: Optional[str] = None,
         verify: Union[str, bool, None] = None,
         api_client: Optional[APIClient] = None,
@@ -145,7 +153,6 @@ class WatsonxEmbeddings(BaseEmbedding):
                 token=token,
                 username=username,
                 password=password,
-                instance_id=instance_id,
             )
 
         url = creds.get("url").get_secret_value() if creds.get("url") else None
@@ -156,11 +163,6 @@ class WatsonxEmbeddings(BaseEmbedding):
         )
         username = (
             creds.get("username").get_secret_value() if creds.get("username") else None
-        )
-        instance_id = (
-            creds.get("instance_id").get_secret_value()
-            if creds.get("instance_id")
-            else None
         )
 
         super().__init__(
@@ -173,7 +175,6 @@ class WatsonxEmbeddings(BaseEmbedding):
             token=token,
             password=password,
             username=username,
-            instance_id=instance_id,
             version=version,
             verify=verify,
             persistent_connection=persistent_connection,
@@ -216,7 +217,6 @@ class WatsonxEmbeddings(BaseEmbedding):
             "token": self.token,
             "password": self.password,
             "username": self.username,
-            "instance_id": self.instance_id,
             "version": self.version,
         }
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/llama_index/embeddings/ibm/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/llama_index/embeddings/ibm/utils.py
@@ -1,6 +1,6 @@
 import os
-import urllib.parse
 from typing import Dict, Optional, Union
+from ibm_watsonx_ai import APIClient
 
 
 from llama_index.core.base.llms.generic_utils import (
@@ -22,7 +22,6 @@ def resolve_watsonx_credentials(
     token: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
-    instance_id: Optional[str] = None,
 ) -> Dict[str, SecretStr]:
     """
     Resolve watsonx.ai credentials. If the value of given param is None
@@ -33,13 +32,11 @@ def resolve_watsonx_credentials(
     :return: Dictionary with resolved credentials items
     :rtype: Dict[str, SecretStr]
     """
-    creds = {}
-    creds["url"] = convert_to_secret_str(
-        get_from_param_or_env("url", url, "WATSONX_URL")
-    )
+    creds = {
+        "url": convert_to_secret_str(get_from_param_or_env("url", url, "WATSONX_URL"))
+    }
 
-    parsed_url = urllib.parse.urlparse(creds["url"].get_secret_value())
-    if parsed_url.netloc.endswith("cloud.ibm.com"):
+    if creds["url"].get_secret_value() in APIClient.PLATFORM_URLS_MAP:
         if not (apikey or "WATSONX_APIKEY" in os.environ) and not (
             token or "WATSONX_TOKEN" in os.environ
         ):
@@ -97,11 +94,6 @@ def resolve_watsonx_credentials(
 
             creds["username"] = convert_to_secret_str(
                 get_from_param_or_env("username", username, "WATSONX_USERNAME")
-            )
-
-        if not instance_id or "WATSONX_INSTANCE_ID" not in os.environ:
-            creds["instance_id"] = convert_to_secret_str(
-                get_from_param_or_env("instance_id", instance_id, "WATSONX_INSTANCE_ID")
             )
 
     return creds

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
@@ -27,14 +27,14 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-ibm"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index embeddings IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "ibm-watsonx-ai>=1.0.1",
+    "ibm-watsonx-ai>=1.3.36",
     "pyarrow",
     "llama-index-core>=0.13.0,<0.14",
 ]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-ibm"
-version = "0.4.1"
+version = "0.5.0"
 description = "llama-index embeddings IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/tests/test_ibm.py
@@ -22,26 +22,33 @@ class TestWasonxLLMInference:
         ]
 
     def test_initialization(self) -> None:
-        with pytest.raises(ValueError, match=r"^Did not find") as e_info:
+        with pytest.raises(ValueError, match=r"^Did not find"):
             _ = WatsonxEmbeddings(
                 model_id=self.TEST_MODEL, project_id=self.TEST_PROJECT_ID
             )
 
         # Cloud scenario
-        with pytest.raises(
-            ValueError, match=r"^Did not find 'apikey' or 'token',"
-        ) as e_info:
+        with pytest.raises(ValueError, match=r"^Did not find 'apikey' or 'token',"):
             _ = WatsonxEmbeddings(
                 model_id=self.TEST_MODEL,
                 url=self.TEST_URL,
                 project_id=self.TEST_PROJECT_ID,
             )
 
-        # CPD scenario
-        with pytest.raises(ValueError, match=r"^Did not find instance_id") as e_info:
+        # CPD scenario with password and missing username
+        with pytest.raises(ValueError, match=r"^Did not find username"):
             _ = WatsonxEmbeddings(
                 model_id=self.TEST_MODEL,
-                token="123",
+                password="123",
+                url="cpd-instance",
+                project_id=self.TEST_PROJECT_ID,
+            )
+
+        # CPD scenario with apikey and missing username
+        with pytest.raises(ValueError, match=r"^Did not find username"):
+            _ = WatsonxEmbeddings(
+                model_id=self.TEST_MODEL,
+                apikey="123",
                 url="cpd-instance",
                 project_id=self.TEST_PROJECT_ID,
             )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/uv.lock
@@ -1554,7 +1554,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-ibm"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "ibm-watsonx-ai" },

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/uv.lock
@@ -353,6 +353,15 @@ css = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988, upload-time = "2025-08-25T18:57:30.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276, upload-time = "2025-08-25T18:57:29.684Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -1056,9 +1065,10 @@ sdist = { url = "https://files.pythonhosted.org/packages/41/b0/8fc26017341f62046
 
 [[package]]
 name = "ibm-watsonx-ai"
-version = "1.3.11"
+version = "1.3.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachetools" },
     { name = "certifi" },
     { name = "httpx" },
     { name = "ibm-cos-sdk" },
@@ -1069,9 +1079,9 @@ dependencies = [
     { name = "tabulate" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/fd/f7ff11c084ff2af39214dd79531c63b4c798b98266e58126d999ff1fdeb9/ibm_watsonx_ai-1.3.11.tar.gz", hash = "sha256:36d4bf38af6795e3113d9e58d0d47d08fe8bc55347bfe9546820a4a09064981c", size = 714156, upload-time = "2025-04-23T07:39:32.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/21/1a6161d46cdd8d7d9b7aa8a881a21c7f0feeb335c2ada33d9e63d6b8c41f/ibm_watsonx_ai-1.3.36.tar.gz", hash = "sha256:a6b3878fa73925dd3c59e0c495bdb89cd3a6ac1294800caeeb877e18dc19ce7a", size = 767322, upload-time = "2025-08-28T08:07:40.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/af/28627792e9694403b0abb1823e2f17214c3cecd63d642535a1a5d9bef028/ibm_watsonx_ai-1.3.11-py3-none-any.whl", hash = "sha256:7d6571069d241856b6fa7854a786b5f13d5e769c3bc82681594b4ee3bc1c6577", size = 1115138, upload-time = "2025-04-23T07:39:31.007Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bc/f757224cb02dd899d7e4fcae9581dfac83a07662183bde7abb2c5e871cd8/ibm_watsonx_ai-1.3.36-py3-none-any.whl", hash = "sha256:63156858634e218e42bea1d3954d29a891303e4a2044a8c696d2b2e7c6e5e59b", size = 1183595, upload-time = "2025-08-28T08:07:38.212Z" },
 ]
 
 [[package]]
@@ -1544,7 +1554,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-ibm"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "ibm-watsonx-ai" },
@@ -1577,7 +1587,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ibm-watsonx-ai", specifier = ">=1.0.1" },
+    { name = "ibm-watsonx-ai", specifier = ">=1.3.36" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.14" },
     { name = "pyarrow" },
 ]

--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/base.py
@@ -106,34 +106,45 @@ class WatsonxLLM(FunctionCallingLLM):
 
     url: Optional[SecretStr] = Field(
         default=None,
-        description="Url to Watson Machine Learning or CPD instance",
+        description="Url to the IBM watsonx.ai for IBM Cloud or the IBM watsonx.ai software instance.",
         frozen=True,
     )
 
     apikey: Optional[SecretStr] = Field(
         default=None,
-        description="Apikey to Watson Machine Learning or CPD instance",
+        description="API key to the IBM watsonx.ai for IBM Cloud or the IBM watsonx.ai software instance.",
         frozen=True,
     )
 
     token: Optional[SecretStr] = Field(
-        default=None, description="Token to CPD instance", frozen=True
+        default=None,
+        description="Token to the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     password: Optional[SecretStr] = Field(
-        default=None, description="Password to CPD instance", frozen=True
+        default=None,
+        description="Password to the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     username: Optional[SecretStr] = Field(
-        default=None, description="Username to CPD instance", frozen=True
+        default=None,
+        description="Username to the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     instance_id: Optional[SecretStr] = Field(
-        default=None, description="Instance_id of CPD instance", frozen=True
+        default=None,
+        description="Instance_id of the IBM watsonx.ai software instance.",
+        frozen=True,
+        deprecated="The `instance_id` parameter is deprecated and will no longer be utilized for logging to the IBM watsonx.ai software instance.",
     )
 
     version: Optional[SecretStr] = Field(
-        default=None, description="Version of CPD instance", frozen=True
+        default=None,
+        description="Version of the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     verify: Union[str, bool, None] = Field(
@@ -179,7 +190,6 @@ class WatsonxLLM(FunctionCallingLLM):
         token: Optional[str] = None,
         password: Optional[str] = None,
         username: Optional[str] = None,
-        instance_id: Optional[str] = None,
         version: Optional[str] = None,
         verify: Union[str, bool, None] = None,
         api_client: Optional[APIClient] = None,
@@ -201,7 +211,6 @@ class WatsonxLLM(FunctionCallingLLM):
                 token=token,
                 username=username,
                 password=password,
-                instance_id=instance_id,
             )
             if not isinstance(api_client, APIClient)
             else {}
@@ -220,7 +229,6 @@ class WatsonxLLM(FunctionCallingLLM):
             token=creds.get("token"),
             password=creds.get("password"),
             username=creds.get("username"),
-            instance_id=creds.get("instance_id"),
             version=version,
             verify=verify,
             _client=api_client,
@@ -297,7 +305,6 @@ class WatsonxLLM(FunctionCallingLLM):
             "token": self.token,
             "password": self.password,
             "username": self.username,
-            "instance_id": self.instance_id,
             "version": self.version,
         }
 

--- a/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/llama_index/llms/ibm/utils.py
@@ -1,6 +1,6 @@
 import os
-import urllib.parse
 from typing import Dict, Union, Optional, List, Any
+from ibm_watsonx_ai import APIClient
 
 
 from llama_index.core.base.llms.generic_utils import (
@@ -20,7 +20,6 @@ def resolve_watsonx_credentials(
     token: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
-    instance_id: Optional[str] = None,
 ) -> Dict[str, SecretStr]:
     """
     Resolve watsonx.ai credentials. If the value of given param is None
@@ -31,13 +30,11 @@ def resolve_watsonx_credentials(
     :return: Dictionary with resolved credentials items
     :rtype: Dict[str, SecretStr]
     """
-    creds = {}
-    creds["url"] = convert_to_secret_str(
-        get_from_param_or_env("url", url, "WATSONX_URL")
-    )
+    creds = {
+        "url": convert_to_secret_str(get_from_param_or_env("url", url, "WATSONX_URL"))
+    }
 
-    parsed_url = urllib.parse.urlparse(creds["url"].get_secret_value())
-    if parsed_url.netloc.endswith("cloud.ibm.com"):
+    if creds["url"].get_secret_value() in APIClient.PLATFORM_URLS_MAP:
         if not (apikey or "WATSONX_APIKEY" in os.environ) and not (
             token or "WATSONX_TOKEN" in os.environ
         ):
@@ -95,11 +92,6 @@ def resolve_watsonx_credentials(
 
             creds["username"] = convert_to_secret_str(
                 get_from_param_or_env("username", username, "WATSONX_USERNAME")
-            )
-
-        if not instance_id or "WATSONX_INSTANCE_ID" not in os.environ:
-            creds["instance_id"] = convert_to_secret_str(
-                get_from_param_or_env("instance_id", instance_id, "WATSONX_INSTANCE_ID")
             )
 
     return creds

--- a/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
@@ -27,14 +27,14 @@ dev = [
 
 [project]
 name = "llama-index-llms-ibm"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "ibm-watsonx-ai>=1.1.24",
+    "ibm-watsonx-ai>=1.3.36",
     "pyarrow",
     "llama-index-core>=0.13.0,<0.14",
 ]

--- a/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-ibm"
-version = "0.5.1"
+version = "0.6.0"
 description = "llama-index llms IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
 requires-python = ">=3.10,<3.13"

--- a/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/tests/test_ibm.py
@@ -220,24 +220,31 @@ class TestWasonxLLMInference:
     ]
 
     def test_initialization(self) -> None:
-        with pytest.raises(ValueError, match=r"^Did not find") as e_info:
+        with pytest.raises(ValueError, match=r"^Did not find"):
             _ = WatsonxLLM(model=self.TEST_MODEL, project_id=self.TEST_PROJECT_ID)
 
         # Cloud scenario
-        with pytest.raises(
-            ValueError, match=r"^Did not find 'apikey' or 'token',"
-        ) as e_info:
+        with pytest.raises(ValueError, match=r"^Did not find 'apikey' or 'token',"):
             _ = WatsonxLLM(
                 model_id=self.TEST_MODEL,
                 url=self.TEST_URL,
                 project_id=self.TEST_PROJECT_ID,
             )
 
-        # CPD scenario
-        with pytest.raises(ValueError, match=r"^Did not find instance_id") as e_info:
+        # CPD scenario with password and missing username
+        with pytest.raises(ValueError, match=r"^Did not find username"):
             _ = WatsonxLLM(
                 model_id=self.TEST_MODEL,
-                token="123",
+                password="123",
+                url="cpd-instance",
+                project_id=self.TEST_PROJECT_ID,
+            )
+
+        # CPD scenario with apikey and missing username
+        with pytest.raises(ValueError, match=r"^Did not find username"):
+            _ = WatsonxLLM(
+                model_id=self.TEST_MODEL,
+                apikey="123",
                 url="cpd-instance",
                 project_id=self.TEST_PROJECT_ID,
             )

--- a/llama-index-integrations/llms/llama-index-llms-ibm/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/uv.lock
@@ -337,6 +337,15 @@ css = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988, upload-time = "2025-08-25T18:57:30.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276, upload-time = "2025-08-25T18:57:29.684Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -941,9 +950,10 @@ sdist = { url = "https://files.pythonhosted.org/packages/41/b0/8fc26017341f62046
 
 [[package]]
 name = "ibm-watsonx-ai"
-version = "1.3.11"
+version = "1.3.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachetools" },
     { name = "certifi" },
     { name = "httpx" },
     { name = "ibm-cos-sdk" },
@@ -954,9 +964,9 @@ dependencies = [
     { name = "tabulate" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/fd/f7ff11c084ff2af39214dd79531c63b4c798b98266e58126d999ff1fdeb9/ibm_watsonx_ai-1.3.11.tar.gz", hash = "sha256:36d4bf38af6795e3113d9e58d0d47d08fe8bc55347bfe9546820a4a09064981c", size = 714156, upload-time = "2025-04-23T07:39:32.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/21/1a6161d46cdd8d7d9b7aa8a881a21c7f0feeb335c2ada33d9e63d6b8c41f/ibm_watsonx_ai-1.3.36.tar.gz", hash = "sha256:a6b3878fa73925dd3c59e0c495bdb89cd3a6ac1294800caeeb877e18dc19ce7a", size = 767322, upload-time = "2025-08-28T08:07:40.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/af/28627792e9694403b0abb1823e2f17214c3cecd63d642535a1a5d9bef028/ibm_watsonx_ai-1.3.11-py3-none-any.whl", hash = "sha256:7d6571069d241856b6fa7854a786b5f13d5e769c3bc82681594b4ee3bc1c6577", size = 1115138, upload-time = "2025-04-23T07:39:31.007Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bc/f757224cb02dd899d7e4fcae9581dfac83a07662183bde7abb2c5e871cd8/ibm_watsonx_ai-1.3.36-py3-none-any.whl", hash = "sha256:63156858634e218e42bea1d3954d29a891303e4a2044a8c696d2b2e7c6e5e59b", size = 1183595, upload-time = "2025-08-28T08:07:38.212Z" },
 ]
 
 [[package]]
@@ -1438,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-ibm"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "ibm-watsonx-ai" },
@@ -1471,7 +1481,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ibm-watsonx-ai", specifier = ">=1.1.24" },
+    { name = "ibm-watsonx-ai", specifier = ">=1.3.36" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.14" },
     { name = "pyarrow" },
 ]

--- a/llama-index-integrations/llms/llama-index-llms-ibm/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-ibm/uv.lock
@@ -1448,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-ibm"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "ibm-watsonx-ai" },

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/llama_index/postprocessor/ibm/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/llama_index/postprocessor/ibm/base.py
@@ -76,34 +76,45 @@ class WatsonxRerank(BaseNodePostprocessor):
 
     url: Optional[SecretStr] = Field(
         default=None,
-        description="Url to Watson Machine Learning or CPD instance",
+        description="Url to the IBM watsonx.ai for IBM Cloud or the IBM watsonx.ai software instance.",
         frozen=True,
     )
 
     apikey: Optional[SecretStr] = Field(
         default=None,
-        description="Apikey to Watson Machine Learning or CPD instance",
+        description="API key to the IBM watsonx.ai for IBM Cloud or the IBM watsonx.ai software instance.",
         frozen=True,
     )
 
     token: Optional[SecretStr] = Field(
-        default=None, description="Token to CPD instance", frozen=True
+        default=None,
+        description="Token to the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     password: Optional[SecretStr] = Field(
-        default=None, description="Password to CPD instance", frozen=True
+        default=None,
+        description="Password to the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     username: Optional[SecretStr] = Field(
-        default=None, description="Username to CPD instance", frozen=True
+        default=None,
+        description="Username to the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     instance_id: Optional[SecretStr] = Field(
-        default=None, description="Instance_id of CPD instance", frozen=True
+        default=None,
+        description="Instance_id of CPD instance",
+        frozen=True,
+        deprecated="The `instance_id` parameter is deprecated and will no longer be utilized for logging to the IBM watsonx.ai software instance.",
     )
 
     version: Optional[SecretStr] = Field(
-        default=None, description="Version of CPD instance", frozen=True
+        default=None,
+        description="Version of the IBM watsonx.ai software instance.",
+        frozen=True,
     )
 
     verify: Union[str, bool, None] = Field(
@@ -133,7 +144,6 @@ class WatsonxRerank(BaseNodePostprocessor):
         token: Optional[str] = None,
         password: Optional[str] = None,
         username: Optional[str] = None,
-        instance_id: Optional[str] = None,
         version: Optional[str] = None,
         verify: Union[str, bool, None] = None,
         api_client: Optional[APIClient] = None,
@@ -152,7 +162,6 @@ class WatsonxRerank(BaseNodePostprocessor):
                 token=token,
                 username=username,
                 password=password,
-                instance_id=instance_id,
             )
             if not isinstance(api_client, APIClient)
             else {}
@@ -169,7 +178,6 @@ class WatsonxRerank(BaseNodePostprocessor):
             token=creds.get("token"),
             password=creds.get("password"),
             username=creds.get("username"),
-            instance_id=creds.get("instance_id"),
             version=version,
             verify=verify,
             _client=api_client,
@@ -210,7 +218,6 @@ class WatsonxRerank(BaseNodePostprocessor):
             "token": self.token,
             "password": self.password,
             "username": self.username,
-            "instance_id": self.instance_id,
             "version": self.version,
         }
 

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/llama_index/postprocessor/ibm/utils.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/llama_index/postprocessor/ibm/utils.py
@@ -1,6 +1,6 @@
 import os
-import urllib.parse
 from typing import Dict, Union, Optional
+from ibm_watsonx_ai import APIClient
 
 
 from llama_index.core.base.llms.generic_utils import (
@@ -19,7 +19,6 @@ def resolve_watsonx_credentials(
     token: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
-    instance_id: Optional[str] = None,
 ) -> Dict[str, SecretStr]:
     """
     Resolve watsonx.ai credentials. If the value of given param is None
@@ -30,13 +29,11 @@ def resolve_watsonx_credentials(
     :return: Dictionary with resolved credentials items
     :rtype: Dict[str, SecretStr]
     """
-    creds = {}
-    creds["url"] = convert_to_secret_str(
-        get_from_param_or_env("url", url, "WATSONX_URL")
-    )
+    creds = {
+        "url": convert_to_secret_str(get_from_param_or_env("url", url, "WATSONX_URL"))
+    }
 
-    parsed_url = urllib.parse.urlparse(creds["url"].get_secret_value())
-    if parsed_url.netloc.endswith(".cloud.ibm.com"):
+    if creds["url"].get_secret_value() in APIClient.PLATFORM_URLS_MAP:
         if not (apikey or "WATSONX_APIKEY" in os.environ) and not (
             token or "WATSONX_TOKEN" in os.environ
         ):
@@ -94,11 +91,6 @@ def resolve_watsonx_credentials(
 
             creds["username"] = convert_to_secret_str(
                 get_from_param_or_env("username", username, "WATSONX_USERNAME")
-            )
-
-        if not instance_id or "WATSONX_INSTANCE_ID" not in os.environ:
-            creds["instance_id"] = convert_to_secret_str(
-                get_from_param_or_env("instance_id", instance_id, "WATSONX_INSTANCE_ID")
             )
 
     return creds

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/pyproject.toml
@@ -27,14 +27,14 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-ibm"
-version = "0.2.0"
+version = "0.2.1"
 description = "llama-index postprocessor IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "ibm-watsonx-ai>=1.1.16",
+    "ibm-watsonx-ai>=1.3.36",
     "pyarrow",
     "llama-index-core>=0.13.0,<0.14",
 ]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-ibm"
-version = "0.2.1"
+version = "0.3.0"
 description = "llama-index postprocessor IBM watsonx.ai integration"
 authors = [{name = "IBM"}]
 requires-python = ">=3.10,<3.13"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/tests/test_ibm.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/tests/test_ibm.py
@@ -11,24 +11,31 @@ class TestWasonxRerank:
     TEST_MODEL = "test_rerank_model"
 
     def test_initialization(self) -> None:
-        with pytest.raises(ValueError, match=r"^Did not find") as e_info:
+        with pytest.raises(ValueError, match=r"^Did not find"):
             _ = WatsonxRerank(model_id=self.TEST_MODEL, project_id=self.TEST_PROJECT_ID)
 
         # Cloud scenario
-        with pytest.raises(
-            ValueError, match=r"^Did not find 'apikey' or 'token',"
-        ) as e_info:
+        with pytest.raises(ValueError, match=r"^Did not find 'apikey' or 'token',"):
             _ = WatsonxRerank(
                 model_id=self.TEST_MODEL,
                 url=self.TEST_URL,
                 project_id=self.TEST_PROJECT_ID,
             )
 
-        # CPD scenario
-        with pytest.raises(ValueError, match=r"^Did not find instance_id") as e_info:
+        # CPD scenario with password and missing username
+        with pytest.raises(ValueError, match=r"^Did not find username"):
             _ = WatsonxRerank(
                 model_id=self.TEST_MODEL,
-                token="test-token",
-                url="test-cpd-instance",
+                password="123",
+                url="cpd-instance",
+                project_id=self.TEST_PROJECT_ID,
+            )
+
+        # CPD scenario with apikey and missing username
+        with pytest.raises(ValueError, match=r"^Did not find username"):
+            _ = WatsonxRerank(
+                model_id=self.TEST_MODEL,
+                apikey="123",
+                url="cpd-instance",
                 project_id=self.TEST_PROJECT_ID,
             )

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/uv.lock
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/uv.lock
@@ -337,6 +337,15 @@ css = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988, upload-time = "2025-08-25T18:57:30.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276, upload-time = "2025-08-25T18:57:29.684Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -941,9 +950,10 @@ sdist = { url = "https://files.pythonhosted.org/packages/41/b0/8fc26017341f62046
 
 [[package]]
 name = "ibm-watsonx-ai"
-version = "1.3.11"
+version = "1.3.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachetools" },
     { name = "certifi" },
     { name = "httpx" },
     { name = "ibm-cos-sdk" },
@@ -954,9 +964,9 @@ dependencies = [
     { name = "tabulate" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/fd/f7ff11c084ff2af39214dd79531c63b4c798b98266e58126d999ff1fdeb9/ibm_watsonx_ai-1.3.11.tar.gz", hash = "sha256:36d4bf38af6795e3113d9e58d0d47d08fe8bc55347bfe9546820a4a09064981c", size = 714156, upload-time = "2025-04-23T07:39:32.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/21/1a6161d46cdd8d7d9b7aa8a881a21c7f0feeb335c2ada33d9e63d6b8c41f/ibm_watsonx_ai-1.3.36.tar.gz", hash = "sha256:a6b3878fa73925dd3c59e0c495bdb89cd3a6ac1294800caeeb877e18dc19ce7a", size = 767322, upload-time = "2025-08-28T08:07:40.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/af/28627792e9694403b0abb1823e2f17214c3cecd63d642535a1a5d9bef028/ibm_watsonx_ai-1.3.11-py3-none-any.whl", hash = "sha256:7d6571069d241856b6fa7854a786b5f13d5e769c3bc82681594b4ee3bc1c6577", size = 1115138, upload-time = "2025-04-23T07:39:31.007Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/bc/f757224cb02dd899d7e4fcae9581dfac83a07662183bde7abb2c5e871cd8/ibm_watsonx_ai-1.3.36-py3-none-any.whl", hash = "sha256:63156858634e218e42bea1d3954d29a891303e4a2044a8c696d2b2e7c6e5e59b", size = 1183595, upload-time = "2025-08-28T08:07:38.212Z" },
 ]
 
 [[package]]
@@ -1438,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-postprocessor-ibm"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "ibm-watsonx-ai" },
@@ -1471,7 +1481,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ibm-watsonx-ai", specifier = ">=1.1.16" },
+    { name = "ibm-watsonx-ai", specifier = ">=1.3.36" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.14" },
     { name = "pyarrow" },
 ]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/uv.lock
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-ibm/uv.lock
@@ -1448,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-postprocessor-ibm"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "ibm-watsonx-ai" },


### PR DESCRIPTION
# Description

Changes:

- Support for additional/external urls like AWS etc.
- Make instance_id as deprecated parameter when initialising on CPD

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
