### PR TITLE
fix: fix sub-package publishing action

### DIFF
--- a/.github/workflows/publish_sub_package.yml
+++ b/.github/workflows/publish_sub_package.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   publish_subpackage_if_needed:
@@ -55,3 +55,4 @@ jobs:
 
             cd - >/dev/null
           done
+          exit $result # exit with a non-zero code if one or more failures


### PR DESCRIPTION
Use python 3.12 to run sub-package publishing and avoid silent failures by exiting with a non-zero code if there have been one or more publishing failures

Closes #20716 
