### PR TITLE
feat: add configurable empty response message to synthesizers

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -50,14 +50,6 @@ logger = logging.getLogger(__name__)
 QueryTextType = QueryType
 
 
-def empty_response_generator() -> Generator[str, None, None]:
-    yield "Empty Response"
-
-
-async def empty_response_agenerator() -> AsyncGenerator[str, None]:
-    yield "Empty Response"
-
-
 class BaseSynthesizer(PromptMixin, DispatcherSpanMixin):
     """Response builder class."""
 


### PR DESCRIPTION
# Description

Add a configurable `empty_response` parameter to `BaseSynthesizer`, allowing users to customize the response returned when no nodes are provided to the synthesizer.

Currently, when `synthesize()` or `asynthesize()` receives an empty node list, it returns a hardcoded `"Empty Response"` string. This makes it difficult for users to customize the behavior for their use cases (e.g., returning a guidance message, instructing the LLM to use general knowledge, etc.).

This change adds backward-compatible configurability similar to LangChain's `response_if_no_docs_found` parameter.

Fixes #16857

## New Package?

- [x] No

## Version Bump?

- [x] No (this is `llama-index-core`)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

```python
# Test default behavior (backward compatible)
synth = TestSynthesizer(llm=mock_llm)
result = synth.synthesize(QueryBundle('test'), [])
assert result.response == 'Empty Response'

# Test custom empty response
synth2 = TestSynthesizer(llm=mock_llm, empty_response='No documents found.')
result2 = synth2.synthesize(QueryBundle('test'), [])
assert result2.response == 'No documents found.'
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
