### PR TITLE
Replace ChatMemoryBuffer with Memory

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -23,7 +23,7 @@ from llama_index.core.indices.base_retriever import BaseRetriever
 from llama_index.core.indices.query.schema import QueryBundle
 from llama_index.core.base.llms.generic_utils import messages_to_history_str
 from llama_index.core.llms.llm import LLM
-from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
+from llama_index.core.memory import BaseMemory, Memory
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.response_synthesizers import CompactAndRefine
@@ -152,7 +152,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         llm = llm or Settings.llm
 
         chat_history = chat_history or []
-        memory = memory or ChatMemoryBuffer.from_defaults(
+        memory = memory or Memory.from_defaults(
             chat_history=chat_history, token_limit=llm.metadata.context_window - 256
         )
 

--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -21,7 +21,7 @@ from llama_index.core.chat_engine.utils import (
 )
 from llama_index.core.base.llms.generic_utils import messages_to_history_str
 from llama_index.core.llms.llm import LLM
-from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
+from llama_index.core.memory import BaseMemory, Memory
 from llama_index.core.prompts.base import BasePromptTemplate, PromptTemplate
 from llama_index.core.settings import Settings
 
@@ -79,7 +79,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
         condense_question_prompt: Optional[BasePromptTemplate] = None,
         chat_history: Optional[List[ChatMessage]] = None,
         memory: Optional[BaseMemory] = None,
-        memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
+        memory_cls: Type[BaseMemory] = Memory,
         verbose: bool = False,
         system_prompt: Optional[str] = None,
         prefix_messages: Optional[List[ChatMessage]] = None,

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -20,7 +20,7 @@ from llama_index.core.chat_engine.types import (
     ToolOutput,
 )
 from llama_index.core.llms.llm import LLM
-from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
+from llama_index.core.memory import BaseMemory, Memory
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.response_synthesizers import CompactAndRefine
@@ -108,7 +108,7 @@ class ContextChatEngine(BaseChatEngine):
         llm = llm or Settings.llm
 
         chat_history = chat_history or []
-        memory = memory or ChatMemoryBuffer.from_defaults(
+        memory = memory or Memory.from_defaults(
             chat_history=chat_history, token_limit=llm.metadata.context_window - 256
         )
 

--- a/llama-index-core/llama_index/core/chat_engine/multi_modal_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/multi_modal_context.py
@@ -26,7 +26,7 @@ from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.schema import ImageNode, NodeWithScore, MetadataMode
 from llama_index.core.base.llms.generic_utils import image_node_to_image_block
-from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
+from llama_index.core.memory import BaseMemory, Memory
 
 # from llama_index.core.query_engine.multi_modal import _get_image_and_text_nodes
 from llama_index.core.llms.llm import (
@@ -120,7 +120,7 @@ class MultiModalContextChatEngine(BaseChatEngine):
         multi_modal_llm = multi_modal_llm or Settings.llm
 
         chat_history = chat_history or []
-        memory = memory or ChatMemoryBuffer.from_defaults(
+        memory = memory or Memory.from_defaults(
             chat_history=chat_history,
             token_limit=multi_modal_llm.metadata.context_window - 256,
         )

--- a/llama-index-core/llama_index/core/chat_engine/simple.py
+++ b/llama-index-core/llama_index/core/chat_engine/simple.py
@@ -9,7 +9,7 @@ from llama_index.core.chat_engine.types import (
     StreamingAgentChatResponse,
 )
 from llama_index.core.llms.llm import LLM
-from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
+from llama_index.core.memory import BaseMemory, Memory
 from llama_index.core.settings import Settings
 from llama_index.core.types import Thread
 
@@ -39,7 +39,7 @@ class SimpleChatEngine(BaseChatEngine):
         cls,
         chat_history: Optional[List[ChatMessage]] = None,
         memory: Optional[BaseMemory] = None,
-        memory_cls: Type[BaseMemory] = ChatMemoryBuffer,
+        memory_cls: Type[BaseMemory] = Memory,
         system_prompt: Optional[str] = None,
         prefix_messages: Optional[List[ChatMessage]] = None,
         llm: Optional[LLM] = None,


### PR DESCRIPTION
# Description

@AstraBert pointed out [here](https://github.com/run-llama/llama_index/pull/20446#discussion_r2661940280), that `ChatMemoryBuffer` is deprecated. In order to have all the chat engines consistent, I went ahead to replace `ChatMemoryBuffer` with `Memory` as is recommended [here](https://github.com/run-llama/llama_index/blob/c15138ec211ad7f67ccb4b1ad9fd02efd6407e50/llama-index-core/llama_index/core/memory/chat_memory_buffer.py#L21).

The replacement was a straight-forward process. However, `CondenseQuestionChatEngine` and `SimpleChatEngine` had to be adapted to not pass the llm anymore to the memory in order to compute the token limit. Just like the other chat engines, this is now done at the call site. It's for this reason that this PR has two commits. One to align `CondenseQuestionChatEngine` and `SimpleChatEngine` with the other chat engines and the second one for the actual replacement.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Avoiding a deprecated class.

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
