### PR TITLE
fix(core):handled a edge case in truncate_text function

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -352,7 +352,7 @@ def truncate_text(text: str, max_length: int) -> str:
     """Truncate text to a maximum length."""
     if len(text) <= max_length:
         return text
-    if max_length-3 < 0:
+    if max_length - 3 < 0:
         return text[:max_length]
     return text[: max_length - 3] + "..."
 

--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -18,7 +18,7 @@ from llama_index.core.utils import (
     iter_batch,
     print_text,
     retry_on_exceptions_with_backoff,
-    truncate_text
+    truncate_text,
 )
 
 
@@ -205,11 +205,11 @@ def test_get_color_mapping() -> None:
     assert all(color in _ANSI_COLORS for color in color_mapping_ansi.values())
 
 
-
 def test_truncate_text() -> None:
     """Test truncate_text function."""
     text = "Hello, world!"
     assert truncate_text(text, 5) == "He" + "..."
+
 
 def test_truncate_text_with_less_chars() -> None:
     text = "hello"
@@ -218,6 +218,7 @@ def test_truncate_text_with_less_chars() -> None:
 
     assert truncate_text(text1, 1) == "w"
     assert truncate_text(text, 2) == "he"
+
 
 def test_get_colored_text() -> None:
     """Test _get_colored_text function."""


### PR DESCRIPTION
# Description

When calling truncate_text(text, max_length) with a small max_length value , the function returns a string that significantly exceeds the specified max_length.



Fixes :  #20539 
 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
