### PR TITLE
Add entries to advanced retrieval meta configuration

### DIFF
--- a/docs/src/content/docs/framework/optimizing/advanced_retrieval/_meta.yml
+++ b/docs/src/content/docs/framework/optimizing/advanced_retrieval/_meta.yml
@@ -1,2 +1,5 @@
 label: Advanced Retrieval
 collapsed: true
+entries:
+  - advanced_retrieval
+  - query_transformations


### PR DESCRIPTION
## Description
This PR adds the missing `entries` list to the `_meta.yml` file in the advanced_retrieval documentation folder, which explicitly includes both the "Query Transformations" and "Advanced Retrieval Strategies" pages in the sidebar navigation.

## Issue
Closes #20181

## Changes
- Updated `docs/src/content/docs/framework/optimizing/advanced_retrieval/_meta.yml` to include:
  - `advanced_retrieval` entry
  - `query_transformations` entry

These pages now appear in the sidebar navigation, making them discoverable to documentation users while maintaining the existing collapsed state of the Advanced Retrieval section.