### PR TITLE
fix(openai): make image detail optional in to_openai_message_dict

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -282,7 +282,6 @@ def test_to_openai_message_dicts_with_content_blocks() -> None:
                 "type": "image_url",
                 "image_url": {
                     "url": "https://example.com/image.jpg",
-                    "detail": "auto",
                 },
             },
         ],


### PR DESCRIPTION
Fixes #20585. 

Currently, `to_openai_message_dict` forces `detail: 'auto'` even when not specified in the `ImageBlock`. This causes 422 errors for some OpenAI-compatible providers (e.g. OVH) that strictly follow the documentation which states `detail` is optional.

This PR:
1. Makes `detail` optional in `to_openai_message_dict` and `to_openai_responses_message_dict`.
2. Makes `from_openai_message_dict` more defensive when `detail` is missing from the incoming data.
3. Updates unit tests to reflect these changes.