### PR TITLE
feat: support reasoning_content in OpenAI Chat Completions

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -44,6 +44,7 @@ from llama_index.core.base.llms.types import (
     CompletionResponseGen,
     LLMMetadata,
     MessageRole,
+    ThinkingBlock,
     ToolCallBlock,
     TextBlock,
 )
@@ -540,6 +541,7 @@ class OpenAI(FunctionCallingLLM):
 
         def gen() -> ChatResponseGen:
             content = ""
+            reasoning_content = ""
             tool_calls: List[ChoiceDeltaToolCall] = []
 
             is_function = False
@@ -565,13 +567,24 @@ class OpenAI(FunctionCallingLLM):
                 role = delta.role or MessageRole.ASSISTANT
                 content_delta = delta.content or ""
                 content += content_delta
+
+                # Extract reasoning_content for chain-of-thought streaming.
+                # Many OpenAI-compatible providers surface this extra field.
+                raw_reasoning = getattr(delta, "reasoning_content", None)
+                reasoning_delta = (
+                    raw_reasoning if isinstance(raw_reasoning, str) else ""
+                )
+                reasoning_content += reasoning_delta
+
+                if reasoning_content:
+                    blocks.append(ThinkingBlock(content=reasoning_content))
                 blocks.append(TextBlock(text=content))
 
-                additional_kwargs = {}
+                message_additional_kwargs = {}
                 if is_function:
                     tool_calls = update_tool_calls(tool_calls, delta.tool_calls)
                     if tool_calls:
-                        additional_kwargs["tool_calls"] = tool_calls
+                        message_additional_kwargs["tool_calls"] = tool_calls
                         for tool_call in tool_calls:
                             if tool_call.function:
                                 blocks.append(
@@ -582,15 +595,21 @@ class OpenAI(FunctionCallingLLM):
                                     )
                                 )
 
+                # thinking_delta goes in ChatResponse.additional_kwargs
+                # (same pattern as Ollama) so agents can read it
+                response_additional_kwargs = self._get_response_token_counts(response)
+                if reasoning_delta:
+                    response_additional_kwargs["thinking_delta"] = reasoning_delta
+
                 yield ChatResponse(
                     message=ChatMessage(
                         role=role,
                         blocks=blocks,
-                        additional_kwargs=additional_kwargs,
+                        additional_kwargs=message_additional_kwargs,
                     ),
                     delta=content_delta,
                     raw=response,
-                    additional_kwargs=self._get_response_token_counts(response),
+                    additional_kwargs=response_additional_kwargs,
                 )
 
         return gen()
@@ -807,6 +826,7 @@ class OpenAI(FunctionCallingLLM):
 
         async def gen() -> ChatResponseAsyncGen:
             content = ""
+            reasoning_content = ""
             tool_calls: List[ChoiceDeltaToolCall] = []
 
             is_function = False
@@ -843,13 +863,24 @@ class OpenAI(FunctionCallingLLM):
                 role = delta.role or MessageRole.ASSISTANT
                 content_delta = delta.content or ""
                 content += content_delta
+
+                # Extract reasoning_content for chain-of-thought streaming.
+                # Many OpenAI-compatible providers surface this extra field.
+                raw_reasoning = getattr(delta, "reasoning_content", None)
+                reasoning_delta = (
+                    raw_reasoning if isinstance(raw_reasoning, str) else ""
+                )
+                reasoning_content += reasoning_delta
+
+                if reasoning_content:
+                    blocks.append(ThinkingBlock(content=reasoning_content))
                 blocks.append(TextBlock(text=content))
 
-                additional_kwargs = {}
+                message_additional_kwargs = {}
                 if is_function:
                     tool_calls = update_tool_calls(tool_calls, delta.tool_calls)
                     if tool_calls:
-                        additional_kwargs["tool_calls"] = tool_calls
+                        message_additional_kwargs["tool_calls"] = tool_calls
                         for tool_call in tool_calls:
                             if tool_call.function:
                                 blocks.append(
@@ -860,15 +891,21 @@ class OpenAI(FunctionCallingLLM):
                                     )
                                 )
 
+                # thinking_delta goes in ChatResponse.additional_kwargs
+                # (same pattern as Ollama) so agents can read it
+                response_additional_kwargs = self._get_response_token_counts(response)
+                if reasoning_delta:
+                    response_additional_kwargs["thinking_delta"] = reasoning_delta
+
                 yield ChatResponse(
                     message=ChatMessage(
                         role=role,
                         blocks=blocks,
-                        additional_kwargs=additional_kwargs,
+                        additional_kwargs=message_additional_kwargs,
                     ),
                     delta=content_delta,
                     raw=response,
-                    additional_kwargs=self._get_response_token_counts(response),
+                    additional_kwargs=response_additional_kwargs,
                 )
 
         return gen()


### PR DESCRIPTION
# Description

Extract the `reasoning_content` field from streaming and non-streaming Chat Completion responses, surfacing it as `ThinkingBlock` and `thinking_delta` so that agents can consume chain-of-thought output from any OpenAI-compatible provider (the implementation is provider-agnostic).

This enables `FunctionAgent` / `ReActAgent` to stream reasoning content when using `OpenAILike` (or the base `OpenAI` class) with models that emit `reasoning_content` in their responses.

### Changes

- **`base.py`** – `_stream_chat` and `_astream_chat` now accumulate `reasoning_content` from each delta, build a `ThinkingBlock`, and pass `thinking_delta` in `ChatResponse.additional_kwargs` (same pattern as Ollama).
- **`utils.py`** – `from_openai_message` extracts `reasoning_content` for non-streaming responses; `to_openai_message_dict` skips `ThinkingBlock` when round-tripping messages back to the Chat Completions API.

Fixes #19124

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added 7 new unit tests covering: sync streaming, async streaming, non-streaming, no-reasoning fallback, `ThinkingBlock` skip in `to_openai_message_dict`, and `from_openai_message` with/without `reasoning_content`.
- [x] All 27 existing + new tests pass (`uv run pytest tests/test_openai.py`)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods