### PR TITLE
Fix `TypeError: unhashable type: 'dict'` in Ollama stream chat with tools

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -427,7 +427,7 @@ class Ollama(FunctionCallingLLM):
                         content=response_txt,
                         role=r["message"].get("role", MessageRole.ASSISTANT),
                         additional_kwargs={
-                            "tool_calls": list(set(all_tool_calls)),
+                            "tool_calls": all_tool_calls,
                             "thinking": thinking_txt,
                         },
                     ),

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-ollama"
-version = "0.7.3"
+version = "0.7.4"
 description = "llama-index llms ollama integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -160,6 +160,25 @@ def test_chat_with_tools() -> None:
     assert tool_result.raw_output is not None
     assert isinstance(tool_result.raw_output, Song)
 
+@pytest.mark.skipif(
+    client is None, reason="Ollama client is not available or test model is missing"
+)
+def test_stream_chat_with_tools() -> None:
+    """Makes sure that stream chat with tools returns tool call message without any errors"""
+    llm = Ollama(model=test_model, context_window=8000)
+    response = llm.stream_chat_with_tools(
+        [tool], user_msg="Hello! Generate a random artist and song."
+    )
+
+    for r in response:
+        tool_calls = llm.get_tool_calls_from_response(r)
+        assert len(tool_calls) == 1
+        assert tool_calls[0].tool_name == tool.metadata.name
+
+        tool_result = tool(**tool_calls[0].tool_kwargs)
+        assert tool_result.raw_output is not None
+        assert isinstance(tool_result.raw_output, Song)
+
 
 @pytest.mark.skipif(
     client is None, reason="Ollama client is not available or test model is missing"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -160,6 +160,7 @@ def test_chat_with_tools() -> None:
     assert tool_result.raw_output is not None
     assert isinstance(tool_result.raw_output, Song)
 
+
 @pytest.mark.skipif(
     client is None, reason="Ollama client is not available or test model is missing"
 )


### PR DESCRIPTION
# Description

When use Ollama's stream_chat with tools, it will throw an exception if it decides to call a tool:
```
TypeError: unhashable type: 'dict'

Traceback (most recent call last):
  File "C:\projects\llama_index\llama-index-integrations\llms\llama-index-llms-ollama\llama_index\llms\ollama\base.py", line 430, in gen
    "tool_calls": list(set(all_tool_calls)),
```

The other methods in base.py doesn't seem to call list(set(all_tool_calls)) since it looks like there's already logic above it that guarantees uniqueness in the tool calls.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
