### PR TITLE
fix(llms-cohere): handle additional error types in retry logic

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/utils.py
@@ -206,7 +206,15 @@ def _create_retry_decorator(max_retries: int) -> Callable[[Any], Any]:
         reraise=True,
         stop=stop_after_attempt(max_retries),
         wait=wait_exponential(multiplier=1, min=min_seconds, max=max_seconds),
-        retry=(retry_if_exception_type(cohere.errors.ServiceUnavailableError)),
+        retry=(
+            retry_if_exception_type(
+                (
+                    cohere.errors.ServiceUnavailableError,
+                    cohere.errors.InternalServerError,
+                    cohere.errors.GatewayTimeoutError,
+                )
+            )
+        ),
         before_sleep=before_sleep_log(logger, logging.WARNING),
     )
 

--- a/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-cohere"
-version = "0.7.0"
+version = "0.7.1"
 description = "llama-index llms cohere integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-cohere/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/uv.lock
@@ -1723,7 +1723,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-cohere"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
# Description

Add retry logic for transient server errors in Cohere LLM integration.

Previously, the retry decorator only handled `ServiceUnavailableError`. This PR extends retry coverage to include:
- `InternalServerError` (HTTP 500)
- `GatewayTimeoutError` (HTTP 504)

This aligns with the retry behavior of other LLM integrations:

| Provider | Retryable Exceptions |
|----------|---------------------|
| **OpenAI** | `APIConnectionError`, `APITimeoutError`, `RateLimitError`, `InternalServerError` |
| **Google GenAI** | `ServerError`, `ConnectError`, `ConnectTimeout`, status 429, status 408 |
| **Cohere (before)** | `ServiceUnavailableError` only |
| **Cohere (after)** | `ServiceUnavailableError`, `InternalServerError`, `GatewayTimeoutError` |

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

The retry decorator uses the same tenacity-based pattern already tested in the codebase. The change only expands the exception types that trigger retries.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
