### PR TITLE
fix(vllm): support v1 completions payloads

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/utils.py
@@ -1,12 +1,42 @@
 import json
-from typing import Iterable, List
+from typing import Any, Iterable, List
 
 import requests
 
 
+def extract_text_list(data: Any) -> List[str]:
+    """Normalize vLLM completion payloads into a list of strings."""
+    if not isinstance(data, dict):
+        return []
+
+    if "choices" in data and isinstance(data["choices"], list):
+        texts: List[str] = []
+        for choice in data["choices"]:
+            if isinstance(choice, dict):
+                if "text" in choice and choice["text"] is not None:
+                    texts.append(choice["text"])
+                elif (
+                    "message" in choice
+                    and isinstance(choice["message"], dict)
+                    and "content" in choice["message"]
+                ):
+                    texts.append(choice["message"]["content"])
+        if texts:
+            return texts
+
+    if "text" in data:
+        text_field = data["text"]
+        if isinstance(text_field, list):
+            return [text for text in text_field if isinstance(text, str)]
+        if isinstance(text_field, str):
+            return [text_field]
+
+    return []
+
+
 def get_response(response: requests.Response) -> List[str]:
     data = json.loads(response.content)
-    return data["text"]
+    return extract_text_list(data)
 
 
 def post_http_request(
@@ -15,7 +45,7 @@ def post_http_request(
     headers = {"User-Agent": "Test Client"}
     sampling_params["stream"] = stream
 
-    return requests.post(api_url, headers=headers, json=sampling_params, stream=True)
+    return requests.post(api_url, headers=headers, json=sampling_params, stream=stream)
 
 
 def get_streaming_response(response: requests.Response) -> Iterable[List[str]]:
@@ -24,4 +54,14 @@ def get_streaming_response(response: requests.Response) -> Iterable[List[str]]:
     ):
         if chunk:
             data = json.loads(chunk.decode("utf-8"))
-            yield data["text"]
+            texts = extract_text_list(data)
+            if texts:
+                yield texts
+
+
+__all__ = [
+    "get_response",
+    "post_http_request",
+    "get_streaming_response",
+    "extract_text_list",
+]

--- a/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.core.callbacks import CallbackManager
 
@@ -28,3 +30,42 @@ def test_server_callback() -> None:
     )
     assert remote.callback_manager == callback_manager
     del remote
+
+
+@patch("llama_index.llms.vllm.base.get_response", return_value=["ok"])
+@patch("llama_index.llms.vllm.base.post_http_request")
+def test_server_complete_includes_model(mock_post: MagicMock, mock_get: MagicMock):
+    from llama_index.llms.vllm import VllmServer
+
+    mock_post.return_value = MagicMock()
+    server = VllmServer(
+        api_url="http://localhost:8000/v1/completions",
+        model="test-model",
+    )
+
+    server.complete("Hello world")
+
+    assert mock_post.call_count == 1
+    payload = mock_post.call_args[0][1]
+    assert payload["model"] == "test-model"
+    assert payload["prompt"] == "Hello world"
+    mock_get.assert_called_once_with(mock_post.return_value)
+
+
+@patch("llama_index.llms.vllm.base.get_response", return_value=["ok"])
+@patch("llama_index.llms.vllm.base.post_http_request")
+def test_server_complete_respects_custom_model(
+    mock_post: MagicMock, mock_get: MagicMock
+):
+    from llama_index.llms.vllm import VllmServer
+
+    mock_post.return_value = MagicMock()
+    server = VllmServer(
+        api_url="http://localhost:8000/v1/completions",
+        model="default-model",
+    )
+
+    server.complete("Hello world", model="override")
+
+    payload = mock_post.call_args[0][1]
+    assert payload["model"] == "override"

--- a/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_utils.py
@@ -1,0 +1,25 @@
+import json
+from types import SimpleNamespace
+
+from llama_index.llms.vllm.utils import get_response
+
+
+def _build_response(payload: dict) -> SimpleNamespace:
+    return SimpleNamespace(content=json.dumps(payload).encode("utf-8"))
+
+
+def test_get_response_handles_legacy_text_field() -> None:
+    resp = _build_response({"text": ["hello world"]})
+    assert get_response(resp) == ["hello world"]
+
+
+def test_get_response_handles_choices_format() -> None:
+    resp = _build_response(
+        {
+            "choices": [
+                {"text": "choice-1"},
+                {"text": "choice-2"},
+            ]
+        }
+    )
+    assert get_response(resp) == ["choice-1", "choice-2"]


### PR DESCRIPTION
# Description
- normalize vLLM server responses through a single parser so the legacy `{"text": [...]}` schema and the new OpenAI-style `{"choices": [...]}` schema are both understood, including during streaming
- always send a `model` field when calling the vLLM server (still overrideable) so v1/completions requests work out of the box
- guard the optional `torch` import in the cleanup hook so remote-only users aren’t forced to install GPU deps
- extend the vllm test suite to cover the parser and payload shaping regression
Fixes #20258

## New Package?
- [ ] Yes
- [x] No

## Version Bump?
- [ ] Yes
- [x] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
