### PR TITLE
perf(redis-chat-store): Use Pydantic directly for ChatMessage serialization & deserialization

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/llama_index/storage/chat_store/redis/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/llama_index/storage/chat_store/redis/base.py
@@ -1,33 +1,19 @@
-import json
+import asyncio
 import logging
 import sys
-import asyncio
-from typing import Any, List, Optional, Union, Tuple
+from typing import Any, List, Optional, Tuple, Union
 from urllib.parse import urlparse
-
-import redis
-from redis import Redis
-from redis.cluster import RedisCluster
-from redis.sentinel import Sentinel
-
-import redis.asyncio
-from redis.asyncio import Redis as AsyncRedis
-from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
-from redis.asyncio.sentinel import Sentinel as AsyncSentinel
 
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.llms import ChatMessage
 from llama_index.core.storage.chat_store.base import BaseChatStore
 
-
-# Convert a ChatMessage to a json object for Redis
-def _message_to_dict(message: ChatMessage) -> dict:
-    return message.dict()
-
-
-# Convert the json object in Redis to a ChatMessage
-def _dict_to_message(d: dict) -> ChatMessage:
-    return ChatMessage.model_validate(d)
+from redis.asyncio.client import Redis as AsyncRedis
+from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from redis.asyncio.sentinel import Sentinel as AsyncSentinel
+from redis.client import Redis
+from redis.cluster import RedisCluster
+from redis.sentinel import Sentinel
 
 
 class RedisChatStore(BaseChatStore):
@@ -80,26 +66,21 @@ class RedisChatStore(BaseChatStore):
         items = self._redis_client.lrange(key, 0, -1)
         if len(items) == 0:
             return []
-
-        items_json = [json.loads(m.decode("utf-8")) for m in items]
-        return [_dict_to_message(d) for d in items_json]
+        return [ChatMessage.model_validate_json(item) for item in items]
 
     async def aget_messages(self, key: str) -> List[ChatMessage]:
         """Get messages for a key."""
         items = await self._aredis_client.lrange(key, 0, -1)
         if len(items) == 0:
             return []
-
-        items_json = [json.loads(m.decode("utf-8")) for m in items]
-        return [_dict_to_message(d) for d in items_json]
+        return [ChatMessage.model_validate_json(item) for item in items]
 
     def add_message(
         self, key: str, message: ChatMessage, idx: Optional[int] = None
     ) -> None:
         """Add a message for a key."""
         if idx is None:
-            item = json.dumps(_message_to_dict(message))
-            self._redis_client.rpush(key, item)
+            self._redis_client.rpush(key, message.model_dump_json())
         else:
             self._insert_element_at_index(key, idx, message)
 
@@ -111,8 +92,7 @@ class RedisChatStore(BaseChatStore):
     ) -> None:
         """Add a message for a key."""
         if idx is None:
-            item = json.dumps(_message_to_dict(message))
-            await self._aredis_client.rpush(key, item)
+            await self._aredis_client.rpush(key, message.model_dump_json())
         else:
             await self._ainsert_element_at_index(key, idx, message)
 
@@ -351,7 +331,7 @@ class RedisChatStore(BaseChatStore):
             redis_client = self._redis_sentinel_client(redis_url, **kwargs)
         else:
             # connect to redis server from url, reconnect with cluster client if needed
-            redis_client = redis.from_url(redis_url, **kwargs)
+            redis_client = Redis.from_url(redis_url, **kwargs)
             if self._check_for_cluster(redis_client):
                 redis_client.close()
                 redis_client = self._redis_cluster_client(redis_url, **kwargs)
@@ -371,8 +351,8 @@ class RedisChatStore(BaseChatStore):
             aredis_client = self._aredis_sentinel_client(redis_url, **kwargs)
         else:
             # connect to redis server from url, reconnect with cluster client if needed
-            aredis_client = redis.asyncio.from_url(redis_url, **kwargs)
-            redis_client = redis.from_url(redis_url, **kwargs)
+            aredis_client = AsyncRedis.from_url(redis_url, **kwargs)
+            redis_client = Redis.from_url(redis_url, **kwargs)
             is_cluster = self._check_for_cluster(redis_client)
             redis_client.close()
 

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/pyproject.toml
@@ -10,12 +10,13 @@ dev = [
     "pre-commit==3.2.0",
     "pylint==2.15.10",
     "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
     "pytest-mock==3.11.1",
     "ruff==0.11.11",
     "types-Deprecated>=0.1.0",
     "types-PyYAML>=6.0.12.12,<7",
     "types-protobuf>=4.24.0.4,<5",
-    "types-redis==4.5.5.0",
+    "types-redis==4.6.0.20241004",
     "types-requests==2.28.11.8",
     "types-setuptools==67.1.0.0",
     "black[jupyter]<=23.9.1,>=23.7.0",
@@ -26,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-storage-chat-store-redis"
-version = "0.5.1"
+version = "0.6.0"
 description = "llama-index storage-chat-store redis integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.9,<4.0"

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/tests/conftest.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/tests/conftest.py
@@ -1,0 +1,2 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/tests/test_chat_store_redis_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/tests/test_chat_store_redis_chat_store.py
@@ -1,7 +1,274 @@
+from typing import Generator
+
+import pytest
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.storage.chat_store.base import BaseChatStore
 from llama_index.storage.chat_store.redis import RedisChatStore
+
+REDIS_KEY = "redis_chat_store_tests"
+
+# Run Redis Open Source locally via Docker:
+# docker run --name redis -p 6379:6379 redis:<version> (omit `:version` or use `:latest` for latest)
+#
+# https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/
+try:
+    from redis.client import Redis
+
+    redis_client = Redis.from_url("redis://localhost:6379")
+    redis_client.info()
+    redis_available = True
+except (ImportError, Exception):
+    redis_available = False
+
+needs_redis_conn = pytest.mark.skipif(
+    not redis_available, reason="Redis Open Source not running locally"
+)
+"""
+Tests marked with this decorator require a running instance of Redis. Otherwise, the
+test is skipped.
+"""
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in RedisChatStore.__mro__]
     assert BaseChatStore.__name__ in names_of_base_classes
+
+
+@pytest.fixture()
+def redis_chat_store() -> Generator[RedisChatStore, None, None]:
+    chat_store = None
+    try:
+        chat_store = RedisChatStore(
+            redis_url="redis://localhost:6379",
+            ttl=300,  # 5 minutes
+        )
+        yield chat_store
+    finally:
+        if chat_store:
+            chat_store.delete_messages(REDIS_KEY)
+
+
+@needs_redis_conn
+def test_add_message(redis_chat_store: RedisChatStore):
+    message = ChatMessage(role=MessageRole.USER, content="test_user_message")
+    redis_chat_store.add_message(REDIS_KEY, message)
+
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 1
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+
+
+@needs_redis_conn
+def test_add_message_with_additional_kwargs(redis_chat_store: RedisChatStore):
+    message = ChatMessage(
+        role=MessageRole.USER,
+        content="test_user_message",
+        additional_kwargs={"metadata": {"foo": "bar", "count": 5}},
+    )
+    redis_chat_store.add_message(REDIS_KEY, message)
+
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 1
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+
+    assert stored_messages[0].additional_kwargs
+    assert "metadata" in stored_messages[0].additional_kwargs
+    assert stored_messages[0].additional_kwargs["metadata"]["foo"] == "bar"
+    assert stored_messages[0].additional_kwargs["metadata"]["count"] == 5
+
+
+@needs_redis_conn
+@pytest.mark.asyncio
+async def test_async_add_message(redis_chat_store: RedisChatStore):
+    message = ChatMessage(role=MessageRole.USER, content="async_test_user_message")
+    await redis_chat_store.async_add_message(REDIS_KEY, message)
+
+    stored_messages = await redis_chat_store.aget_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 1
+    assert stored_messages[0].content == "async_test_user_message"
+    assert stored_messages[0].role == "user"
+
+
+@needs_redis_conn
+@pytest.mark.asyncio
+async def test_async_add_message_with_additional_kwargs(
+    redis_chat_store: RedisChatStore,
+):
+    message = ChatMessage(
+        role=MessageRole.USER,
+        content="test_user_message",
+        additional_kwargs={"metadata": {"foo": "bar", "count": 5}},
+    )
+    await redis_chat_store.async_add_message(REDIS_KEY, message)
+
+    stored_messages = await redis_chat_store.aget_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 1
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+
+    assert stored_messages[0].additional_kwargs
+    assert "metadata" in stored_messages[0].additional_kwargs
+    assert stored_messages[0].additional_kwargs["metadata"]["foo"] == "bar"
+    assert stored_messages[0].additional_kwargs["metadata"]["count"] == 5
+
+
+@needs_redis_conn
+def test_set_messages(redis_chat_store: RedisChatStore):
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="test_user_message"),
+        ChatMessage(role=MessageRole.SYSTEM, content="test_system_message"),
+    ]
+    redis_chat_store.set_messages(REDIS_KEY, messages)
+
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 2
+    # Assert first message
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+    # Assert second message
+    assert stored_messages[1].content == "test_system_message"
+    assert stored_messages[1].role == "system"
+
+
+@needs_redis_conn
+@pytest.mark.asyncio
+async def test_aset_messages(redis_chat_store: RedisChatStore):
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="test_user_message"),
+        ChatMessage(role=MessageRole.SYSTEM, content="test_system_message"),
+    ]
+    await redis_chat_store.aset_messages(REDIS_KEY, messages)
+
+    stored_messages = await redis_chat_store.aget_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 2
+    # Assert first message
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+    # Assert second message
+    assert stored_messages[1].content == "test_system_message"
+    assert stored_messages[1].role == "system"
+
+
+@needs_redis_conn
+def test_delete_messages(redis_chat_store: RedisChatStore):
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="test_user_message"),
+        ChatMessage(role=MessageRole.SYSTEM, content="test_system_message"),
+    ]
+    redis_chat_store.set_messages(REDIS_KEY, messages)
+
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 2
+
+    redis_chat_store.delete_messages(REDIS_KEY)
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 0
+    assert stored_messages == []
+
+
+@needs_redis_conn
+@pytest.mark.asyncio
+async def test_adelete_messages(redis_chat_store: RedisChatStore):
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="test_user_message"),
+        ChatMessage(role=MessageRole.SYSTEM, content="test_system_message"),
+    ]
+    await redis_chat_store.aset_messages(REDIS_KEY, messages)
+
+    stored_messages = await redis_chat_store.aget_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 2
+
+    await redis_chat_store.adelete_messages(REDIS_KEY)
+    stored_messages = await redis_chat_store.aget_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 0
+    assert stored_messages == []
+
+
+@needs_redis_conn
+def test_delete_message(redis_chat_store: RedisChatStore):
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="test_user_message"),
+        ChatMessage(role=MessageRole.SYSTEM, content="test_system_message"),
+    ]
+    redis_chat_store.set_messages(REDIS_KEY, messages)
+
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 2
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+
+    redis_chat_store.delete_message(REDIS_KEY, 0)
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 1
+    assert stored_messages[0].content == "test_system_message"
+    assert stored_messages[0].role == "system"
+
+
+@needs_redis_conn
+@pytest.mark.asyncio
+async def test_adelete_message(redis_chat_store: RedisChatStore):
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="test_user_message"),
+        ChatMessage(role=MessageRole.SYSTEM, content="test_system_message"),
+    ]
+    await redis_chat_store.aset_messages(REDIS_KEY, messages)
+
+    stored_messages = await redis_chat_store.aget_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 2
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+
+    await redis_chat_store.adelete_message(REDIS_KEY, 0)
+    stored_messages = await redis_chat_store.aget_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 1
+    assert stored_messages[0].content == "test_system_message"
+    assert stored_messages[0].role == "system"
+
+
+@needs_redis_conn
+def test_delete_last_message(redis_chat_store: RedisChatStore):
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="test_user_message"),
+        ChatMessage(role=MessageRole.SYSTEM, content="test_system_message"),
+    ]
+    redis_chat_store.set_messages(REDIS_KEY, messages)
+
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 2
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+
+    redis_chat_store.delete_last_message(REDIS_KEY)
+    stored_messages = redis_chat_store.get_messages(REDIS_KEY)
+
+    assert len(stored_messages) == 1
+    assert stored_messages[0].content == "test_user_message"
+    assert stored_messages[0].role == "user"
+
+
+@needs_redis_conn
+def test_get_keys(redis_chat_store: RedisChatStore):
+    message = ChatMessage(role=MessageRole.USER, content="test_user_message")
+    redis_chat_store.add_message(REDIS_KEY, message)
+
+    keys = redis_chat_store.get_keys()
+
+    assert len(keys) == 1
+    assert keys[0] == REDIS_KEY

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/uv.lock
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1638,7 +1638,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-storage-chat-store-redis"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1657,6 +1657,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pylint" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -1685,13 +1686,14 @@ dev = [
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
     { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest-asyncio", specifier = "==0.21.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = "==3.11.1" },
     { name = "ruff", specifier = "==0.11.11" },
     { name = "types-deprecated", specifier = ">=0.1.0" },
     { name = "types-protobuf", specifier = ">=4.24.0.4,<5" },
     { name = "types-pyyaml", specifier = ">=6.0.12.12,<7" },
-    { name = "types-redis", specifier = "==4.5.5.0" },
+    { name = "types-redis", specifier = "==4.6.0.20241004" },
     { name = "types-requests", specifier = "==2.28.11.8" },
     { name = "types-setuptools", specifier = "==67.1.0.0" },
 ]
@@ -2771,6 +2773,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/c7/9db0c6215f12f26b590c24acc96d048e03989315f198454540dff95109cd/pytest-asyncio-0.21.0.tar.gz", hash = "sha256:2b38a496aef56f56b0e87557ec313e11e1ab9276fc3863f6a7be0f1d0e415e1b", size = 29898, upload-time = "2023-03-19T10:27:25.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/73/817ddb37c627338ecbb96486c03fe69a19bef72de1b6bd641aa06fed13f4/pytest_asyncio-0.21.0-py3-none-any.whl", hash = "sha256:f2b3366b7cd501a4056858bd39349d5af19742aed2d81660b7998b6341c7eb9c", size = 13131, upload-time = "2023-03-19T10:27:23.135Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3651,15 +3665,15 @@ wheels = [
 
 [[package]]
 name = "types-redis"
-version = "4.5.5.0"
+version = "4.6.0.20241004"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "types-pyopenssl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/75/c6723bb134dcbc0012fc3f9381e5c8a0a3594dcb454a7a475e2589db2587/types-redis-4.5.5.0.tar.gz", hash = "sha256:26547d91f011a4024375d9216cd4d917b4678c984201d46f72c604526c138523", size = 47082, upload-time = "2023-05-09T15:15:54.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/95/c054d3ac940e8bac4ca216470c80c26688a0e79e09f520a942bb27da3386/types-redis-4.6.0.20241004.tar.gz", hash = "sha256:5f17d2b3f9091ab75384153bfa276619ffa1cf6a38da60e10d5e6749cc5b902e", size = 49679, upload-time = "2024-10-04T02:43:59.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/d9/7be6ed2b7f78263c12c1c6fbeaa144ffb638188220bb2e5359395a6e9694/types_redis-4.5.5.0-py3-none-any.whl", hash = "sha256:c7132e0cedeb52a83d20138c0440721bfae89cd2027c1ef57a294b56dfde4ee8", size = 56870, upload-time = "2023-05-09T15:15:52.615Z" },
+    { url = "https://files.pythonhosted.org/packages/55/82/7d25dce10aad92d2226b269bce2f85cfd843b4477cd50245d7d40ecf8f89/types_redis-4.6.0.20241004-py3-none-any.whl", hash = "sha256:ef5da68cb827e5f606c8f9c0b49eeee4c2669d6d97122f301d3a55dc6a63f6ed", size = 58737, upload-time = "2024-10-04T02:43:57.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Introduces a small set of changes for `RedisChatStore` to ensure that the serialization & deserialization of `ChatMessage`s is done on the Pydantic core side (in Rust). This small optimization comes directly from the [Pydantic "Performance tips" page](https://docs.pydantic.dev/latest/concepts/performance/). This change also replaces usage of the _deprecated_ `.dict()` method with `.model_dump_json()`.

I've also included some additional cleanup, and added a collection of integration tests.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
