### PR TITLE
Fix: add model parameter and improve response parsing for vllm v1/completions

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -236,6 +236,7 @@ class Vllm(LLM):
     @property
     def _model_kwargs(self) -> Dict[str, Any]:
         base_kwargs = {
+            "model": self.model,
             "temperature": self.temperature,
             "max_tokens": self.max_new_tokens,
             "n": self.n,
@@ -435,8 +436,7 @@ class VllmServer(Vllm):
         sampling_params["prompt"] = prompt
         response = post_http_request(self.api_url, sampling_params, stream=False)
         output = get_response(response)
-
-        return CompletionResponse(text=output[0])
+        return CompletionResponse(text=output)
 
     @llm_completion_callback()
     def stream_complete(

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/utils.py
@@ -6,7 +6,9 @@ import requests
 
 def get_response(response: requests.Response) -> List[str]:
     data = json.loads(response.content)
-    return data["text"]
+    if "text" not in data and "choices" in data:
+        return data["choices"][0]["text"]
+    return data["text"][0]
 
 
 def post_http_request(


### PR DESCRIPTION


 Tested with vllm 0.7.3 and confirmed compatibility with both new (choices-based) and legacy (top-level text) response formats.

Fix: add model parameter and improve response parsing for v1/completions

# Description

Add model parameter to vllm v1/completions requests to resolve "missing Field required" errors, as the vllm API requires both model and prompt fields. Adjust response parsing to extract text from choices field (compatible with recent vllm versions) while preserving fallback to top-level text field for backward compatibility with older versions.

Fixes # (issue)
This addresses two issues:

1. Missing model parameter in API requests causing validation failures 
2. Incorrect response parsing that failed to handle vllm's standard choices-nested text structure

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [√] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [√] No

## Type of Change

Please delete options that are not relevant.

- [√] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [√] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [√] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [√] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [√] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
