### PR TITLE
fix(llms/fireworks): Cannot use Fireworks Deepseek V3.1-20006 issue

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-fireworks/llama_index/llms/fireworks/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-fireworks/llama_index/llms/fireworks/utils.py
@@ -36,6 +36,7 @@ FUNCTION_CALLING_MODELS = {
 
 DEEPSEEK_MODELS = {
     "accounts/fireworks/models/deepseek-v3": 131072,
+    "accounts/fireworks/models/deepseek-v3p1": 131072,
     "accounts/fireworks/models/deepseek-r1": 163840,
 }
 


### PR DESCRIPTION
# Description

Adds support for Fireworks DeepSeek V3.1 model by adding it to the `DEEPSEEK_MODELS` dictionary with the correct context window size (131,072 tokens).

Fixes #20006

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I believe this change is already covered by existing unit tests
- [x] Tested locally with the change - model works as expected

## Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes