### PR TITLE
chore: get `__version__` dynamically instead of hardcoding the value

### DIFF
--- a/llama-dev/llama_dev/release/check.py
+++ b/llama-dev/llama_dev/release/check.py
@@ -1,5 +1,4 @@
 import json
-import re
 import subprocess
 import urllib.request
 from pathlib import Path
@@ -24,18 +23,6 @@ def _get_version_from_pyproject(repo_root: Path) -> str:
     return pyproject_data["project"]["version"]
 
 
-def _get_version_from_init(repo_root: Path) -> str:
-    init_py_path = (
-        repo_root / "llama-index-core" / "llama_index" / "core" / "__init__.py"
-    )
-
-    init_py_content = init_py_path.read_text()
-    match = re.search(r'__version__ = "(.+)"', init_py_content)
-    if match is None:
-        raise click.ClickException(f"Could not find __version__ in {init_py_path}")
-    return match.group(1)
-
-
 def _get_version_from_pypi() -> str:
     try:
         url = "https://pypi.org/pypi/llama-index-core/json"
@@ -57,7 +44,6 @@ def check(obj: dict):
     Check if all the pre-requisites for the release are satisfied.
 
     Pre-requisites:
-    - llama-index-core/pyproject.toml and llama-index-core/llama_index/core/__init__.py are consistent
     - current branch is not `main`
     - llama-index-core/pyproject.toml is newer than the latest on PyPI
 
@@ -75,22 +61,8 @@ def check(obj: dict):
         exit(1)
     console.print("✅ You are not on the `main` branch.")
 
-    # Check consistency between pyproject.toml and __init__.py
-    pyproject_version = _get_version_from_pyproject(repo_root)
-    init_py_version = _get_version_from_init(repo_root)
-
-    if pyproject_version != init_py_version:
-        console.print(
-            f"❌ Version mismatch between 'pyproject.toml' ({pyproject_version}) and "
-            f"'__init__.py' ({init_py_version})",
-            style="error",
-        )
-        exit(1)
-    console.print(
-        f"✅ Versions in 'pyproject.toml' and '__init__.py' are consistent ({pyproject_version})"
-    )
-
     # Check if llama-index-core version is newer than PyPI
+    pyproject_version = _get_version_from_pyproject(repo_root)
     pypi_version = _get_version_from_pypi()
     if not parse_version(pyproject_version) > parse_version(pypi_version):
         console.print(

--- a/llama-dev/tests/release/test_check.py
+++ b/llama-dev/tests/release/test_check.py
@@ -6,7 +6,6 @@ import pytest
 from llama_dev.cli import cli
 from llama_dev.release.check import (
     _get_current_branch_name,
-    _get_version_from_init,
     _get_version_from_pypi,
     _get_version_from_pyproject,
     check,
@@ -27,22 +26,6 @@ version = \"1.2.3\"
 """
     (core_path / "pyproject.toml").write_text(pyproject_content)
     assert _get_version_from_pyproject(tmp_path) == "1.2.3"
-
-
-def test_get_version_from_init(tmp_path):
-    core_init_path = tmp_path / "llama-index-core" / "llama_index" / "core"
-    core_init_path.mkdir(parents=True)
-    init_content = '__version__ = "1.2.3"'
-    (core_init_path / "__init__.py").write_text(init_content)
-    assert _get_version_from_init(tmp_path) == "1.2.3"
-
-
-def test_get_version_from_init_no_version(tmp_path):
-    core_init_path = tmp_path / "llama-index-core" / "llama_index" / "core"
-    core_init_path.mkdir(parents=True)
-    (core_init_path / "__init__.py").write_text("foo = 'bar'")
-    with pytest.raises(click.ClickException):
-        _get_version_from_init(tmp_path)
 
 
 def test_get_version_from_pypi():
@@ -81,7 +64,6 @@ def test_get_version_from_pypi_error():
             True,
             [
                 "✅ You are not on the `main` branch.",
-                "✅ Versions in 'pyproject.toml' and '__init__.py' are consistent (0.1.1)",
                 "✅ Version 0.1.1 is newer than the latest on PyPI (0.1.0).",
             ],
         ),
@@ -94,18 +76,6 @@ def test_get_version_from_pypi_error():
             False,
             [
                 "❌ You are on the `main` branch. Please create a new branch to release.",
-            ],
-        ),
-        (
-            "version_mismatch",
-            "my-release-branch",
-            "0.1.2",
-            "0.1.1",
-            "0.1.0",
-            False,
-            [
-                "❌ Version mismatch between 'pyproject.toml' (0.1.2) and "
-                "'__init__.py' (0.1.1)",
             ],
         ),
         (
@@ -138,9 +108,6 @@ def test_check_command(
         mock.patch(
             "llama_dev.release.check._get_version_from_pyproject",
             return_value=pyproject_version,
-        ),
-        mock.patch(
-            "llama_dev.release.check._get_version_from_init", return_value=init_version
         ),
         mock.patch(
             "llama_dev.release.check._get_version_from_pypi", return_value=pypi_version

--- a/llama-index-core/llama_index/core/__init__.py
+++ b/llama-index-core/llama_index/core/__init__.py
@@ -1,10 +1,17 @@
 """Top-level imports for LlamaIndex."""
 
-__version__ = "0.14.3"
-
 import logging
+from importlib.metadata import PackageNotFoundError, version
 from logging import NullHandler
 from typing import Callable, Optional
+
+try:
+    __version__ = version("llama-index-core")
+except PackageNotFoundError:
+    # This might happen when running tests or scripts directly without
+    # an editable install.
+    __version__ = "0.0.0"
+
 
 try:
     # Force pants to install eval_type_backport on 3.9


### PR DESCRIPTION
# Description

Still unsure about the implications but @logan-markewich if you can double check this is safe, it will simplify the release process.