### PR TITLE
OpenAI response fix

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -423,10 +423,15 @@ class OpenAIResponses(FunctionCallingLLM):
 
         if self.model in O1_MODELS and self.reasoning_options is not None:
             model_kwargs["reasoning"] = self.reasoning_options
-        
-        if self.reasoning_options is not None:  
-            params_to_exclude_for_reasoning = {'top_p', 'temperature', 'presence_penalty', 'frequency_penalty'}  
-            for param in params_to_exclude_for_reasoning:  
+
+        if self.reasoning_options is not None:
+            params_to_exclude_for_reasoning = {
+                "top_p",
+                "temperature",
+                "presence_penalty",
+                "frequency_penalty",
+            }
+            for param in params_to_exclude_for_reasoning:
                 model_kwargs.pop(param, None)
 
         # priority is class args > additional_kwargs > runtime args

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.6.14"
+version = "0.6.15"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -16,7 +16,7 @@ from llama_index.core.base.llms.types import (
 )
 
 from llama_index.llms.openai.responses import OpenAIResponses, ResponseFunctionToolCall
-from llama_index.llms.openai.utils import to_openai_message_dicts,O1_MODELS
+from llama_index.llms.openai.utils import to_openai_message_dicts, O1_MODELS
 from llama_index.core.tools import FunctionTool
 from llama_index.core.prompts import PromptTemplate
 from openai.types.responses.response_reasoning_item import Content, Summary
@@ -85,36 +85,36 @@ def test_get_model_name():
         assert llm._get_model_name() == "gpt-4"
 
 
-def test_get_model_kwargs(default_responses_llm):  
-    """Test model kwargs generation."""  
-    llm = default_responses_llm  
-    kwargs = llm._get_model_kwargs()  
-  
-    assert kwargs["model"] == "gpt-4o-mini"  
-  
-    custom_kwargs = llm._get_model_kwargs(top_p=0.8, max_output_tokens=100)  
-    assert custom_kwargs["max_output_tokens"] == 100  
+def test_get_model_kwargs(default_responses_llm):
+    """Test model kwargs generation."""
+    llm = default_responses_llm
+    kwargs = llm._get_model_kwargs()
+
+    assert kwargs["model"] == "gpt-4o-mini"
+
+    custom_kwargs = llm._get_model_kwargs(top_p=0.8, max_output_tokens=100)
+    assert custom_kwargs["max_output_tokens"] == 100
 
 
-def test_get_model_kwargs_excludes_params_with_reasoning(default_responses_llm):  
-    """Test that certain parameters are excluded when reasoning_options is set."""  
-    llm = default_responses_llm  
-    llm.reasoning_options = {"effort": "low"}  
-      
-    kwargs = llm._get_model_kwargs()  
-      
-    assert "top_p" not in kwargs  
-    assert "temperature" not in kwargs  
-    assert "presence_penalty" not in kwargs  
-    assert "frequency_penalty" not in kwargs  
-      
-    assert "model" in kwargs  
-    assert "max_output_tokens" in kwargs  
-      
-    if llm.model in O1_MODELS:  
-        assert "reasoning" in kwargs  
-        assert kwargs["reasoning"] == {"effort": "low"}  
-    else:  
+def test_get_model_kwargs_excludes_params_with_reasoning(default_responses_llm):
+    """Test that certain parameters are excluded when reasoning_options is set."""
+    llm = default_responses_llm
+    llm.reasoning_options = {"effort": "low"}
+
+    kwargs = llm._get_model_kwargs()
+
+    assert "top_p" not in kwargs
+    assert "temperature" not in kwargs
+    assert "presence_penalty" not in kwargs
+    assert "frequency_penalty" not in kwargs
+
+    assert "model" in kwargs
+    assert "max_output_tokens" in kwargs
+
+    if llm.model in O1_MODELS:
+        assert "reasoning" in kwargs
+        assert kwargs["reasoning"] == {"effort": "low"}
+    else:
         assert "reasoning" not in kwargs
 
 


### PR DESCRIPTION
# Description

This change fixes a bug where the `OpenAIResponses` class always includes certain parameters (`top_p`, `temperature`, `presence_penalty`, `frequency_penalty`) in API requests, but GPT-5.2 models with `reasoning_options` enabled don't support these parameters, causing 400 Bad Request errors.

## Summary of Change

The fix modifies the `_get_model_kwargs` method in the `OpenAIResponses` class to conditionally exclude unsupported parameters when `reasoning_options` is set. This prevents the API from rejecting requests with unsupported parameter combinations.

## Issue Fixed

Fixes the issue where using `OpenAIResponses` with GPT-5.2 models and `reasoning_options` would fail with:
```
openai.BadRequestError: 400 - "Unsupported parameter: 'top_p' is not supported with this model."
```

## Motivation and Context

The OpenAI Responses API has parameter compatibility restrictions when reasoning is enabled. Certain models (like GPT-5.2) reject parameters like `top_p`, `temperature`, `presence_penalty`, and `frequency_penalty` when `reasoning_options` is provided. The current implementation always includes these parameters, causing API failures.

## Dependencies

No new dependencies are required. This change only modifies existing code in the `llama-index-llms-openai` package.

## New Package?

- [ ] Yes
- [x] No



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
