### PR TITLE
fix weird pydantic warning

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/interface.py
+++ b/llama-index-core/llama_index/core/node_parser/interface.py
@@ -39,7 +39,7 @@ def _serialize_id_func(f: Callable) -> Any:
 
 IdFuncCallable = Annotated[
     Callable,
-    Field(validate_default=True),
+    Field(),
     BeforeValidator(_validate_id_func),
     WithJsonSchema({"type": "string"}, mode="serialization"),
     WithJsonSchema({"type": "string"}, mode="validation"),


### PR DESCRIPTION
There's some weird warning that happens every so often on this code. There's no reason to run validate_default here since the default is correct.