### PR TITLE
security: add RestrictedUnpickler to SimpleObjectNodeMapping (CWE-502)

### DIFF
--- a/llama-index-core/llama_index/core/objects/base_node_mapping.py
+++ b/llama-index-core/llama_index/core/objects/base_node_mapping.py
@@ -14,25 +14,28 @@ DEFAULT_PERSIST_FNAME = "object_node_mapping.pickle"
 # Classes allowed during deserialization of object node mappings.
 # Restricting unpickling to this set prevents arbitrary code execution
 # via crafted pickle payloads placed in the persist directory (CWE-502).
-_SAFE_PICKLE_CLASSES: frozenset[tuple[str, str]] = frozenset({
-    ("builtins", "dict"),
-    ("builtins", "list"),
-    ("builtins", "set"),
-    ("builtins", "frozenset"),
-    ("builtins", "tuple"),
-    ("builtins", "str"),
-    ("builtins", "bytes"),
-    ("builtins", "int"),
-    ("builtins", "float"),
-    ("builtins", "complex"),
-    ("builtins", "bool"),
-    ("builtins", "NoneType"),
-    (__name__, "SimpleObjectNodeMapping"),
-})
+_SAFE_PICKLE_CLASSES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "frozenset"),
+        ("builtins", "tuple"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        ("builtins", "int"),
+        ("builtins", "float"),
+        ("builtins", "complex"),
+        ("builtins", "bool"),
+        ("builtins", "NoneType"),
+        (__name__, "SimpleObjectNodeMapping"),
+    }
+)
 
 
 class _RestrictedUnpickler(pickle.Unpickler):
-    """Unpickler that restricts class instantiation to an allowlist.
+    """
+    Unpickler that restricts class instantiation to an allowlist.
 
     Prevents arbitrary code execution when loading from untrusted or
     user-configurable persist directories.
@@ -46,6 +49,7 @@ class _RestrictedUnpickler(pickle.Unpickler):
             f"If you need to load custom object types, use a purpose-built "
             f"serialization format instead of pickle."
         )
+
 
 OT = TypeVar("OT")
 

--- a/llama-index-core/tests/objects/test_node_mapping.py
+++ b/llama-index-core/tests/objects/test_node_mapping.py
@@ -122,7 +122,8 @@ def test_sql_table_node_mapping_to_node(mocker: MockerFixture) -> None:
 def test_simple_object_node_mapping_persist_rejects_unsafe_pickle(
     tmp_path,
 ) -> None:
-    """Test that loading a malicious pickle payload is blocked.
+    """
+    Test that loading a malicious pickle payload is blocked.
 
     A crafted pickle file in the persist directory could execute arbitrary
     code (e.g., os.system, eval) when loaded with unrestricted pickle.load().


### PR DESCRIPTION
## Summary

`SimpleObjectNodeMapping.from_persist_dir()` in `llama_index/core/objects/base_node_mapping.py` uses bare `pickle.load()` without restrictions, which allows **arbitrary code execution** if a malicious pickle file is placed in the persist directory ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)).

### Attack scenario

The `persist_dir` parameter defaults to `DEFAULT_PERSIST_DIR` but is fully configurable by the caller. `SimpleObjectNodeMapping.persist()` writes the entire object via `pickle.dump(self, f)` to this directory. An attacker who can write to the persist directory — via a path traversal vulnerability, a shared filesystem, or a compromised data pipeline — can replace `object_node_mapping.pickle` with a crafted payload that executes arbitrary code when `from_persist_dir()` is called.

This is particularly concerning because:
1. The persist directory is a local filesystem path that may be shared or writable
2. The filename (`object_node_mapping.pickle`) is predictable
3. There is no integrity verification (checksum, signature) before loading

### Fix

This PR adds a `_RestrictedUnpickler` (subclass of `pickle.Unpickler`) that restricts deserialization to a strict allowlist:
- **builtins:** dict, list, set, frozenset, tuple, str, bytes, int, float, complex, bool, NoneType
- **module classes:** `SimpleObjectNodeMapping` itself (needed since `persist()` serializes `self`)

Any class not in the allowlist is rejected with a clear `UnpicklingError`, which is caught by the existing `except pickle.PickleError` handler and raised as `ValueError`. This is the [recommended mitigation](https://docs.python.org/3/library/pickle.html#restricting-globals) from the Python docs.

### Backward compatibility

Existing persist/load workflows with standard object types (strings, numbers, dicts) continue to work unchanged. Users storing custom object types in `SimpleObjectNodeMapping` that require pickle deserialization of non-builtin classes would need to migrate to a safer serialization format — this is the intended security trade-off.

## Test plan

- [x] `test_simple_object_node_mapping_persist_rejects_unsafe_pickle` — verifies a crafted payload using `eval` is rejected with `ValueError`
- [x] Existing `test_simple_object_node_mapping_persist` — persist/load round-trip with strings, unchanged

## References

- [Python docs: Restricting Globals for pickle](https://docs.python.org/3/library/pickle.html#restricting-globals)
- [CWE-502: Deserialization of Untrusted Data](https://cwe.mitre.org/data/definitions/502.html)