### PR TITLE
test(core): fix cache dir path test for Windows compatibility

### DIFF
--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Optional, Type, Union
 from unittest import mock
+import os
 
 import pytest
 from _pytest.capture import CaptureFixture
@@ -275,7 +276,7 @@ def test_get_cache_dir_default_behavior(monkeypatch) -> None:
             result = get_cache_dir()
             mock_user_cache_dir.assert_called_once_with("llama_index")
             mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
-            assert result == mock_cache_path
+            assert result == os.path.normpath(mock_cache_path)
 
 
 def test_get_cache_dir_creates_directory(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
# Description
            
## Problem
The `test_get_cache_dir_default_behavior` test in `llama-index-core/tests/test_utils.py` was failing on Windows environments. The test asserted that the result matched a hardcoded Unix-style path string (`/mock/cache/llama_index`), which causes a mismatch when running on Windows where paths utilize backslashes.

## Solution
Updated the assertion to use `os.path.normpath` on the expected path string. This ensures the path is normalized to the operating system's standard separator before comparison, making the test cross-platform compatible.

## Verification
- [x] Ran `uv run pytest llama-index-core/tests/test_utils.py` locally on Windows 10.
- [x] Verified the test passes with the fix.

## New Package?
- [x] No

## Version Bump?
- [x] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)