### PR TITLE
fix(react): pass system_prompt to ReActChatFormatter template

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -3,6 +3,7 @@ from typing import List, Sequence, Optional, cast
 
 from llama_index.core.agent.react.formatter import ReActChatFormatter
 from llama_index.core.agent.react.output_parser import ReActOutputParser
+from llama_index.core.agent.react.prompts import CONTEXT_REACT_CHAT_SYSTEM_HEADER
 from llama_index.core.agent.react.types import (
     ActionReasoningStep,
     BaseReasoningStep,
@@ -59,6 +60,9 @@ class ReActAgent(BaseWorkflowAgent):
             )
         elif not self.formatter.context and self.system_prompt:
             self.formatter.context = self.system_prompt
+
+        if self.formatter.context and "{context}" not in self.formatter.system_header:
+            self.formatter.system_header = CONTEXT_REACT_CHAT_SYSTEM_HEADER
 
         return self
 

--- a/llama-index-core/tests/agent/react/test_prompt_customization.py
+++ b/llama-index-core/tests/agent/react/test_prompt_customization.py
@@ -1,4 +1,8 @@
 from llama_index.core import PromptTemplate
+from llama_index.core.agent.react.prompts import (
+    CONTEXT_REACT_CHAT_SYSTEM_HEADER,
+    REACT_CHAT_SYSTEM_HEADER,
+)
 from llama_index.core.agent.workflow import ReActAgent
 
 from textwrap import dedent
@@ -25,3 +29,39 @@ def test_partial_formatted_system_prompt():
     agent.update_prompts({"react_header": prompt.partial_format(dummy_var=dummy_var)})
 
     assert dummy_var in agent.formatter.system_header
+
+
+def test_system_prompt_passed_to_formatter():
+    """system_prompt should be set as formatter context and use the context-aware template."""
+    system_prompt = "You are a helpful financial advisor."
+    agent = ReActAgent(system_prompt=system_prompt)
+
+    assert agent.formatter.context == system_prompt
+    assert "{context}" in agent.formatter.system_header
+    assert agent.formatter.system_header == CONTEXT_REACT_CHAT_SYSTEM_HEADER
+
+    # Verify the context actually appears in the formatted output
+    formatted = agent.formatter.format(tools=[], chat_history=[])
+    assert system_prompt in formatted[0].content
+
+
+def test_no_system_prompt_uses_default_template():
+    """Without system_prompt the formatter should use the default template (no context placeholder)."""
+    agent = ReActAgent()
+
+    assert agent.formatter.context == ""
+    assert agent.formatter.system_header == REACT_CHAT_SYSTEM_HEADER
+
+
+def test_system_prompt_with_custom_formatter_context():
+    """system_prompt should be prepended to an existing formatter context."""
+    from llama_index.core.agent.react.formatter import ReActChatFormatter
+
+    custom_context = "Extra context from user."
+    formatter = ReActChatFormatter.from_defaults(context=custom_context)
+    system_prompt = "You are a helpful assistant."
+    agent = ReActAgent(system_prompt=system_prompt, formatter=formatter)
+
+    assert system_prompt in agent.formatter.context
+    assert custom_context in agent.formatter.context
+    assert "{context}" in agent.formatter.system_header


### PR DESCRIPTION
## Summary

Fixes #20872

When creating a `ReActAgent` with `system_prompt`, the existing `model_validator` correctly sets `formatter.context` to the system prompt value. However, `ReActChatFormatter.from_defaults()` (called without `context` during default construction) selects `REACT_CHAT_SYSTEM_HEADER` -- a template that **does not contain the `{context}` placeholder**. As a result, even though `formatter.context` is set, it is never rendered into the final system prompt sent to the LLM.

### Root cause

`ReActChatFormatter` has two header templates:
- `REACT_CHAT_SYSTEM_HEADER` -- no `{context}` placeholder (used when no context is provided)
- `CONTEXT_REACT_CHAT_SYSTEM_HEADER` -- includes `{context}` placeholder

The `default_formatter()` factory creates a formatter without context, so `REACT_CHAT_SYSTEM_HEADER` is selected. The `validate_formatter` model validator then sets `formatter.context`, but never switches the `system_header` template to the context-aware variant.

### Fix

Added a check at the end of `validate_formatter`: when `formatter.context` is non-empty but `system_header` does not contain `{context}`, switch to `CONTEXT_REACT_CHAT_SYSTEM_HEADER`.

### Changes

- `llama-index-core/llama_index/core/agent/workflow/react_agent.py`: Import `CONTEXT_REACT_CHAT_SYSTEM_HEADER` and add template switch logic in `validate_formatter`
- `llama-index-core/tests/agent/react/test_prompt_customization.py`: Add three test cases covering `system_prompt` propagation, default behavior without `system_prompt`, and `system_prompt` combined with custom formatter context

## Test plan

- [x] `test_system_prompt_passed_to_formatter` -- verifies `system_prompt` is set as context, the context-aware template is used, and the prompt appears in formatted output
- [x] `test_no_system_prompt_uses_default_template` -- verifies default behavior is unchanged when no `system_prompt` is provided
- [x] `test_system_prompt_with_custom_formatter_context` -- verifies `system_prompt` is prepended to existing formatter context and template is switched
- [x] All 19 existing tests in `tests/agent/react/` pass
- [x] `test_react_agent_prompts` in `tests/agent/workflow/` passes