### PR TITLE
`vector-azureaisearch`: check if user agent already in policy before add it to azure client

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -685,13 +685,27 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 "in, sync or async functions may not work."
             )
 
+        def add_user_agent(
+            client: Union[
+                SearchClient,
+                SearchIndexClient,
+                AsyncSearchIndexClient,
+                AsyncSearchClient,
+            ],
+        ):
+            from azure.core.pipeline.policies import UserAgentPolicy
+
+            user_agent_policy: UserAgentPolicy = (
+                client._client._config.user_agent_policy
+            )
+            if self._user_agent not in user_agent_policy.user_agent:
+                user_agent_policy.add_user_agent(self._user_agent)
+
         # Validate sync search_or_index_client
         if search_or_index_client is not None:
             if isinstance(search_or_index_client, SearchIndexClient):
                 self._index_client = search_or_index_client
-                self._index_client._client._config.user_agent_policy.add_user_agent(
-                    self._user_agent
-                )
+                add_user_agent(self._index_client)
                 if not index_name:
                     raise ValueError(
                         "index_name must be supplied if search_or_index_client is of "
@@ -701,15 +715,11 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._search_client = self._index_client.get_search_client(
                     index_name=index_name
                 )
-                self._search_client._client._config.user_agent_policy.add_user_agent(
-                    self._user_agent
-                )
+                add_user_agent(self._search_client)
 
             elif isinstance(search_or_index_client, SearchClient):
                 self._search_client = search_or_index_client
-                self._search_client._client._config.user_agent_policy.add_user_agent(
-                    self._user_agent
-                )
+                add_user_agent(self._search_client)
                 # Validate index_name
                 if index_name:
                     raise ValueError(
@@ -724,9 +734,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         if async_search_or_index_client is not None:
             if isinstance(async_search_or_index_client, AsyncSearchIndexClient):
                 self._async_index_client = async_search_or_index_client
-                self._async_index_client._client._config.user_agent_policy.add_user_agent(
-                    self._user_agent
-                )
+                add_user_agent(self._async_index_client)
 
                 if not index_name:
                     raise ValueError(
@@ -737,15 +745,11 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._async_search_client = self._async_index_client.get_search_client(
                     index_name=index_name
                 )
-                self._async_search_client._client._config.user_agent_policy.add_user_agent(
-                    self._user_agent
-                )
+                add_user_agent(self._async_search_client)
 
             elif isinstance(async_search_or_index_client, AsyncSearchClient):
                 self._async_search_client = async_search_or_index_client
-                self._async_search_client._client._config.user_agent_policy.add_user_agent(
-                    self._user_agent
-                )
+                add_user_agent(self._async_search_client)
 
                 # Validate index_name
                 if index_name:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-azureaisearch"
-version = "0.4.2"
+version = "0.4.3"
 description = "llama-index vector_stores azureaisearch integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

If the Azure AI search client is reused while creating multiple vector store instances, the user-agent gets appended repeatedly. In the worst-case scenario, this repetition results in a user-agent header that exceeds the permitted length, causing a "400 Bad Request: The size of the request headers is too long" error.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
