### PR TITLE
fix(cli): replace os.system with subprocess.run for security hardening

### DIFF
--- a/llama-index-cli/llama_index/cli/rag/base.py
+++ b/llama-index-cli/llama_index/cli/rag/base.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
-import shlex
 import shutil
+import subprocess
 from argparse import ArgumentParser
 from glob import iglob
 from pathlib import Path
@@ -246,9 +246,10 @@ class RagCLI(BaseModel):
                                 "none",
                                 "--engine",
                                 "context",
-                                f"--files {shlex.quote(path)}",
+                                "--files",
+                                path,
                             ]
-                            os.system(" ".join(command_args))
+                            subprocess.run(command_args, check=True)
 
         if question is not None:
             await self.handle_question(question)

--- a/llama-index-cli/tests/test_rag.py
+++ b/llama-index-cli/tests/test_rag.py
@@ -1,9 +1,12 @@
 import glob
+import subprocess
+from pathlib import Path
 from unittest import mock
-
+import tempfile
 
 from llama_index.cli import command_line
 from llama_index.cli.rag import RagCLI
+from llama_index.core.ingestion import IngestionPipeline
 
 
 @mock.patch.object(RagCLI, "handle_cli", return_value="noop")
@@ -14,3 +17,216 @@ from llama_index.cli.rag import RagCLI
 def test_handle_cli_files(mock_handle_cli) -> None:
     command_line.main()
     mock_handle_cli.assert_called_once()
+
+
+@mock.patch("os.path.exists")
+@mock.patch("llama_index.cli.rag.base.subprocess.run")
+@mock.patch("shutil.which")
+def test_create_llama_subprocess_call_security(
+    mock_which, mock_subprocess_run, mock_exists
+):
+    """Test that subprocess.run is called with shell=False for security."""
+    # Setup
+    mock_which.return_value = "/usr/local/bin/npx"  # npx is available
+    mock_subprocess_run.return_value = mock.Mock(returncode=0)
+
+    # Create a temporary directory for testing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Mock os.path.exists to return True for test path, False for persist_dir check
+        def exists_side_effect(path):
+            if path == "/test/data/folder":
+                return True  # Test path exists
+            elif path == temp_dir:
+                return False  # persist_dir doesn't exist (for clear check)
+            return str(path).endswith("files_history.txt")
+
+        mock_exists.side_effect = exists_side_effect
+
+        # Mock the IngestionPipeline to avoid OpenAI API key requirement
+        with mock.patch(
+            "llama_index.core.ingestion.IngestionPipeline"
+        ) as mock_pipeline_class:
+            mock_pipeline_instance = mock.Mock(spec=IngestionPipeline)
+            mock_pipeline_instance.vector_store = None
+            mock_pipeline_class.return_value = mock_pipeline_instance
+
+            # Create a RagCLI instance with test configuration
+            with mock.patch(
+                "llama_index.cli.rag.base._try_load_openai_llm"
+            ) as mock_llm:
+                mock_llm.return_value = mock.Mock()
+                rag_cli = RagCLI(
+                    persist_dir=temp_dir, ingestion_pipeline=mock_pipeline_instance
+                )
+
+        # Create the history file with a single path
+        history_file = Path(temp_dir) / "files_history.txt"
+        test_path = "/test/data/folder"
+        history_file.write_text(test_path + "\n")
+
+        # Execute the code path that calls subprocess.run
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(rag_cli.handle_cli(create_llama=True))
+        loop.close()
+
+        # Verify subprocess.run was called with the correct arguments
+        mock_subprocess_run.assert_called_once()
+
+        # Get the call arguments
+        call_args = mock_subprocess_run.call_args
+
+        # Verify shell=False is used (check=True is passed, shell is not passed or is False)
+        assert call_args[1].get("shell", False) is False, (
+            "subprocess.run must not use shell=True"
+        )
+
+        # Verify check=True is set for proper error handling
+        assert call_args[1].get("check") is True, "subprocess.run should use check=True"
+
+        # Verify the command is passed as a list (required for shell=False)
+        command = call_args[0][0]
+        assert isinstance(command, list), "Command must be a list when shell=False"
+
+        # Verify the command structure
+        expected_command = [
+            "npx",
+            "create-llama@latest",
+            "--frontend",
+            "--template",
+            "streaming",
+            "--framework",
+            "fastapi",
+            "--ui",
+            "shadcn",
+            "--vector-db",
+            "none",
+            "--engine",
+            "context",
+            "--files",
+            test_path,
+        ]
+        assert command == expected_command, f"Command mismatch: {command}"
+
+
+@mock.patch("os.path.exists")
+@mock.patch("llama_index.cli.rag.base.subprocess.run")
+@mock.patch("shutil.which")
+def test_create_llama_handles_special_characters_in_path(
+    mock_which, mock_subprocess_run, mock_exists
+):
+    """Test that paths with special characters are handled safely."""
+    # Setup
+    mock_which.return_value = "/usr/local/bin/npx"
+    mock_subprocess_run.return_value = mock.Mock(returncode=0)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Test with a path containing spaces and special characters
+        test_path = "/test/data folder/with spaces & special; chars"
+
+        # Mock os.path.exists to return True for test path
+        def exists_side_effect(path):
+            if path == test_path:
+                return True
+            return str(path).endswith("files_history.txt")
+
+        mock_exists.side_effect = exists_side_effect
+
+        # Mock the IngestionPipeline to avoid OpenAI API key requirement
+        with mock.patch(
+            "llama_index.core.ingestion.IngestionPipeline"
+        ) as mock_pipeline_class:
+            mock_pipeline_instance = mock.Mock(spec=IngestionPipeline)
+            mock_pipeline_instance.vector_store = None
+            mock_pipeline_class.return_value = mock_pipeline_instance
+
+            # Create a RagCLI instance with test configuration
+            with mock.patch(
+                "llama_index.cli.rag.base._try_load_openai_llm"
+            ) as mock_llm:
+                mock_llm.return_value = mock.Mock()
+                rag_cli = RagCLI(
+                    persist_dir=temp_dir, ingestion_pipeline=mock_pipeline_instance
+                )
+
+        # Create history file
+        history_file = Path(temp_dir) / "files_history.txt"
+        history_file.write_text(test_path + "\n")
+
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(rag_cli.handle_cli(create_llama=True))
+        loop.close()
+
+        # Verify the path is passed as-is in the list (no shell escaping needed)
+        call_args = mock_subprocess_run.call_args
+        command = call_args[0][0]
+        assert command[-1] == test_path, "Path should be passed unchanged in list form"
+        assert call_args[1].get("shell", False) is False, "Must not use shell=True"
+
+
+@mock.patch("os.path.exists")
+@mock.patch("llama_index.cli.rag.base.subprocess.run")
+@mock.patch("shutil.which")
+def test_create_llama_subprocess_error_handling(
+    mock_which, mock_subprocess_run, mock_exists
+):
+    """Test that subprocess errors are properly handled."""
+    # Setup
+    mock_which.return_value = "/usr/local/bin/npx"
+
+    # Simulate subprocess failure
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, ["npx"])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_path = "/test/data/folder"
+
+        # Mock os.path.exists to return True for test path
+        def exists_side_effect(path):
+            if path == test_path:
+                return True
+            return str(path).endswith("files_history.txt")
+
+        mock_exists.side_effect = exists_side_effect
+
+        # Mock the IngestionPipeline to avoid OpenAI API key requirement
+        with mock.patch(
+            "llama_index.core.ingestion.IngestionPipeline"
+        ) as mock_pipeline_class:
+            mock_pipeline_instance = mock.Mock(spec=IngestionPipeline)
+            mock_pipeline_instance.vector_store = None
+            mock_pipeline_class.return_value = mock_pipeline_instance
+
+            # Create a RagCLI instance with test configuration
+            with mock.patch(
+                "llama_index.cli.rag.base._try_load_openai_llm"
+            ) as mock_llm:
+                mock_llm.return_value = mock.Mock()
+                rag_cli = RagCLI(
+                    persist_dir=temp_dir, ingestion_pipeline=mock_pipeline_instance
+                )
+
+        history_file = Path(temp_dir) / "files_history.txt"
+        history_file.write_text(test_path + "\n")
+
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        # Should raise CalledProcessError due to check=True
+        try:
+            loop.run_until_complete(rag_cli.handle_cli(create_llama=True))
+            raise AssertionError("Should have raised CalledProcessError")
+        except subprocess.CalledProcessError:
+            pass  # Expected
+        finally:
+            loop.close()
+
+        # Verify subprocess.run was called with check=True
+        call_args = mock_subprocess_run.call_args
+        assert call_args[1].get("check") is True, "subprocess.run should use check=True"


### PR DESCRIPTION
Low-risk security improvement: Replaces `os.system()` with `subprocess.run()` to avoid shell execution. While not currently exploitable (input comes from locally-controlled files), this follows security best practices.

- Replaced `os.system(" ".join(command_args))` with `subprocess.run(command_args, check=True)`
- Removed `shlex.quote()` escaping as it's no longer needed
- Command arguments are now passed as a list instead of a shell string

`os.system()` always executes through the shell, which can be vulnerable to command injection. While the current code uses `shlex.quote()` for escaping and only processes locally-controlled file paths, using `subprocess.run()` without shell is a security best practice that eliminates the command injection entirely.

Added unit tests to verify:
- Commands execute without shell
- Special characters in paths are handled safely
- Subprocess errors are properly raised with `check=True`


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
