### PR TITLE
docs: Fix typos in memory docs/examples

### DIFF
--- a/docs/docs/examples/memory/custom_multi_turn_memory.ipynb
+++ b/docs/docs/examples/memory/custom_multi_turn_memory.ipynb
@@ -42,7 +42,7 @@
     "## Setup\n",
     "\n",
     "To make this work, we need two things\n",
-    "1. A memory block that condenses a;; past chat messages into a single string while maintaining a token limit\n",
+    "1. A memory block that condenses all past chat messages into a single string while maintaining a token limit\n",
     "2. A `Memory` instance that uses that memory block, and has token limits configured such that multi-turn conversations are always flushed to the memory block for handling"
    ]
   },

--- a/docs/docs/module_guides/deploying/agents/memory.md
+++ b/docs/docs/module_guides/deploying/agents/memory.md
@@ -143,7 +143,7 @@ blocks = [
 Here, we've setup three memory blocks:
 
 - `core_info`: A static memory block that stores some core information about the user. The static content can either be a string or a list of `ContentBlock` objects like `TextBlock`, `ImageBlock`, etc. This information will always be inserted into the memory.
-- `extracted_info`: An extracted memory block that will extract information from the chat history. Here we've passed in the `llm` to use to extarct facts from the flushed chat history, and set the `max_facts` to 50. If the number of extracted facts exceeds this limit, the `max_facts` will be automatically summarized and reduced to leave room for new information.
+- `extracted_info`: An extracted memory block that will extract information from the chat history. Here we've passed in the `llm` to use to extract facts from the flushed chat history, and set the `max_facts` to 50. If the number of extracted facts exceeds this limit, the `max_facts` will be automatically summarized and reduced to leave room for new information.
 - `vector_memory`: A vector memory block that will store and retrieve batches of chat messages from a vector database. Each batch is a list of the flushed chat messages. Here we've passed in the `vector_store` and `embed_model` to use to store and retrieve the chat messages.
 
 You'll also notice that we've set the `priority` for each block. This is used to determine the handling when the memory blocks content (i.e. long-term memory) + short-term memory exceeds the token limit on the `Memory` object.


### PR DESCRIPTION
# Description

Small fixes for typos in the [Memory docs](https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/memory/) and ["Reducing Multi-Turn Confusion with LlamaIndex Memory" example](https://docs.llamaindex.ai/en/stable/examples/memory/custom_multi_turn_memory/).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
