### PR TITLE
fix(openai): omit parallel_tool_calls when no tools are provided

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -1010,15 +1010,16 @@ class OpenAI(FunctionCallingLLM):
         if user_msg:
             messages.append(user_msg)
 
-        return {
+        result: Dict[str, Any] = {
             "messages": messages,
-            "tools": tool_specs or None,
-            "tool_choice": resolve_tool_choice(tool_choice, tool_required)
-            if tool_specs
-            else None,
-            "parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,
             **kwargs,
         }
+        if tool_specs:
+            result["tools"] = tool_specs
+            result["tool_choice"] = resolve_tool_choice(tool_choice, tool_required)
+            result["parallel_tool_calls"] = allow_parallel_tool_calls
+
+        return result
 
     def _validate_chat_with_tools_response(
         self,

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
@@ -123,9 +123,9 @@ def test_prepare_chat_with_tools_no_tools():
     )
 
     assert "messages" in result
-    assert result["tools"] is None
-    assert result["tool_choice"] is None
-    assert result["parallel_tool_calls"] is None
+    assert "tools" not in result
+    assert "tool_choice" not in result
+    assert "parallel_tool_calls" not in result
 
 
 def test_prepare_chat_with_tools_explicit_tool_choice_overrides_tool_required():


### PR DESCRIPTION
## Summary

Since `llama-index-llms-openai` 0.6.19 (#20744), `parallel_tool_calls` is sent to the OpenAI API with a `null` value when `tools=[]`, causing a `400 BadRequestError`:

```
openai.BadRequestError: Invalid type for 'parallel_tool_calls':
expected a boolean, but got null instead.
```

## Root Cause

`_prepare_chat_with_tools` returns `parallel_tool_calls: None` when there are no tool specs:

```python
"parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,
```

The `None` is serialized as `null` in JSON and sent to the API.

## Fix

Only include `tools`, `tool_choice`, and `parallel_tool_calls` keys in the request dict when there are actual tool specs. When `tools=[]`, these keys are omitted entirely.

## Tests

```
9 passed, 2 skipped in 0.90s
```

Updated `test_prepare_chat_with_tools_no_tools` to verify the keys are absent (not `None`).

Fixes #20814