### PR TITLE
Fix multi_agent.md markdown formatting

### DIFF
--- a/docs/src/content/docs/framework/understanding/agent/multi_agent.md
+++ b/docs/src/content/docs/framework/understanding/agent/multi_agent.md
@@ -13,6 +13,7 @@ When more than one specialist is required to solve a task you have several optio
 ---
 
 <div id="pattern-1--agentworkflow-ie-linear-swarm-pattern"></div>
+
 ## Pattern 1 – AgentWorkflow (i.e. linear "swarm" pattern)
 
 **When to use** – you want multi-agent behaviour out-of-the-box with almost no extra code, and you are happy with the default hand-off heuristics that ship with `AgentWorkflow`.
@@ -81,6 +82,7 @@ print(resp)
 ---
 
 <div id="pattern-2--orchestrator-agent-sub-agents-as-tools"></div>
+
 ## Pattern 2 – Orchestrator agent (sub-agents as tools)
 
 **When to use** – you want a single place that decides _every_ step so you can inject custom logic, but you still prefer the declarative _agent as tool_ experience over writing your own planner.
@@ -184,6 +186,7 @@ Because the orchestrator is just another `FunctionAgent` you get streaming, tool
 ---
 
 <div id="pattern-3--custom-planner-diy-prompting--parsing"></div>
+
 ## Pattern 3 – Custom planner (DIY prompting + parsing)
 
 **When to use** – ultimate flexibility. You need to impose a very specific plan format, integrate with external schedulers, or gather additional metadata that the previous patterns cannot provide out-of-the-box.


### PR DESCRIPTION
# Description

Fixes a formatting issue on one of the markdown documentation pages. Three headers on the page aren't being rendered correctly, which also prevents them from showing up in the nav bar on the right.
<img width="1172" height="405" alt="Screenshot 2025-12-09 at 11 05 54 AM" src="https://github.com/user-attachments/assets/9274254b-312c-43fd-82b6-c7674feb16ef" />

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

No, lmk if I should.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods (attempted, but don't have the git hooks installed)
