### PR TITLE
fix(document_summary_index): remove unexpected show_progress kwarg

### DIFF
--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -95,12 +95,12 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
         )
         self._summary_query = summary_query
         self._embed_summaries = embed_summaries
+        self._show_progress = show_progress
 
         super().__init__(
             nodes=nodes,
             index_struct=index_struct,
             storage_context=storage_context,
-            show_progress=show_progress,
             objects=objects,
             **kwargs,
         )


### PR DESCRIPTION
Fixes #20510 - stores show_progress as instance variable instead of passing to super().__init__()