### PR TITLE
feat: add Merge Agent Handler tool integration

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+.venv/
+.DS_Store
+uv.lock

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0 - 2026-03-04
+
+- Initial release of `llama-index-tools-merge-agent-handler`.
+- Added `MergeAgentHandlerToolSpec` with four methods:
+  - `list_tool_packs`
+  - `list_registered_users`
+  - `list_tools`
+  - `call_tool`
+- Added unit tests with mocked Merge API/MCP responses.
+- Added example script and Streamlit local UI tester.

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Merge Agent Handler Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/Makefile
@@ -1,0 +1,6 @@
+lint:
+	uv run --extra dev ruff check .
+	uv run --extra dev mypy llama_index/tools/merge_agent_handler/base.py tests/test_tools.py examples/merge_agent_handler_example.py ui/merge_agent_handler_ui.py
+
+test:
+	uv run --extra dev pytest tests/ --cov=llama_index/tools/merge_agent_handler --cov-report=term-missing

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/README.md
@@ -1,0 +1,115 @@
+# LlamaIndex Merge Agent Handler ToolSpec
+
+LlamaIndex tool integration for connecting AI agents to [Merge Agent Handler](https://merge.dev/agent-handler) Tool Packs over MCP.
+
+This package provides four agent-callable methods:
+
+- `list_tool_packs`
+- `list_registered_users`
+- `list_tools`
+- `call_tool`
+
+## Prerequisites
+
+- Python 3.9+
+- Merge Agent Handler API key
+- At least one Merge Tool Pack and Registered User
+
+## Installation
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -e .[dev]
+```
+
+## Quick Start
+
+```python
+from llama_index.tools.merge_agent_handler import MergeAgentHandlerToolSpec
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+
+merge_tools = MergeAgentHandlerToolSpec(
+    api_key="your-merge-api-key",
+    tool_pack_id="your-tool-pack-id",
+    registered_user_id="your-registered-user-id",
+)
+
+tools = merge_tools.to_tool_list()
+
+llm = OpenAI(model="gpt-4o")
+agent = ReActAgent.from_tools(tools, llm=llm, verbose=True)
+
+response = agent.chat(
+    "List the available tools in my Merge Tool Pack, then use one to fetch recent Jira tickets."
+)
+print(response)
+```
+
+Example file: [`examples/merge_agent_handler_example.py`](./examples/merge_agent_handler_example.py)
+
+## Constructor Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `api_key` | `str` | Merge Agent Handler API key |
+| `tool_pack_id` | `str \| None` | Default Tool Pack ID fallback for `list_tools` and `call_tool` |
+| `registered_user_id` | `str \| None` | Default Registered User ID fallback for `list_tools` and `call_tool` |
+| `environment` | `str` | Default environment (`production` or `test`) for `list_registered_users` |
+
+## Tool Reference
+
+| Method | Description |
+|---|---|
+| `list_tool_packs()` | Lists Merge Tool Packs available to the API key |
+| `list_registered_users(environment=None)` | Lists registered users filtered by `production` or `test` |
+| `list_tools(tool_pack_id=None, registered_user_id=None)` | Lists MCP tools for a Tool Pack + Registered User |
+| `call_tool(tool_name, arguments="{}", tool_pack_id=None, registered_user_id=None)` | Executes an MCP tool and returns text output or an error string |
+
+## Local UI Tester
+
+A Streamlit UI is included for manual testing.
+
+```bash
+source .venv/bin/activate
+streamlit run ui/merge_agent_handler_ui.py
+```
+
+UI capabilities:
+
+- initialize `MergeAgentHandlerToolSpec`
+- list tool packs
+- list registered users
+- list MCP tools
+- call MCP tools with raw JSON arguments
+
+## Testing and Linting
+
+```bash
+source .venv/bin/activate
+pytest tests/test_tools.py
+ruff check .
+mypy llama_index/tools/merge_agent_handler/base.py tests/test_tools.py examples/merge_agent_handler_example.py ui/merge_agent_handler_ui.py
+```
+
+Or using the project make targets:
+
+```bash
+make lint
+make test
+```
+
+## Related Links
+
+- Merge Agent Handler docs: <https://docs.ah.merge.dev/>
+- Merge dashboard: <https://ah.merge.dev/>
+- n8n implementation: `/Users/pritak/Documents/n8n-nodes-merge`
+- Langflow implementation: `/Users/pritak/Documents/langflow-merge-agent-handler`
+- Agno implementation: `/Users/pritak/Documents/agno-merge-agent-handler`
+- Letta implementation: `/Users/pritak/Documents/letta-merge-agent-handler`
+
+## License
+
+[MIT](./LICENSE)

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/examples/merge_agent_handler_example.py
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/examples/merge_agent_handler_example.py
@@ -1,0 +1,26 @@
+"""Merge Agent Handler - Connect a LlamaIndex agent to Merge Tool Packs via MCP."""
+
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.merge_agent_handler import MergeAgentHandlerToolSpec
+
+# Initialize the tool spec
+merge_tools = MergeAgentHandlerToolSpec(
+    api_key="your-merge-api-key",
+    tool_pack_id="your-tool-pack-id",
+    registered_user_id="your-registered-user-id",
+)
+
+# Convert to LlamaIndex tools
+tools = merge_tools.to_tool_list()
+
+# Create agent
+llm = OpenAI(model="gpt-4o")
+agent = ReActAgent.from_tools(tools, llm=llm, verbose=True)
+
+# Query
+response = agent.chat(
+    "List the available tools in my Merge Tool Pack, then use the "
+    "appropriate tool to fetch my recent tickets from Jira."
+)
+print(response)

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/llama_index/tools/merge_agent_handler/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/llama_index/tools/merge_agent_handler/__init__.py
@@ -1,0 +1,5 @@
+"""Merge Agent Handler tool spec for LlamaIndex."""
+
+from llama_index.tools.merge_agent_handler.base import MergeAgentHandlerToolSpec
+
+__all__ = ["MergeAgentHandlerToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/llama_index/tools/merge_agent_handler/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/llama_index/tools/merge_agent_handler/base.py
@@ -1,0 +1,339 @@
+"""Merge Agent Handler tool spec."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://ah-api.merge.dev/api/v1"
+
+
+class MergeAgentHandlerToolSpec(BaseToolSpec):
+    """
+    Merge Agent Handler tool spec.
+
+    Connects AI agents to Merge Agent Handler Tool Packs via the Model
+    Context Protocol (MCP). Provides access to pre-built integrations
+    across HRIS, ATS, CRM, accounting, ticketing, and file storage.
+    """
+
+    spec_functions = [
+        "list_tool_packs",
+        "list_registered_users",
+        "list_tools",
+        "call_tool",
+    ]
+
+    def __init__(
+        self,
+        api_key: str,
+        tool_pack_id: Optional[str] = None,
+        registered_user_id: Optional[str] = None,
+        environment: str = "production",
+        timeout: float = 30.0,
+    ) -> None:
+        """
+        Initialize with Merge Agent Handler credentials.
+
+        Args:
+            api_key: Merge Agent Handler API key.
+            tool_pack_id: Default Tool Pack ID (can be overridden per-call).
+            registered_user_id: Default Registered User ID (can be overridden per-call).
+            environment: Either "production" or "test". Defaults to "production".
+            timeout: HTTP timeout in seconds.
+
+        """
+        self.api_key = api_key
+        self.tool_pack_id = tool_pack_id
+        self.registered_user_id = registered_user_id
+        self.environment = environment
+        self._headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-Source": "llamaindex-tool",
+        }
+        self._client = httpx.Client(
+            base_url=BASE_URL,
+            timeout=timeout,
+            headers=self._headers,
+        )
+
+    def close(self) -> None:
+        """Close the shared HTTP client."""
+        self._client.close()
+
+    def _resolve_environment(self, environment: Optional[str]) -> str:
+        resolved = (environment or self.environment or "production").strip().lower()
+        if resolved not in {"production", "test"}:
+            raise ValueError("environment must be either 'production' or 'test'")
+        return resolved
+
+    def _resolve_identifiers(
+        self,
+        tool_pack_id: Optional[str],
+        registered_user_id: Optional[str],
+    ) -> tuple[str, str]:
+        resolved_tool_pack_id = tool_pack_id or self.tool_pack_id
+        resolved_registered_user_id = registered_user_id or self.registered_user_id
+
+        if not resolved_tool_pack_id:
+            raise ValueError("tool_pack_id is required. Pass it in __init__ or this method call.")
+        if not resolved_registered_user_id:
+            raise ValueError("registered_user_id is required. Pass it in __init__ or this method call.")
+
+        return resolved_tool_pack_id, resolved_registered_user_id
+
+    def _parse_arguments(self, arguments: str) -> Dict[str, Any]:
+        try:
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError as exc:
+            raise ValueError("arguments must be a valid JSON string representing an object") from exc
+
+        if parsed is None:
+            return {}
+        if not isinstance(parsed, dict):
+            raise ValueError("arguments must decode to a JSON object")
+
+        return parsed
+
+    def _fetch_all_pages(
+        self,
+        url: str,
+        params: Optional[Dict[str, str]] = None,
+    ) -> List[Dict[str, Any]]:
+        all_results: List[Dict[str, Any]] = []
+        page = 1
+        base_params = dict(params or {})
+
+        while True:
+            response = self._client.get(url, params={**base_params, "page": str(page)})
+            response.raise_for_status()
+            payload = response.json()
+
+            if isinstance(payload, list):
+                return [item for item in payload if isinstance(item, dict)]
+
+            if not isinstance(payload, dict):
+                raise ValueError("Unexpected API response format")
+
+            results = payload.get("results", [])
+            if not isinstance(results, list):
+                raise ValueError("Unexpected paginated response format")
+
+            all_results.extend(item for item in results if isinstance(item, dict))
+
+            if not payload.get("next"):
+                break
+            page += 1
+
+        return all_results
+
+    def _post_mcp(
+        self,
+        tool_pack_id: str,
+        registered_user_id: str,
+        rpc_request: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        response = self._client.post(
+            f"/tool-packs/{tool_pack_id}/registered-users/{registered_user_id}/mcp",
+            json=rpc_request,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Unexpected MCP response format")
+        return payload
+
+    @staticmethod
+    def _extract_text(content: Any) -> str:
+        if not isinstance(content, list):
+            return ""
+
+        text_chunks: List[str] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "text" and isinstance(item.get("text"), str):
+                text_chunks.append(item["text"])
+        return "\n".join(text_chunks).strip()
+
+    def list_tool_packs(self) -> str:
+        """
+        List all available Merge Agent Handler Tool Packs.
+
+        Fetches the Tool Packs configured in your Merge Agent Handler account.
+        Each Tool Pack bundles connectors for services like Jira, Salesforce,
+        Greenhouse, etc. Use the returned tool pack IDs with list_tools and call_tool.
+
+        Returns:
+            str: JSON array of tool packs, each with "id", "name", "description",
+                and "connectors" (list of connected services).
+
+        """
+        tool_packs = self._fetch_all_pages("/tool-packs/")
+
+        normalized_tool_packs: List[Dict[str, Any]] = []
+        for tool_pack in tool_packs:
+            raw_connectors = tool_pack.get("connectors")
+            connectors: List[Dict[str, Any]] = raw_connectors if isinstance(raw_connectors, list) else []
+            normalized_tool_packs.append(
+                {
+                    "id": tool_pack.get("id"),
+                    "name": tool_pack.get("name"),
+                    "description": tool_pack.get("description"),
+                    "connectors": [
+                        {"name": connector.get("name"), "slug": connector.get("slug")}
+                        for connector in connectors
+                        if isinstance(connector, dict)
+                    ],
+                }
+            )
+
+        return json.dumps(normalized_tool_packs)
+
+    def list_registered_users(self, environment: Optional[str] = None) -> str:
+        """
+        List registered users for Merge Agent Handler.
+
+        Args:
+            environment: "production" or "test". Defaults to the value set in constructor.
+
+        Returns:
+            str: JSON array of registered users with "id", "origin_user_name",
+                and "authenticated_connectors".
+
+        """
+        resolved_environment = self._resolve_environment(environment)
+        is_test = resolved_environment == "test"
+        users = self._fetch_all_pages("/registered-users", {"is_test": str(is_test).lower()})
+
+        normalized_users = [
+            {
+                "id": user.get("id"),
+                "origin_user_name": user.get("origin_user_name"),
+                "authenticated_connectors": user.get("authenticated_connectors"),
+            }
+            for user in users
+        ]
+
+        return json.dumps(normalized_users)
+
+    def list_tools(
+        self,
+        tool_pack_id: Optional[str] = None,
+        registered_user_id: Optional[str] = None,
+    ) -> str:
+        """
+        List available MCP tools in a Merge Tool Pack.
+
+        Args:
+            tool_pack_id: Tool Pack ID. Uses default from constructor if not provided.
+            registered_user_id: Registered User ID. Uses default from constructor if not provided.
+
+        Returns:
+            str: JSON array of tools, each with "name" and "description".
+
+        """
+        resolved_tool_pack_id, resolved_registered_user_id = self._resolve_identifiers(
+            tool_pack_id,
+            registered_user_id,
+        )
+
+        rpc_request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {},
+        }
+
+        response = self._post_mcp(resolved_tool_pack_id, resolved_registered_user_id, rpc_request)
+
+        if "error" in response:
+            error = response.get("error", {})
+            if isinstance(error, dict):
+                raise ValueError(f"MCP tools/list failed: {error.get('message', 'Unknown error')}")
+            raise ValueError("MCP tools/list failed: Unknown error")
+
+        result = response.get("result", {})
+        tools = result.get("tools", []) if isinstance(result, dict) else []
+        if not isinstance(tools, list):
+            raise ValueError("Unexpected tools payload format")
+
+        normalized_tools = [
+            {
+                "name": tool.get("name"),
+                "description": tool.get("description"),
+            }
+            for tool in tools
+            if isinstance(tool, dict)
+        ]
+        return json.dumps(normalized_tools)
+
+    def call_tool(
+        self,
+        tool_name: str,
+        arguments: str = "{}",
+        tool_pack_id: Optional[str] = None,
+        registered_user_id: Optional[str] = None,
+    ) -> str:
+        """
+        Execute an MCP tool from a Merge Tool Pack.
+
+        Args:
+            tool_name: The name of the MCP tool to execute (from list_tools).
+            arguments: JSON string of arguments to pass to the tool.
+            tool_pack_id: Tool Pack ID. Uses default from constructor if not provided.
+            registered_user_id: Registered User ID. Uses default from constructor if not provided.
+
+        Returns:
+            str: The tool's text output, or an error message if the call failed.
+
+        """
+        try:
+            resolved_tool_pack_id, resolved_registered_user_id = self._resolve_identifiers(
+                tool_pack_id,
+                registered_user_id,
+            )
+            parsed_arguments = self._parse_arguments(arguments)
+
+            rpc_request = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": tool_name,
+                    "arguments": {"input": parsed_arguments},
+                },
+            }
+
+            response = self._post_mcp(resolved_tool_pack_id, resolved_registered_user_id, rpc_request)
+        except Exception as exc:
+            logger.exception(exc)
+            return f'Error calling tool "{tool_name}": {exc}'
+
+        if "error" in response:
+            error = response.get("error", {})
+            if isinstance(error, dict):
+                return f'Tool "{tool_name}" returned error: {error.get("message", "Unknown error")}'
+            return f'Tool "{tool_name}" returned error: Unknown error'
+
+        result = response.get("result")
+        if not isinstance(result, dict):
+            return json.dumps(result)
+
+        if result.get("isError"):
+            error_text = self._extract_text(result.get("content")) or "Unknown error"
+            return f'Tool "{tool_name}" failed: {error_text}'
+
+        content = result.get("content")
+        text_output = self._extract_text(content)
+        if text_output:
+            return text_output
+
+        return json.dumps(result)

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llama-index-tools-merge-agent-handler"
+version = "0.1.0"
+description = "LlamaIndex tool integration for Merge Agent Handler - connect AI agents to Merge Tool Packs via MCP"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.9,<4.0"
+authors = [{ name = "Merge Agent Handler Contributors" }]
+dependencies = [
+  "llama-index-core>=0.13.0,<0.15",
+  "httpx>=0.25.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0",
+  "pytest-cov>=4.0",
+  "respx>=0.21",
+  "mypy==0.991",
+  "ruff==0.11.11",
+  "streamlit>=1.30.0",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/", "examples/", "tests/", "ui/", "README.md", "LICENSE", "CHANGELOG.md", "Makefile"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+follow_imports = "skip"
+namespace_packages = true
+explicit_package_bases = true
+pretty = true
+show_error_codes = true
+files = [
+  "llama_index/tools/merge_agent_handler/base.py",
+  "tests/test_tools.py",
+  "examples/merge_agent_handler_example.py",
+  "ui/merge_agent_handler_ui.py",
+]
+
+[tool.llamahub]
+import_path = "llama_index.tools.merge_agent_handler"
+classes = ["MergeAgentHandlerToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/tests/test_tools.py
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/tests/test_tools.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from llama_index.core.tools.function_tool import FunctionTool
+
+from llama_index.tools.merge_agent_handler import MergeAgentHandlerToolSpec
+
+
+@pytest.fixture
+def tool_spec() -> MergeAgentHandlerToolSpec:
+    spec = MergeAgentHandlerToolSpec(
+        api_key="test-api-key",
+        tool_pack_id="tp_default",
+        registered_user_id="ru_default",
+    )
+    yield spec
+    spec.close()
+
+
+def test_spec_functions_are_expected() -> None:
+    assert MergeAgentHandlerToolSpec.spec_functions == [
+        "list_tool_packs",
+        "list_registered_users",
+        "list_tools",
+        "call_tool",
+    ]
+
+
+def test_init_stores_credentials_and_defaults(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    assert tool_spec.api_key == "test-api-key"
+    assert tool_spec.tool_pack_id == "tp_default"
+    assert tool_spec.registered_user_id == "ru_default"
+    assert tool_spec.environment == "production"
+
+
+@respx.mock
+def test_fetch_all_pages_handles_pagination(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    def _paged_response(request: httpx.Request) -> httpx.Response:
+        page = request.url.params.get("page")
+        if page == "1":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"id": "tp_1", "name": "Finance Pack", "connectors": []}],
+                    "next": "https://ah-api.merge.dev/api/v1/tool-packs/?page=2",
+                },
+            )
+        if page == "2":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"id": "tp_2", "name": "Support Pack", "connectors": []}],
+                    "next": None,
+                },
+            )
+        return httpx.Response(404, json={"detail": "unexpected page"})
+
+    route = respx.get("https://ah-api.merge.dev/api/v1/tool-packs/").mock(side_effect=_paged_response)
+
+    result = tool_spec._fetch_all_pages("/tool-packs/")
+    assert route.call_count == 2
+    assert [item["id"] for item in result] == ["tp_1", "tp_2"]
+
+
+@respx.mock
+def test_list_tool_packs_returns_expected_json(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    respx.get("https://ah-api.merge.dev/api/v1/tool-packs/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": "tp_1",
+                        "name": "Support Pack",
+                        "description": "Ticketing tools",
+                        "connectors": [{"name": "Jira", "slug": "jira", "id": "ignored"}],
+                    }
+                ],
+                "next": None,
+            },
+        )
+    )
+
+    result = json.loads(tool_spec.list_tool_packs())
+    assert result == [
+        {
+            "id": "tp_1",
+            "name": "Support Pack",
+            "description": "Ticketing tools",
+            "connectors": [{"name": "Jira", "slug": "jira"}],
+        }
+    ]
+
+
+@respx.mock
+def test_list_registered_users_applies_environment_filter(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    route = respx.get("https://ah-api.merge.dev/api/v1/registered-users").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": "ru_1",
+                        "origin_user_name": "Alex",
+                        "authenticated_connectors": ["jira"],
+                        "is_test": True,
+                    }
+                ],
+                "next": None,
+            },
+        )
+    )
+
+    result = json.loads(tool_spec.list_registered_users(environment="test"))
+    assert route.calls[0].request.url.params["is_test"] == "true"
+    assert result == [
+        {
+            "id": "ru_1",
+            "origin_user_name": "Alex",
+            "authenticated_connectors": ["jira"],
+        }
+    ]
+
+
+@respx.mock
+def test_list_tools_sends_expected_mcp_request(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    route = respx.post(
+        "https://ah-api.merge.dev/api/v1/tool-packs/tp_default/registered-users/ru_default/mcp"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "tools": [
+                        {
+                            "name": "jira_list_tickets",
+                            "description": "List Jira tickets",
+                            "inputSchema": {"type": "object"},
+                        }
+                    ]
+                },
+            },
+        )
+    )
+
+    result = json.loads(tool_spec.list_tools())
+    assert result == [{"name": "jira_list_tickets", "description": "List Jira tickets"}]
+
+    payload = json.loads(route.calls[0].request.content.decode())
+    assert payload["method"] == "tools/list"
+    assert payload["params"] == {}
+
+
+@respx.mock
+def test_list_tools_uses_parameter_overrides(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    route = respx.post(
+        "https://ah-api.merge.dev/api/v1/tool-packs/tp_override/registered-users/ru_override/mcp"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": 1, "result": {"tools": []}},
+        )
+    )
+
+    result = json.loads(tool_spec.list_tools(tool_pack_id="tp_override", registered_user_id="ru_override"))
+    assert result == []
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_list_tools_raises_on_mcp_error(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    respx.post("https://ah-api.merge.dev/api/v1/tool-packs/tp_default/registered-users/ru_default/mcp").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": 1, "error": {"code": 500, "message": "boom"}},
+        )
+    )
+
+    with pytest.raises(ValueError, match="MCP tools/list failed: boom"):
+        tool_spec.list_tools()
+
+
+@respx.mock
+def test_call_tool_wraps_arguments_under_input(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    route = respx.post(
+        "https://ah-api.merge.dev/api/v1/tool-packs/tp_default/registered-users/ru_default/mcp"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"content": [{"type": "text", "text": "ok"}], "isError": False},
+            },
+        )
+    )
+
+    result = tool_spec.call_tool("jira_list_tickets", arguments='{"limit": 5}')
+    assert result == "ok"
+
+    payload = json.loads(route.calls[0].request.content.decode())
+    assert payload["method"] == "tools/call"
+    assert payload["params"]["name"] == "jira_list_tickets"
+    assert payload["params"]["arguments"] == {"input": {"limit": 5}}
+
+
+@respx.mock
+def test_call_tool_returns_error_string_on_mcp_error(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    respx.post("https://ah-api.merge.dev/api/v1/tool-packs/tp_default/registered-users/ru_default/mcp").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": 1, "error": {"code": 500, "message": "boom"}},
+        )
+    )
+
+    result = tool_spec.call_tool("jira_list_tickets", arguments="{}")
+    assert result == 'Tool "jira_list_tickets" returned error: boom'
+
+
+@respx.mock
+def test_call_tool_returns_error_string_on_is_error(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    respx.post("https://ah-api.merge.dev/api/v1/tool-packs/tp_default/registered-users/ru_default/mcp").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "isError": True,
+                    "content": [{"type": "text", "text": "permission denied"}],
+                },
+            },
+        )
+    )
+
+    result = tool_spec.call_tool("jira_list_tickets", arguments="{}")
+    assert result == 'Tool "jira_list_tickets" failed: permission denied'
+
+
+def test_call_tool_rejects_invalid_argument_json(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    result = tool_spec.call_tool("jira_list_tickets", arguments="{invalid")
+    assert "arguments must be a valid JSON string representing an object" in result
+
+
+def test_list_registered_users_rejects_invalid_environment(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    with pytest.raises(ValueError, match="environment must be either"):
+        tool_spec.list_registered_users(environment="staging")
+
+
+def test_to_tool_list_returns_four_function_tools(tool_spec: MergeAgentHandlerToolSpec) -> None:
+    tools = tool_spec.to_tool_list()
+    assert len(tools) == 4
+    assert all(isinstance(tool, FunctionTool) for tool in tools)

--- a/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/ui/merge_agent_handler_ui.py
+++ b/llama-index-integrations/tools/llama-index-tools-merge-agent-handler/ui/merge_agent_handler_ui.py
@@ -1,0 +1,134 @@
+"""Streamlit UI for manual testing of the LlamaIndex Merge Agent Handler ToolSpec."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import streamlit as st
+
+from llama_index.tools.merge_agent_handler import MergeAgentHandlerToolSpec
+
+
+def _render_output(raw: Any) -> None:
+    if isinstance(raw, (dict, list)):
+        st.json(raw)
+        return
+    if isinstance(raw, str):
+        try:
+            st.json(json.loads(raw))
+            return
+        except json.JSONDecodeError:
+            st.code(raw, language="text")
+            return
+    st.write(raw)
+
+
+def _build_spec(
+    api_key: str,
+    tool_pack_id: str,
+    registered_user_id: str,
+    environment: str,
+) -> MergeAgentHandlerToolSpec:
+    return MergeAgentHandlerToolSpec(
+        api_key=api_key,
+        tool_pack_id=tool_pack_id or None,
+        registered_user_id=registered_user_id or None,
+        environment=environment,
+    )
+
+
+st.set_page_config(page_title="LlamaIndex Merge Agent Handler", page_icon=":toolbox:", layout="wide")
+st.title("LlamaIndex Merge Agent Handler Tester")
+st.caption("Use this UI to test list_tool_packs, list_registered_users, list_tools, and call_tool.")
+
+with st.sidebar:
+    st.header("Connection")
+    api_key_input = st.text_input("Merge API Key", type="password")
+    tool_pack_id_input = st.text_input("Default Tool Pack ID (optional)")
+    registered_user_id_input = st.text_input("Default Registered User ID (optional)")
+    environment_input = st.selectbox("Environment", ["production", "test"], index=0)
+    initialize = st.button("Initialize ToolSpec", type="primary")
+
+if initialize:
+    if not api_key_input:
+        st.error("Merge API Key is required to initialize the tool spec.")
+    else:
+        try:
+            existing = st.session_state.get("tool_spec")
+            if existing:
+                existing.close()
+            st.session_state["tool_spec"] = _build_spec(
+                api_key=api_key_input,
+                tool_pack_id=tool_pack_id_input,
+                registered_user_id=registered_user_id_input,
+                environment=environment_input,
+            )
+            st.success("ToolSpec initialized.")
+        except Exception as exc:
+            st.error(f"Failed to initialize tool spec: {exc}")
+
+tool_spec = st.session_state.get("tool_spec")
+if not tool_spec:
+    st.info("Initialize the tool spec from the sidebar to begin testing.")
+    st.stop()
+
+left_col, right_col = st.columns(2)
+
+with left_col:
+    st.subheader("Discovery")
+
+    if st.button("List Tool Packs"):
+        try:
+            _render_output(tool_spec.list_tool_packs())
+        except Exception as exc:
+            st.error(str(exc))
+
+    if st.button("List Registered Users"):
+        try:
+            _render_output(tool_spec.list_registered_users(environment_input))
+        except Exception as exc:
+            st.error(str(exc))
+
+with right_col:
+    st.subheader("MCP Tools")
+    list_tool_pack_id = st.text_input("Tool Pack ID override", value=tool_pack_id_input, key="list_tool_pack")
+    list_registered_user_id = st.text_input(
+        "Registered User ID override",
+        value=registered_user_id_input,
+        key="list_registered_user",
+    )
+
+    if st.button("List MCP Tools"):
+        try:
+            _render_output(tool_spec.list_tools(list_tool_pack_id or None, list_registered_user_id or None))
+        except Exception as exc:
+            st.error(str(exc))
+
+st.divider()
+st.subheader("Call MCP Tool")
+call_tool_name = st.text_input("Tool Name")
+call_tool_pack_id = st.text_input(
+    "Tool Pack ID override (optional)",
+    value=tool_pack_id_input,
+    key="call_tool_pack",
+)
+call_registered_user_id = st.text_input(
+    "Registered User ID override (optional)",
+    value=registered_user_id_input,
+    key="call_registered_user",
+)
+call_arguments = st.text_area("Arguments JSON", value="{}", height=180)
+
+if st.button("Call Tool", type="primary"):
+    if not call_tool_name:
+        st.error("Tool Name is required.")
+    else:
+        _render_output(
+            tool_spec.call_tool(
+                tool_name=call_tool_name,
+                arguments=call_arguments,
+                tool_pack_id=call_tool_pack_id or None,
+                registered_user_id=call_registered_user_id or None,
+            )
+        )


### PR DESCRIPTION
## Summary
Adds a new LlamaIndex tool integration package:
`llama-index-integrations/tools/llama-index-tools-merge-agent-handler`

## What’s Included
- `MergeAgentHandlerToolSpec` with:
  - `list_tool_packs`
  - `list_registered_users`
  - `list_tools`
  - `call_tool`
- LlamaHub metadata in `pyproject.toml`
- Unit tests for MCP request/response behavior, pagination, fallbacks, error handling, and `to_tool_list()`
- Example usage script
- Streamlit local UI tester
- README, CHANGELOG, LICENSE, Makefile

## Validation
- `make lint`
- `make test`
- Result: 14 tests passed, 89% coverage