### PR TITLE
extract json from partial json string

### DIFF
--- a/llama-index-core/llama_index/core/llms/utils.py
+++ b/llama-index-core/llama_index/core/llms/utils.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional, Union, Dict
 import json
+import re
 
 if TYPE_CHECKING:
     from langchain.base_language import BaseLanguageModel  # pants: no-infer-dep
@@ -173,6 +174,12 @@ def parse_partial_json(s: str) -> Dict:
     # Close any remaining open structures in the reverse order that they were opened.
     for closing_char in reversed(stack):
         new_s += closing_char
+
+    # Extract the JSON from the string
+    json_match = re.search(r"(\{.*?\}|\[.*?\])", new_s, re.DOTALL)
+    if not json_match:
+        raise ValueError("No JSON found in the string")
+    new_s = json_match.group(0)
 
     # Attempt to parse the modified string as JSON.
     try:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The OpenRouter deepseek/deepseek-chat-v3.1 model returns tool call JSON like `{"a": 10, "b": 5}<｜tool▁call▁end｜>`. This fix extracts the correct JSON content before decoding.


Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
