### PR TITLE
fix: add bounds check to prevent infinite loop in ChatMemoryBuffer.get()

### DIFF
--- a/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
@@ -127,7 +127,7 @@ class ChatMemoryBuffer(BaseChatStoreMemory):
 
         while token_count > self.token_limit and message_count > 1:
             message_count -= 1
-            while chat_history[-message_count].role in (
+            while message_count > 1 and chat_history[-message_count].role in (
                 MessageRole.TOOL,
                 MessageRole.ASSISTANT,
             ):


### PR DESCRIPTION
## Summary

- Fixes a potential infinite loop in `ChatMemoryBuffer.get()` where the inner `while` loop that skips `TOOL`/`ASSISTANT` messages has no bounds check on `message_count`.
- If all messages in the chat history have `TOOL` or `ASSISTANT` role, `message_count` decrements past 0 and Python's negative indexing causes the list access to wrap around, creating an infinite loop.
- Adds `message_count > 1` as a guard condition to the inner `while` loop, consistent with the outer loop's bounds check.

## Reproduction

```python
from llama_index.core.memory.chat_memory_buffer import ChatMemoryBuffer
from llama_index.core.base.llms.types import ChatMessage, MessageRole

# Create a buffer with only ASSISTANT and TOOL messages
buf = ChatMemoryBuffer.from_defaults(
    chat_history=[
        ChatMessage(role=MessageRole.ASSISTANT, content="hi"),
        ChatMessage(role=MessageRole.TOOL, content="result"),
        ChatMessage(role=MessageRole.ASSISTANT, content="done"),
    ],
    token_limit=1,  # force trimming
)
buf.get()  # hangs forever
```

## Fix

Added `message_count > 1` guard to the inner while condition (line 130):

```python
# Before
while chat_history[-message_count].role in (MessageRole.TOOL, MessageRole.ASSISTANT):
    message_count -= 1

# After
while message_count > 1 and chat_history[-message_count].role in (MessageRole.TOOL, MessageRole.ASSISTANT):
    message_count -= 1
```

Signed-off-by: JiangNan <1394485448@qq.com>