### PR TITLE
improve how state snapshotting works in AG-UI

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
@@ -75,10 +75,6 @@ class AGUIWorkflowRouter:
                 # Finish the run
                 _ = await handler
 
-                # Update the state
-                state = await handler.ctx.store.get("state", default={})
-                yield workflow_event_to_sse(StateSnapshotWorkflowEvent(snapshot=state))
-
                 yield workflow_event_to_sse(
                     RunFinishedWorkflowEvent(
                         timestamp=timestamp(),

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.2.1"
+version = "0.2.2"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},


### PR DESCRIPTION
Rather than blindly emitting state snapshots at the end of the run, we should update the state at the start (using the input state) and after each tool call (tool calls are the only place where state might be modified)