### PR TITLE
chore: remove manually added seltz tools reference to avoid docs build crashing

### DIFF
--- a/docs/api_reference/api_reference/tools/seltz.md
+++ b/docs/api_reference/api_reference/tools/seltz.md
@@ -1,3 +1,0 @@
-::: llama_index.tools.seltz
-options:
-members: - SeltzToolSpec


### PR DESCRIPTION
As per title, API reference will be correctly auto-generated on docs build, so we remove the manually-added file
