### PR TITLE
docs: Add llamaindex-soul integration for persistent memory

### DIFF
--- a/docs/src/content/docs/framework/community/integrations.md
+++ b/docs/src/content/docs/framework/community/integrations.md
@@ -43,7 +43,7 @@ for full tracing integrations.
 
 ## Memory and Chat Storage
 
-- [llamaindex-soul](/python/framework/community/integrations/llamaindex_soul) - Markdown-native chat storage with RAG+RLM hybrid retrieval
+- [llamaindex-soul](/python/framework/community/integrations/llamaindex_soul)
 
 ## Storage and Managed Indexes
 

--- a/docs/src/content/docs/framework/community/integrations/llamaindex_soul.md
+++ b/docs/src/content/docs/framework/community/integrations/llamaindex_soul.md
@@ -43,6 +43,11 @@ memory = ChatMemoryBuffer.from_defaults(
 
 # Use with any LlamaIndex agent
 from llama_index.core.agent import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+# Define your tools and LLM
+tools = []  # Add your Tool objects here
+llm = OpenAI(model="gpt-4")
 
 agent = FunctionAgent(tools=tools, llm=llm)
 await agent.run("Hello!", memory=memory)
@@ -88,9 +93,11 @@ memory = ChatMemoryBuffer.from_defaults(
 ```python
 from llamaindex_soul import create_chat_store
 
-# Switch backends easily
+# Choose your backend:
 store = create_chat_store("local")      # File-based
-store = create_chat_store("soulmate")   # Managed cloud
+
+# OR for managed cloud:
+# store = create_chat_store("soulmate", api_key="your-key")
 ```
 
 ## Links


### PR DESCRIPTION
## Summary

This PR adds documentation for [llamaindex-soul](https://pypi.org/project/llamaindex-soul/), a community integration for persistent chat storage with hybrid RAG+RLM retrieval.

## What is llamaindex-soul?

llamaindex-soul provides markdown-native chat storage for LlamaIndex with:

- **Persistent Memory**: Chat history stored in human-readable markdown files
- **RAG + RLM Hybrid Retrieval**: Auto-routes queries to semantic search or exhaustive reasoning
- **Database Schema Intelligence**: Auto-document databases via LLM (soul-schema)
- **Managed Cloud Option**: SoulMate API for zero-infrastructure deployments
- **Git-Versionable**: Memory files you can read, edit, and version control

## Installation

```bash
pip install llamaindex-soul
```

## Quick Start

```python
from llamaindex_soul import SoulChatStore
from llama_index.core.memory import ChatMemoryBuffer

chat_store = SoulChatStore()
memory = ChatMemoryBuffer.from_defaults(
    chat_store=chat_store,
    chat_store_key="user1",
)
```

## Links

- PyPI: https://pypi.org/project/llamaindex-soul/
- GitHub: https://github.com/menonpg/llamaindex-soul
- Blog: https://menonlab-blog-production.up.railway.app/blog/langchain-llamaindex-soul-integrations

## Changes

- Added `docs/src/content/docs/framework/community/integrations/llamaindex_soul.md`
- Added "Memory and Chat Storage" section to `integrations.md`