### PR TITLE
Fix: Extract file extension from file_path for SimpleFileNodeParser (#20217)

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/simple_file.py
+++ b/llama-index-core/llama_index/core/node_parser/file/simple_file.py
@@ -1,5 +1,6 @@
 """Simple file node parser."""
 
+import os
 from typing import Any, Dict, List, Optional, Sequence, Type
 
 from llama_index.core.callbacks.base import CallbackManager
@@ -70,8 +71,14 @@ class SimpleFileNodeParser(NodeParser):
         )
 
         for document in documents_with_progress:
-            ext = document.metadata.get("extension", "None")
-            if ext in FILE_NODE_PARSERS:
+            # Try to get extension from metadata, or extract from file_path
+            ext = document.metadata.get("extension")
+            if ext is None and "file_path" in document.metadata:
+                # Extract extension from file_path
+                _, ext = os.path.splitext(document.metadata["file_path"])
+                ext = ext.lower()
+
+            if ext and ext in FILE_NODE_PARSERS:
                 parser = FILE_NODE_PARSERS[ext](
                     include_metadata=self.include_metadata,
                     include_prev_next_rel=self.include_prev_next_rel,


### PR DESCRIPTION
## Summary

Fixes #20217

SimpleFileNodeParser was not applying MarkdownNodeParser to markdown files because it was checking for an 'extension' key in metadata that was never set. SimpleDirectoryReader only sets 'file_path' and 'file_type' (mimetype) in metadata.

## Root Cause

The parser was looking for `document.metadata.get("extension")`, but SimpleDirectoryReader's `default_file_metadata_func` only sets:
- `file_path` (e.g., "/path/to/file.md")
- `file_type` (e.g., "text/markdown")

It never sets the `extension` key, causing all files to fall through to the default text parsing.

## Changes

- Added fallback logic to extract extension from `file_path` metadata using `os.path.splitext()`
- Extension is normalized to lowercase for case-insensitive matching
- Maintains backward compatibility with explicit `extension` key if provided
- Applies to all supported file types: `.md`, `.html`, `.json`

## Testing

### Before:
```python
# Markdown files were parsed as plain text
parser = SimpleFileNodeParser()
nodes = parser.get_nodes_from_documents([markdown_doc])
# Result: Single node with full file content
```

### After:
```python
# Markdown files correctly use MarkdownNodeParser
parser = SimpleFileNodeParser()
nodes = parser.get_nodes_from_documents([markdown_doc])
# Result: Multiple nodes split by markdown headers
```

## Impact

- Fixes markdown file parsing in SimpleFileNodeParser
- Also fixes HTML and JSON file parsing
- No breaking changes - backward compatible