### PR TITLE
fix(schema): remove conflicting metadata_seperator from TextNode

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -722,10 +722,6 @@ class TextNode(BaseNode):
     end_char_idx: Optional[int] = Field(
         default=None, description="End char index of the node."
     )
-    metadata_seperator: str = Field(
-        default="\n",
-        description="Separator between metadata fields when converting to string.",
-    )
     text_template: str = Field(
         default=DEFAULT_TEXT_NODE_TMPL,
         description=(
@@ -773,7 +769,7 @@ class TextNode(BaseNode):
                 if key in usable_metadata_keys:
                     usable_metadata_keys.remove(key)
 
-        return self.metadata_seperator.join(
+        return self.metadata_separator.join(
             [
                 self.metadata_template.format(key=key, value=str(value))
                 for key, value in self.metadata.items()


### PR DESCRIPTION
Removes the misspelled `metadata_seperator` field from TextNode that shadows the correctly-spelled `metadata_separator` inherited from BaseNode.

The BaseNode class already defines `metadata_separator` with `alias="metadata_seperator"` for backward compatibility, so the field in TextNode was redundant and caused inconsistent behavior.

Fixes #20645