### PR TITLE
fix: print proper unit "MB" when file downloading for LlamaCPP backend

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-llama-cpp/llama_index/llms/llama_cpp/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-llama-cpp/llama_index/llms/llama_cpp/base.py
@@ -242,6 +242,7 @@ class LlamaCPP(CustomLLM):
                     for chunk in tqdm(
                         r.iter_content(chunk_size=chunk_size),
                         total=int(total_size / chunk_size),
+                        unit="MB",
                     ):
                         file.write(chunk)
             completed = True


### PR DESCRIPTION
# Description

Set the unit to "MB" when file downloading for the LlamaCPP backend.

Without this change:

```
total size (MB): 7161.09
  1%|          | 46/6829 [00:01<03:30, 32.27it/s]
```

With this change:

```
total size (MB): 7161.09
 10%|█         | 684/6829 [00:21<03:11, 32.16MB/s]
```

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
