### PR TITLE
Fix: Respect cloud parameter when fetching child pages in ConfluenceR…

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/llama_index/readers/confluence/base.py
@@ -446,15 +446,20 @@ class ConfluenceReader(BaseReader, DispatcherSpanMixin):
                 type="page",
                 max_num_results=max_num_remaining,
             )
-        ] + [
-            (child_id, "folder")
-            for child_id in self._get_data_with_paging(
-                self.confluence.get_child_id_list,
-                page_id=id,
-                type="folder",
-                max_num_results=max_num_remaining,
-            )
         ]
+
+        if self.confluence.cloud:
+            child_items.extend(
+                [
+                    (child_id, "folder")
+                    for child_id in self._get_data_with_paging(
+                        self.confluence.get_child_id_list,
+                        page_id=id,
+                        type="folder",
+                        max_num_results=max_num_remaining,
+                    )
+                ]
+            )
 
         for child_id, child_type in child_items:
             if max_num_remaining is not None and max_num_remaining <= 0:

--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-confluence"
-version = "0.4.3"
+version = "0.4.4"
 description = "llama-index readers confluence integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This change fixes a bug where the ConfluenceReader fails when run against an on-premise (non-cloud) instance with the include_children=True parameter.

As reported in the issue, users on on-premise installations receive an HTTPError: No ContentTypeBinding found for type: folder because the reader unconditionally attempts to fetch "folders," a feature that only exists in Confluence Cloud.
This is resolved by adding a conditional check to the `_dfs_page_ids` method, which now only attempts to fetch 'folder' type children when the reader is configured for a Confluence Cloud instance.

No new dependencies are required for this change.

Fixes #19964

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

A new test class, TestChildPageFetching, was added to test_new_features.py. These tests specifically verify the correct behavior for both on-premise (cloud=False) and cloud (cloud=True) environments. The tests cover recursion, error handling, and parameter limits to ensure the fix is robust and does not introduce regressions.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
