### PR TITLE
fix: prevent silent KeyError in ReActAgent after update_prompts()

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/formatter.py
+++ b/llama-index-core/llama_index/core/agent/react/formatter.py
@@ -14,6 +14,7 @@ from llama_index.core.agent.react.types import (
 )
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.bridge.pydantic import BaseModel, ConfigDict, Field
+from llama_index.core.prompts.utils import format_string
 from llama_index.core.tools import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,8 @@ class ReActChatFormatter(BaseAgentChatFormatter):
         if self.context:
             format_args["context"] = self.context
 
-        fmt_sys_header = self.system_header.format(**format_args)
+        fmt_sys_header = format_string(self.system_header, **format_args)
+        fmt_sys_header = fmt_sys_header.replace("{{", "{").replace("}}", "}")
 
         # format reasoning history as alternating user and assistant messages
         # where the assistant messages are thoughts and actions and the tool

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -1,4 +1,5 @@
 import uuid
+import warnings
 from typing import List, Sequence, Optional, cast
 
 from llama_index.core.agent.react.formatter import ReActChatFormatter
@@ -79,7 +80,18 @@ class ReActAgent(BaseWorkflowAgent):
             react_header = prompts["react_header"]
             if isinstance(react_header, str):
                 react_header = PromptTemplate(react_header)
-            self.formatter.system_header = react_header.format()
+            new_header = react_header.format()
+            for var in ("tool_desc", "tool_names"):
+                if f"{{{var}}}" not in new_header:
+                    warnings.warn(
+                        f"Updated react_header is missing required placeholder "
+                        f"'{{{var}}}'. The agent may not function correctly. "
+                        f"Use '{{{var}}}' (not pre-formatted) in your prompt "
+                        f"template.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+            self.formatter.system_header = new_header
 
     async def _get_response(self, current_llm_input: List[ChatMessage]) -> ChatResponse:
         return await self.llm.achat(current_llm_input)

--- a/llama-index-core/tests/agent/react/test_prompt_customization.py
+++ b/llama-index-core/tests/agent/react/test_prompt_customization.py
@@ -4,7 +4,10 @@ from unittest.mock import MagicMock
 
 from llama_index.core import PromptTemplate
 from llama_index.core.agent.react.formatter import ReActChatFormatter
-from llama_index.core.agent.react.prompts import REACT_CHAT_SYSTEM_HEADER
+from llama_index.core.agent.react.prompts import (
+    CONTEXT_REACT_CHAT_SYSTEM_HEADER,
+    REACT_CHAT_SYSTEM_HEADER,
+)
 from llama_index.core.agent.workflow import ReActAgent
 
 
@@ -29,6 +32,40 @@ def test_partial_formatted_system_prompt():
     agent.update_prompts({"react_header": prompt.partial_format(dummy_var=dummy_var)})
 
     assert dummy_var in agent.formatter.system_header
+
+
+def test_system_prompt_passed_to_formatter():
+    """system_prompt should be set as formatter context and use the context-aware template."""
+    system_prompt = "You are a helpful financial advisor."
+    agent = ReActAgent(system_prompt=system_prompt)
+
+    assert agent.formatter.context == system_prompt
+    assert "{context}" in agent.formatter.system_header
+    assert agent.formatter.system_header == CONTEXT_REACT_CHAT_SYSTEM_HEADER
+
+    # Verify the context actually appears in the formatted output
+    formatted = agent.formatter.format(tools=[], chat_history=[])
+    assert system_prompt in formatted[0].content
+
+
+def test_no_system_prompt_uses_default_template():
+    """Without system_prompt the formatter should use the default template (no context placeholder)."""
+    agent = ReActAgent()
+
+    assert agent.formatter.context == ""
+    assert agent.formatter.system_header == REACT_CHAT_SYSTEM_HEADER
+
+
+def test_system_prompt_with_custom_formatter_context():
+    """system_prompt should be prepended to an existing formatter context."""
+    custom_context = "Extra context from user."
+    formatter = ReActChatFormatter.from_defaults(context=custom_context)
+    system_prompt = "You are a helpful assistant."
+    agent = ReActAgent(system_prompt=system_prompt, formatter=formatter)
+
+    assert system_prompt in agent.formatter.context
+    assert custom_context in agent.formatter.context
+    assert "{context}" in agent.formatter.system_header
 
 
 def test_formatter_with_literal_braces():
@@ -95,7 +132,8 @@ def test_update_prompts_with_preformatted_template():
 
 
 def test_formatter_substitutes_tool_args_with_literal_braces():
-    """tool_desc and tool_names should be substituted while literal braces survive.
+    """
+    tool_desc and tool_names should be substituted while literal braces survive.
 
     This is the exact scenario from the bug report: a user-supplied template
     contains literal JSON examples (single braces) alongside {tool_desc} and
@@ -104,8 +142,8 @@ def test_formatter_substitutes_tool_args_with_literal_braces():
     """
     formatter = ReActChatFormatter(
         system_header=(
-            'You have access to:\n{tool_desc}\n'
-            'Use tools: {tool_names}\n'
+            "You have access to:\n{tool_desc}\n"
+            "Use tools: {tool_names}\n"
             'Action Input must be JSON, e.g. {"query": "search term"}'
         )
     )

--- a/llama-index-core/tests/agent/react/test_prompt_customization.py
+++ b/llama-index-core/tests/agent/react/test_prompt_customization.py
@@ -1,11 +1,14 @@
+import warnings
+from textwrap import dedent
+from unittest.mock import MagicMock
+
 from llama_index.core import PromptTemplate
+from llama_index.core.agent.react.formatter import ReActChatFormatter
 from llama_index.core.agent.react.prompts import (
     CONTEXT_REACT_CHAT_SYSTEM_HEADER,
     REACT_CHAT_SYSTEM_HEADER,
 )
 from llama_index.core.agent.workflow import ReActAgent
-
-from textwrap import dedent
 
 
 def test_partial_formatted_system_prompt():
@@ -55,8 +58,6 @@ def test_no_system_prompt_uses_default_template():
 
 def test_system_prompt_with_custom_formatter_context():
     """system_prompt should be prepended to an existing formatter context."""
-    from llama_index.core.agent.react.formatter import ReActChatFormatter
-
     custom_context = "Extra context from user."
     formatter = ReActChatFormatter.from_defaults(context=custom_context)
     system_prompt = "You are a helpful assistant."
@@ -65,3 +66,127 @@ def test_system_prompt_with_custom_formatter_context():
     assert system_prompt in agent.formatter.context
     assert custom_context in agent.formatter.context
     assert "{context}" in agent.formatter.system_header
+
+
+def test_formatter_with_literal_braces():
+    """Formatter should not raise KeyError on strings with literal braces."""
+    formatter = ReActChatFormatter(
+        system_header='Use JSON like {"input": "hello"}\n{tool_desc}\n{tool_names}'
+    )
+
+    mock_tool = MagicMock()
+    mock_tool.metadata.name = "test_tool"
+    mock_tool.metadata.get_name.return_value = "test_tool"
+    mock_tool.metadata.description = "A test tool"
+    mock_tool.metadata.fn_schema_str = '{"type": "object"}'
+
+    # Should not raise KeyError
+    messages = formatter.format(tools=[mock_tool], chat_history=[])
+    assert len(messages) > 0
+    assert '{"input": "hello"}' in messages[0].content
+
+
+def test_default_template_preserves_json_examples():
+    """Default template's {{...}} should produce {...} in the formatted output."""
+    formatter = ReActChatFormatter()
+
+    mock_tool = MagicMock()
+    mock_tool.metadata.name = "test_tool"
+    mock_tool.metadata.get_name.return_value = "test_tool"
+    mock_tool.metadata.description = "A test tool"
+    mock_tool.metadata.fn_schema_str = '{"type": "object"}'
+
+    messages = formatter.format(tools=[mock_tool], chat_history=[])
+    content = messages[0].content
+
+    # The default template has {{"input": "hello world", "num_beams": 5}}
+    # which should become {"input": "hello world", "num_beams": 5} in the output
+    assert '{"input": "hello world", "num_beams": 5}' in content
+    # Should NOT contain double braces in the output
+    assert '{{"input"' not in content
+
+
+def test_update_prompts_with_preformatted_template():
+    """Pre-formatted template with literal braces should not crash the formatter."""
+    agent = ReActAgent()
+
+    # Simulate what the issue reporter does: pre-format the default template
+    # This collapses {{ to { and fills placeholders
+    preformatted = REACT_CHAT_SYSTEM_HEADER.format(
+        tool_desc="{tool_desc}",
+        tool_names="{tool_names}",
+    )
+    # preformatted now contains literal { from collapsed {{
+
+    agent.update_prompts({"react_header": preformatted})
+
+    mock_tool = MagicMock()
+    mock_tool.metadata.name = "test_tool"
+    mock_tool.metadata.get_name.return_value = "test_tool"
+    mock_tool.metadata.description = "A test tool"
+    mock_tool.metadata.fn_schema_str = '{"type": "object"}'
+
+    # Should not raise KeyError
+    messages = agent.formatter.format(tools=[mock_tool], chat_history=[])
+    assert len(messages) > 0
+
+
+def test_formatter_substitutes_tool_args_with_literal_braces():
+    """
+    tool_desc and tool_names should be substituted while literal braces survive.
+
+    This is the exact scenario from the bug report: a user-supplied template
+    contains literal JSON examples (single braces) alongside {tool_desc} and
+    {tool_names} placeholders.  The old str.format() code raised KeyError here;
+    format_string() tolerates the literal braces.
+    """
+    formatter = ReActChatFormatter(
+        system_header=(
+            "You have access to:\n{tool_desc}\n"
+            "Use tools: {tool_names}\n"
+            'Action Input must be JSON, e.g. {"query": "search term"}'
+        )
+    )
+
+    mock_tool = MagicMock()
+    mock_tool.metadata.name = "search"
+    mock_tool.metadata.get_name.return_value = "search"
+    mock_tool.metadata.description = "Search the web"
+    mock_tool.metadata.fn_schema_str = '{"type": "object"}'
+
+    messages = formatter.format(tools=[mock_tool], chat_history=[])
+    content = messages[0].content
+
+    # tool_desc and tool_names must be substituted with actual values
+    assert "Search the web" in content
+    assert "> Tool Name: search" in content
+
+    # Literal JSON braces must survive intact in the output
+    assert '{"query": "search term"}' in content
+
+
+def test_update_prompts_warns_on_missing_placeholders():
+    """Updating with a prompt missing required placeholders should warn."""
+    agent = ReActAgent()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        agent.update_prompts({"react_header": "No placeholders here"})
+        # Should have warnings for both tool_desc and tool_names
+        warning_messages = [str(warning.message) for warning in w]
+        assert any("tool_desc" in msg for msg in warning_messages)
+        assert any("tool_names" in msg for msg in warning_messages)
+
+
+def test_update_prompts_no_warning_when_placeholders_present():
+    """Updating with a prompt that has required placeholders should not warn."""
+    agent = ReActAgent()
+
+    prompt_with_placeholders = "Tools: {tool_desc}\nNames: {tool_names}"
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        agent.update_prompts({"react_header": prompt_with_placeholders})
+        warning_messages = [str(warning.message) for warning in w]
+        assert not any("tool_desc" in msg for msg in warning_messages)
+        assert not any("tool_names" in msg for msg in warning_messages)

--- a/llama-index-core/tests/agent/react/test_prompt_customization.py
+++ b/llama-index-core/tests/agent/react/test_prompt_customization.py
@@ -4,10 +4,7 @@ from unittest.mock import MagicMock
 
 from llama_index.core import PromptTemplate
 from llama_index.core.agent.react.formatter import ReActChatFormatter
-from llama_index.core.agent.react.prompts import (
-    CONTEXT_REACT_CHAT_SYSTEM_HEADER,
-    REACT_CHAT_SYSTEM_HEADER,
-)
+from llama_index.core.agent.react.prompts import REACT_CHAT_SYSTEM_HEADER
 from llama_index.core.agent.workflow import ReActAgent
 
 
@@ -32,40 +29,6 @@ def test_partial_formatted_system_prompt():
     agent.update_prompts({"react_header": prompt.partial_format(dummy_var=dummy_var)})
 
     assert dummy_var in agent.formatter.system_header
-
-
-def test_system_prompt_passed_to_formatter():
-    """system_prompt should be set as formatter context and use the context-aware template."""
-    system_prompt = "You are a helpful financial advisor."
-    agent = ReActAgent(system_prompt=system_prompt)
-
-    assert agent.formatter.context == system_prompt
-    assert "{context}" in agent.formatter.system_header
-    assert agent.formatter.system_header == CONTEXT_REACT_CHAT_SYSTEM_HEADER
-
-    # Verify the context actually appears in the formatted output
-    formatted = agent.formatter.format(tools=[], chat_history=[])
-    assert system_prompt in formatted[0].content
-
-
-def test_no_system_prompt_uses_default_template():
-    """Without system_prompt the formatter should use the default template (no context placeholder)."""
-    agent = ReActAgent()
-
-    assert agent.formatter.context == ""
-    assert agent.formatter.system_header == REACT_CHAT_SYSTEM_HEADER
-
-
-def test_system_prompt_with_custom_formatter_context():
-    """system_prompt should be prepended to an existing formatter context."""
-    custom_context = "Extra context from user."
-    formatter = ReActChatFormatter.from_defaults(context=custom_context)
-    system_prompt = "You are a helpful assistant."
-    agent = ReActAgent(system_prompt=system_prompt, formatter=formatter)
-
-    assert system_prompt in agent.formatter.context
-    assert custom_context in agent.formatter.context
-    assert "{context}" in agent.formatter.system_header
 
 
 def test_formatter_with_literal_braces():
@@ -132,8 +95,7 @@ def test_update_prompts_with_preformatted_template():
 
 
 def test_formatter_substitutes_tool_args_with_literal_braces():
-    """
-    tool_desc and tool_names should be substituted while literal braces survive.
+    """tool_desc and tool_names should be substituted while literal braces survive.
 
     This is the exact scenario from the bug report: a user-supplied template
     contains literal JSON examples (single braces) alongside {tool_desc} and
@@ -142,8 +104,8 @@ def test_formatter_substitutes_tool_args_with_literal_braces():
     """
     formatter = ReActChatFormatter(
         system_header=(
-            "You have access to:\n{tool_desc}\n"
-            "Use tools: {tool_names}\n"
+            'You have access to:\n{tool_desc}\n'
+            'Use tools: {tool_names}\n'
             'Action Input must be JSON, e.g. {"query": "search term"}'
         )
     )


### PR DESCRIPTION
## Summary

Fixes #20416 — `ReActAgent` silently stops working after updating the system prompt via `update_prompts()`.

**Root cause:** The formatter at `formatter.py:81` uses Python's `str.format()` on the stored system header, which crashes with `KeyError` when the string contains literal braces (`{`, `}`) from pre-formatted template escape sequences (`{{`, `}}`). The exception propagates through the workflow runtime and produces empty agent output with no traceback.

**Fix (2 files, ~15 lines):**
- `formatter.py`: Replace `str.format()` with `format_string()` (the existing `SafeFormatter` utility) followed by brace escape processing. This safely substitutes `{tool_desc}` and `{tool_names}` without crashing on literal braces, while preserving the default template's JSON examples for the LLM.
- `react_agent.py`: Add `UserWarning` when `update_prompts()` receives a prompt missing required `{tool_desc}` or `{tool_names}` placeholders, giving users immediate feedback instead of silent runtime failure.

## Test plan

- [x] 6 new tests in `test_prompt_customization.py` (formatter with literal braces, default template JSON examples, pre-formatted template update, warning on missing placeholders, no false warnings)
- [x] 1 existing `test_react_agent_prompts` passes
- [x] 1 existing `test_inheritance_react_chat_formatter` passes
- [x] 14 existing `test_react_output_parser` tests pass
- [x] Zero regressions — default template output is identical before and after the fix

<!-- hermes-labs:attribution v2 produced-by=agents responsible-human=roli-lpci selection=unspecified review=fable-qc -->
<!-- hermes-labs:attribution v1 -->
This contribution was produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->
