### PR TITLE
rag-cli: ensure chat_engine validator runs

### DIFF
--- a/llama-index-cli/llama_index/cli/rag/base.py
+++ b/llama-index-cli/llama_index/cli/rag/base.py
@@ -73,6 +73,7 @@ class RagCLI(BaseModel):
     chat_engine: Optional[CondenseQuestionChatEngine] = Field(
         description="Chat engine to use for chatting.",
         default=None,
+        validate_default=True,
     )
     file_extractor: Optional[Dict[str, BaseReader]] = Field(
         description="File extractor to use for extracting text from files.",

--- a/llama-index-cli/pyproject.toml
+++ b/llama-index-cli/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-cli"
-version = "0.5.3"
+version = "0.5.4"
 description = "llama-index cli"
 authors = [{name = "llamaindex"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Add `validate_default=True` to `chat_engine` Field so the
`@field_validator(..., mode="before")` fires even when the default is None.

Fixes # ([20783](https://github.com/run-llama/llama_index/issues/20783))

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
