### PR TITLE
fix: The classmethod of ReActChatFormatter should use cls instead of the class name

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/formatter.py
+++ b/llama-index-core/llama_index/core/agent/react/formatter.py
@@ -118,7 +118,7 @@ class ReActChatFormatter(BaseAgentChatFormatter):
                 else CONTEXT_REACT_CHAT_SYSTEM_HEADER
             )
 
-        return ReActChatFormatter(
+        return cls(
             system_header=system_header,
             context=context or "",
             observation_role=observation_role,
@@ -135,6 +135,6 @@ class ReActChatFormatter(BaseAgentChatFormatter):
         logger.warning(
             "ReActChatFormatter.from_context is deprecated, please use `from_defaults` instead."
         )
-        return ReActChatFormatter.from_defaults(
+        return cls.from_defaults(
             system_header=CONTEXT_REACT_CHAT_SYSTEM_HEADER, context=context
         )

--- a/llama-index-core/tests/agent/react/test_react_chat_formatter.py
+++ b/llama-index-core/tests/agent/react/test_react_chat_formatter.py
@@ -1,0 +1,29 @@
+from typing import List, Optional, Sequence
+
+from llama_index.core.agent.react.formatter import ReActChatFormatter
+from llama_index.core.agent.react.types import (
+    BaseReasoningStep,
+)
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.llms import MessageRole
+from llama_index.core.tools import BaseTool
+
+
+class MockReActChatFormatter(ReActChatFormatter):
+    def format(
+        self,
+        tools: Sequence[BaseTool],
+        chat_history: List[ChatMessage],
+        current_reasoning: Optional[List[BaseReasoningStep]] = None,
+    ) -> List[ChatMessage]:
+        return [ChatMessage(role=MessageRole.SYSTEM, content="mock data!")]
+
+
+def test_inheritance_react_chat_formatter():
+    formatter_from_defaults = MockReActChatFormatter.from_defaults()
+    format_default_message = formatter_from_defaults.format([], [])
+    assert format_default_message[0].content == "mock data!"
+
+    formatter_from_context = MockReActChatFormatter.from_context("mock context!")
+    format_context_message = formatter_from_context.format([], [])
+    assert format_context_message[0].content == "mock data!"


### PR DESCRIPTION
# Description
In ReActChatFormatter, two class methods instantiate objects using the hardcoded class name instead of the cls parameter, which can introduce security risks in inheritance hierarchies.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
