### PR TITLE
Bump version constraint for `atlassian-python-api` to include 4.x

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 maintainers = [{name = "zywilliamli"}]
 dependencies = [
-    "atlassian-python-api>=3.41.9,<4",
+    "atlassian-python-api>=3.41.9,<5",
     "html2text>=2024.2.26,<2025",
     "pytesseract>=0.3.10,<0.4",
     "pdf2image>=1.17.0,<2",

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-confluence"
-version = "0.4.2"
+version = "0.4.3"
 description = "llama-index readers confluence integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-confluence/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1730,7 +1730,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "atlassian-python-api", specifier = ">=3.41.9,<4" },
+    { name = "atlassian-python-api", specifier = ">=3.41.9,<5" },
     { name = "docx2txt", specifier = ">=0.8,<0.9" },
     { name = "html2text", specifier = ">=2024.2.26,<2025" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },


### PR DESCRIPTION
# Description

Widens the version constraint for the `atlassian-python-api` dependency to allow the 4.x.x series to be installed. This allows projects that consume both this Confluence reader and `atlassian-python-api` (directly or via other libraries) to upgrade to recent versions of Atlassian's package.

The only relevant breaking change from 3.x to 4.0 was dropping support for Python 2, which `llama_index` already doesn't support (so this is not a breaking change).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
