### PR TITLE
Update IngestionPipeline async document store insertion

### DIFF
--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -286,3 +286,179 @@ def test_pipeline_with_transform_error() -> None:
         pipeline.run(documents=[document1])
 
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+
+
+@pytest.mark.asyncio
+async def test_arun_pipeline() -> None:
+    pipeline = IngestionPipeline(
+        readers=[
+            ReaderConfig(
+                reader=StringIterableReader(),
+                reader_kwargs={"texts": ["This is a test."]},
+            )
+        ],
+        documents=[Document.example()],
+        transformations=[
+            SentenceSplitter(),
+            KeywordExtractor(llm=MockLLM()),
+        ],
+    )
+
+    nodes = await pipeline.arun()
+
+    assert len(nodes) == 2
+    assert len(nodes[0].metadata) > 0
+
+
+@pytest.mark.asyncio
+async def test_arun_pipeline_with_ref_doc_id():
+    documents = [
+        Document(text="one", doc_id="1"),
+    ]
+    pipeline = IngestionPipeline(
+        documents=documents,
+        transformations=[
+            MarkdownElementNodeParser(),
+            SentenceSplitter(),
+            MockEmbedding(embed_dim=8),
+        ],
+    )
+
+    nodes = await pipeline.arun()
+
+    assert len(nodes) == 1
+    assert nodes[0].ref_doc_id == "1"
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_update_text_content() -> None:
+    document1 = Document.example()
+    document1.id_ = "1"
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    nodes = await pipeline.arun(documents=[document1])
+    assert len(nodes) == 19
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 1
+
+    # adjust document content
+    document1 = Document(text="test", doc_id="1")
+
+    # run pipeline again
+    nodes = pipeline.run(documents=[document1])
+
+    assert len(nodes) == 1
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 1
+    assert next(iter(pipeline.docstore.docs.values())).text == "test"  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_update_metadata() -> None:
+    """Test that IngestionPipeline updates document metadata, if it changed."""
+    old_metadata = {"filename": "README.md", "category": "codebase"}
+    document1 = Document.example()
+    document1.metadata = old_metadata
+    document1.id_ = "1"
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    nodes = await pipeline.arun(documents=[document1])
+    assert len(nodes) >= 1
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 1
+    for node in nodes:
+        assert node.metadata == old_metadata
+
+    # adjust document metadata
+    new_metadata = {"filename": "README.md", "category": "documentation"}
+    document1.metadata = new_metadata
+
+    # run pipeline again
+    nodes_new = pipeline.run(documents=[document1])
+
+    assert len(nodes_new) == len(nodes)
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 1
+    assert next(iter(pipeline.docstore.docs.values())).metadata == new_metadata  # type: ignore
+    for node in nodes_new:
+        assert node.metadata == new_metadata
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_dedup_duplicates_only() -> None:
+    documents = [
+        Document(text="one", doc_id="1"),
+        Document(text="two", doc_id="2"),
+        Document(text="three", doc_id="3"),
+    ]
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    nodes = await pipeline.arun(documents=documents)
+    assert len(nodes) == 3
+
+    nodes = await pipeline.arun(documents=documents)
+    assert len(nodes) == 0
+
+
+async def test_async_pipeline_parallel() -> None:
+    document1 = Document.example()
+    document1.id_ = "1"
+    document2 = Document(text="One\n\n\nTwo\n\n\nThree.", doc_id="2")
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    num_workers = min(2, cpu_count())
+    nodes = await pipeline.arun(
+        documents=[document1, document2], num_workers=num_workers
+    )
+    assert len(nodes) == 20
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_with_transform_error() -> None:
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError
+
+    document1 = Document.example()
+    document1.id_ = "1"
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+            RaisingTransform(),
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    with pytest.raises(RuntimeError):
+        await pipeline.arun(documents=[document1])
+
+    assert pipeline.docstore.get_node("1", raise_error=False) is None


### PR DESCRIPTION
# Description

The PR #19849 updates the document store insertion behavior in the sync methods of `IngestionPipeline`. However, I forgot to do the same in the async methods. This PR fixes it by moving the document store insertion after the vector store insertion in `IngestionPipeline.arun`.

I also added some missing tests to cover the async methods of `IngestionPipeline`.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
