### PR TITLE
fix: replace mutable default argument in load_all_file_paths

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-bitbucket/llama_index/readers/bitbucket/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-bitbucket/llama_index/readers/bitbucket/base.py
@@ -67,10 +67,12 @@ class BitbucketReader(BaseReader):
         slugs.append(self.repository)
         return slugs
 
-    def load_all_file_paths(self, slug, branch, directory_path="", paths=[]):
+    def load_all_file_paths(self, slug, branch, directory_path="", paths=None):
         """
         Go inside every file that is present in the repository and get the paths for each file.
         """
+        if paths is None:
+            paths = []
         content_url = f"{self.base_url}/rest/api/latest/projects/{self.project_key}/repos/{slug}/browse/{directory_path}"
 
         query_params = {

--- a/llama-index-integrations/readers/llama-index-readers-bitbucket/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-bitbucket/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-bitbucket"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index readers bitbucket integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
The load_all_file_paths method in the Bitbucket reader uses a mutable list as a default argument. This can lead to unexpected behavior if the method is called without explicitly passing the paths parameter. Changed to use None as default and initialize an empty list inside the function.