### PR TITLE
Add progress bar for multiprocess loading

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -380,7 +380,9 @@ def concat_dirs(dirname: str, basename: str) -> str:
     return os.path.join(dirname, basename)
 
 
-def get_tqdm_iterable(items: Iterable, show_progress: bool, desc: str) -> Iterable:
+def get_tqdm_iterable(
+    items: Iterable, show_progress: bool, desc: str, total: Optional[int] = None
+) -> Iterable:
     """
     Optionally get a tqdm iterable. Ensures tqdm.auto is used.
     """
@@ -389,7 +391,7 @@ def get_tqdm_iterable(items: Iterable, show_progress: bool, desc: str) -> Iterab
         try:
             from tqdm.auto import tqdm
 
-            return tqdm(items, desc=desc)
+            return tqdm(items, desc=desc, total=total)
         except ImportError:
             pass
     return _iterator


### PR DESCRIPTION
# Description

Replaces `Pool.starmap` with `Pool.imap` to enable progress bar for loading data with multiple workers. Also reduces code duplication across single and multi-worker paths and adds an optional total parameter to `get_tqdm_iterable`.

Fixes #20047

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods