### PR TITLE
Add client headers to Gemini API requests

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-google-genai"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index embeddings google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/tests/test_embeddings_gemini.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/tests/test_embeddings_gemini.py
@@ -282,3 +282,24 @@ def test_no_retry_on_auth_error(mock_client_class):
 
     # Verify embed_content was called exactly once (no retries)
     mock_embed_content.assert_called_once()
+
+
+@patch("google.genai.Client")
+def test_client_header_initialization(mock_client_class):
+    """Test that the client header is correctly passed to the GoogleGenAIEmbedding."""
+    # Setup mock client
+    mock_client = mock_client_class.return_value
+    mock_client_class.return_value = mock_client
+
+    # Initialize embedding model
+    GoogleGenAIEmbedding(api_key="fake_key")
+
+    # Check if http_options were passed to the client constructor
+    call_args = mock_client_class.call_args
+    _, kwargs = call_args
+
+    http_options = kwargs["http_options"]
+    headers = http_options.headers
+
+    assert "x-goog-api-client" in headers
+    assert headers["x-goog-api-client"].startswith("llamaindex/")

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.8.3"
+version = "0.8.4"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1884,3 +1884,24 @@ async def test_thoughts_with_async_chat() -> None:
         )
         != 0
     )
+
+
+def test_client_header_initialization() -> None:
+    """Test that the client header is correctly passed to the GoogleGenAI LLM."""
+    with patch("google.genai.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_model = MagicMock()
+        mock_client.models.get.return_value = mock_model
+
+        GoogleGenAI(model="models/gemini-3.0-flash", api_key="test-key")
+
+        # Check if http_options were passed to the client constructor
+        call_args = mock_client_class.call_args
+        _, kwargs = call_args
+        http_options = kwargs["http_options"]
+        headers = http_options.headers
+
+        assert "x-goog-api-client" in headers
+        assert headers["x-goog-api-client"].startswith("llamaindex/")

--- a/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/llama_index/voice_agents/gemini_live/base.py
+++ b/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/llama_index/voice_agents/gemini_live/base.py
@@ -1,4 +1,5 @@
 import asyncio
+from importlib.metadata import PackageNotFoundError, version
 import logging
 from typing import Optional, Any, List, Dict, Callable
 from typing_extensions import override
@@ -56,8 +57,17 @@ class GeminiLiveVoiceAgent(BaseVoiceAgent):
     @property
     def client(self) -> Client:
         if not self._client:
+            try:
+                package_v = version("llama-index-voice-agents-gemini-live")
+            except PackageNotFoundError:
+                package_v = "0.0.0"
+
             self._client = Client(
-                api_key=self.api_key, http_options={"api_version": "v1beta"}
+                api_key=self.api_key,
+                http_options={
+                    "api_version": "v1beta",
+                    "headers": {"x-goog-api-client": f"llamaindex/{package_v}"},
+                },
             )
         return self._client
 

--- a/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/pyproject.toml
+++ b/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-voice-agents-gemini-live"
-version = "0.2.1"
+version = "0.2.2"
 description = "LlamaIndex x Gemini Live integration"
 authors = [{name = "Clelia Astra Bertelli", email = "clelia@runllama.ai"}]
 requires-python = ">=3.9,<4.0"
@@ -36,7 +36,7 @@ maintainers = [{name = "AstraBert"}]
 dependencies = [
     "pyaudio>=0.2.14,<0.3",
     "llama-index-core>=0.13.0,<0.15",
-    "google-genai>=1.26.0,<1.27",
+    "google-genai>=1.52.0,<2",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/tests/test_gemini_live.py
+++ b/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/tests/test_gemini_live.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock, patch
+from llama_index.voice_agents.gemini_live.base import GeminiLiveVoiceAgent
+
+
+def test_client_header_initialization():
+    """Test that the client header is correctly passed to the GeminiLiveVoiceAgent."""
+    with patch("llama_index.voice_agents.gemini_live.base.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        agent = GeminiLiveVoiceAgent(api_key="test-key")
+
+        # Access the client property to trigger initialization
+        _ = agent.client
+
+        # Check if http_options were passed to the client constructor
+        call_args = mock_client_class.call_args
+        _, kwargs = call_args
+
+        http_options = kwargs["http_options"]
+        headers = http_options["headers"]
+        assert headers["x-goog-api-client"].startswith("llamaindex/")

--- a/uv.lock
+++ b/uv.lock
@@ -1574,7 +1574,7 @@ wheels = [
 
 [[package]]
 name = "llama-index"
-version = "0.14.12"
+version = "0.14.13"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-cli", marker = "python_full_version >= '3.10'" },
@@ -1613,7 +1613,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "llama-index-cli", marker = "python_full_version >= '3.10'", specifier = ">=0.5.0,<0.6" },
-    { name = "llama-index-core", specifier = ">=0.14.12,<0.15.0" },
+    { name = "llama-index-core", specifier = ">=0.14.13,<0.15.0" },
     { name = "llama-index-embeddings-openai", specifier = ">=0.5.0,<0.6" },
     { name = "llama-index-indices-managed-llama-cloud", specifier = ">=0.4.0" },
     { name = "llama-index-llms-openai", specifier = ">=0.6.0,<0.7" },
@@ -1661,7 +1661,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.14.12"
+version = "0.14.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1699,9 +1699,9 @@ dependencies = [
     { name = "typing-inspect" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/d3/9d65f3c631a41fbb0dac47c52adad0fdbbaee3456518a97d558d8c754788/llama_index_core-0.14.12.tar.gz", hash = "sha256:6917e5865c6c789046dca001ebeea5a7f80e1ba83ac646dc793aaa041e8feb12", size = 11584083, upload-time = "2025-12-30T01:06:24.875Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/54/d6043a088e5e9c1d62300db7ad0ef417c6b9a92f7b4a5cade066aeafdaca/llama_index_core-0.14.13.tar.gz", hash = "sha256:c3b30d20ae0407e5d0a1d35bb3376a98e242661ebfc22da754b5a3da1f8108c0", size = 11589074, upload-time = "2026-01-21T20:44:16.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/c7/a39d65aeb7b1df234719e918a27b9122eeee81744e2e39f60b12a57a3e09/llama_index_core-0.14.12-py3-none-any.whl", hash = "sha256:a3a7e3a084b01700458874dd635ba40d00af2680daa47f072e357e8f0d172872", size = 11927498, upload-time = "2025-12-30T01:06:27.459Z" },
+    { url = "https://files.pythonhosted.org/packages/76/59/9769f03f1cccadcc014b3b65c166de18999b51459a0f0a579d80f6c91d80/llama_index_core-0.14.13-py3-none-any.whl", hash = "sha256:392f0a5a09433e9dea786964ef5fe5ca2a2b10aee9f979a9507c19a14da2a20a", size = 11934761, upload-time = "2026-01-21T20:44:18.892Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Updated the `google-genai` library usage across: llms, embeddings and live clients.

This [best practice](https://goo.gle/gemini-partners) helps us identify erroneous traffic, and who to talk to if we're breaking something.

## Version Bump?

Is this required? Not sure? I've done it anyway

- [x] Yes

## Type of Change

- [x] Chore

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
