### PR TITLE
fix: make doc_id column configurable in DatabricksVectorSearch

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
@@ -113,12 +113,14 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
     _delta_sync_index_spec: dict = PrivateAttr()
     _direct_access_index_spec: dict = PrivateAttr()
     _doc_id_to_pk: dict = PrivateAttr()
+    _doc_id_column: str = PrivateAttr()
 
     def __init__(
         self,
         index: VectorSearchIndex,
         text_column: Optional[str] = None,
         columns: Optional[List[str]] = None,
+        doc_id_column: str = "doc_id",
     ) -> None:
         super().__init__(text_column=text_column, columns=columns)
 
@@ -135,6 +137,7 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
             )
 
         self._index = index
+        self._doc_id_column = doc_id_column
 
         # unpack the index spec
         index_description = _DatabricksIndexDescription.parse_obj(
@@ -149,8 +152,8 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
 
         if columns is None:
             columns = []
-        if "doc_id" not in columns:
-            columns = columns[:19] + ["doc_id"]
+        if self._doc_id_column not in columns:
+            columns = columns[:19] + [self._doc_id_column]
 
         # initialize the column name for the text column in the delta table
         if self._is_databricks_managed_embeddings():
@@ -216,8 +219,8 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
             metadata_columns = self.columns or []
 
             # explicitly record doc_id as metadata (for delete)
-            if "doc_id" not in metadata_columns:
-                metadata_columns.append("doc_id")
+            if self._doc_id_column not in metadata_columns:
+                metadata_columns.append(self._doc_id_column)
 
             entry = {
                 self._primary_key: node_id,


### PR DESCRIPTION
## Summary

Fixes #19515

The `DatabricksVectorSearch` class hardcodes `"doc_id"` as the expected column name for document IDs. Users whose Databricks tables use a different column name (e.g. `"id"`) get a `BAD_REQUEST` error because the column doesn't exist in their index.

This PR adds a `doc_id_column` parameter to the `DatabricksVectorSearch` constructor that defaults to `"doc_id"` for full backward compatibility, but allows users to specify their own column name.

### Changes

- Added `_doc_id_column: str` private attribute to `DatabricksVectorSearch`
- Added `doc_id_column` parameter to `__init__` (default: `"doc_id"`)
- Replaced hardcoded `"doc_id"` references in `__init__` and `add()` with `self._doc_id_column`

### Usage

```python
# Before (only works if your table has a "doc_id" column):
store = DatabricksVectorSearch(index=idx, text_column="title")

# After (specify your own column name):
store = DatabricksVectorSearch(index=idx, text_column="title", doc_id_column="id")
```

## Test plan

- [ ] Existing behavior unchanged when `doc_id_column` is not specified (defaults to `"doc_id"`)
- [ ] Custom `doc_id_column` value is used in column fetching during `__init__` and `add()`
- [ ] No regressions in existing Databricks vector store tests