### PR TITLE
fix: guard against ZeroDivisionError in LlamaDebugHandler._get_time_stats_from_event_pairs

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/llama_debug.py
+++ b/llama-index-core/llama_index/core/callbacks/llama_debug.py
@@ -124,6 +124,9 @@ class LlamaDebugHandler(PythonicallyPrintingBaseHandler):
         self, event_pairs: List[List[CBEvent]]
     ) -> EventStats:
         """Calculate time-based stats for a set of event pairs."""
+        if not event_pairs:
+            return EventStats(total_secs=0.0, average_secs=0.0, total_count=0)
+
         total_secs = 0.0
         for event_pair in event_pairs:
             start_time = datetime.strptime(event_pair[0].time, TIMESTAMP_FORMAT)


### PR DESCRIPTION
## Summary
- Add empty list guard before `total_secs / len(event_pairs)` in `_get_time_stats_from_event_pairs`
- `get_event_pairs()` can return empty list for event types with no events, causing ZeroDivisionError

## Test plan
- [x] Empty event_pairs returns zero stats instead of crashing
- [x] Non-empty event_pairs behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)