### PR TITLE
Fix shell injection vulnerability in llama-dev changelog command

### DIFF
--- a/llama-dev/llama_dev/release/changelog.py
+++ b/llama-dev/llama_dev/release/changelog.py
@@ -1,5 +1,6 @@
 import json
 import re
+import shlex
 import subprocess
 from datetime import date
 from pathlib import Path
@@ -13,7 +14,8 @@ CHANGELOG_PLACEHOLDER = "<!--- generated changelog --->"
 
 def _run_command(command: str) -> str:
     """Helper to run a shell command and return the output."""
-    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    args = shlex.split(command)
+    result = subprocess.run(args, capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(f"Command failed: {command}\n{result.stderr}")
     return result.stdout.strip()

--- a/llama-dev/tests/release/test_changelog.py
+++ b/llama-dev/tests/release/test_changelog.py
@@ -254,3 +254,15 @@ def test_update_changelog_file():
     handle.seek.assert_called_once_with(0)
     handle.truncate.assert_called_once()
     handle.write.assert_called_once_with(expected_content)
+
+
+def test_run_command_no_shell_and_args_list():
+    with mock.patch("subprocess.run") as mock_run:
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "ok"
+        mock_run.return_value = mock_result
+        _run_command("echo ok")
+        args, kwargs = mock_run.call_args
+        assert isinstance(args[0], list)
+        assert not kwargs.get("shell", False)


### PR DESCRIPTION
This PR addresses a security vulnerability in the `llama-dev` changelog generation tool by replacing the unsafe `shell=True` parameter in subprocess calls with proper command parsing using `shlex.split()`.

- Modified `_run_command()` function in `llama-dev/llama_dev/release/changelog.py` to parse commands into argument lists using `shlex.split()`
- Removed `shell=True` parameter from `subprocess.run()` calls, preventing potential command injection attacks
- Added unit test to verify commands are executed without shell and properly use argument lists

**Risk Level: Low** - While this fixes a genuine shell injection vulnerability, the exploitability is limited because:
1. The `llama-dev` tool is a development utility not exposed to external inputs
2. Commands passed to `_run_command()` are typically hardcoded Git commands within the codebase
3. No user-controlled input flows directly into these command strings

This is a proactive security hardening measure following best practices for subprocess execution, even though the practical exploit risk in this context is minimal.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [x ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
