### PR TITLE
fix(core): parse_partial_json preserves incomplete string values

### DIFF
--- a/llama-index-core/tests/llms/test_parse_partial_json.py
+++ b/llama-index-core/tests/llms/test_parse_partial_json.py
@@ -1,0 +1,87 @@
+"""Tests for parse_partial_json in llama_index.core.llms.utils."""
+
+import pytest
+
+from llama_index.core.llms.utils import parse_partial_json
+
+
+class TestParsePartialJsonCompleteCases:
+    """Complete, well-formed JSON should round-trip unchanged."""
+
+    def test_complete_simple_object(self):
+        assert parse_partial_json('{"key": "value"}') == {"key": "value"}
+
+    def test_complete_nested_object(self):
+        assert parse_partial_json('{"a": {"b": 1}}') == {"a": {"b": 1}}
+
+    def test_complete_object_multiple_keys(self):
+        assert parse_partial_json('{"a": 1, "b": 2}') == {"a": 1, "b": 2}
+
+    def test_complete_object_with_array(self):
+        assert parse_partial_json('{"items": [1, 2, 3]}') == {"items": [1, 2, 3]}
+
+
+class TestParsePartialJsonIncompleteValue:
+    """Truncated string values should be preserved, not dropped (issue #20541)."""
+
+    def test_incomplete_string_value_returns_partial_value(self):
+        # Root cause of #20541: {"key": "value  →  was returning {'key': None}
+        result = parse_partial_json('{"key": "value')
+        assert result == {"key": "value"}
+
+    def test_incomplete_string_value_empty_partial(self):
+        # Opening quote for value with no content yet
+        result = parse_partial_json('{"key": "')
+        assert result == {"key": ""}
+
+    def test_incomplete_string_value_second_key(self):
+        # First key-value pair is complete; second value is truncated
+        result = parse_partial_json('{"k1": "v1", "k2": "val')
+        assert result == {"k1": "v1", "k2": "val"}
+
+    def test_incomplete_string_value_with_spaces(self):
+        result = parse_partial_json('{"description": "hello world')
+        assert result == {"description": "hello world"}
+
+    def test_incomplete_numeric_value_is_not_affected(self):
+        # Numeric values are not strings; the function should handle truncated objects too
+        result = parse_partial_json('{"count": 42')
+        assert result == {"count": 42}
+
+
+class TestParsePartialJsonIncompleteKey:
+    """Truncated string keys (no colon yet) should be removed, not completed."""
+
+    def test_incomplete_key_is_removed(self):
+        # Only the object opener and a partial key — remove the partial key
+        result = parse_partial_json('{"key')
+        assert result == {}
+
+    def test_incomplete_key_after_complete_pair(self):
+        # First pair complete; second key is truncated
+        result = parse_partial_json('{"a": 1, "b')
+        assert result == {"a": 1}
+
+
+class TestParsePartialJsonMiscellaneous:
+    """Other partial-JSON edge cases."""
+
+    def test_trailing_comma_removed(self):
+        result = parse_partial_json('{"a": 1,')
+        assert result == {"a": 1}
+
+    def test_incomplete_object_with_colon_no_value(self):
+        # Key present, colon present, but value missing entirely
+        result = parse_partial_json('{"key":')
+        assert result == {"key": None}
+
+    def test_malformed_json_raises(self):
+        with pytest.raises(ValueError, match="Malformed"):
+            parse_partial_json('{"key": }')
+
+    def test_empty_object(self):
+        assert parse_partial_json("{}") == {}
+
+    def test_empty_string_raises(self):
+        with pytest.raises((ValueError, Exception)):
+            parse_partial_json("")


### PR DESCRIPTION
## Problem

Closes #20541.

`parse_partial_json` returned `{'key': None}` for the input `'{"key": "value'` instead of the expected `{'key': 'value'}`.

### Root cause

The condition used to tell apart an **incomplete key** from an **incomplete value** checked the wrong side of the opening quote:

```python
# Old — checks for a colon AFTER the opening quote (wrong)
if is_inside_string and '"' in new_s and ":" not in new_s[new_s.rindex('"') :]:
    new_s = new_s[: new_s.rindex('"')]  # removes the partial string
elif is_inside_string:
    new_s += '"'                          # closes the partial string
```

For `'{"key": "value'`:
- `new_s.rindex('"')` points to the `"` before `value`
- `new_s[that_pos:]` is `"value` — no colon inside → **incorrectly classified as a key → dropped**

## Fix

Instead of looking after the opening quote, look **before** it.  If the content between the last entry delimiter (`{`, `[`, or `,`) and the opening quote already contains a colon, a key has been established and the unfinished string is a **value** (close it).  Otherwise it is a **key** (remove it).

```python
# New
if is_inside_string:
    opening_quote_pos = new_s.rindex('"')
    before_quote = new_s[:opening_quote_pos]
    last_delimiter = max(
        before_quote.rfind("{"),
        before_quote.rfind("["),
        before_quote.rfind(","),
    )
    current_entry = before_quote[last_delimiter + 1 :]
    if ":" not in current_entry:
        new_s = new_s[:opening_quote_pos]   # incomplete key — remove
    else:
        new_s += '"'                         # incomplete value — close
```

### Verification

| Input | Before | After |
|---|---|---|
| `'{"key": "value'` | `{'key': None}` ❌ | `{'key': 'value'}` ✅ |
| `'{"key": "'` | `{'key': None}` ❌ | `{'key': ''}` ✅ |
| `'{"k1": "v1", "k2": "val'` | `{'k1': 'v1', 'k2': None}` ❌ | `{'k1': 'v1', 'k2': 'val'}` ✅ |
| `'{"key'` | `{}` ✅ | `{}` ✅ |
| `'{"a": 1, "b'` | `{'a': 1}` ✅ | `{'a': 1}` ✅ |

## Tests

New file `llama-index-core/tests/llms/test_parse_partial_json.py` with 16 cases:
- Complete JSON round-trips (4 tests)
- Incomplete string **values** are preserved (5 tests, including the exact reproduction from the issue)
- Incomplete string **keys** are removed (2 tests)
- Miscellaneous edge cases — trailing comma, missing value, malformed input (5 tests)

All 16 tests pass.