### PR TITLE
Fix BM25Retriever mapping in upgrade tool / 修复升级工具中的 BM25Retriever 映射

### DIFF
--- a/llama-index-core/llama_index/core/command_line/mappings.json
+++ b/llama-index-core/llama_index/core/command_line/mappings.json
@@ -330,7 +330,7 @@
   "RecursiveRetriever": "llama_index.core.retrievers",
   "AutoMergingRetriever": "llama_index.core.retrievers",
   "RouterRetriever": "llama_index.core.retrievers",
-  "BM25Retriever": "llama_index.core.retrievers",
+  "BM25Retriever": "llama_index.retrievers.bm25",
   "QueryFusionRetriever": "llama_index.core.retrievers",
   "# property graphBasePGRetriever": "llama_index.core.retrievers",
   "PGRetriever": "llama_index.core.retrievers",


### PR DESCRIPTION
- Update mappings.json to point BM25Retriever to llama_index.retrievers.bm25 instead of llama_index.core.retrievers
- BM25Retriever is located in optional llama-index-retrievers-bm25 package
- This fix ensures the upgrade tool correctly migrates old code

- 修改 mappings.json，将 BM25Retriever 指向 llama_index.retrievers.bm25
- BM25Retriever 位于可选包中，不在核心包中
- 确保升级工具能正确迁移使用 BM25Retriever 的旧代码

# Description

**English**:
This PR fixes an incorrect mapping in `mappings.json` used by the upgrade tool. The `BM25Retriever` was incorrectly mapped to `llama_index.core.retrievers`, but it is actually located in the optional package `llama-index-retrievers-bm25`. This caused the upgrade tool to generate incorrect import statements when migrating old code.

The fix updates the mapping from:
```json
"BM25Retriever": "llama_index.core.retrievers"
```
to:
```json
"BM25Retriever": "llama_index.retrievers.bm25"
```

This ensures the upgrade tool correctly transforms old imports:
```python
from llama_index.retrievers import BM25Retriever
```
to the correct new location:
```python
from llama_index.retrievers.bm25 import BM25Retriever
```

This bug has existed since the v0.10.0 refactoring where `BM25Retriever` was moved to an optional package.

**中文**:
此 PR 修复了升级工具使用的 `mappings.json` 文件中的错误映射。`BM25Retriever` 被错误地映射到 `llama_index.core.retrievers`，但实际上它位于可选包 `llama-index-retrievers-bm25` 中。这导致升级工具在迁移旧代码时生成错误的 import 语句。

修复将映射从：
```json
"BM25Retriever": "llama_index.core.retrievers"
```
更新为：
```json
"BM25Retriever": "llama_index.retrievers.bm25"
```

这确保升级工具正确地将旧的导入：
```python
from llama_index.retrievers import BM25Retriever
```
转换为正确的新位置：
```python
from llama_index.retrievers.bm25 import BM25Retriever
```

此错误自 v0.10.0 重构以来一直存在，当时 `BM25Retriever` 被移至可选包中。

Fixes # (issue)

## New Package?

Did I fill in `tool.llamahub` section in `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

**Testing notes**:
- Verified JSON syntax validity after the change
- Compared with other retriever mappings (e.g., `MongoDBAtlasBM25Retriever`) to ensure consistency
- Existing upgrade tool tests should verify the mapping correctness

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
