### PR TITLE
Fix CTE support in SQLWrapper by implementing intelligent schema prefixing

### DIFF
--- a/llama-index-core/tests/utilities/test_sql_wrapper.py
+++ b/llama-index-core/tests/utilities/test_sql_wrapper.py
@@ -96,3 +96,175 @@ def test_long_string_no_truncation(sql_database: SQLDatabase) -> None:
     result_str, _ = sql_database.run_sql("SELECT * FROM test_table;")
 
     assert result_str == f"[(1, '{long_string}')]"
+
+
+# Test CTE functionality
+def test_cte_extraction(sql_database: SQLDatabase) -> None:
+    """Test that CTE names are correctly extracted from SQL queries."""
+    # Test single CTE
+    query1 = "WITH my_cte AS (SELECT * FROM test_table) SELECT * FROM my_cte"
+    cte_names = sql_database._extract_cte_names(query1)
+    assert cte_names == {"my_cte"}
+
+    # Test multiple CTEs
+    query2 = "WITH cte1 AS (SELECT * FROM test_table), cte2 AS (SELECT * FROM test_table) SELECT * FROM cte1 JOIN cte2"
+    cte_names = sql_database._extract_cte_names(query2)
+    assert cte_names == {"cte1", "cte2"}
+
+    # Test no CTE
+    query3 = "SELECT * FROM test_table"
+    cte_names = sql_database._extract_cte_names(query3)
+    assert cte_names == set()
+
+    # Test case insensitive
+    query4 = "with my_cte as (SELECT * FROM test_table) SELECT * FROM my_cte"
+    cte_names = sql_database._extract_cte_names(query4)
+    assert cte_names == {"my_cte"}
+
+
+def test_schema_prefixing_without_cte(sql_database: SQLDatabase) -> None:
+    """Test that schema prefixing works correctly for regular queries without CTEs."""
+    # Create a database with schema
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    table_name = "test_table"
+    Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+    )
+    metadata.create_all(engine)
+
+    # Create SQLDatabase with schema
+    db_with_schema = SQLDatabase(
+        engine=engine,
+        schema="test_schema",
+        metadata=metadata,
+        sample_rows_in_table_info=1,
+    )
+
+    # Test simple query
+    query = "SELECT * FROM test_table"
+    modified = db_with_schema._add_schema_prefix_smart(query)
+    assert modified == "SELECT * FROM test_schema.test_table"
+
+    # Test JOIN query
+    query2 = "SELECT * FROM test_table t1 JOIN test_table t2 ON t1.id = t2.id"
+    modified2 = db_with_schema._add_schema_prefix_smart(query2)
+    assert "test_schema.test_table" in modified2
+    assert modified2.count("test_schema.test_table") == 2
+
+
+def test_schema_prefixing_with_cte(sql_database: SQLDatabase) -> None:
+    """Test that schema prefixing works correctly with CTEs."""
+    # Create a database with schema
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    table_name = "test_table"
+    Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+    )
+    metadata.create_all(engine)
+
+    # Create SQLDatabase with schema
+    db_with_schema = SQLDatabase(
+        engine=engine,
+        schema="test_schema",
+        metadata=metadata,
+        sample_rows_in_table_info=1,
+    )
+
+    # Test CTE query - CTE name should not be prefixed, but table should be
+    query = "WITH my_cte AS (SELECT * FROM test_table) SELECT * FROM my_cte"
+    modified = db_with_schema._add_schema_prefix_smart(query)
+    assert "FROM test_schema.test_table" in modified
+    assert "FROM my_cte" in modified  # CTE name should not be prefixed
+
+    # Test multiple CTEs
+    query2 = "WITH cte1 AS (SELECT * FROM test_table), cte2 AS (SELECT * FROM test_table) SELECT * FROM cte1 JOIN cte2"
+    modified2 = db_with_schema._add_schema_prefix_smart(query2)
+    assert "FROM test_schema.test_table" in modified2
+    assert "FROM cte1" in modified2
+    assert "JOIN cte2" in modified2
+
+    # Test CTE with JOIN
+    query3 = "WITH my_cte AS (SELECT * FROM test_table) SELECT * FROM my_cte JOIN test_table ON my_cte.id = test_table.id"
+    modified3 = db_with_schema._add_schema_prefix_smart(query3)
+    assert "FROM my_cte" in modified3  # CTE should not be prefixed
+    assert "JOIN test_schema.test_table" in modified3  # Table should be prefixed
+
+
+def test_schema_prefixing_already_qualified(sql_database: SQLDatabase) -> None:
+    """Test that already schema-qualified table names are not modified."""
+    # Create a database with schema
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    table_name = "test_table"
+    Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+    )
+    metadata.create_all(engine)
+
+    # Create SQLDatabase with schema
+    db_with_schema = SQLDatabase(
+        engine=engine,
+        schema="test_schema",
+        metadata=metadata,
+        sample_rows_in_table_info=1,
+    )
+
+    # Test already qualified table name
+    query = "SELECT * FROM other_schema.test_table"
+    modified = db_with_schema._add_schema_prefix_smart(query)
+    assert modified == query  # Should remain unchanged
+
+    # Test mixed qualified and unqualified
+    query2 = (
+        "SELECT * FROM test_table t1 JOIN other_schema.test_table t2 ON t1.id = t2.id"
+    )
+    modified2 = db_with_schema._add_schema_prefix_smart(query2)
+    assert "FROM test_schema.test_table" in modified2
+    assert "JOIN other_schema.test_table" in modified2
+
+
+def test_run_sql_with_cte_and_schema(sql_database: SQLDatabase) -> None:
+    """Test that run_sql works correctly with CTEs and schema prefixing."""
+    # Create a database with schema
+    engine = create_engine("sqlite:///:memory:")
+    metadata = MetaData()
+    table_name = "test_table"
+    Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+    )
+    metadata.create_all(engine)
+
+    # Create SQLDatabase with schema
+    db_with_schema = SQLDatabase(
+        engine=engine,
+        schema="test_schema",
+        metadata=metadata,
+        sample_rows_in_table_info=1,
+    )
+
+    # Insert test data
+    db_with_schema.insert_into_table("test_table", {"id": 1, "name": "Alice"})
+    db_with_schema.insert_into_table("test_table", {"id": 2, "name": "Bob"})
+
+    # Test CTE query
+    query = "WITH filtered_users AS (SELECT * FROM test_table WHERE id > 1) SELECT * FROM filtered_users"
+    result_str, result_dict = db_with_schema.run_sql(query)
+
+    # Should return Bob's record
+    assert "Bob" in result_str
+    assert "Alice" not in result_str
+    assert len(result_dict["result"]) == 1


### PR DESCRIPTION
- Add _extract_cte_names() method to identify CTE names in SQL queries
- Add _add_schema_prefix_smart() method to intelligently prefix table names while preserving CTE names
- Update run_sql() method to use smart schema prefixing instead of naive string replacement
- Add comprehensive tests for CTE functionality including:
  - CTE name extraction
  - Schema prefixing with CTEs
  - Multiple CTEs handling
  - Already schema-qualified table handling
  - End-to-end integration tests

Fixes #19889

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
