### PR TITLE
llama-dev: update lockfile during pre-release

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -42,6 +42,10 @@ jobs:
           VERSION=$(uv run -- llama-dev --repo-root .. pkg info --json . | jq -r .version)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Update root lockfile
+        run: |
+          uv lock
+
       - name: Create Release PR
         id: rpr
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
# Description

Since the pre-release changes the `llama-index-core` dependency, we should recreate the lockfile.
