### PR TITLE
llama-dev: Add `release check` command and run it before releasing the package via CI

### DIFF
--- a/.github/workflows/release_core.yml
+++ b/.github/workflows/release_core.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Pre-release sanity check
+        shell: bash
+        working-directory: llama-dev
+        run: |
+          uv run -- llama-dev --repo-root .. release check
+
       - name: Install core dependencies
         working-directory: llama-index-core
         run: |

--- a/llama-dev/llama_dev/cli.py
+++ b/llama-dev/llama_dev/cli.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.theme import Theme
 
 from .pkg import pkg
+from .release import release
 from .test import test
 
 LLAMA_DEV_THEME = Theme(
@@ -40,3 +41,4 @@ def cli(ctx, repo_root: str, debug: bool):
 
 cli.add_command(pkg)
 cli.add_command(test)
+cli.add_command(release)

--- a/llama-dev/llama_dev/release/__init__.py
+++ b/llama-dev/llama_dev/release/__init__.py
@@ -1,0 +1,11 @@
+import click
+
+from .check import check
+
+
+@click.group(short_help="Utilities for the release process in the monorepo")
+def release():
+    pass  # pragma: no cover
+
+
+release.add_command(check)

--- a/llama-dev/llama_dev/release/check.py
+++ b/llama-dev/llama_dev/release/check.py
@@ -1,0 +1,103 @@
+import json
+import re
+import subprocess
+import urllib.request
+from pathlib import Path
+
+import click
+import tomli
+from packaging.version import parse as parse_version
+
+
+def _get_current_branch_name() -> str:
+    return (
+        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        .decode("utf-8")
+        .strip()
+    )
+
+
+def _get_version_from_pyproject(repo_root: Path) -> str:
+    with open(repo_root / "llama-index-core" / "pyproject.toml", "rb") as f:
+        pyproject_data = tomli.load(f)
+
+    return pyproject_data["project"]["version"]
+
+
+def _get_version_from_init(repo_root: Path) -> str:
+    init_py_path = (
+        repo_root / "llama-index-core" / "llama_index" / "core" / "__init__.py"
+    )
+
+    init_py_content = init_py_path.read_text()
+    match = re.search(r'__version__ = "(.+)"', init_py_content)
+    if match is None:
+        raise click.ClickException(f"Could not find __version__ in {init_py_path}")
+    return match.group(1)
+
+
+def _get_version_from_pypi() -> str:
+    try:
+        url = "https://pypi.org/pypi/llama-index-core/json"
+        with urllib.request.urlopen(url, timeout=10) as response:
+            data = json.load(response)
+        return data["info"]["version"]
+    except Exception as e:
+        raise click.ClickException(
+            f"Failed to fetch llama-index-core version from PyPI: {e}"
+        )
+
+
+@click.command(
+    short_help="Check if all the pre-requisites for the release are satisfied"
+)
+@click.pass_obj
+def check(obj: dict):
+    """
+    Check if all the pre-requisites for the release are satisfied.
+
+    Pre-requisites:
+    - llama-index-core/pyproject.toml and llama-index-core/llama_index/core/__init__.py are consistent
+    - current branch is not `main`
+    - llama-index-core/pyproject.toml is newer than the latest on PyPI
+
+    """
+    console = obj["console"]
+    repo_root = obj["repo_root"]
+
+    # Check current branch is not main
+    current_branch = _get_current_branch_name()
+    if current_branch == "main":
+        console.print(
+            "❌ You are on the `main` branch. Please create a new branch to release.",
+            style="error",
+        )
+        exit(1)
+    console.print("✅ You are not on the `main` branch.")
+
+    # Check consistency between pyproject.toml and __init__.py
+    pyproject_version = _get_version_from_pyproject(repo_root)
+    init_py_version = _get_version_from_init(repo_root)
+
+    if pyproject_version != init_py_version:
+        console.print(
+            f"❌ Version mismatch between 'pyproject.toml' ({pyproject_version}) and "
+            f"'__init__.py' ({init_py_version})",
+            style="error",
+        )
+        exit(1)
+    console.print(
+        f"✅ Versions in 'pyproject.toml' and '__init__.py' are consistent ({pyproject_version})"
+    )
+
+    # Check if llama-index-core version is newer than PyPI
+    pypi_version = _get_version_from_pypi()
+    if not parse_version(pyproject_version) > parse_version(pypi_version):
+        console.print(
+            f"❌ Version {pyproject_version} is not newer than the latest on PyPI ({pypi_version}).",
+            style="error",
+        )
+        exit(1)
+    console.print(
+        f"✅ Version {pyproject_version} is newer than the latest on PyPI ({pypi_version})."
+    )

--- a/llama-dev/tests/conftest.py
+++ b/llama-dev/tests/conftest.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -20,3 +21,9 @@ def mock_current_version(monkeypatch):
         monkeypatch.setattr(sys, "version_info", mock_version)
 
     return _set_version
+
+
+@pytest.fixture
+def mock_rich_console():
+    """Fixture to mock the rich console."""
+    return MagicMock()

--- a/llama-dev/tests/release/test_check.py
+++ b/llama-dev/tests/release/test_check.py
@@ -1,0 +1,162 @@
+import json
+from unittest import mock
+
+import click
+import pytest
+from llama_dev.cli import cli
+from llama_dev.release.check import (
+    _get_current_branch_name,
+    _get_version_from_init,
+    _get_version_from_pypi,
+    _get_version_from_pyproject,
+    check,
+)
+
+
+def test_get_current_branch_name():
+    with mock.patch("subprocess.check_output", return_value=b"my-branch\n"):
+        assert _get_current_branch_name() == "my-branch"
+
+
+def test_get_version_from_pyproject(tmp_path):
+    core_path = tmp_path / "llama-index-core"
+    core_path.mkdir()
+    pyproject_content = """
+[project]
+version = \"1.2.3\"
+"""
+    (core_path / "pyproject.toml").write_text(pyproject_content)
+    assert _get_version_from_pyproject(tmp_path) == "1.2.3"
+
+
+def test_get_version_from_init(tmp_path):
+    core_init_path = tmp_path / "llama-index-core" / "llama_index" / "core"
+    core_init_path.mkdir(parents=True)
+    init_content = '__version__ = "1.2.3"'
+    (core_init_path / "__init__.py").write_text(init_content)
+    assert _get_version_from_init(tmp_path) == "1.2.3"
+
+
+def test_get_version_from_init_no_version(tmp_path):
+    core_init_path = tmp_path / "llama-index-core" / "llama_index" / "core"
+    core_init_path.mkdir(parents=True)
+    (core_init_path / "__init__.py").write_text("foo = 'bar'")
+    with pytest.raises(click.ClickException):
+        _get_version_from_init(tmp_path)
+
+
+def test_get_version_from_pypi():
+    with mock.patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = json.dumps(
+            {"info": {"version": "1.2.3"}}
+        ).encode("utf-8")
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        assert _get_version_from_pypi() == "1.2.3"
+
+
+def test_get_version_from_pypi_error():
+    with mock.patch("urllib.request.urlopen", side_effect=Exception("test error")):
+        with pytest.raises(click.ClickException):
+            _get_version_from_pypi()
+
+
+@pytest.mark.parametrize(
+    (
+        "test_id",
+        "branch_name",
+        "pyproject_version",
+        "init_version",
+        "pypi_version",
+        "should_pass",
+        "expected_message",
+    ),
+    [
+        (
+            "success",
+            "my-release-branch",
+            "0.1.1",
+            "0.1.1",
+            "0.1.0",
+            True,
+            [
+                "✅ You are not on the `main` branch.",
+                "✅ Versions in 'pyproject.toml' and '__init__.py' are consistent (0.1.1)",
+                "✅ Version 0.1.1 is newer than the latest on PyPI (0.1.0).",
+            ],
+        ),
+        (
+            "on_main",
+            "main",
+            "0.1.1",
+            "0.1.1",
+            "0.1.0",
+            False,
+            [
+                "❌ You are on the `main` branch. Please create a new branch to release.",
+            ],
+        ),
+        (
+            "version_mismatch",
+            "my-release-branch",
+            "0.1.2",
+            "0.1.1",
+            "0.1.0",
+            False,
+            [
+                "❌ Version mismatch between 'pyproject.toml' (0.1.2) and "
+                "'__init__.py' (0.1.1)",
+            ],
+        ),
+        (
+            "not_newer",
+            "my-release-branch",
+            "0.1.0",
+            "0.1.0",
+            "0.1.0",
+            False,
+            [
+                "❌ Version 0.1.0 is not newer than the latest on PyPI (0.1.0).",
+            ],
+        ),
+    ],
+)
+def test_check_command(
+    mock_rich_console,
+    test_id,
+    branch_name,
+    pyproject_version,
+    init_version,
+    pypi_version,
+    should_pass,
+    expected_message,
+):
+    with (
+        mock.patch(
+            "llama_dev.release.check._get_current_branch_name", return_value=branch_name
+        ),
+        mock.patch(
+            "llama_dev.release.check._get_version_from_pyproject",
+            return_value=pyproject_version,
+        ),
+        mock.patch(
+            "llama_dev.release.check._get_version_from_init", return_value=init_version
+        ),
+        mock.patch(
+            "llama_dev.release.check._get_version_from_pypi", return_value=pypi_version
+        ),
+    ):
+        ctx = click.Context(cli)
+        ctx.obj = {"console": mock_rich_console, "repo_root": ""}
+
+        if should_pass:
+            ctx.invoke(check)
+            for msg in expected_message:
+                mock_rich_console.print.assert_any_call(msg)
+        else:
+            with pytest.raises(SystemExit) as e:
+                ctx.invoke(check)
+            assert e.type is SystemExit
+            assert e.value.code == 1
+            for msg in expected_message:
+                mock_rich_console.print.assert_any_call(msg, style="error")


### PR DESCRIPTION
# Description

In the spirit of automating the release process more and more, a new command `release check` was added to `llama-dev` in order to ensure all the requirements are met before releasing `llama-index-core`, part of the `llama-index` release process.

This PR keeps the trigger manual, but it adds a GHA step to run the check in `release_core.yml`.