### PR TITLE
feat: Add optional creds argument to GoogleCalendarToolSpec

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-google/CLAUDE.md
+++ b/llama-index-integrations/tools/llama-index-tools-google/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a LlamaIndex tools integration package (`llama-index-tools-google`) that provides Google services integration for LlamaIndex agents. It includes three main tool specifications:
+
+1. **GoogleSearchToolSpec** - Custom Google search functionality using Google Custom Search API
+2. **GmailToolSpec** - Gmail email reading, searching, drafting, and sending capabilities
+3. **GoogleCalendarToolSpec** - Google Calendar event reading and creation
+
+## Development Commands
+
+### Testing
+
+```bash
+make test              # Run all tests via pytest
+pytest tests          # Direct pytest invocation
+```
+
+### Linting and Formatting
+
+```bash
+make lint             # Run pre-commit hooks (black, ruff, codespell) and mypy
+make format           # Run black autoformatter only
+```
+
+### Documentation
+
+```bash
+make watch-docs       # Build and watch documentation with sphinx-autobuild
+```
+
+## Code Architecture
+
+### Tool Specifications Structure
+
+Each Google service is implemented as a separate tool spec inheriting from `BaseToolSpec`:
+
+- **Base classes**: All tools extend `llama_index.core.tools.tool_spec.base.BaseToolSpec`
+- **Authentication**: Gmail and Calendar tools use OAuth 2.0 with local credential files (`credentials.json` and `token.json`)
+- **Search tool**: Uses API key authentication with Google Custom Search API
+
+### Key Components
+
+#### GmailToolSpec (`llama_index/tools/google/gmail/base.py`)
+
+- **Functions**: `load_data`, `search_messages`, `create_draft`, `update_draft`, `get_draft`, `send_draft`
+- **Authentication**: OAuth 2.0 with Gmail API scopes for compose and readonly access
+- **Message parsing**: Supports both HTML (BeautifulSoup) and iterative plain text extraction
+
+#### GoogleCalendarToolSpec (`llama_index/tools/google/calendar/base.py`)
+
+- **Functions**: `load_data`, `create_event`, `get_date`
+- **Authentication**: OAuth 2.0 with Calendar API scope
+- **Event handling**: Loads upcoming events and creates new calendar events with attendees
+
+#### GoogleSearchToolSpec (`llama_index/tools/google/search/base.py`)
+
+- **Functions**: `google_search`, `agoogle_search` (async version)
+- **Authentication**: API key based
+- **Configuration**: Requires custom search engine ID and supports result count limits (1-10)
+
+### Authentication Requirements
+
+- **Gmail/Calendar**: Requires `credentials.json` OAuth client file in project root
+- **Search**: Requires Google Custom Search API key and custom search engine ID
+- **Token storage**: OAuth tokens automatically saved to `token.json`
+
+## Development Notes
+
+- Uses `hatchling` as build backend
+- Python 3.9+ required
+- Pre-commit hooks configured for black, ruff, codespell, and mypy
+- Tests located in `tests/` directory
+- Examples provided in Jupyter notebooks under `examples/`
+
+## Known Issues
+
+- Calendar tool may fail to create events if timezone cannot be inferred by the agent
+- OAuth authentication requires manual approval each time tools are invoked

--- a/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/calendar/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/calendar/base.py
@@ -35,6 +35,17 @@ class GoogleCalendarToolSpec(BaseToolSpec):
 
     spec_functions = ["load_data", "create_event", "get_date"]
 
+    def __init__(self, creds: Optional[Any] = None):
+        """
+        Initialize the GoogleCalendarToolSpec.
+
+        Args:
+            creds (Optional[Any]): Pre-configured credentials to use for authentication.
+                                 If provided, these will be used instead of the OAuth flow.
+
+        """
+        self.creds = creds
+
     def load_data(
         self,
         number_of_results: Optional[int] = 100,
@@ -119,6 +130,9 @@ class GoogleCalendarToolSpec(BaseToolSpec):
             Credentials, the obtained credential.
 
         """
+        if self.creds is not None:
+            return self.creds
+
         from google_auth_oauthlib.flow import InstalledAppFlow
 
         from google.auth.transport.requests import Request

--- a/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-google"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index tools google integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-google/tests/test_tools_google.py
+++ b/llama-index-integrations/tools/llama-index-tools-google/tests/test_tools_google.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock, patch
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.tools.google import (
     GmailToolSpec,
@@ -15,3 +16,45 @@ def test_class():
 
     names_of_base_classes = [b.__name__ for b in GoogleSearchToolSpec.__mro__]
     assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_google_calendar_tool_spec_init_without_creds():
+    """Test GoogleCalendarToolSpec initialization without credentials."""
+    tool = GoogleCalendarToolSpec()
+    assert tool.creds is None
+
+
+def test_google_calendar_tool_spec_init_with_creds():
+    """Test GoogleCalendarToolSpec initialization with credentials."""
+    mock_creds = Mock()
+    tool = GoogleCalendarToolSpec(creds=mock_creds)
+    assert tool.creds is mock_creds
+
+
+def test_google_calendar_tool_spec_get_credentials_with_provided_creds():
+    """Test _get_credentials returns provided credentials when available."""
+    mock_creds = Mock()
+    tool = GoogleCalendarToolSpec(creds=mock_creds)
+
+    credentials = tool._get_credentials()
+    assert credentials is mock_creds
+
+
+@patch("os.path.exists")
+@patch("google.oauth2.credentials.Credentials.from_authorized_user_file")
+def test_google_calendar_tool_spec_get_credentials_oauth_flow(
+    mock_from_file, mock_exists
+):
+    """Test _get_credentials falls back to OAuth flow when no creds provided."""
+    mock_exists.return_value = True
+    mock_creds = Mock()
+    mock_creds.valid = True
+    mock_from_file.return_value = mock_creds
+
+    tool = GoogleCalendarToolSpec()  # No creds provided
+
+    credentials = tool._get_credentials()
+    assert credentials is mock_creds
+    mock_from_file.assert_called_once_with(
+        "token.json", ["https://www.googleapis.com/auth/calendar"]
+    )


### PR DESCRIPTION
# Description

  Added optional `creds` parameter to `GoogleCalendarToolSpec` constructor to allow dynamic credential configuration. This enables creating the tool with pre-populated credentials
   instead of relying solely on OAuth flow, making it production-ready for scenarios where credentials are managed externally.

  ## Version Bump?

  - [x] Yes - bumped from 0.6.1 to 0.6.2
  - [ ] No

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

  ## How Has This Been Tested?

  - [x] I added new unit tests to cover this change
  - [ ] I believe this change is already covered by existing unit tests

  ## Suggested Checklist:

  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added Google Colab support for the newly added notebooks
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I ran `uv run make format; uv run make lint` to appease the lint gods