### PR TITLE
docs(cohere): update first basic usage example to chat API

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cohere/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/README.md
@@ -17,10 +17,12 @@ from llama_index.llms.cohere import Cohere
 # Set your API key
 api_key = "Your api key"
 
-# Call complete function
-resp = Cohere(api_key=api_key).complete("Paul Graham is ")
-# Note: Your text contains a trailing whitespace, which has been trimmed to ensure high quality generations.
-print(resp)
+# Initialize the model
+llm = Cohere(api_key=api_key)
+
+# Call chat
+resp = llm.chat("Who is Paul Graham?")
+print(resp.message.content)
 
 # Output
 # an English computer scientist, entrepreneur and investor.


### PR DESCRIPTION
## Summary
- update the first Basic usage example in the Cohere integration README
- switch from one-line `Cohere(...).complete(...)` to explicit `llm = Cohere(...)` and `llm.chat(...)` usage
- print `resp.message.content`, matching current chat response shape

## Why
The first sample was reported as out of date in #20888. This keeps the first quickstart example aligned with the currently recommended Cohere usage pattern.

Closes #20888
