### PR TITLE
Bug Fix :- Not Able to Fetch Page whose latest is empty or null

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-service-now/llama_index/readers/service_now/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/llama_index/readers/service_now/base.py
@@ -444,7 +444,11 @@ class SnowKBReader(BaseReader):
             gr.add_query("number", "IN", ",".join(numbers))
         else:
             raise ValueError("Must provide article_sys_id or number")
-        gr.add_query("latest", "true")  # Only fetch latest version
+
+        # Handle latest field: include records where latest is true OR latest field is not present/empty
+        latest_condition = gr.add_query("latest", "true")
+        latest_condition.add_or_condition("latest", "ISEMPTY")
+
         gr.add_query(
             "workflow_state", status or DEFAULT_WORKFLOW_STATE
         )  # Include only published articles

--- a/llama-index-integrations/readers/llama-index-readers-service-now/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-service-now"
-version = "0.2.1"
+version = "0.2.2"
 description = "llama-index readers service-now integration"
 authors = [{name = "Ameetpal Singh", email = "ameetpal.singh@maersk.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Current Loader is not able to fetch page which have single version, in those pages latest is null or empty so added a check consider those pages as well 

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [-] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [-] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [-] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [-] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [-] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods