### PR TITLE
fix: ScrapflyReader Pydantic validation error

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/scrapfly_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/scrapfly_web/base.py
@@ -39,7 +39,11 @@ class ScrapflyReader(BasePydanticReader):
                 "`scrapfly` package not found, please run `pip install scrapfly-sdk`"
             )
         scrapfly = ScrapflyClient(key=api_key)
-        super().__init__(api_key=api_key, ignore_scrape_failures=ignore_scrape_failures, scrapfly=scrapfly)
+        super().__init__(
+            api_key=api_key,
+            ignore_scrape_failures=ignore_scrape_failures,
+            scrapfly=scrapfly,
+        )
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-web"
-version = "0.5.4"
+version = "0.5.5"
 description = "llama-index readers web integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Fixes the Pydantic validation error thrown on ScrapflyReader:
```
PydanticUserError(self._error_message, code=self._code) pydantic.errors.PydanticUserError: ScrapflyReader is not fully defined; you should define ScrapflyClient, then call ScrapflyReader.model_rebuild()
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
