### PR TITLE
fix (test) : use >= 1 to avoid racy `stream_chat` memory assertion

### DIFF
--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -71,7 +71,7 @@ def test_stream_chat_memory_not_lost_on_incomplete_consumption(
     # when the background thread writes memory.
     chat_engine._memory = ChatMemoryBuffer.from_defaults()
     response = chat_engine.stream_chat("Hello World!")
-    assert len(chat_engine.chat_history) == 1
+    assert len(chat_engine.chat_history) >= 1
     assert chat_engine.chat_history[0].role == MessageRole.USER
     assert "Hello World!" in str(chat_engine.chat_history[0].content)
     for i, _ in enumerate(response.response_gen):

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -147,7 +147,7 @@ def test_stream_chat_memory_not_lost_on_incomplete_consumption(
     # when the background thread writes memory.
     chat_engine._memory = ChatMemoryBuffer.from_defaults()
     response = chat_engine.stream_chat("Hello World!")
-    assert len(chat_engine.chat_history) == 1
+    assert len(chat_engine.chat_history) >= 1
     assert chat_engine.chat_history[0].role == MessageRole.USER
     assert "Hello World!" in str(chat_engine.chat_history[0].content)
     for i, _ in enumerate(response.response_gen):
@@ -185,7 +185,7 @@ def test_stream_chat_history_write_completes_on_early_exit(
 ):
     chat_engine._memory = ChatMemoryBuffer.from_defaults()
     response = chat_engine.stream_chat("Hello World!")
-    assert len(chat_engine.chat_history) == 1
+    assert len(chat_engine.chat_history) >= 1
     gen = response.response_gen
     for i, _ in enumerate(gen):
         if i >= 2:

--- a/llama-index-core/tests/chat_engine/test_mm_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_mm_condense_plus_context.py
@@ -123,7 +123,7 @@ def test_stream_chat_memory_not_lost_on_incomplete_consumption(
     # when the background thread writes memory.
     chat_engine._memory = ChatMemoryBuffer.from_defaults()
     response = chat_engine.stream_chat("Hello World!")
-    assert len(chat_engine.chat_history) == 1
+    assert len(chat_engine.chat_history) >= 1
     assert chat_engine.chat_history[0].role == MessageRole.USER
     assert "Hello World!" in str(chat_engine.chat_history[0].content)
     for i, _ in enumerate(response.response_gen):

--- a/llama-index-core/tests/chat_engine/test_multi_modal_context.py
+++ b/llama-index-core/tests/chat_engine/test_multi_modal_context.py
@@ -237,7 +237,7 @@ def test_stream_chat_memory_not_lost_on_incomplete_consumption(
     # when the background thread writes memory.
     chat_engine._memory = ChatMemoryBuffer.from_defaults()
     response = chat_engine.stream_chat("Hello World!")
-    assert len(chat_engine.chat_history) == 1
+    assert len(chat_engine.chat_history) >= 1
     assert chat_engine.chat_history[0].role == MessageRole.USER
     assert "Hello World!" in str(chat_engine.chat_history[0].content)
     for i, _ in enumerate(response.response_gen):


### PR DESCRIPTION
# Description

PR #20897 moved memory writes to a background thread. With MockLLM, that background thread can complete almost immediately, so the test assertion may run after the write has already happened. As a result, checks like `len == 1` can fail nondeterministically.

I saw this in today’s PR #20974, where CI passed once and failed once for the same reason. I Changed `len == 1` to `len >= 1` in 5 sync tests across 4 files. Async tests are unaffected.

cc @AstraBert @logan-markewich for visibility before other PRs are reviewed.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
