### PR TITLE
Block filesystem/network I/O and add timeout to safe_exec/safe_eval

### DIFF
--- a/llama-index-experimental/pyproject.toml
+++ b/llama-index-experimental/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 
 [project]
 name = "llama-index-experimental"
-version = "0.6.4"
+version = "0.6.5"
 description = "llama-index experimental package"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-experimental/tests/test_exec_utils.py
+++ b/llama-index-experimental/tests/test_exec_utils.py
@@ -1,4 +1,17 @@
-from llama_index.experimental.exec_utils import _contains_protected_access
+import sys
+
+import pytest
+
+from llama_index.experimental.exec_utils import (
+    _contains_protected_access,
+    safe_eval,
+    safe_exec,
+)
+
+
+# ---------------------------------------------------------------------------
+# _contains_protected_access -- existing tests (preserved)
+# ---------------------------------------------------------------------------
 
 
 def test_contains_protected_access() -> None:
@@ -15,3 +28,170 @@ def test_contains_protected_access() -> None:
     assert not _contains_protected_access("a.b"), "access to attribute of a public name"
     assert _contains_protected_access("a._b"), "access to protected attribute of a name"
     assert not _contains_protected_access("a.b"), "access to public attribute of a name"
+
+
+# ---------------------------------------------------------------------------
+# I/O operation blocking -- pandas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        'pd.read_csv("/etc/passwd")',
+        'df.to_csv("/tmp/data.csv")',
+        'pd.read_excel("file.xlsx")',
+        'df.to_parquet("out.parquet")',
+        'pd.read_sql("SELECT 1", conn)',
+        'pd.read_pickle("model.pkl")',
+        'df.to_pickle("out.pkl")',
+        'pd.read_json("data.json")',
+    ],
+    ids=[
+        "read_csv",
+        "to_csv",
+        "read_excel",
+        "to_parquet",
+        "read_sql",
+        "read_pickle",
+        "to_pickle",
+        "read_json",
+    ],
+)
+def test_blocks_pandas_io(code: str) -> None:
+    assert _contains_protected_access(code)
+
+
+# ---------------------------------------------------------------------------
+# I/O operation blocking -- numpy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        'np.load("file.npy")',
+        'np.save("file.npy", x)',
+        'np.loadtxt("data.txt")',
+        'np.savetxt("out.txt", arr)',
+        'np.genfromtxt("data.csv")',
+        'np.fromfile("raw.bin")',
+        'arr.tofile("out.bin")',
+    ],
+    ids=["load", "save", "loadtxt", "savetxt", "genfromtxt", "fromfile", "tofile"],
+)
+def test_blocks_numpy_io(code: str) -> None:
+    assert _contains_protected_access(code)
+
+
+# ---------------------------------------------------------------------------
+# I/O operation blocking -- polars
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        'pl.scan_csv("file.csv")',
+        'pl.scan_parquet("file.parquet")',
+        'df.write_csv("out.csv")',
+        'df.write_parquet("out.parquet")',
+    ],
+    ids=["scan_csv", "scan_parquet", "write_csv", "write_parquet"],
+)
+def test_blocks_polars_io(code: str) -> None:
+    assert _contains_protected_access(code)
+
+
+# ---------------------------------------------------------------------------
+# I/O operation blocking -- general dangerous calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        'os.system("rm -rf /")',
+        'os.popen("cat /etc/shadow")',
+    ],
+    ids=["system", "popen"],
+)
+def test_blocks_dangerous_system_calls(code: str) -> None:
+    assert _contains_protected_access(code)
+
+
+# ---------------------------------------------------------------------------
+# Allowed operations must still work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        'df.groupby("col").mean()',
+        'df.merge(df2, on="col")',
+        'df.sort_values("col")',
+        "df.head(10)",
+        "df.describe()",
+        'df.rename(columns={"a": "b"})',
+        "df.dropna()",
+        "df.fillna(0)",
+    ],
+    ids=[
+        "groupby",
+        "merge",
+        "sort_values",
+        "head",
+        "describe",
+        "rename",
+        "dropna",
+        "fillna",
+    ],
+)
+def test_allows_safe_dataframe_ops(code: str) -> None:
+    assert not _contains_protected_access(code)
+
+
+# ---------------------------------------------------------------------------
+# safe_exec / safe_eval smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_safe_eval_basic() -> None:
+    result = safe_eval("1 + 2")
+    assert result == 3
+
+
+def test_safe_exec_basic() -> None:
+    local_vars: dict = {}
+    safe_exec("x = 1 + 2", __locals=local_vars)
+    assert local_vars["x"] == 3
+
+
+def test_safe_exec_rejects_io() -> None:
+    with pytest.raises(RuntimeError, match="forbidden"):
+        safe_exec('pd.read_csv("/etc/passwd")')
+
+
+def test_safe_eval_rejects_io() -> None:
+    with pytest.raises(RuntimeError, match="forbidden"):
+        safe_eval('pd.read_csv("/etc/passwd")')
+
+
+# ---------------------------------------------------------------------------
+# Timeout enforcement (Unix only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGALRM not available on Windows")
+def test_safe_exec_timeout() -> None:
+    with pytest.raises(TimeoutError, match="time limit"):
+        safe_exec("while True: pass", timeout_seconds=1)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGALRM not available on Windows")
+def test_safe_eval_timeout() -> None:
+    # A generator expression that loops in Python bytecode (interruptible).
+    code = "sum(x * x for x in range(10**18))"
+    with pytest.raises(TimeoutError, match="time limit"):
+        safe_eval(code, timeout_seconds=1)


### PR DESCRIPTION
Closes #20690

Builds on the original RCE fix from #7054. The existing sandbox blocks direct imports and dunder/private attribute access, but LLM-generated code can still reach the filesystem and network through pandas, numpy, and polars methods that are already in the execution locals. There is also no timeout, so an infinite loop hangs the process forever.

## What changes are proposed

**I/O operation blocking (AST-level):** Added `_DANGEROUS_ATTR_CALLS` -- a frozenset of ~50 method names covering pandas read/write (`read_csv`, `to_csv`, `read_sql`, `to_parquet`, ...), numpy file I/O (`load`, `save`, `loadtxt`, `fromfile`, ...), polars lazy/eager I/O (`scan_csv`, `write_parquet`, ...), and general dangerous calls (`system`, `popen`). The existing `DunderVisitor` now flags these during AST analysis, so they are rejected before any code runs.

**Timeout enforcement:** Added `_time_limit()` context manager using `signal.SIGALRM` (no-op on Windows where SIGALRM is unavailable). Both `safe_exec` and `safe_eval` now accept a `timeout_seconds` parameter (default 30s). Same pattern used in the evaporate sandbox.

**Tests expanded from 18 to ~200 lines:** 36 parametrized tests covering pandas I/O blocking (8 cases), numpy I/O blocking (7 cases), polars I/O blocking (4 cases), system call blocking, safe DataFrame operations still passing (8 cases), basic safe_exec/safe_eval smoke tests, and timeout enforcement for both exec and eval.

Normal DataFrame operations (`groupby`, `merge`, `sort_values`, `head`, `describe`, `rename`, `dropna`, `fillna`) are unaffected.

## How is this PR tested?

```
$ python3 -m pytest llama-index-experimental/tests/test_exec_utils.py -v
36 passed in 4.60s

$ python3 -m pytest llama-index-experimental/tests/test_pandas.py -v
3 passed, 1 skipped (e2e test requires OPENAI_API_KEY)

$ python3 -m ruff check llama-index-experimental/
All checks passed!
```