### PR TITLE
fix: make postgres regex punctuation handling consistent with plainto_tsquery

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -875,7 +875,7 @@ class PGVectorStore(BasePydanticVectorStore):
 
         # Remove special characters used by ts_query (essentially, all punctuation except single periods within words)
         # and collapse multiple spaces
-        query_str = re.sub(r"(?!\b\.\b)\W+", " " query_str).strip()
+        query_str = re.sub(r"(?!\b\.\b)\W+", " ", query_str).strip()
 
         # Replace space with "|" to perform an OR search for higher recall
         query_str = query_str.replace(" ", "|")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -873,11 +873,9 @@ class PGVectorStore(BasePydanticVectorStore):
         if query_str is None:
             raise ValueError("query_str must be specified for a sparse vector query.")
 
-        # Remove special characters used by ts_query
-        query_str = re.sub(r"[&|!:*()'<>]", " ", query_str)
-
-        # Collapse multiple spaces
-        query_str = re.sub(r"\s+", " ", query_str).strip()
+        # Remove special characters used by ts_query (essentially, all punctuation except single periods within words)
+        # and collapse multiple spaces
+        query_str = re.sub(r"(?!\b\.\b)\W+", " " query_str).strip()
 
         # Replace space with "|" to perform an OR search for higher recall
         query_str = query_str.replace(" ", "|")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -726,6 +726,7 @@ async def test_sparse_query(
     assert res.nodes[0].node_id == "ccc"
     assert res.nodes[1].node_id == "ddd"
 
+
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -737,12 +737,12 @@ async def test_sparse_query_special_character_parsing(
 ) -> None:
     q = VectorStoreQuery(
         query_embedding=_get_sample_vector(0.1),
-        query_str="   who' &..s |     (the): <-> **fox**?!!!",
+        query_str="   who' &..s |     (the): <-> **fox**?!!! lazy.hound lazy..dog ?jumped,over?",
         sparse_top_k=2,
         mode=VectorStoreQueryMode.SPARSE,
     )
     built_query = pg_hybrid._build_sparse_query(q)
-    assert built_query.compile().params["to_tsquery_1"] == "who|s|the|fox"
+    assert built_query.compile().params["to_tsquery_1"] == "who|s|the|fox|lazy.hound|lazy|dog|jump|over"
 
 
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -729,7 +729,6 @@ async def test_sparse_query(
 
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_async", [True, False])
 async def test_sparse_query_special_character_parsing(
     pg_hybrid: PGVectorStore,
     use_async: bool,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -726,6 +726,7 @@ async def test_sparse_query(
     assert res.nodes[0].node_id == "ccc"
     assert res.nodes[1].node_id == "ddd"
 
+print(postgres_not_available)
 
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
 @pytest.mark.asyncio
@@ -749,7 +750,6 @@ async def test_sparse_query_with_special_characters(
         sparse_top_k=2,
         mode=VectorStoreQueryMode.SPARSE,
     )
-
     built_query = pg_hybrid._build_sparse_query(q)
     assert built_query.compile().params["to_tsquery_1"] == "who|s|the|fox"
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -732,17 +732,16 @@ async def test_sparse_query(
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_sparse_query_special_character_parsing(
     pg_hybrid: PGVectorStore,
-    hybrid_node_embeddings: List[TextNode],
     use_async: bool,
 ) -> None:
-    q = VectorStoreQuery(
-        query_embedding=_get_sample_vector(0.1),
+    built_query = pg_hybrid._build_sparse_query(
         query_str="   who' &..s |     (the): <-> **fox**?!!! lazy.hound lazy..dog ?jumped,over?",
-        sparse_top_k=2,
-        mode=VectorStoreQueryMode.SPARSE,
+        limit=5,
     )
-    built_query = pg_hybrid._build_sparse_query(q)
-    assert built_query.compile().params["to_tsquery_1"] == "who|s|the|fox|lazy.hound|lazy|dog|jump|over"
+    assert (
+        built_query.compile().params["to_tsquery_1"]
+        == "who|s|the|fox|lazy.hound|lazy|dog|jumped|over"
+    )
 
 
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -745,10 +745,13 @@ async def test_sparse_query_with_special_characters(
     # text search should work with special characters
     q = VectorStoreQuery(
         query_embedding=_get_sample_vector(0.1),
-        query_str="   who' &..s |     (the): <-> **fox**?!!! lorem.ipsum ",
+        query_str="   who' &..s |     (the): <-> **fox**?!!!",
         sparse_top_k=2,
         mode=VectorStoreQueryMode.SPARSE,
     )
+
+    built_query = pg_hybrid._build_sparse_query(q)
+    assert built_query.compile().params["to_tsquery_1"] == "who|s|the|fox"
 
     if use_async:
         res = await pg_hybrid.aquery(q)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -743,7 +743,8 @@ async def test_sparse_query_special_character_parsing(
     )
     built_query = pg_hybrid._build_sparse_query(q)
     assert built_query.compile().params["to_tsquery_1"] == "who|s|the|fox"
-    
+
+
 @pytest.mark.skipif(postgres_not_available, reason="postgres db is not available")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -745,7 +745,7 @@ async def test_sparse_query_with_special_characters(
     # text search should work with special characters
     q = VectorStoreQuery(
         query_embedding=_get_sample_vector(0.1),
-        query_str="   who' & s |     (the): <-> **fox**?!!!  ",
+        query_str="   who' &..s |     (the): <-> **fox**?!!! lorem.ipsum ",
         sparse_top_k=2,
         mode=VectorStoreQueryMode.SPARSE,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ maintainers = [
 name = "llama-index"
 readme = "README.md"
 requires-python = ">=3.9,<4.0"
-version = "0.13.4"
+version = "0.13.5"
 
 [project.scripts]
 llamaindex-cli = "llama_index.cli.command_line:main"


### PR DESCRIPTION
# Description

This modifies the RegEx sub in the postgres sparse query method. It now handles punctuation in the exact same way that plainto_tsquery does (without incurring the double-stemming issue that would come from using that). All punctuation, except for single periods in the interior of a word, will be turned into single spaces, which are subsequently turned into OR queries.

Fixes #19783

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
