### PR TITLE
fix: preserve empty strings in DocumentBlock fields

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -697,9 +697,10 @@ class DocumentBlock(BaseContentBlock):
 
     @model_validator(mode="after")
     def document_validation(self) -> Self:
-        self.document_mimetype = self.document_mimetype or self._guess_mimetype()
+        if self.document_mimetype is None:
+            self.document_mimetype = self._guess_mimetype()
 
-        if not self.title:
+        if self.title is None:
             self.title = "input_document"
 
         # skip data validation if no byte is provided


### PR DESCRIPTION
## Summary
- Uses explicit `is None` checks instead of falsy evaluation for `document_mimetype` and `title` in `DocumentBlock.document_validation()`
- Previously, empty strings were coerced to defaults because Python treats `""` as falsy — `document_mimetype` would get overwritten by `_guess_mimetype()` and `title` would become `"input_document"`
- Follows the same pattern as #19302 which fixed the identical issue for `ChatMessage`

Fixes #20462

## Test plan
- [ ] `DocumentBlock(data=b"", url="", title="", document_mimetype="")` should preserve empty strings for `title` and `document_mimetype`
- [ ] `DocumentBlock(data=b"test")` without explicit fields should still default `title` to `"input_document"` and `document_mimetype` to the guessed type
- [ ] Run existing tests in `test_types.py`

https://claude.ai/code/session_011TWMvnjeLgAJg9XtxoLfZT