### PR TITLE
Update CohereRerank to ClientV2 to enable V4 rerankers

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -76,13 +76,13 @@ class CohereRerank(BaseNodePostprocessor):
                 "specify via COHERE_API_KEY environment variable "
             )
         try:
-            from cohere import Client
+            from cohere import ClientV2
         except ImportError:
             raise ImportError(
                 "Cannot import cohere package, please `pip install cohere`."
             )
 
-        self._client = Client(api_key=api_key, base_url=base_url)
+        self._client = ClientV2(api_key=api_key, base_url=base_url)
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
@@ -26,14 +26,14 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-cohere-rerank"
-version = "0.6.0"
+version = "0.7.0"
 description = "llama-index postprocessor cohere rerank integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "cohere>=5.1.1,<6",
+    "cohere>=5.15,<6",
     "llama-index-core>=0.13.0,<0.15",
     "tenacity>=8.2.0,<10",
 ]

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/uv.lock
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1723,7 +1723,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-postprocessor-cohere-rerank"
-version = "0.5.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },
@@ -1756,7 +1756,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cohere", specifier = ">=5.1.1,<6" },
+    { name = "cohere", specifier = ">=5.15,<6" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
     { name = "tenacity", specifier = ">=8.2.0,<10" },
 ]


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Update of the Cohere client used by the integration.

## How Has This Been Tested?

The integration does not contain any client-version-related logic and the [client API remains unchanged when migrating from V1 -> V2](https://docs.cohere.com/docs/migrating-v1-to-v2). I confirmed in my local setup, that the Postprocessor works with the Azure AI Foundry as well as the official Cohere API.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
