### PR TITLE
docs: fix typo 'Finentuning' -> Finetuning in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ While we welcome contributions, we do not recommend to work on these areas:
 
 - Experimental features (`llama-index-experimental`)
 - Packs (`llama-index-packs`)
-- Finentuning (`llama-index-finentuning`)
+- Finetuning (`llama-index-finetuning`)
 - CLI (`llama-index-cli`)
 
 ---


### PR DESCRIPTION
# Description

Fixed a typo in [CONTRIBUTING.md](cci:7://file:///d:/llama_index/CONTRIBUTING.md:0:0-0:0) line 65: `Finentuning` → `Finetuning`.
The actual package on disk is named `llama-index-finetuning`, confirming this is a typo.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the [pyproject.toml](cci:7://file:///d:/llama_index/pyproject.toml:0:0-0:0) and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No (not applicable — this is a documentation typo fix)

## Version Bump?

Did I bump the version in the [pyproject.toml](cci:7://file:///d:/llama_index/pyproject.toml:0:0-0:0) file of the package I am updating?

- [ ] Yes
- [x] No (not applicable — no package code was changed)

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests
  (No code was changed — this is a single-word typo fix in a markdown file)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
