### PR TITLE
Bump version of bedrock-embedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-bedrock"
-version = "0.7.1"
+version = "0.7.2"
 description = "llama-index embeddings bedrock integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1721,7 +1722,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-bedrock"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

  This PR bumps the version of `llama-index-embeddings-bedrock` from `0.7.1` to
  `0.7.2` to make the bug fix from #20295 available to users via package managers.

  ## Context

  PR #20295 fixed a bug where regionally-scoped Bedrock model names (e.g.,
  `"eu.cohere.embed-v4:0"`) were causing "Provider not supported" errors. The fix
  introduced a `_get_provider()` method that correctly extracts the provider name
  from both:
  - 2-part model names: `provider.model` (e.g., `"amazon.titan-embed-text-v1"`)
  - 3-part model names: `region.provider.model` (e.g., `"eu.cohere.embed-v4:0"`)

  **Without this version bump**, users cannot get the bug fix via `pip install` or
  `uv pip install`, as package managers rely on version numbers to distribute
  updates.

  ## Changes

  - Bumped version in `pyproject.toml`: `0.7.1` → `0.7.2`
  - Updated `uv.lock` to reflect new version

  ## Related PR

  - Fixes implemented in: #20295

  Fixes # (issue)

  ## New Package?

  Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a
  detailed README.md for my new integration or package?

  - [ ] Yes
  - [x] No

  ## Version Bump?

  Did I bump the version in the `pyproject.toml` file of the package I am updating?
  (Except for the `llama-index-core` package)

  - [x] Yes
  - [ ] No

  ## Type of Change

  Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
  - [ ] This change requires a documentation update

  ## How Has This Been Tested?

  Your pull-request will likely not be merged unless it is covered by some form of
  impactful unit testing.

  - [ ] I added new unit tests to cover this change
  - [x] I believe this change is already covered by existing unit tests

  Note: The bug fix in #20295 included comprehensive unit tests that were already
  merged.

  ## Suggested Checklist:

  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added Google Colab support for the newly added notebooks.
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I ran `uv run make format; uv run make lint` to appease the lint gods