### PR TITLE
docs: add Kiln in integrations.md

### DIFF
--- a/docs/src/content/docs/framework/community/integrations.md
+++ b/docs/src/content/docs/framework/community/integrations.md
@@ -31,6 +31,7 @@ for full tracing integrations.
 
 ## Experiment Tracking
 
+- [Kiln](https://github.com/Kiln-AI/Kiln/tree/main/libs/core#taking-kiln-rag-to-production)
 - [MLflow](/python/examples/observability/mlflow)
 
 ## Structured Outputs


### PR DESCRIPTION
# Description

Docs-only change:
- added Kiln to the **Integrations** page under *Experiment Tracking*

[Kiln](https://kiln.tech) is an open-source desktop app for building and evaluating LlamaIndex-based RAG pipelines. It allows users to experiment with different models, chunking, and embedding strategies, run evaluations locally, and export their datasets as LlamaIndex nodes for indexing in any LlamaIndex-supported vector store.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

(docs-only change)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
