### PR TITLE
fix: set _drive_id_endpoint before early return in SharePointReader._get_drive_id

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -312,13 +312,13 @@ class SharePointReader(
             ValueError: If there is an error in obtaining the drive ID.
 
         """
+        self._drive_id_endpoint = f"https://graph.microsoft.com/v1.0/sites/{self._site_id_with_host_name}/drives"
+
         if hasattr(self, "_drive_id"):
             return self._drive_id
 
         if self.drive_id:
             return self.drive_id
-
-        self._drive_id_endpoint = f"https://graph.microsoft.com/v1.0/sites/{self._site_id_with_host_name}/drives"
 
         # Use generic pagination helper to get all drives
         drives = self._get_all_items_with_pagination(self._drive_id_endpoint)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.8.0"
+version = "0.8.1"
 description = "llama-index readers microsoft_sharepoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -577,3 +577,32 @@ def test_get_all_items_with_pagination_empty_result():
         )
 
     assert len(items) == 0
+
+
+def test_drive_id_endpoint_set_when_drive_id_provided():
+    """
+    Test that _drive_id_endpoint is set even when drive_id is provided directly.
+
+    Regression test for https://github.com/run-llama/llama_index/issues/18753
+    """
+    reader = SharePointReader(
+        client_id="dummy_client_id",
+        client_secret="dummy_client_secret",
+        tenant_id="dummy_tenant_id",
+        drive_id="my_drive_id",
+    )
+    reader._site_id_with_host_name = "dummy_site_id"
+
+    # Bypass the autouse _get_drive_id mock by calling the unpatched method directly
+    # via the descriptor protocol on the original class
+    import importlib
+
+    mod = importlib.import_module("llama_index.readers.microsoft_sharepoint.base")
+    importlib.reload(mod)
+    orig_get_drive_id = mod.SharePointReader._get_drive_id
+    result = orig_get_drive_id(reader)
+
+    assert result == "my_drive_id"
+    assert reader._drive_id_endpoint == (
+        "https://graph.microsoft.com/v1.0/sites/dummy_site_id/drives"
+    )

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1657,7 +1657,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.6.1"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

When `drive_id` is provided directly to `SharePointReader`, `_get_drive_id()` returned early without setting `_drive_id_endpoint`, causing `AttributeError` in downstream methods like `_get_sharepoint_folder_id`, `_get_permissions_info`, `_list_folder_contents`, and `_list_drive_contents`.

Moved the `_drive_id_endpoint` assignment before the early return checks so it is always set regardless of how the drive ID is resolved.

Fixes #18753

## New Package?

- [x] No

## Version Bump?

- [x] Yes — `llama-index-readers-microsoft-sharepoint` bumped from `0.8.0` → `0.8.1`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_drive_id_endpoint_set_when_drive_id_provided` which verifies that `_drive_id_endpoint` is properly set when `drive_id` is provided directly.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods