### PR TITLE
feat: add support for additional kwargs in aget_text_embedding_batch method

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -492,7 +492,10 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
 
     @dispatcher.span
     async def aget_text_embedding_batch(
-        self, texts: List[str], show_progress: bool = False
+        self,
+        texts: List[str],
+        show_progress: bool = False,
+        **kwargs: Any,
     ) -> List[Embedding]:
         """Asynchronously get a list of text embeddings, with batching."""
         num_workers = self.num_workers


### PR DESCRIPTION
# Description
Fix for #19707

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
