### PR TITLE
Improved Ollama batch embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 
 - feat(llama-index-embeddings-ollama): Add keep_alive parameter ([#20395](https://github.com/run-llama/llama_index/pull/20395))
 - docs: improve Ollama embeddings README with comprehensive documentation ([#20414](https://github.com/run-llama/llama_index/pull/20414))
-- improve Ollama batch embedding ([#20447](https://github.com/run-llama/llama_index/pull/20447))
 
 ### llama-index-embeddings-voyageai [0.5.2]
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ollama/llama_index/embeddings/ollama/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ollama/llama_index/embeddings/ollama/base.py
@@ -129,11 +129,11 @@ class OllamaEmbedding(BaseEmbedding):
         )
         return result.embeddings[0]
 
-    async def aget_general_text_embedding(self, texts: str) -> List[float]:
+    async def aget_general_text_embedding(self, prompt: str) -> List[float]:
         """Asynchronously get Ollama embedding."""
         result = await self._async_client.embed(
             model=self.model_name,
-            input=texts,
+            input=prompt,
             options=self.ollama_additional_kwargs,
             keep_alive=self.keep_alive,
         )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ollama/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ollama/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-ollama"
-version = "0.8.5"
+version = "0.8.6"
 description = "llama-index embeddings ollama integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

This PR improves batch embedding in `OllamaEmbedding` so that it is done in batches instead of sequentially. 

Batch embedding is supported by ollama, but the current implementation of `OllamaEmbedding` does embedding sequentially. I rewrote `_get_text_embeddings` and `_aget_text_embeddings` so that embedding is done in batches.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
