### PR TITLE
fix(memory): ensure first message in queue is always a user message after flush

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -741,30 +741,25 @@ class Memory(BaseMemory):
                         if reversed_queue and reversed_queue[0].role != "user":
                             messages_to_flush.append(reversed_queue.pop(0))
 
-                        # Find the most recent complete conversation turn
-                        # (user → assistant/tool sequence) in messages_to_flush
-                        found_user = False
-                        turn_messages: List[ChatMessage] = []
+                        # Find the most recent complete conversation turn in messages_to_flush
+                        # A complete turn is: user message + all subsequent assistant/tool responses
+                        # This correctly handles tool calling: user → assistant → tool → assistant
+                        # Search from end to find the last user message
+                        turn_start_idx = -1
 
-                        # Go through messages_to_flush in reverse (newest first)
-                        # First collect assistant/tool messages, then find the user message
-                        for msg in reversed(messages_to_flush):
-                            if msg.role == "user":
-                                found_user = True
-                                turn_messages.insert(0, msg)
-                                break  # Found the user message, complete turn found
-                            else:
-                                # Collect assistant/tool messages (they come first in reverse)
-                                turn_messages.insert(0, msg)
+                        for i in range(len(messages_to_flush) - 1, -1, -1):
+                            if messages_to_flush[i].role == "user":
+                                turn_start_idx = i
+                                break
 
-                        # If we found a complete turn, keep it
-                        if found_user and turn_messages:
-                            # Remove these messages from messages_to_flush
-                            for msg in turn_messages:
-                                if msg in messages_to_flush:
-                                    messages_to_flush.remove(msg)
-                            # Add them back to the queue
+                        # If we found a user message, keep everything from that user to the end
+                        if turn_start_idx >= 0:
+                            turn_messages = messages_to_flush[turn_start_idx:]
+                            # Keep only messages before the turn for flushing
+                            messages_to_flush = messages_to_flush[:turn_start_idx]
+                            # Add the complete turn back to the queue
                             reversed_queue = turn_messages[::-1] + reversed_queue
+                        # else: No user message found - queue may remain empty (defensive)
 
                 # Archive the flushed messages
                 if messages_to_flush:


### PR DESCRIPTION
# Description

When Memory's `token_limit` and `token_flush_size` are set low enough that a single conversation turn triggers the flushing behavior, the active message queue could end up with only an assistant message remaining instead of starting with a user message.

This breaks providers like Amazon Bedrock that require the first message to be from the user.

## Root Cause

The `_manage_queue` method in `Memory` class had two issues:

1. **Incomplete trigger condition**: The recovery logic only triggered when the queue was completely empty (`if not reversed_queue`), but not when it had exactly one non-user message remaining.

2. **Incorrect iteration logic**: When recovering a conversation turn from `messages_to_flush`, the code iterated in reverse (newest first) but immediately broke on the first non-user message, failing to find the preceding user message.

## Fix

1. Expanded the recovery logic trigger condition to also handle the case when the queue has exactly one non-user message.
2. Fixed the iteration logic to first collect assistant/tool messages, then find the user message to form a complete conversation turn.

Fixes #20256

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added two new test cases in `llama-index-core/tests/memory/test_memory_base.py`:

1. `test_manage_queue_first_message_must_be_user`: Verifies that after flushing with low token limits, the first message is always a user message.
2. `test_manage_queue_preserves_conversation_turn`: Verifies that at least one complete conversation turn (user → assistant) is preserved.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods