### PR TITLE
Refactor/shard key helpers

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-qdrant"
-version = "0.8.2"
+version = "0.8.3"
 description = "llama-index vector_stores qdrant integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<3.14"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -653,3 +653,44 @@ def test_payload_indexes_created_on_existing_collection_sync(
         missing = schema_keys - payload_keys
         extra = payload_keys - schema_keys
         assert not missing and not extra, f"Missing: {missing}, Extra: {extra}"
+
+
+@requires_qdrant_cluster
+@pytest.mark.asyncio
+async def test_arecreate_shard_keys(
+    shard_vector_store: QdrantVectorStore,
+):
+    await shard_vector_store._acreate_shard_keys()
+
+
+@requires_qdrant_cluster
+def test_recreate_shard_keys(
+    shard_vector_store: QdrantVectorStore,
+):
+    shard_vector_store._create_shard_keys()
+
+
+@pytest.mark.asyncio
+async def test_acreate_shard_keys_returns_early_when_no_shard_keys(
+    vector_store: QdrantVectorStore,
+):
+    await vector_store._acreate_shard_keys()
+
+
+def test_create_shard_keys_returns_early_when_no_shard_keys(
+    vector_store: QdrantVectorStore,
+):
+    vector_store._create_shard_keys()
+
+
+@pytest.mark.asyncio
+async def test_acreate_payload_indexes_returns_early_when_no_payload_indexes(
+    vector_store: QdrantVectorStore,
+):
+    await vector_store._acreate_payload_indexes()
+
+
+def test_create_payload_indexes_returns_early_when_no_payload_indexes(
+    vector_store: QdrantVectorStore,
+):
+    vector_store._create_payload_indexes()


### PR DESCRIPTION
This pull request refactors the creation of shard keys and payload indexes in the Qdrant vector store integration, improving code organization and test coverage. The main logic for creating shard keys (both synchronous and asynchronous) is now encapsulated in dedicated methods, and new tests have been added to ensure correct early returns and idempotency.

**Refactoring and code organization:**

* Moved shard key creation logic from inline loops in `_create_collection` and `_acreate_collection` to dedicated methods `_create_shard_keys` and `_acreate_shard_keys`, improving maintainability and reusability. [[1]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391L846-R846) [[2]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391L873-R870) [[3]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391L935-R919) [[4]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R942-R967)
* Added early return checks in `_create_shard_keys`, `_acreate_shard_keys`, `_create_payload_indexes`, and `_acreate_payload_indexes` to prevent unnecessary operations when there are no shard keys or payload indexes. [[1]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391R942-R967) [[2]](diffhunk://#diff-8a8a7e87e0f204c690b8622e399d709f025cb1007af65085ff4a4e3a7795d391L976-R999)

**Testing improvements:**

* Introduced new tests for shard key and payload index creation, including checks that the methods return early when there are no keys or indexes to create, and that re-creation is idempotent.

## Version Bump?
Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
- [x] Yes

## Type of Change
- [x] Refactor

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
