### PR TITLE
add thinking_delta field to AgentStream events to expose Ollama's reasoning (feat: [19270])

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
@@ -250,6 +250,9 @@ class CodeActAgent(BaseWorkflowAgent):
                     tool_calls=[],
                     raw=raw,
                     current_agent_name=self.name,
+                    thinking_delta=last_chat_response.additional_kwargs.get(
+                        "thinking_delta", ""
+                    ),
                 )
             )
 

--- a/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
@@ -220,11 +220,11 @@ class CodeActAgent(BaseWorkflowAgent):
                 raise ValueError("llm must be a function calling LLM to use handoff")
 
             tools = [tool for tool in tools if tool.metadata.name == "handoff"]
-            response = await self.llm.astream_chat_with_tools(
+            response = self.llm.astream_chat_with_tools(
                 tools=tools, chat_history=current_llm_input
             )
         else:
-            response = await self.llm.astream_chat(current_llm_input)
+            response = self.llm.astream_chat(current_llm_input)
 
         last_chat_response = ChatResponse(message=ChatMessage())
         full_response_text = ""

--- a/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
@@ -220,11 +220,11 @@ class CodeActAgent(BaseWorkflowAgent):
                 raise ValueError("llm must be a function calling LLM to use handoff")
 
             tools = [tool for tool in tools if tool.metadata.name == "handoff"]
-            response = self.llm.astream_chat_with_tools(
+            response = await self.llm.astream_chat_with_tools(
                 tools=tools, chat_history=current_llm_input
             )
         else:
-            response = self.llm.astream_chat(current_llm_input)
+            response = await self.llm.astream_chat(current_llm_input)
 
         last_chat_response = ChatResponse(message=ChatMessage())
         full_response_text = ""

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -88,6 +88,9 @@ class FunctionAgent(BaseWorkflowAgent):
                     tool_calls=tool_calls or [],
                     raw=raw,
                     current_agent_name=self.name,
+                    thinking_delta=last_chat_response.additional_kwargs.get(
+                        "thinking_delta", ""
+                    ),
                 )
             )
 

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -66,7 +66,7 @@ class FunctionAgent(BaseWorkflowAgent):
         ):
             chat_kwargs["tool_choice"] = self.initial_tool_choice
 
-        response = self.llm.astream_chat_with_tools(  # type: ignore
+        response = await self.llm.astream_chat_with_tools(  # type: ignore
             **chat_kwargs
         )
         # last_chat_response will be used later, after the loop.

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -66,7 +66,7 @@ class FunctionAgent(BaseWorkflowAgent):
         ):
             chat_kwargs["tool_choice"] = self.initial_tool_choice
 
-        response = await self.llm.astream_chat_with_tools(  # type: ignore
+        response = self.llm.astream_chat_with_tools(  # type: ignore
             **chat_kwargs
         )
         # last_chat_response will be used later, after the loop.

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -101,6 +101,9 @@ class ReActAgent(BaseWorkflowAgent):
                     response=last_chat_response.message.content or "",
                     raw=raw,
                     current_agent_name=self.name,
+                    thinking_delta=last_chat_response.additional_kwargs.get(
+                        "thinking_delta", ""
+                    ),
                 )
             )
 

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -82,7 +82,7 @@ class ReActAgent(BaseWorkflowAgent):
     async def _get_streaming_response(
         self, ctx: Context, current_llm_input: List[ChatMessage]
     ) -> ChatResponse:
-        response = await self.llm.astream_chat(
+        response = self.llm.astream_chat(
             current_llm_input,
         )
 

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -82,7 +82,7 @@ class ReActAgent(BaseWorkflowAgent):
     async def _get_streaming_response(
         self, ctx: Context, current_llm_input: List[ChatMessage]
     ) -> ChatResponse:
-        response = self.llm.astream_chat(
+        response = await self.llm.astream_chat(
             current_llm_input,
         )
 

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -43,6 +43,7 @@ class AgentStream(Event):
     current_agent_name: str
     tool_calls: list[ToolSelection] = Field(default_factory=list)
     raw: Optional[Any] = Field(default=None, exclude=True)
+    thinking_delta: str = Field(default="")
 
 
 class AgentStreamStructuredOutput(Event):

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -43,7 +43,7 @@ class AgentStream(Event):
     current_agent_name: str
     tool_calls: list[ToolSelection] = Field(default_factory=list)
     raw: Optional[Any] = Field(default=None, exclude=True)
-    thinking_delta: str = Field(default="")
+    thinking_delta: str = Field(default_factory=str)
 
 
 class AgentStreamStructuredOutput(Event):

--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -1,0 +1,52 @@
+from llama_index.core.agent.workflow.workflow_events import AgentStream
+
+
+def test_agent_stream_with_thinking_delta():
+    """Test AgentStream creation and serialization with thinking_delta."""
+    stream = AgentStream(
+        delta="Hello",
+        response="Hello there",
+        current_agent_name="test_agent",
+        thinking_delta="I'm thinking about this response...",
+    )
+
+    assert stream.delta == "Hello"
+    assert stream.response == "Hello there"
+    assert stream.thinking_delta == "I'm thinking about this response..."
+    assert stream.current_agent_name == "test_agent"
+
+
+def test_agent_stream_default_thinking_delta():
+    """Test AgentStream defaults thinking_delta to empty string."""
+    stream = AgentStream(
+        delta="Hello", response="Hello there", current_agent_name="test_agent"
+    )
+
+    assert stream.thinking_delta == ""
+
+
+def test_thinking_delta_extraction():
+    """Test that thinking_delta is correctly extracted from ChatResponse additional_kwargs."""
+    from llama_index.core.base.llms.types import ChatResponse, ChatMessage
+
+    # should have thinking_delta present
+    response_with_thinking = ChatResponse(
+        message=ChatMessage(role="assistant", content="Hello"),
+        delta="Hello",
+        additional_kwargs={"thinking_delta": "I'm thinking..."},
+    )
+
+    thinking_delta = response_with_thinking.additional_kwargs.get("thinking_delta", "")
+    assert thinking_delta == "I'm thinking..."
+
+    # should default to empty string
+    response_without_thinking = ChatResponse(
+        message=ChatMessage(role="assistant", content="Hello"),
+        delta="Hello",
+        additional_kwargs={},
+    )
+
+    thinking_delta = response_without_thinking.additional_kwargs.get(
+        "thinking_delta", ""
+    )
+    assert thinking_delta == ""

--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -1,4 +1,82 @@
+"""Tests for thinking_delta functionality in agents."""
+
+import pytest
+from typing import Any, AsyncGenerator, List
+from unittest.mock import AsyncMock
+
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse, LLMMetadata
+from llama_index.core.llms import MockLLM
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.core.agent.workflow.codeact_agent import CodeActAgent
+from llama_index.core.agent.workflow.react_agent import ReActAgent
 from llama_index.core.agent.workflow.workflow_events import AgentStream
+from llama_index.core.workflow import Context
+
+
+class MockThinkingLLM(MockLLM):
+    """Mock LLM that supports thinking_delta in responses."""
+
+    def __init__(
+        self, thinking_deltas: List[str] = None, response_deltas: List[str] = None
+    ):
+        super().__init__()
+        self._thinking_deltas = thinking_deltas or [
+            "",
+            "I need to think about this...",
+            " Let me consider the options.",
+        ]
+        self._response_deltas = response_deltas or ["Hello", " there", "!"]
+        self._response_index = 0
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(is_function_calling_model=True)
+
+    async def astream_chat_with_tools(
+        self, tools: List[Any], chat_history: List[ChatMessage], **kwargs: Any
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Stream chat responses with thinking_delta."""
+        for i in range(len(self._response_deltas)):
+            response_delta = self._response_deltas[i]
+            thinking_delta = self._thinking_deltas[i]
+
+            yield ChatResponse(
+                message=ChatMessage(
+                    role="assistant",
+                    content=response_delta,
+                ),
+                delta=response_delta,
+                additional_kwargs={"thinking_delta": thinking_delta},
+                raw={
+                    "message": {"content": response_delta, "thinking": thinking_delta}
+                },
+            )
+
+    async def astream_chat(
+        self, messages: List[ChatMessage], **kwargs: Any
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Stream chat responses for CodeActAgent and ReActAgent."""
+        for i in range(len(self._response_deltas)):
+            response_delta = self._response_deltas[i]
+            thinking_delta = self._thinking_deltas[i]
+
+            yield ChatResponse(
+                message=ChatMessage(
+                    role="assistant",
+                    content=response_delta,
+                ),
+                delta=response_delta,
+                additional_kwargs={"thinking_delta": thinking_delta},
+                raw={
+                    "message": {"content": response_delta, "thinking": thinking_delta}
+                },
+            )
+
+    def get_tool_calls_from_response(
+        self, response: ChatResponse, error_on_no_tool_call: bool = False
+    ):
+        """Mock method for getting tool calls from response."""
+        return []
 
 
 def test_agent_stream_with_thinking_delta():
@@ -50,3 +128,146 @@ def test_thinking_delta_extraction():
         "thinking_delta", ""
     )
     assert thinking_delta == ""
+
+
+@pytest.mark.asyncio
+async def test_function_agent_comprehensive_thinking_streaming():
+    """Comprehensive test: FunctionAgent streams thinking_delta correctly."""
+    mock_llm = MockThinkingLLM()
+    agent = FunctionAgent(llm=mock_llm, streaming=True)
+
+    # Mock context to capture stream events
+    mock_context = AsyncMock(spec=Context)
+    stream_events = []
+
+    def capture_event(event):
+        stream_events.append(event)
+
+    mock_context.write_event_to_stream.side_effect = capture_event
+
+    # Call the streaming method
+    await agent._get_streaming_response(
+        mock_context, [ChatMessage(role="user", content="test")], []
+    )
+
+    # Verify AgentStream events contain thinking_delta
+    agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
+    assert len(agent_streams) == 3  # 3 deltas from mock
+
+    # Check that thinking deltas are passed through correctly
+    assert agent_streams[0].thinking_delta == ""
+    assert agent_streams[1].thinking_delta == "I need to think about this..."
+    assert agent_streams[2].thinking_delta == " Let me consider the options."
+
+    # Verify other fields are still correct
+    assert agent_streams[0].delta == "Hello"
+    assert agent_streams[1].delta == " there"
+    assert agent_streams[2].delta == "!"
+
+
+@pytest.mark.asyncio
+async def test_codeact_agent_comprehensive_thinking_streaming():
+    """Comprehensive test: CodeActAgent streams thinking_delta correctly."""
+
+    def mock_code_execute(code: str):
+        return {"output": "executed"}
+
+    mock_llm = MockThinkingLLM()
+    agent = CodeActAgent(
+        llm=mock_llm, code_execute_fn=mock_code_execute, streaming=True
+    )
+
+    # Mock context to capture stream events
+    mock_context = AsyncMock(spec=Context)
+    stream_events = []
+
+    def capture_event(event):
+        stream_events.append(event)
+
+    mock_context.write_event_to_stream.side_effect = capture_event
+
+    # Call the streaming method
+    await agent._get_streaming_response(
+        mock_context, [ChatMessage(role="user", content="test")], []
+    )
+
+    # Verify AgentStream events contain thinking_delta
+    agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
+    assert len(agent_streams) == 3  # 3 deltas from mock
+
+    # Check that thinking deltas are passed through correctly
+    assert agent_streams[0].thinking_delta == ""
+    assert agent_streams[1].thinking_delta == "I need to think about this..."
+    assert agent_streams[2].thinking_delta == " Let me consider the options."
+
+
+@pytest.mark.asyncio
+async def test_react_agent_comprehensive_thinking_streaming():
+    """Comprehensive test: ReActAgent streams thinking_delta correctly."""
+    mock_llm = MockThinkingLLM()
+    agent = ReActAgent(llm=mock_llm, streaming=True)
+
+    # Mock context to capture stream events
+    mock_context = AsyncMock(spec=Context)
+    stream_events = []
+
+    def capture_event(event):
+        stream_events.append(event)
+
+    mock_context.write_event_to_stream.side_effect = capture_event
+
+    # Call the streaming method
+    await agent._get_streaming_response(
+        mock_context, [ChatMessage(role="user", content="test")]
+    )
+
+    # Verify AgentStream events contain thinking_delta
+    agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
+    assert len(agent_streams) == 3  # 3 deltas from mock
+
+    # Check that thinking deltas are passed through correctly
+    assert agent_streams[0].thinking_delta == ""
+    assert agent_streams[1].thinking_delta == "I need to think about this..."
+    assert agent_streams[2].thinking_delta == " Let me consider the options."
+
+
+@pytest.mark.asyncio
+async def test_agents_handle_missing_thinking_delta():
+    """Test all agents handle LLMs without thinking_delta gracefully."""
+
+    class MockNonThinkingLLM(MockLLM):
+        @property
+        def metadata(self) -> LLMMetadata:
+            return LLMMetadata(is_function_calling_model=True)
+
+        async def astream_chat_with_tools(
+            self, tools: List[Any], chat_history: List[ChatMessage], **kwargs: Any
+        ) -> AsyncGenerator[ChatResponse, None]:
+            yield ChatResponse(
+                message=ChatMessage(role="assistant", content="Hello!"),
+                delta="Hello!",
+                additional_kwargs={},  # No thinking_delta
+                raw={"message": {"content": "Hello!"}},
+            )
+
+        def get_tool_calls_from_response(
+            self, response: ChatResponse, error_on_no_tool_call: bool = False
+        ):
+            """Mock method for getting tool calls from response."""
+            return []
+
+    # Test FunctionAgent
+    mock_llm = MockNonThinkingLLM()
+    agent = FunctionAgent(llm=mock_llm, streaming=True)
+    mock_context = AsyncMock(spec=Context)
+    stream_events = []
+    mock_context.write_event_to_stream.side_effect = lambda event: stream_events.append(
+        event
+    )
+
+    await agent._get_streaming_response(
+        mock_context, [ChatMessage(role="user", content="test")], []
+    )
+    agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
+    assert len(agent_streams) == 1
+    assert agent_streams[0].thinking_delta == ""  # Should default to empty string

--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -36,41 +36,55 @@ class MockThinkingLLM(MockLLM):
         self, tools: List[Any], chat_history: List[ChatMessage], **kwargs: Any
     ) -> AsyncGenerator[ChatResponse, None]:
         """Stream chat responses with thinking_delta."""
-        for i in range(len(self._response_deltas)):
-            response_delta = self._response_deltas[i]
-            thinking_delta = self._thinking_deltas[i]
 
-            yield ChatResponse(
-                message=ChatMessage(
-                    role="assistant",
-                    content=response_delta,
-                ),
-                delta=response_delta,
-                additional_kwargs={"thinking_delta": thinking_delta},
-                raw={
-                    "message": {"content": response_delta, "thinking": thinking_delta}
-                },
-            )
+        async def _gen():
+            for i in range(len(self._response_deltas)):
+                response_delta = self._response_deltas[i]
+                thinking_delta = self._thinking_deltas[i]
+
+                yield ChatResponse(
+                    message=ChatMessage(
+                        role="assistant",
+                        content=response_delta,
+                    ),
+                    delta=response_delta,
+                    additional_kwargs={"thinking_delta": thinking_delta},
+                    raw={
+                        "message": {
+                            "content": response_delta,
+                            "thinking": thinking_delta,
+                        }
+                    },
+                )
+
+        return _gen()
 
     async def astream_chat(
         self, messages: List[ChatMessage], **kwargs: Any
     ) -> AsyncGenerator[ChatResponse, None]:
         """Stream chat responses for CodeActAgent and ReActAgent."""
-        for i in range(len(self._response_deltas)):
-            response_delta = self._response_deltas[i]
-            thinking_delta = self._thinking_deltas[i]
 
-            yield ChatResponse(
-                message=ChatMessage(
-                    role="assistant",
-                    content=response_delta,
-                ),
-                delta=response_delta,
-                additional_kwargs={"thinking_delta": thinking_delta},
-                raw={
-                    "message": {"content": response_delta, "thinking": thinking_delta}
-                },
-            )
+        async def _gen():
+            for i in range(len(self._response_deltas)):
+                response_delta = self._response_deltas[i]
+                thinking_delta = self._thinking_deltas[i]
+
+                yield ChatResponse(
+                    message=ChatMessage(
+                        role="assistant",
+                        content=response_delta,
+                    ),
+                    delta=response_delta,
+                    additional_kwargs={"thinking_delta": thinking_delta},
+                    raw={
+                        "message": {
+                            "content": response_delta,
+                            "thinking": thinking_delta,
+                        }
+                    },
+                )
+
+        return _gen()
 
     def get_tool_calls_from_response(
         self, response: ChatResponse, error_on_no_tool_call: bool = False
@@ -243,12 +257,15 @@ async def test_agents_handle_missing_thinking_delta():
         async def astream_chat_with_tools(
             self, tools: List[Any], chat_history: List[ChatMessage], **kwargs: Any
         ) -> AsyncGenerator[ChatResponse, None]:
-            yield ChatResponse(
-                message=ChatMessage(role="assistant", content="Hello!"),
-                delta="Hello!",
-                additional_kwargs={},  # No thinking_delta
-                raw={"message": {"content": "Hello!"}},
-            )
+            async def _gen():
+                yield ChatResponse(
+                    message=ChatMessage(role="assistant", content="Hello!"),
+                    delta="Hello!",
+                    additional_kwargs={},  # No thinking_delta
+                    raw={"message": {"content": "Hello!"}},
+                )
+
+            return _gen()
 
         def get_tool_calls_from_response(
             self, response: ChatResponse, error_on_no_tool_call: bool = False

--- a/llama-index-core/uv.lock
+++ b/llama-index-core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1048,7 +1048,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# Description

- Add thinking_delta field to AgentStream class with default empty string
- Update FunctionAgent, CodeActAgent, and ReActAgent to pass thinking_delta from ChatResponse
Fixes #19270

## Type of Change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
