### PR TITLE
feat(seltz): update Seltz integration to SDK 0.2.0

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-seltz/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-seltz/README.md
@@ -35,6 +35,8 @@ await agent.run("What are the latest developments in AI reasoning?")
 
 - `query` (str): The search query text.
 - `max_documents` (int, optional): Maximum number of documents to return (default: 10).
+- `context` (str, optional): Additional context to refine search results.
+- `profile` (str, optional): Profile to customize search behavior.
 
 ### Example
 

--- a/llama-index-integrations/tools/llama-index-tools-seltz/llama_index/tools/seltz/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-seltz/llama_index/tools/seltz/base.py
@@ -27,20 +27,30 @@ class SeltzToolSpec(BaseToolSpec):
         """
         self.client = Seltz(api_key=api_key)
 
-    def search(self, query: str, max_documents: Optional[int] = 10) -> List[Document]:
+    def search(
+        self,
+        query: str,
+        max_documents: Optional[int] = 10,
+        context: Optional[str] = None,
+        profile: Optional[str] = None,
+    ) -> List[Document]:
         """
         Search the web using Seltz and return relevant documents with sources.
 
         Args:
             query: The search query text.
             max_documents: Maximum number of documents to return (default: 10).
+            context: Optional context to refine search results.
+            profile: Optional profile to customize search behavior.
 
         Returns:
             A list of Document objects containing web content and source URLs.
 
         """
         includes = Includes(max_documents=max_documents) if max_documents else None
-        response = self.client.search(query, includes=includes)
+        response = self.client.search(
+            query, includes=includes, context=context, profile=profile
+        )
         return [
             Document(text=doc.content or "", metadata={"url": doc.url or ""})
             for doc in response.documents

--- a/llama-index-integrations/tools/llama-index-tools-seltz/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-seltz/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-seltz"
-version = "0.1.0"
+version = "0.2.0"
 description = "llama-index tools seltz integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"
@@ -34,7 +34,7 @@ readme = "README.md"
 license = "MIT"
 maintainers = [{name = "WilliamEspegren"}]
 dependencies = [
-    "seltz>=0.1.4",
+    "seltz>=0.2.0",
     "llama-index-core>=0.13.0,<0.15",
 ]
 

--- a/llama-index-integrations/tools/llama-index-tools-seltz/tests/test_tools_seltz.py
+++ b/llama-index-integrations/tools/llama-index-tools-seltz/tests/test_tools_seltz.py
@@ -49,7 +49,9 @@ def test_search(mock_seltz, mock_includes_class):
     results = tool.search("test query", max_documents=5)
 
     mock_includes_class.assert_called_once_with(max_documents=5)
-    mock_client.search.assert_called_once_with("test query", includes=mock_includes)
+    mock_client.search.assert_called_once_with(
+        "test query", includes=mock_includes, context=None, profile=None
+    )
 
     assert len(results) == 2
     assert all(isinstance(doc, Document) for doc in results)
@@ -57,6 +59,35 @@ def test_search(mock_seltz, mock_includes_class):
     assert results[0].metadata["url"] == "https://example1.com"
     assert results[1].text == "Result content 2"
     assert results[1].metadata["url"] == "https://example2.com"
+
+
+@patch("llama_index.tools.seltz.base.Includes")
+@patch("llama_index.tools.seltz.base.Seltz")
+def test_search_with_context_and_profile(mock_seltz, mock_includes_class):
+    mock_response = Mock()
+    mock_response.documents = []
+
+    mock_client = Mock()
+    mock_client.search.return_value = mock_response
+    mock_seltz.return_value = mock_client
+
+    mock_includes = Mock()
+    mock_includes_class.return_value = mock_includes
+
+    tool = SeltzToolSpec(api_key="test-key")
+    tool.search(
+        "test query",
+        max_documents=5,
+        context="extra context",
+        profile="my-profile",
+    )
+
+    mock_client.search.assert_called_once_with(
+        "test query",
+        includes=mock_includes,
+        context="extra context",
+        profile="my-profile",
+    )
 
 
 @patch("llama_index.tools.seltz.base.Includes")
@@ -76,7 +107,9 @@ def test_search_default_max_documents(mock_seltz, mock_includes_class):
     tool.search("test query")
 
     mock_includes_class.assert_called_once_with(max_documents=10)
-    mock_client.search.assert_called_once_with("test query", includes=mock_includes)
+    mock_client.search.assert_called_once_with(
+        "test query", includes=mock_includes, context=None, profile=None
+    )
 
 
 @patch("llama_index.tools.seltz.base.Seltz")

--- a/llama-index-integrations/tools/llama-index-tools-seltz/uv.lock
+++ b/llama-index-integrations/tools/llama-index-tools-seltz/uv.lock
@@ -2439,7 +2439,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-tools-seltz"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -2472,7 +2472,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
-    { name = "seltz", specifier = ">=0.1.3" },
+    { name = "seltz", specifier = ">=0.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -4801,15 +4801,15 @@ wheels = [
 
 [[package]]
 name = "seltz"
-version = "0.1.3"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/f3/a81823416850ec97f5d95f330d13e0ca5d0352caa9ebaa65732f4c0ff073/seltz-0.1.3.tar.gz", hash = "sha256:c77f024fe4eb1dc3ce1a439d8cbb72060b2102520c0b99a9d16b1bc738b0dec3", size = 11533, upload-time = "2026-02-03T00:34:11.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/9a/fb73753caabb67f59daabb4eef1dea39c8309161d2ceba325963967e3118/seltz-0.2.0.tar.gz", hash = "sha256:6549ab29507195231af180d0d665f6b90490f1d6cbd8bc2cdba1561139f3a82d", size = 9504, upload-time = "2026-03-04T19:02:23.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/c1/4db9fcfc1102d99b33f0925101b6182ab2f844c671c3d8a98d4b3df96d90/seltz-0.1.3-py3-none-any.whl", hash = "sha256:16a3e576a2fbcc855d139c6b8a9e0a512e5fc171d8b3c0ff97d8580068b1f078", size = 12363, upload-time = "2026-02-03T00:34:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/27/26d7d21f44a559b7a99dce66f61db294b868f1e0f646cd954f751bb63af8/seltz-0.2.0-py3-none-any.whl", hash = "sha256:c0bc5399f48d3284dadf7860e0682e5f013ce0bc14abbd731d4491fb4b6843e5", size = 10223, upload-time = "2026-03-04T19:02:22.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Update the Seltz tool integration to use the new Seltz SDK 0.2.0. The SDK migrated its transport layer from HTTP to gRPC and added new search parameters.

### Changes
- Bump `seltz` dependency from `>=0.1.4` to `>=0.2.0`
- Bump package version from `0.1.0` to `0.2.0`
- Add new optional `context` and `profile` parameters to `search()` method, matching the new SDK capabilities
- Update unit tests to cover new parameters
- Update README to document new parameters
- Regenerate `uv.lock`

## Version Bump?

- [x] Yes

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] 7/7 unit tests pass
- [x] 2/2 integration tests pass against the real Seltz API
- [x] Example notebook executed end-to-end successfully (search + agent)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `ruff check` and `ruff format` with no issues


---

Twitter/X: [@WilliamEspegren](https://x.com/WilliamEspegren)