### PR TITLE
fix: preserve empty strings in DocumentBlock fields

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -349,9 +349,10 @@ class DocumentBlock(BaseModel):
 
     @model_validator(mode="after")
     def document_validation(self) -> Self:
-        self.document_mimetype = self.document_mimetype or self._guess_mimetype()
+        if self.document_mimetype is None:
+            self.document_mimetype = self._guess_mimetype()
 
-        if not self.title:
+        if self.title is None:
             self.title = "input_document"
 
         # skip data validation if no byte is provided

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -359,6 +359,19 @@ def test_document_block_from_url(pdf_url: str):
     assert document.title == "dummy_pdf"
 
 
+def test_document_block_preserves_empty_strings(pdf_base64: bytes):
+    """Test that empty string fields are not coerced to None or default values."""
+    document = DocumentBlock(
+        data=pdf_base64,
+        document_mimetype="",
+        title="",
+        url="",
+    )
+    assert document.document_mimetype == ""
+    assert document.title == ""
+    assert document.url == ""
+
+
 def test_empty_bytes(empty_bytes: bytes, png_1px: bytes):
     errors = []
     try:


### PR DESCRIPTION
## Summary

Fixes #20462

The `DocumentBlock` class incorrectly coerces empty strings to `None` or default values for `document_mimetype` and `title` fields. This happens because the validation logic uses Python's truthy evaluation (`or` and `not`), which treats empty strings as falsy.

This fix follows the same pattern established in #19302 (which resolved the identical issue for `ChatMessage`), using explicit `is None` checks instead:

**Before (buggy):**
```python
self.document_mimetype = self.document_mimetype or self._guess_mimetype()
if not self.title:
    self.title = "input_document"
```

**After (fixed):**
```python
if self.document_mimetype is None:
    self.document_mimetype = self._guess_mimetype()
if self.title is None:
    self.title = "input_document"
```

## Test plan

- Added `test_document_block_preserves_empty_strings` to verify empty strings are preserved
- All existing tests in `test_types.py` pass (37/37)
- Manually verified with reproduction code from the issue

---

Happy to make any changes or improvements the team suggests.