### PR TITLE
test: fix typo 'reponse' to 'response' in variable names

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-qianfan/tests/test_llms_qianfan.py
+++ b/llama-index-integrations/llms/llama-index-llms-qianfan/tests/test_llms_qianfan.py
@@ -13,7 +13,7 @@ from llama_index.llms.qianfan import Qianfan
 # https://cloud.baidu.com/doc/WENXINWORKSHOP/s/4lqoklvr1
 # https://cloud.baidu.com/doc/WENXINWORKSHOP/s/clntwmv7t
 
-mock_service_list_reponse = {
+mock_service_list_response = {
     "log_id": "4102908182",
     "success": True,
     "result": {
@@ -318,7 +318,7 @@ mock_stream_chat_response = [
 @patch("httpx.Client")
 def test_from_model_name(mock_client: httpx.Client):
     mock_response = MagicMock()
-    mock_response.json.return_value = mock_service_list_reponse
+    mock_response.json.return_value = mock_service_list_response
     mock_client.return_value.__enter__.return_value.send.return_value = mock_response
 
     llm = Qianfan.from_model_name(
@@ -337,7 +337,7 @@ def test_from_model_name(mock_client: httpx.Client):
 @patch("httpx.AsyncClient")
 def test_afrom_model_name(mock_client: httpx.AsyncClient):
     mock_response = MagicMock()
-    mock_response.json.return_value = mock_service_list_reponse
+    mock_response.json.return_value = mock_service_list_response
     mock_client.return_value.__aenter__.return_value.send.return_value = mock_response
 
     async def async_process():

--- a/llama-index-utils/llama-index-utils-qianfan/tests/test_apis.py
+++ b/llama-index-utils/llama-index-utils-qianfan/tests/test_apis.py
@@ -10,7 +10,7 @@ from llama_index.utils.qianfan.apis import (
     ServiceItem,
 )
 
-mock_service_list_reponse = {
+mock_service_list_response = {
     "log_id": "4102908182",
     "success": True,
     "result": {
@@ -48,7 +48,7 @@ mock_service_list_reponse = {
 @patch("httpx.Client")
 def test_get_service_list(mock_client: httpx.Client):
     mock_response = MagicMock()
-    mock_response.json.return_value = mock_service_list_reponse
+    mock_response.json.return_value = mock_service_list_response
     mock_client.return_value.__enter__.return_value.send.return_value = mock_response
 
     service_list: List[ServiceItem] = get_service_list(
@@ -69,7 +69,7 @@ def test_get_service_list(mock_client: httpx.Client):
 @patch("httpx.AsyncClient")
 def test_aget_service_list(mock_client: httpx.AsyncClient):
     mock_response = MagicMock()
-    mock_response.json.return_value = mock_service_list_reponse
+    mock_response.json.return_value = mock_service_list_response
     mock_client.return_value.__aenter__.return_value.send.return_value = mock_response
 
     async def async_process():


### PR DESCRIPTION
# Description

Fixed a typo in `test_llms_qianfan.py` and `test_apis.py` where the variable `mock_service_list_reponse` was misspelled (missing the 's' in response). 

I have renamed the variable definition and updated all references to it in the test functions to match the correct spelling (`mock_service_list_response`).

Fixes # N/A

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods