### PR TITLE
feat: add support for gpt-5.2 and 5.2 pro

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -78,6 +78,7 @@ from llama_index.llms.openai.utils import (
     to_openai_message_dicts,
     update_tool_calls,
     is_json_schema_supported,
+    is_chatcomp_api_supported,
 )
 from openai import AsyncOpenAI
 from openai import OpenAI as SyncOpenAI
@@ -298,6 +299,11 @@ class OpenAI(FunctionCallingLLM):
         # TODO: Temp forced to 1.0 for o1
         if model in O1_MODELS:
             temperature = 1.0
+
+        if not is_chatcomp_api_supported(model):
+            raise ValueError(
+                f"Cannot use model {model} as it is only supported by the Responses API. Use the OpenAIResponses class for it."
+            )
 
         super().__init__(
             model=model,

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -68,6 +68,13 @@ O1_MODELS: Dict[str, int] = {
     "gpt-5.1": 400000,
     "gpt-5.1-2025-11-13": 400000,
     "gpt-5.1-chat-latest": 128000,
+    "gpt-5.2": 400000,
+    "gpt-5.2-2025-12-11": 400000,
+}
+
+RESPONSES_API_ONLY_MODELS = {
+    "gpt-5.2-pro": 400000,
+    "gpt-5.2-pro-2025-12-11": 400000,
 }
 
 O1_MODELS_WITHOUT_FUNCTION_CALLING = {
@@ -208,7 +215,12 @@ JSON_SCHEMA_MODELS = [
     "gpt-4o",
     "gpt-4.1",
     "gpt-5",
+    "gpt-5.2",
 ]
+
+
+def is_chatcomp_api_supported(model: str) -> bool:
+    return model not in RESPONSES_API_ONLY_MODELS
 
 
 def is_json_schema_supported(model: str) -> bool:

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.6.10"
+version = "0.6.11"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -38,6 +38,7 @@ from llama_index.llms.openai.utils import (
     is_function_calling_model,
     ALL_AVAILABLE_MODELS,
     CHAT_MODELS,
+    is_chatcomp_api_supported,
 )
 
 
@@ -446,3 +447,8 @@ def test_gpt_5_chat_latest_model_support() -> None:
 
     # Test that model is in CHAT_MODELS
     assert model_name in CHAT_MODELS, f"{model_name} should be in CHAT_MODELS"
+
+
+def test_is_chatcomp_api_supported() -> None:
+    assert is_chatcomp_api_supported("gpt-5.2")
+    assert not is_chatcomp_api_supported("gpt-5.2-pro")


### PR DESCRIPTION
As per title.

Interstingly, `gpt-5.2-pro` is only available in the responses API, so I needed a workaround for that
