### PR TITLE
chore: Update cachable Anthropic models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -100,6 +100,7 @@ ANTHROPIC_MODELS: Dict[str, int] = {
     "claude-sonnet-4-5": 200000,
     "claude-haiku-4-5-20251001": 200000,
     "claude-haiku-4-5": 200000,
+    "claude-opus-4-5": 200000,
     "claude-opus-4-5-20251101": 200000,
 }
 
@@ -559,6 +560,9 @@ def force_single_tool_call(response: ChatResponse) -> None:
 # Anthropic models that support prompt caching
 # Based on: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
 ANTHROPIC_PROMPT_CACHING_SUPPORTED_MODELS: Tuple[str, ...] = (
+    # Claude 4.5 Opus
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-5",
     # Claude 4.1 Opus
     "claude-opus-4-1-20250805",
     "claude-opus-4-1",
@@ -580,6 +584,9 @@ ANTHROPIC_PROMPT_CACHING_SUPPORTED_MODELS: Tuple[str, ...] = (
     "claude-3-5-sonnet-20241022",
     "claude-3-5-sonnet-20240620",
     "claude-3-5-sonnet-latest",
+    # Claude 4.5 Haiku
+    "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5",
     # Claude 3.5 Haiku
     "claude-3-5-haiku-20241022",
     "claude-3-5-haiku-latest",

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-anthropic"
-version = "0.10.6"
+version = "0.10.7"
 description = "llama-index llms anthropic integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_anthropic_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_anthropic_utils.py
@@ -28,6 +28,11 @@ from anthropic.types.beta import (
 class TestAnthropicPromptCachingSupport:
     """Test suite for Anthropic prompt caching model validation."""
 
+    def test_claude_4_5_opus_supported(self):
+        """Test Claude 4.5 Opus models support prompt caching."""
+        assert is_anthropic_prompt_caching_supported_model("claude-opus-4-5-20251101")
+        assert is_anthropic_prompt_caching_supported_model("claude-opus-4-5")
+
     def test_claude_4_1_opus_supported(self):
         """Test Claude 4.1 Opus models support prompt caching."""
         assert is_anthropic_prompt_caching_supported_model("claude-opus-4-1-20250805")
@@ -60,6 +65,11 @@ class TestAnthropicPromptCachingSupport:
         assert is_anthropic_prompt_caching_supported_model("claude-3-5-sonnet-20241022")
         assert is_anthropic_prompt_caching_supported_model("claude-3-5-sonnet-20240620")
         assert is_anthropic_prompt_caching_supported_model("claude-3-5-sonnet-latest")
+
+    def test_claude_4_5_haiku_supported(self):
+        """Test Claude 4.5 Haiku models support prompt caching."""
+        assert is_anthropic_prompt_caching_supported_model("claude-haiku-4-5-20251001")
+        assert is_anthropic_prompt_caching_supported_model("claude-haiku-4-5")
 
     def test_claude_3_5_haiku_supported(self):
         """Test Claude 3.5 Haiku models support prompt caching."""
@@ -99,12 +109,14 @@ class TestAnthropicPromptCachingSupport:
         assert len(ANTHROPIC_PROMPT_CACHING_SUPPORTED_MODELS) > 0
 
         expected_patterns = [
+            "claude-opus-4-5",
             "claude-opus-4-1",
             "claude-opus-4-0",
             "claude-sonnet-4-5",
             "claude-sonnet-4-0",
             "claude-3-7-sonnet",
             "claude-3-5-sonnet",
+            "claude-haiku-4-5",
             "claude-3-5-haiku",
             "claude-3-haiku",
             "claude-3-opus",

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/uv.lock
@@ -1921,7 +1921,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-anthropic"
-version = "0.10.5"
+version = "0.10.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic", extra = ["bedrock", "vertex"] },


### PR DESCRIPTION
# Description

This updates the list of models that support caching to allow caching for Opus 4.5 and Haiku 4.5. Which are supported according to the latest information here: https://platform.claude.com/docs/en/build-with-claude/prompt-caching#supported-models 

This also adds the `claude-opus-4-5` model alias to the list of valid models to go along with `claude-sonnet-4-5` and `claude-haiku-4-5`

No code changes are made other than inclusion of these new model names in the various lists.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
