### PR TITLE
Fix SQLi Vulnerability in SingleStore Db

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/llama_index/vector_stores/singlestoredb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/llama_index/vector_stores/singlestoredb/base.py
@@ -293,7 +293,11 @@ class SingleStoreVectorStore(BasePydanticVectorStore):
                     )
                     cur.execute(
                         query,
-                        (formatted_vector, *tuple(where_clause_values), similarity_top_k),
+                        (
+                            formatted_vector,
+                            *tuple(where_clause_values),
+                            similarity_top_k,
+                        ),
                     )
                     results = cur.fetchall()
                 finally:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/llama_index/vector_stores/singlestoredb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/llama_index/vector_stores/singlestoredb/base.py
@@ -284,13 +284,16 @@ class SingleStoreVectorStore(BasePydanticVectorStore):
                 try:
                     logger.debug("vector field: %s", formatted_vector)
                     logger.debug("similarity_top_k: %s", similarity_top_k)
-                    cur.execute(
+                    query = (
                         f"SELECT {self.content_field}, {self.metadata_field}, "
                         f"DOT_PRODUCT({self.vector_field}, "
                         "JSON_ARRAY_PACK(%s)) as similarity_score "
                         f"FROM {self.table_name} {where_clause} "
-                        f"ORDER BY similarity_score DESC LIMIT {similarity_top_k}",
-                        (formatted_vector, *tuple(where_clause_values)),
+                        "ORDER BY similarity_score DESC LIMIT %s"
+                    )
+                    cur.execute(
+                        query,
+                        (formatted_vector, *tuple(where_clause_values), similarity_top_k),
                     )
                     results = cur.fetchall()
                 finally:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-singlestoredb"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index vector_stores singlestoredb integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/tests/test_vector_stores_singlestoredb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/tests/test_vector_stores_singlestoredb.py
@@ -1,7 +1,10 @@
 from unittest.mock import MagicMock, patch
 import pytest
 import json
-from llama_index.core.vector_stores.types import BasePydanticVectorStore, VectorStoreQuery
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    VectorStoreQuery,
+)
 from llama_index.vector_stores.singlestoredb import SingleStoreVectorStore
 
 
@@ -10,115 +13,108 @@ def test_class():
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
 
 
-@patch('singlestoredb.connect')
-@patch.object(SingleStoreVectorStore, '_create_table')
+@patch("singlestoredb.connect")
+@patch.object(SingleStoreVectorStore, "_create_table")
 def test_query_with_embedding_parameterized(mock_create_table, mock_s2_connect):
     """Test that query properly uses parameterized queries to prevent SQL injection."""
     mock_s2_connect.return_value = MagicMock()
-    
+
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
     mock_conn.cursor.return_value = mock_cursor
-    
+
     mock_metadata = {
         "node_id": "test-node-id",
         "node_type": "TextNode",
         "ref_doc_id": "test-doc-id",
         "metadata": {},
-        "embedding": None
+        "embedding": None,
     }
     mock_cursor.fetchall.return_value = [
-        ('test content', json.dumps(mock_metadata), 0.95)
+        ("test content", json.dumps(mock_metadata), 0.95)
     ]
-    
-    with patch('sqlalchemy.pool.QueuePool') as mock_pool_class:
+
+    with patch("sqlalchemy.pool.QueuePool") as mock_pool_class:
         mock_pool = MagicMock()
         mock_pool_class.return_value = mock_pool
         mock_pool.connect.return_value = mock_conn
-        
+
         store = SingleStoreVectorStore(
             table_name="test_table",
             content_field="content",
-            metadata_field="metadata", 
-            vector_field="vector"
+            metadata_field="metadata",
+            vector_field="vector",
         )
-        
-        query = VectorStoreQuery(
-            query_embedding=[0.1, 0.2, 0.3],
-            similarity_top_k=5
-        )
-        
+
+        query = VectorStoreQuery(query_embedding=[0.1, 0.2, 0.3], similarity_top_k=5)
+
         result = store.query(query)
-        
+
         assert result is not None
 
 
-@patch('singlestoredb.connect')
-@patch.object(SingleStoreVectorStore, '_create_table')
+@patch("singlestoredb.connect")
+@patch.object(SingleStoreVectorStore, "_create_table")
 def test_query_with_embedding_and_filter(mock_create_table, mock_s2_connect):
     """Test query with both embedding and filter using parameterized queries."""
     mock_s2_connect.return_value = MagicMock()
-    
+
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
     mock_conn.cursor.return_value = mock_cursor
-    
+
     mock_metadata = {
         "node_id": "filtered-node-id",
         "node_type": "TextNode",
         "ref_doc_id": "test-doc-id",
         "metadata": {"category": "test"},
-        "embedding": None
+        "embedding": None,
     }
     mock_cursor.fetchall.return_value = [
-        ('filtered content', json.dumps(mock_metadata), 0.85)
+        ("filtered content", json.dumps(mock_metadata), 0.85)
     ]
-    
-    with patch('sqlalchemy.pool.QueuePool') as mock_pool_class:
+
+    with patch("sqlalchemy.pool.QueuePool") as mock_pool_class:
         mock_pool = MagicMock()
         mock_pool_class.return_value = mock_pool
         mock_pool.connect.return_value = mock_conn
-        
+
         store = SingleStoreVectorStore(
             table_name="test_table",
             content_field="content",
             metadata_field="metadata",
-            vector_field="vector"
+            vector_field="vector",
         )
-        
-        query = VectorStoreQuery(
-            query_embedding=[0.4, 0.5, 0.6],
-            similarity_top_k=10
-        )
-        
+
+        query = VectorStoreQuery(query_embedding=[0.4, 0.5, 0.6], similarity_top_k=10)
+
         filter_dict = {"category": "test"}
         result = store.query(query, filter=filter_dict)
-        
+
         assert result is not None
 
 
-@patch('singlestoredb.connect')
-@patch.object(SingleStoreVectorStore, '_create_table')
+@patch("singlestoredb.connect")
+@patch.object(SingleStoreVectorStore, "_create_table")
 def test_query_similarity_top_k_validation(mock_create_table, mock_s2_connect):
     """Test that invalid similarity_top_k values raise an error."""
     mock_s2_connect.return_value = MagicMock()
-    
-    with patch('sqlalchemy.pool.QueuePool') as mock_pool_class:
+
+    with patch("sqlalchemy.pool.QueuePool") as mock_pool_class:
         mock_pool = MagicMock()
         mock_pool_class.return_value = mock_pool
-        
-        store = SingleStoreVectorStore(
-            table_name="test_table"
-        )
-        
-        query = VectorStoreQuery(
-            query_embedding=[0.1, 0.2],
-            similarity_top_k=-1
-        )
-        
-        with pytest.raises(ValueError, match="similarity_top_k must be a positive integer"):
+
+        store = SingleStoreVectorStore(table_name="test_table")
+
+        query = VectorStoreQuery(query_embedding=[0.1, 0.2], similarity_top_k=-1)
+
+        with pytest.raises(
+            ValueError, match="similarity_top_k must be a positive integer"
+        ):
             store.query(query)
-        
+
         query.similarity_top_k = 0
-        with pytest.raises(ValueError, match="similarity_top_k must be a positive integer"):
+        with pytest.raises(
+            ValueError, match="similarity_top_k must be a positive integer"
+        ):
             store.query(query)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/tests/test_vector_stores_singlestoredb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-singlestoredb/tests/test_vector_stores_singlestoredb.py
@@ -1,7 +1,124 @@
-from llama_index.core.vector_stores.types import BasePydanticVectorStore
+from unittest.mock import MagicMock, patch
+import pytest
+import json
+from llama_index.core.vector_stores.types import BasePydanticVectorStore, VectorStoreQuery
 from llama_index.vector_stores.singlestoredb import SingleStoreVectorStore
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in SingleStoreVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+@patch('singlestoredb.connect')
+@patch.object(SingleStoreVectorStore, '_create_table')
+def test_query_with_embedding_parameterized(mock_create_table, mock_s2_connect):
+    """Test that query properly uses parameterized queries to prevent SQL injection."""
+    mock_s2_connect.return_value = MagicMock()
+    
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    
+    mock_metadata = {
+        "node_id": "test-node-id",
+        "node_type": "TextNode",
+        "ref_doc_id": "test-doc-id",
+        "metadata": {},
+        "embedding": None
+    }
+    mock_cursor.fetchall.return_value = [
+        ('test content', json.dumps(mock_metadata), 0.95)
+    ]
+    
+    with patch('sqlalchemy.pool.QueuePool') as mock_pool_class:
+        mock_pool = MagicMock()
+        mock_pool_class.return_value = mock_pool
+        mock_pool.connect.return_value = mock_conn
+        
+        store = SingleStoreVectorStore(
+            table_name="test_table",
+            content_field="content",
+            metadata_field="metadata", 
+            vector_field="vector"
+        )
+        
+        query = VectorStoreQuery(
+            query_embedding=[0.1, 0.2, 0.3],
+            similarity_top_k=5
+        )
+        
+        result = store.query(query)
+        
+        assert result is not None
+
+
+@patch('singlestoredb.connect')
+@patch.object(SingleStoreVectorStore, '_create_table')
+def test_query_with_embedding_and_filter(mock_create_table, mock_s2_connect):
+    """Test query with both embedding and filter using parameterized queries."""
+    mock_s2_connect.return_value = MagicMock()
+    
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    
+    mock_metadata = {
+        "node_id": "filtered-node-id",
+        "node_type": "TextNode",
+        "ref_doc_id": "test-doc-id",
+        "metadata": {"category": "test"},
+        "embedding": None
+    }
+    mock_cursor.fetchall.return_value = [
+        ('filtered content', json.dumps(mock_metadata), 0.85)
+    ]
+    
+    with patch('sqlalchemy.pool.QueuePool') as mock_pool_class:
+        mock_pool = MagicMock()
+        mock_pool_class.return_value = mock_pool
+        mock_pool.connect.return_value = mock_conn
+        
+        store = SingleStoreVectorStore(
+            table_name="test_table",
+            content_field="content",
+            metadata_field="metadata",
+            vector_field="vector"
+        )
+        
+        query = VectorStoreQuery(
+            query_embedding=[0.4, 0.5, 0.6],
+            similarity_top_k=10
+        )
+        
+        filter_dict = {"category": "test"}
+        result = store.query(query, filter=filter_dict)
+        
+        assert result is not None
+
+
+@patch('singlestoredb.connect')
+@patch.object(SingleStoreVectorStore, '_create_table')
+def test_query_similarity_top_k_validation(mock_create_table, mock_s2_connect):
+    """Test that invalid similarity_top_k values raise an error."""
+    mock_s2_connect.return_value = MagicMock()
+    
+    with patch('sqlalchemy.pool.QueuePool') as mock_pool_class:
+        mock_pool = MagicMock()
+        mock_pool_class.return_value = mock_pool
+        
+        store = SingleStoreVectorStore(
+            table_name="test_table"
+        )
+        
+        query = VectorStoreQuery(
+            query_embedding=[0.1, 0.2],
+            similarity_top_k=-1
+        )
+        
+        with pytest.raises(ValueError, match="similarity_top_k must be a positive integer"):
+            store.query(query)
+        
+        query.similarity_top_k = 0
+        with pytest.raises(ValueError, match="similarity_top_k must be a positive integer"):
+            store.query(query)


### PR DESCRIPTION
This PR addresses a SQL injection vulnerability in the SingleStore vector store implementation by properly parameterizing the `LIMIT` clause in the similarity search query.

- Moved the `similarity_top_k` value from being directly interpolated in the SQL string to being passed as a parameterized query argument
- Split the query construction for better readability while fixing the security issue

Previously, the `similarity_top_k` parameter was directly embedded in the SQL query string using f-string formatting, which could potentially allow SQL injection if the value came from untrusted sources. This change ensures all user-provided values are properly escaped through parameterized queries.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
