### PR TITLE
fix: : CondensePlusContextChatEngine.astream_chat silently aborts

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -27,7 +27,7 @@ from llama_index.core.memory import BaseMemory, Memory
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.response_synthesizers import CompactAndRefine
-from llama_index.core.schema import NodeWithScore
+from llama_index.core.schema import NodeWithScore, TextNode
 from llama_index.core.settings import Settings
 from llama_index.core.utilities.token_counting import TokenCounter
 from llama_index.core.chat_engine.utils import (
@@ -323,7 +323,8 @@ class CondensePlusContextChatEngine(BaseChatEngine):
     ) -> AgentChatResponse:
         synthesizer, context_source, context_nodes = self._run_c3(message, chat_history)
 
-        response = synthesizer.synthesize(message, context_nodes)
+        synth_nodes = context_nodes or [NodeWithScore(node=TextNode(text=""))]
+        response = synthesizer.synthesize(message, synth_nodes)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
@@ -346,7 +347,8 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history, streaming=True
         )
 
-        response = synthesizer.synthesize(message, context_nodes)
+        synth_nodes = context_nodes or [NodeWithScore(node=TextNode(text=""))]
+        response = synthesizer.synthesize(message, synth_nodes)
         assert isinstance(response, StreamingResponse)
 
         def wrapped_gen(response: StreamingResponse) -> ChatResponseGen:
@@ -382,7 +384,8 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history
         )
 
-        response = await synthesizer.asynthesize(message, context_nodes)
+        synth_nodes = context_nodes or [NodeWithScore(node=TextNode(text=""))]
+        response = await synthesizer.asynthesize(message, synth_nodes)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
@@ -405,7 +408,8 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history, streaming=True
         )
 
-        response = await synthesizer.asynthesize(message, context_nodes)
+        synth_nodes = context_nodes or [NodeWithScore(node=TextNode(text=""))]
+        response = await synthesizer.asynthesize(message, synth_nodes)
         assert isinstance(response, AsyncStreamingResponse)
 
         async def wrapped_gen(response: AsyncStreamingResponse) -> ChatResponseAsyncGen:

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -1,14 +1,22 @@
+from typing import List
+
 import pytest
 
 from llama_index.core import MockEmbedding
+from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.chat_engine.condense_plus_context import (
     CondensePlusContextChatEngine,
 )
 from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.llms.mock import MockLLM
-from llama_index.core.schema import Document
+from llama_index.core.schema import Document, NodeWithScore, QueryBundle
 
 SYSTEM_PROMPT = "Talk like a pirate."
+
+
+class EmptyRetriever(BaseRetriever):
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return []
 
 
 @pytest.fixture()
@@ -98,3 +106,54 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+@pytest.fixture()
+def empty_chat_engine() -> CondensePlusContextChatEngine:
+    return CondensePlusContextChatEngine.from_defaults(
+        EmptyRetriever(), llm=MockLLM(), system_prompt=SYSTEM_PROMPT
+    )
+
+
+def test_chat_empty_nodes(empty_chat_engine: CondensePlusContextChatEngine):
+    response = empty_chat_engine.chat("Hello World!")
+    assert str(response) != "Empty Response"
+    assert "Hello World!" in str(response)
+    assert len(empty_chat_engine.chat_history) == 2
+
+
+def test_chat_stream_empty_nodes(empty_chat_engine: CondensePlusContextChatEngine):
+    response = empty_chat_engine.stream_chat("Hello World!")
+
+    num_iters = 0
+    for _ in response.response_gen:
+        num_iters += 1
+
+    assert num_iters > 0
+    assert str(response) != "Empty Response"
+    assert "Hello World!" in str(response)
+    assert len(empty_chat_engine.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_achat_empty_nodes(empty_chat_engine: CondensePlusContextChatEngine):
+    response = await empty_chat_engine.achat("Hello World!")
+    assert str(response) != "Empty Response"
+    assert "Hello World!" in str(response)
+    assert len(empty_chat_engine.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_empty_nodes(
+    empty_chat_engine: CondensePlusContextChatEngine,
+):
+    response = await empty_chat_engine.astream_chat("Hello World!")
+
+    num_iters = 0
+    async for _ in response.async_response_gen():
+        num_iters += 1
+
+    assert num_iters > 0
+    assert str(response) != "Empty Response"
+    assert "Hello World!" in str(response)
+    assert len(empty_chat_engine.chat_history) == 2


### PR DESCRIPTION
Closes #20894

**What**: Pass an empty-text placeholder node to the synthesizer when the retriever returns 0 nodes, instead of letting it short-circuit with a hardcoded `"Empty Response"`.

**Why**: Previously, `CompactAndRefine.synthesize`/`asynthesize` received an empty node list and skipped the LLM call entirely. Now, a `NodeWithScore(node=TextNode(text=""))` placeholder ensures the synthesizer still invokes the LLM with the full prompt template.

**How**: In `condense_plus_context.py`, all four chat paths (`chat`, `stream_chat`, `achat`, `astream_chat`) now gate `context_nodes` with `synth_nodes = context_nodes or [NodeWithScore(node=TextNode(text=""))]` before passing to the synthesizer. This is a minimal, localized fix — the retriever, prompt construction, and memory logic are untouched.

Added an `EmptyRetriever` helper and an `empty_chat_engine` fixture in `test_condense_plus_context.py`, with four new tests (`test_chat_empty_nodes`, `test_stream_chat_empty_nodes`, `test_achat_empty_nodes`, `test_astream_chat_empty_nodes`) that assert the response is not `"Empty Response"` and that chat history is correctly updated.

## Description
See above.

## New Package?
No.

## Version Bump?
No — bug fix only, no API change.

## Type of Change
Bug fix (non-breaking).

## How Has This Been Tested?
Four new unit tests covering sync, streaming, async, and async-streaming paths with an `EmptyRetriever` that returns `[]`. All assert the LLM is actually called and produces real output.

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation — N/A, no docs needed