### PR TITLE
fix: preserve response metadata in async retrieval from IndexNode (#20994)

### DIFF
--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -107,7 +107,12 @@ class BaseRetriever(PromptMixin, DispatcherSpanMixin):
             return [NodeWithScore(node=obj, score=score)]
         elif isinstance(obj, BaseQueryEngine):
             response = await obj.aquery(query_bundle)
-            return [NodeWithScore(node=TextNode(text=str(response)), score=score)]
+            return [
+                NodeWithScore(
+                    node=TextNode(text=str(response), metadata=response.metadata or {}),
+                    score=score,
+                )
+            ]
         elif isinstance(obj, BaseRetriever):
             return await obj.aretrieve(query_bundle)
         else:


### PR DESCRIPTION
## Problem

When an `IndexNode` resolves to a `BaseQueryEngine`, async retrieval drops source metadata. The sync path in `_retrieve_from_object()` correctly passes `metadata=response.metadata`, but the async path `_aretrieve_from_object()` creates `TextNode` without metadata.

This causes async retrieval to lose provenance metadata, making sync and async behavior inconsistent.

## Reproduction

```python
retriever = build_retriever()  # IndexNode -> BaseQueryEngine with metadata
sync_nodes = retriever.retrieve("query")
async_nodes = await retriever.aretrieve("query")

print(sync_nodes[0].node.metadata)   # {'source': 'geography.pdf'}
print(async_nodes[0].node.metadata)  # {} ← BUG: metadata lost
```

## Fix

Pass `metadata=response.metadata or {}` in the async path, matching the sync behavior.

Fixes #20994