### PR TITLE
readers: add HADSReader for Human-AI Document Standard files

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-hads/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-hads/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/readers/llama-index-readers-hads/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-hads/README.md
@@ -1,0 +1,72 @@
+# LlamaIndex HADS Reader
+
+Load [Human-AI Document Standard (HADS)](https://github.com/catcam/hads) files into LlamaIndex, filtering to only the tagged blocks your pipeline needs.
+
+## Installation
+
+```bash
+pip install llama-index-readers-hads
+```
+
+## Usage
+
+```python
+from pathlib import Path
+from llama_index.readers.hads import HADSReader
+
+# Load only SPEC blocks (default) — ~70% token reduction
+reader = HADSReader()
+docs = reader.load_data(Path("architecture.hads.md"))
+
+# Load SPEC + NOTE blocks
+reader = HADSReader(block_types=["SPEC", "NOTE"])
+docs = reader.load_data(Path("architecture.hads.md"))
+
+# Load all block types
+reader = HADSReader(block_types=["SPEC", "NOTE", "BUG", "?"])
+docs = reader.load_data(Path("architecture.hads.md"))
+```
+
+## What is HADS?
+
+HADS is a lightweight Markdown convention where documentation is tagged with semantic block types:
+
+```markdown
+**[SPEC]**
+The cache uses LRU eviction with a 5-minute TTL.
+
+**[NOTE]**
+This was rewritten in Q3 to address memory growth.
+
+**[BUG cache-invalidation]**
+Cache is not invalidated on config reload.
+
+**[?]**
+Should the TTL be configurable per-key?
+```
+
+By loading only `SPEC` blocks (implementation facts), LLM context usage drops ~70% compared to loading the full document — without losing the information the model actually needs.
+
+## Block Types
+
+| Tag | Purpose |
+|-----|---------|
+| `SPEC` | Specification / implementation facts |
+| `NOTE` | Background context, history, rationale |
+| `BUG <title>` | Known bugs and workarounds |
+| `?` | Open questions, unresolved decisions |
+
+## Metadata
+
+Each returned `Document` includes:
+
+```python
+{
+    "source": "path/to/file.hads.md",
+    "hads": True,
+    "block_types": ["SPEC"],
+    "blocks_found": 3,
+    "block_tag": "SPEC",           # tag of this specific block
+    "manifest": "Load SPEC for..." # from ## AI READING INSTRUCTION section
+}
+```

--- a/llama-index-integrations/readers/llama-index-readers-hads/llama_index/readers/hads/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-hads/llama_index/readers/hads/__init__.py
@@ -1,0 +1,5 @@
+"""HADS (Human-AI Document Standard) reader for LlamaIndex."""
+
+from llama_index.readers.hads.base import HADSReader
+
+__all__ = ["HADSReader"]

--- a/llama-index-integrations/readers/llama-index-readers-hads/llama_index/readers/hads/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-hads/llama_index/readers/hads/base.py
@@ -1,0 +1,164 @@
+"""HADS (Human-AI Document Standard) reader for LlamaIndex."""
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+BLOCK_PATTERN = re.compile(
+    r"\*\*\[(SPEC|NOTE|BUG[^\]]*|\?)\]\*\*\n((?:(?!\*\*\[).*\n?)*)",
+    re.MULTILINE,
+)
+MANIFEST_PATTERN = re.compile(
+    r"##\s+AI READING INSTRUCTION\s*\n(.*?)(?=\n##|\Z)", re.DOTALL
+)
+HEADER_PATTERN = re.compile(r"^(#{1,3})\s+(.+)$", re.MULTILINE)
+
+
+class HADSReader(BaseReader):
+    """Reader for Human-AI Document Standard (HADS) files.
+
+    HADS is a lightweight convention for AI-optimized technical documentation.
+    Files contain tagged blocks like **[SPEC]**, **[NOTE]**, **[BUG title]**,
+    and **[?]** that allow selective loading to reduce context usage by ~70%.
+
+    Args:
+        block_types: Block type prefixes to include. Defaults to ["SPEC"].
+            Use ["SPEC", "NOTE", "BUG", "?"] to include all blocks.
+        include_section_headers: Whether to prepend H1/H2/H3 headers to each
+            block for context. Defaults to True.
+
+    Example:
+        .. code-block:: python
+
+            from llama_index.readers.hads import HADSReader
+
+            reader = HADSReader(block_types=["SPEC", "NOTE"])
+            documents = reader.load_data(Path("architecture.hads.md"))
+    """
+
+    def __init__(
+        self,
+        block_types: Optional[List[str]] = None,
+        include_section_headers: bool = True,
+    ) -> None:
+        self.block_types = block_types if block_types is not None else ["SPEC"]
+        self.include_section_headers = include_section_headers
+
+    def load_data(
+        self,
+        file: Path,
+        extra_info: Optional[Dict[str, Any]] = None,
+        fs: Optional[Any] = None,
+    ) -> List[Document]:
+        """Load HADS blocks from a file.
+
+        Args:
+            file: Path to the HADS file.
+            extra_info: Optional extra metadata to merge.
+            fs: Optional fsspec filesystem. If provided, used instead of
+                local filesystem.
+
+        Returns:
+            List of Documents, one per matching block.
+        """
+        if fs is not None:
+            with fs.open(str(file), encoding="utf-8") as f:
+                content = f.read()
+                if isinstance(content, bytes):
+                    content = content.decode("utf-8")
+        else:
+            try:
+                content = Path(file).read_text(encoding="utf-8")
+            except FileNotFoundError as e:
+                raise ValueError(f"File not found: {file}") from e
+
+        blocks = self._extract_blocks(content)
+        manifest = self._extract_manifest(content)
+
+        metadata: Dict[str, Any] = {
+            "source": str(file),
+            "hads": True,
+            "block_types": self.block_types,
+            "blocks_found": len(blocks),
+        }
+        if manifest:
+            metadata["manifest"] = manifest
+        if extra_info:
+            metadata.update(extra_info)
+
+        if not blocks:
+            return [Document(text="", metadata=metadata)]
+
+        return [
+            Document(
+                text=block_text,
+                metadata={**metadata, "block_tag": block_tag},
+            )
+            for block_tag, block_text in blocks
+        ]
+
+    def _should_include(self, tag: str) -> bool:
+        """Return True if tag matches any requested block_type prefix."""
+        tag_upper = tag.upper()
+        return any(tag_upper.startswith(bt.upper()) for bt in self.block_types)
+
+    def _extract_blocks(self, content: str) -> List[tuple]:
+        """Extract matching tagged blocks, optionally with section headers."""
+        blocks = []
+        current_headers: Dict[int, str] = {}
+
+        lines = content.splitlines(keepends=True)
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+
+            # Track section headers for context
+            hm = HEADER_PATTERN.match(line.rstrip())
+            if hm:
+                level = len(hm.group(1))
+                current_headers[level] = hm.group(2).strip()
+                # Clear lower-level headers when a higher-level one appears
+                for lvl in list(current_headers):
+                    if lvl > level:
+                        del current_headers[lvl]
+                i += 1
+                continue
+
+            # Check for HADS block tag
+            tag_match = re.match(r"\*\*\[([^\]]+)\]\*\*", line.strip())
+            if tag_match:
+                tag = tag_match.group(1)
+                if self._should_include(tag):
+                    # Collect block body until next tag or EOF
+                    body_lines = []
+                    i += 1
+                    while i < len(lines):
+                        if re.match(r"\*\*\[([^\]]+)\]\*\*", lines[i].strip()):
+                            break
+                        body_lines.append(lines[i])
+                        i += 1
+
+                    body = "".join(body_lines).strip()
+
+                    if self.include_section_headers and current_headers:
+                        header_ctx = " > ".join(
+                            current_headers[lvl]
+                            for lvl in sorted(current_headers)
+                        )
+                        text = f"[{tag}] ({header_ctx})\n{body}"
+                    else:
+                        text = f"[{tag}]\n{body}"
+
+                    blocks.append((tag, text))
+                    continue
+            i += 1
+
+        return blocks
+
+    def _extract_manifest(self, content: str) -> Optional[str]:
+        """Extract the AI READING INSTRUCTION manifest if present."""
+        m = MANIFEST_PATTERN.search(content)
+        return m.group(1).strip() if m else None

--- a/llama-index-integrations/readers/llama-index-readers-hads/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-hads/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest==7.2.1",
+    "pytest-cov>=6.1.1",
+]
+
+[project]
+name = "llama-index-readers-hads"
+version = "0.1.0"
+description = "llama-index readers HADS (Human-AI Document Standard) integration"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10,<4.0"
+dependencies = ["llama-index-core>=0.13.0,<0.15"]
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.hads"
+
+[tool.llamahub.class_authors]
+HADSReader = "catcam"

--- a/llama-index-integrations/readers/llama-index-readers-hads/tests/test_hads.py
+++ b/llama-index-integrations/readers/llama-index-readers-hads/tests/test_hads.py
@@ -1,0 +1,131 @@
+"""Tests for HADSReader."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from llama_index.readers.hads import HADSReader
+
+SAMPLE_HADS = """\
+# My Module
+
+## AI READING INSTRUCTION
+Load SPEC blocks for implementation details. Load NOTE for context.
+
+## Core Logic
+
+**[SPEC]**
+This is a specification block with implementation details.
+
+**[NOTE]**
+This is a note with background context.
+
+**[BUG memory-leak]**
+Memory leak in the connection pool under load.
+
+**[?]**
+Should we use async here?
+"""
+
+SPEC_ONLY = """\
+**[SPEC]**
+Only block here.
+"""
+
+MULTI_SECTION = """\
+# Top Level
+
+## Section A
+
+**[SPEC]**
+Block in section A.
+
+## Section B
+
+**[SPEC]**
+Block in section B.
+"""
+
+
+def _write(content: str, suffix: str = ".md") -> Path:
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=suffix, delete=False, encoding="utf-8"
+    )
+    tmp.write(content)
+    tmp.close()
+    return Path(tmp.name)
+
+
+def test_default_loads_spec_only():
+    reader = HADSReader()
+    docs = reader.load_data(_write(SAMPLE_HADS))
+    assert len(docs) == 1
+    assert "[SPEC]" in docs[0].text
+    assert "[NOTE]" not in docs[0].text
+
+
+def test_spec_and_note():
+    reader = HADSReader(block_types=["SPEC", "NOTE"])
+    docs = reader.load_data(_write(SAMPLE_HADS))
+    tags = [d.metadata["block_tag"] for d in docs]
+    assert "SPEC" in tags
+    assert "NOTE" in tags
+    assert len([t for t in tags if t.startswith("BUG")]) == 0
+
+
+def test_all_block_types():
+    reader = HADSReader(block_types=["SPEC", "NOTE", "BUG", "?"])
+    docs = reader.load_data(_write(SAMPLE_HADS))
+    assert len(docs) == 4
+
+
+def test_bug_prefix_matching():
+    reader = HADSReader(block_types=["BUG"])
+    docs = reader.load_data(_write(SAMPLE_HADS))
+    assert len(docs) == 1
+    assert "memory-leak" in docs[0].text
+
+
+def test_manifest_extracted_to_metadata():
+    reader = HADSReader()
+    docs = reader.load_data(_write(SAMPLE_HADS))
+    assert "manifest" in docs[0].metadata
+    assert "SPEC" in docs[0].metadata["manifest"]
+
+
+def test_metadata_fields():
+    reader = HADSReader()
+    docs = reader.load_data(_write(SPEC_ONLY))
+    meta = docs[0].metadata
+    assert meta["hads"] is True
+    assert meta["block_types"] == ["SPEC"]
+    assert "source" in meta
+    assert meta["blocks_found"] == 1
+
+
+def test_section_headers_in_text():
+    reader = HADSReader(include_section_headers=True)
+    docs = reader.load_data(_write(MULTI_SECTION))
+    assert len(docs) == 2
+    assert "Section A" in docs[0].text
+    assert "Section B" in docs[1].text
+
+
+def test_no_section_headers_when_disabled():
+    reader = HADSReader(include_section_headers=False)
+    docs = reader.load_data(_write(MULTI_SECTION))
+    assert "Section A" not in docs[0].text
+
+
+def test_missing_file_raises():
+    reader = HADSReader()
+    with pytest.raises(ValueError, match="not found"):
+        reader.load_data(Path("/nonexistent/file.hads.md"))
+
+
+def test_no_matching_blocks_returns_empty_doc():
+    reader = HADSReader(block_types=["BUG"])
+    docs = reader.load_data(_write(SPEC_ONLY))
+    assert len(docs) == 1
+    assert docs[0].text == ""


### PR DESCRIPTION
## Summary

Adds `HADSReader` — a reader for [Human-AI Document Standard (HADS)](https://github.com/catcam/hads) files.

HADS is a lightweight Markdown convention that tags documentation blocks with `**[SPEC]**`, `**[NOTE]**`, `**[BUG title]**`, and `**[?]**`. Loading only `SPEC` blocks (implementation facts) reduces LLM context usage **~70%** compared to loading the full document — without losing the information the model actually needs.

## What it does

```python
from llama_index.readers.hads import HADSReader

# Load only SPEC blocks (default) — ~70% token reduction
reader = HADSReader()
docs = reader.load_data(Path("architecture.hads.md"))

# Load SPEC + NOTE
reader = HADSReader(block_types=["SPEC", "NOTE"])
docs = reader.load_data(Path("architecture.hads.md"))
```

## Features

- Extends `BaseReader`, implements `load_data()` with fsspec support
- Prefix-based block type filtering (`block_types=["SPEC"]`)
- Section headers (H1/H2/H3) injected into each `Document` for context
- `## AI READING INSTRUCTION` manifest extracted to metadata
- 10 pytest tests, zero external dependencies

## Block types

| Tag | Purpose |
|-----|---------|
| `SPEC` | Specification / implementation facts |
| `NOTE` | Background context, history, rationale |
| `BUG <title>` | Known bugs and workarounds |
| `?` | Open questions, unresolved decisions |

## Related

- HADS spec: https://github.com/catcam/hads
- LangChain equivalent: langchain-ai/langchain-community#593