### PR TITLE
fix(langchain): add LangChain 1.x compatibility for imports

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-langchain/llama_index/llms/langchain/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-langchain/llama_index/llms/langchain/base.py
@@ -20,8 +20,14 @@ from llama_index.core.base.llms.generic_utils import (
 from llama_index.core.llms.llm import LLM
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode, Thread
 
-from langchain.base_language import BaseLanguageModel
-from langchain.schema import AIMessage
+# LangChain 1.x compatibility
+try:
+    from langchain_core.language_models.base import BaseLanguageModel
+    from langchain_core.messages import AIMessage
+except ImportError:
+    # Fallback for LangChain < 1.0
+    from langchain.base_language import BaseLanguageModel
+    from langchain.schema import AIMessage
 
 
 class LangChainLLM(LLM):


### PR DESCRIPTION
## Summary
Add try-except to support both LangChain 1.x (`langchain_core`) and older versions (`langchain.base_language`).

## Changes
- Updated imports in `llama-index-llms-langchain/base.py` to first try `langchain_core` (1.x), then fallback to old paths

## Note
Full LangChain 1.x support also requires updates to `llama-index-core/bridge/langchain.py`. This PR is a partial fix focusing on the LLM integration package.

Partial fix for #20335