### PR TITLE
remove release requirement for core to be on a branch

### DIFF
--- a/llama-dev/llama_dev/release/check.py
+++ b/llama-dev/llama_dev/release/check.py
@@ -49,7 +49,6 @@ def check(obj: dict, before_core: bool):
 
     \b
     Requisites before releasing llama-index-core (passing --before-core):
-    - current branch is not `main`
     - llama-index-core/pyproject.toml is newer than the latest on PyPI
 
     Requisite after llama-index-core was published (without passing --before-core):
@@ -60,24 +59,14 @@ def check(obj: dict, before_core: bool):
     repo_root = obj["repo_root"]
 
     current_branch = _get_current_branch_name()
-    if before_core:
-        # Check current branch is NOT main
-        if current_branch == "main":
-            console.print(
-                "❌ You are on the `main` branch. Please create a new branch to release.",
-                style="error",
-            )
-            exit(1)
-        console.print("✅ You are not on the `main` branch.")
-    else:
-        # Check current branch IS main
-        if current_branch != "main":
-            console.print(
-                "❌ To release 'llama-index' you have to checkout the `main` branch.",
-                style="error",
-            )
-            exit(1)
-        console.print("✅ You are on the `main` branch.")
+    # Check current branch IS main
+    if current_branch != "main":
+        console.print(
+            "❌ To release 'llama-index' you have to checkout the `main` branch.",
+            style="error",
+        )
+        exit(1)
+    console.print("✅ You are on the `main` branch.")
 
     if before_core:
         # Check llama-index-core version is NEWER than PyPI

--- a/llama-dev/tests/release/test_check.py
+++ b/llama-dev/tests/release/test_check.py
@@ -56,15 +56,14 @@ def test_get_version_from_pypi_error():
     ),
     [
         (
-            "success",
+            "fail",
             "my-release-branch",
             "0.1.1",
             "0.1.1",
             "0.1.0",
-            True,
+            False,
             [
-                "✅ You are not on the `main` branch.",
-                "✅ Version 0.1.1 is newer than the latest on PyPI (0.1.0).",
+                "❌ To release 'llama-index' you have to checkout the `main` branch.",
             ],
         ),
         (
@@ -73,14 +72,15 @@ def test_get_version_from_pypi_error():
             "0.1.1",
             "0.1.1",
             "0.1.0",
-            False,
+            True,
             [
-                "❌ You are on the `main` branch. Please create a new branch to release.",
+                "✅ You are on the `main` branch.",
+                "✅ Version 0.1.1 is newer than the latest on PyPI (0.1.0).",
             ],
         ),
         (
             "not_newer",
-            "my-release-branch",
+            "main",
             "0.1.0",
             "0.1.0",
             "0.1.0",
@@ -118,6 +118,7 @@ def test_check_command(
 
         if should_pass:
             ctx.invoke(check, before_core=True)
+            # print messages from console
             for msg in expected_message:
                 mock_rich_console.print.assert_any_call(msg)
         else:


### PR DESCRIPTION
As noted in https://github.com/run-llama/llama_index/issues/20004, the release failed 

This is a very new action -- looks like there was an old check for main branch that doesn't need to be there