### PR TITLE
fix: preserve doc_id in legacy_json_to_doc

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/utils.py
+++ b/llama-index-core/llama_index/core/storage/docstore/utils.py
@@ -66,18 +66,18 @@ def legacy_json_to_doc(doc_dict: dict) -> BaseNode:
 
     if doc_type == Document.get_type():
         doc = Document(
-            text=text, metadata=metadata, id=id_, relationships=relationships
+            text=text, metadata=metadata, id_=id_, relationships=relationships
         )
     elif doc_type == TextNode.get_type():
         doc = TextNode(
-            text=text, metadata=metadata, id=id_, relationships=relationships
+            text=text, metadata=metadata, id_=id_, relationships=relationships
         )
     elif doc_type == ImageNode.get_type():
         image = data_dict.get("image", None)
         doc = ImageNode(
             text=text,
             metadata=metadata,
-            id=id_,
+            id_=id_,
             relationships=relationships,
             image=image,
         )
@@ -86,7 +86,7 @@ def legacy_json_to_doc(doc_dict: dict) -> BaseNode:
         doc = IndexNode(
             text=text,
             metadata=metadata,
-            id=id_,
+            id_=id_,
             relationships=relationships,
             index_id=index_id,
         )


### PR DESCRIPTION
## Description

Fixes #20749

`legacy_json_to_doc` was passing `id=id_` to the node constructors, but the Pydantic field is named `id_`, not `id`. This caused the persisted `doc_id` to be silently dropped and a new UUID to be generated, breaking backward compatibility for users restoring or migrating persisted docstores.

## Changes

Changed `id=id_` to `id_=id_` in all four constructor calls within `legacy_json_to_doc` (Document, TextNode, ImageNode, IndexNode).

## Reproduction

```python
from llama_index.core.constants import DATA_KEY, TYPE_KEY
from llama_index.core.schema import Document
from llama_index.core.storage.docstore.utils import legacy_json_to_doc

doc_dict = {
    TYPE_KEY: Document.get_type(),
    DATA_KEY: {
        "text": "hello",
        "extra_info": {},
        "doc_id": "doc-123",
        "relationships": {},
    },
}

loaded = legacy_json_to_doc(doc_dict)
assert loaded.id_ == "doc-123"  # Previously failed: got a new UUID
```

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*