### PR TITLE
add classmethod IngestionCache.from_persist_dir and add/fix some test…

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/cache.py
+++ b/llama-index-core/llama_index/core/ingestion/cache.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Sequence
 
 import fsspec
@@ -10,7 +11,9 @@ from llama_index.core.storage.kvstore import (
 from llama_index.core.storage.kvstore.types import (
     BaseKVStore as BaseCache,
 )
+from llama_index.core.utils import concat_dirs
 
+DEFAULT_PERSIST_DIR = "./cache"
 DEFAULT_CACHE_NAME = "llama_cache"
 
 
@@ -62,13 +65,28 @@ class IngestionCache(BaseModel):
             print("Warning: skipping persist, only needed for SimpleCache.")
 
     @classmethod
-    def from_persist_path(
+    def from_persist_dir(
         cls,
-        persist_path: str,
-        collection: str = DEFAULT_CACHE_NAME,
+        persist_dir: str = DEFAULT_PERSIST_DIR,
+        collection: Optional[str] = None,
         fs: Optional[fsspec.AbstractFileSystem] = None,
     ) -> "IngestionCache":
         """Create a IngestionCache from a persist directory."""
+        if fs is not None:
+            persist_path = concat_dirs(persist_dir, DEFAULT_CACHE_NAME)
+        else:
+            persist_path = os.path.join(persist_dir, DEFAULT_CACHE_NAME)
+        return cls.from_persist_path(persist_path, collection=collection, fs=fs)
+
+    @classmethod
+    def from_persist_path(
+        cls,
+        persist_path: str,
+        collection: Optional[str] = None,
+        fs: Optional[fsspec.AbstractFileSystem] = None,
+    ) -> "IngestionCache":
+        """Create a IngestionCache from a persist path."""
+        collection = collection or DEFAULT_CACHE_NAME
         return cls(
             collection=collection,
             cache=SimpleCache.from_persist_path(persist_path, fs=fs),

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -4,6 +4,7 @@ from typing import Sequence, Any
 import pytest
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.extractors import KeywordExtractor
+from llama_index.core.ingestion.cache import IngestionCache
 from llama_index.core.ingestion.pipeline import IngestionPipeline
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.node_parser import SentenceSplitter, MarkdownElementNodeParser
@@ -115,10 +116,10 @@ def test_save_load_pipeline() -> None:
     pipeline2.load("./test_pipeline")
 
     # dedup will catch the last node
-    nodes = pipeline.run(documents=[documents[-1]])
+    nodes = pipeline2.run(documents=[documents[-1]])
     assert len(nodes) == 0
-    assert pipeline.docstore is not None
-    assert len(pipeline.docstore.docs) == 2
+    assert pipeline2.docstore is not None
+    assert len(pipeline2.docstore.docs) == 2
 
 
 def test_save_load_pipeline_without_docstore() -> None:
@@ -155,9 +156,9 @@ def test_save_load_pipeline_without_docstore() -> None:
     pipeline2.load("./test_pipeline")
 
     # dedup will not catch the last node if the document store is not set
-    nodes = pipeline.run(documents=[documents[-1]])
+    nodes = pipeline2.run(documents=[documents[-1]])
     assert len(nodes) == 1
-    assert pipeline.docstore is None
+    assert pipeline2.docstore is None
 
 
 def test_pipeline_update_text_content() -> None:
@@ -286,6 +287,49 @@ def test_pipeline_with_transform_error() -> None:
         pipeline.run(documents=[document1])
 
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+
+
+def test_pipeline_with_preload_from_persist_dir() -> None:
+    documents = [
+        Document(text="one", doc_id="1"),
+        Document(text="two", doc_id="2"),
+        Document(text="one", doc_id="1"),
+    ]
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        cache=IngestionCache(),
+        docstore=SimpleDocumentStore(),
+    )
+
+    nodes = pipeline.run(documents=documents)
+    assert len(nodes) == 2
+    assert pipeline.docstore is not None
+    assert len(pipeline.docstore.docs) == 2
+    assert pipeline.cache is not None
+
+    # save
+    pipeline.persist("./test_pipeline")
+
+    # preload cache & docstore
+    cache = IngestionCache.from_persist_dir("./test_pipeline")
+    docstore = SimpleDocumentStore.from_persist_dir("./test_pipeline")
+    pipeline2 = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+        ],
+        cache=cache,
+        docstore=docstore,
+    )
+
+    # dedup will catch the last node
+    nodes = pipeline2.run(documents=[documents[-1]])
+    assert len(nodes) == 0
+    assert pipeline2.docstore is not None
+    assert len(pipeline2.docstore.docs) == 2
+    assert pipeline2.cache is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

I added the `from_persist_dir` interface to the `IngestionCache` class. This is intended for use when utilizing `IngestionPipeline` without using `load`, instead directly passing pre-generated instances of `docstore` and `cache`. It was implemented to resolve the imbalance where `from_persist_dir` exists on the `docstore` side but not on the `cache` side.

Additionally, while creating the test case for the newly added from_persist_dir (test_pipeline_with_preload_from_persist_dir @test_pipeline.py), I discovered that The existing test cases `test_save_load_pipeline` and ` test_save_load_pipeline_without_docstore` were re-running the first pipeline after the second pipeline generation to verify dedup. This seemed inconsistent with the intended behavior, so I corrected it as well.

After adding `from_persist_dir` and fixing the test cases, I confirmed all tests pass.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
