### PR TITLE
llama-dev: Parametrize the release branch name, show release number in PR title

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           commit-message: Prepare release
           signoff: false
-          branch: pre-release
+          branch: ${{ secrets.RELEASE_BRANCH_NAME }}
           delete-branch: true
-          title: "Prepare release"
+          title: "Release"
           draft: false

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -31,6 +31,7 @@ jobs:
           python-version: "3.10"
 
       - name: Prepare
+        id: prepare
         shell: bash
         working-directory: llama-dev
         env:
@@ -38,6 +39,8 @@ jobs:
         run: |
           uv run -- llama-dev --repo-root .. release prepare --version-type ${{ github.event.inputs.version-type }}
           uv run -- llama-dev --repo-root .. release changelog
+          VERSION=$(uv run -- llama-dev --repo-root .. pkg info --json . | jq -r .version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release PR
         id: rpr
@@ -47,5 +50,5 @@ jobs:
           signoff: false
           branch: ${{ secrets.RELEASE_BRANCH_NAME }}
           delete-branch: true
-          title: "Release"
+          title: "Release ${{ steps.prepare.outputs.version }}"
           draft: false


### PR DESCRIPTION
# Description

Make the workflow more robust by parametrizing the release branch name and leaving a free format for the PR title, so we can show the version number for better UX.

Example generated PR: https://github.com/run-llama/llama_index/pull/19958