### PR TITLE
refactor: deprecate asyncio_module in favour of get_asyncio_module

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -11,7 +11,7 @@ import llama_index.core.instrumentation as instrument
 dispatcher = instrument.get_dispatcher(__name__)
 
 
-def asyncio_module(show_progress: bool = False) -> Any:
+def get_asyncio_module(show_progress: bool = False) -> Any:
     if show_progress:
         from tqdm.asyncio import tqdm_asyncio
 
@@ -20,6 +20,18 @@ def asyncio_module(show_progress: bool = False) -> Any:
         module = asyncio
 
     return module
+
+
+def asyncio_module(show_progress: bool = False) -> Any:
+    import warnings
+
+    warnings.warn(
+        "asyncio_module() is deprecated and will be removed in a future release. "
+        "Use get_asyncio_module() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_asyncio_module(show_progress=show_progress)
 
 
 def asyncio_run(coro: Coroutine) -> Any:
@@ -116,17 +128,6 @@ async def batch_gather(
         if verbose:
             print(f"Completed {len(output)} out of {len(tasks)} tasks")
     return output
-
-
-def get_asyncio_module(show_progress: bool = False) -> Any:
-    if show_progress:
-        from tqdm.asyncio import tqdm_asyncio
-
-        module = tqdm_asyncio
-    else:
-        module = asyncio
-
-    return module
 
 
 DEFAULT_NUM_WORKERS = 4


### PR DESCRIPTION
# Description

[llama-index-core/llama_index/core/async_utils.py](cci:7://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:0:0-0:0) contained two functions
with identical signatures and bodies:

- [asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:24:0-33:58) (line 14)
- [get_asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:13:0-21:17) (line 121)

[get_asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:13:0-21:17) follows Python naming conventions better (verb-prefixed getter) and is the intended canonical version. This PR deprecates [asyncio_module (cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:24:0-33:58)
in favour of [get_asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:13:0-21:17) to eliminate the duplication.

**Changes made:**
- Moved [get_asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:13:0-21:17) above [asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:24:0-33:58) so the deprecated wrapper can safely delegate to it.
- Converted [asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:24:0-33:58) into a thin wrapper that emits a `DeprecationWarning` and calls [get_asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:13:0-21:17).
- Removed the duplicate [get_asyncio_module](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:13:0-21:17) definition from its old position (line 121).

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No (not a new package)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (change is in `llama-index-core`, exempt from version bump requirement)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
      (intentionally introduces a `DeprecationWarning` on [asyncio_module()](cci:1://file:///d:/llama_index/llama-index-core/llama_index/core/async_utils.py:24:0-33:58)
       to signal its deprecation in favour of `get_asyncio_module()`)

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
