### PR TITLE
feat: allow ChatMessage inputs in context chat engines

### DIFF
--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -6,6 +6,7 @@ from llama_index.core.chat_engine.condense_plus_context import (
 )
 from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.llms.mock import MockLLM
+from llama_index.core.base.llms.types import ChatMessage, TextBlock
 from llama_index.core.schema import Document
 
 SYSTEM_PROMPT = "Talk like a pirate."
@@ -33,6 +34,15 @@ def test_chat(chat_engine: CondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+def test_chat_with_chat_message(chat_engine: CondensePlusContextChatEngine):
+    response = chat_engine.chat(
+        ChatMessage(role="user", blocks=[TextBlock(text="Hello from ChatMessage!")])
+    )
+    assert "Hello from ChatMessage!" in str(response)
+    assert len(chat_engine.chat_history) == 2
+    assert chat_engine.chat_history[0].content == "Hello from ChatMessage!"
 
 
 def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
@@ -72,6 +82,16 @@ async def test_achat(chat_engine: CondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+@pytest.mark.asyncio
+async def test_achat_with_chat_message(chat_engine: CondensePlusContextChatEngine):
+    response = await chat_engine.achat(
+        ChatMessage(role="user", blocks=[TextBlock(text="Hello async ChatMessage!")])
+    )
+    assert "Hello async ChatMessage!" in str(response)
+    assert len(chat_engine.chat_history) == 2
+    assert chat_engine.chat_history[0].content == "Hello async ChatMessage!"
 
 
 @pytest.mark.asyncio

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -6,6 +6,7 @@ from llama_index.core.chat_engine.context import (
 )
 from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.llms.mock import MockLLM
+from llama_index.core.base.llms.types import ChatMessage, TextBlock
 from llama_index.core.schema import Document, QueryBundle
 
 SYSTEM_PROMPT = "Talk like a pirate."
@@ -40,6 +41,15 @@ def test_chat(chat_engine: ContextChatEngine):
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])
+
+
+def test_chat_with_chat_message(chat_engine: ContextChatEngine):
+    response = chat_engine.chat(
+        ChatMessage(role="user", blocks=[TextBlock(text="Hello from ChatMessage!")])
+    )
+    assert "Hello from ChatMessage!" in str(response)
+    assert len(chat_engine.chat_history) == 2
+    assert chat_engine.chat_history[0].content == "Hello from ChatMessage!"
 
 
 def test_chat_stream(chat_engine: ContextChatEngine):
@@ -97,6 +107,16 @@ async def test_achat(chat_engine: ContextChatEngine):
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])
+
+
+@pytest.mark.asyncio
+async def test_achat_with_chat_message(chat_engine: ContextChatEngine):
+    response = await chat_engine.achat(
+        ChatMessage(role="user", blocks=[TextBlock(text="Hello async ChatMessage!")])
+    )
+    assert "Hello async ChatMessage!" in str(response)
+    assert len(chat_engine.chat_history) == 2
+    assert chat_engine.chat_history[0].content == "Hello async ChatMessage!"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update `ContextChatEngine` and `CondensePlusContextChatEngine` to accept `ChatMessage` inputs in `chat`, `stream_chat`, `achat`, and `astream_chat`
- normalize input into retrieval text + persisted user message, preserving the original `ChatMessage` in memory when provided
- keep backward compatibility for existing string and non-string inputs by falling back to `str(message)` for retrieval text
- add validation for `ChatMessage` inputs without text content (these engines require text queries for retrieval)
- add sync/async regression tests for both engines to verify `ChatMessage` inputs are accepted and persisted

## Testing
- PYTHONPATH=llama-index-core python3 -m pytest llama-index-core/tests/chat_engine/test_context.py llama-index-core/tests/chat_engine/test_condense_plus_context.py

Fixes #15667
