### PR TITLE
fix: extract thinking stream from gpt-oss raw response

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -380,7 +380,6 @@ class IngestionPipeline(BaseModel):
     def _handle_duplicates(
         self,
         nodes: Sequence[BaseNode],
-        store_doc_text: bool = True,
     ) -> Sequence[BaseNode]:
         """Handle docstore duplicates by checking all hashes."""
         assert self.docstore is not None
@@ -394,14 +393,11 @@ class IngestionPipeline(BaseModel):
                 nodes_to_run.append(node)
                 current_hashes.append(node.hash)
 
-        self.docstore.add_documents(nodes_to_run, store_text=store_doc_text)
-
         return nodes_to_run
 
     def _handle_upserts(
         self,
         nodes: Sequence[BaseNode],
-        store_doc_text: bool = True,
     ) -> Sequence[BaseNode]:
         """Handle docstore upserts by checking hashes and ids."""
         assert self.docstore is not None
@@ -437,11 +433,7 @@ class IngestionPipeline(BaseModel):
                 if self.vector_store is not None:
                     self.vector_store.delete(ref_doc_id)
 
-        nodes_to_run = list(deduped_nodes_to_run.values())
-        self.docstore.set_document_hashes({n.id_: n.hash for n in nodes_to_run})
-        self.docstore.add_documents(nodes_to_run, store_text=store_doc_text)
-
-        return nodes_to_run
+        return list(deduped_nodes_to_run.values())
 
     @staticmethod
     def _node_batcher(
@@ -451,6 +443,23 @@ class IngestionPipeline(BaseModel):
         batch_size = max(1, int(len(nodes) / num_batches))
         for i in range(0, len(nodes), batch_size):
             yield nodes[i : i + batch_size]
+
+    def _update_docstore(
+        self, nodes: Sequence[BaseNode], store_doc_text: bool = True
+    ) -> None:
+        """Update the document store with the given nodes."""
+        assert self.docstore is not None
+
+        if self.docstore_strategy in (
+            DocstoreStrategy.UPSERTS,
+            DocstoreStrategy.UPSERTS_AND_DELETE,
+        ):
+            self.docstore.set_document_hashes({n.id_: n.hash for n in nodes})
+            self.docstore.add_documents(nodes, store_text=store_doc_text)
+        elif self.docstore_strategy == DocstoreStrategy.DUPLICATES_ONLY:
+            self.docstore.add_documents(nodes, store_text=store_doc_text)
+        else:
+            raise ValueError(f"Invalid docstore strategy: {self.docstore_strategy}")
 
     @dispatcher.span
     def run(
@@ -493,13 +502,9 @@ class IngestionPipeline(BaseModel):
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = self._handle_upserts(
-                    input_nodes, store_doc_text=store_doc_text
-                )
+                nodes_to_run = self._handle_upserts(input_nodes)
             elif self.docstore_strategy == DocstoreStrategy.DUPLICATES_ONLY:
-                nodes_to_run = self._handle_duplicates(
-                    input_nodes, store_doc_text=store_doc_text
-                )
+                nodes_to_run = self._handle_duplicates(input_nodes)
             else:
                 raise ValueError(f"Invalid docstore strategy: {self.docstore_strategy}")
         elif self.docstore is not None and self.vector_store is None:
@@ -515,10 +520,7 @@ class IngestionPipeline(BaseModel):
                     "Switching to duplicates_only strategy."
                 )
                 self.docstore_strategy = DocstoreStrategy.DUPLICATES_ONLY
-            nodes_to_run = self._handle_duplicates(
-                input_nodes, store_doc_text=store_doc_text
-            )
-
+            nodes_to_run = self._handle_duplicates(input_nodes)
         else:
             nodes_to_run = input_nodes
 
@@ -563,6 +565,9 @@ class IngestionPipeline(BaseModel):
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]
             if nodes_with_embeddings:
                 self.vector_store.add(nodes_with_embeddings)
+
+        if self.docstore is not None:
+            self._update_docstore(nodes_to_run, store_doc_text=store_doc_text)
 
         return nodes
 

--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -308,7 +308,7 @@ class Ollama(FunctionCallingLLM):
         error_on_no_tool_call: bool = True,
     ) -> List[ToolSelection]:
         """Predict and call the tool."""
-        tool_calls = response.message.additional_kwargs.get("tool_calls", [])
+        tool_calls = response.message.additional_kwargs.get("tool_calls", []) or []
         if len(tool_calls) < 1:
             if error_on_no_tool_call:
                 raise ValueError(
@@ -353,7 +353,7 @@ class Ollama(FunctionCallingLLM):
 
         response = dict(response)
 
-        tool_calls = response["message"].get("tool_calls", [])
+        tool_calls = response["message"].get("tool_calls", []) or []
         thinking = response["message"].get("thinking", None)
         token_counts = self._get_response_token_counts(response)
         if token_counts:
@@ -535,7 +535,7 @@ class Ollama(FunctionCallingLLM):
 
         response = dict(response)
 
-        tool_calls = response["message"].get("tool_calls", [])
+        tool_calls = response["message"].get("tool_calls", []) or []
         thinking = response["message"].get("thinking", None)
         token_counts = self._get_response_token_counts(response)
         if token_counts:

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-ollama"
-version = "0.7.2"
+version = "0.7.3"
 description = "llama-index llms ollama integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -208,3 +208,51 @@ async def test_async_chat_with_think() -> None:
     think = response.message.additional_kwargs.get("thinking", None)
     assert think is not None
     assert str(think).strip() != ""
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+def test_chat_with_tools_returns_empty_array_if_no_tools_were_called() -> None:
+    """Make sure get_tool_calls_from_response can gracefully handle no tools in response"""
+    llm = Ollama(model=test_model, context_window=1000)
+    response = llm.chat(
+        tools=[],
+        messages=[
+            ChatMessage(
+                role="system",
+                content="You are a useful tool calling agent.",
+            ),
+            ChatMessage(role="user", content="Hello, how are you?"),
+        ],
+    )
+
+    assert response.message.additional_kwargs.get("tool_calls", []) == []
+
+    tool_calls = llm.get_tool_calls_from_response(response, error_on_no_tool_call=False)
+    assert len(tool_calls) == 0
+
+
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+@pytest.mark.asyncio
+async def test_async_chat_with_tools_returns_empty_array_if_no_tools_were_called() -> (
+    None
+):
+    """
+    Test that achat returns [] for no tool calls since subsequent processes expect []
+    instead of None
+    """
+    llm = Ollama(model=test_model, context_window=1000)
+    response = await llm.achat(
+        tools=[],
+        messages=[
+            ChatMessage(
+                role="system",
+                content="You are a useful tool calling agent.",
+            ),
+            ChatMessage(role="user", content="Hello, how are you?"),
+        ],
+    )
+    assert response.message.additional_kwargs.get("tool_calls", []) == []

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/__init__.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/__init__.py
@@ -1,3 +1,4 @@
 from llama_index.llms.openai_like.base import OpenAILike
+from llama_index.llms.openai_like.gpt_oss import GptOss
 
-__all__ = ["OpenAILike"]
+__all__ = ["OpenAILike", "GptOss"]

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/gpt_oss.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/gpt_oss.py
@@ -1,0 +1,22 @@
+from typing import Any, AsyncGenerator, List
+from llama_index.llms.openai_like.base import OpenAILike
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse
+
+
+class GptOss(OpenAILike):
+    """OpenAI-like LLM for gpt-oss models with thinking stream support."""
+
+    async def astream_chat(
+        self, messages: List[ChatMessage], **kwargs: Any
+    ) -> AsyncGenerator[ChatResponse, None]:
+        async for response in await super().astream_chat(messages, **kwargs):
+            # Extract thinking stream from gpt-oss raw format
+            if (
+                hasattr(response.raw, "choices")
+                and len(response.raw.choices) > 0
+                and hasattr(response.raw.choices[0].delta, "reasoning")
+            ):
+                response.additional_kwargs["thinking_delta"] = response.raw.choices[
+                    0
+                ].delta.reasoning
+            yield response

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_gpt_oss.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_gpt_oss.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse
+from llama_index.llms.openai_like.gpt_oss import GptOss
+
+# Define the path to the parent class method we want to mock.
+SUPER_ASTREAM_CHAT_PATH = "llama_index.llms.openai_like.base.OpenAILike.astream_chat"
+
+
+# Helper function to create an async generator from a list
+async def list_to_async_generator(items):
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_extracts_thinking_delta(mocker):
+    """Test extraction of thinking_delta from the reasoning field."""
+    # Arrange
+    llm = GptOss(model="test", api_key="fake")
+    mock_choice = MagicMock()
+    mock_choice.delta.reasoning = "test reasoning"
+    response_chunk = ChatResponse(
+        message=ChatMessage(role="assistant", content="response"),
+        delta="delta",
+        raw=MagicMock(choices=[mock_choice]),
+    )
+
+    # This mock setup is CORRECT. It simulates a method that must be awaited.
+    mock_parent_stream = AsyncMock(
+        return_value=list_to_async_generator([response_chunk])
+    )
+    mocker.patch(SUPER_ASTREAM_CHAT_PATH, mock_parent_stream)
+
+    # Act
+    # The fix is here: llm.astream_chat() returns an async generator directly.
+    # We iterate over it, we don't await it.
+    results = [
+        chunk
+        async for chunk in llm.astream_chat([ChatMessage(role="user", content="test")])
+    ]
+
+    # Assert
+    assert len(results) == 1
+    assert results[0].additional_kwargs["thinking_delta"] == "test reasoning"
+    mock_parent_stream.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_reasoning_field(mocker):
+    """Test when the reasoning field doesn't exist."""
+    # Arrange
+    llm = GptOss(model="test", api_key="fake")
+    mock_choice = MagicMock()
+    mock_choice.delta = MagicMock(spec=["content"])
+    mock_choice.delta.content = "some content"
+    response_chunk = ChatResponse(
+        message=ChatMessage(role="assistant", content="response"),
+        delta="delta",
+        raw=MagicMock(choices=[mock_choice]),
+        additional_kwargs={"existing": "data"},
+    )
+
+    mock_parent_stream = AsyncMock(
+        return_value=list_to_async_generator([response_chunk])
+    )
+    mocker.patch(SUPER_ASTREAM_CHAT_PATH, mock_parent_stream)
+
+    # Act
+    results = [
+        chunk
+        async for chunk in llm.astream_chat([ChatMessage(role="user", content="test")])
+    ]
+
+    # Assert
+    assert len(results) == 1
+    assert "thinking_delta" not in results[0].additional_kwargs
+    assert results[0].additional_kwargs == {"existing": "data"}
+    mock_parent_stream.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_empty_choices(mocker):
+    """Test when the 'choices' array in the raw response is empty."""
+    # Arrange
+    llm = GptOss(model="test", api_key="fake")
+    response_chunk = ChatResponse(
+        message=ChatMessage(role="assistant", content="response"),
+        delta="delta",
+        raw=MagicMock(choices=[]),
+        additional_kwargs={},
+    )
+
+    mock_parent_stream = AsyncMock(
+        return_value=list_to_async_generator([response_chunk])
+    )
+    mocker.patch(SUPER_ASTREAM_CHAT_PATH, mock_parent_stream)
+
+    # Act
+    results = [
+        chunk
+        async for chunk in llm.astream_chat([ChatMessage(role="user", content="test")])
+    ]
+
+    # Assert
+    assert len(results) == 1
+    assert "thinking_delta" not in results[0].additional_kwargs
+    mock_parent_stream.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_choices_attribute(mocker):
+    """Test when the raw response object has no 'choices' attribute."""
+    # Arrange
+    llm = GptOss(model="test", api_key="fake")
+    raw_mock = MagicMock(spec=[])
+    response_chunk = ChatResponse(
+        message=ChatMessage(role="assistant", content="response"),
+        delta="delta",
+        raw=raw_mock,
+        additional_kwargs={},
+    )
+
+    mock_parent_stream = AsyncMock(
+        return_value=list_to_async_generator([response_chunk])
+    )
+    mocker.patch(SUPER_ASTREAM_CHAT_PATH, mock_parent_stream)
+
+    # Act
+    results = [
+        chunk
+        async for chunk in llm.astream_chat([ChatMessage(role="user", content="test")])
+    ]
+
+    # Assert
+    assert len(results) == 1
+    assert "thinking_delta" not in results[0].additional_kwargs
+    mock_parent_stream.assert_awaited_once()

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/github_client.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/github_client.py
@@ -50,7 +50,7 @@ class GitTreeResponseModel(DataClassJsonMixin):
         mode: str
         type: str
         sha: str
-        url: str
+        url: Optional[str] = None
         size: Optional[int] = None
 
     sha: str

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-github"
-version = "0.8.1"
+version = "0.8.2"
 description = "llama-index readers github integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/calendar/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-google/llama_index/tools/google/calendar/base.py
@@ -35,6 +35,17 @@ class GoogleCalendarToolSpec(BaseToolSpec):
 
     spec_functions = ["load_data", "create_event", "get_date"]
 
+    def __init__(self, creds: Optional[Any] = None):
+        """
+        Initialize the GoogleCalendarToolSpec.
+
+        Args:
+            creds (Optional[Any]): Pre-configured credentials to use for authentication.
+                                 If provided, these will be used instead of the OAuth flow.
+
+        """
+        self.creds = creds
+
     def load_data(
         self,
         number_of_results: Optional[int] = 100,
@@ -119,6 +130,9 @@ class GoogleCalendarToolSpec(BaseToolSpec):
             Credentials, the obtained credential.
 
         """
+        if self.creds is not None:
+            return self.creds
+
         from google_auth_oauthlib.flow import InstalledAppFlow
 
         from google.auth.transport.requests import Request

--- a/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-google/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-google"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index tools google integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-google/tests/test_tools_google.py
+++ b/llama-index-integrations/tools/llama-index-tools-google/tests/test_tools_google.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock, patch
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.tools.google import (
     GmailToolSpec,
@@ -15,3 +16,45 @@ def test_class():
 
     names_of_base_classes = [b.__name__ for b in GoogleSearchToolSpec.__mro__]
     assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_google_calendar_tool_spec_init_without_creds():
+    """Test GoogleCalendarToolSpec initialization without credentials."""
+    tool = GoogleCalendarToolSpec()
+    assert tool.creds is None
+
+
+def test_google_calendar_tool_spec_init_with_creds():
+    """Test GoogleCalendarToolSpec initialization with credentials."""
+    mock_creds = Mock()
+    tool = GoogleCalendarToolSpec(creds=mock_creds)
+    assert tool.creds is mock_creds
+
+
+def test_google_calendar_tool_spec_get_credentials_with_provided_creds():
+    """Test _get_credentials returns provided credentials when available."""
+    mock_creds = Mock()
+    tool = GoogleCalendarToolSpec(creds=mock_creds)
+
+    credentials = tool._get_credentials()
+    assert credentials is mock_creds
+
+
+@patch("os.path.exists")
+@patch("google.oauth2.credentials.Credentials.from_authorized_user_file")
+def test_google_calendar_tool_spec_get_credentials_oauth_flow(
+    mock_from_file, mock_exists
+):
+    """Test _get_credentials falls back to OAuth flow when no creds provided."""
+    mock_exists.return_value = True
+    mock_creds = Mock()
+    mock_creds.valid = True
+    mock_from_file.return_value = mock_creds
+
+    tool = GoogleCalendarToolSpec()  # No creds provided
+
+    credentials = tool._get_credentials()
+    assert credentials is mock_creds
+    mock_from_file.assert_called_once_with(
+        "token.json", ["https://www.googleapis.com/auth/calendar"]
+    )


### PR DESCRIPTION
# Description
This fix moves gpt-oss thinking stream logic to LLM level as recommended by maintainer. Creates GptOss LLM class that extracts reasoning from raw.choices[0].delta.reasoning and places it in additional_kwargs['thinking_delta'] where agents expect it. Reverts function_agent.py to simple approach.

Addresses maintainer feedback in #19857

## Changes
- Create GptOss LLM class to handle gpt-oss thinking stream extraction
- Revert function_agent.py to simple additional_kwargs approach  
- Add comprehensive tests for GptOss
- Remove gpt-oss specific logic from agent tests
- Maintains backward compatibility

## New Package?
- [x] No

## Version Bump?  
- [x] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods