### PR TITLE
fix(evaluation): add response_field param to BaseEvaluator to prevent token explosion with SQL engines

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/base.py
+++ b/llama-index-core/llama_index/core/evaluation/base.py
@@ -94,6 +94,7 @@ class BaseEvaluator(PromptMixin):
         self,
         query: Optional[str] = None,
         response: Optional[Response] = None,
+        response_field: Optional[str] = None,
         **kwargs: Any,
     ) -> EvaluationResult:
         """
@@ -101,11 +102,23 @@ class BaseEvaluator(PromptMixin):
 
         Subclasses can override this method to provide custom evaluation logic and
         take in additional arguments.
+
+        Args:
+            query: Query string.
+            response: Response object.
+            response_field: If set, use response.metadata[response_field]
+                instead of response.response as the response string sent to
+                the evaluator.  Useful when the full response.response is very
+                large (e.g. raw SQL result sets) and a compact representation
+                is available in metadata.
         """
         response_str: Optional[str] = None
         contexts: Optional[Sequence[str]] = None
         if response is not None:
-            response_str = response.response
+            if response_field is not None:
+                response_str = (response.metadata or {}).get(response_field)
+            else:
+                response_str = response.response
             contexts = [node.get_content() for node in response.source_nodes]
 
         return self.evaluate(
@@ -116,6 +129,7 @@ class BaseEvaluator(PromptMixin):
         self,
         query: Optional[str] = None,
         response: Optional[Response] = None,
+        response_field: Optional[str] = None,
         **kwargs: Any,
     ) -> EvaluationResult:
         """
@@ -123,11 +137,23 @@ class BaseEvaluator(PromptMixin):
 
         Subclasses can override this method to provide custom evaluation logic and
         take in additional arguments.
+
+        Args:
+            query: Query string.
+            response: Response object.
+            response_field: If set, use response.metadata[response_field]
+                instead of response.response as the response string sent to
+                the evaluator.  Useful when the full response.response is very
+                large (e.g. raw SQL result sets) and a compact representation
+                is available in metadata.
         """
         response_str: Optional[str] = None
         contexts: Optional[Sequence[str]] = None
         if response is not None:
-            response_str = response.response
+            if response_field is not None:
+                response_str = (response.metadata or {}).get(response_field)
+            else:
+                response_str = response.response
             contexts = [node.get_content() for node in response.source_nodes]
 
         return await self.aevaluate(

--- a/llama-index-core/tests/evaluation/test_base.py
+++ b/llama-index-core/tests/evaluation/test_base.py
@@ -62,3 +62,75 @@ def test_evaluator_basic() -> None:
     )
 
     assert eval_result_0 == eval_result_1
+
+
+def test_evaluate_response_with_response_field() -> None:
+    """Test that response_field extracts value from response.metadata."""
+    test_evaluator = MockEvaluator()
+    large_response = "x" * 400_000  # simulate huge SQL result set
+    sql_query = "SELECT * FROM users LIMIT 10"
+
+    result = test_evaluator.evaluate_response(
+        query="test query",
+        response=Response(
+            response=large_response,
+            source_nodes=[
+                NodeWithScore(node=TextNode(text="ctx"), score=1.0),
+            ],
+            metadata={"sql_query": sql_query},
+        ),
+        response_field="sql_query",
+    )
+
+    # The evaluator should receive the compact sql_query, not the huge response
+    assert result.response == sql_query
+
+
+def test_evaluate_response_field_missing_key() -> None:
+    """Test that a missing metadata key yields None response string."""
+    test_evaluator = MockEvaluator()
+
+    result = test_evaluator.evaluate_response(
+        query="test query",
+        response=Response(
+            response="some response",
+            source_nodes=[],
+            metadata={"other_key": "value"},
+        ),
+        response_field="nonexistent_key",
+    )
+
+    assert result.response is None
+
+
+def test_evaluate_response_field_none_metadata() -> None:
+    """Test that None metadata with response_field yields None response string."""
+    test_evaluator = MockEvaluator()
+
+    result = test_evaluator.evaluate_response(
+        query="test query",
+        response=Response(
+            response="some response",
+            source_nodes=[],
+            metadata=None,
+        ),
+        response_field="sql_query",
+    )
+
+    assert result.response is None
+
+
+def test_evaluate_response_without_response_field_unchanged() -> None:
+    """Test that default behavior (no response_field) is unchanged."""
+    test_evaluator = MockEvaluator()
+
+    result = test_evaluator.evaluate_response(
+        query="test query",
+        response=Response(
+            response="original response",
+            source_nodes=[],
+            metadata={"sql_query": "SELECT 1"},
+        ),
+    )
+
+    assert result.response == "original response"


### PR DESCRIPTION
Fixes #20300

## Problem

When `NLSQLTableQueryEngine(synthesize_response=False)` is combined with `RetryGuidelineQueryEngine`, the `GuidelineEvaluator` receives the full raw SQL result set (potentially thousands of rows) as the string to evaluate, instead of the compact SQL query string. This causes token consumption to spike from ~20k to ~400k+, triggering rate limits and excessive API costs.

## Root Cause

`BaseEvaluator.evaluate_response()` always passes `response.response` (the full result string) to the LLM evaluator. For `NLSQLTableQueryEngine` with `synthesize_response=False`, this is the raw database result, not the SQL query — which is what should be evaluated for correctness.

## Fix

Added an optional `response_field` parameter to `BaseEvaluator.evaluate_response()` and `aevaluate_response()`. When `response_field` is specified, the evaluator uses `response.metadata[response_field]` instead of `response.response`.

**Backward compatible** — default behavior (`response_field=None`) is unchanged.

Usage:
```python
evaluator = GuidelineEvaluator(guidelines="...")
result = await evaluator.aevaluate_response(
    query=query,
    response=response,
    response_field="sql_query"  # use metadata field instead of full result
)
```