### PR TITLE
fix(vertex): implement async streaming and Gemini tool-config compatibility

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -1,9 +1,12 @@
+import asyncio
 import deprecated
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
+    Iterator,
     List,
     Tuple,
     Optional,
@@ -24,6 +27,15 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
+from llama_index.core.base.llms.generic_utils import (
+    achat_to_completion_decorator,
+    astream_chat_to_completion_decorator,
+    async_stream_completion_response_to_chat_response,
+    chat_to_completion_decorator,
+    completion_response_to_chat_response,
+    stream_chat_to_completion_decorator,
+    stream_completion_response_to_chat_response,
+)
 from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.core.llms.function_calling import FunctionCallingLLM, ToolSelection
 from llama_index.core.utilities.gemini_utils import merge_neighboring_same_role_messages
@@ -46,6 +58,52 @@ from vertexai.generative_models import ToolConfig
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
+
+
+_STREAM_DONE = object()
+
+
+@dataclass(frozen=True)
+class ChatRequestParams:
+    prompt: Any
+    chat_request_params: Dict[str, Any]
+    model_params: Dict[str, Any]
+
+
+def _async_stream_from_sync(stream_factory: Callable[[], Iterator[Any]]) -> Any:
+    """
+    Adapt a sync streaming generator into an async generator.
+
+    Classic `vertexai.language_models` chat/completion clients expose native
+    async streaming APIs, and this integration uses those directly.
+    Reference:
+    https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.language_models.ChatSession
+    https://docs.cloud.google.com/python/docs/reference/vertexai/latest/summary_method
+
+    The remaining case is Gemini-through-Vertex (`vertexai.generative_models`),
+    where this integration already has a working sync streaming path but does
+    not have a clearly documented native async streaming API to call here.
+    Reference:
+    https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai.generative_models.ChatSession
+    This helper preserves the async LlamaIndex surface by:
+
+    This follows the same pull-based pattern used in other integrations such as
+    `zhipuai`: advance the blocking sync iterator with `asyncio.to_thread(...)`
+    and yield the resulting chunks through an async generator.
+
+    This keeps `astream_chat()` / `astream_complete()` workflow-compatible
+    without duplicating the Gemini sync streaming logic.
+    """
+    stream = stream_factory()
+
+    async def gen() -> Any:
+        while True:
+            item = await asyncio.to_thread(next, stream, _STREAM_DONE)
+            if item is _STREAM_DONE:
+                break
+            yield item
+
+    return gen()
 
 
 @deprecated.deprecated(
@@ -152,6 +210,8 @@ class Vertex(FunctionCallingLLM):
         )
 
         self._safety_settings = safety_settings
+        self._client = None
+        self._chat_client = None
         self._is_gemini = False
         self._is_chat_model = False
         if model in CHAT_MODELS:
@@ -227,8 +287,10 @@ class Vertex(FunctionCallingLLM):
             content = ""
         return content, tool_calls
 
-    @llm_chat_callback()
-    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+    def _prepare_chat_request(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatRequestParams:
+        """Prepare the prompt, chat request params, and model params for chat calls."""
         merged_messages = (
             merge_neighboring_same_role_messages(messages)
             if self._is_gemini
@@ -236,11 +298,9 @@ class Vertex(FunctionCallingLLM):
         )
         question = _parse_message(merged_messages[-1], self._is_gemini)
         chat_history = _parse_chat_history(merged_messages[:-1], self._is_gemini)
-
         chat_params = {**chat_history}
 
         kwargs = kwargs if kwargs else {}
-
         params = {**self._model_kwargs, **kwargs}
 
         if self.iscode and "candidate_count" in params:
@@ -254,80 +314,26 @@ class Vertex(FunctionCallingLLM):
                 )
             )
 
-        generation = completion_with_retry(
-            client=self._chat_client,
+        return ChatRequestParams(
             prompt=question,
-            chat=True,
-            stream=False,
-            is_gemini=self._is_gemini,
-            params=chat_params,
-            max_retries=self.max_retries,
-            **params,
+            chat_request_params=chat_params,
+            model_params=params,
         )
 
-        content, tool_calls = self._get_content_and_tool_calls(generation)
-
-        return ChatResponse(
-            message=ChatMessage(
-                role=MessageRole.ASSISTANT,
-                content=content,
-                additional_kwargs={"tool_calls": tool_calls},
-            ),
-            raw=generation.__dict__,
-        )
-
-    @llm_completion_callback()
-    def complete(
-        self, prompt: str, formatted: bool = False, **kwargs: Any
-    ) -> CompletionResponse:
-        kwargs = kwargs if kwargs else {}
-        params = {**self._model_kwargs, **kwargs}
-        if self.iscode and "candidate_count" in params:
-            raise (ValueError("candidate_count is not supported by the codey model's"))
-
-        completion = completion_with_retry(
-            self._client,
-            prompt,
-            max_retries=self.max_retries,
-            is_gemini=self._is_gemini,
-            **params,
-        )
-        return CompletionResponse(text=completion.text, raw=completion.__dict__)
-
-    @llm_chat_callback()
-    def stream_chat(
+    def _stream_chat_impl(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
-        merged_messages = (
-            merge_neighboring_same_role_messages(messages)
-            if self._is_gemini
-            else messages
-        )
-        question = _parse_message(merged_messages[-1], self._is_gemini)
-        chat_history = _parse_chat_history(merged_messages[:-1], self._is_gemini)
-        chat_params = {**chat_history}
-        kwargs = kwargs if kwargs else {}
-        params = {**self._model_kwargs, **kwargs}
-        if self.iscode and "candidate_count" in params:
-            raise (ValueError("candidate_count is not supported by the codey model's"))
-        if self.examples and "examples" not in params:
-            chat_params["examples"] = _parse_examples(self.examples)
-        elif "examples" in params:
-            raise (
-                ValueError(
-                    "examples are not supported in chat generation pass them as a constructor parameter"
-                )
-            )
+        prepared = self._prepare_chat_request(messages, **kwargs)
 
         response = completion_with_retry(
             client=self._chat_client,
-            prompt=question,
+            prompt=prepared.prompt,
             chat=True,
             stream=True,
             is_gemini=self._is_gemini,
-            params=chat_params,
+            params=prepared.chat_request_params,
             max_retries=self.max_retries,
-            **params,
+            **prepared.model_params,
         )
 
         def gen() -> ChatResponseGen:
@@ -344,9 +350,8 @@ class Vertex(FunctionCallingLLM):
 
         return gen()
 
-    @llm_completion_callback()
-    def stream_complete(
-        self, prompt: str, formatted: bool = False, **kwargs: Any
+    def _stream_complete_impl(
+        self, prompt: str, **kwargs: Any
     ) -> CompletionResponseGen:
         kwargs = kwargs if kwargs else {}
         params = {**self._model_kwargs, **kwargs}
@@ -373,40 +378,161 @@ class Vertex(FunctionCallingLLM):
 
         return gen()
 
-    @llm_chat_callback()
-    async def achat(
+    async def _astream_chat_impl(
         self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponse:
-        merged_messages = (
-            merge_neighboring_same_role_messages(messages)
-            if self._is_gemini
-            else messages
+    ) -> ChatResponseAsyncGen:
+        prepared = self._prepare_chat_request(messages, **kwargs)
+
+        response = await acompletion_with_retry(
+            client=self._chat_client,
+            prompt=prepared.prompt,
+            chat=True,
+            stream=True,
+            is_gemini=self._is_gemini,
+            params=prepared.chat_request_params,
+            max_retries=self.max_retries,
+            **prepared.model_params,
         )
-        question = _parse_message(merged_messages[-1], self._is_gemini)
-        chat_history = _parse_chat_history(merged_messages[:-1], self._is_gemini)
-        chat_params = {**chat_history}
+
+        async def gen() -> ChatResponseAsyncGen:
+            content = ""
+            role = MessageRole.ASSISTANT
+            async for r in response:
+                content_delta = r.text
+                content += content_delta
+                yield ChatResponse(
+                    message=ChatMessage(role=role, content=content),
+                    delta=content_delta,
+                    raw=r.__dict__,
+                )
+
+        return gen()
+
+    async def _astream_complete_impl(
+        self, prompt: str, **kwargs: Any
+    ) -> CompletionResponseAsyncGen:
+        kwargs = kwargs if kwargs else {}
+        params = {**self._model_kwargs, **kwargs}
+        if "candidate_count" in params:
+            raise (ValueError("candidate_count is not supported by the streaming"))
+
+        completion = await acompletion_with_retry(
+            client=self._client,
+            prompt=prompt,
+            stream=True,
+            is_gemini=self._is_gemini,
+            max_retries=self.max_retries,
+            **params,
+        )
+
+        async def gen() -> CompletionResponseAsyncGen:
+            content = ""
+            async for r in completion:
+                content_delta = r.text
+                content += content_delta
+                yield CompletionResponse(
+                    text=content, delta=content_delta, raw=r.__dict__
+                )
+
+        return gen()
+
+    @llm_chat_callback()
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        if not self.metadata.is_chat_model:
+            prompt = self.messages_to_prompt(messages)
+            return completion_response_to_chat_response(
+                self.complete(prompt, formatted=True, **kwargs)
+            )
+
+        prepared = self._prepare_chat_request(messages, **kwargs)
+
+        generation = completion_with_retry(
+            client=self._chat_client,
+            prompt=prepared.prompt,
+            chat=True,
+            stream=False,
+            is_gemini=self._is_gemini,
+            params=prepared.chat_request_params,
+            max_retries=self.max_retries,
+            **prepared.model_params,
+        )
+
+        content, tool_calls = self._get_content_and_tool_calls(generation)
+
+        return ChatResponse(
+            message=ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content=content,
+                additional_kwargs={"tool_calls": tool_calls},
+            ),
+            raw=generation.__dict__,
+        )
+
+    @llm_completion_callback()
+    def complete(
+        self, prompt: str, formatted: bool = False, **kwargs: Any
+    ) -> CompletionResponse:
+        if self.metadata.is_chat_model and self._client is None:
+            return chat_to_completion_decorator(self.chat)(prompt, **kwargs)
+
         kwargs = kwargs if kwargs else {}
         params = {**self._model_kwargs, **kwargs}
         if self.iscode and "candidate_count" in params:
             raise (ValueError("candidate_count is not supported by the codey model's"))
-        if self.examples and "examples" not in params:
-            chat_params["examples"] = _parse_examples(self.examples)
-        elif "examples" in params:
-            raise (
-                ValueError(
-                    "examples are not supported in chat generation pass them as a constructor parameter"
-                )
-            )
-        generation = await acompletion_with_retry(
-            client=self._chat_client,
-            prompt=question,
-            chat=True,
-            is_gemini=self._is_gemini,
-            params=chat_params,
+
+        completion = completion_with_retry(
+            self._client,
+            prompt,
             max_retries=self.max_retries,
+            is_gemini=self._is_gemini,
             **params,
         )
-        ##this is due to a bug in vertex AI we have to await twice
+        return CompletionResponse(text=completion.text, raw=completion.__dict__)
+
+    @llm_chat_callback()
+    def stream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseGen:
+        if not self.metadata.is_chat_model:
+            prompt = self.messages_to_prompt(messages)
+            return stream_completion_response_to_chat_response(
+                self.stream_complete(prompt, formatted=True, **kwargs)
+            )
+
+        return self._stream_chat_impl(messages, **kwargs)
+
+    @llm_completion_callback()
+    def stream_complete(
+        self, prompt: str, formatted: bool = False, **kwargs: Any
+    ) -> CompletionResponseGen:
+        if self.metadata.is_chat_model and self._client is None:
+            return stream_chat_to_completion_decorator(self.stream_chat)(
+                prompt, **kwargs
+            )
+
+        return self._stream_complete_impl(prompt, **kwargs)
+
+    @llm_chat_callback()
+    async def achat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        if not self.metadata.is_chat_model:
+            prompt = self.messages_to_prompt(messages)
+            return completion_response_to_chat_response(
+                await self.acomplete(prompt, formatted=True, **kwargs)
+            )
+
+        prepared = self._prepare_chat_request(messages, **kwargs)
+        generation = await acompletion_with_retry(
+            client=self._chat_client,
+            prompt=prepared.prompt,
+            chat=True,
+            is_gemini=self._is_gemini,
+            params=prepared.chat_request_params,
+            max_retries=self.max_retries,
+            **prepared.model_params,
+        )
+        # This is due to a bug in Vertex AI where code models must be awaited twice.
         if self.iscode:
             generation = await generation
 
@@ -424,6 +550,9 @@ class Vertex(FunctionCallingLLM):
     async def acomplete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponse:
+        if self.metadata.is_chat_model and self._client is None:
+            return await achat_to_completion_decorator(self.achat)(prompt, **kwargs)
+
         kwargs = kwargs if kwargs else {}
         params = {**self._model_kwargs, **kwargs}
         if self.iscode and "candidate_count" in params:
@@ -441,13 +570,35 @@ class Vertex(FunctionCallingLLM):
     async def astream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
-        raise (ValueError("Not Implemented"))
+        if not self.metadata.is_chat_model:
+            prompt = self.messages_to_prompt(messages)
+            completion_stream = await self.astream_complete(
+                prompt, formatted=True, **kwargs
+            )
+            return async_stream_completion_response_to_chat_response(completion_stream)
+
+        if not self._is_gemini:
+            return await self._astream_chat_impl(messages, **kwargs)
+
+        return _async_stream_from_sync(
+            lambda: self._stream_chat_impl(messages, **kwargs),
+        )
 
     @llm_completion_callback()
     async def astream_complete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponseAsyncGen:
-        raise (ValueError("Not Implemented"))
+        if self.metadata.is_chat_model and self._client is None:
+            return await astream_chat_to_completion_decorator(self.astream_chat)(
+                prompt, **kwargs
+            )
+
+        if not self._is_gemini:
+            return await self._astream_complete_impl(prompt, **kwargs)
+
+        return _async_stream_from_sync(
+            lambda: self._stream_complete_impl(prompt, **kwargs),
+        )
 
     def _prepare_chat_with_tools(
         self,
@@ -482,7 +633,6 @@ class Vertex(FunctionCallingLLM):
             else {}
         )
 
-        print("tool_config", tool_config)
         return {
             "messages": chat_history,
             "tools": tool_dicts or None,

--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/utils.py
@@ -69,6 +69,41 @@ def to_gemini_tools(tools) -> Any:
     return [gemini_tools]
 
 
+def _split_gemini_request_kwargs(kwargs: Any) -> tuple[Any, Any, Any]:
+    """Split Gemini chat kwargs into tools, tool_config, and generation_config."""
+    request_kwargs = dict(kwargs)
+    tools = request_kwargs.pop("tools", None)
+    tool_config = request_kwargs.pop("tool_config", None)
+
+    return (
+        to_gemini_tools(tools) if tools else [],
+        tool_config,
+        request_kwargs if request_kwargs else {},
+    )
+
+
+def _start_gemini_chat(
+    client: Any,
+    history: Any,
+    tools: Any,
+    tool_config: Any,
+) -> tuple[Any, Any]:
+    """Start a Gemini chat session, binding tool config on the model when needed."""
+    if tool_config is None:
+        return client.start_chat(history=history), tools
+
+    bound_client = client.__class__(
+        model_name=client._model_name,
+        generation_config=getattr(client, "_generation_config", None),
+        safety_settings=getattr(client, "_safety_settings", None),
+        tools=tools or getattr(client, "_tools", None),
+        tool_config=tool_config,
+        system_instruction=getattr(client, "_system_instruction", None),
+        labels=getattr(client, "_labels", None),
+    )
+    return bound_client.start_chat(history=history), None
+
+
 def completion_with_retry(
     client: Any,
     prompt: Optional[Any],
@@ -86,18 +121,18 @@ def completion_with_retry(
     def _completion_with_retry(**kwargs: Any) -> Any:
         if is_gemini:
             history = params["message_history"] if "message_history" in params else []
-            generation = client.start_chat(history=history)
-            kwargs = dict(kwargs)
-            tools = kwargs.pop("tools", None) if "tools" in kwargs else []
-            tools = to_gemini_tools(tools) if tools else []
-            generation_config = kwargs if kwargs else {}
-
-            return generation.send_message(
-                prompt,
-                stream=stream,
-                tools=tools,
-                generation_config=generation_config,
+            tools, tool_config, generation_config = _split_gemini_request_kwargs(kwargs)
+            generation, request_tools = _start_gemini_chat(
+                client, history, tools, tool_config
             )
+
+            send_kwargs = {
+                "stream": stream,
+                "generation_config": generation_config,
+            }
+            if request_tools:
+                send_kwargs["tools"] = request_tools
+            return generation.send_message(prompt, **send_kwargs)
         elif chat:
             generation = client.start_chat(**params)
             if stream:
@@ -115,34 +150,47 @@ def completion_with_retry(
 
 async def acompletion_with_retry(
     client: Any,
-    prompt: Optional[str],
+    prompt: Optional[Any],
     max_retries: int = 5,
     chat: bool = False,
+    stream: bool = False,
     is_gemini: bool = False,
     params: Any = {},
     **kwargs: Any,
 ) -> Any:
-    """Use tenacity to retry the completion call."""
+    """
+    Retry async Vertex calls for chat/completion and classic async streaming.
+
+    Native async streaming is used only for classic `vertexai.language_models`
+    clients. Gemini-through-Vertex async streaming is handled separately in
+    `base.py` via the sync-to-async fallback.
+    """
     retry_decorator = _create_retry_decorator(max_retries=max_retries)
 
     @retry_decorator
     async def _completion_with_retry(**kwargs: Any) -> Any:
         if is_gemini:
             history = params["message_history"] if "message_history" in params else []
-            generation = client.start_chat(history=history)
-            kwargs = dict(kwargs)
-            tools = kwargs.pop("tools", None) if "tools" in kwargs else []
-            tools = to_gemini_tools(tools) if tools else []
-            generation_config = kwargs if kwargs else {}
-            return await generation.send_message_async(
-                prompt,
-                tools=tools,
-                generation_config=generation_config,
+            tools, tool_config, generation_config = _split_gemini_request_kwargs(kwargs)
+            generation, request_tools = _start_gemini_chat(
+                client, history, tools, tool_config
             )
+            if stream:
+                raise ValueError(
+                    "Async streaming is not supported for Gemini through this Vertex integration."
+                )
+            send_kwargs = {"generation_config": generation_config}
+            if request_tools:
+                send_kwargs["tools"] = request_tools
+            return await generation.send_message_async(prompt, **send_kwargs)
         elif chat:
             generation = client.start_chat(**params)
+            if stream:
+                return generation.send_message_streaming_async(prompt, **kwargs)
             return await generation.send_message_async(prompt, **kwargs)
         else:
+            if stream:
+                return client.predict_streaming_async(prompt, **kwargs)
             return await client.predict_async(prompt, **kwargs)
 
     return await _completion_with_retry(**kwargs)

--- a/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "codespell[toml]>=v2.2.6",
     "diff-cover>=9.2.0",
     "pytest-cov>=6.1.1",
+    "pytest-asyncio>=0.23.8",
 ]
 
 [project]

--- a/llama-index-integrations/llms/llama-index-llms-vertex/tests/test_llms_vertex.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/tests/test_llms_vertex.py
@@ -1,11 +1,21 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    CompletionResponse,
+    MessageRole,
+)
 from llama_index.llms.vertex import Vertex
+from llama_index.llms.vertex.utils import acompletion_with_retry, completion_with_retry
 
 
 def test_vertex_metadata_function_calling():
     """Test that Vertex LLM metadata correctly identifies Gemini models as function calling models."""
     # This test uses mocks to avoid actual API calls
-    from unittest.mock import patch, Mock
-
     with patch(
         "llama_index.llms.vertex.gemini_utils.create_gemini_client"
     ) as mock_create_client:
@@ -23,8 +33,6 @@ def test_vertex_metadata_function_calling():
 
 def test_vertex_metadata_non_function_calling():
     """Test that Vertex LLM metadata correctly identifies non-Gemini models as non-function calling models."""
-    from unittest.mock import patch, Mock
-
     with patch(
         "vertexai.language_models.ChatModel.from_pretrained"
     ) as mock_from_pretrained:
@@ -37,3 +45,394 @@ def test_vertex_metadata_non_function_calling():
         assert metadata.is_function_calling_model is False
         assert metadata.model_name == "chat-bison"
         assert metadata.is_chat_model is True
+
+
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("vertexai.language_models.ChatModel.from_pretrained")
+def test_vertex_complete_falls_back_to_chat(
+    mock_from_pretrained: Mock, mock_init_vertexai: Mock
+) -> None:
+    mock_from_pretrained.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="chat-bison", project="test-project")
+    response = ChatResponse(
+        message=ChatMessage(role=MessageRole.ASSISTANT, content="fallback response")
+    )
+
+    with patch.object(Vertex, "chat", return_value=response) as mock:
+        completion = llm.complete("Hi")
+
+    assert completion.text == "fallback response"
+    mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("vertexai.language_models.TextGenerationModel.from_pretrained")
+async def test_vertex_achat_falls_back_to_acomplete(
+    mock_from_pretrained: Mock, mock_init_vertexai: Mock
+) -> None:
+    mock_from_pretrained.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="text-bison", project="test-project")
+    completion = CompletionResponse(text="fallback response")
+
+    with patch.object(
+        Vertex, "acomplete", new=AsyncMock(return_value=completion)
+    ) as mock:
+        response = await llm.achat([ChatMessage(role=MessageRole.USER, content="Hi")])
+
+    assert response.message.content == "fallback response"
+    mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("vertexai.language_models.TextGenerationModel.from_pretrained")
+async def test_vertex_astream_chat_falls_back_to_astream_complete(
+    mock_from_pretrained: Mock, mock_init_vertexai: Mock
+) -> None:
+    mock_from_pretrained.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="text-bison", project="test-project")
+
+    async def completion_stream():
+        yield CompletionResponse(text="Hi", delta="Hi")
+        yield CompletionResponse(text="Hi!", delta="!")
+
+    with patch.object(
+        Vertex,
+        "astream_complete",
+        new=AsyncMock(return_value=completion_stream()),
+    ) as mock:
+        stream = await llm.astream_chat(
+            [ChatMessage(role=MessageRole.USER, content="Hi")]
+        )
+        responses = [response async for response in stream]
+
+    assert [response.delta for response in responses] == ["Hi", "!"]
+    assert [response.message.content for response in responses] == ["Hi", "Hi!"]
+    mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("vertexai.language_models.ChatModel.from_pretrained")
+@patch("llama_index.llms.vertex.base.acompletion_with_retry")
+async def test_vertex_astream_chat_streams_chat_models(
+    mock_acompletion_with_retry: AsyncMock,
+    mock_from_pretrained: Mock,
+    mock_init_vertexai: Mock,
+) -> None:
+    mock_from_pretrained.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="chat-bison", project="test-project")
+
+    async def chat_stream():
+        yield SimpleNamespace(text="Hi")
+        yield SimpleNamespace(text="!")
+
+    mock_acompletion_with_retry.return_value = chat_stream()
+    stream = await llm.astream_chat([ChatMessage(role=MessageRole.USER, content="Hi")])
+    responses = [response async for response in stream]
+
+    assert [response.delta for response in responses] == ["Hi", "!"]
+    assert [response.message.content for response in responses] == ["Hi", "Hi!"]
+    mock_acompletion_with_retry.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("vertexai.language_models.ChatModel.from_pretrained")
+async def test_vertex_astream_complete_falls_back_to_astream_chat(
+    mock_from_pretrained: Mock, mock_init_vertexai: Mock
+) -> None:
+    mock_from_pretrained.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="chat-bison", project="test-project")
+
+    async def chat_stream():
+        yield ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content="Hi"),
+            delta="Hi",
+        )
+        yield ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content="Hi!"),
+            delta="!",
+        )
+
+    with patch.object(
+        Vertex,
+        "astream_chat",
+        new=AsyncMock(return_value=chat_stream()),
+    ) as mock:
+        stream = await llm.astream_complete("Hi")
+        responses = [response async for response in stream]
+
+    assert [response.delta for response in responses] == ["Hi", "!"]
+    assert [response.text for response in responses] == ["Hi", "Hi!"]
+    mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("vertexai.language_models.TextGenerationModel.from_pretrained")
+@patch("llama_index.llms.vertex.base.acompletion_with_retry")
+async def test_vertex_astream_complete_streams_completion_models(
+    mock_acompletion_with_retry: AsyncMock,
+    mock_from_pretrained: Mock,
+    mock_init_vertexai: Mock,
+) -> None:
+    mock_from_pretrained.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="text-bison", project="test-project")
+
+    async def completion_stream():
+        yield SimpleNamespace(text="Hi")
+        yield SimpleNamespace(text="!")
+
+    mock_acompletion_with_retry.return_value = completion_stream()
+    stream = await llm.astream_complete("Hi")
+    responses = [response async for response in stream]
+
+    assert [response.delta for response in responses] == ["Hi", "!"]
+    assert [response.text for response in responses] == ["Hi", "Hi!"]
+    mock_acompletion_with_retry.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("llama_index.llms.vertex.gemini_utils.create_gemini_client")
+async def test_vertex_gemini_astream_chat_uses_sync_fallback(
+    mock_create_client: Mock, mock_init_vertexai: Mock
+) -> None:
+    mock_create_client.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="gemini-pro", project="test-project")
+    chat_stream = iter(
+        [
+            ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content="Hi"),
+                delta="Hi",
+            ),
+            ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content="Hi!"),
+                delta="!",
+            ),
+        ]
+    )
+
+    with patch.object(llm, "_stream_chat_impl", return_value=chat_stream) as mock:
+        stream = await llm.astream_chat(
+            [ChatMessage(role=MessageRole.USER, content="Hi")]
+        )
+        responses = [response async for response in stream]
+
+    assert [response.delta for response in responses] == ["Hi", "!"]
+    assert [response.message.content for response in responses] == ["Hi", "Hi!"]
+    mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("llama_index.llms.vertex.gemini_utils.create_gemini_client")
+async def test_vertex_gemini_astream_complete_uses_sync_fallback(
+    mock_create_client: Mock, mock_init_vertexai: Mock
+) -> None:
+    mock_create_client.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="gemini-pro", project="test-project")
+    completion_stream = iter(
+        [
+            CompletionResponse(text="Hi", delta="Hi"),
+            CompletionResponse(text="Hi!", delta="!"),
+        ]
+    )
+
+    with patch.object(
+        llm, "_stream_complete_impl", return_value=completion_stream
+    ) as mock:
+        stream = await llm.astream_complete("Hi")
+        responses = [response async for response in stream]
+
+    assert [response.delta for response in responses] == ["Hi", "!"]
+    assert [response.text for response in responses] == ["Hi", "Hi!"]
+    mock.assert_called_once_with("Hi")
+
+
+@pytest.mark.asyncio
+async def test_acompletion_with_retry_gemini_stream_raises() -> None:
+    mock_client = Mock()
+    mock_client.start_chat.return_value = Mock()
+
+    with pytest.raises(
+        ValueError,
+        match="Async streaming is not supported for Gemini through this Vertex integration.",
+    ):
+        await acompletion_with_retry(
+            client=mock_client,
+            prompt="Hi",
+            is_gemini=True,
+            stream=True,
+        )
+
+
+def test_completion_with_retry_gemini_binds_tool_config_on_model() -> None:
+    class FakeChatSession:
+        def __init__(self) -> None:
+            self.send_message = Mock()
+
+    class FakeClient:
+        instances = []
+
+        def __init__(
+            self,
+            model_name: str,
+            generation_config=None,
+            safety_settings=None,
+            tools=None,
+            tool_config=None,
+            system_instruction=None,
+            labels=None,
+        ) -> None:
+            self._model_name = model_name
+            self._generation_config = generation_config
+            self._safety_settings = safety_settings
+            self._tools = tools
+            self._tool_config = tool_config
+            self._system_instruction = system_instruction
+            self._labels = labels
+            self.chat_session = FakeChatSession()
+            self.history = None
+            type(self).instances.append(self)
+
+        def start_chat(self, history=None):
+            self.history = history
+            return self.chat_session
+
+    tool_config = object()
+    base_client = FakeClient("gemini-pro")
+
+    with patch("llama_index.llms.vertex.utils.to_gemini_tools", return_value=["tool"]):
+        completion_with_retry(
+            client=base_client,
+            prompt="Hi",
+            is_gemini=True,
+            params={"message_history": ["history"]},
+            tools=[
+                {"name": "add_numbers", "description": "Add numbers", "parameters": {}}
+            ],
+            tool_config=tool_config,
+            temperature=0.2,
+            max_output_tokens=32,
+        )
+
+    assert len(FakeClient.instances) == 2
+    bound_client = FakeClient.instances[1]
+    assert bound_client._tools == ["tool"]
+    assert bound_client._tool_config is tool_config
+    assert bound_client.history == ["history"]
+    bound_client.chat_session.send_message.assert_called_once_with(
+        "Hi",
+        stream=False,
+        generation_config={"temperature": 0.2, "max_output_tokens": 32},
+    )
+
+
+@pytest.mark.asyncio
+async def test_acompletion_with_retry_gemini_binds_tool_config_on_model() -> None:
+    class FakeChatSession:
+        def __init__(self) -> None:
+            self.send_message_async = AsyncMock()
+
+    class FakeClient:
+        instances = []
+
+        def __init__(
+            self,
+            model_name: str,
+            generation_config=None,
+            safety_settings=None,
+            tools=None,
+            tool_config=None,
+            system_instruction=None,
+            labels=None,
+        ) -> None:
+            self._model_name = model_name
+            self._generation_config = generation_config
+            self._safety_settings = safety_settings
+            self._tools = tools
+            self._tool_config = tool_config
+            self._system_instruction = system_instruction
+            self._labels = labels
+            self.chat_session = FakeChatSession()
+            self.history = None
+            type(self).instances.append(self)
+
+        def start_chat(self, history=None):
+            self.history = history
+            return self.chat_session
+
+    tool_config = object()
+    base_client = FakeClient("gemini-pro")
+
+    with patch("llama_index.llms.vertex.utils.to_gemini_tools", return_value=["tool"]):
+        await acompletion_with_retry(
+            client=base_client,
+            prompt="Hi",
+            is_gemini=True,
+            params={"message_history": ["history"]},
+            tools=[
+                {"name": "add_numbers", "description": "Add numbers", "parameters": {}}
+            ],
+            tool_config=tool_config,
+            temperature=0.2,
+            max_output_tokens=32,
+        )
+
+    assert len(FakeClient.instances) == 2
+    bound_client = FakeClient.instances[1]
+    assert bound_client._tools == ["tool"]
+    assert bound_client._tool_config is tool_config
+    assert bound_client.history == ["history"]
+    bound_client.chat_session.send_message_async.assert_awaited_once_with(
+        "Hi",
+        generation_config={"temperature": 0.2, "max_output_tokens": 32},
+    )
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.vertex.base.init_vertexai")
+@patch("vertexai.language_models.CodeChatModel.from_pretrained")
+@patch("llama_index.llms.vertex.base.acompletion_with_retry")
+async def test_vertex_achat_code_models_await_twice(
+    mock_acompletion_with_retry: AsyncMock,
+    mock_from_pretrained: Mock,
+    mock_init_vertexai: Mock,
+) -> None:
+    mock_from_pretrained.return_value = Mock()
+    mock_init_vertexai.return_value = None
+
+    llm = Vertex(model="codechat-bison", project="test-project", iscode=True)
+
+    generation = Mock()
+    generation.candidates = [Mock(function_calls=[])]
+    generation.text = "fallback response"
+
+    async def second_await():
+        return generation
+
+    mock_acompletion_with_retry.return_value = second_await()
+
+    response = await llm.achat([ChatMessage(role=MessageRole.USER, content="Hi")])
+
+    assert response.message.content == "fallback response"
+    mock_acompletion_with_retry.assert_awaited_once()


### PR DESCRIPTION
# Description

This PR implements the previously `Not Implemented` async methods in the Vertex LLM integration:
- `astream_chat`
- `astream_complete`

It also completes the async/sync fallback paths needed for workflow usage and includes a small cleanup/refactor to reduce duplicated request logic in the `Vertex` class.

Fixes #18381

## Background

Issue #18381 asked for missing async chat/streaming support so the Vertex integration can work with newer workflow/agent paths.

The code changes are a bit larger than the issue title suggests because the `Vertex` class has multiple branches:
- legacy chat models
- legacy text/code completion models
- Gemini-through-Vertex models
- sync and async entrypoints
- chat/completion fallback conversions

Because of that branching, adding `astream_chat` / `astream_complete` cleanly required some internal refactoring to share request preparation and streaming behavior across sync and async paths instead of duplicating logic.

There was also a Gemini-specific compatibility issue found during live validation:
- the current Vertex SDK path used here does not expose a native async streaming API for Gemini chat in the same way as classic Vertex language models
- to preserve the async LlamaIndex interface, this PR adapts the existing sync Gemini streaming path into an async generator
- Gemini tool-calling also needed compatibility handling for the current Vertex SDK request shape

## Smoke Test

Added a real runtime smoke test script for Vertex AI validation:

- `chat`
- `complete`
- `stream_chat`
- `stream_complete`
- `achat`
- `acomplete`
- `astream_chat`
- `astream_complete`
- `chat_with_tools`
- `achat_with_tools`

Live smoke validation was run against a real Vertex AI project with `gemini-2.5-flash`.
<img width="1466" height="308" alt="image" src="https://github.com/user-attachments/assets/b05c6586-b534-4077-8a15-6ac5f3d299b5" />



## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods