### PR TITLE
feat: pass a custom tracer provider

### DIFF
--- a/llama-index-integrations/observability/llama-index-observability-otel/llama_index/observability/otel/base.py
+++ b/llama-index-integrations/observability/llama-index-observability-otel/llama_index/observability/otel/base.py
@@ -233,6 +233,10 @@ class LlamaIndexOpenTelemetry(BaseModel):
         default_factory=list,
         description="List of OpenTelemetry Span Processors to add to the tracer provider.",
     )
+    tracer_provider: Optional[TracerProvider] = Field(
+        default=None,
+        description="Tracer Provider to inherint from the existing observability context. Defaults to None.",
+    )
     service_name_or_resource: Union[str, Resource] = Field(
         default=Resource(attributes={SERVICE_NAME: "llamaindex.opentelemetry"}),
         description="Service name or resource for OpenTelemetry. Defaults to a Resource with 'llamaindex.opentelemetry' as service name.",
@@ -250,7 +254,10 @@ class LlamaIndexOpenTelemetry(BaseModel):
             self.service_name_or_resource = Resource(
                 attributes={SERVICE_NAME: self.service_name_or_resource}
             )
-        tracer_provider = TracerProvider(resource=self.service_name_or_resource)
+        if self.tracer_provider is None:
+            tracer_provider = TracerProvider(resource=self.service_name_or_resource)
+        else:
+            tracer_provider = self.tracer_provider
         assert self.span_exporter is not None, (
             "span_exporter has to be non-null to be used within simple or batch span processors"
         )

--- a/llama-index-integrations/observability/llama-index-observability-otel/pyproject.toml
+++ b/llama-index-integrations/observability/llama-index-observability-otel/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-observability-otel"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index observability integration with OpenTelemetry"
 authors = [{name = "Clelia Astra Bertelli", email = "clelia@runllama.ai"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
Pass a custom tracer provider for OTel integration to inherint from the current observability context instead of creating one from scratch
