### PR TITLE
fix(github-reader): replace run_until_complete with asyncio_run for async compatibility

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/collaborators/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/collaborators/base.py
@@ -18,11 +18,11 @@ Each collaborator is converted to a document by doing the following:
 
 """
 
-import asyncio
 import enum
 import logging
 from typing import Dict, List
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
 from llama_index.readers.github.collaborators.github_client import (
@@ -88,15 +88,6 @@ class GitHubRepositoryCollaboratorsReader(BaseReader):
         self._owner = owner
         self._repo = repo
         self._verbose = verbose
-
-        # Set up the event loop
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # If there is no running loop, create a new one
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-
         self._github_client = github_client
 
     def load_data(
@@ -127,7 +118,7 @@ class GitHubRepositoryCollaboratorsReader(BaseReader):
         page = 1
         # Loop until there are no more collaborators
         while True:
-            collaborators: Dict = self._loop.run_until_complete(
+            collaborators: Dict = asyncio_run(
                 self._github_client.get_collaborators(
                     self._owner, self._repo, page=page
                 )

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/issues/base.py
@@ -19,11 +19,11 @@ Each issue is converted to a document by doing the following:
 
 """
 
-import asyncio
 import enum
 import logging
 from typing import Dict, List, Optional, Tuple
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
 from llama_index.readers.github.issues.github_client import (
@@ -106,15 +106,6 @@ class GitHubRepositoryIssuesReader(BaseReader):
         self._owner = owner
         self._repo = repo
         self._verbose = verbose
-
-        # Set up the event loop
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # If there is no running loop, create a new one
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-
         self._github_client = github_client
 
     def load_data(
@@ -150,7 +141,7 @@ class GitHubRepositoryIssuesReader(BaseReader):
         page = 1
         # Loop until there are no more issues
         while True:
-            issues: Dict = self._loop.run_until_complete(
+            issues: Dict = asyncio_run(
                 self._github_client.get_issues(
                     self._owner, self._repo, state=state.value, page=page
                 )

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/base.py
@@ -17,6 +17,7 @@ import re
 import tempfile
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.readers.file.base import _try_loading_included_file_formats
 from llama_index.core.schema import Document
@@ -190,17 +191,7 @@ class GithubRepositoryReader(BaseReader):
         self.logger = logger or logging.getLogger(__name__)
         self._process_file_callback = process_file_callback
         self.fail_on_error = fail_on_error
-
-        # Set up the event loop
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # If there is no running loop, create a new one
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-
         self._github_client = github_client
-
         self._file_readers: Dict[str, BaseReader] = custom_parsers or {}
         self._supported_suffix = list(DEFAULT_FILE_READER_CLS.keys())
         self.dispatcher = get_dispatcher()
@@ -565,7 +556,7 @@ class GithubRepositoryReader(BaseReader):
             file_paths = [file_path]
 
         if file_paths is not None:
-            return self._loop.run_until_complete(
+            return asyncio_run(
                 self._load_files_by_path(
                     ref=commit_sha,
                     file_paths=file_paths,
@@ -580,7 +571,7 @@ class GithubRepositoryReader(BaseReader):
             )
         )
 
-        commit_response: GitCommitResponseModel = self._loop.run_until_complete(
+        commit_response: GitCommitResponseModel = asyncio_run(
             self._github_client.get_commit(
                 self._owner,
                 self._repo,
@@ -591,7 +582,7 @@ class GithubRepositoryReader(BaseReader):
         )
 
         tree_sha = commit_response.commit.tree.sha
-        blobs_and_paths = self._loop.run_until_complete(self._recurse_tree(tree_sha))
+        blobs_and_paths = asyncio_run(self._recurse_tree(tree_sha))
 
         # Filter ignoring file paths
         if ignore_file_paths:
@@ -620,7 +611,7 @@ class GithubRepositoryReader(BaseReader):
             )
         )
 
-        documents = self._loop.run_until_complete(
+        documents = asyncio_run(
             self._generate_documents(
                 blobs_and_paths=blobs_and_paths,
                 id=commit_sha,
@@ -635,8 +626,6 @@ class GithubRepositoryReader(BaseReader):
                 total_documents=len(documents),
             )
         )
-
-        return documents
 
         return documents
 
@@ -664,7 +653,7 @@ class GithubRepositoryReader(BaseReader):
             file_paths = [file_path]
 
         if file_paths is not None:
-            return self._loop.run_until_complete(
+            return asyncio_run(
                 self._load_files_by_path(
                     ref=branch,
                     file_paths=file_paths,
@@ -679,7 +668,7 @@ class GithubRepositoryReader(BaseReader):
             )
         )
 
-        branch_data: GitBranchResponseModel = self._loop.run_until_complete(
+        branch_data: GitBranchResponseModel = asyncio_run(
             self._github_client.get_branch(
                 self._owner,
                 self._repo,
@@ -690,7 +679,7 @@ class GithubRepositoryReader(BaseReader):
         )
 
         tree_sha = branch_data.commit.commit.tree.sha
-        blobs_and_paths = self._loop.run_until_complete(self._recurse_tree(tree_sha))
+        blobs_and_paths = asyncio_run(self._recurse_tree(tree_sha))
 
         # Filter ignoring file paths
         if ignore_file_paths:
@@ -719,7 +708,7 @@ class GithubRepositoryReader(BaseReader):
             )
         )
 
-        documents = self._loop.run_until_complete(
+        documents = asyncio_run(
             self._generate_documents(
                 blobs_and_paths=blobs_and_paths,
                 id=branch,
@@ -895,7 +884,6 @@ class GithubRepositoryReader(BaseReader):
             github_client=self._github_client,
             owner=self._owner,
             repo=self._repo,
-            loop=self._loop,
             buffer_size=self._concurrent_requests,  # TODO: make this configurable
             verbose=self._verbose,
             timeout=self._timeout,

--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/utils.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/utils.py
@@ -7,6 +7,7 @@ This module contains utility functions for the Github readers.
 import asyncio
 import os
 import time
+import warnings
 from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 
@@ -104,8 +105,8 @@ class BufferedGitBlobDataIterator(BufferedAsyncIterator):
         github_client: GithubClient,
         owner: str,
         repo: str,
-        loop: asyncio.AbstractEventLoop,
         buffer_size: int,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         verbose: bool = False,
         timeout: Optional[int] = 5,
         retries: int = 0,
@@ -119,14 +120,22 @@ class BufferedGitBlobDataIterator(BufferedAsyncIterator):
             - github_client (GithubClient): Github client.
             - owner (str): Owner of the repository.
             - repo (str): Name of the repository.
-            - loop (asyncio.AbstractEventLoop): Event loop.
-            - verbose (bool): Whether to print verbose messages.
             - buffer_size (int): Size of the buffer.
+            - loop (Optional[asyncio.AbstractEventLoop]): Deprecated. No longer used.
+                Kept for backwards compatibility.
+            - verbose (bool): Whether to print verbose messages.
             - timeout (int or None): Timeout for the requests to the Github API. Default is 5.
             - retries (int): Number of retries for requests made to the Github API. Default is 0.
 
         """
         super().__init__(buffer_size)
+        if loop is not None:
+            warnings.warn(
+                "The 'loop' parameter is deprecated and will be removed in a future release. "
+                "It is no longer used internally.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._blobs_and_paths = blobs_and_paths
         self._github_client = github_client
         self._owner = owner
@@ -134,10 +143,6 @@ class BufferedGitBlobDataIterator(BufferedAsyncIterator):
         self._verbose = verbose
         self._timeout = timeout
         self._retries = retries
-        if loop is None:
-            loop = asyncio.get_event_loop()
-            if loop is None:
-                raise ValueError("No event loop found")
 
     async def _fill_buffer(self) -> None:
         """

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-github"
-version = "0.11.0"
+version = "0.11.1"
 description = "llama-index readers github integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-github/tests/test_asyncio_run_in_running_loop.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/tests/test_asyncio_run_in_running_loop.py
@@ -1,0 +1,211 @@
+"""
+Tests for issue #19367: GitHub readers should work in async contexts.
+
+Previously, GitHubRepositoryIssuesReader, GitHubRepositoryCollaboratorsReader,
+and GithubRepositoryReader used `self._loop.run_until_complete()` which raises
+`RuntimeError: This event loop is already running` when called from within an
+async context (e.g. FastAPI, MCP servers, Jupyter notebooks).
+
+The fix replaces all `run_until_complete` calls with `asyncio_run` from
+`llama_index.core.async_utils`, which handles running loops by dispatching
+to a separate thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+from llama_index.readers.github import GithubRepositoryReader
+from llama_index.readers.github.repository.github_client import (
+    GitBlobResponseModel,
+    GitBranchResponseModel,
+    GitTreeResponseModel,
+    GithubClient,
+)
+from llama_index.readers.github.issues.github_client import GitHubIssuesClient
+from llama_index.readers.github.collaborators.github_client import (
+    GitHubCollaboratorsClient,
+)
+from llama_index.readers.github import (
+    GitHubRepositoryIssuesReader,
+    GitHubRepositoryCollaboratorsReader,
+)
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "fake-token-for-tests")
+
+BRANCH_JSON = '{"name":"main","commit":{"sha":"abc123","node_id":"C_test","commit":{"author":{"name":"Test","email":"test@test.com","date":"2024-01-01T00:00:00Z"},"committer":{"name":"Test","email":"test@test.com","date":"2024-01-01T00:00:00Z"},"message":"test commit","tree":{"sha":"tree123","url":"https://api.github.com/test/trees/tree123"},"url":"https://api.github.com/test/commits/abc123","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/test/commits/abc123","html_url":"https://github.com/test/test/commit/abc123","comments_url":"https://api.github.com/test/commits/abc123/comments","author":null,"committer":null,"parents":[]},"_links":{"self":"https://api.github.com/test/branches/main","html":"https://github.com/test/test/tree/main"},"protected":false}'
+
+TREE_JSON = '{"sha":"tree123","url":"https://api.github.com/test/trees/tree123","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"blob123","size":10,"url":"https://api.github.com/test/blobs/blob123"}],"truncated":false}'
+
+BLOB_JSON = '{"sha":"blob123","node_id":"B_test","size":10,"url":"https://api.github.com/test/blobs/blob123","content":"SGVsbG8gV29ybGQ=","encoding":"base64"}'
+
+
+@pytest.fixture()
+def mock_github_client(monkeypatch):
+    """Mock GithubClient API methods to avoid real network calls."""
+
+    async def mock_get_branch(self, *args, **kwargs):
+        return GitBranchResponseModel.from_json(BRANCH_JSON)
+
+    async def mock_get_tree(self, *args, **kwargs):
+        return GitTreeResponseModel.from_json(TREE_JSON)
+
+    async def mock_get_blob(self, *args, **kwargs):
+        return GitBlobResponseModel.from_json(BLOB_JSON)
+
+    monkeypatch.setattr(GithubClient, "get_branch", mock_get_branch)
+    monkeypatch.setattr(GithubClient, "get_tree", mock_get_tree)
+    monkeypatch.setattr(GithubClient, "get_blob", mock_get_blob)
+
+
+def test_github_repository_reader_no_loop_attribute():
+    """GithubRepositoryReader.__init__ must not create self._loop."""
+    client = GithubClient(GITHUB_TOKEN)
+    reader = GithubRepositoryReader(client, "owner", "repo")
+    assert not hasattr(reader, "_loop"), (
+        "GithubRepositoryReader should not have _loop attribute after fix"
+    )
+
+
+def test_github_issues_reader_no_loop_attribute():
+    """GitHubRepositoryIssuesReader.__init__ must not create self._loop."""
+    client = GitHubIssuesClient(github_token=GITHUB_TOKEN)
+    reader = GitHubRepositoryIssuesReader(
+        github_client=client, owner="owner", repo="repo"
+    )
+    assert not hasattr(reader, "_loop"), (
+        "GitHubRepositoryIssuesReader should not have _loop attribute after fix"
+    )
+
+
+def test_github_collaborators_reader_no_loop_attribute():
+    """GitHubRepositoryCollaboratorsReader.__init__ must not create self._loop."""
+    client = GitHubCollaboratorsClient(github_token=GITHUB_TOKEN)
+    reader = GitHubRepositoryCollaboratorsReader(
+        github_client=client, owner="owner", repo="repo"
+    )
+    assert not hasattr(reader, "_loop"), (
+        "GitHubRepositoryCollaboratorsReader should not have _loop attribute after fix"
+    )
+
+
+def test_repository_reader_load_data_within_running_loop(mock_github_client):
+    """
+    GithubRepositoryReader.load_data() must succeed when called from within
+    a running event loop (simulating FastAPI / MCP server / Jupyter context).
+
+    Before the fix this raised:
+        RuntimeError: This event loop is already running
+    """
+
+    async def run_in_async_context():
+        client = GithubClient(GITHUB_TOKEN)
+        reader = GithubRepositoryReader(client, "owner", "repo")
+        # load_data is synchronous but internally calls async code;
+        # with asyncio_run it must handle the already-running loop.
+        return reader.load_data(branch="main")
+
+    documents = asyncio.run(run_in_async_context())
+    assert isinstance(documents, list)
+
+
+def test_issues_reader_load_data_within_running_loop():
+    """
+    GitHubRepositoryIssuesReader.load_data() must succeed in async context.
+    """
+    empty_page: list = []
+
+    async def mock_get_issues(self, *args, **kwargs):
+        return empty_page
+
+    async def run_in_async_context():
+        with patch.object(GitHubIssuesClient, "get_issues", mock_get_issues):
+            client = GitHubIssuesClient(github_token=GITHUB_TOKEN)
+            reader = GitHubRepositoryIssuesReader(
+                github_client=client, owner="owner", repo="repo"
+            )
+            return reader.load_data()
+
+    documents = asyncio.run(run_in_async_context())
+    assert documents == []
+
+
+def test_collaborators_reader_load_data_within_running_loop():
+    """
+    GitHubRepositoryCollaboratorsReader.load_data() must succeed in async context.
+    """
+    empty_page: list = []
+
+    async def mock_get_collaborators(self, *args, **kwargs):
+        return empty_page
+
+    async def run_in_async_context():
+        with patch.object(
+            GitHubCollaboratorsClient, "get_collaborators", mock_get_collaborators
+        ):
+            client = GitHubCollaboratorsClient(github_token=GITHUB_TOKEN)
+            reader = GitHubRepositoryCollaboratorsReader(
+                github_client=client, owner="owner", repo="repo"
+            )
+            return reader.load_data()
+
+    documents = asyncio.run(run_in_async_context())
+    assert documents == []
+
+
+def test_buffered_git_blob_iterator_loop_param_deprecation():
+    """
+    BufferedGitBlobDataIterator should emit DeprecationWarning when 'loop'
+    is passed, for backwards compatibility.
+    """
+    import warnings
+    from llama_index.readers.github.repository.utils import BufferedGitBlobDataIterator
+
+    client = GithubClient(GITHUB_TOKEN)
+    loop = asyncio.new_event_loop()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            BufferedGitBlobDataIterator(
+                blobs_and_paths=[],
+                github_client=client,
+                owner="owner",
+                repo="repo",
+                buffer_size=5,
+                loop=loop,
+            )
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) == 1
+        assert "loop" in str(deprecation_warnings[0].message).lower()
+    finally:
+        loop.close()
+
+
+def test_buffered_git_blob_iterator_no_loop_param_no_warning():
+    """
+    BufferedGitBlobDataIterator should not emit DeprecationWarning when
+    'loop' is not passed (the normal post-fix usage).
+    """
+    import warnings
+    from llama_index.readers.github.repository.utils import BufferedGitBlobDataIterator
+
+    client = GithubClient(GITHUB_TOKEN)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        BufferedGitBlobDataIterator(
+            blobs_and_paths=[],
+            github_client=client,
+            owner="owner",
+            repo="repo",
+            buffer_size=5,
+        )
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecation_warnings) == 0


### PR DESCRIPTION
## Description

Fixes #19367

The three GitHub readers (`GitHubRepositoryIssuesReader`, `GitHubRepositoryCollaboratorsReader`, `GithubRepositoryReader`) use `self._loop.run_until_complete()` in their `load_data()` methods, which raises `RuntimeError: This event loop is already running` when called from async contexts (MCP servers, FastAPI, Jupyter notebooks).

## Changes

**Root cause:** Each reader captures an event loop in `__init__` (`self._loop = asyncio.get_running_loop()`) and calls `self._loop.run_until_complete(coro)` in sync methods. When an event loop is already running, this fails.

**Fix:** Replace all `self._loop.run_until_complete(coro)` calls with `asyncio_run(coro)` from `llama_index.core.async_utils`, which already handles the running-loop case by executing the coroutine in a separate thread.

### Files changed

- `llama_index/readers/github/issues/base.py` — 1 substitution + remove `self._loop`
- `llama_index/readers/github/collaborators/base.py` — 1 substitution + remove `self._loop`
- `llama_index/readers/github/repository/base.py` — 7 substitutions + remove `self._loop` + remove `loop` param from `BufferedGitBlobDataIterator` call
- `llama_index/readers/github/repository/utils.py` — deprecate `loop` parameter in `BufferedGitBlobDataIterator` (backward compatible)
- `pyproject.toml` — version bump 0.11.0 → 0.11.1

### Tests added

`tests/test_asyncio_run_in_running_loop.py` — 8 tests covering:
- Absence of `self._loop` attribute in all 3 readers
- `load_data()` working inside `asyncio.run()` (the exact failing scenario)
- `DeprecationWarning` behavior for the `loop` parameter

**All 52 tests pass, 9 skipped (pre-existing).**

## New Package Versions?

- `llama-index-readers-github`: 0.11.0 → 0.11.1

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>