### PR TITLE
[BUG] bump: dependencies to add Python 3.14 support for confluence reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -29,7 +29,7 @@ name = "llama-index-readers-confluence"
 version = "0.6.0"
 description = "llama-index readers confluence integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 readme = "README.md"
 license = "MIT"
 maintainers = [{name = "zywilliamli"}]
@@ -37,7 +37,7 @@ dependencies = [
     "atlassian-python-api>=3.41.9,<5",
     "pytesseract>=0.3.10,<0.4",
     "pdf2image>=1.17.0,<2",
-    "pillow>=10.2.0,<11",
+    "pillow>=10.2.0,<12",
     "docx2txt>=0.8,<0.9",
     "xlrd>=2.0.1,<3",
     "svglib>=1.5,<1.6",


### PR DESCRIPTION
# Description

Llama index confluence reader integration did not support Python 3.14. As state by the maintainer in #20133 the project aims to support 3.9 to 3.14

Closes #20367

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No, no new package

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
