### PR TITLE
fix: prevent command injection in pre-release workflow version-type parameter

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -42,8 +42,9 @@ jobs:
         working-directory: llama-dev
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION_TYPE: ${{ github.event.inputs.version-type }}
         run: |
-          uv run -- llama-dev --repo-root .. release prepare --version-type ${{ github.event.inputs.version-type }}
+          uv run -- llama-dev --repo-root .. release prepare --version-type "$VERSION_TYPE"
           uv run -- llama-dev --repo-root .. release changelog
           VERSION=$(uv run -- llama-dev --repo-root .. pkg info --json . | jq -r .version)
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Fixes a command injection vulnerability in the pre-release workflow by properly handling the `version-type` input parameter.

## Security Issue
The previous implementation directly interpolated the `version-type` input into a shell command without proper quoting:
```yaml
uv run -- llama-dev --repo-root .. release prepare --version-type ${{ github.event.inputs.version-type }}
```

This could allow command injection if a malicious value like `patch; malicious-command` was provided. While the risk is **low** (requires maintainer access to trigger the workflow with malicious input), it's still a security best practice to prevent this attack vector.

## Fix
- Store `github.event.inputs.version-type` in the `VERSION_TYPE` environment variable
- Properly quote `"$VERSION_TYPE"` when passing to the command

This ensures the value is treated as a literal string and cannot break out to execute arbitrary commands.

## Risk Assessment
- **Severity**: Low
- **Attack Vector**: Requires maintainer access to manually trigger the workflow with crafted input
- **Impact**: Could execute arbitrary commands in the GitHub Actions runner context