### PR TITLE
Fix invalid use of field-specific metadata

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -1,7 +1,7 @@
 """Node parser interface."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Sequence, Optional
+from typing import Any, Callable, Dict, List, Sequence
 from typing_extensions import Annotated
 
 from llama_index.core.bridge.pydantic import (
@@ -60,8 +60,8 @@ class NodeParser(TransformComponent, ABC):
     callback_manager: CallbackManager = Field(
         default_factory=lambda: CallbackManager([]), exclude=True
     )
-    id_func: Optional[IdFuncCallable] = Field(
-        default=None,
+    id_func: IdFuncCallable = Field(
+        default=default_id_func,
         description="Function to generate node IDs.",
     )
 


### PR DESCRIPTION
This patch fixes `id_func` to be non-optional and default to `default_id_func`, as it did prior to v0.11.0. This also fixes an `UnsupportedFieldAttributeWarning` that is emitted upon importing `llama_index.core` when using the latest version of Pydantic, which recently added this warning [[1]].

The bug was originally introduced in v0.11.0, as part of migrating to Pydantic V2 [[2], [3], [4]].

[1]: https://github.com/pydantic/pydantic/pull/12028
[2]: https://github.com/run-llama/llama_index/pull/15398
[3]: https://github.com/run-llama/llama_index/pull/15282
[4]: https://github.com/run-llama/llama_index/pull/15282/commits/a408fe70f8ba9c333ce41d78568a06112beb7672
