### PR TITLE
fix: add stacklevel=2 to warnings.warn() for accurate caller reporting

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -578,7 +578,8 @@ class BaseWorkflowAgent(
                     )
                 except Exception as e:
                     warnings.warn(
-                        f"There was a problem with the generation of the structured output: {e}"
+                        f"There was a problem with the generation of the structured output: {e}",
+                        stacklevel=2,
                     )
             if self.output_cls is not None:
                 try:
@@ -596,7 +597,8 @@ class BaseWorkflowAgent(
                     )
                 except Exception as e:
                     warnings.warn(
-                        f"There was a problem with the generation of the structured output: {e}"
+                        f"There was a problem with the generation of the structured output: {e}",
+                        stacklevel=2,
                     )
 
             await ctx.store.set("current_tool_calls", [])

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -588,7 +588,8 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                     )
                 except Exception as e:
                     warnings.warn(
-                        f"There was a problem with the generation of the structured output: {e}"
+                        f"There was a problem with the generation of the structured output: {e}",
+                        stacklevel=2,
                     )
             if self.output_cls is not None:
                 try:
@@ -606,7 +607,8 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                     )
                 except Exception as e:
                     warnings.warn(
-                        f"There was a problem with the generation of the structured output: {e}"
+                        f"There was a problem with the generation of the structured output: {e}",
+                        stacklevel=2,
                     )
 
             return StopEvent(result=output)

--- a/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
+++ b/llama-index-core/llama_index/core/agent/workflow/workflow_events.py
@@ -60,6 +60,7 @@ class AgentStreamStructuredOutput(Event):
             warnings.warn(
                 f"Conversion of structured response to Pydantic model failed because:\n\n{e.title}\n\nPlease check the model you provided.",
                 PydanticConversionWarning,
+                stacklevel=2,
             )
             return None
 
@@ -86,6 +87,7 @@ class AgentOutput(Event):
             warnings.warn(
                 f"Conversion of structured response to Pydantic model failed because:\n\n{e.title}\n\nPlease check the model you provided.",
                 PydanticConversionWarning,
+                stacklevel=2,
             )
             return None
 

--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -551,7 +551,8 @@ class IngestionPipeline(BaseModel):
             if num_workers > num_cpus:
                 warnings.warn(
                     "Specified num_workers exceed number of CPUs in the system. "
-                    "Setting `num_workers` down to the maximum CPU count."
+                    "Setting `num_workers` down to the maximum CPU count.",
+                    stacklevel=2,
                 )
                 num_workers = num_cpus
 
@@ -757,7 +758,8 @@ class IngestionPipeline(BaseModel):
             if num_workers > num_cpus:
                 warnings.warn(
                     "Specified num_workers exceed number of CPUs in the system. "
-                    "Setting `num_workers` down to the maximum CPU count."
+                    "Setting `num_workers` down to the maximum CPU count.",
+                    stacklevel=2,
                 )
                 num_workers = num_cpus
 

--- a/llama-index-core/llama_index/core/llama_dataset/generator.py
+++ b/llama-index-core/llama_index/core/llama_dataset/generator.py
@@ -180,7 +180,8 @@ class RagDatasetGenerator(PromptMixin):
             if num_questions_generated < self.num_questions_per_chunk:
                 warnings.warn(
                     f"Fewer questions generated ({num_questions_generated}) "
-                    f"than requested ({self.num_questions_per_chunk})."
+                    f"than requested ({self.num_questions_per_chunk}).",
+                    stacklevel=2,
                 )
 
             index = summary_indices[idx]

--- a/llama-index-core/llama_index/core/llama_dataset/legacy/embedding.py
+++ b/llama-index-core/llama_index/core/llama_dataset/legacy/embedding.py
@@ -102,7 +102,8 @@ def generate_qa_embedding_pairs(
         if num_questions_generated < num_questions_per_chunk:
             warnings.warn(
                 f"Fewer questions generated ({num_questions_generated}) "
-                f"than requested ({num_questions_per_chunk})."
+                f"than requested ({num_questions_per_chunk}).",
+                stacklevel=2,
             )
 
         for question in questions:

--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -753,7 +753,8 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
             if num_workers > num_cpus:
                 warnings.warn(
                     "Specified num_workers exceed number of CPUs in the system. "
-                    "Setting `num_workers` down to the maximum CPU count."
+                    "Setting `num_workers` down to the maximum CPU count.",
+                    stacklevel=2,
                 )
                 num_workers = num_cpus
 

--- a/llama-index-core/llama_index/core/readers/json.py
+++ b/llama-index-core/llama_index/core/readers/json.py
@@ -150,5 +150,8 @@ class JSONReader(BaseReader):
                         )
             return documents
         except RecursionError:
-            warnings.warn("Recursion error occurred while processing JSON data.")
+            warnings.warn(
+                "Recursion error occurred while processing JSON data.",
+                stacklevel=2,
+            )
             return []


### PR DESCRIPTION
## Summary
- Add `stacklevel=2` to all `warnings.warn()` calls in `llama-index-core` that were missing it
- Without `stacklevel`, Python's warning system reports the file/line of the llama_index internal code rather than the user's calling code
- This makes it easier for users to identify which line in *their* code triggered a deprecation or runtime warning

### Files changed (8 files, 12 call sites)
- `agent/workflow/workflow_events.py` — 2 Pydantic conversion warnings
- `agent/workflow/base_agent.py` — 2 structured output generation warnings
- `agent/workflow/multi_agent_workflow.py` — 2 structured output generation warnings
- `ingestion/pipeline.py` — 2 num_workers CPU count warnings
- `llama_dataset/generator.py` — 1 fewer-questions-generated warning
- `llama_dataset/legacy/embedding.py` — 1 fewer-questions-generated warning
- `readers/file/base.py` — 1 num_workers CPU count warning
- `readers/json.py` — 1 recursion error warning

## Test plan
- [x] Verify all `warnings.warn()` calls in llama-index-core now include `stacklevel` (validated via AST analysis)
- [x] No functional behavior change — only warning source location reporting is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)