### PR TITLE
re-enable search on api reference docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,10 +4,8 @@ extra:
     provider: google
 extra_css:
   - css/style.css
-  - css/algolia.css
 extra_javascript:
   - javascript/runllm.js
-  - javascript/algolia.js
 markdown_extensions:
   - attr_list
   - admonition

--- a/docs/overrides/partials/search.html
+++ b/docs/overrides/partials/search.html
@@ -1,4 +1,0 @@
-{% import "partials/language.html" as lang with context %}
-
-<!-- Search interface -->
-<div id="docsearch"></div>


### PR DESCRIPTION
Algolia was getting in the way and breaking things. Removing so that mkdocs built-in lunr search starts working again for API reference

Fixes https://github.com/run-llama/llama_index/issues/19901