### PR TITLE
fix: open telemetry url typo in docs

### DIFF
--- a/docs/src/content/docs/framework/module_guides/observability/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/index.md
@@ -41,7 +41,7 @@ And that's it! Executions will get seamlessly piped to downstream service and yo
 
 ### OpenTelemetry
 
-[OpenTelemetry](https://openetelemetry.io) is a widely used open-source service for tracing and observability, with numerous backend integrations (such as Jaeger, Zipkin or Prometheus).
+[OpenTelemetry](https://opentelemetry.io) is a widely used open-source service for tracing and observability, with numerous backend integrations (such as Jaeger, Zipkin or Prometheus).
 
 Our OpenTelemetry integration traces all the events produced by pieces of LlamaIndex code, including LLMs, Agents, RAG pipeline components and many more: everything you would get out with LlamaIndex native instrumentation you can export in OpenTelemetry format!
 


### PR DESCRIPTION
# Description

Corrected the URL for OpenTelemetry from 'openetelemetry.io' to 'opentelemetry.io'.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests


