### PR TITLE
fix(core): preserve incomplete string values in parse_partial_json

### DIFF
--- a/llama-index-core/llama_index/core/llms/utils.py
+++ b/llama-index-core/llama_index/core/llms/utils.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional, Union, Dict
 import json
+import re
 
 if TYPE_CHECKING:
     try:
@@ -172,12 +173,15 @@ def parse_partial_json(s: str) -> Dict:
         # Append the processed character to the new string.
         new_s += char
 
-    # If we're still inside a string at the end of processing and no colon was found after the opening quote,
-    # this is an incomplete key - remove it
-    if is_inside_string and '"' in new_s and ":" not in new_s[new_s.rindex('"') :]:
-        new_s = new_s[: new_s.rindex('"')]
-    elif is_inside_string:
-        new_s += '"'
+    # If we're still inside a string at the end of processing, distinguish between:
+    # - an incomplete object key (drop it), and
+    # - an incomplete string value (close it and keep it).
+    if is_inside_string:
+        incomplete_key_match = re.search(r"[{,]\s*\"[^\"]*$", new_s)
+        if incomplete_key_match:
+            new_s = new_s[: incomplete_key_match.start()]
+        else:
+            new_s += '"'
 
     # Check if we have an incomplete key-value pair
     new_s = new_s.rstrip()

--- a/llama-index-core/tests/llms/test_utils.py
+++ b/llama-index-core/tests/llms/test_utils.py
@@ -1,0 +1,13 @@
+from llama_index.core.llms.utils import parse_partial_json
+
+
+def test_parse_partial_json_keeps_incomplete_string_value() -> None:
+    parsed = parse_partial_json('{"query": "hello')
+
+    assert parsed == {"query": "hello"}
+
+
+def test_parse_partial_json_drops_incomplete_key() -> None:
+    parsed = parse_partial_json('{"query": "ok", "incomp')
+
+    assert parsed == {"query": "ok"}


### PR DESCRIPTION
## Summary
- fix `parse_partial_json` so unfinished string **values** are preserved instead of being truncated
- keep behavior for unfinished object keys by dropping incomplete key fragments
- add regression tests for both incomplete string value and incomplete key cases

## Why
`parse_partial_json` currently checks for `:` after the last quote to infer whether the unfinished string is a key. That heuristic drops valid partial values like:

```json
{"query": "hello
```

This patch distinguishes incomplete key fragments via a targeted pattern and preserves partial values.

Related to #20881