### PR TITLE
security: block dangerous builtins in safe_eval/safe_exec sandbox

### DIFF
--- a/llama-index-experimental/llama_index/experimental/exec_utils.py
+++ b/llama-index-experimental/llama_index/experimental/exec_utils.py
@@ -145,13 +145,17 @@ class DunderVisitor(ast.NodeVisitor):
         if isinstance(node.func, ast.Name) and node.func.id in DANGEROUS_BUILTINS:
             self.has_dangerous_builtin_call = True
         # Check attribute calls that might access dangerous functions
-        if isinstance(node.func, ast.Attribute) and node.func.attr in DANGEROUS_BUILTINS:
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in DANGEROUS_BUILTINS
+        ):
             self.has_dangerous_builtin_call = True
         self.generic_visit(node)
 
 
 def _contains_protected_access(code: str) -> bool:
-    """Check if code contains protected/dangerous access patterns.
+    """
+    Check if code contains protected/dangerous access patterns.
 
     This function detects:
     - Import statements


### PR DESCRIPTION
## Summary

The `safe_eval()` and `safe_exec()` functions in `exec_utils.py` can be bypassed using `getattr()` and similar functions to access dunder methods on allowed objects, enabling arbitrary code execution.

**Vulnerability**: An attacker can use `getattr(getattr(pd, '__class__'), '__bases__')[0].__subclasses__()` to traverse the object hierarchy and access dangerous classes like `Popen`.

## Changes

- Adds `DANGEROUS_BUILTINS` set with functions that can bypass sandbox restrictions (`getattr`, `setattr`, `delattr`, `vars`, `dir`, `globals`, `locals`, `compile`, `exec`, `eval`, `open`, `input`, etc.)
- Updates `DunderVisitor` to detect calls to dangerous builtins via new `visit_Call()` method
- Blocks code that attempts to use these sandbox-bypassing functions

## Test Plan

- [ ] Existing tests pass (`pytest llama-index-experimental/tests/`)
- [ ] Manual verification that bypass attempts are now blocked:
  ```python
  from llama_index.experimental.exec_utils import safe_eval
  safe_eval("getattr(pd, '__class__')", {"pd": pd})  # Should raise RuntimeError
  ```

Identified using [aisentry](https://aisentry.co)