### PR TITLE
fix(nvidia-rerank): correct private attribute reference

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/llama_index/postprocessor/nvidia_rerank/base.py
@@ -163,7 +163,7 @@ class NVIDIARerank(BaseNodePostprocessor):
     def _get_models(self) -> List[Model]:
         client = self.client
         _headers = self._get_headers(
-            auth_required=bool(self._api_key != "NO_API_KEY_PROVIDED" and self.api_key)
+            auth_required=bool(self._api_key != "NO_API_KEY_PROVIDED" and self._api_key)
             or self._is_hosted
         )
         url = (

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-nvidia-rerank"
-version = "0.5.2"
+version = "0.5.3"
 description = "llama-index postprocessor nvidia_rerank integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/uv.lock
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-nvidia-rerank/uv.lock
@@ -1651,7 +1651,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-postprocessor-nvidia-rerank"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

Fixed a bad attribute reference that was introduced by https://github.com/run-llama/llama_index/pull/20560.

Bumped version to 0.5.3.

Correction for PR: https://github.com/run-llama/llama_index/pull/20560
Completely fixes: https://github.com/run-llama/llama_index/issues/20558

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
