### PR TITLE
fix(bedrock-converse): capture thinking signature from signature-only stream chunks

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -533,11 +533,14 @@ class BedrockConverse(FunctionCallingLLM):
                     content = join_two_dicts(content, content_delta)
 
                     thinking_delta_value = extract_thinking_from_block(content_delta)
+                    # Capture signature from any reasoningContent delta, even when
+                    # the chunk carries only a signature and no text (which makes
+                    # thinking_delta_value None and would otherwise skip this line).
+                    thinking_signature += (
+                        content_delta.get("reasoningContent", {}).get("signature", "")
+                    )
                     if thinking_delta_value:
                         thinking += thinking_delta_value
-                        thinking_signature += content_delta.get(
-                            "reasoningContent", {}
-                        ).get("signature", "")
 
                     # If this delta contains tool call info, update current tool call
                     if "toolUse" in content_delta:
@@ -816,11 +819,14 @@ class BedrockConverse(FunctionCallingLLM):
                     content = join_two_dicts(content, content_delta)
 
                     thinking_delta_value = extract_thinking_from_block(content_delta)
+                    # Capture signature from any reasoningContent delta, even when
+                    # the chunk carries only a signature and no text (which makes
+                    # thinking_delta_value None and would otherwise skip this line).
+                    thinking_signature += (
+                        content_delta.get("reasoningContent", {}).get("signature", "")
+                    )
                     if thinking_delta_value:
                         thinking += thinking_delta_value
-                        thinking_signature += content_delta.get(
-                            "reasoningContent", {}
-                        ).get("signature", "")
 
                     # If this delta contains tool call info, update current tool call
                     if "toolUse" in content_delta:


### PR DESCRIPTION
## Summary

Fixes #20851 — a regression introduced in #20664 that causes `botocore.errorfactory.ValidationException: thinking.signature: Field required` when using BedrockConverse with extended thinking and tools.

## Root Cause

When streaming extended thinking responses, Bedrock sends the reasoning signature in a **separate chunk** that contains only a `signature` field and no `text`:

```json
{"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "..."}}, "contentBlockIndex": 0}}
```

PR #20664 refactored thinking extraction to use `extract_thinking_from_block()`, but placed `thinking_signature` accumulation inside the `if thinking_delta_value:` guard:

```python
thinking_delta_value = extract_thinking_from_block(content_delta)
if thinking_delta_value:          # ← False for signature-only chunks
    thinking += thinking_delta_value
    thinking_signature += content_delta.get("reasoningContent", {}).get("signature", "")  # ← never reached
```

Since `extract_thinking_from_block()` returns `None` for signature-only chunks (no `text` field present), the `thinking_signature +=` line was never executed for these chunks. The signature was silently dropped, causing Bedrock to reject the subsequent request with `thinking.signature: Field required`.

## Fix

Move `thinking_signature` accumulation **outside** the `if thinking_delta_value:` guard so it runs for every chunk containing a `reasoningContent` delta, regardless of whether that chunk also carries text. Applied to both sync and async streaming paths.

```python
thinking_delta_value = extract_thinking_from_block(content_delta)
# Capture signature from any reasoningContent delta, even when
# the chunk carries only a signature and no text.
thinking_signature += content_delta.get("reasoningContent", {}).get("signature", "")
if thinking_delta_value:
    thinking += thinking_delta_value
```

## Test plan

- [ ] Reproduce locally: create a `BedrockConverse` LLM with `thinking={"type": "enabled", "budget_tokens": 1000}` and a tool, run a FunctionAgent — confirm no `ValidationException`
- [ ] Verify sync streaming path (line ~535) and async streaming path (line ~821) are both fixed
- [ ] Confirm existing tests still pass: `pytest llama-index-integrations/llms/llama-index-llms-bedrock-converse/`