### PR TITLE
fix: call LLM directly when retriever returns 0 nodes instead of Empty Response

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -251,6 +251,27 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             refine_function_mappings=self._context_refine_prompt_template.function_mappings,
         )
 
+    def _build_llm_messages(
+        self, message: str, chat_history: List[ChatMessage]
+    ) -> List[ChatMessage]:
+        """Build messages for direct LLM call when no context nodes are found.
+
+        Constructs a message list with the system prompt and chat history,
+        allowing the LLM to respond using its base knowledge.
+        """
+        system_prompt = self._system_prompt or ""
+        messages: List[ChatMessage] = []
+        if system_prompt:
+            messages.append(
+                ChatMessage(
+                    content=system_prompt,
+                    role=self._llm.metadata.system_role,
+                )
+            )
+        messages.extend(chat_history)
+        messages.append(ChatMessage(content=message, role=MessageRole.USER))
+        return messages
+
     def _run_c3(
         self,
         message: str,
@@ -323,17 +344,27 @@ class CondensePlusContextChatEngine(BaseChatEngine):
     ) -> AgentChatResponse:
         synthesizer, context_source, context_nodes = self._run_c3(message, chat_history)
 
-        response = synthesizer.synthesize(message, context_nodes)
+        if len(context_nodes) == 0:
+            # When no nodes are found, call the LLM directly instead of
+            # returning "Empty Response". This lets the LLM answer using
+            # its base knowledge and the system prompt / chat history.
+            chat_history_for_llm = self._memory.get(input=message)
+            messages = self._build_llm_messages(message, chat_history_for_llm)
+            llm_response = self._llm.chat(messages)
+            response_text = llm_response.message.content or ""
+        else:
+            response = synthesizer.synthesize(message, context_nodes)
+            response_text = str(response)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
-            content=str(response), role=MessageRole.ASSISTANT
+            content=response_text, role=MessageRole.ASSISTANT
         )
         self._memory.put(user_message)
         self._memory.put(assistant_message)
 
         return AgentChatResponse(
-            response=str(response),
+            response=response_text,
             sources=[context_source],
             source_nodes=context_nodes,
         )
@@ -345,6 +376,35 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         synthesizer, context_source, context_nodes = self._run_c3(
             message, chat_history, streaming=True
         )
+
+        if len(context_nodes) == 0:
+            # When no nodes are found, stream from the LLM directly instead
+            # of returning "Empty Response".
+            chat_history_for_llm = self._memory.get(input=message)
+            messages = self._build_llm_messages(message, chat_history_for_llm)
+            llm_stream = self._llm.stream_chat(messages)
+
+            def wrapped_gen_from_llm(
+                llm_stream: ChatResponseGen,
+            ) -> ChatResponseGen:
+                full_response = ""
+                for chat_response in llm_stream:
+                    full_response = chat_response.message.content or ""
+                    yield chat_response
+
+                user_message = ChatMessage(content=message, role=MessageRole.USER)
+                assistant_message = ChatMessage(
+                    content=full_response, role=MessageRole.ASSISTANT
+                )
+                self._memory.put(user_message)
+                self._memory.put(assistant_message)
+
+            return StreamingAgentChatResponse(
+                chat_stream=wrapped_gen_from_llm(llm_stream),
+                sources=[context_source],
+                source_nodes=context_nodes,
+                is_writing_to_memory=False,
+            )
 
         response = synthesizer.synthesize(message, context_nodes)
         assert isinstance(response, StreamingResponse)
@@ -382,17 +442,26 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history
         )
 
-        response = await synthesizer.asynthesize(message, context_nodes)
+        if len(context_nodes) == 0:
+            # When no nodes are found, call the LLM directly instead of
+            # returning "Empty Response".
+            chat_history_for_llm = await self._memory.aget(input=message)
+            messages = self._build_llm_messages(message, chat_history_for_llm)
+            llm_response = await self._llm.achat(messages)
+            response_text = llm_response.message.content or ""
+        else:
+            response = await synthesizer.asynthesize(message, context_nodes)
+            response_text = str(response)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
-            content=str(response), role=MessageRole.ASSISTANT
+            content=response_text, role=MessageRole.ASSISTANT
         )
         await self._memory.aput(user_message)
         await self._memory.aput(assistant_message)
 
         return AgentChatResponse(
-            response=str(response),
+            response=response_text,
             sources=[context_source],
             source_nodes=context_nodes,
         )
@@ -404,6 +473,35 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         synthesizer, context_source, context_nodes = await self._arun_c3(
             message, chat_history, streaming=True
         )
+
+        if len(context_nodes) == 0:
+            # When no nodes are found, stream from the LLM directly instead
+            # of returning "Empty Response".
+            chat_history_for_llm = await self._memory.aget(input=message)
+            messages = self._build_llm_messages(message, chat_history_for_llm)
+            llm_stream = await self._llm.astream_chat(messages)
+
+            async def wrapped_gen_from_llm(
+                llm_stream: ChatResponseAsyncGen,
+            ) -> ChatResponseAsyncGen:
+                full_response = ""
+                async for chat_response in llm_stream:
+                    full_response = chat_response.message.content or ""
+                    yield chat_response
+
+                user_message = ChatMessage(content=message, role=MessageRole.USER)
+                assistant_message = ChatMessage(
+                    content=full_response, role=MessageRole.ASSISTANT
+                )
+                await self._memory.aput(user_message)
+                await self._memory.aput(assistant_message)
+
+            return StreamingAgentChatResponse(
+                achat_stream=wrapped_gen_from_llm(llm_stream),
+                sources=[context_source],
+                source_nodes=context_nodes,
+                is_writing_to_memory=False,
+            )
 
         response = await synthesizer.asynthesize(message, context_nodes)
         assert isinstance(response, AsyncStreamingResponse)


### PR DESCRIPTION
## Description

Fixes #20894.

When `CondensePlusContextChatEngine`'s retriever returns 0 nodes (e.g., empty vector store, strict metadata filters), `BaseSynthesizer.synthesize()` / `asynthesize()` short-circuits with a hardcoded `"Empty Response"` string without ever calling the LLM. This is problematic for chat engines where the LLM should still respond conversationally using its base knowledge and the system prompt.

This is especially painful in multi-tenant RAG systems where a new user with an empty vector space expects the AI to still interact conversationally.

## Fix

When no context nodes are retrieved, `CondensePlusContextChatEngine` now bypasses the synthesizer and calls the LLM directly with the system prompt, chat history, and user message. This is handled consistently in all 4 chat methods:

- `chat()` — calls `self._llm.chat(messages)`
- `stream_chat()` — calls `self._llm.stream_chat(messages)`
- `achat()` — calls `self._llm.achat(messages)`
- `astream_chat()` — calls `self._llm.astream_chat(messages)`

A shared `_build_llm_messages()` helper constructs the message list (system prompt + chat history + user message) for all cases.

## Why this approach

- **Targeted**: Only changes the chat engine, not `BaseSynthesizer` (which may intentionally skip LLM calls for other use cases like pure QA)
- **Consistent with `MultiModalCondensePlusContextChatEngine`**: That engine already calls the LLM directly and never goes through `BaseSynthesizer`, so it never had this bug
- **No new dependencies or parameters**: No configuration needed — a chat engine should always produce a conversational response
- **Memory is still updated**: The user and assistant messages are written to memory in all code paths

## Before / After

| Scenario | Before | After |
|---|---|---|
| Retriever returns 0 nodes (sync) | Returns `"Empty Response"` instantly, no LLM call | LLM responds using base knowledge + system prompt |
| Retriever returns 0 nodes (streaming) | Yields `"Empty Response"` token instantly | Streams LLM response normally |
| Retriever returns nodes | Normal behavior (unchanged) | Normal behavior (unchanged) |

**AI Disclosure:** This PR was authored by Claude (AI), directed by @MaxwellCalkin.