### PR TITLE
chore(bedrock-converse): Remove extraneous thinking_delta kwarg from ChatMessage

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -1,5 +1,6 @@
 import warnings
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -9,16 +10,21 @@ from typing import (
     Sequence,
     Tuple,
     Union,
-    TYPE_CHECKING,
 )
 
+from llama_index.core.base.llms.generic_utils import (
+    achat_to_completion_decorator,
+    astream_chat_to_completion_decorator,
+    chat_to_completion_decorator,
+    stream_chat_to_completion_decorator,
+)
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
-    ChatResponseGen,
     ChatResponseAsyncGen,
-    CompletionResponseAsyncGen,
+    ChatResponseGen,
     CompletionResponse,
+    CompletionResponseAsyncGen,
     CompletionResponseGen,
     LLMMetadata,
     MessageRole,
@@ -33,26 +39,20 @@ from llama_index.core.llms.callbacks import (
     llm_chat_callback,
     llm_completion_callback,
 )
-from llama_index.core.base.llms.generic_utils import (
-    achat_to_completion_decorator,
-    astream_chat_to_completion_decorator,
-    chat_to_completion_decorator,
-    stream_chat_to_completion_decorator,
-)
 from llama_index.core.llms.function_calling import FunctionCallingLLM, ToolSelection
 from llama_index.core.llms.utils import parse_partial_json
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.llms.bedrock_converse.utils import (
+    ThinkingDict,
     bedrock_modelname_to_context_size,
     converse_with_retry,
     converse_with_retry_async,
     force_single_tool_call,
     is_bedrock_function_calling_model,
+    is_reasoning,
     join_two_dicts,
     messages_to_converse_messages,
     tools_to_converse_tools,
-    is_reasoning,
-    ThinkingDict,
 )
 
 if TYPE_CHECKING:
@@ -364,7 +364,9 @@ class BedrockConverse(FunctionCallingLLM):
         }
 
     def _get_content_and_tool_calls(
-        self, response: Optional[Dict[str, Any]] = None, content: Dict[str, Any] = None
+        self,
+        response: Optional[Dict[str, Any]] = None,
+        content: Optional[Dict[str, Any]] = None,
     ) -> Tuple[
         List[Union[TextBlock, ThinkingBlock, ToolCallBlock]], List[str], List[str]
     ]:
@@ -681,7 +683,6 @@ class BedrockConverse(FunctionCallingLLM):
                                 },
                             ),
                             delta="",
-                            thinking_delta=None,
                             raw=chunk,
                             additional_kwargs=self._get_response_token_counts(metadata),
                         )
@@ -966,7 +967,6 @@ class BedrockConverse(FunctionCallingLLM):
                                 },
                             ),
                             delta="",
-                            thinking_delta=None,
                             raw=chunk,
                             additional_kwargs=self._get_response_token_counts(metadata),
                         )

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.12.3"
+version = "0.12.4"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -2223,7 +2223,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.12.3"
+version = "0.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

As part of #20355 , it [was decided that `additional_kwargs` would be used](https://github.com/run-llama/llama_index/pull/20355#discussion_r2612951104) instead of a new `thinking_delta` attribute on `ChatMessage`.

The [subsequent commit](https://github.com/run-llama/llama_index/pull/20355/changes/bb505328b02ae49c679092eece04b4c556e2b7fb) didn't fully remove `thinking_delta` from the `ChatMessages`s within `BedrockConverse`, so I've gone ahead and cleaned it up (along with some other small formatting/type-checking changes).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
