### PR TITLE
fix(lantern,yugabytedb): remove deprecated sessionmaker.close_all() from close()

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/llama_index/vector_stores/lantern/base.py
@@ -240,10 +240,10 @@ class LanternVectorStore(BasePydanticVectorStore):
         if not self._is_initialized:
             return
 
-        self._session.close_all()
-        self._engine.dispose()
-
-        await self._async_engine.dispose()
+        if self._engine:
+            self._engine.dispose()
+        if self._async_engine:
+            await self._async_engine.dispose()
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lantern/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-lantern"
-version = "0.4.1"
+version = "0.4.2"
 description = "llama-index vector_stores lantern integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-yugabytedb/llama_index/vector_stores/yugabytedb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-yugabytedb/llama_index/vector_stores/yugabytedb/base.py
@@ -348,7 +348,6 @@ class YBVectorStore(BasePydanticVectorStore):
         if not self._is_initialized:
             return
 
-        self._session.close_all()
         if self._engine:
             self._engine.dispose()
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-yugabytedb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-yugabytedb/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-yugabytedb"
-version = "0.5.4"
+version = "0.5.5"
 description = "llama-index vector_stores yugabytedb integration"
 authors = [{name = "YugabyteDB", email = "pypi@yugabyte.com"}]
 requires-python = ">=3.9,<4.0"


### PR DESCRIPTION
# Description

Remove `self._session.close_all()` from `LanternVectorStore.close()` and `YBVectorStore.close()`.

`sessionmaker.close_all()` is deprecated in SQLAlchemy and closes **all** sessions globally — not just the ones owned by the calling store instance. This can unexpectedly kill unrelated postgres sessions across the application. The call is also unnecessary since all sessions are already scoped with context managers (`with`).

This is the same fix applied to `PGVectorStore` in #20312, now extended to its Lantern and YugabyteDB forks which were missed.

Also guards `engine.dispose()` calls with `if` checks to match the PGVectorStore pattern and avoid errors when engines are not initialized.

Fixes #19451

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

The change removes a single deprecated method call from each store's `close()`. The fix is identical to what was already merged for PGVectorStore in #20312.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods