### PR TITLE
Fix for ValueError: ChatMessage contains multiple blocks, use 'ChatMe…

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -37,6 +37,7 @@ from llama_index.core.base.llms.types import (
     LLMMetadata,
     MessageRole,
     ThinkingBlock,
+    TextBlock,
 )
 from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
@@ -393,7 +394,7 @@ class GoogleGenAI(FunctionCallingLLM):
                     llama_resp.message.additional_kwargs.get("tool_calls", [])
                 )
                 llama_resp.delta = content_delta
-                llama_resp.message.content = content
+                llama_resp.message.blocks = [TextBlock(text=content)]
                 llama_resp.message.blocks.append(ThinkingBlock(content=thoughts))
                 llama_resp.message.additional_kwargs["tool_calls"] = existing_tool_calls
                 yield llama_resp
@@ -453,7 +454,7 @@ class GoogleGenAI(FunctionCallingLLM):
                                 )
                             )
                             llama_resp.delta = content_delta
-                            llama_resp.message.content = content
+                            llama_resp.message.blocks = [TextBlock(text=content)]
                             llama_resp.message.blocks.append(
                                 ThinkingBlock(content=thoughts)
                             )

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1652,7 +1652,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.14.1"
+version = "0.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1686,9 +1686,9 @@ dependencies = [
     { name = "typing-inspect" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/d4/cf8a3372f4cb71c67c9804c7aa0eb8770c1fad93f34c9c599824eecd9872/llama_index_core-0.14.1.tar.gz", hash = "sha256:b9a68d8f848f22dad0e3ea17539d72a6d01f99ad4e2ba8dca074bbabb2f4fcc2", size = 11577266, upload-time = "2025-09-10T21:59:05.943Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/e4/6a4ab9465b66c9d31b74ed0221293aeebe9072ec9db3b3b229f96028af78/llama_index_core-0.14.3.tar.gz", hash = "sha256:ca8a473ac92fe54f2849175f6510655999852c83fa8b7d75fd3908a8863da05a", size = 11577791, upload-time = "2025-09-24T18:21:03.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/fb/b4d8f58ffee6cca1356206cbbbeb8fe6ea1728126f8b5a8f7bd1a798f4d2/llama_index_core-0.14.1-py3-none-any.whl", hash = "sha256:bf471b12d963563dc6ef1d9c1a65c5d924c8cb827dd41532af192aaf94f18fe4", size = 11918358, upload-time = "2025-09-10T21:59:02.642Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5a/de1002b10109a0dfa122ba84a3b640124cf2418a78e00ac0b382574f2b3f/llama_index_core-0.14.3-py3-none-any.whl", hash = "sha256:fc4291fbae8c6609e3367da39a85a453099476685d5a3e97b766d82d4bcce5a4", size = 11918952, upload-time = "2025-09-24T18:21:00.744Z" },
 ]
 
 [[package]]
@@ -1706,7 +1706,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-google-genai"
-version = "0.3.2"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },
@@ -1741,7 +1741,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "google-genai", specifier = ">=1.24.0,<2" },
-    { name = "llama-index-core", specifier = ">=0.14.1,<0.15" },
+    { name = "llama-index-core", specifier = ">=0.14.3,<0.15" },
     { name = "pillow", specifier = ">=10.2.0" },
 ]
 


### PR DESCRIPTION
…ssage.blocks' instead.

# Description

Upgrading to `llama-index-llms-google-genai>=0.6.1`, I starting seeing this stack trace (note: paths and the top of the callstack have been redacted):

```
Traceback (most recent call last):
  File ".venv/lib/python3.12/site-packages/workflows/workflow.py", line 407, in _run_workflow
    raise exception_raised
  File ".venv/lib/python3.12/site-packages/workflows/context/context.py", line 822, in _step_worker
    new_ev = await instrumented_step(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/llama_index_instrumentation/dispatcher.py", line 365, in async_wrapper
    result = await func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/llama_index/core/agent/workflow/multi_agent_workflow.py", line 410, in run_agent_step
    agent_output = await agent.take_step(
                   ^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/llama_index/core/agent/workflow/function_agent.py", line 120, in take_step
    last_chat_response = await self._get_streaming_response(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/llama_index/core/agent/workflow/function_agent.py", line 75, in _get_streaming_response
    async for last_chat_response in response:
  File ".venv/lib/python3.12/site-packages/llama_index/core/llms/callbacks.py", line 89, in wrapped_gen
    async for x in f_return_val:
  File ".venv/lib/python3.12/site-packages/llama_index/llms/google_genai/base.py", line 456, in gen
    llama_resp.message.content = content
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/pydantic/main.py", line 998, in __setattr__
    setattr_handler(self, name, value)  # call here to not memo on possibly unknown fields
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/pydantic/main.py", line 1038, in <lambda>
    return lambda model, _name, val: attr.__set__(model, val)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/llama_index/core/base/llms/types.py", line 532, in content
    raise ValueError(
```

I think this started to happen when `ThinkingBlocks` were introduced (https://github.com/run-llama/llama_index/pull/19919/files#diff-b0287e7fc5241f21fe7ad711693b2b7d21e494ca700ac892a353e5de633a037b).

Fixes # N/A. Didn't file an issue.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
