### PR TITLE
fix(bm25): retrieve nodes from vector store when docstore is empty

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -178,9 +178,28 @@ class BM25Retriever(BaseRetriever):
         if docstore is not None:
             nodes = cast(List[BaseNode], list(docstore.docs.values()))
 
-        assert nodes is not None, (
-            "Please pass exactly one of index, nodes, or docstore."
-        )
+        # If nodes is empty and an index was provided, try fetching from
+        # the vector store directly.  This covers vector stores that keep
+        # the original text (stores_text=True) such as ChromaDB, where
+        # the docstore is intentionally left empty.
+        if index is not None and (nodes is None or len(nodes) == 0):
+            vector_store = index.vector_store
+            if hasattr(vector_store, "stores_text") and vector_store.stores_text:
+                try:
+                    nodes = cast(
+                        List[BaseNode], vector_store.get_nodes()
+                    )
+                except NotImplementedError:
+                    pass
+
+        if not nodes:
+            raise ValueError(
+                "No nodes found for the BM25 retriever. "
+                "If you are using an external vector store (e.g. ChromaDB) that "
+                "stores text, make sure the collection is not empty. "
+                "Alternatively, pass nodes directly via the `nodes` parameter or "
+                "use `store_nodes_override=True` when building the index."
+            )
 
         return cls(
             nodes=nodes,

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
@@ -1,8 +1,12 @@
 import os
 import shutil
+from unittest.mock import MagicMock
+
+import pytest
 
 from llama_index.core import Document
 from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.schema import TextNode
 from llama_index.retrievers.bm25.base import BM25Retriever
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.vector_stores.types import (
@@ -148,3 +152,66 @@ def test_persist_and_load():
         # Clean up the test_retriever directory
         if os.path.exists("test_retriever"):
             shutil.rmtree("test_retriever")
+
+
+def test_from_defaults_with_vector_store_that_stores_text():
+    """Test BM25Retriever.from_defaults with stores_text vector stores."""
+    # Build text nodes that would normally live in the vector store
+    text_nodes = [
+        TextNode(text="A hero fights an evil force", id_="1"),
+        TextNode(text="A journey toward a specific goal", id_="2"),
+    ]
+
+    # Mock vector store: stores_text=True, get_nodes() returns nodes
+    mock_vector_store = MagicMock()
+    mock_vector_store.stores_text = True
+    mock_vector_store.get_nodes.return_value = text_nodes
+
+    # Mock docstore: empty (no docs stored)
+    mock_docstore = MagicMock()
+    mock_docstore.docs = {}
+
+    # Mock VectorStoreIndex
+    mock_index = MagicMock()
+    mock_index.docstore = mock_docstore
+    mock_index.vector_store = mock_vector_store
+
+    retriever = BM25Retriever.from_defaults(index=mock_index, similarity_top_k=2)
+    results = retriever.retrieve("hero")
+
+    assert len(results) > 0
+    mock_vector_store.get_nodes.assert_called_once()
+
+
+def test_from_defaults_with_empty_vector_store_raises():
+    """Test clear error when both docstore and vector store are empty."""
+    mock_vector_store = MagicMock()
+    mock_vector_store.stores_text = True
+    mock_vector_store.get_nodes.return_value = []
+
+    mock_docstore = MagicMock()
+    mock_docstore.docs = {}
+
+    mock_index = MagicMock()
+    mock_index.docstore = mock_docstore
+    mock_index.vector_store = mock_vector_store
+
+    with pytest.raises(ValueError, match="No nodes found"):
+        BM25Retriever.from_defaults(index=mock_index, similarity_top_k=2)
+
+
+def test_from_defaults_with_vector_store_get_nodes_not_implemented():
+    """Test fallback when vector store does not implement get_nodes."""
+    mock_vector_store = MagicMock()
+    mock_vector_store.stores_text = True
+    mock_vector_store.get_nodes.side_effect = NotImplementedError
+
+    mock_docstore = MagicMock()
+    mock_docstore.docs = {}
+
+    mock_index = MagicMock()
+    mock_index.docstore = mock_docstore
+    mock_index.vector_store = mock_vector_store
+
+    with pytest.raises(ValueError, match="No nodes found"):
+        BM25Retriever.from_defaults(index=mock_index, similarity_top_k=2)


### PR DESCRIPTION
## Summary

Fixes #20601

`BM25Retriever.from_defaults(index=index)` fails with a `ValueError: max() arg is an empty sequence` when backed by vector stores that keep the original text (`stores_text=True`), such as **ChromaDB**, **S3Vectors**, etc.

### Root cause

When a vector store has `stores_text=True`, `VectorStoreIndex._add_nodes_to_index` intentionally skips adding plain `TextNode` objects to the docstore (only `ImageNode`/`IndexNode` are stored). As a result, `index.docstore.docs` returns an empty dict, and BM25Retriever receives an empty corpus which causes `bm25s` to crash.

### Fix

In `BM25Retriever.from_defaults`, when the docstore yields no nodes and the index's vector store has `stores_text=True`, nodes are now fetched directly via `vector_store.get_nodes()`. If `get_nodes()` is not implemented by the specific vector store, the code falls back gracefully. A clear `ValueError` with actionable guidance is raised when no nodes can be found from either source.

This also fixes the same issue reported in #19527 (S3Vectors).

## Test plan

- [x] Added `test_from_defaults_with_vector_store_that_stores_text` - verifies BM25Retriever works when docstore is empty but vector store returns nodes
- [x] Added `test_from_defaults_with_empty_vector_store_raises` - verifies clear error when both sources are empty
- [x] Added `test_from_defaults_with_vector_store_get_nodes_not_implemented` - verifies graceful fallback when `get_nodes()` is not implemented
- [x] All 8 existing + new tests pass
- [x] `ruff check` passes with no errors