### PR TITLE
fix(nvidia-rerank): fix initialization logic for on-prem auth

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
@@ -162,7 +162,10 @@ class NVIDIARerank(BaseNodePostprocessor):
 
     def _get_models(self) -> List[Model]:
         client = self.client
-        _headers = self._get_headers(auth_required=self._is_hosted)
+        _headers = self._get_headers(
+            auth_required=bool(self._api_key != "NO_API_KEY_PROVIDED" and self.api_key)
+            or self._is_hosted
+        )
         url = (
             "https://integrate.api.nvidia.com/v1/models"
             if self._is_hosted

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-nvidia-rerank"
-version = "0.5.1"
+version = "0.5.2"
 description = "llama-index postprocessor nvidia_rerank integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/uv.lock
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1651,7 +1651,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-postprocessor-nvidia-rerank"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

1.  Updated the logic in _get_models to determine auth_required based on the presence of a real API key (checked  against the default "NO_API_KEY_PROVIDED" placeholder) or the hosted flag.

2. Ensured headers are correctly populated for non-hosted environments that still require security.

3. Bumped the package version to 0.5.2.


Fixes #20558


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
