### PR TITLE
feat(callbacks): add TokenBudgetHandler for cost governance

### DIFF
--- a/llama-index-core/tests/callbacks/test_token_budget.py
+++ b/llama-index-core/tests/callbacks/test_token_budget.py
@@ -1,27 +1,74 @@
 import pytest
-from llama_index.core.callbacks.schema import CBEventType
-from llama_index.core.callbacks.token_counting import TokenBudgetHandler
+from unittest.mock import Mock
+from types import SimpleNamespace
+
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
+from llama_index.core.callbacks.token_counting import TokenCountingHandler
+from llama_index.core.llms import CompletionResponse
 
 
-def test_budget_enforcement():
-    """Test that the budget handler raises an error when limit is hit."""
-    # 1. Setup: Create a handler with a strict budget of 100 tokens
-    handler = TokenBudgetHandler(token_budget=100, verbose=True)
+def test_token_budget_enforcement():
+    """Test that the TokenCountingHandler enforces the budget in on_event_end."""
+    # 1. Create a Mock Tokenizer
+    # We configure it so every time it runs, it returns a list of 5 tokens.
+    mock_tokenizer = Mock()
+    mock_tokenizer.return_value = [1, 2, 3, 4, 5]  # Always 5 tokens
 
-    # 2. Simulate a safe event (Manually setting count to 50)
-    # We cheat and set the internal counter directly to simulate usage
-    handler.llm_token_counts = [type("MockEvent", (), {"total_token_count": 50})]
+    # 2. Setup Handler with Budget of 15
+    handler = TokenCountingHandler(tokenizer=mock_tokenizer, token_budget=15)
 
-    # This should pass (50 < 100)
-    handler.on_event_start(event_type=CBEventType.LLM)
+    # 3. Create a valid CompletionResponse object
+    # The handler expects an object with a .raw attribute, not just a string.
+    response_object = CompletionResponse(text="generated text")
 
-    # 3. Simulate an unsafe event (Manually setting count to 150)
-    handler.llm_token_counts = [type("MockEvent", (), {"total_token_count": 150})]
+    # 4. First Event: Safe
+    # Prompt (5 tokens) + Completion (5 tokens) = 10 tokens total.
+    # Budget is 15. This should pass.
+    handler.on_event_end(
+        event_type=CBEventType.LLM,
+        payload={
+            EventPayload.PROMPT: "input prompt",
+            EventPayload.COMPLETION: response_object,
+        },
+    )
 
-    # This should CRASH (150 > 100)
+    # 5. Second Event: Unsafe
+    # This adds another 10 tokens. Total = 20.
+    # Budget is 15. This should CRASH.
     with pytest.raises(ValueError) as excinfo:
-        handler.on_event_start(event_type=CBEventType.LLM)
+        handler.on_event_end(
+            event_type=CBEventType.LLM,
+            payload={
+                EventPayload.PROMPT: "input prompt",
+                EventPayload.COMPLETION: response_object,
+            },
+        )
 
-    # 4. Verify the error message is correct
+    # 6. Verify Error
     assert "Token budget exceeded" in str(excinfo.value)
-    assert "Limit: 100" in str(excinfo.value)
+    assert "Limit: 15" in str(excinfo.value)
+
+
+def test_token_budget_via_callback_manager():
+    mock_tokenizer = Mock()
+    mock_tokenizer.return_value = [1, 2, 3, 4, 5]
+
+    handler = TokenCountingHandler(tokenizer=mock_tokenizer, token_budget=15)
+    cm = CallbackManager([handler])
+
+    # minimal object that satisfies your get_tokens_from_response fallback behavior
+    resp = SimpleNamespace(raw=None, additional_kwargs={})
+
+    # first event -> 10 tokens (5 prompt + 5 completion) OK
+    cm.on_event_end(
+        CBEventType.LLM,
+        payload={EventPayload.PROMPT: "p", EventPayload.COMPLETION: resp},
+    )
+
+    # second event -> total 20 tokens => should exceed
+    with pytest.raises(ValueError):
+        cm.on_event_end(
+            CBEventType.LLM,
+            payload={EventPayload.PROMPT: "p", EventPayload.COMPLETION: resp},
+        )

--- a/llama-index-core/tests/callbacks/test_token_budget.py
+++ b/llama-index-core/tests/callbacks/test_token_budget.py
@@ -1,0 +1,27 @@
+import pytest
+from llama_index.core.callbacks.schema import CBEventType
+from llama_index.core.callbacks.token_counting import TokenBudgetHandler
+
+
+def test_budget_enforcement():
+    """Test that the budget handler raises an error when limit is hit."""
+    # 1. Setup: Create a handler with a strict budget of 100 tokens
+    handler = TokenBudgetHandler(token_budget=100, verbose=True)
+
+    # 2. Simulate a safe event (Manually setting count to 50)
+    # We cheat and set the internal counter directly to simulate usage
+    handler.llm_token_counts = [type("MockEvent", (), {"total_token_count": 50})]
+
+    # This should pass (50 < 100)
+    handler.on_event_start(event_type=CBEventType.LLM)
+
+    # 3. Simulate an unsafe event (Manually setting count to 150)
+    handler.llm_token_counts = [type("MockEvent", (), {"total_token_count": 150})]
+
+    # This should CRASH (150 > 100)
+    with pytest.raises(ValueError) as excinfo:
+        handler.on_event_start(event_type=CBEventType.LLM)
+
+    # 4. Verify the error message is correct
+    assert "Token budget exceeded" in str(excinfo.value)
+    assert "Limit: 100" in str(excinfo.value)


### PR DESCRIPTION
# Description
This PR introduces a new `TokenBudgetHandler` to the `llama-index-core` callbacks.

**Motivation:**
Currently, `TokenCountingHandler` provides visibility into token usage but lacks enforcement mechanisms. In production environments and automated pipelines, this can lead to runaway costs if an agent enters an infinite loop or processes unexpectedly large documents.

**Changes:**
- Implemented `TokenBudgetHandler`, a subclass of `TokenCountingHandler`.
- It monitors usage in real-time via the `on_event_start` hook.
- It raises a `ValueError` immediately when the budget is exceeded, preventing further API calls.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

**Test Details:**
- Created `tests/callbacks/test_token_budget.py`.
- Verified that `ValueError` is raised exactly when the token count exceeds the budget.
- Verified that standard `TokenCountingHandler` behavior remains unchanged.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
