### PR TITLE
fix(bedrock-converse): Improve handling of reasoningContent in responses from Converse & ConverStream requests

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -47,7 +47,6 @@ from llama_index.llms.bedrock_converse.utils import (
     bedrock_modelname_to_context_size,
     converse_with_retry,
     converse_with_retry_async,
-    extract_thinking_from_block,
     force_single_tool_call,
     is_bedrock_adaptive_thinking_supported_model,
     is_bedrock_function_calling_model,
@@ -304,8 +303,8 @@ class BedrockConverse(FunctionCallingLLM):
         }
 
         try:
-            import boto3
             import aioboto3
+            import boto3
             from botocore.config import Config
 
             self._config = (
@@ -382,11 +381,12 @@ class BedrockConverse(FunctionCallingLLM):
         response: Optional[Dict[str, Any]] = None,
         content: Optional[Dict[str, Any]] = None,
     ) -> Tuple[
-        List[Union[TextBlock, ThinkingBlock, ToolCallBlock]],
-        List[str],
-        List[str],
-        Optional[str],
+        List[Union[TextBlock, ThinkingBlock, ToolCallBlock]], List[str], List[str]
     ]:
+        """
+        Returns a tuple containing content, tool call ids, and status by parsing the
+        response from a Bedrock Converse (non-streaming) request.
+        """
         assert response is not None or content is not None, (
             f"Either response or content must be provided. Got response: {response}, content: {content}"
         )
@@ -395,7 +395,6 @@ class BedrockConverse(FunctionCallingLLM):
         )
         tool_call_ids = []
         status = []
-        thinking_text = ""
         blocks: List[TextBlock | ThinkingBlock | ToolCallBlock] = []
         if content is not None:
             content_list = [content]
@@ -405,16 +404,15 @@ class BedrockConverse(FunctionCallingLLM):
         for content_block in content_list:
             if text := content_block.get("text", None):
                 blocks.append(TextBlock(text=text))
-            if reasoning_text := extract_thinking_from_block(content_block):
-                if reasoning_text:
-                    thinking_text += reasoning_text
+            if reasoning_content := content_block.get("reasoningContent", None):
+                # For Converse (non-streaming) requests, reasoning text and signature
+                # are both stored within `reasoningContent.reasoningText`.
+                reasoning_text = reasoning_content.get("reasoningText", {})
                 blocks.append(
                     ThinkingBlock(
-                        content=reasoning_text,
+                        content=reasoning_text.get("text", None),
                         additional_information={
-                            "signature": content_block.get("reasoningContent", {})
-                            .get("reasoningText", {})
-                            .get("signature", None)
+                            "signature": reasoning_text.get("signature", None)
                         },
                     )
                 )
@@ -438,7 +436,7 @@ class BedrockConverse(FunctionCallingLLM):
                 tool_call_ids.append(tool_result.get("toolUseId", ""))
                 status.append(tool_result.get("status", ""))
 
-        return blocks, tool_call_ids, status, (thinking_text or None)
+        return blocks, tool_call_ids, status
 
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
@@ -465,9 +463,7 @@ class BedrockConverse(FunctionCallingLLM):
             **all_kwargs,
         )
 
-        blocks, tool_call_ids, status, thinking_text = self._get_content_and_tool_calls(
-            response
-        )
+        blocks, tool_call_ids, status = self._get_content_and_tool_calls(response)
 
         additional_kwargs = self._get_response_token_counts(dict(response))
 
@@ -532,12 +528,15 @@ class BedrockConverse(FunctionCallingLLM):
                     content_delta = content_block_delta["delta"]
                     content = join_two_dicts(content, content_delta)
 
-                    thinking_delta_value = extract_thinking_from_block(content_delta)
-                    if thinking_delta_value:
-                        thinking += thinking_delta_value
-                        thinking_signature += content_delta.get(
-                            "reasoningContent", {}
-                        ).get("signature", "")
+                    thinking_delta_value = None
+                    if "reasoningContent" in content_delta:
+                        # For ConverseStream (streaming) requests, reasoning text, signature,
+                        # redacted content are stored within `reasoningContent`.
+                        reasoning_content = content_delta.get("reasoningContent", {})
+                        reasoning_text = reasoning_content.get("text", "")
+                        thinking += reasoning_text
+                        thinking_delta_value = reasoning_text
+                        thinking_signature += reasoning_content.get("signature", "")
 
                     # If this delta contains tool call info, update current tool call
                     if "toolUse" in content_delta:
@@ -746,9 +745,7 @@ class BedrockConverse(FunctionCallingLLM):
             **all_kwargs,
         )
 
-        blocks, tool_call_ids, status, thinking_text = self._get_content_and_tool_calls(
-            response
-        )
+        blocks, tool_call_ids, status = self._get_content_and_tool_calls(response)
 
         additional_kwargs = self._get_response_token_counts(dict(response))
 
@@ -815,12 +812,15 @@ class BedrockConverse(FunctionCallingLLM):
                     content_delta = content_block_delta["delta"]
                     content = join_two_dicts(content, content_delta)
 
-                    thinking_delta_value = extract_thinking_from_block(content_delta)
-                    if thinking_delta_value:
-                        thinking += thinking_delta_value
-                        thinking_signature += content_delta.get(
-                            "reasoningContent", {}
-                        ).get("signature", "")
+                    thinking_delta_value = None
+                    if "reasoningContent" in content_delta:
+                        # For ConverseStream (streaming) requests, reasoning text, signature,
+                        # redacted content are stored within `reasoningContent`.
+                        reasoning_content = content_delta.get("reasoningContent", {})
+                        reasoning_text = reasoning_content.get("text", "")
+                        thinking += reasoning_text
+                        thinking_delta_value = reasoning_text
+                        thinking_signature += reasoning_content.get("signature", "")
 
                     # If this delta contains tool call info, update current tool call
                     if "toolUse" in content_delta:

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -854,28 +854,6 @@ async def converse_with_retry_async(
         return await _conversion_with_retry(**converse_kwargs)
 
 
-def extract_thinking_from_block(block: Dict[str, Any]) -> Optional[str]:
-    """Extract thinking content from a Bedrock Converse content block or delta."""
-    if "reasoningContent" in block:
-        # For non-streaming, it's reasoningContent.reasoningText.text
-        # For streaming, it's reasoningContent.text
-        reasoning = block["reasoningContent"]
-        if "reasoningText" in reasoning:
-            return reasoning["reasoningText"].get("text")
-        return reasoning.get("text")
-
-    # Fallback for other potential keys (Nova, etc.)
-    for key in ("reasoning_content", "thinking", "reasoning"):
-        if key in block:
-            val = block[key]
-            if isinstance(val, str):
-                return val
-            if isinstance(val, dict):
-                return val.get("text") or val.get("content")
-
-    return None
-
-
 def join_two_dicts(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> Dict[str, Any]:
     """
     Joins two dictionaries, summing shared keys and adding new keys.

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.12.11"
+version = "0.13.0"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -2223,7 +2223,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.12.10"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

Fixes #20851 by addressing a regression introduced in #20664 that caused certain fields within `reasoningContent`, such as `signature`, to not be captured as expected when using the Bedrock Converse/ConverseStream APIs. This renders certain usage of BedrockConverse unusable, such as using the LLM with extended thinking and tool calling.

The changes in this PR were made to stay aligned with the Converse/ConverseStream specifications.

As part of the review of #20664 , a variety of changes were made that ultimately left the PR in a state where no new behaviors were being introduced. Additionally, as mentioned in [my comment](https://github.com/run-llama/llama_index/issues/20851#issuecomment-3987566847) on #20851 , I also noticed that #20664 introduced some changes that aren't clear. For example, the added `extract_thinking_from_block` function contains a "Fallback for other potential keys (Nova, etc.)", but I can't find that in the Converse documentation.

This fix rolls back some of these changes in an effort to stay aligned with the Bedrock specifications, as the abstraction of `extract_thinking_from_block` does not appear to be needed. Per AWS documentation, content blocks from Converse and content block deltas from ConverseStream are distinct, and as such, keeping them logically distinct in the code seems sensical.

https://github.com/run-llama/llama_index/blob/a771a4f67e43bb5d2675972496a4e5c70f847052/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py#L867-L874

- ConverseStream:
  - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlockDelta.html
  - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html
- Converse:
  - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
  - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html

Also, it adds `thinking_text` as part of the tuple returned from `_get_content_and_tool_calls`, but it isn't used anywhere, as decided by @AstraBert [in this comment](https://github.com/run-llama/llama_index/pull/20664#discussion_r2787298274) and then later removed by the author of the PR.

One other observation is that the original PR made a change here, which I'm not really sure about (sorry for the formatting in the diff). @logan-markewich , @AstraBert would like your input on the change as I was hesitant to roll it back or adjust.

```diff
                if text := tool_result_content.get("text", None):
-                  text_content += text
-               tool_call_ids.append(tool_result_content.get("toolUseId", ""))
+                  # Use first text block as content for compatibility
+                  pass
+              tool_call_ids.append(tool_result.get("toolUseId", ""))
                status.append(tool_result.get("status", ""))
```

https://github.com/run-llama/llama_index/blob/a771a4f67e43bb5d2675972496a4e5c70f847052/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py#L435-L438

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
