### PR TITLE
Fix typo in README.md for Reddit integration

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-reddit/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-reddit/README.md
@@ -4,7 +4,7 @@
 pip install llama-index-readers-reddit
 ```
 
-For any subreddit(s) you're interested in, search for relevant posts using keyword(s) and load the resulting text in the post and and top-level comments into LLMs/ LangChains.
+For any subreddit(s) you're interested in, search for relevant posts using keyword(s) and load the resulting text in the post and top-level comments into LLMs/ LangChains.
 
 ## Get your Reddit credentials ready
 


### PR DESCRIPTION
## Description
This PR fixes a small typo in the `llama-index-readers-reddit` README where the word "and" was duplicated.

## Related Issue
Fixes #20282 

## Type of Change
- [x] Documentation update.