### PR TITLE
fix: Pin azure-ai-projects version to prevent breaking changes

### DIFF
--- a/llama-index-integrations/agent/llama-index-agent-azure/pyproject.toml
+++ b/llama-index-integrations/agent/llama-index-agent-azure/pyproject.toml
@@ -34,7 +34,7 @@ requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "azure-ai-projects >= 1.0.0b11",
+    "azure-ai-projects >= 1.0.0b11, < 2.0.0",
     "azure-ai-agents >= 1.0.0b3",
     "azure-identity",
     "openai>=1.14.0",


### PR DESCRIPTION
## Description

Pin `azure-ai-projects` to `< 2.0.0` to prevent test failures in the Azure Foundry Agent integration caused by breaking changes introduced in version 2.0.0b1 (released November 11, 2025).

## Root Cause

The loose dependency constraint `azure-ai-projects >= 1.0.0b11` allowed CI to pull version 2.0.0b1, which introduced breaking changes:

- Agent operations were rebuilt on OpenAI's `Responses` protocol
- The package removed its dependency on `azure-ai-agents`
- The `AIProjectClient` API structure changed significantly
- The `agents` attribute implementation changed in ways that broke the test mocks

## Changes

- **pyproject.toml**: Changed `azure-ai-projects >= 1.0.0b11` to `azure-ai-projects >= 1.0.0b11, < 2.0.0`

This is the minimal fix that prevents the breaking changes until a proper migration can be done.

## Testing

- This change prevents azure-ai-projects 2.0.0b1+ from being installed
- Tests will continue to work with 1.x versions (1.0.0b11 through 1.x)
- No lock files needed updating (package uses pyproject.toml only)

## Future Work

A follow-up PR should update the integration to support `azure-ai-projects` 2.0.0+ with the new agent API patterns. See the [azure-sdk-for-python CHANGELOG](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ai/azure-ai-projects/CHANGELOG.md) and `samples/agents` folder for migration guidance.

## Fixes

- test_azure_foundry_agent_constructor
- test_azure_foundry_agent_constructor_defaults