### PR TITLE
[CI]: Pre-release workflow

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Install uv and set python version
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -2,6 +2,9 @@ name: Pre-release for llama-index
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - massi/bump
 
 permissions:
   contents: write

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -2,9 +2,15 @@ name: Pre-release for llama-index
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - massi/bump
+    inputs:
+      version-type:
+        description: "The type of release to prepare"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -28,7 +34,7 @@ jobs:
         shell: bash
         working-directory: llama-dev
         run: |
-          uv run -- llama-dev --repo-root .. release prepare
+          uv run -- llama-dev --repo-root .. release prepare --version-type ${{ github.event.inputs.version-type }}
           uv run -- llama-dev --repo-root .. release changelog
 
       - name: Create Release PR

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -1,0 +1,38 @@
+name: Pre-release for llama-index
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    if: github.repository == 'run-llama/llama_index'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv and set python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.10"
+
+      - name: Prepare
+        shell: bash
+        working-directory: llama-dev
+        run: |
+          uv run -- llama-dev --repo-root .. release prepare
+          uv run -- llama-dev --repo-root .. release changelog
+
+      - name: Create Release PR
+        id: rpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Prepare release
+          signoff: false
+          branch: pre-release
+          delete-branch: true
+          title: "Prepare release"
+          draft: false

--- a/llama-dev/llama_dev/pkg/bump.py
+++ b/llama-dev/llama_dev/pkg/bump.py
@@ -1,54 +1,13 @@
-import re
-from enum import Enum
-from pathlib import Path
-
 import click
-from packaging.version import Version
 
-from llama_dev.utils import find_all_packages, is_llama_index_package, load_pyproject
-
-
-class BumpType(str, Enum):
-    MAJOR = "major"
-    MINOR = "minor"
-    PATCH = "patch"
-
-
-def bump_version(current_version: str, bump_type: BumpType) -> str:
-    """Bump a version string according to semver rules."""
-    v = Version(current_version)
-
-    # Parse the version components
-    release = v.release
-    major = release[0] if len(release) > 0 else 0
-    minor = release[1] if len(release) > 1 else 0
-    micro = release[2] if len(release) > 2 else 0
-
-    version_str = ""
-    if bump_type == BumpType.MAJOR:
-        version_str = f"{major + 1}.0.0"
-    elif bump_type == BumpType.MINOR:
-        version_str = f"{major}.{minor + 1}.0"
-    elif bump_type == BumpType.PATCH:
-        version_str = f"{major}.{minor}.{micro + 1}"
-
-    return version_str
-
-
-def update_pyproject_version(package_path: Path, new_version: str) -> None:
-    """Update the version in a pyproject.toml file."""
-    pyproject_path = package_path / "pyproject.toml"
-
-    # Read the file content
-    with open(pyproject_path, "r") as f:
-        content = f.read()
-
-    pattern = r'(\[project\][^\[]*?version\s*=\s*["\'])([^"\']+)(["\'])'
-    new_content = re.sub(pattern, rf"\g<1>{new_version}\g<3>", content, flags=re.DOTALL)
-
-    # Write the updated content back
-    with open(pyproject_path, "w") as f:
-        f.write(new_content)
+from llama_dev.utils import (
+    BumpType,
+    bump_version,
+    find_all_packages,
+    is_llama_index_package,
+    load_pyproject,
+    update_pyproject_version,
+)
 
 
 @click.command(short_help="Bump package version")

--- a/llama-dev/llama_dev/release/__init__.py
+++ b/llama-dev/llama_dev/release/__init__.py
@@ -2,6 +2,7 @@ import click
 
 from .changelog import changelog
 from .check import check
+from .prepare import prepare
 
 
 @click.group(short_help="Utilities for the release process in the monorepo")
@@ -11,3 +12,4 @@ def release():
 
 release.add_command(check)
 release.add_command(changelog)
+release.add_command(prepare)

--- a/llama-dev/llama_dev/release/prepare.py
+++ b/llama-dev/llama_dev/release/prepare.py
@@ -53,7 +53,7 @@ def prepare(
     current_version = root_package_data["project"]["version"]
     new_version = bump_version(current_version, bump_enum)
     new_dep_string = (
-        f"llama-index-core<={new_version},<{bump_version(new_version, BumpType.MINOR)}"
+        f"llama-index-core>={new_version},<{bump_version(new_version, BumpType.MINOR)}"
     )
 
     if dry_run:

--- a/llama-dev/llama_dev/release/prepare.py
+++ b/llama-dev/llama_dev/release/prepare.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import click
+
+from llama_dev.utils import (
+    BumpType,
+    bump_version,
+    load_pyproject,
+    update_pyproject_version,
+)
+
+
+def _replace_core_dependency(project_path: Path, old_dep: str, new_dep: str):
+    pyproject_path = project_path / "pyproject.toml"
+    # Read the file content
+    with open(pyproject_path, "r") as f:
+        content = f.read()
+
+    # Replace the old dependency string
+    new_content = content.replace(old_dep, new_dep)
+
+    # Write the updated content back
+    with open(pyproject_path, "w") as f:
+        f.write(new_content)
+
+
+@click.command(
+    short_help="Bump the versions to begin a llama_index umbrella package release"
+)
+@click.option(
+    "--version-type",
+    type=click.Choice([t.value for t in BumpType], case_sensitive=False),
+    default=BumpType.PATCH.value,
+    help="Type of version bump to perform (default: patch)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be done without making changes",
+)
+@click.pass_obj
+def prepare(
+    obj: dict,
+    version_type: str,
+    dry_run: bool,
+):
+    """Bump the version numbers to initiate the llama_index umbrella package release."""
+    console = obj["console"]
+    repo_root = obj["repo_root"]
+    bump_enum = BumpType(version_type)
+
+    root_package_data = load_pyproject(repo_root)
+    current_version = root_package_data["project"]["version"]
+    new_version = bump_version(current_version, bump_enum)
+    new_dep_string = (
+        f"llama-index-core<={new_version},<{bump_version(new_version, BumpType.MINOR)}"
+    )
+
+    if dry_run:
+        console.print(f"Would bump llama_index from {current_version} to {new_version}")
+        console.print(f"llama_index will depend on '{new_dep_string}'")
+    else:
+        # Update llama-index version number
+        update_pyproject_version(repo_root, new_version)
+        # Update llama-index-core version number
+        update_pyproject_version(repo_root / "llama-index-core", new_version)
+        # Update llama-index-core dependency version
+        for dep in root_package_data["project"]["dependencies"]:
+            if dep.startswith("llama-index-core"):
+                _replace_core_dependency(repo_root, dep, new_dep_string)
+                break

--- a/llama-dev/llama_dev/utils.py
+++ b/llama-dev/llama_dev/utils.py
@@ -46,8 +46,10 @@ def update_pyproject_version(package_path: Path, new_version: str) -> None:
     with open(pyproject_path, "r") as f:
         content = f.read()
 
-    pattern = r'(\[project\][^\[]*?version\s*=\s*["\'])([^"\']+)(["\'])'
-    new_content = re.sub(pattern, rf"\g<1>{new_version}\g<3>", content, flags=re.DOTALL)
+    pattern = r'^version = "[^"]+"'
+    new_content = re.sub(
+        pattern, f'version = "{new_version}"', content, flags=re.MULTILINE
+    )
 
     # Write the updated content back
     with open(pyproject_path, "w") as f:

--- a/llama-dev/llama_dev/utils.py
+++ b/llama-dev/llama_dev/utils.py
@@ -1,12 +1,59 @@
 import re
 import subprocess
 import sys
+from enum import Enum
 from pathlib import Path
 
 import tomli
 from packaging import specifiers, version
+from packaging.version import Version
+
+from llama_dev.utils import find_all_packages, is_llama_index_package, load_pyproject
 
 DEP_NAME_REGEX = re.compile(r"([^<>=\[\];\s]+)")
+
+
+class BumpType(str, Enum):
+    MAJOR = "major"
+    MINOR = "minor"
+    PATCH = "patch"
+
+
+def bump_version(current_version: str, bump_type: BumpType) -> str:
+    """Bump a version string according to semver rules."""
+    v = Version(current_version)
+
+    # Parse the version components
+    release = v.release
+    major = release[0] if len(release) > 0 else 0
+    minor = release[1] if len(release) > 1 else 0
+    micro = release[2] if len(release) > 2 else 0
+
+    version_str = ""
+    if bump_type == BumpType.MAJOR:
+        version_str = f"{major + 1}.0.0"
+    elif bump_type == BumpType.MINOR:
+        version_str = f"{major}.{minor + 1}.0"
+    elif bump_type == BumpType.PATCH:
+        version_str = f"{major}.{minor}.{micro + 1}"
+
+    return version_str
+
+
+def update_pyproject_version(package_path: Path, new_version: str) -> None:
+    """Update the version in a pyproject.toml file."""
+    pyproject_path = package_path / "pyproject.toml"
+
+    # Read the file content
+    with open(pyproject_path, "r") as f:
+        content = f.read()
+
+    pattern = r'(\[project\][^\[]*?version\s*=\s*["\'])([^"\']+)(["\'])'
+    new_content = re.sub(pattern, rf"\g<1>{new_version}\g<3>", content, flags=re.DOTALL)
+
+    # Write the updated content back
+    with open(pyproject_path, "w") as f:
+        f.write(new_content)
 
 
 def package_has_tests(package_path: Path) -> bool:

--- a/llama-dev/llama_dev/utils.py
+++ b/llama-dev/llama_dev/utils.py
@@ -8,8 +8,6 @@ import tomli
 from packaging import specifiers, version
 from packaging.version import Version
 
-from llama_dev.utils import find_all_packages, is_llama_index_package, load_pyproject
-
 DEP_NAME_REGEX = re.compile(r"([^<>=\[\];\s]+)")
 
 


### PR DESCRIPTION
# Description

Adding a workflow that's supposed to be triggered manually (via GitHub UI or `gh`). This workflow will:
- Check the `main` branch is in a "releaseable" state
- Create a release branch
- Bump the versions of `llama-index` and `llama-index-core`
- Generate the changelog
- Open a PR with all the above changes

Example of generated PR: https://github.com/run-llama/llama_index/pull/19945

This is the first step, next will be triggering the build of the packages and the PyPI publishing (separate PR)