### PR TITLE
test(tei-rerank): add test coverage for rerank retry coverage

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-tei-rerank/tests/test_postprocessor_tei_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-tei-rerank/tests/test_postprocessor_tei_rerank.py
@@ -1,7 +1,64 @@
+from unittest.mock import patch
+
+from llama_index.core import QueryBundle
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
+from llama_index.core.schema import NodeWithScore, TextNode
 from llama_index.postprocessor.tei_rerank import TextEmbeddingInference
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in TextEmbeddingInference.__mro__]
+
     assert BaseNodePostprocessor.__name__ in names_of_base_classes
+
+
+def test_rerank_logic():
+    nodes = [
+        NodeWithScore(node=TextNode(text="text1"), score=0.5),
+        NodeWithScore(node=TextNode(text="text2"), score=0.5),
+    ]
+    query_bundle = QueryBundle(query_str="test query")
+
+    # Mock the _call_api method to return scores with indices
+    with patch.object(
+        TextEmbeddingInference,
+        "_call_api",
+        return_value=[
+            {"index": 1, "score": 0.9},
+            {"index": 0, "score": 0.1},
+        ],
+    ) as mock_call_api:
+        # Test Case 1: Basic Reranking
+        postprocessor = TextEmbeddingInference(top_n=2)
+        new_nodes = postprocessor.postprocess_nodes(nodes, query_bundle=query_bundle)
+
+        # Verify API call
+        mock_call_api.assert_called_once()
+
+        # Check if nodes are sorted by score
+        assert len(new_nodes) == 2
+        assert new_nodes[0].node.text == "text2"
+        assert new_nodes[0].score == 0.9
+        assert new_nodes[1].node.text == "text1"
+        assert new_nodes[1].score == 0.1
+
+    # Test Case 2: Keep Retrieval Score
+    with patch.object(
+        TextEmbeddingInference,
+        "_call_api",
+        return_value=[
+            {"index": 1, "score": 0.9},
+            {"index": 0, "score": 0.1},
+        ],
+    ):
+        postprocessor = TextEmbeddingInference(top_n=2)
+        postprocessor.keep_retrieval_score = True
+
+        # Reset scores to ensure we are testing the preservation
+        nodes[0].score = 0.5
+        nodes[1].score = 0.5
+
+        new_nodes = postprocessor.postprocess_nodes(nodes, query_bundle=query_bundle)
+
+        assert new_nodes[0].node.metadata["retrieval_score"] == 0.5
+        assert new_nodes[1].node.metadata["retrieval_score"] == 0.5


### PR DESCRIPTION
# Description

This PR was initially intended to fix the score assignment logic for nodes. Since PR #20599  has already addressed the core logic change, I have updated this PR to focus exclusively on providing comprehensive test coverage for that logic to prevent future regressions.

Fixes #20597 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Test coverage


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
