### PR TITLE
Remove debug print

### DIFF
--- a/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
+++ b/llama-index-core/llama_index/core/storage/kvstore/simple_kvstore.py
@@ -51,7 +51,6 @@ class SimpleKVStore(MutableMappingKVStore[dict]):
         """Load a SimpleKVStore from a persist path and filesystem."""
         fs = fs or fsspec.filesystem("file")
         logger.debug(f"Loading {__name__} from {persist_path}.")
-        print(f"Loading {__name__} from {persist_path}.")
         with fs.open(persist_path, "rb") as f:
             data = json.load(f)
         return cls(data)


### PR DESCRIPTION
This was added in fa1c1325382244a415a57de4de08d0ace25b2a99. There is already a `logger.debug()` statement; the duplicated print is unnecessary.