### PR TITLE
security: fix path traversal and SSRF in download module (CWE-22, CWE-319)

### DIFF
--- a/llama-index-core/llama_index/core/download/dataset.py
+++ b/llama-index-core/llama_index/core/download/dataset.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import tqdm
 from llama_index.core.download.utils import (
+    _validate_path_component,
     get_file_content,
     get_file_content_bytes,
     get_source_files_list,
@@ -74,6 +75,10 @@ def get_dataset_info(
         if dataset_class in library:
             dataset_id = library[dataset_class]["id"]
             source_files = library[dataset_class].get("source_files", [])
+            # Validate even cached values — cache file could be tampered
+            _validate_path_component(dataset_id, "dataset_id")
+            for sf in source_files:
+                _validate_path_component(sf, "source_file")
 
     # Fetch up-to-date library from remote repo if dataset_id not found
     if dataset_id is None:
@@ -85,6 +90,8 @@ def get_dataset_info(
             raise ValueError("Loader class name not found in library")
 
         dataset_id = library[dataset_class]["id"]
+        # Validate path component from remote manifest to prevent traversal
+        _validate_path_component(dataset_id, "dataset_id")
 
         # get data card
         raw_card_content, _ = get_file_content(
@@ -99,6 +106,9 @@ def get_dataset_info(
                 str(remote_source_dir_path),
                 f"/llama_datasets/{dataset_id}/{source_files_path}",
             )
+            # Validate source file names from remote tree listing
+            for sf in source_files:
+                _validate_path_component(sf, "source_file")
 
         # create cache dir if needed
         local_library_dir = os.path.dirname(local_library_path)

--- a/llama-index-core/llama_index/core/download/module.py
+++ b/llama-index-core/llama_index/core/download/module.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import requests
 from llama_index.core.download.utils import (
+    _validate_path_component,
     get_exports,
     get_file_content,
     initialize_directory,
@@ -58,6 +59,10 @@ def get_module_info(
         if module_class in library:
             module_id = library[module_class]["id"]
             extra_files = library[module_class].get("extra_files", [])
+            # Validate even cached values — cache file could be tampered
+            _validate_path_component(module_id, "module_id")
+            for ef in extra_files:
+                _validate_path_component(ef, "extra_file")
 
     # Fetch up-to-date library from remote repo if module_id not found
     if module_id is None:
@@ -70,6 +75,11 @@ def get_module_info(
 
         module_id = library[module_class]["id"]
         extra_files = library[module_class].get("extra_files", [])
+
+        # Validate path components from remote manifest to prevent traversal
+        _validate_path_component(module_id, "module_id")
+        for ef in extra_files:
+            _validate_path_component(ef, "extra_file")
 
         # create cache dir if needed
         local_library_dir = os.path.dirname(local_library_path)

--- a/llama-index-core/llama_index/core/download/utils.py
+++ b/llama-index-core/llama_index/core/download/utils.py
@@ -7,7 +7,8 @@ import requests
 
 
 def _validate_url(full_url: str) -> None:
-    """Validate URL scheme before making HTTP requests.
+    """
+    Validate URL scheme before making HTTP requests.
 
     Prevents accidental use of non-HTTPS URLs which could expose data
     in transit or facilitate downgrade attacks.
@@ -21,7 +22,8 @@ def _validate_url(full_url: str) -> None:
 
 
 def _validate_path_component(component: str, label: str = "path component") -> None:
-    """Validate that a path component from a remote manifest is safe.
+    """
+    Validate that a path component from a remote manifest is safe.
 
     Prevents directory traversal attacks when constructing local file paths
     from values sourced from remote manifests (e.g., library.json).
@@ -40,12 +42,8 @@ def _validate_path_component(component: str, label: str = "path component") -> N
             f"Invalid {label}: '{component}' contains directory traversal."
         )
     # Check for absolute paths (Unix-style or Windows-style drive letters)
-    if normalized.startswith("/") or (
-        len(normalized) >= 2 and normalized[1] == ":"
-    ):
-        raise ValueError(
-            f"Invalid {label}: '{component}' is an absolute path."
-        )
+    if normalized.startswith("/") or (len(normalized) >= 2 and normalized[1] == ":"):
+        raise ValueError(f"Invalid {label}: '{component}' is an absolute path.")
 
 
 def get_file_content(url: str, path: str) -> Tuple[str, int]:

--- a/llama-index-core/llama_index/core/download/utils.py
+++ b/llama-index-core/llama_index/core/download/utils.py
@@ -1,19 +1,66 @@
 import os
 from pathlib import Path
 from typing import List, Optional, Tuple
+from urllib.parse import urlparse
 
 import requests
 
 
+def _validate_url(full_url: str) -> None:
+    """Validate URL scheme before making HTTP requests.
+
+    Prevents accidental use of non-HTTPS URLs which could expose data
+    in transit or facilitate downgrade attacks.
+    """
+    parsed = urlparse(full_url)
+    if parsed.scheme not in ("https",):
+        raise ValueError(
+            f"URL scheme '{parsed.scheme}' is not allowed. "
+            f"Only HTTPS URLs are permitted for remote content fetching."
+        )
+
+
+def _validate_path_component(component: str, label: str = "path component") -> None:
+    """Validate that a path component from a remote manifest is safe.
+
+    Prevents directory traversal attacks when constructing local file paths
+    from values sourced from remote manifests (e.g., library.json).
+    A malicious manifest could set module_id or extra_files to values like
+    '../../.bashrc' to write files outside the intended directory.
+    """
+    if not component:
+        raise ValueError(f"Empty {label} is not allowed.")
+    if "\x00" in component:
+        raise ValueError(f"Invalid {label}: contains null byte.")
+    # Normalize separators and check for traversal
+    normalized = component.replace("\\", "/")
+    parts = [p for p in normalized.split("/") if p]
+    if ".." in parts:
+        raise ValueError(
+            f"Invalid {label}: '{component}' contains directory traversal."
+        )
+    # Check for absolute paths (Unix-style or Windows-style drive letters)
+    if normalized.startswith("/") or (
+        len(normalized) >= 2 and normalized[1] == ":"
+    ):
+        raise ValueError(
+            f"Invalid {label}: '{component}' is an absolute path."
+        )
+
+
 def get_file_content(url: str, path: str) -> Tuple[str, int]:
     """Get the content of a file from the GitHub REST API."""
-    resp = requests.get(url + path, timeout=(60, 60))
+    full_url = url + path
+    _validate_url(full_url)
+    resp = requests.get(full_url, timeout=(60, 60))
     return resp.text, resp.status_code
 
 
 def get_file_content_bytes(url: str, path: str) -> Tuple[bytes, int]:
     """Get the content of a file from the GitHub REST API."""
-    resp = requests.get(url + path, timeout=(60, 60))
+    full_url = url + path
+    _validate_url(full_url)
+    resp = requests.get(full_url, timeout=(60, 60))
     return resp.content, resp.status_code
 
 

--- a/llama-index-core/tests/download/test_download_security.py
+++ b/llama-index-core/tests/download/test_download_security.py
@@ -1,0 +1,155 @@
+"""Tests for download module security validations.
+
+Validates that path traversal and SSRF protections prevent malicious
+values from remote manifests (library.json) from being used to write
+files outside intended directories or make requests to non-HTTPS URLs.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from llama_index.core.download.utils import (
+    _validate_path_component,
+    _validate_url,
+)
+
+
+class TestValidatePathComponent:
+    """Test _validate_path_component against directory traversal attacks."""
+
+    def test_simple_filename(self):
+        """Normal filenames should pass validation."""
+        _validate_path_component("base.py", "file")
+        _validate_path_component("utils.py", "file")
+        _validate_path_component("__init__.py", "file")
+
+    def test_nested_path(self):
+        """Nested paths like 'web/simple_web' should pass validation."""
+        _validate_path_component("web/simple_web", "module_id")
+        _validate_path_component("readers/github", "module_id")
+
+    def test_traversal_simple(self):
+        """Paths with '..' should be rejected."""
+        with pytest.raises(ValueError, match="directory traversal"):
+            _validate_path_component("../../etc/passwd", "module_id")
+
+    def test_traversal_embedded(self):
+        """Paths with embedded '..' should be rejected."""
+        with pytest.raises(ValueError, match="directory traversal"):
+            _validate_path_component("web/../../etc/passwd", "module_id")
+
+    def test_traversal_backslash(self):
+        """Windows-style backslash traversal should be rejected."""
+        with pytest.raises(ValueError, match="directory traversal"):
+            _validate_path_component("..\\..\\windows\\system32", "module_id")
+
+    def test_absolute_path_unix(self):
+        """Unix absolute paths should be rejected."""
+        with pytest.raises(ValueError, match="absolute path"):
+            _validate_path_component("/etc/passwd", "module_id")
+
+    def test_absolute_path_windows(self):
+        """Windows absolute paths should be rejected."""
+        with pytest.raises(ValueError, match="absolute path"):
+            _validate_path_component("C:\\Windows\\System32", "module_id")
+
+    def test_null_byte(self):
+        """Null bytes should be rejected."""
+        with pytest.raises(ValueError, match="null byte"):
+            _validate_path_component("file\x00.py", "file")
+
+    def test_empty_string(self):
+        """Empty strings should be rejected."""
+        with pytest.raises(ValueError, match="Empty"):
+            _validate_path_component("", "module_id")
+
+
+class TestValidateUrl:
+    """Test _validate_url against SSRF attacks."""
+
+    def test_https_url(self):
+        """HTTPS URLs should pass validation."""
+        _validate_url("https://raw.githubusercontent.com/org/repo/main/file.json")
+
+    def test_http_url_rejected(self):
+        """HTTP URLs should be rejected (downgrade attack)."""
+        with pytest.raises(ValueError, match="not allowed"):
+            _validate_url("http://internal-server.local/library.json")
+
+    def test_file_url_rejected(self):
+        """file:// URLs should be rejected."""
+        with pytest.raises(ValueError, match="not allowed"):
+            _validate_url("file:///etc/passwd")
+
+    def test_ftp_url_rejected(self):
+        """FTP URLs should be rejected."""
+        with pytest.raises(ValueError, match="not allowed"):
+            _validate_url("ftp://server/file")
+
+
+class TestGetModuleInfoPathTraversal:
+    """Test that get_module_info rejects malicious library.json entries."""
+
+    @patch("llama_index.core.download.module.get_file_content")
+    def test_malicious_module_id_from_remote(self, mock_get):
+        """A malicious library.json with traversal in module_id should be rejected."""
+        from llama_index.core.download.module import get_module_info
+
+        malicious_library = {
+            "MyLoader": {
+                "id": "../../.ssh/authorized_keys",
+                "extra_files": [],
+            }
+        }
+        mock_get.return_value = (json.dumps(malicious_library), 200)
+
+        with pytest.raises(ValueError, match="directory traversal"):
+            get_module_info(
+                local_dir_path="/tmp/test",
+                remote_dir_path="https://raw.githubusercontent.com/test",
+                module_class="MyLoader",
+                refresh_cache=True,
+            )
+
+    @patch("llama_index.core.download.module.get_file_content")
+    def test_malicious_extra_file_from_remote(self, mock_get):
+        """A malicious library.json with traversal in extra_files should be rejected."""
+        from llama_index.core.download.module import get_module_info
+
+        malicious_library = {
+            "MyLoader": {
+                "id": "web/loader",
+                "extra_files": ["../../../.bashrc"],
+            }
+        }
+        mock_get.return_value = (json.dumps(malicious_library), 200)
+
+        with pytest.raises(ValueError, match="directory traversal"):
+            get_module_info(
+                local_dir_path="/tmp/test",
+                remote_dir_path="https://raw.githubusercontent.com/test",
+                module_class="MyLoader",
+                refresh_cache=True,
+            )
+
+    def test_malicious_module_id_from_cache(self, tmp_path):
+        """A tampered cached library.json should also be validated."""
+        from llama_index.core.download.module import get_module_info
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        malicious_library = {
+            "MyLoader": {
+                "id": "../../etc",
+                "extra_files": [],
+            }
+        }
+        (cache_dir / "library.json").write_text(json.dumps(malicious_library))
+
+        with pytest.raises(ValueError, match="directory traversal"):
+            get_module_info(
+                local_dir_path=str(cache_dir),
+                remote_dir_path="https://raw.githubusercontent.com/test",
+                module_class="MyLoader",
+            )

--- a/llama-index-core/tests/download/test_download_security.py
+++ b/llama-index-core/tests/download/test_download_security.py
@@ -1,4 +1,5 @@
-"""Tests for download module security validations.
+"""
+Tests for download module security validations.
 
 Validates that path traversal and SSRF protections prevent malicious
 values from remote manifests (library.json) from being used to write
@@ -6,7 +7,7 @@ files outside intended directories or make requests to non-HTTPS URLs.
 """
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from llama_index.core.download.utils import (


### PR DESCRIPTION
## Summary

The download module (`llama_index/core/download/`) constructs local file paths using values from remote `library.json` manifests without validation, enabling a **path traversal → arbitrary file write** attack chain ([CWE-22](https://cwe.mitre.org/data/definitions/22.html)). Additionally, HTTP requests are made with no URL scheme validation ([CWE-319](https://cwe.mitre.org/data/definitions/319.html)).

### Attack scenario

The `download_llama_module()` and `download_llama_dataset()` functions accept a configurable URL parameter (`llama_hub_url` / `llama_datasets_url`). An attacker who can influence this parameter — or who can compromise the remote repository — can serve a malicious `library.json`:

```json
{
  "MyLoader": {
    "id": "../../.ssh/authorized_keys",
    "extra_files": ["../../../.bashrc"]
  }
}
```

The code then constructs paths like `f"{local_dir_path}/../../.ssh/authorized_keys"` and writes attacker-controlled content there, achieving **arbitrary file write** on the local filesystem.

**Affected locations:**
- `module.py` line 110: `module_path = f"{local_dir_path}/{module_id}"`
- `module.py` line 126: `f"{module_path}/{base_file_name}"`
- `module.py` line 148: `f"{module_path}/{extra_file}"`
- `dataset.py` line 142: `module_path = f"{local_dir_path}/{dataset_id}"`
- `dataset.py` line 153: `f"{module_path}/{base_file_name}"`

### Fix

**Path traversal protection** (`_validate_path_component`):
- Rejects `..` in any path segment (handles both `/` and `\` separators)
- Rejects absolute paths (Unix `/` and Windows `C:\` style)
- Rejects null bytes
- Applied to `module_id`, `extra_files`, `dataset_id`, and `source_files` at the point they're read from manifests
- Validates both remote fetches AND cached values (local `library.json` could also be tampered)

**HTTPS enforcement** (`_validate_url`):
- Requires HTTPS scheme for all `get_file_content()` and `get_file_content_bytes()` calls
- Prevents downgrade attacks via `http://` URLs

### Backward compatibility

All existing `library.json` entries use clean path components (e.g., `web/simple_web`, `base.py`) which pass validation. Only path traversal payloads (`../`, absolute paths, null bytes) are blocked. No API changes.

## Test plan

- [x] `TestValidatePathComponent` — 9 tests: simple files, nested paths, traversal (simple, embedded, backslash), absolute paths (unix, windows), null bytes, empty strings
- [x] `TestValidateUrl` — 4 tests: HTTPS allowed, HTTP/file/FTP rejected
- [x] `TestGetModuleInfoPathTraversal` — 3 tests: malicious module_id from remote, malicious extra_file from remote, tampered cached library.json

## References

- [CWE-22: Path Traversal](https://cwe.mitre.org/data/definitions/22.html)
- [CWE-319: Cleartext Transmission of Sensitive Information](https://cwe.mitre.org/data/definitions/319.html)
- [OWASP: Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)