### PR TITLE
fix(confluence): support Python 3.14

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-confluence/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-confluence"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index readers confluence integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
## Summary
- Update `requires-python` from `<3.14` to `<4.0`
- Remove pillow upper bound (`<11`) to allow v11 which supports Python 3.14

Fixes #20367