### PR TITLE
fix: bump ver to trigger  llama-index-llms-langchain integration release

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-langchain/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-langchain"
-version = "0.7.1"
+version = "0.7.2"
 description = "llama-index llms langchain integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

With LangChain v1 support, the llama-index-llms-langchain integration was updated, but the version number was not incremented. As a result, the build did not trigger a package release on PyPI. This fix bumps the version to ensure the package is published in the next release of LlamaIndex.

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods