### PR TITLE
fix: raise ValueError when 'model' is passed instead of 'model_name' in BedrockEmbedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -147,6 +147,12 @@ class BedrockEmbedding(BaseEmbedding):
         output_parser: Optional[BaseOutputParser] = None,
         **kwargs: Any,
     ):
+        if "model" in kwargs:
+            raise ValueError(
+                "The 'model' parameter is not supported. "
+                "Please use 'model_name' instead to specify the Bedrock model ID."
+            )
+
         additional_kwargs = additional_kwargs or {}
 
         session_kwargs = {

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-bedrock"
-version = "0.7.3"
+version = "0.7.4"
 description = "llama-index embeddings bedrock integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
@@ -9,6 +9,13 @@ def test_class():
     assert BaseEmbedding.__name__ in names_of_base_classes
 
 
+def test_model_param_raises_error():
+    """Test that passing 'model' instead of 'model_name' raises ValueError."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    with pytest.raises(ValueError, match="Please use 'model_name' instead"):
+        BedrockEmbedding(model="cohere.embed-multilingual-v3", client=bedrock_client)
+
+
 def test_get_provider_two_part_format():
     """Test _get_provider with 2-part model names (provider.model)."""
     bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
@@ -1722,7 +1722,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-bedrock"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

Raises a clear `ValueError` when users pass `model=` instead of `model_name=` to `BedrockEmbedding`. Previously, `model=` was silently absorbed by `**kwargs` and ignored, causing the default model (`amazon.titan-embed-text-v1`) to be used unexpectedly.

Fixes #14401

## New Package?

- [x] No

## Version Bump?

- [x] Yes — `llama-index-embeddings-bedrock` bumped from `0.7.3` → `0.7.4`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_model_param_raises_error` which verifies that `BedrockEmbedding(model="cohere.embed-multilingual-v3")` raises `ValueError` with a message guiding to use `model_name`.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods