### PR TITLE
FunctionAgent: pass back thinking stream from gpt-oss (#19857)

### DIFF
--- a/llama-index-core/tests/agent/workflow/test_thinking_delta.py
+++ b/llama-index-core/tests/agent/workflow/test_thinking_delta.py
@@ -336,7 +336,7 @@ async def test_agents_handle_missing_thinking_delta():
 @pytest.mark.asyncio
 async def test_function_agent_ollama_reasoning_extraction():
     """Test FunctionAgent extracts thinking_delta from Ollama's raw.choices[0].delta.reasoning format."""
-    
+
     class MockOllamaLLM(MockLLM):
         @property
         def metadata(self) -> LLMMetadata:
@@ -348,18 +348,19 @@ async def test_function_agent_ollama_reasoning_extraction():
             async def _gen():
                 # Simulate Ollama's response structure with object-based access
                 from unittest.mock import MagicMock
-                
+
                 mock_raw = MagicMock()
                 mock_raw.choices = [MagicMock()]
                 mock_raw.choices[0].delta = MagicMock()
                 mock_raw.choices[0].delta.reasoning = "Ollama thinking process..."
-                
+
                 yield ChatResponse(
                     message=ChatMessage(role="assistant", content="Response"),
                     delta="Response",
                     additional_kwargs={},  # No thinking_delta in additional_kwargs
                     raw=mock_raw,
                 )
+
             return _gen()
 
         def get_tool_calls_from_response(
@@ -371,12 +372,14 @@ async def test_function_agent_ollama_reasoning_extraction():
     agent = FunctionAgent(llm=mock_llm, streaming=True)
     mock_context = AsyncMock(spec=Context)
     stream_events = []
-    mock_context.write_event_to_stream.side_effect = lambda event: stream_events.append(event)
+    mock_context.write_event_to_stream.side_effect = lambda event: stream_events.append(
+        event
+    )
 
     await agent._get_streaming_response(
         mock_context, [ChatMessage(role="user", content="test")], []
     )
-    
+
     agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
     assert len(agent_streams) == 1
     assert agent_streams[0].thinking_delta == "Ollama thinking process..."
@@ -385,7 +388,7 @@ async def test_function_agent_ollama_reasoning_extraction():
 @pytest.mark.asyncio
 async def test_function_agent_groq_reasoning_extraction():
     """Test FunctionAgent extracts thinking_delta from Groq's dictionary-based raw['choices'][0]['delta']['reasoning'] format."""
-    
+
     class MockGroqLLM(MockLLM):
         @property
         def metadata(self) -> LLMMetadata:
@@ -405,12 +408,13 @@ async def test_function_agent_groq_reasoning_extraction():
                             {
                                 "delta": {
                                     "reasoning": "Groq thinking process...",
-                                    "content": "Response"
+                                    "content": "Response",
                                 }
                             }
                         ]
                     },
                 )
+
             return _gen()
 
         def get_tool_calls_from_response(
@@ -422,12 +426,14 @@ async def test_function_agent_groq_reasoning_extraction():
     agent = FunctionAgent(llm=mock_llm, streaming=True)
     mock_context = AsyncMock(spec=Context)
     stream_events = []
-    mock_context.write_event_to_stream.side_effect = lambda event: stream_events.append(event)
+    mock_context.write_event_to_stream.side_effect = lambda event: stream_events.append(
+        event
+    )
 
     await agent._get_streaming_response(
         mock_context, [ChatMessage(role="user", content="test")], []
     )
-    
+
     agent_streams = [event for event in stream_events if isinstance(event, AgentStream)]
     assert len(agent_streams) == 1
     assert agent_streams[0].thinking_delta == "Groq thinking process..."


### PR DESCRIPTION
# Description
Fixes #19857 - FunctionAgent does not pass back thinking stream from gpt-oss

The original issue reported that Ollama's gpt-oss:20b model wasn't returning the thinking stream in `additional_kwargs['thinking_delta']` but rather in `raw.choices[0].delta.reasoning`. During investigation, I discovered this affects multiple providers due to different response formats:

- **Ollama/Local models**: Store reasoning in `raw.choices[0].delta.reasoning` (object-based access)
- **Groq API**: Store reasoning in `raw["choices"][0]["delta"]["reasoning"]` (dictionary-based access)  
- **Other providers**: May use `additional_kwargs["thinking_delta"]` (existing approach)

Implemented a multi-format extraction strategy in `_get_streaming_response()` that handles different provider response structures with proper type checking and graceful fallback.

## New Package?
Did I fill in the tool.llamahub section in the pyproject.toml and provide a detailed README.md for my new integration or package?
- [ ] Yes
- [x] No

## Version Bump?
Did I bump the version in the pyproject.toml file of the package I am updating? (Except for the llama-index-core package)
- [ ] Yes
- [x] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran uv run make format; uv run make lint to appease the lint gods

