### PR TITLE
fix: Update qdrant-client version constraints

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -28,14 +28,14 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-qdrant"
-version = "0.8.7"
+version = "0.8.8"
 description = "llama-index vector_stores qdrant integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<3.14"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "qdrant-client>=1.7.1",
+    "qdrant-client>=1.7.1,<1.16.0",
     "grpcio>=1.60.0,<2",
     "llama-index-core>=0.13.0,<0.15",
 ]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-vector-stores-qdrant"
-version = "0.8.5"
+version = "0.8.8"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },
@@ -1846,7 +1846,7 @@ dev = [
 requires-dist = [
     { name = "grpcio", specifier = ">=1.60.0,<2" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
-    { name = "qdrant-client", specifier = ">=1.7.1" },
+    { name = "qdrant-client", specifier = ">=1.7.1,<1.16.0" },
 ]
 provides-extras = ["fastembed"]
 


### PR DESCRIPTION
# Description

Added a constraint for the qdrant client to be less than 1.16.0

Unblocks #20279 , but will require a larger fix to migrate the client version

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
