### PR TITLE
fix(openai-like): default is_chat_model to True for modern API compatibility

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
@@ -35,7 +35,7 @@ class OpenAILike(OpenAI):
             Defaults to "https://api.openai.com/v1".
         is_chat_model (bool):
             Whether the model uses the chat or completion endpoint.
-            Defaults to False.
+            Defaults to True.
         is_function_calling_model (bool):
             Whether the model supports OpenAI function calling/tools over the API.
             Defaults to False.
@@ -98,7 +98,7 @@ class OpenAILike(OpenAI):
         description=LLMMetadata.model_fields["context_window"].description,
     )
     is_chat_model: bool = Field(
-        default=False,
+        default=True,
         description=LLMMetadata.model_fields["is_chat_model"].description,
     )
     is_function_calling_model: bool = Field(


### PR DESCRIPTION
## Summary

Changes the default value of `is_chat_model` in `OpenAILike` from `False` to `True`.

## Problem

When using `OpenAILike` with modern OpenAI-compatible APIs (e.g., Google Gemini via `generativelanguage.googleapis.com/v1beta/openai`), users get a **404 error** because the class defaults to the legacy `/v1/completions` endpoint instead of `/v1/chat/completions`.

```
openai.NotFoundError: Error code: 404
```

The user must explicitly pass `is_chat_model=True` to fix this, which is unintuitive since virtually all modern providers only support the chat completions endpoint.

## Solution

Default `is_chat_model` to `True`. The legacy completions API has been deprecated by OpenAI since 2023, and nearly all OpenAI-compatible providers (Gemini, vLLM, Ollama, LM Studio, etc.) only implement `/v1/chat/completions`. Users who genuinely need the legacy endpoint can still pass `is_chat_model=False` explicitly.

This aligns with how the class is used in practice — the documentation example already shows `is_chat_model=True`, and all subclasses in the codebase (`Cerebras`, `LlamaAPI`, etc.) either set it to `True` explicitly or inherit the default.

## Changes

- `llama_index/llms/openai_like/base.py`: Changed `is_chat_model` Field default from `False` to `True`
- Updated docstring to reflect new default

Fixes #20784