### PR TITLE
fix path handling in SimpleDirectoryReader and PDFReader path fix

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -307,9 +307,41 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         )
 
     def is_empty_file(self, path: Path | PurePosixPath) -> bool:
-        if isinstance(path, PurePosixPath):
-            path = Path(path)
-        return path.is_file() and len(path.read_bytes()) == 0
+        return self.fs.isfile(str(path)) and self.fs.info(str(path)).get("size", 0) == 0
+
+    def _is_directory(self, path: Path | PurePosixPath) -> bool:
+        """
+        Check if a path is a directory, with special handling for S3 filesystems.
+
+        For S3 filesystems, directories are often represented as 0-byte objects
+        ending with '/'. This method provides more reliable directory detection
+        than fs.isdir() alone.
+        """
+        try:
+            # First try the standard isdir check
+            if self.fs.isdir(path):
+                return True
+
+            # For non-default filesystems (like S3), also check for directory placeholders
+            if not is_default_fs(self.fs):
+                try:
+                    info = self.fs.info(str(path))
+                    # Check if it's a 0-byte object ending with '/'
+                    # This is how S3 typically represents directory placeholders
+                    if (
+                        info.get("size", 0) == 0
+                        and str(path).endswith("/")
+                        and info.get("type") != "file"
+                    ):
+                        return True
+                except Exception:
+                    # If we can't get info, fall back to the original isdir check
+                    pass
+
+            return False
+        except Exception:
+            # If anything fails, assume it's not a directory to be safe
+            return False
 
     def _add_files(self, input_dir: Path | PurePosixPath) -> list[Path | PurePosixPath]:
         """Add files."""
@@ -348,13 +380,12 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
                 c += 1
                 if limit and c > limit:
                     break
-                file_refs.append(os.path.join(root, file))
+                file_refs.append(_Path(root, file))
 
-        for _ref in file_refs:
+        for ref in file_refs:
             # Manually check if file is hidden or directory instead of
             # in glob for backwards compatibility.
-            ref = _Path(_ref)
-            is_dir = self.fs.isdir(ref)
+            is_dir = self._is_directory(ref)
             skip_because_hidden = self.exclude_hidden and self.is_hidden(ref)
             skip_because_empty = self.exclude_empty and self.is_empty_file(ref)
             skip_because_bad_ext = (
@@ -475,10 +506,10 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         raise_on_error = kwargs.get("raise_on_error", self.raise_on_error)
         fs = kwargs.get("fs", self.fs)
 
-        path_func = Path if is_default_fs(fs) else PurePosixPath
+        _Path = Path if is_default_fs(fs) else PurePosixPath
 
         return SimpleDirectoryReader.load_file(
-            input_file=path_func(resource_id),
+            input_file=_Path(resource_id),
             file_metadata=file_metadata,
             file_extractor=file_extractor,
             filename_as_id=filename_as_id,
@@ -499,9 +530,10 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         errors = kwargs.get("errors", self.errors)
         raise_on_error = kwargs.get("raise_on_error", self.raise_on_error)
         fs = kwargs.get("fs", self.fs)
+        _Path = Path if is_default_fs(fs) else PurePosixPath
 
         return await SimpleDirectoryReader.aload_file(
-            input_file=Path(resource_id),
+            input_file=_Path(resource_id),
             file_metadata=file_metadata,
             file_extractor=file_extractor,
             filename_as_id=filename_as_id,

--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -365,7 +365,7 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
                     else:
                         rejected_files.add(_Path(str(file)))
 
-        file_refs: list[str] = []
+        file_refs: list[Union[Path, PurePosixPath]] = []
         limit = (
             self.num_files_limit
             if self.num_files_limit is not None and self.num_files_limit > 0

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
@@ -9,8 +9,8 @@ import io
 import logging
 import struct
 import zlib
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, List, Optional, Union
 
 from tenacity import retry, stop_after_attempt
 
@@ -39,13 +39,15 @@ class PDFReader(BaseReader):
     )
     def load_data(
         self,
-        file: Path,
+        file: Union[Path, PurePosixPath],
         extra_info: Optional[Dict] = None,
         fs: Optional[AbstractFileSystem] = None,
     ) -> List[Document]:
         """Parse file."""
-        if not isinstance(file, Path):
-            file = Path(file)
+        fs = fs or get_default_fs()
+        _Path = Path if is_default_fs(fs) else PurePosixPath
+        if not isinstance(file, (Path, PurePosixPath)):
+            file = _Path(file)
 
         try:
             import pypdf
@@ -53,7 +55,7 @@ class PDFReader(BaseReader):
             raise ImportError(
                 "pypdf is required to read PDF files: `pip install pypdf`"
             )
-        fs = fs or get_default_fs()
+
         with fs.open(str(file), "rb") as fp:
             # Load the file in memory if the filesystem is not the default one to avoid
             # issues with pypdf

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-file"
-version = "0.5.2"
+version = "0.5.3"
 description = "llama-index readers file integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
- Improves path handling in SimpleDirectoryReader by ensure we use `fs` operations and the proper `Path` function
- Fixes a bug in PDFReader when handling different operating systems and fs combinations 