### PR TITLE
Update core/indices/base.py to remove depreciation warning

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -237,7 +237,7 @@ class BaseIndex(Generic[IS], ABC):
             )
 
             self.insert_nodes(nodes, **insert_kwargs)
-            self.docstore.set_document_hash(document.get_doc_id(), document.hash)
+            self.docstore.set_document_hash(document.id_, document.hash)
 
     async def ainsert(self, document: Document, **insert_kwargs: Any) -> None:
         """Asynchronously insert a document."""
@@ -250,7 +250,7 @@ class BaseIndex(Generic[IS], ABC):
             )
 
             await self.ainsert_nodes(nodes, **insert_kwargs)
-            await self.docstore.aset_document_hash(document.get_doc_id(), document.hash)
+            await self.docstore.aset_document_hash(document.id_, document.hash)
 
     @abstractmethod
     def _delete_node(self, node_id: str, **delete_kwargs: Any) -> None:
@@ -383,7 +383,7 @@ class BaseIndex(Generic[IS], ABC):
         """
         with self._callback_manager.as_trace("update_ref_doc"):
             self.delete_ref_doc(
-                document.get_doc_id(),
+                document.id_,
                 delete_from_docstore=True,
                 **update_kwargs.pop("delete_kwargs", {}),
             )
@@ -403,7 +403,7 @@ class BaseIndex(Generic[IS], ABC):
         """
         with self._callback_manager.as_trace("aupdate_ref_doc"):
             await self.adelete_ref_doc(
-                document.get_doc_id(),
+                document.id_,
                 delete_from_docstore=True,
                 **update_kwargs.pop("delete_kwargs", {}),
             )
@@ -440,7 +440,7 @@ class BaseIndex(Generic[IS], ABC):
             refreshed_documents = [False] * len(documents)
             for i, document in enumerate(documents):
                 existing_doc_hash = self._docstore.get_document_hash(
-                    document.get_doc_id()
+                    document.id_
                 )
                 if existing_doc_hash is None:
                     self.insert(document, **update_kwargs.pop("insert_kwargs", {}))
@@ -467,7 +467,7 @@ class BaseIndex(Generic[IS], ABC):
             refreshed_documents = [False] * len(documents)
             for i, document in enumerate(documents):
                 existing_doc_hash = await self._docstore.aget_document_hash(
-                    document.get_doc_id()
+                    document.id_
                 )
                 if existing_doc_hash is None:
                     await self.ainsert(

--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -439,9 +439,7 @@ class BaseIndex(Generic[IS], ABC):
         with self._callback_manager.as_trace("refresh_ref_docs"):
             refreshed_documents = [False] * len(documents)
             for i, document in enumerate(documents):
-                existing_doc_hash = self._docstore.get_document_hash(
-                    document.id_
-                )
+                existing_doc_hash = self._docstore.get_document_hash(document.id_)
                 if existing_doc_hash is None:
                     self.insert(document, **update_kwargs.pop("insert_kwargs", {}))
                     refreshed_documents[i] = True


### PR DESCRIPTION
# Description

Fix  `DeprecationWarning: Call to deprecated method get_doc_id. ('get_doc_id' is deprecated, access the 'id_' property instead.) -- Deprecated since version 0.12.2`

Fixes #19988

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
