### PR TITLE
Add example for handling low-confidence retrieval with fallback

### DIFF
--- a/examples/querying/rag_with_similarity_threshold_fallback.py
+++ b/examples/querying/rag_with_similarity_threshold_fallback.py
@@ -1,0 +1,100 @@
+"""
+Example: RAG with similarity-threshold-based fallback.
+
+This example shows a simple pattern for avoiding answers when retrieval
+confidence is insufficient:
+
+1) Run a dry query (response_mode="no_text") to inspect retrieved nodes without
+   calling an LLM.
+2) Apply SimilarityPostprocessor(similarity_cutoff=...).
+3) Gate on max retrieved node score; if below the cutoff, abstain (fallback).
+
+This file uses MockEmbedding and MockLLM to keep the example runnable without
+API keys or optional dependencies. It demonstrates control flow, not answer
+quality.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from llama_index.core import Settings, VectorStoreIndex
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.llms import MockLLM
+from llama_index.core.postprocessor import SimilarityPostprocessor
+from llama_index.core.query_engine import RetrieverQueryEngine
+from llama_index.core.retrievers import VectorIndexRetriever
+from llama_index.core.schema import Document
+
+
+def run_query(query: str, similarity_cutoff: float) -> None:
+    documents = [
+        Document(text="The author grew up in a small town and played soccer."),
+        Document(
+            text=(
+                "The author studied computer science and later worked in industry."
+            )
+        ),
+        Document(text="This document is about cooking recipes and travel."),
+    ]
+
+    index = VectorStoreIndex.from_documents(documents)
+    retriever = VectorIndexRetriever(index=index, similarity_top_k=5)
+
+    dry_engine = RetrieverQueryEngine.from_args(
+        retriever=retriever,
+        node_postprocessors=[
+            SimilarityPostprocessor(similarity_cutoff=similarity_cutoff),
+        ],
+        response_mode="no_text",
+    )
+    dry_resp = dry_engine.query(query)
+    source_nodes = dry_resp.source_nodes or []
+
+    scores: List[float] = [
+        n.score for n in source_nodes if getattr(n, "score", None) is not None
+    ]
+    max_score: Optional[float] = max(scores) if scores else None
+
+    print(f"\nQuery: {query!r}")
+    print(f"Similarity cutoff: {similarity_cutoff}")
+    print(f"Retrieved nodes after cutoff: {len(source_nodes)}")
+    if max_score is None:
+        print("Max similarity score: None")
+    else:
+        print(f"Max similarity score: {max_score:.4f}")
+
+    if (max_score is None) or (max_score < similarity_cutoff):
+        print(
+            "Fallback: No sufficiently relevant context was found to answer "
+            "reliably.\n"
+            "Action: Ask the user to provide more details or rephrase the "
+            "question."
+        )
+        return
+
+    answer_engine = RetrieverQueryEngine.from_args(
+        retriever=retriever,
+        node_postprocessors=[
+            SimilarityPostprocessor(similarity_cutoff=similarity_cutoff),
+        ],
+    )
+    resp = answer_engine.query(query)
+    print("Answer:")
+    print(resp)
+
+
+def main() -> None:
+    Settings.embed_model = MockEmbedding(embed_dim=1536)
+    Settings.llm = MockLLM(max_tokens=128)
+
+    run_query("What did the author do growing up?", similarity_cutoff=0.0)
+
+    # Cutoff > 1.0 forces fallback for cosine-like similarity scores.
+    run_query(
+        "Explain the tax rules for offshore trusts.", similarity_cutoff=1.1
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

This PR adds a self-contained querying example that demonstrates a recommended
pattern for handling low-confidence retrieval in RAG pipelines.

The example shows how to:
- Run a dry retrieval pass using response_mode="no_text"
- Apply a similarity-based gate before synthesis
- Fallback / abstain when no sufficiently relevant context is found

The example uses MockEmbedding and MockLLM to remain fully offline and
reproducible without API keys or optional dependencies.

Verified locally with `uv run pre-commit run --all-files`.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
