### PR TITLE
fix a typo in basic agent example

### DIFF
--- a/docs/src/content/docs/framework/getting_started/starter_example_local.mdx
+++ b/docs/src/content/docs/framework/getting_started/starter_example_local.mdx
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-This will output something like: `The answer to 1234 * 4567 is: 5,618,916.`
+This will output something like: `The answer to 1234 * 4567 is 5635678.`
 
 What happened is:
 


### PR DESCRIPTION
# Description

There is a typo in basic agent example in online document, the result of `1234*4567` appears to be wrong. This pull request fixes it.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
