### PR TITLE
fix: catch all exceptions in SubQuestionQueryEngine sub-question execution

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/sub_question_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/sub_question_query_engine.py
@@ -242,8 +242,8 @@ class SubQuestionQueryEngine(BaseQueryEngine):
                 event.on_end(payload={EventPayload.SUB_QUESTION: qa_pair})
 
             return qa_pair
-        except ValueError:
-            logger.warning(f"[{sub_q.tool_name}] Failed to run {question}")
+        except Exception as e:
+            logger.warning(f"[{sub_q.tool_name}] Failed to run {question}: {e}")
             return None
 
     def _query_subq(
@@ -273,6 +273,6 @@ class SubQuestionQueryEngine(BaseQueryEngine):
                 event.on_end(payload={EventPayload.SUB_QUESTION: qa_pair})
 
             return qa_pair
-        except ValueError:
-            logger.warning(f"[{sub_q.tool_name}] Failed to run {question}")
+        except Exception as e:
+            logger.warning(f"[{sub_q.tool_name}] Failed to run {question}: {e}")
             return None


### PR DESCRIPTION
# Description

`_query_subq` and `_aquery_subq` in `SubQuestionQueryEngine` only caught `ValueError`, but sub-question execution can raise various exceptions (provider API errors, transport errors, timeouts, `KeyError` for invalid tool names, etc.). These uncaught exceptions caused the entire query to fail instead of gracefully skipping the failed sub-question — defeating the partial-failure tolerance that the class is designed for via `filter(None, qa_pairs_all)`.

Widen the catch to `Exception` and include error details in the warning log message.

Fixes #20904

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No