### PR TITLE
feat: Add support for Bedrock Guardrails streamProcessingMode

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -4,6 +4,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Sequence,
     Tuple,
@@ -157,6 +158,13 @@ class BedrockConverse(FunctionCallingLLM):
     guardrail_version: Optional[str] = Field(
         description="The version number for the guardrail. The value can also be DRAFT"
     )
+    guardrail_stream_processing_mode: Optional[Literal["sync", "async"]] = Field(
+        description=(
+            "The stream processing mode to use when leveraging a guardrail in a streaming request (ConverseStream). "
+            "If set, the specified mode will be included in the request's guardrail configuration object, altering the streaming response behavior. "
+            "If a value is not provided, no mode will be explicitly included in the request's guardrail configuration object, and thus Amazon Bedrock's default, Synchronous Mode, will be used."
+        )
+    )
     application_inference_profile_arn: Optional[str] = Field(
         description="The ARN of an application inference profile to invoke in place of the model. If provided, make sure the model argument refers to the same one underlying the application inference profile."
     )
@@ -211,6 +219,7 @@ class BedrockConverse(FunctionCallingLLM):
         output_parser: Optional[BaseOutputParser] = None,
         guardrail_identifier: Optional[str] = None,
         guardrail_version: Optional[str] = None,
+        guardrail_stream_processing_mode: Optional[Literal["sync", "async"]] = None,
         application_inference_profile_arn: Optional[str] = None,
         trace: Optional[str] = None,
         thinking: Optional[ThinkingDict] = None,
@@ -263,6 +272,7 @@ class BedrockConverse(FunctionCallingLLM):
             botocore_config=botocore_config,
             guardrail_identifier=guardrail_identifier,
             guardrail_version=guardrail_version,
+            guardrail_stream_processing_mode=guardrail_stream_processing_mode,
             application_inference_profile_arn=application_inference_profile_arn,
             trace=trace,
             thinking=thinking,
@@ -474,6 +484,7 @@ class BedrockConverse(FunctionCallingLLM):
             stream=True,
             guardrail_identifier=self.guardrail_identifier,
             guardrail_version=self.guardrail_version,
+            guardrail_stream_processing_mode=self.guardrail_stream_processing_mode,
             trace=self.trace,
             **all_kwargs,
         )
@@ -668,6 +679,7 @@ class BedrockConverse(FunctionCallingLLM):
             stream=False,
             guardrail_identifier=self.guardrail_identifier,
             guardrail_version=self.guardrail_version,
+            guardrail_stream_processing_mode=self.guardrail_stream_processing_mode,
             trace=self.trace,
             boto_client_kwargs=self._boto_client_kwargs,
             **all_kwargs,

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -563,6 +563,7 @@ def converse_with_retry(
     stream: bool = False,
     guardrail_identifier: Optional[str] = None,
     guardrail_version: Optional[str] = None,
+    guardrail_stream_processing_mode: Optional[Literal["sync", "async"]] = None,
     trace: Optional[str] = None,
     **kwargs: Any,
 ) -> Any:
@@ -603,6 +604,10 @@ def converse_with_retry(
         converse_kwargs["guardrailConfig"]["guardrailVersion"] = guardrail_version
         if trace:
             converse_kwargs["guardrailConfig"]["trace"] = trace
+        if guardrail_stream_processing_mode and stream:
+            converse_kwargs["guardrailConfig"]["streamProcessingMode"] = (
+                guardrail_stream_processing_mode
+            )
 
     converse_kwargs = join_two_dicts(
         converse_kwargs,
@@ -644,6 +649,7 @@ async def converse_with_retry_async(
     stream: bool = False,
     guardrail_identifier: Optional[str] = None,
     guardrail_version: Optional[str] = None,
+    guardrail_stream_processing_mode: Optional[Literal["sync", "async"]] = None,
     trace: Optional[str] = None,
     boto_client_kwargs: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
@@ -690,6 +696,10 @@ async def converse_with_retry_async(
         converse_kwargs["guardrailConfig"]["guardrailVersion"] = guardrail_version
         if trace:
             converse_kwargs["guardrailConfig"]["trace"] = trace
+        if guardrail_stream_processing_mode and stream:
+            converse_kwargs["guardrailConfig"]["streamProcessingMode"] = (
+                guardrail_stream_processing_mode
+            )
     converse_kwargs = join_two_dicts(
         converse_kwargs,
         {

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.10.6"
+version = "0.10.7"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import pytest
 from llama_index.llms.bedrock_converse.utils import (
     get_model_name,
@@ -547,3 +548,52 @@ def test_converse_with_retry_list_system_prompt():
     assert response is not None
     assert "system" in captured_kwargs
     assert captured_kwargs["system"] == system_prompt
+
+
+@pytest.mark.parametrize("stream_processing_mode", ["sync", "async"])
+def test_converse_with_retry_guardrail_stream_processing_mode(
+    stream_processing_mode: Literal["sync", "async"],
+):
+    """
+    Test use of guardrail_stream_processing_mode in converse_with_retry with streaming.
+    """
+    client = MockClient()
+
+    with patch.object(client, "converse_stream") as patched_converse_stream:
+        converse_with_retry(
+            client=client,
+            model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+            messages=[],
+            stream=True,  # with streaming
+            guardrail_identifier="IDENT",
+            guardrail_version="DRAFT",
+            guardrail_stream_processing_mode=stream_processing_mode,
+        )
+        call_kwargs = patched_converse_stream.call_args.kwargs
+        assert "guardrailConfig" in call_kwargs
+        assert "streamProcessingMode" in call_kwargs["guardrailConfig"]
+        assert (
+            call_kwargs["guardrailConfig"]["streamProcessingMode"]
+            == stream_processing_mode
+        )
+
+
+def test_converse_with_retry_guardrail_stream_processing_mode_without_stream():
+    """
+    Test use of guardrail_stream_processing_mode in converse_with_retry WITHOUT streaming.
+    """
+    client = MockClient()
+
+    with patch.object(client, "converse") as patched_converse_stream:
+        converse_with_retry(
+            client=client,
+            model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+            messages=[],
+            stream=False,  # without streaming
+            guardrail_identifier="IDENT",
+            guardrail_version="DRAFT",
+            guardrail_stream_processing_mode="async",
+        )
+        call_kwargs = patched_converse_stream.call_args.kwargs
+        assert "guardrailConfig" in call_kwargs
+        assert "streamProcessingMode" not in call_kwargs["guardrailConfig"]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.10.2"
+version = "0.10.7"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

By default, when using Bedrock Guardrails alongside ConverseStream requests, [the guardrails operate in "Synchronous mode"](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-streaming.html), which may or may not be desired.

This PR adds a new attribute, `guardrail_stream_processing_mode`, to `BedrockConverse`, allowing users to configure the streaming response behavior when using guardrails in a streaming fashion.

Supporting Documentation:
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html#bedrock-runtime_ConverseStream-request-guardrailConfig
- https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-streaming.html

Related:
- #17281 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
