### PR TITLE
fix(google-genai): replace asyncio.run() with asyncio_run() to support nested event loops

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -24,6 +24,7 @@ from typing import (
 
 
 import llama_index.core.instrumentation as instrument
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.llms.generic_utils import (
     chat_to_completion_decorator,
     achat_to_completion_decorator,
@@ -345,7 +346,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs, file_api_names = asyncio.run(
+        next_msg, chat_kwargs, file_api_names = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.file_mode, self._client, **params
             )
@@ -400,7 +401,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs, file_api_names = asyncio.run(
+        next_msg, chat_kwargs, file_api_names = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.file_mode, self._client, **params
             )
@@ -611,7 +612,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
         messages = prompt.format_messages(**prompt_args)
         contents_and_names = [
-            asyncio.run(chat_message_to_gemini(message, self.file_mode, self._client))
+            asyncio_run(chat_message_to_gemini(message, self.file_mode, self._client))
             for message in messages
         ]
         contents = [it[0] for it in contents_and_names]
@@ -662,7 +663,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents_and_names = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.file_mode, self._client)
                 )
                 for message in messages
@@ -764,7 +765,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents_and_names = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.file_mode, self._client)
                 )
                 for message in messages


### PR DESCRIPTION
## Summary

Fixes #20782

Replace all 5 occurrences of `asyncio.run()` in sync methods with `asyncio_run()` from `llama_index.core.async_utils`.

## Problem

When sync methods like `_chat()`, `_stream_chat()`, `structured_predict()`, `stream_structured_predict()`, and the internal `_structured_predict_without_function_calling()` are invoked from within an already-running event loop (e.g., `start_chat_repl()`), `asyncio.run()` raises:

```
RuntimeError: asyncio.run() cannot be called when another event loop is already running
```

## Fix

Replace `asyncio.run()` with `asyncio_run()` from `llama_index.core.async_utils`, which:
1. Detects if an event loop is already running
2. If so, runs the coroutine in a separate thread with a new event loop
3. Preserves context variables via `contextvars.copy_context()`
4. Falls back to standard `asyncio.run()` when no loop is running

This is the same pattern already used elsewhere in LlamaIndex (see PR #20240 for a prior similar fix in a different method).

## Changes

- **`base.py`**: Added `from llama_index.core.async_utils import asyncio_run`
- **5 call sites** updated from `asyncio.run()` to `asyncio_run()`:
  - `_chat()` — line 349
  - `_stream_chat()` — line 404
  - `_structured_predict_without_function_calling()` — line 615
  - `structured_predict()` — line 666
  - `stream_structured_predict()` — line 768

`asyncio.gather()` calls in async methods (`astructured_predict`, `astream_structured_predict`) are intentionally left unchanged — they're already in async context.

## Testing

- All 27 unit tests pass (46 skipped — require API keys)
- Import verification: `from llama_index.llms.google_genai import GoogleGenAI` succeeds