### PR TITLE
fix(azureaisearch): raise on unsupported query modes

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -1292,7 +1292,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                     **kwargs,
                 )
             )
-        if query.mode == VectorStoreQueryMode.SPARSE:
+        elif query.mode == VectorStoreQueryMode.SPARSE:
             azure_query_result_search = AzureQueryResultSearchSparse(
                 query,
                 self._field_mapping,
@@ -1320,6 +1320,8 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._semantic_configuration_name or "mySemanticConfig",
                 **kwargs,
             )
+        else:
+            raise ValueError(f"Unsupported query mode: {query.mode}")
         return azure_query_result_search.search()
 
     async def aquery(
@@ -1337,17 +1339,18 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             if query.filters is not None:
                 odata_filter = self._create_odata_filter(query.filters)
 
-        azure_query_result_search: AzureQueryResultSearchBase = (
-            AzureQueryResultSearchDefault(
-                query,
-                self._field_mapping,
-                odata_filter,
-                self._search_client,
-                self._async_search_client,
-                **kwargs,
+        if query.mode == VectorStoreQueryMode.DEFAULT:
+            azure_query_result_search: AzureQueryResultSearchBase = (
+                AzureQueryResultSearchDefault(
+                    query,
+                    self._field_mapping,
+                    odata_filter,
+                    self._search_client,
+                    self._async_search_client,
+                    **kwargs,
+                )
             )
-        )
-        if query.mode == VectorStoreQueryMode.SPARSE:
+        elif query.mode == VectorStoreQueryMode.SPARSE:
             azure_query_result_search = AzureQueryResultSearchSparse(
                 query,
                 self._field_mapping,
@@ -1375,6 +1378,8 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
                 self._semantic_configuration_name or "mySemanticConfig",
                 **kwargs,
             )
+        else:
+            raise ValueError(f"Unsupported query mode: {query.mode}")
         return await azure_query_result_search.asearch()
 
     def _build_filter_str(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-azureaisearch"
-version = "0.4.4"
+version = "0.4.5"
 description = "llama-index vector_stores azureaisearch integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, List, Optional
 from unittest.mock import MagicMock, patch
@@ -329,6 +330,40 @@ def test_azureaisearch_semantic_query() -> None:
     assert len(result.nodes) == 2
     assert len(result.ids) == 2
     assert len(result.similarities) == 2
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
+def test_azureaisearch_query_raises_for_unsupported_mode() -> None:
+    search_client = mock_client_with_user_agent("search")
+    vector_store = create_mock_vector_store(search_client)
+    query = VectorStoreQuery(
+        query_str="test query",
+        similarity_top_k=1,
+        mode=VectorStoreQueryMode.TEXT_SEARCH,
+    )
+
+    with pytest.raises(ValueError, match="Unsupported query mode"):
+        vector_store.query(query)
+
+    search_client.search.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
+def test_azureaisearch_aquery_raises_for_unsupported_mode() -> None:
+    search_client = mock_client_with_user_agent("search")
+    vector_store = create_mock_vector_store(search_client)
+    query = VectorStoreQuery(
+        query_str="test query",
+        similarity_top_k=1,
+        mode=VectorStoreQueryMode.TEXT_SEARCH,
+    )
+
+    with pytest.raises(ValueError, match="Unsupported query mode"):
+        asyncio.run(vector_store.aquery(query))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# Description

This PR fixes silent misconfiguration in the Azure AI Search vector store retriever path.

`index.as_retriever()` can accept incorrect kwargs (e.g. `mode=` instead of `vector_store_query_mode=`), and the resulting `query.mode` can be unsupported by AzureAISearchVectorStore. Previously, unsupported modes could silently fall through to default behavior, which masked user mistakes.


Fixes #19848

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
