### PR TITLE
fix: pass reasoning param for any model with reasoning_options

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -421,10 +421,8 @@ class OpenAIResponses(FunctionCallingLLM):
             "user": self.user,
         }
 
-        if self.model in O1_MODELS and self.reasoning_options is not None:
-            model_kwargs["reasoning"] = self.reasoning_options
-
         if self.reasoning_options is not None:
+            model_kwargs["reasoning"] = self.reasoning_options
             params_to_exclude_for_reasoning = {
                 "top_p",
                 "temperature",


### PR DESCRIPTION
## Summary
- Fixes issue where `top_p` parameter was rejected by GPT-5.2 when using `reasoning_options`
- The `reasoning` parameter was only being added for models in the hardcoded `O1_MODELS` list

## Changes
- Changed the condition to pass `reasoning` parameter whenever `reasoning_options` is set, regardless of model
- This allows users to use reasoning with newer models without waiting for the list to be updated

## Behavior
When `reasoning_options` is set:
- ✅ `reasoning` parameter is now passed to the API (was only passed for O1_MODELS)
- ✅ `top_p`, `temperature`, etc. are excluded (already working)

## Test
```python
from llama_index.llms.openai import OpenAIResponses

llm = OpenAIResponses(
    model="gpt-5.2-2025-12-11",
    reasoning_options={"effort": "low"},
)

# Now works correctly - reasoning param is passed, top_p is excluded
response = llm.chat([ChatMessage(role="user", content="Hello")])
```

Fixes #20459

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)