### PR TITLE
fix(openai): omit tool params from request when no tools provided

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -1010,15 +1010,17 @@ class OpenAI(FunctionCallingLLM):
         if user_msg:
             messages.append(user_msg)
 
-        return {
+        result: Dict[str, Any] = {
             "messages": messages,
-            "tools": tool_specs or None,
-            "tool_choice": resolve_tool_choice(tool_choice, tool_required)
-            if tool_specs
-            else None,
-            "parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,
             **kwargs,
         }
+
+        if tool_specs:
+            result["tools"] = tool_specs
+            result["tool_choice"] = resolve_tool_choice(tool_choice, tool_required)
+            result["parallel_tool_calls"] = allow_parallel_tool_calls
+
+        return result
 
     def _validate_chat_with_tools_response(
         self,

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
@@ -123,9 +123,9 @@ def test_prepare_chat_with_tools_no_tools():
     )
 
     assert "messages" in result
-    assert result["tools"] is None
-    assert result["tool_choice"] is None
-    assert result["parallel_tool_calls"] is None
+    assert "tools" not in result
+    assert "tool_choice" not in result
+    assert "parallel_tool_calls" not in result
 
 
 def test_prepare_chat_with_tools_explicit_tool_choice_overrides_tool_required():


### PR DESCRIPTION
## Summary

Fixes #20814

Since `llama-index-llms-openai` v0.6.19 (PR #20744), when `_prepare_chat_with_tools()` is called with no tools, the request dict includes `parallel_tool_calls: None`. The OpenAI API rejects this with a `400 BadRequestError` because it expects a boolean.

## Changes

- **`base.py`**: Only include `tools`, `tool_choice`, and `parallel_tool_calls` keys in the return dict when `tool_specs` is non-empty. When no tools are provided, these keys are omitted entirely (matching OpenAI API expectations).
- **`test_llms_openai.py`**: Updated `test_prepare_chat_with_tools_no_tools` to assert these keys are absent from the result (not just `None`).

## Root Cause

```python
# Before (sends parallel_tool_calls=null to API):
return {
    "messages": ...,
    "tools": tool_specs or None,
    "tool_choice": resolve_tool_choice(...) if tool_specs else None,
    "parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,
}

# After (omits tool keys entirely when no tools):
result = {"messages": ...}
if tool_specs:
    result["tools"] = tool_specs
    result["tool_choice"] = resolve_tool_choice(tool_choice)
    result["parallel_tool_calls"] = allow_parallel_tool_calls
return result
```

## Testing

All 9 tests pass (2 skipped due to no API key):
```
tests/test_llms_openai.py - 9 passed, 2 skipped
```