### PR TITLE
Ingestion to vector store now ensures that _node-content is readable

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/utils.py
+++ b/llama-index-core/llama_index/core/vector_stores/utils.py
@@ -63,7 +63,7 @@ def node_to_metadata_dict(
     node_dict["embedding"] = None
 
     # dump remainder of node_dict to json string
-    metadata["_node_content"] = json.dumps(node_dict)
+    metadata["_node_content"] = json.dumps(node_dict, ensure_ascii=False)
     metadata["_node_type"] = node.class_name()
 
     # store ref doc id at top level to allow metadata filtering


### PR DESCRIPTION


# Description

Currently the the lack of ensure_ascii in node_to_metadata_dict doesn't impact the retrieval from vector store (the retrieved text in NodeWithScore has unescaped characters), but in the console of the vector store the text value has every non-ascii character escaped, which makes querying the vector db directly harder and unreadable, also impact filter by keywords in Qdrant. With this one-liner fix, the values in vector store has unescaped characters, which solves all the mentioned issues.  

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No new package

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No, updating llama-index-core

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
