### PR TITLE
Update Scrapy dependency to 2.13.3

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
     "markdownify>=1.1.0",
     "oxylabs>=2.0.0",
     "firecrawl-py>=4.3.3",
-    "Scrapy>=2.10.0",
+    "Scrapy>=2.13.3",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/readers/llama-index-readers-web/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-web/uv.lock
@@ -1856,7 +1856,7 @@ requires-dist = [
     { name = "oxylabs", specifier = ">=2.0.0" },
     { name = "playwright", specifier = ">=1.30,<2.0" },
     { name = "requests", specifier = ">=2.31.0,<3" },
-    { name = "scrapy", specifier = ">=2.10.0" },
+    { name = "scrapy", specifier = ">=2.13.3" },
     { name = "selenium", specifier = ">=4.17.2,<5" },
     { name = "spider-client", specifier = ">=0.0.27,<0.0.28" },
     { name = "urllib3", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary
Updates the Scrapy dependency to version 2.13.3 in the llama-index-readers-web package to address CVE-2025-6176.

## Changes
- Updated Scrapy requirement from >=2.10.0 to >=2.13.3 in pyproject.toml
- Updated uv.lock with corresponding dependency changes

## Context
This update resolves CVE-2025-6176, which addresses a denial of service vulnerability in Scrapy's brotli decompression implementation. Versions up to 2.13.2 are vulnerable to decompression bombs when processing brotli-compressed responses from remote servers.

## Test Plan
- Pre-commit checks passed successfully
- No code changes required, only dependency version bumps