### PR TITLE
Bug: asyncio.run fails when synchronous method is called from already running async context

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -19,7 +19,7 @@ from typing import (
     Callable,
 )
 
-
+from llama_index.core.async_utils import asyncio_run
 import llama_index.core.instrumentation as instrument
 from llama_index.core.base.llms.generic_utils import (
     chat_to_completion_decorator,
@@ -309,7 +309,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs = asyncio.run(
+        next_msg, chat_kwargs = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.use_file_api, self._client, **params
             )
@@ -320,7 +320,7 @@ class GoogleGenAI(FunctionCallingLLM):
         )
 
         if self.use_file_api:
-            asyncio.run(
+            asyncio_run(
                 delete_uploaded_files([*chat_kwargs["history"], next_msg], self._client)
             )
 
@@ -366,7 +366,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs = asyncio.run(
+        next_msg, chat_kwargs = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.use_file_api, self._client, **params
             )
@@ -405,7 +405,7 @@ class GoogleGenAI(FunctionCallingLLM):
                 yield llama_resp
 
             if self.use_file_api:
-                asyncio.run(
+                asyncio_run(
                     delete_uploaded_files(
                         [*chat_kwargs["history"], next_msg], self._client
                     )
@@ -594,7 +594,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
         messages = prompt.format_messages(**prompt_args)
         contents = [
-            asyncio.run(
+            asyncio_run(
                 chat_message_to_gemini(message, self.use_file_api, self._client)
             )
             for message in messages
@@ -614,7 +614,7 @@ class GoogleGenAI(FunctionCallingLLM):
         )
 
         if self.use_file_api:
-            asyncio.run(delete_uploaded_files(contents, self._client))
+            asyncio_run(delete_uploaded_files(contents, self._client))
 
         if isinstance(response.parsed, BaseModel):
             return response.parsed
@@ -644,7 +644,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.use_file_api, self._client)
                 )
                 for message in messages
@@ -656,7 +656,7 @@ class GoogleGenAI(FunctionCallingLLM):
             )
 
             if self.use_file_api:
-                asyncio.run(delete_uploaded_files(contents, self._client))
+                asyncio_run(delete_uploaded_files(contents, self._client))
 
             if isinstance(response.parsed, BaseModel):
                 return response.parsed
@@ -738,7 +738,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.use_file_api, self._client)
                 )
                 for message in messages
@@ -767,7 +767,7 @@ class GoogleGenAI(FunctionCallingLLM):
                             yield streaming_model
 
                 if self.use_file_api:
-                    asyncio.run(delete_uploaded_files(contents, self._client))
+                    asyncio_run(delete_uploaded_files(contents, self._client))
 
             return gen()
         else:


### PR DESCRIPTION
# Description
- Gemini structured_predict was failing when called inside a synchronous method that is inside an asyncio event loop.
- Use `from llama_index.core.async_utils import asyncio_run` instead of `asyncio.run()` to make sure the synchronous methods also work inside a asyncio event loop.

Regression caused in PR: 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
