### PR TITLE
fix: resolved sub_dict KeyError when using VectorMemory with ChromaDB

### DIFF
--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -147,7 +147,7 @@ class VectorMemory(BaseMemory):
         return [
             ChatMessage.model_validate(sub_dict)
             for node in nodes
-            for sub_dict in node.metadata["sub_dicts"]
+            for sub_dict in node.metadata.get("sub_dicts", [])
         ]
 
     def get_all(self) -> List[ChatMessage]:

--- a/llama-index-core/tests/agent/memory/test_vector_memory.py
+++ b/llama-index-core/tests/agent/memory/test_vector_memory.py
@@ -1,10 +1,13 @@
 """Test vector memory."""
 
 from typing import Any, List
-from llama_index.core.memory import VectorMemory
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.base.llms.types import MessageRole
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
-from unittest.mock import patch
 from llama_index.core.llms import ChatMessage
+from llama_index.core.memory import VectorMemory
+from llama_index.core.schema import TextNode
 
 
 def mock_get_text_embedding(text: str) -> List[float]:
@@ -62,3 +65,122 @@ def test_vector_memory(
     assert len(msgs) == 2
     assert msgs[0].content == "Jerry likes juice."
     assert msgs[1].content == "That's nice."
+
+
+def test_vector_memory_get_handles_nodes_without_sub_dicts() -> None:
+    """
+    Test that VectorMemory.get() gracefully handles nodes without sub_dicts metadata.
+
+    This occurs when using ChromaDB or other vector stores with a shared/pre-existing
+    collection containing document chunks (e.g. from VectorStoreIndex.from_documents)
+    that don't have the VectorMemory sub_dicts structure. Before the fix, this would
+    raise KeyError: 'sub_dicts'.
+    """
+    # Create VectorMemory with in-memory store
+    embed_model = MockEmbedding(embed_dim=5)
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=None,
+        embed_model=embed_model,
+        retriever_kwargs={"similarity_top_k": 5},
+    )
+
+    # Create mock nodes: one WITH sub_dicts (valid VectorMemory node),
+    # one WITHOUT (e.g. from document indexing)
+    valid_sub_dict = ChatMessage.from_str("hello from memory", "user").model_dump()
+    node_with_sub_dicts = TextNode(
+        text="User said hello",
+        metadata={
+            "sub_dicts": [valid_sub_dict],
+        },
+    )
+    node_without_sub_dicts = TextNode(
+        text="Some document content",
+        metadata={"file_name": "doc.pdf", "page_label": "1"},  # No sub_dicts
+    )
+
+    # Mock the retriever to return both types (simulating shared Chroma collection)
+    mock_retriever = MagicMock()
+    mock_retriever.retrieve.return_value = [
+        node_with_sub_dicts,
+        node_without_sub_dicts,
+    ]
+
+    mock_index = MagicMock()
+    mock_index.as_retriever.return_value = mock_retriever
+
+    vector_memory.vector_index = mock_index
+
+    # Act - should not raise KeyError
+    msgs = vector_memory.get("hello")
+
+    # Assert - only messages from node with sub_dicts; node without is skipped
+    assert len(msgs) == 1
+    assert msgs[0].content == "hello from memory"
+    assert msgs[0].role == MessageRole.USER
+
+
+def test_vector_memory_get_handles_only_nodes_without_sub_dicts() -> None:
+    """
+    Test that VectorMemory.get() returns empty list when all nodes lack sub_dicts.
+
+    When using a pre-populated Chroma collection (e.g. from document ingestion),
+    retrieval may return only document nodes. Before the fix this raised KeyError.
+    """
+    embed_model = MockEmbedding(embed_dim=5)
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=None,
+        embed_model=embed_model,
+        retriever_kwargs={"similarity_top_k": 5},
+    )
+
+    # Only document-style nodes (no sub_dicts)
+    document_nodes = [
+        TextNode(
+            text="Document chunk 1",
+            metadata={"file_name": "doc1.pdf", "page_label": "1"},
+        ),
+        TextNode(
+            text="Document chunk 2",
+            metadata={"file_name": "doc2.pdf", "page_label": "2"},
+        ),
+    ]
+
+    mock_retriever = MagicMock()
+    mock_retriever.retrieve.return_value = document_nodes
+
+    mock_index = MagicMock()
+    mock_index.as_retriever.return_value = mock_retriever
+
+    vector_memory.vector_index = mock_index
+
+    # Act - should not raise KeyError, returns empty list
+    msgs = vector_memory.get("query")
+
+    assert len(msgs) == 0
+
+
+def test_vector_memory_get_handles_nodes_with_empty_sub_dicts() -> None:
+    """Test that VectorMemory.get() handles nodes with sub_dicts=[] (empty list)."""
+    embed_model = MockEmbedding(embed_dim=5)
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=None,
+        embed_model=embed_model,
+        retriever_kwargs={"similarity_top_k": 5},
+    )
+
+    node_with_empty_sub_dicts = TextNode(
+        text="",
+        metadata={"sub_dicts": []},
+    )
+
+    mock_retriever = MagicMock()
+    mock_retriever.retrieve.return_value = [node_with_empty_sub_dicts]
+
+    mock_index = MagicMock()
+    mock_index.as_retriever.return_value = mock_retriever
+
+    vector_memory.vector_index = mock_index
+
+    msgs = vector_memory.get("query")
+
+    assert len(msgs) == 0

--- a/llama-index-core/tests/agent/memory/test_vector_memory_chroma.py
+++ b/llama-index-core/tests/agent/memory/test_vector_memory_chroma.py
@@ -1,0 +1,66 @@
+"""
+    Test VectorMemory with ChromaVectorStore.
+
+Verifies that VectorMemory.get() does not raise KeyError when the Chroma
+collection contains nodes without sub_dicts metadata (e.g. document chunks
+from a shared/pre-existing collection). See: KeyError 'sub_dicts' bug fix.
+
+Requires llama-index-core with the fix (node.metadata.get('sub_dicts', [])).
+"""
+
+import chromadb
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.memory import VectorMemory
+from llama_index.core.schema import TextNode
+from llama_index.vector_stores.chroma import ChromaVectorStore
+
+
+def test_vector_memory_with_chroma_handles_document_nodes() -> None:
+    """
+    VectorMemory.get() should not raise KeyError when Chroma returns document nodes.
+
+    When using a Chroma collection that was populated with documents (e.g. via
+    VectorStoreIndex.from_documents), similarity search returns nodes without
+    sub_dicts. VectorMemory must gracefully skip these instead of raising KeyError.
+    """
+    # Use EphemeralClient for isolated in-memory test (no disk, no cleanup needed)
+    client = chromadb.EphemeralClient()
+    collection = client.create_collection(
+        "vector_memory_test", metadata={"hnsw:space": "cosine"}
+    )
+
+    # ChromaVectorStore with flat_metadata=False to allow document-style metadata
+    # (sub_dicts would still fail at add time for Chroma, but document nodes work)
+    vector_store = ChromaVectorStore(chroma_collection=collection, flat_metadata=False)
+
+    # Add document-style nodes (no sub_dicts) - simulates shared collection
+    # from VectorStoreIndex.from_documents or similar
+    doc_nodes = [
+        TextNode(
+            text="Document content about apples",
+            metadata={"file_name": "doc1.pdf", "page_label": "1"},
+            embedding=[0.1, 0.2, 0.3, 0.4, 0.5],
+        ),
+        TextNode(
+            text="Document content about oranges",
+            metadata={"file_name": "doc2.pdf", "page_label": "2"},
+            embedding=[0.2, 0.3, 0.4, 0.5, 0.6],
+        ),
+    ]
+    vector_store.add(doc_nodes)
+
+    # Create VectorMemory with this Chroma-backed store
+    embed_model = MockEmbedding(embed_dim=5)
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=vector_store,
+        embed_model=embed_model,
+        retriever_kwargs={"similarity_top_k": 3},
+    )
+
+    # Act - should NOT raise KeyError: 'sub_dicts'
+    # Retrieved nodes are document chunks without sub_dicts; they get skipped
+    msgs = vector_memory.get("apples and oranges")
+
+    # Assert - returns empty list (no VectorMemory-formatted nodes in collection)
+    assert isinstance(msgs, list)
+    assert len(msgs) == 0


### PR DESCRIPTION
# Description

Fixes the `KeyError: 'sub_dicts'` that occurs when `VectorMemory.get()` is used with a ChromaDB vector store whose collection was populated in document chunks (e.g. via `VectorStoreIndex.from_documents()`) and protects against the possibility of the issue happening for other vector stores in the future by containing nodes without the VectorMemory `sub_dicts` metadata.

VectorMemory previously assumed every retrieved node had `metadata["sub_dicts"]`. Similarity search can return nodes from other indexing flows, which don't have this field, causing a KeyError.

Fixes #15681

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
Three unit tests were added to test_vector_memory.py:
test_vector_memory_get_handles_nodes_without_sub_dicts – mixed nodes (with and without sub_dicts)
test_vector_memory_get_handles_only_nodes_without_sub_dicts – only document-style nodes
test_vector_memory_get_handles_nodes_with_empty_sub_dicts – nodes with empty sub_dicts
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
