### PR TITLE
Fix OpenAILike Gemini OpenAI compatibility

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -135,10 +135,27 @@ class OpenAILike(OpenAI):
 
     @property
     def metadata(self) -> LLMMetadata:
+        is_chat_model = self.is_chat_model
+
+        # Auto-detect chat models for certain OpenAI-compatible providers.
+        api_base = getattr(self, "api_base", None)
+        if not is_chat_model and isinstance(api_base, str):
+            base = api_base.lower().rstrip("/")
+            # Gemini's OpenAI compatibility endpoint only supports the
+            # Chat Completions API. If users configure OpenAILike with the
+            # Gemini OpenAI-compatible base URL but forget to set
+            # `is_chat_model=True`, we still need to route traffic through
+            # the chat endpoint, otherwise the Completions endpoint will
+            # return 404.
+            if "generativelanguage.googleapis.com" in base or base.endswith(
+                "/v1beta/openai"
+            ):
+                is_chat_model = True
+
         return LLMMetadata(
             context_window=self.context_window,
             num_output=self.max_tokens or -1,
-            is_chat_model=self.is_chat_model,
+            is_chat_model=is_chat_model,
             is_function_calling_model=self.is_function_calling_model,
             model_name=self.model,
         )

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_openai_like.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_openai_like.py
@@ -172,3 +172,28 @@ def test_serialization() -> None:
     # Check OpenAILike subclass specifics
     assert serialized["context_window"] == 43
     assert serialized["is_chat_model"]
+
+
+@patch("llama_index.llms.openai.base.SyncOpenAI")
+def test_gemini_openai_compat_defaults_to_chat(
+    MockSyncOpenAI: MagicMock,
+) -> None:
+    content = "hello from gemini"
+
+    mock_instance = MockSyncOpenAI.return_value
+    mock_instance.chat.completions.create.return_value = mock_chat_completion(content)
+
+    llm = OpenAILike(
+        model=STUB_MODEL_NAME,
+        api_key=STUB_API_KEY,
+        api_base="https://generativelanguage.googleapis.com/v1beta/openai/",
+        context_window=1024,
+        max_tokens=None,
+        # is_chat_model left as default False; heuristics should route via chat API.
+    )
+
+    response = llm.complete("A prompt to Gemini")
+    assert response.text == content
+
+    mock_instance.chat.completions.create.assert_called_once()
+    mock_instance.completions.create.assert_not_called()


### PR DESCRIPTION
Ensure OpenAILike routes Gemini OpenAI-compatible endpoints through the Chat Completions API so that Gemini models no longer return 404 when used via `OpenAILike`.

This change auto-detects Gemini's OpenAI compatibility base URL and defaults `is_chat_model` to True in that case.

Closes #20784.