### PR TITLE
Bug fix agent streaming thinking delta pydantic validation

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
@@ -251,7 +251,7 @@ class CodeActAgent(BaseWorkflowAgent):
                     raw=raw,
                     current_agent_name=self.name,
                     thinking_delta=last_chat_response.additional_kwargs.get(
-                        "thinking_delta", ""
+                        "thinking_delta", None
                     ),
                 )
             )

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -89,7 +89,7 @@ class FunctionAgent(BaseWorkflowAgent):
                     raw=raw,
                     current_agent_name=self.name,
                     thinking_delta=last_chat_response.additional_kwargs.get(
-                        "thinking_delta", ""
+                        "thinking_delta", None
                     ),
                 )
             )

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -102,7 +102,7 @@ class ReActAgent(BaseWorkflowAgent):
                     raw=raw,
                     current_agent_name=self.name,
                     thinking_delta=last_chat_response.additional_kwargs.get(
-                        "thinking_delta", ""
+                        "thinking_delta", None
                     ),
                 )
             )

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -43,7 +43,7 @@ class AgentStream(Event):
     current_agent_name: str
     tool_calls: list[ToolSelection] = Field(default_factory=list)
     raw: Optional[Any] = Field(default=None, exclude=True)
-    thinking_delta: str = Field(default_factory=str)
+    thinking_delta: Optional[str] = Field(default_factory=str)
 
 
 class AgentStreamStructuredOutput(Event):

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -43,7 +43,7 @@ class AgentStream(Event):
     current_agent_name: str
     tool_calls: list[ToolSelection] = Field(default_factory=list)
     raw: Optional[Any] = Field(default=None, exclude=True)
-    thinking_delta: Optional[str] = Field(default_factory=str)
+    thinking_delta: Optional[str] = Field(default=None)
 
 
 class AgentStreamStructuredOutput(Event):

--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -154,7 +154,7 @@ def test_thinking_delta_extraction():
 
 @pytest.mark.asyncio
 async def test_streaming_an_agent_with_thinking_delta_none():
-    """Comprehensive test: FunctionAgent streams thinking_delta correctly."""
+    """Test an agent runs properly with thinking_delta value of None"""
     mock_llm = MockThinkingLLM(thinking_deltas=[None], response_deltas=[None])
     agent = FunctionAgent(llm=mock_llm, streaming=True)
 

--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -109,7 +109,7 @@ def test_agent_stream_with_thinking_delta():
 
 def test_agent_stream_default_thinking_delta():
     """Test AgentStream with thinking_delta value of None does not cause Pydantic validation error.  
-    For Ollama, thinking_delta comes from the message's thinking which can be None.
+    For Ollama, thinking_delta comes from the message's thinking field, which can be None.
     """
     stream = AgentStream(
         delta="Hello", response="Hello there", current_agent_name="test_agent", thinking_delta=None

--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -107,15 +107,21 @@ def test_agent_stream_with_thinking_delta():
     assert stream.thinking_delta == "I'm thinking about this response..."
     assert stream.current_agent_name == "test_agent"
 
+
 def test_agent_stream_default_thinking_delta_none():
-    """Test AgentStream with thinking_delta value of None does not cause Pydantic validation error.  
+    """
+    Test AgentStream with thinking_delta value of None does not cause Pydantic validation error.
     For Ollama, thinking_delta comes from the message's thinking field, which can be None.
     """
     stream = AgentStream(
-        delta="Hello", response="Hello there", current_agent_name="test_agent", thinking_delta=None
+        delta="Hello",
+        response="Hello there",
+        current_agent_name="test_agent",
+        thinking_delta=None,
     )
 
-    assert stream.thinking_delta == None
+    assert stream.thinking_delta is None
+
 
 def test_agent_stream_default_thinking_delta():
     """Test AgentStream defaults thinking_delta to None."""
@@ -123,7 +129,7 @@ def test_agent_stream_default_thinking_delta():
         delta="Hello", response="Hello there", current_agent_name="test_agent"
     )
 
-    assert stream.thinking_delta == None
+    assert stream.thinking_delta is None
 
 
 def test_thinking_delta_extraction():
@@ -150,7 +156,8 @@ def test_thinking_delta_extraction():
     thinking_delta = response_without_thinking.additional_kwargs.get(
         "thinking_delta", None
     )
-    assert thinking_delta == None
+    assert thinking_delta is None
+
 
 @pytest.mark.asyncio
 async def test_streaming_an_agent_with_thinking_delta_none():
@@ -177,7 +184,8 @@ async def test_streaming_an_agent_with_thinking_delta_none():
     assert len(agent_streams) == 1  # 1 deltas from mock
 
     # Check that thinking deltas are passed through correctly
-    assert agent_streams[0].thinking_delta == None
+    assert agent_streams[0].thinking_delta is None
+
 
 @pytest.mark.asyncio
 async def test_function_agent_comprehensive_thinking_streaming():
@@ -322,4 +330,4 @@ async def test_agents_handle_missing_thinking_delta():
     )
     agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
     assert len(agent_streams) == 1
-    assert agent_streams[0].thinking_delta == None  # Should default to None
+    assert agent_streams[0].thinking_delta is None  # Should default to None

--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -107,7 +107,7 @@ def test_agent_stream_with_thinking_delta():
     assert stream.thinking_delta == "I'm thinking about this response..."
     assert stream.current_agent_name == "test_agent"
 
-def test_agent_stream_default_thinking_delta():
+def test_agent_stream_default_thinking_delta_none():
     """Test AgentStream with thinking_delta value of None does not cause Pydantic validation error.  
     For Ollama, thinking_delta comes from the message's thinking field, which can be None.
     """
@@ -118,12 +118,12 @@ def test_agent_stream_default_thinking_delta():
     assert stream.thinking_delta == None
 
 def test_agent_stream_default_thinking_delta():
-    """Test AgentStream defaults thinking_delta to empty string."""
+    """Test AgentStream defaults thinking_delta to None."""
     stream = AgentStream(
         delta="Hello", response="Hello there", current_agent_name="test_agent"
     )
 
-    assert stream.thinking_delta == ""
+    assert stream.thinking_delta == None
 
 
 def test_thinking_delta_extraction():
@@ -140,7 +140,7 @@ def test_thinking_delta_extraction():
     thinking_delta = response_with_thinking.additional_kwargs.get("thinking_delta", "")
     assert thinking_delta == "I'm thinking..."
 
-    # should default to empty string
+    # should default to None
     response_without_thinking = ChatResponse(
         message=ChatMessage(role="assistant", content="Hello"),
         delta="Hello",
@@ -148,9 +148,9 @@ def test_thinking_delta_extraction():
     )
 
     thinking_delta = response_without_thinking.additional_kwargs.get(
-        "thinking_delta", ""
+        "thinking_delta", None
     )
-    assert thinking_delta == ""
+    assert thinking_delta == None
 
 @pytest.mark.asyncio
 async def test_streaming_an_agent_with_thinking_delta_none():
@@ -322,4 +322,4 @@ async def test_agents_handle_missing_thinking_delta():
     )
     agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
     assert len(agent_streams) == 1
-    assert agent_streams[0].thinking_delta == ""  # Should default to empty string
+    assert agent_streams[0].thinking_delta == None  # Should default to None


### PR DESCRIPTION
# Description
- Fixes the following pyandantic validation error when using Ollama with an Agent with Streaming (#19785)
```
Exception has occurred: WorkflowRuntimeError
Error in step 'run_agent_step': 1 validation error for AgentStream
thinking_delta
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
