### PR TITLE
fix(openai): exclude parallel_tool_calls from request when no tools provided

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -1010,15 +1010,17 @@ class OpenAI(FunctionCallingLLM):
         if user_msg:
             messages.append(user_msg)
 
-        return {
+        result = {
             "messages": messages,
             "tools": tool_specs or None,
             "tool_choice": resolve_tool_choice(tool_choice, tool_required)
             if tool_specs
             else None,
-            "parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,
             **kwargs,
         }
+        if tool_specs:
+            result["parallel_tool_calls"] = allow_parallel_tool_calls
+        return result
 
     def _validate_chat_with_tools_response(
         self,

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_llms_openai.py
@@ -125,7 +125,7 @@ def test_prepare_chat_with_tools_no_tools():
     assert "messages" in result
     assert result["tools"] is None
     assert result["tool_choice"] is None
-    assert result["parallel_tool_calls"] is None
+    assert "parallel_tool_calls" not in result
 
 
 def test_prepare_chat_with_tools_explicit_tool_choice_overrides_tool_required():

--- a/llama-index-integrations/llms/llama-index-llms-openai/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-openai/uv.lock
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-openai"
-version = "0.6.20"
+version = "0.6.21"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
## Summary

Fixes #20814

Since v0.6.19 (PR #20744), `parallel_tool_calls` is sent as `null` to the OpenAI API when no tools are provided, causing a `400 BadRequestError`:

```
openai.BadRequestError: Invalid type for 'parallel_tool_calls': expected a boolean, but got null instead.
```

## Root Cause

```python
# Before (buggy):
return {
    ...
    "parallel_tool_calls": allow_parallel_tool_calls if tool_specs else None,
    # ← sends null when no tools, API rejects it
}
```

## Fix

Only include `parallel_tool_calls` in the request dict when `tool_specs` is truthy:

```python
# After (fixed):
result = { "messages": ..., "tools": ..., "tool_choice": ..., **kwargs }
if tool_specs:
    result["parallel_tool_calls"] = allow_parallel_tool_calls
return result
```

## Tests

```bash
cd llama-index-integrations/llms/llama-index-llms-openai
pytest tests/test_llms_openai.py -v
# 9 passed, 2 skipped
```

Updated `test_prepare_chat_with_tools_no_tools` to verify the key is absent rather than `None`.