### PR TITLE
[Bug]: RichPromptTemplate example error #19850

### DIFF
--- a/llama-index-core/README.md
+++ b/llama-index-core/README.md
@@ -8,3 +8,9 @@ Storage, Callables and several others.
 We've designed the core library so that it can be easily extended through subclasses.
 Building LLM applications with LlamaIndex thus involves building with LlamaIndex
 core as well as with the LlamaIndex [integrations](https://github.com/run-llama/llama_index/tree/main/llama-index-integrations) needed for your application.
+
+## RichPromptTemplate images (| image)
+
+- Accepts http/https URLs and local filesystem paths.
+- http/https inputs are mapped to ImageBlock.url.
+- Local paths are embedded as bytes (ImageBlock.image) so no network fetch is attempted. Windows paths like C:\... are supported.

--- a/llama-index-core/llama_index/core/prompts/rich.py
+++ b/llama-index-core/llama_index/core/prompts/rich.py
@@ -106,7 +106,9 @@ class RichPromptTemplate(BasePromptTemplate):  # type: ignore[no-redef]
                     if bank_block.type == BanksContentBlockType.text:
                         llama_blocks.append(TextBlock(text=bank_block.text))
                     elif bank_block.type == BanksContentBlockType.image_url:
-                        llama_blocks.append(self.make_image_block(bank_block.image_url.url))
+                        llama_blocks.append(
+                            self.make_image_block(bank_block.image_url.url)
+                        )
                     elif bank_block.type == BanksContentBlockType.audio:
                         llama_blocks.append(
                             AudioBlock(audio=bank_block.input_audio.data)

--- a/llama-index-core/tests/prompts/test_rich_image.py
+++ b/llama-index-core/tests/prompts/test_rich_image.py
@@ -1,0 +1,51 @@
+import pathlib
+from PIL import Image
+from llama_index.core.base.llms.types import ImageBlock, ChatMessage
+from llama_index.core.prompts import RichPromptTemplate
+
+def _create_temp_jpeg(path: pathlib.Path) -> None:
+    img = Image.new("RGB", (8, 8), (255, 0, 0))
+    img.save(path, format="JPEG")
+
+def _get_image_block(messages: list[ChatMessage]) -> ImageBlock:
+    for b in messages[0].blocks:
+        if getattr(b, "block_type", "") == "image":
+            return b
+    raise AssertionError("No ImageBlock found in messages")
+
+def test_local_path_image_in_bytes(tmp_path: pathlib.Path) -> None:
+    img_path = tmp_path / "sample.jpg"
+    _create_temp_jpeg(img_path)
+
+    prompt = RichPromptTemplate(
+        """
+        {% chat role='user' %}
+        Describe the following image: {{ image_path | image }}
+        {% endchat %}
+        """
+    )
+
+    messages = prompt.format_messages(image_path=str(img_path))
+    block: ImageBlock = _get_image_block(messages)
+
+    assert block.image is not None
+    assert block.url is None
+    assert block.path is None
+
+def test_http_url() -> None:
+    http_url = "https://example.com/img.png"
+    prompt = RichPromptTemplate(
+        """
+        {% chat role='user' %}
+        Here is an image: {{ image_path | image }}
+        {% endchat %}
+        """
+    )
+
+    messages = prompt.format_messages(image_path=http_url)
+    block = _get_image_block(messages)
+
+    assert str(block.url) == http_url
+    assert block.image is None
+    assert block.path is None
+

--- a/llama-index-core/tests/prompts/test_rich_image.py
+++ b/llama-index-core/tests/prompts/test_rich_image.py
@@ -3,15 +3,18 @@ from PIL import Image
 from llama_index.core.base.llms.types import ImageBlock, ChatMessage
 from llama_index.core.prompts import RichPromptTemplate
 
+
 def _create_temp_jpeg(path: pathlib.Path) -> None:
     img = Image.new("RGB", (8, 8), (255, 0, 0))
     img.save(path, format="JPEG")
+
 
 def _get_image_block(messages: list[ChatMessage]) -> ImageBlock:
     for b in messages[0].blocks:
         if getattr(b, "block_type", "") == "image":
             return b
     raise AssertionError("No ImageBlock found in messages")
+
 
 def test_local_path_image_in_bytes(tmp_path: pathlib.Path) -> None:
     img_path = tmp_path / "sample.jpg"
@@ -32,6 +35,7 @@ def test_local_path_image_in_bytes(tmp_path: pathlib.Path) -> None:
     assert block.url is None
     assert block.path is None
 
+
 def test_http_url() -> None:
     http_url = "https://example.com/img.png"
     prompt = RichPromptTemplate(
@@ -48,4 +52,3 @@ def test_http_url() -> None:
     assert str(block.url) == http_url
     assert block.image is None
     assert block.path is None
-


### PR DESCRIPTION
[Bug]: RichPromptTemplate example error #19850

# Description

ImageBlock only worked for image_url and when the local file is passed it threw  adapter exception. As fix if the scheme is data I am building the ImageBlock using the image_bytes to make it work.

Fixes # (19850)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
