### PR TITLE
feat(finetuning) : add semantic deduplication for synthetic queries generation 

### DIFF
--- a/llama-index-finetuning/pyproject.toml
+++ b/llama-index-finetuning/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 
 [project]
 name = "llama-index-finetuning"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index finetuning"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
@@ -39,6 +39,7 @@ dependencies = [
     "llama-index-embeddings-adapter>=0.4.0,<0.5",
     "mistralai>=1.7.0",
     "sentence-transformers>=2.3.0",
+    "faiss-cpu>=1.7.0",
 ]
 
 [tool.codespell]


### PR DESCRIPTION

# Description


Fixes : #20809 

## Summary

Adds optional semantic deduplication for synthetic query generation in cross-encoder training.

### Problem
`generate_synthetic_queries_over_documents()` generates duplicate questions across chunks, inflating dataset size  without adding semantic value.

### Solution
Add a deduplication step user can opti-in  made it backward compatibility  user can opt-in or out and uses faiss for faster operations

### Dependencies
- Added: `faiss-cpu>=1.7.0`
- Existing: `sentence-transformers>=2.3.0`

### Usage
```python
questions = generate_synthetic_queries_over_documents(
    documents,
    enable_deduplication=True,  # Opt-in
    similarity_threshold=0.92    # Configurable
    embedding_model_name="all-MiniLM-L6-v2"  #Configurable 
)
```

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
