### PR TITLE
feat(gitlab): add pagination params for repository tree and issues

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/__init__.py
@@ -1,7 +1,6 @@
 from llama_index.readers.gitlab.issues.base import GitLabIssuesReader
 from llama_index.readers.gitlab.repository.base import GitLabRepositoryReader
 
-
 __all__ = [
     "GitLabIssuesReader",
     "GitLabRepositoryReader",

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/issues/base.py
@@ -1,13 +1,14 @@
 """GitLab issues reader."""
 
-from datetime import datetime
 import enum
+from datetime import datetime
 from typing import Any, List, Optional, Union
+
+from llama_index.core import Document
+from llama_index.core.readers.base import BaseReader
 
 import gitlab
 from gitlab.v4.objects import Issue as GitLabIssue
-from llama_index.core import Document
-from llama_index.core.readers.base import BaseReader
 
 
 class GitLabIssuesReader(BaseReader):
@@ -133,6 +134,7 @@ class GitLabIssuesReader(BaseReader):
         state: Optional[IssueState] = IssueState.OPEN,
         updated_after: Optional[datetime] = None,
         updated_before: Optional[datetime] = None,
+        get_all: bool = False,
         **kwargs: Any,
     ) -> List[Document]:
         """
@@ -167,6 +169,7 @@ class GitLabIssuesReader(BaseReader):
             - state: State of the issues to retrieve.
             - updated_after: Filter issues updated after the specified date.
             - updated_before: Filter issues updated before the specified date.
+            - get_all: Get all the items whisout pagination (for a long lists).
 
 
         Returns:
@@ -188,6 +191,7 @@ class GitLabIssuesReader(BaseReader):
             "state": state.value if state else None,
             "updated_after": to_gitlab_datetime_format(updated_after),
             "updated_before": to_gitlab_datetime_format(updated_before),
+            "get_all": get_all,
         }
 
         if isinstance(assignee, str):

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/llama_index/readers/gitlab/repository/base.py
@@ -2,9 +2,10 @@
 
 from typing import List, Optional
 
-import gitlab
 from llama_index.core import Document
 from llama_index.core.readers.base import BaseReader
+
+import gitlab
 
 
 class GitLabRepositoryReader(BaseReader):
@@ -52,6 +53,7 @@ class GitLabRepositoryReader(BaseReader):
         file_path: Optional[str] = None,
         path: Optional[str] = None,
         recursive: bool = False,
+        iterator: bool = False,
     ) -> List[Document]:
         """
         Load data from a GitLab repository.
@@ -61,6 +63,7 @@ class GitLabRepositoryReader(BaseReader):
             file_path: Path to the file to load.
             path: Path to the directory to load.
             recursive: Whether to load files recursively.
+            iterator: Return a generator handling API pagination automatically
 
         Returns:
             List[Document]: List of documents loaded from the repository
@@ -75,6 +78,7 @@ class GitLabRepositoryReader(BaseReader):
             "ref": ref,
             "path": path,
             "recursive": recursive,
+            "iterator": iterator,
         }
 
         filtered_params = {k: v for k, v in params.items() if v is not None}

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-gitlab"
-version = "0.4.1"
+version = "0.5.1"
 description = "llama-index readers gitlab integration"
 authors = [{name = "Jiacheng Zhang", email = "jiachengzz@outlook.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_issues.py
@@ -1,10 +1,11 @@
-import pytest
 from unittest.mock import MagicMock
-from llama_index.readers.gitlab import GitLabIssuesReader
+
 import gitlab
+import pytest
 
 # import so that pants sees it as a dependency
 import pytest_mock  # noqa
+from llama_index.readers.gitlab import GitLabIssuesReader
 
 
 @pytest.fixture()

--- a/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_repository.py
+++ b/llama-index-integrations/readers/llama-index-readers-gitlab/tests/test_readers_gitlab_repository.py
@@ -1,7 +1,8 @@
-import pytest
 from unittest import mock
-from llama_index.readers.gitlab import GitLabRepositoryReader
+
+import pytest
 from llama_index.core import Document
+from llama_index.readers.gitlab import GitLabRepositoryReader
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

Fixes pagination issue in GitLab reader where only 20 items were returned from repository tree and issues list.

## Changes
- Added `get_all` parameter to `project.repository_tree()` calls
- Added `iterator` parameter to `project.issues.list()` calls

Fixes #20051 #17993 (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
