### PR TITLE
fix(core): preserve incomplete string values in parse_partial_json

### DIFF
--- a/llama-index-core/llama_index/core/llms/utils.py
+++ b/llama-index-core/llama_index/core/llms/utils.py
@@ -142,6 +142,11 @@ def parse_partial_json(s: str) -> Dict:
     stack = []
     is_inside_string = False
     escaped = False
+    # Track container context so we can tell if an unfinished string is
+    # supposed to be an object key or a value.
+    # - object containers track whether the next string token should be a key.
+    # - array containers never expect keys.
+    context_stack = []
 
     # Process each character in the string one at a time.
     for char in s:
@@ -160,11 +165,25 @@ def parse_partial_json(s: str) -> Dict:
                 escaped = False
             elif char == "{":
                 stack.append("}")
+                context_stack.append({"type": "object", "expecting_key": True})
             elif char == "[":
                 stack.append("]")
+                context_stack.append({"type": "array"})
+            elif char == ":":
+                if (
+                    context_stack
+                    and context_stack[-1]["type"] == "object"
+                    and context_stack[-1]["expecting_key"]
+                ):
+                    context_stack[-1]["expecting_key"] = False
+            elif char == ",":
+                if context_stack and context_stack[-1]["type"] == "object":
+                    context_stack[-1]["expecting_key"] = True
             elif char == "}" or char == "]":
                 if stack and stack[-1] == char:
                     stack.pop()
+                    if context_stack:
+                        context_stack.pop()
                 else:
                     # Mismatched closing character; the input is malformed.
                     raise ValueError("Malformed partial JSON encountered.")
@@ -172,12 +191,22 @@ def parse_partial_json(s: str) -> Dict:
         # Append the processed character to the new string.
         new_s += char
 
-    # If we're still inside a string at the end of processing and no colon was found after the opening quote,
-    # this is an incomplete key - remove it
-    if is_inside_string and '"' in new_s and ":" not in new_s[new_s.rindex('"') :]:
-        new_s = new_s[: new_s.rindex('"')]
-    elif is_inside_string:
-        new_s += '"'
+    # If we ended inside a string, close unfinished string values, but strip
+    # unfinished object keys so we don't create malformed key/value pairs.
+    if is_inside_string:
+        if '"' not in new_s:
+            raise ValueError("Malformed partial JSON encountered.")
+
+        is_incomplete_object_key = (
+            context_stack
+            and context_stack[-1]["type"] == "object"
+            and context_stack[-1]["expecting_key"]
+        )
+
+        if is_incomplete_object_key:
+            new_s = new_s[: new_s.rindex('"')]
+        else:
+            new_s += '"'
 
     # Check if we have an incomplete key-value pair
     new_s = new_s.rstrip()

--- a/llama-index-core/tests/llms/test_utils.py
+++ b/llama-index-core/tests/llms/test_utils.py
@@ -1,0 +1,22 @@
+from llama_index.core.llms.utils import parse_partial_json
+
+
+def test_parse_partial_json_keeps_incomplete_string_value() -> None:
+    """Regression test for #20541: unfinished string values should be preserved."""
+    parsed = parse_partial_json('{"key": "value')
+
+    assert parsed == {"key": "value"}
+
+
+def test_parse_partial_json_drops_incomplete_object_key() -> None:
+    """Unfinished object keys should still be removed to keep partial JSON valid."""
+    parsed = parse_partial_json('{"key": 1, "dangling')
+
+    assert parsed == {"key": 1}
+
+
+def test_parse_partial_json_keeps_incomplete_string_value_in_array() -> None:
+    """Unfinished string values in arrays should be preserved too."""
+    parsed = parse_partial_json('{"items": ["alpha", "bet')
+
+    assert parsed == {"items": ["alpha", "bet"]}


### PR DESCRIPTION
## Summary
- fix `parse_partial_json` so unfinished string **values** are preserved instead of being dropped
- keep existing behavior for unfinished object **keys** by trimming dangling key fragments
- add focused regression tests for object value, object key, and array value partial-string scenarios

## Why
`parse_partial_json('{"key": "value')` currently returns `{"key": None}` because the parser misclassifies the unfinished string as a key fragment. This PR tracks object/array context while scanning so the parser can distinguish incomplete keys from incomplete values.

Closes #20541.

## Testing
- `uv run -- pytest tests/llms/test_utils.py -q`
- `uv run -- pytest tests/llms -q`
- `uv run -- ruff check llama_index/core/llms/utils.py tests/llms/test_utils.py`
