### PR TITLE
fix: async retry backoff to avoid blocking event loop

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -328,7 +328,7 @@ async def aretry_on_exceptions_with_backoff(
             check_fn = error_checks.get(e.__class__)
             if check_fn and not check_fn(e):
                 raise
-            time.sleep(backoff_secs)
+            await asyncio.sleep(backoff_secs)
             backoff_secs = min(backoff_secs * 2, max_backoff_secs)
 
 


### PR DESCRIPTION
Fixes #20763 

# Description

This PR fixes a blocking behavior in the async retry helper `aretry_on_exceptions_with_backoff`. The function previously used `time.sleep()` for retry backoff inside an `async def`, which blocks the asyncio event loop and prevents other coroutines from running concurrently. The backoff logic has been updated to use `await asyncio.sleep()` instead.

I also added a regression test for this change. The fix actually showed a significant performance improvement in async workloads. Since there is no existing place in the repository for benchmarks, I just added the code below so that it can be used to measure performance before and after the fix. I have also attached the benchmark results from my local machine for reference.

<details>
  <summary>Benchmark Code</summary>

``` python 
import asyncio
import time
import json
import os
import statistics
from dataclasses import dataclass, asdict
from typing import Optional, Any, Callable, List, Dict

from llama_index.core.utils import aretry_on_exceptions_with_backoff, ErrorToRetry

class TransientError(Exception):
    pass

@dataclass
class Scenario:
    name: str
    concurrency: int
    backoff: float
    work_delay: float
    fail_times: Optional[int]
    mixed_ratio: float
    repeats: int

def make_task(task_id: int, work_delay: float, fail_times: Optional[int]) -> Callable[[], Any]:
    attempts = {"n": 0}
    async def fn():
        attempts["n"] += 1
        await asyncio.sleep(work_delay)
        if fail_times is None or fail_times == 0:
            return f"ok-{task_id}"
        if fail_times == -1:
            raise TransientError(f"task {task_id} always fails")
        if attempts["n"] <= fail_times:
            raise TransientError(f"task {task_id} transient failure")
        return f"ok-{task_id}"
    return fn

async def run_once(s: Scenario) -> float:
    start = time.perf_counter()
    async def one(i: int):
        use_fail = s.fail_times
        if s.mixed_ratio < 1.0:
            cutoff = int(s.concurrency * s.mixed_ratio)
            if i >= cutoff:
                use_fail = 0
        fn = make_task(i, s.work_delay, use_fail)
        if use_fail == -1:
            max_tries = 3
        elif use_fail is None or use_fail == 0:
            max_tries = 1
        else:
            max_tries = use_fail + 1
        return await aretry_on_exceptions_with_backoff(
            fn,
            errors_to_retry=[ErrorToRetry(TransientError)],
            max_tries=max_tries,
            min_backoff_secs=s.backoff,
            max_backoff_secs=s.backoff,
        )
    try:
        await asyncio.gather(*(one(i) for i in range(s.concurrency)))
    except Exception:
        pass
    return time.perf_counter() - start

async def run_scenario(s: Scenario) -> Dict[str, Any]:
    times = []
    for _ in range(s.repeats):
        times.append(await run_once(s))
    return {
        "scenario": asdict(s),
        "n": len(times),
        "mean_s": statistics.mean(times),
        "median_s": statistics.median(times),
        "min_s": min(times),
        "max_s": max(times),
        "samples_s": times,
    }

def scenarios() -> List[Scenario]:
    base = [
        ("always_ok", None, 1.0),
        ("fail_once", 1, 1.0),
        ("fail_twice", 2, 1.0),
        ("always_fail", -1, 1.0),
        ("mixed_50pct_fail_once", 1, 0.5),
    ]
    concurrencies = [10, 50]
    backoffs = [0.01, 0.2]
    work_delay = 0.01
    reps = 3
    out = []
    for c in concurrencies:
        for b in backoffs:
            for (name, fail_times, mixed_ratio) in base:
                out.append(
                    Scenario(
                        name=f"{name}",
                        concurrency=c,
                        backoff=b,
                        work_delay=work_delay,
                        fail_times=fail_times,
                        mixed_ratio=mixed_ratio,
                        repeats=reps,
                    )
                )
    return out

def save_json(path: str, payload: Any) -> None:
    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
    with open(path, "w", encoding="utf-8") as f:
        json.dump(payload, f, indent=2)

def load_json(path: str) -> Any:
    with open(path, "r", encoding="utf-8") as f:
        return json.load(f)

def key_of(r: Dict[str, Any]) -> str:
    s = r["scenario"]
    return f'{s["name"]}|c={s["concurrency"]}|b={s["backoff"]}|d={s["work_delay"]}|f={s["fail_times"]}|m={s["mixed_ratio"]}'

def fmt(x: float) -> str:
    return f"{x:.3f}s"

def compare(before_path: str, after_path: str) -> None:
    before = load_json(before_path)["results"]
    after = load_json(after_path)["results"]
    bmap = {key_of(r): r for r in before}
    amap = {key_of(r): r for r in after}
    keys = sorted(set(bmap.keys()) & set(amap.keys()))
    header = ["scenario", "before(median)", "after(median)", "speedup", "before(mean)", "after(mean)"]
    rows = []
    for k in keys:
        br = bmap[k]
        ar = amap[k]
        bmed = br["median_s"]
        amed = ar["median_s"]
        sp = (bmed / amed) if amed > 0 else float("inf")
        rows.append([k, fmt(bmed), fmt(amed), f"{sp:.2f}x", fmt(br["mean_s"]), fmt(ar["mean_s"])])
    widths = [max(len(str(row[i])) for row in ([header] + rows)) for i in range(len(header))]
    def print_row(row):
        print(" | ".join(str(row[i]).ljust(widths[i]) for i in range(len(row))))
    print_row(header)
    print("-+-".join("-" * w for w in widths))
    for r in rows:
        print_row(r)

async def run_all(out_path: str) -> None:
    res = []
    for s in scenarios():
        res.append(await run_scenario(s))
    save_json(out_path, {"results": res})

def main():
    import sys
    if len(sys.argv) < 2 or sys.argv[1] not in {"before", "after", "compare"}:
        print("Usage: python bench_async_retry.py before|after|compare")
        raise SystemExit(2)
    mode = sys.argv[1]
    before_path = os.path.join("bench_out", "before.json")
    after_path = os.path.join("bench_out", "after.json")
    if mode == "before":
        asyncio.run(run_all(before_path))
        print(f"Wrote {before_path}")
    elif mode == "after":
        asyncio.run(run_all(after_path))
        print(f"Wrote {after_path}")
    else:
        compare(before_path, after_path)

if __name__ == "__main__":
    main()
```
</details>

| scenario                                           | before (median) | after (median) | speedup | before (mean) | after (mean) |
|----------------------------------------------------|------------------|---------------|---------|---------------|--------------|
| always_fail\|c=10\|b=0.01\|d=0.01\|f=-1\|m=1.0     | 0.284s           | 0.086s        | 3.29x   | 0.323s        | 0.088s       |
| always_fail\|c=10\|b=0.2\|d=0.01\|f=-1\|m=1.0      | 4.234s           | 0.482s        | 8.79x   | 4.221s        | 0.511s       |
| always_fail\|c=50\|b=0.01\|d=0.01\|f=-1\|m=1.0     | 1.342s           | 0.110s        | 12.21x  | 1.381s        | 0.105s       |
| always_fail\|c=50\|b=0.2\|d=0.01\|f=-1\|m=1.0      | 20.411s          | 0.469s        | 43.53x  | 20.447s       | 0.477s       |
| always_ok\|c=10\|b=0.01\|d=0.01\|f=None\|m=1.0     | 0.016s           | 0.016s        | 1.03x   | 0.017s        | 0.014s       |
| always_ok\|c=10\|b=0.2\|d=0.01\|f=None\|m=1.0      | 0.015s           | 0.016s        | 0.94x   | 0.014s        | 0.016s       |
| always_ok\|c=50\|b=0.01\|d=0.01\|f=None\|m=1.0     | 0.020s           | 0.016s        | 1.21x   | 0.020s        | 0.016s       |
| always_ok\|c=50\|b=0.2\|d=0.01\|f=None\|m=1.0      | 0.016s           | 0.016s        | 1.02x   | 0.016s        | 0.016s       |
| fail_once\|c=10\|b=0.01\|d=0.01\|f=1\|m=1.0        | 0.134s           | 0.048s        | 2.80x   | 0.137s        | 0.048s       |
| fail_once\|c=10\|b=0.2\|d=0.01\|f=1\|m=1.0         | 2.042s           | 0.238s        | 8.59x   | 2.049s        | 0.253s       |
| fail_once\|c=50\|b=0.01\|d=0.01\|f=1\|m=1.0        | 0.834s           | 0.048s        | 17.51x  | 0.801s        | 0.048s       |
| fail_once\|c=50\|b=0.2\|d=0.01\|f=1\|m=1.0         | 10.221s          | 0.239s        | 42.72x  | 10.223s       | 0.249s       |
| fail_twice\|c=10\|b=0.01\|d=0.01\|f=2\|m=1.0       | 0.304s           | 0.080s        | 3.82x   | 0.319s        | 0.085s       |
| fail_twice\|c=10\|b=0.2\|d=0.01\|f=2\|m=1.0        | 4.074s           | 0.460s        | 8.87x   | 4.078s        | 0.459s       |
| fail_twice\|c=50\|b=0.01\|d=0.01\|f=2\|m=1.0       | 1.339s           | 0.096s        | 13.99x  | 1.335s        | 0.095s       |
| fail_twice\|c=50\|b=0.2\|d=0.01\|f=2\|m=1.0        | 20.478s          | 0.474s        | 43.17x  | 20.479s       | 0.537s       |
| mixed_50pct_fail_once\|c=10\|b=0.01\|d=0.01\|f=1\|m=0.5 | 0.102s      | 0.032s        | 3.19x   | 0.097s        | 0.033s       |
| mixed_50pct_fail_once\|c=10\|b=0.2\|d=0.01\|f=1\|m=0.5  | 1.039s      | 0.253s        | 4.10x   | 1.038s        | 0.251s       |
| mixed_50pct_fail_once\|c=50\|b=0.01\|d=0.01\|f=1\|m=0.5 | 0.338s      | 0.048s        | 7.07x   | 0.338s        | 0.064s       |
| mixed_50pct_fail_once\|c=50\|b=0.2\|d=0.01\|f=1\|m=0.5  | 5.177s      | 0.238s        | 21.77x  | 5.189s        | 0.238s       |


## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
