### PR TITLE
Feat/add document block handling

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -345,6 +345,21 @@ def to_openai_message_dict(
         if isinstance(block, TextBlock):
             content.append({"type": "text", "text": block.text})
             content_txt += block.text
+        elif isinstance(block, DocumentBlock):
+            if not block.data:
+                file_buffer = block.resolve_document()
+                b64_string = block._get_b64_string(file_buffer)
+                mimetype = block._guess_mimetype()
+            else:
+                b64_string = block.data.decode("utf-8")
+                mimetype = block._guess_mimetype()
+            content.append(
+                {
+                    "type": "input_file",
+                    "filename": block.title,
+                    "file_data": f"data:{mimetype};base64,{b64_string}",
+                }
+            )
         elif isinstance(block, ImageBlock):
             if block.url:
                 content.append(
@@ -463,6 +478,7 @@ def to_openai_responses_message_dict(
                 mimetype = block._guess_mimetype()
             else:
                 b64_string = block.data.decode("utf-8")
+                mimetype = block._guess_mimetype()
             content.append(
                 {
                     "type": "input_file",

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.5.4"
+version = "0.5.5"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description
This pull request updates the handling of document blocks in OpenAI message construction and bumps the package version. The main changes improve support for document file uploads and ensure correct MIME type processing.

**Enhancements to OpenAI message construction:**

* Added support for `DocumentBlock` in `to_openai_message_dict`, allowing document files to be included as input files with proper base64 encoding and MIME type detection.
* Ensured MIME type is correctly set for document blocks in `to_openai_responses_message_dict` when decoding base64 data.

**Project version update:**

* Updated the package version in `pyproject.toml` from `0.5.4` to `0.5.5`.

Fixes [#19666](https://github.com/run-llama/llama_index/issues/19666)

## Version Bump?
Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
- [x] Yes

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
