### PR TITLE
fix(tei-rerank): use index field from API response for correct score …

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-tei-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-tei-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-tei-rerank"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index postprocessor text embedding inference rerank integration"
 authors = [{name = "Rohith Ramakrishnan", email = "rrohith2001@gmail.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
…assignment

The TEI /rerank API returns results sorted by score descending with an 'index' field indicating the original document position. The previous implementation incorrectly used zip() to pair nodes with scores directly, ignoring the index field, which caused scores to be assigned to wrong nodes.

This fix uses the 'index' field from each score item to correctly assign the rerank score to the corresponding node.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
