### PR TITLE
fix(openai): strip chat-only params from completions endpoint

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -620,6 +620,10 @@ class OpenAI(FunctionCallingLLM):
         all_kwargs = self._get_model_kwargs(**kwargs)
         self._update_max_tokens(all_kwargs, prompt)
 
+        # The completions endpoint does not support chat-only parameters
+        for _chat_only in ("tools", "tool_choice", "parallel_tool_calls"):
+            all_kwargs.pop(_chat_only, None)
+
         if self.reuse_client:
             response = client.completions.create(
                 prompt=prompt,
@@ -652,6 +656,10 @@ class OpenAI(FunctionCallingLLM):
         client = self._get_client()
         all_kwargs = self._get_model_kwargs(stream=True, **kwargs)
         self._update_max_tokens(all_kwargs, prompt)
+
+        # The completions endpoint does not support chat-only parameters
+        for _chat_only in ("tools", "tool_choice", "parallel_tool_calls"):
+            all_kwargs.pop(_chat_only, None)
 
         def gen() -> CompletionResponseGen:
             text = ""


### PR DESCRIPTION
## Problem

When `OpenAILike` with `is_function_calling_model=False` is used as a `StructuredLLM`, `structured_predict` passes `tool_choice` through `llm_kwargs` to `_complete()`, which forwards it to `client.completions.create()`. The completions API does not support `tools`, `tool_choice`, or `parallel_tool_calls`, causing:

```
TypeError: Completions.create() got an unexpected keyword argument 'tool_choice'
```

## Root Cause

`_get_model_kwargs()` merges all kwargs (including chat-only params) into a single dict. `_complete()` and `_stream_complete()` pass these directly to `client.completions.create()` without filtering.

## Fix

Strip `tools`, `tool_choice`, and `parallel_tool_calls` in both `_complete()` and `_stream_complete()` before calling the completions endpoint.

## Test

73 tests pass, 2 consecutive clean runs.

Fixes #20790