### PR TITLE
fix(core): partial-failure handling in SubQuestionQueryEngine

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/sub_question_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/sub_question_query_engine.py
@@ -242,8 +242,11 @@ class SubQuestionQueryEngine(BaseQueryEngine):
                 event.on_end(payload={EventPayload.SUB_QUESTION: qa_pair})
 
             return qa_pair
-        except ValueError:
-            logger.warning(f"[{sub_q.tool_name}] Failed to run {question}")
+        except Exception:
+            logger.warning(
+                f"[{sub_q.tool_name}] Failed to run {question}",
+                exc_info=True,
+            )
             return None
 
     def _query_subq(
@@ -273,6 +276,9 @@ class SubQuestionQueryEngine(BaseQueryEngine):
                 event.on_end(payload={EventPayload.SUB_QUESTION: qa_pair})
 
             return qa_pair
-        except ValueError:
-            logger.warning(f"[{sub_q.tool_name}] Failed to run {question}")
+        except Exception:
+            logger.warning(
+                f"[{sub_q.tool_name}] Failed to run {question}",
+                exc_info=True,
+            )
             return None

--- a/llama-index-core/tests/query_engine/test_sub_question_query_engine.py
+++ b/llama-index-core/tests/query_engine/test_sub_question_query_engine.py
@@ -1,0 +1,106 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llama_index.core.base.response.schema import Response
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core.question_gen.types import SubQuestion
+from llama_index.core.query_engine.sub_question_query_engine import (
+    SubQuestionQueryEngine,
+)
+from llama_index.core.schema import QueryBundle
+from llama_index.core.tools import QueryEngineTool, ToolMetadata
+
+
+def _make_tool(name: str, raises=None):
+    engine = MagicMock()
+    engine.callback_manager = CallbackManager([])
+    resp = Response(response=f"answer from {name}", source_nodes=[])
+    if raises:
+        engine.query.side_effect = raises
+        engine.aquery = AsyncMock(side_effect=raises)
+    else:
+        engine.query.return_value = resp
+        engine.aquery = AsyncMock(return_value=resp)
+    return QueryEngineTool(
+        query_engine=engine,
+        metadata=ToolMetadata(name=name, description=name),
+    )
+
+
+def _make_components():
+    tools = [
+        _make_tool("good_engine"),
+        _make_tool("bad_engine", raises=RuntimeError("API rate limit exceeded")),
+    ]
+    sub_questions = [
+        SubQuestion(sub_question="q1", tool_name="good_engine"),
+        SubQuestion(sub_question="q2", tool_name="bad_engine"),
+    ]
+    question_gen = MagicMock()
+    question_gen.generate.return_value = sub_questions
+    question_gen.agenerate = AsyncMock(return_value=sub_questions)
+
+    synth = MagicMock()
+    synth.synthesize.return_value = Response(response="final")
+    synth.asynthesize = AsyncMock(return_value=Response(response="final"))
+
+    return tools, question_gen, synth
+
+
+def test_partial_failure_sync():
+    """use_async=False: RuntimeError from one engine should not crash the query."""
+    tools, question_gen, synth = _make_components()
+    engine = SubQuestionQueryEngine(
+        question_gen=question_gen,
+        response_synthesizer=synth,
+        query_engine_tools=tools,
+        use_async=False,
+        verbose=False,
+    )
+
+    response = engine.query(QueryBundle(query_str="compare sources"))
+
+    assert str(response) == "final"
+    tools[0].query_engine.query.assert_called_once()
+    tools[1].query_engine.query.assert_called_once()
+    assert len(synth.synthesize.call_args.kwargs["nodes"]) == 1
+
+
+def test_partial_failure_sync_use_async():
+    """use_async=True via run_async_tasks: RuntimeError should not crash the query."""
+    tools, question_gen, synth = _make_components()
+    engine = SubQuestionQueryEngine(
+        question_gen=question_gen,
+        response_synthesizer=synth,
+        query_engine_tools=tools,
+        use_async=True,
+        verbose=False,
+    )
+
+    response = engine.query(QueryBundle(query_str="compare sources"))
+
+    assert str(response) == "final"
+    tools[0].query_engine.aquery.assert_awaited_once()
+    tools[1].query_engine.aquery.assert_awaited_once()
+    assert len(synth.synthesize.call_args.kwargs["nodes"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_aquery():
+    """_aquery via asyncio.gather: RuntimeError should not crash the query."""
+    tools, question_gen, synth = _make_components()
+    engine = SubQuestionQueryEngine(
+        question_gen=question_gen,
+        response_synthesizer=synth,
+        query_engine_tools=tools,
+        use_async=True,
+        verbose=False,
+    )
+
+    response = await engine.aquery(QueryBundle(query_str="compare sources"))
+
+    assert str(response) == "final"
+    tools[0].query_engine.aquery.assert_awaited_once()
+    tools[1].query_engine.aquery.assert_awaited_once()
+    assert len(synth.asynthesize.call_args.kwargs["nodes"]) == 1


### PR DESCRIPTION
# Description

Fixes #20904

Broadened to `except Exception` with `exc_info=True` so failed sub-questions are logged and skipped, allowing the remaining results to be synthesized. Also added tests covering all three execution paths (sync, sync with `use_async=True`, and fully async) to make sure that a failing sub-question is skipped and does not crash the overall query.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
