### PR TITLE
Add User-Agent header for Anthropic API calls

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-anthropic"
-version = "0.10.9"
+version = "0.10.10"
 description = "llama-index llms anthropic integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
@@ -23,13 +23,37 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.base.llms.types import ThinkingBlock
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.anthropic import Anthropic
-from llama_index.llms.anthropic.base import AnthropicChatResponse
+from llama_index.llms.anthropic.base import AnthropicChatResponse, _get_default_headers
 from llama_index.llms.anthropic.utils import messages_to_anthropic_messages
 
 
 def test_text_inference_embedding_class():
     names_of_base_classes = [b.__name__ for b in Anthropic.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_get_default_headers_returns_user_agent():
+    """Test that _get_default_headers returns a User-Agent header."""
+    headers = _get_default_headers()
+    assert isinstance(headers, dict)
+    assert "User-Agent" in headers
+    assert headers["User-Agent"].startswith("llama-index/")
+
+
+def test_get_default_headers_merges_user_headers():
+    """Test that user-provided headers are merged and take precedence."""
+    user_headers = {"X-Custom": "value", "User-Agent": "my-app/1.0"}
+    headers = _get_default_headers(user_headers)
+    assert headers["X-Custom"] == "value"
+    assert headers["User-Agent"] == "my-app/1.0"
+
+
+def test_get_default_headers_preserves_default_when_no_conflict():
+    """Test that default User-Agent is preserved when user headers don't override it."""
+    user_headers = {"X-Custom": "value"}
+    headers = _get_default_headers(user_headers)
+    assert headers["X-Custom"] == "value"
+    assert headers["User-Agent"].startswith("llama-index/")
 
 
 @pytest.mark.skipif(

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/uv.lock
@@ -1921,7 +1921,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-anthropic"
-version = "0.10.7"
+version = "0.10.10"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic", extra = ["bedrock", "vertex"] },


### PR DESCRIPTION
# Description

Passes User-Agent: llama-index-llms-anthropic/{version} to the Anthropic SDK so Anthropic can identify traffic from LlamaIndex integrations.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] I added new unit tests to cover this change

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
