### PR TITLE
fix(bedrock-converse): use MIME-type for document format; deduplicate document names

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -318,9 +318,8 @@ def _content_block_to_bedrock_format(
         else:
             data = base64.b64decode(block.data)
         title = block.title
-        # NOTE: At the time of writing, "txt" format works for all file types
-        # The API then infers the format from the file type based on the bytes
-        return {"document": {"format": "txt", "name": title, "source": {"bytes": data}}}
+        fmt = __get_doc_format_from_document_mimetype(block.document_mimetype)
+        return {"document": {"format": fmt, "name": title, "source": {"bytes": data}}}
     elif isinstance(block, ImageBlock):
         if role != MessageRole.USER:
             logger.warning(
@@ -363,6 +362,45 @@ def _content_block_to_bedrock_format(
     else:
         logger.warning(f"Unsupported block type: {type(block)}")
         return None
+
+
+# Maps MIME types to Bedrock DocumentFormat enum values.
+# The canonical list of valid format strings lives in the botocore service model:
+#   botocore/data/bedrock-runtime/2023-09-30/service-2.json -> DocumentFormat.enum
+# If AWS adds a new supported format, add the corresponding MIME type here.
+_MIME_TO_BEDROCK_DOC_FORMAT: Dict[str, str] = {
+    "application/pdf": "pdf",
+    "text/csv": "csv",
+    "application/msword": "doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    "text/html": "html",
+    "text/plain": "txt",
+    "text/markdown": "md",
+}
+
+
+def __get_doc_format_from_document_mimetype(document_mimetype: Optional[str]) -> str:
+    """
+    Get the Bedrock document format string from the document mimetype.
+
+    Falls back to "txt" for unknown or missing mimetypes, which allows Bedrock
+    to infer the format from the file bytes.  This fallback also preserves the
+    workaround for scanned (image-only) PDFs where Bedrock may detect PLAIN_TEXT
+    even when the bytes are a valid PDF (see https://github.com/run-llama/llama_index/issues/18789).
+    """
+    if document_mimetype is None:
+        return "txt"
+    fmt = _MIME_TO_BEDROCK_DOC_FORMAT.get(document_mimetype)
+    if fmt is None:
+        logger.warning(
+            f"Unsupported document mimetype: {document_mimetype}. "
+            f"Bedrock Converse API supports: {', '.join(_MIME_TO_BEDROCK_DOC_FORMAT.keys())}. "
+            "Defaulting to txt."
+        )
+        return "txt"
+    return fmt
 
 
 def __get_img_format_from_image_mimetype(image_mimetype: str) -> str:
@@ -516,7 +554,24 @@ def messages_to_converse_messages(
             )
     if current_system_prompt != "":
         system_prompt.append({"text": current_system_prompt.strip()})
-    return __merge_common_role_msgs(converse_messages), system_prompt
+
+    merged = __merge_common_role_msgs(converse_messages)
+
+    # Bedrock Converse API requires document names to be unique within a request.
+    # DocumentBlock defaults title to "input_document" when not set, so multiple
+    # documents without explicit titles will collide.  Deduplicate by appending
+    # an incrementing suffix to any repeated names.
+    seen_doc_names: Dict[str, int] = {}
+    for block in (b for msg in merged for b in msg.get("content", [])):
+        if "document" in block:
+            name = block["document"]["name"]
+            if name in seen_doc_names:
+                seen_doc_names[name] += 1
+                block["document"]["name"] = f"{name}_{seen_doc_names[name]}"
+            else:
+                seen_doc_names[name] = 0
+
+    return merged, system_prompt
 
 
 def tools_to_converse_tools(

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.13.0"
+version = "0.13.1"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
@@ -1,3 +1,4 @@
+import base64
 from io import BytesIO
 from typing import Literal
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ from llama_index.core.base.llms.types import (
     CacheControl,
     CachePoint,
     ChatMessage,
+    DocumentBlock,
     ImageBlock,
     MessageRole,
     TextBlock,
@@ -18,6 +20,7 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.bedrock_converse.utils import (
     ThinkingDict,
+    __get_doc_format_from_document_mimetype,
     __get_img_format_from_image_mimetype,
     _content_block_to_bedrock_format,
     converse_with_retry,
@@ -765,3 +768,105 @@ def test_thinking_dict_adaptive_no_budget():
     td: ThinkingDict = {"type": "adaptive"}
     assert td["type"] == "adaptive"
     assert "budget_tokens" not in td
+
+
+# ---------------------------------------------------------------------------
+# DocumentBlock format mapping tests
+# ---------------------------------------------------------------------------
+
+_PDF_DATA = base64.b64encode(b"fake-pdf-bytes")
+
+
+def test_get_doc_format_pdf():
+    assert __get_doc_format_from_document_mimetype("application/pdf") == "pdf"
+
+
+def test_get_doc_format_csv():
+    assert __get_doc_format_from_document_mimetype("text/csv") == "csv"
+
+
+def test_get_doc_format_docx():
+    assert (
+        __get_doc_format_from_document_mimetype(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        == "docx"
+    )
+
+
+def test_get_doc_format_unknown_mimetype_falls_back_to_txt(caplog):
+    result = __get_doc_format_from_document_mimetype("application/octet-stream")
+    assert result == "txt"
+    assert "Unsupported document mimetype" in caplog.text
+
+
+def test_get_doc_format_none_mimetype_falls_back_to_txt():
+    """No mimetype -> 'txt', preserving the scanned-PDF workaround from #18789."""
+    assert __get_doc_format_from_document_mimetype(None) == "txt"
+
+
+def test_content_block_to_bedrock_format_document_pdf():
+    """DocumentBlock with PDF mimetype should produce format='pdf', not 'txt'."""
+    block = DocumentBlock(data=_PDF_DATA, document_mimetype="application/pdf", title="my-doc")
+    result = _content_block_to_bedrock_format(block, MessageRole.USER)
+    assert result is not None
+    assert result["document"]["format"] == "pdf"
+    assert result["document"]["name"] == "my-doc"
+
+
+def test_content_block_to_bedrock_format_document_no_mimetype():
+    """DocumentBlock without mimetype should fall back to format='txt'."""
+    block = DocumentBlock(data=_PDF_DATA, title="my-doc")
+    # Clear the mimetype that _guess_mimetype() may have set
+    block.document_mimetype = None
+    result = _content_block_to_bedrock_format(block, MessageRole.USER)
+    assert result is not None
+    assert result["document"]["format"] == "txt"
+
+
+# ---------------------------------------------------------------------------
+# Document name deduplication tests
+# ---------------------------------------------------------------------------
+
+
+def test_messages_to_converse_messages_duplicate_document_names_deduplicated():
+    """Two DocumentBlocks with the same title get distinct names after deduplication."""
+    doc_data = base64.b64encode(b"content")
+    messages = [
+        ChatMessage(
+            role=MessageRole.USER,
+            blocks=[
+                DocumentBlock(data=doc_data, title="input_document", document_mimetype="application/pdf"),
+                DocumentBlock(data=doc_data, title="input_document", document_mimetype="application/pdf"),
+            ],
+        )
+    ]
+
+    converse_messages, _ = messages_to_converse_messages(messages)
+
+    doc_blocks = [b for b in converse_messages[0]["content"] if "document" in b]
+    assert len(doc_blocks) == 2
+    names = {b["document"]["name"] for b in doc_blocks}
+    assert len(names) == 2, f"Expected distinct names, got: {names}"
+
+
+def test_messages_to_converse_messages_explicit_unique_titles_unchanged():
+    """DocumentBlocks with already-distinct titles are not modified."""
+    doc_data = base64.b64encode(b"content")
+    messages = [
+        ChatMessage(
+            role=MessageRole.USER,
+            blocks=[
+                DocumentBlock(data=doc_data, title="doc-alpha", document_mimetype="application/pdf"),
+                DocumentBlock(data=doc_data, title="doc-beta", document_mimetype="application/pdf"),
+            ],
+        )
+    ]
+
+    converse_messages, _ = messages_to_converse_messages(messages)
+
+    doc_blocks = [b for b in converse_messages[0]["content"] if "document" in b]
+    assert len(doc_blocks) == 2
+    names = [b["document"]["name"] for b in doc_blocks]
+    assert "doc-alpha" in names
+    assert "doc-beta" in names


### PR DESCRIPTION
## Description

Fixes two bugs in `_content_block_to_bedrock_format` for `DocumentBlock` in the Bedrock Converse adapter. These are both newly discovered bugs with no existing issue; this PR serves as the bug report and fix.

### Bug 1: Hardcoded `"txt"` format breaks multi-document requests

PR #18791 set `format: "txt"` for all documents so Bedrock would infer the real type from the raw bytes. This works for a **single** document but silently breaks **multi-document** requests: when multiple documents are all labelled `"txt"`, Bedrock cannot distinguish between them and fails to surface the document content to the model.

Fix: add a `__get_doc_format_from_document_mimetype` helper (following the existing pattern of `__get_img_format_from_image_mimetype`) that maps `document_mimetype` to the correct Bedrock format string (`pdf`, `csv`, `docx`, etc.). The helper falls back to `"txt"` for unknown or missing mimetypes, **preserving** the original workaround for scanned PDFs from #18789.

### Bug 2: Default title `"input_document"` causes duplicate-name `ValidationException`

`DocumentBlock` defaults `title` to `"input_document"` when not explicitly set. Bedrock's Converse API requires document names to be unique within a single request, so sending multiple `DocumentBlock` instances without explicit titles raises a `ValidationException`.

Fix: after `__merge_common_role_msgs`, add a post-processing pass over all document blocks in the merged messages that appends an incrementing suffix (`_1`, `_2`, …) to any repeated names.

## New Package?

- N/A (modifying existing package)

## Version Bump?

- [x] I have bumped the version in the `pyproject.toml` file (0.13.0 → 0.13.1)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added 9 new unit tests to `tests/test_bedrock_converse_utils.py`:

- `test_get_doc_format_pdf` — `application/pdf` → `"pdf"`
- `test_get_doc_format_csv` — `text/csv` → `"csv"`
- `test_get_doc_format_docx` — docx MIME → `"docx"`
- `test_get_doc_format_unknown_mimetype_falls_back_to_txt` — unknown MIME → `"txt"` with warning
- `test_get_doc_format_none_mimetype_falls_back_to_txt` — `None` → `"txt"` (preserves scanned-PDF workaround)
- `test_content_block_to_bedrock_format_document_pdf` — end-to-end: PDF block produces `format: "pdf"`
- `test_content_block_to_bedrock_format_document_no_mimetype` — no mimetype produces `format: "txt"`
- `test_messages_to_converse_messages_duplicate_document_names_deduplicated` — two default-titled docs get distinct names
- `test_messages_to_converse_messages_explicit_unique_titles_unchanged` — distinct explicit titles are not modified

All 51 tests pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand areas of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `ruff check` on changed files (1 pre-existing `PYI034` in the test fixture, not introduced by this PR)