### PR TITLE
docs: add RAG Failure Mode Checklist

### DIFF
--- a/docs/src/content/docs/framework/optimizing/rag_failure_mode_checklist.md
+++ b/docs/src/content/docs/framework/optimizing/rag_failure_mode_checklist.md
@@ -162,10 +162,12 @@ When your RAG pipeline isn't performing as expected, it can be difficult to pinp
 Use this to narrow down where the problem is:
 
 1. **Check retrieval first:** Print retrieved nodes and verify they contain the answer manually.
+
    - If **retrieved nodes are wrong** → Focus on items 1-5, 7-8 above.
    - If **retrieved nodes are correct** → Focus on items 6, 9 above.
 
 2. **Check a known-good query:** Try a query where you know exactly which document contains the answer.
+
    - If it **fails** → Likely an indexing or embedding issue (items 3-5).
    - If it **works** → The issue is query-specific (items 1, 7-8).
 


### PR DESCRIPTION
## Summary

Adds a comprehensive **RAG Failure Mode Checklist** documentation page to help users diagnose and fix common RAG pipeline issues.

## Failure Modes Covered

1. **Retrieval Hallucination** — retriever returns superficially relevant but wrong chunks
2. **Wrong Chunk Selection (Poor Chunking)** — critical context split across chunks
3. **Index Fragmentation** — duplicate/outdated/conflicting documents in index
4. **Config Drift** — embedding model mismatch between index and query time
5. **Embedding Model Mismatch** — wrong model for the domain
6. **Context Window Overflow** — too many chunks stuffed into LLM prompt
7. **Missing Metadata Filtering** — retrieval not scoped to relevant subset
8. **Poor Query Understanding** — ambiguous or short queries
9. **LLM Synthesis Failures** — right chunks retrieved but bad answer generated

Each section includes symptoms and minimal fixes referencing LlamaIndex components. Also includes a quick diagnostic flowchart.

Closes #20702