### PR TITLE
Fix: Only calculate embeddings for query modes that require them (#20242)

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/retrievers/retriever.py
@@ -91,9 +91,13 @@ class VectorIndexRetriever(BaseRetriever):
 
     def _needs_embedding(self) -> bool:
         """Check if the current query mode requires embeddings."""
-        return self._vector_store.is_embedding_query and self._vector_store_query_mode not in (
-            VectorStoreQueryMode.TEXT_SEARCH,
-            VectorStoreQueryMode.SPARSE,
+        return (
+            self._vector_store.is_embedding_query
+            and self._vector_store_query_mode
+            not in (
+                VectorStoreQueryMode.TEXT_SEARCH,
+                VectorStoreQueryMode.SPARSE,
+            )
         )
 
     @dispatcher.span


### PR DESCRIPTION
## Summary

Fixes #20242

VectorIndexRetriever was calculating query embeddings regardless of `vector_store_query_mode`, even for modes like `TEXT_SEARCH` and `SPARSE` that don't require embeddings. This resulted in unnecessary external API calls to embedding services.

## Changes

- Added `_needs_embedding()` helper method to determine if the current query mode requires embeddings
- Updated `_retrieve()` to skip embedding calculation for TEXT_SEARCH and SPARSE modes  
- Updated `_aretrieve()` to skip embedding calculation for TEXT_SEARCH and SPARSE modes
- Embedding calculation now only happens when `is_embedding_query` is True AND query mode is not TEXT_SEARCH or SPARSE

## Impact

- **Performance**: Reduces unnecessary embedding API calls for text search and sparse retrieval
- **Cost savings**: Fewer API calls to embedding services
- **QueryFusionRetriever**: Also fixes the issue where async mode (`_aretrieve`) was generating duplicate embeddings for each retriever

## Testing

The fix maintains backward compatibility - all query modes that previously generated embeddings will continue to do so:
- ✅ DEFAULT mode - still generates embeddings
- ✅ SEMANTIC_HYBRID mode - still generates embeddings  
- ✅ HYBRID mode - still generates embeddings
- ✅ MMR mode - still generates embeddings
- ✅ TEXT_SEARCH mode - now skips embedding generation (fix)
- ✅ SPARSE mode - now skips embedding generation (fix)