### PR TITLE
safely initialize RefDocInfo in Docstore

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -393,7 +393,10 @@ class KVDocumentStore(BaseDocumentStore):
             ref_doc_info_dict["metadata"] = ref_doc_info_dict.get("extra_info", {})
             ref_doc_info_dict.pop("extra_info")
 
-        return RefDocInfo(**ref_doc_info_dict)
+        return RefDocInfo(
+            metadata=ref_doc_info_dict.get("metadata", {}),
+            node_ids=ref_doc_info_dict.get("node_ids", [])
+        )
 
     def get_ref_doc_info(self, ref_doc_id: str) -> Optional[RefDocInfo]:
         """Get the RefDocInfo for a given ref_doc_id."""


### PR DESCRIPTION
Fixes https://github.com/run-llama/llama_index/issues/19930