### PR TITLE
Add llama-index-readers-causal for .causal knowledge graphs

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-causal/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-causal/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG
+
+## [0.1.0] - 2026-01-24
+
+### Added
+
+- Initial release of `llama-index-readers-causal`
+- `CausalReader` for loading `.causal` knowledge graph files
+- Support for filtering by confidence threshold
+- Support for including/excluding inferred triplets
+- Rich metadata including provenance tracking

--- a/llama-index-integrations/readers/llama-index-readers-causal/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-causal/README.md
@@ -1,0 +1,98 @@
+# LlamaIndex Readers Integration: Causal
+
+Reader for `.causal` binary knowledge graph files with embedded deterministic inference.
+
+## Overview
+
+The `.causal` format solves the fundamental problem of AI-assisted discovery: **LLMs hallucinate, databases don't reason**.
+
+| Technology | What it does | What's missing |
+|------------|--------------|----------------|
+| **SQLite** | Stores facts | No reasoning |
+| **Vector RAG** | Finds similar text | No logic |
+| **LLMs** | Reasons creatively | Hallucination risk |
+| **.causal** | Stores + Reasons | **Zero hallucination** |
+
+### Key Features
+
+- **30-40x faster queries** than SQLite (pre-computed inference)
+- **50-200% fact amplification** through transitive chains
+- **Zero hallucination** - pure deterministic logic with full provenance
+- **Edge AI ready** - compact enough for mobile/offline use
+
+## Installation
+
+```bash
+pip install llama-index-readers-causal
+```
+
+## Usage
+
+```python
+from llama_index.readers.causal import CausalReader
+
+# Initialize reader
+reader = CausalReader(
+    include_inferred=True,  # Include derived facts
+    min_confidence=0.5,     # Filter by confidence
+)
+
+# Load all triplets from a .causal file
+documents = reader.load_data("knowledge.causal")
+
+# Or search for specific topics
+documents = reader.load_data(
+    "knowledge.causal",
+    query="COVID fatigue",
+    limit=10,
+)
+
+# Each document contains a triplet
+for doc in documents:
+    print(doc.text)
+    # [INFERRED] SARS-CoV-2 → damages → mitochondria → causes → fatigue
+
+    print(doc.metadata)
+    # {'trigger': 'SARS-CoV-2', 'mechanism': 'causes', 'outcome': 'fatigue',
+    #  'confidence': 0.85, 'is_inferred': True, 'provenance': [...]}
+```
+
+### With Query Engine
+
+```python
+from llama_index.core import VectorStoreIndex
+from llama_index.readers.causal import CausalReader
+
+# Load knowledge graph
+reader = CausalReader()
+documents = reader.load_data("knowledge.causal")
+
+# Build index
+index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
+
+# Query with zero-hallucination grounding
+response = query_engine.query(
+    "What mechanisms connect COVID to chronic fatigue?"
+)
+```
+
+## Document Metadata
+
+Each document includes rich metadata:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trigger` | str | The cause/trigger entity |
+| `mechanism` | str | The relationship type |
+| `outcome` | str | The effect/outcome entity |
+| `confidence` | float | Confidence score (0-1) |
+| `is_inferred` | bool | Whether derived or explicit |
+| `provenance` | list | Source triplets for inferred facts |
+| `source` | str | Original source (e.g., paper) |
+
+## References
+
+- **PyPI**: https://pypi.org/project/dotcausal/
+- **GitHub**: https://github.com/DT-Foss/dotcausal
+- **Whitepaper**: https://doi.org/10.5281/zenodo.18326222

--- a/llama-index-integrations/readers/llama-index-readers-causal/llama_index/readers/causal/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-causal/llama_index/readers/causal/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.readers.causal.base import CausalReader
+
+__all__ = ["CausalReader"]

--- a/llama-index-integrations/readers/llama-index-readers-causal/llama_index/readers/causal/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-causal/llama_index/readers/causal/base.py
@@ -1,0 +1,169 @@
+"""Reader for .causal knowledge graph files."""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from llama_index.core.readers.base import BasePydanticReader
+from llama_index.core.schema import Document
+
+
+class CausalReader(BasePydanticReader):
+    """
+    Reader for .causal binary knowledge graph files.
+
+    The .causal format provides deterministic inference with zero hallucination.
+    It pre-computes transitive chains at storage time, enabling 30-40x faster
+    queries than SQLite while amplifying facts by 50-200%.
+
+    Args:
+        include_inferred: Whether to include inferred triplets (default: True)
+        min_confidence: Minimum confidence threshold (default: 0.0)
+
+    Example:
+        >>> from llama_index.readers.causal import CausalReader
+        >>> reader = CausalReader()
+        >>> documents = reader.load_data("knowledge.causal")
+        >>> # Each document contains a triplet with metadata
+
+    References:
+        - PyPI: https://pypi.org/project/dotcausal/
+        - GitHub: https://github.com/DT-Foss/dotcausal
+        - Paper: https://doi.org/10.5281/zenodo.18326222
+    """
+
+    is_remote: bool = False
+    include_inferred: bool = True
+    min_confidence: float = 0.0
+
+    def __init__(
+        self,
+        include_inferred: bool = True,
+        min_confidence: float = 0.0,
+    ) -> None:
+        """Initialize CausalReader.
+
+        Args:
+            include_inferred: Include inferred (derived) triplets
+            min_confidence: Minimum confidence threshold for triplets
+        """
+        try:
+            import dotcausal  # noqa
+        except ImportError:
+            raise ImportError(
+                "`dotcausal` package not found, please run `pip install dotcausal`"
+            )
+
+        super().__init__(
+            include_inferred=include_inferred,
+            min_confidence=min_confidence,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "CausalReader"
+
+    def load_data(
+        self,
+        file_path: str,
+        query: Optional[str] = None,
+        limit: Optional[int] = None,
+        **load_kwargs: Any,
+    ) -> List[Document]:
+        """
+        Load data from a .causal knowledge graph file.
+
+        Args:
+            file_path: Path to the .causal file
+            query: Optional search query to filter triplets
+            limit: Maximum number of triplets to return
+            **load_kwargs: Additional arguments passed to search
+
+        Returns:
+            List of Document objects, each containing a triplet
+        """
+        from dotcausal import CausalReader as DotCausalReader
+
+        path = Path(file_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Causal file not found: {file_path}")
+
+        reader = DotCausalReader(str(path))
+
+        # Get triplets - either search or get all
+        if query:
+            results = reader.search(
+                query=query,
+                limit=limit or 100,
+                **load_kwargs,
+            )
+        else:
+            # Get all triplets
+            stats = reader.get_stats()
+            results = []
+
+            # Get explicit triplets
+            explicit = reader.search("", limit=stats.get("explicit_triplets", 1000))
+            results.extend(explicit)
+
+            # Get inferred if requested
+            if self.include_inferred:
+                inferred = reader.search(
+                    "", limit=stats.get("inferred_triplets", 1000)
+                )
+                for r in inferred:
+                    if r.get("is_inferred") and r not in results:
+                        results.append(r)
+
+        # Filter and convert to Documents
+        documents = []
+        for r in results:
+            # Apply filters
+            if r.get("confidence", 1.0) < self.min_confidence:
+                continue
+            if not self.include_inferred and r.get("is_inferred", False):
+                continue
+
+            # Format content
+            tag = "[INFERRED]" if r.get("is_inferred") else "[EXPLICIT]"
+            content = (
+                f"{tag} {r['trigger']} → {r['mechanism']} → {r['outcome']}"
+            )
+
+            # Build metadata
+            metadata: Dict[str, Any] = {
+                "file_path": str(file_path),
+                "trigger": r["trigger"],
+                "mechanism": r["mechanism"],
+                "outcome": r["outcome"],
+                "confidence": r.get("confidence", 1.0),
+                "is_inferred": r.get("is_inferred", False),
+                "source": r.get("source", ""),
+                "provenance": r.get("provenance", []),
+            }
+
+            documents.append(
+                Document(
+                    text=content,
+                    metadata=metadata,
+                )
+            )
+
+            if limit and len(documents) >= limit:
+                break
+
+        return documents
+
+    def get_stats(self, file_path: str) -> Dict[str, Any]:
+        """
+        Get statistics about a .causal knowledge graph.
+
+        Args:
+            file_path: Path to the .causal file
+
+        Returns:
+            Dictionary with triplet counts and amplification stats
+        """
+        from dotcausal import CausalReader as DotCausalReader
+
+        reader = DotCausalReader(file_path)
+        return reader.get_stats()

--- a/llama-index-integrations/readers/llama-index-readers-causal/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-causal/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llama-index-readers-causal"
+version = "0.1.0"
+description = "LlamaIndex reader for .causal knowledge graph files with embedded inference"
+authors = [{name = "David Tom Foss", email = "david@foss.com.de"}]
+requires-python = ">=3.9,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "DT-Foss"}]
+keywords = [
+    "llama-index",
+    "knowledge-graph",
+    "causal-inference",
+    "rag",
+    "zero-hallucination",
+]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "dotcausal>=0.3.0",
+]
+
+[project.urls]
+Homepage = "https://dotcausal.com"
+Repository = "https://github.com/DT-Foss/dotcausal"
+Documentation = "https://dotcausal.com/docs"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.causal"
+
+[tool.llamahub.class_authors]
+CausalReader = "DT-Foss"
+
+[tool.mypy]
+disallow_untyped_defs = true
+ignore_missing_imports = true
+python_version = "3.9"

--- a/llama-index-integrations/readers/llama-index-readers-causal/tests/test_readers_causal.py
+++ b/llama-index-integrations/readers/llama-index-readers-causal/tests/test_readers_causal.py
@@ -1,0 +1,132 @@
+"""Tests for CausalReader."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_causal_reader_import():
+    """Test that CausalReader can be imported."""
+    from llama_index.readers.causal import CausalReader
+
+    assert CausalReader is not None
+
+
+def test_causal_reader_class_name():
+    """Test class name."""
+    with patch("llama_index.readers.causal.base.dotcausal"):
+        from llama_index.readers.causal import CausalReader
+
+        assert CausalReader.class_name() == "CausalReader"
+
+
+def test_causal_reader_load_data():
+    """Test loading data from .causal file."""
+    with patch("llama_index.readers.causal.base.dotcausal"):
+        with patch(
+            "llama_index.readers.causal.base.DotCausalReader"
+        ) as mock_reader_class:
+            with patch("pathlib.Path.exists", return_value=True):
+                from llama_index.readers.causal import CausalReader
+
+                # Setup mock
+                mock_reader = MagicMock()
+                mock_reader.search.return_value = [
+                    {
+                        "trigger": "COVID",
+                        "mechanism": "causes",
+                        "outcome": "fatigue",
+                        "confidence": 0.9,
+                        "is_inferred": False,
+                        "source": "paper1.pdf",
+                    },
+                    {
+                        "trigger": "SARS-CoV-2",
+                        "mechanism": "damages",
+                        "outcome": "mitochondria",
+                        "confidence": 0.85,
+                        "is_inferred": True,
+                        "provenance": ["t1", "t2"],
+                    },
+                ]
+                mock_reader_class.return_value = mock_reader
+
+                # Test
+                reader = CausalReader()
+                docs = reader.load_data("test.causal", query="COVID")
+
+                assert len(docs) == 2
+                assert "[EXPLICIT]" in docs[0].text
+                assert "[INFERRED]" in docs[1].text
+                assert docs[0].metadata["trigger"] == "COVID"
+                assert docs[1].metadata["is_inferred"] is True
+
+
+def test_causal_reader_confidence_filter():
+    """Test confidence filtering."""
+    with patch("llama_index.readers.causal.base.dotcausal"):
+        with patch(
+            "llama_index.readers.causal.base.DotCausalReader"
+        ) as mock_reader_class:
+            with patch("pathlib.Path.exists", return_value=True):
+                from llama_index.readers.causal import CausalReader
+
+                mock_reader = MagicMock()
+                mock_reader.search.return_value = [
+                    {
+                        "trigger": "A",
+                        "mechanism": "causes",
+                        "outcome": "B",
+                        "confidence": 0.9,
+                        "is_inferred": False,
+                    },
+                    {
+                        "trigger": "C",
+                        "mechanism": "causes",
+                        "outcome": "D",
+                        "confidence": 0.3,  # Below threshold
+                        "is_inferred": False,
+                    },
+                ]
+                mock_reader_class.return_value = mock_reader
+
+                reader = CausalReader(min_confidence=0.5)
+                docs = reader.load_data("test.causal", query="test")
+
+                assert len(docs) == 1
+                assert docs[0].metadata["confidence"] == 0.9
+
+
+def test_causal_reader_exclude_inferred():
+    """Test excluding inferred triplets."""
+    with patch("llama_index.readers.causal.base.dotcausal"):
+        with patch(
+            "llama_index.readers.causal.base.DotCausalReader"
+        ) as mock_reader_class:
+            with patch("pathlib.Path.exists", return_value=True):
+                from llama_index.readers.causal import CausalReader
+
+                mock_reader = MagicMock()
+                mock_reader.search.return_value = [
+                    {
+                        "trigger": "A",
+                        "mechanism": "causes",
+                        "outcome": "B",
+                        "confidence": 0.9,
+                        "is_inferred": False,
+                    },
+                    {
+                        "trigger": "C",
+                        "mechanism": "causes",
+                        "outcome": "D",
+                        "confidence": 0.85,
+                        "is_inferred": True,
+                    },
+                ]
+                mock_reader_class.return_value = mock_reader
+
+                reader = CausalReader(include_inferred=False)
+                docs = reader.load_data("test.causal", query="test")
+
+                assert len(docs) == 1
+                assert docs[0].metadata["is_inferred"] is False


### PR DESCRIPTION
## Description

This PR adds `llama-index-readers-causal` - a reader for the `.causal` binary knowledge graph format with embedded deterministic inference.

### What is .causal?

The `.causal` format solves the fundamental problem of AI-assisted discovery: **LLMs hallucinate, databases don't reason**.

| Technology | What it does | What's missing |
|------------|--------------|----------------|
| **SQLite** | Stores facts | No reasoning |
| **Vector RAG** | Finds similar text | No logic |
| **LLMs** | Reasons creatively | Hallucination risk |
| **.causal** | Stores + Reasons | **Zero hallucination** |

### Key Features

- **30-40x faster queries** than SQLite (pre-computed inference)
- **50-200% fact amplification** through transitive chains
- **Zero hallucination** - pure deterministic logic with full provenance
- **Edge AI ready** - compact enough for mobile/offline

### Usage

```python
from llama_index.readers.causal import CausalReader

reader = CausalReader(
    include_inferred=True,
    min_confidence=0.5,
)

# Load from .causal file
documents = reader.load_data("knowledge.causal")

# Or search for specific topics
documents = reader.load_data(
    "knowledge.causal",
    query="COVID fatigue",
    limit=10,
)
```

### With Query Engine

```python
from llama_index.core import VectorStoreIndex

index = VectorStoreIndex.from_documents(documents)
query_engine = index.as_query_engine()

response = query_engine.query(
    "What mechanisms connect COVID to chronic fatigue?"
)
```

### Document Metadata

Each document includes:
- `trigger`, `mechanism`, `outcome` - the triplet components
- `confidence` - confidence score (0-1)
- `is_inferred` - whether derived or explicit
- `provenance` - source triplets for inferred facts

## Dependencies

- `dotcausal>=0.3.0` (included in package dependencies)

## References

- **PyPI**: https://pypi.org/project/dotcausal/
- **GitHub**: https://github.com/DT-Foss/dotcausal
- **Whitepaper**: https://doi.org/10.5281/zenodo.18326222

## Tests

Unit tests included with mocked reader to avoid file dependencies.