### PR TITLE
fix: replace mutable default arguments with None

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mlx/llama_index/llms/mlx/tokenizer_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-mlx/llama_index/llms/mlx/tokenizer_utils.py
@@ -308,7 +308,7 @@ def _is_bpe_decoder(decoder):
     return _match(_target_description, decoder)
 
 
-def load_tokenizer(model_path, tokenizer_config_extra={}):
+def load_tokenizer(model_path, tokenizer_config_extra=None):
     """
     Load a huggingface tokenizer and try to infer the type of streaming
     detokenizer to use.
@@ -316,6 +316,8 @@ def load_tokenizer(model_path, tokenizer_config_extra={}):
     Note, to use a fast streaming tokenizer, pass a local file path rather than
     a Hugging Face repo ID.
     """
+    if tokenizer_config_extra is None:
+        tokenizer_config_extra = {}
     detokenizer_class = NaiveStreamingDetokenizer
 
     tokenizer_file = model_path / "tokenizer.json"

--- a/llama-index-integrations/readers/llama-index-readers-document360/llama_index/readers/document360/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-document360/llama_index/readers/document360/base.py
@@ -106,7 +106,9 @@ class Document360Reader(BaseReader):
     def _get_document360_response_data(self, response):
         return response["data"]
 
-    def _process_category_recursively(self, category: Category, parent_categories=[]):
+    def _process_category_recursively(self, category: Category, parent_categories=None):
+        if parent_categories is None:
+            parent_categories = []
         if self.should_process_category and not self.should_process_category(
             category, parent_categories
         ):

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/sec_filings.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/sec_filings.py
@@ -263,7 +263,7 @@ class SECExtractor:
 
         return all_narrative_dict, filing_type
 
-    def pipeline_api(self, text, m_section=[], m_section_regex=[]):
+    def pipeline_api(self, text, m_section=None, m_section_regex=None):
         """
         Unsturcured API to get the text.
 
@@ -280,6 +280,10 @@ class SECExtractor:
                 section and corresponding texts
 
         """
+        if m_section is None:
+            m_section = []
+        if m_section_regex is None:
+            m_section_regex = []
         validate_section_names(m_section)
 
         sec_document = SECDocument.from_string(text)


### PR DESCRIPTION
## Summary
- Fix mutable default arguments (`=[]`, `={}`) in 3 integration packages
- Mutable defaults are shared across all calls, causing subtle data corruption when mutated
- See: https://docs.python.org/3/faq/programming.html#why-are-default-values-shared-between-objects

## Test plan
- [x] Functions work with and without explicit arguments
- [x] No behavior change for existing callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)