### PR TITLE
fix: omit parallel_tool_calls when no tools to prevent null in API request

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -1010,15 +1010,15 @@ class OpenAI(FunctionCallingLLM):
         if user_msg:
             messages.append(user_msg)
 
-        return {
+        result: Dict[str, Any] = {
             "messages": messages,
-            "tools": tool_specs or None,
-            "tool_choice": resolve_tool_choice(tool_choice, tool_required)
-            if tool_specs
-            else None,
-            "parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,
             **kwargs,
         }
+        if tool_specs:
+            result["tools"] = tool_specs
+            result["tool_choice"] = resolve_tool_choice(tool_choice, tool_required)
+            result["parallel_tool_calls"] = allow_parallel_tool_calls
+        return result
 
     def _validate_chat_with_tools_response(
         self,

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
@@ -123,9 +123,9 @@ def test_prepare_chat_with_tools_no_tools():
     )
 
     assert "messages" in result
-    assert result["tools"] is None
-    assert result["tool_choice"] is None
-    assert result["parallel_tool_calls"] is None
+    assert "tools" not in result
+    assert "tool_choice" not in result
+    assert "parallel_tool_calls" not in result
 
 
 def test_prepare_chat_with_tools_explicit_tool_choice_overrides_tool_required():


### PR DESCRIPTION
## Problem

Since v0.6.19 (introduced by #20744), `_prepare_chat_with_tools` sends `parallel_tool_calls: null` to the OpenAI API when no tools are provided. The OpenAI API expects a boolean and rejects the request with:

```
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid type for 'parallel_tool_calls': expected a boolean, but got null instead.", ...}}
```

### Root Cause

The return dict unconditionally includes `parallel_tool_calls`:

```python
return {
    "messages": messages,
    "tools": tool_specs or None,
    "tool_choice": resolve_tool_choice(tool_choice, tool_required) if tool_specs else None,
    "parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,  # ← sends None
    **kwargs,
}
```

When `tool_specs` is empty/falsy, all three tool-related keys are set to `None` and included in the payload sent to OpenAI.

## Fix

Only include `tools`, `tool_choice`, and `parallel_tool_calls` keys in the result dict when `tool_specs` is non-empty. This prevents `null` values from being sent to the API.

```python
result: Dict[str, Any] = {"messages": messages, **kwargs}
if tool_specs:
    result["tools"] = tool_specs
    result["tool_choice"] = resolve_tool_choice(tool_choice, tool_required)
    result["parallel_tool_calls"] = allow_parallel_tool_calls
return result
```

## Test

Updated existing test `test_prepare_chat_with_tools_no_tools` to verify the keys are omitted rather than set to `None`. All 73 tests pass (14 skipped), 2 consecutive clean runs.

Fixes #20814