### PR TITLE
Relax docling Python constraints

### DIFF
--- a/llama-index-integrations/node_parser/llama-index-node-parser-docling/pyproject.toml
+++ b/llama-index-integrations/node_parser/llama-index-node-parser-docling/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-node-parser-docling"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index node_parser docling integration"
 authors = [{name = "Panos Vagenas", email = "pva@zurich.ibm.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-docling/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-docling/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-docling"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index readers docling integration"
 authors = [{name = "Panos Vagenas", email = "pva@zurich.ibm.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Relax docling integration Python version.

Fixes [# (issue)
](https://github.com/run-llama/llama_index/issues/20321#issuecomment-3589538064)


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## How Has This Been Tested?

I've manually copied the existing docling integrations in my Python 3.13 project and they worked fine.  

