### PR TITLE
fixed pydantic type error in cli chat

### DIFF
--- a/llama-index-cli/llama_index/cli/rag/base.py
+++ b/llama-index-cli/llama_index/cli/rag/base.py
@@ -17,7 +17,12 @@ from llama_index.core.base.response.schema import (
     Response,
     StreamingResponse,
 )
-from llama_index.core.bridge.pydantic import BaseModel, Field, field_validator
+from llama_index.core.bridge.pydantic import (
+    BaseModel,
+    Field,
+    ValidationInfo,
+    field_validator,
+)
 from llama_index.core.chat_engine import CondenseQuestionChatEngine
 from llama_index.core.ingestion import IngestionPipeline
 from llama_index.core.llms import LLM
@@ -85,7 +90,7 @@ class RagCLI(BaseModel):
 
     @field_validator("chat_engine", mode="before")
     def chat_engine_from_ingestion_pipeline(
-        cls, chat_engine: Any, values: Dict[str, Any]
+        cls, chat_engine: Any, info: ValidationInfo
     ) -> Optional[CondenseQuestionChatEngine]:
         """
         If chat_engine is not provided, create one from ingestion_pipeline.
@@ -93,12 +98,14 @@ class RagCLI(BaseModel):
         if chat_engine is not None:
             return chat_engine
 
-        ingestion_pipeline = cast(IngestionPipeline, values["ingestion_pipeline"])
+        ingestion_pipeline = cast(
+            IngestionPipeline, info.data.get("ingestion_pipeline")
+        )
         if ingestion_pipeline.vector_store is None:
             return None
 
-        verbose = cast(bool, values["verbose"])
-        llm = cast(LLM, values["llm"])
+        verbose = cast(bool, info.data.get("verbose"))
+        llm = cast(LLM, info.data.get("llm"))
 
         # get embed_model from transformations if possible
         embed_model = None

--- a/llama-index-cli/pyproject.toml
+++ b/llama-index-cli/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-cli"
-version = "0.5.4"
+version = "0.5.5"
 description = "llama-index cli"
 authors = [{name = "llamaindex"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description
The @field_validator in RagCLI uses the old Pydantic v1 signature, expecting values to be a dict. In Pydantic v2, the second argument is a ValidationInfo object, and one must use info.data.get("...") to access other fields.

Fixes (https://github.com/run-llama/llama_index/issues/20868)

## Version Bump?
Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
- [x] Yes
- [ ] No

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)


## Suggested Checklist:
- [x] I have performed a self-review of my own code