### PR TITLE
fix: ensure streaming flag reset on exception in CondenseQuestionChatEngine

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -196,11 +196,12 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             self._query_engine._response_synthesizer._streaming = False
 
         # Query with standalone question
-        query_response = self._query_engine.query(condensed_question)
-
-        # NOTE: reset streaming flag
-        if isinstance(self._query_engine, RetrieverQueryEngine):
-            self._query_engine._response_synthesizer._streaming = is_streaming
+        try:
+            query_response = self._query_engine.query(condensed_question)
+        finally:
+            # NOTE: reset streaming flag
+            if isinstance(self._query_engine, RetrieverQueryEngine):
+                self._query_engine._response_synthesizer._streaming = is_streaming
 
         tool_output = self._get_tool_output_from_response(
             condensed_question, query_response
@@ -240,11 +241,12 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             self._query_engine._response_synthesizer._streaming = True
 
         # Query with standalone question
-        query_response = self._query_engine.query(condensed_question)
-
-        # NOTE: reset streaming flag
-        if isinstance(self._query_engine, RetrieverQueryEngine):
-            self._query_engine._response_synthesizer._streaming = is_streaming
+        try:
+            query_response = self._query_engine.query(condensed_question)
+        finally:
+            # NOTE: reset streaming flag
+            if isinstance(self._query_engine, RetrieverQueryEngine):
+                self._query_engine._response_synthesizer._streaming = is_streaming
 
         tool_output = self._get_tool_output_from_response(
             condensed_question, query_response
@@ -296,11 +298,12 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             self._query_engine._response_synthesizer._streaming = False
 
         # Query with standalone question
-        query_response = await self._query_engine.aquery(condensed_question)
-
-        # NOTE: reset streaming flag
-        if isinstance(self._query_engine, RetrieverQueryEngine):
-            self._query_engine._response_synthesizer._streaming = is_streaming
+        try:
+            query_response = await self._query_engine.aquery(condensed_question)
+        finally:
+            # NOTE: reset streaming flag
+            if isinstance(self._query_engine, RetrieverQueryEngine):
+                self._query_engine._response_synthesizer._streaming = is_streaming
 
         tool_output = self._get_tool_output_from_response(
             condensed_question, query_response
@@ -340,11 +343,12 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             self._query_engine._response_synthesizer._streaming = True
 
         # Query with standalone question
-        query_response = await self._query_engine.aquery(condensed_question)
-
-        # NOTE: reset streaming flag
-        if isinstance(self._query_engine, RetrieverQueryEngine):
-            self._query_engine._response_synthesizer._streaming = is_streaming
+        try:
+            query_response = await self._query_engine.aquery(condensed_question)
+        finally:
+            # NOTE: reset streaming flag
+            if isinstance(self._query_engine, RetrieverQueryEngine):
+                self._query_engine._response_synthesizer._streaming = is_streaming
 
         tool_output = self._get_tool_output_from_response(
             condensed_question, query_response


### PR DESCRIPTION
## Summary

- Fixes a bug in `CondenseQuestionChatEngine` where the query engine's `_streaming` flag is not restored if `query()` or `aquery()` raises an exception.
- Affects all four query methods: `chat()`, `stream_chat()`, `achat()`, and `astream_chat()`.
- After an exception, the query engine is left with an incorrect streaming flag value, causing subsequent calls to behave incorrectly (e.g., returning streaming responses when non-streaming was expected, or vice versa).
- Wraps each query call in a `try/finally` block to guarantee the flag is always reset.

## Reproduction

```python
# If query_engine.query() raises an exception in stream_chat(),
# _streaming remains True for all subsequent calls
engine = CondenseQuestionChatEngine.from_defaults(query_engine=buggy_engine)
try:
    engine.stream_chat("hello")  # raises, _streaming stuck as True
except Exception:
    pass
engine.chat("hello")  # now gets streaming response unexpectedly
```

## Fix

Wrapped the query call and flag reset in `try/finally` in all four methods:

```python
# Before
self._query_engine._response_synthesizer._streaming = True
query_response = self._query_engine.query(condensed_question)
if isinstance(self._query_engine, RetrieverQueryEngine):
    self._query_engine._response_synthesizer._streaming = is_streaming

# After
self._query_engine._response_synthesizer._streaming = True
try:
    query_response = self._query_engine.query(condensed_question)
finally:
    if isinstance(self._query_engine, RetrieverQueryEngine):
        self._query_engine._response_synthesizer._streaming = is_streaming
```

Signed-off-by: JiangNan <1394485448@qq.com>