### PR TITLE
feat: List Claude Sonnet 4.5 as a reasoning model

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -167,6 +167,7 @@ BEDROCK_REASONING_MODELS = (
     "anthropic.claude-3-7-sonnet-20250219-v1:0",
     "anthropic.claude-opus-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-20250514-v1:0",
+    "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "deepseek.r1-v1:0",
 )
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.10.0"
+version = "0.10.1"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

Excitingly, #19936 added "thinking" support to BedrockConverse 😄 However, Claude Sonnet 4.5 wasn't added to `BEDROCK_REASONING_MODELS` despite being a reasoning model.

It does appear that the [list of reasoning models in the AWS documentation isn't fully updated yet](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-reasoning.html), but [Claude Sonnet 4.5 is indeed capable of reasoning](https://docs.claude.com/en/docs/build-with-claude/extended-thinking#supported-models).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
