### PR TITLE
Fix incorrect example usage of llm.stream and llm.stream_predict

### DIFF
--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -653,7 +653,7 @@ class LLM(BaseLLM):
             from llama_index.core.prompts import PromptTemplate
 
             prompt = PromptTemplate("Please write a random name related to {topic}.")
-            gen = llm.stream_predict(prompt, topic="cats")
+            gen = llm.stream(prompt, topic="cats")
             for token in gen:
                 print(token, end="", flush=True)
             ```
@@ -747,7 +747,7 @@ class LLM(BaseLLM):
             from llama_index.core.prompts import PromptTemplate
 
             prompt = PromptTemplate("Please write a random name related to {topic}.")
-            gen = await llm.astream_predict(prompt, topic="cats")
+            gen = await llm.astream(prompt, topic="cats")
             async for token in gen:
                 print(token, end="", flush=True)
             ```

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -160,7 +160,7 @@ class OpenAI(FunctionCallingLLM):
 
         llm = OpenAI(model="gpt-3.5-turbo")
 
-        stream = llm.stream("Hi, write a short story")
+        stream = llm.stream_complete("Hi, write a short story")
 
         for r in stream:
             print(r.delta, end="")


### PR DESCRIPTION
# Description

This PR corrects the method names in the code examples of both llms and llms-openai.

* In llms, examples mistakenly used `astream_predict ` where the correct method should be `stream `
* In llms-openai, examples mistakenly used `stream ` where the correct method should be `stream_complete `

These mismatches could mislead beginners or cause runtime errors if the examples are copied directly.
The updated examples now reflect the correct API usage across both modules.

## New Package?

* [ ] Yes
* [x] No

## Version Bump?

* [ ] Yes
* [x] No

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## How Has This Been Tested?

* [ ] I added new unit tests to cover this change
* [x] I believe this change is already covered by existing unit tests
* [x] Not applicable (comment-only change, no logic was modified)

## Suggested Checklist:

* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation (docstrings)
* [x] My changes generate no new warnings
* [x] New and existing unit tests pass locally with my changes
* [x] I ran `uv run make format; uv run make lint` to appease the lint gods

