### PR TITLE
feat(tools/agentcore): add AgentCoreRuntime adapter

### DIFF
--- a/docs/src/content/docs/framework/community/integrations/aws_bedrock_agentcore.md
+++ b/docs/src/content/docs/framework/community/integrations/aws_bedrock_agentcore.md
@@ -1,0 +1,219 @@
+---
+title: Amazon Bedrock AgentCore Runtime and Tools
+---
+
+[Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) provides managed infrastructure for deploying and running production AI agents. The LlamaIndex integration lets you deploy agents to AgentCore Runtime with a single line of code, and gives your agents access to sandboxed browser automation, code execution, and persistent memory -- all running in secure AWS environments.
+
+## Installation
+
+```sh
+pip install llama-index-tools-aws-bedrock-agentcore
+pip install llama-index-memory-bedrock-agentcore
+```
+
+**Prerequisites:**
+
+- AWS credentials configured via environment variables, AWS CLI profile, or IAM role
+- IAM permissions for `bedrock-agentcore:*` actions (see the [AgentCore documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html))
+- Python 3.9+
+
+## Runtime
+
+The `AgentCoreRuntime` adapter deploys any LlamaIndex agent to [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html) -- a managed compute platform for AI agents. It wraps `BedrockAgentCoreApp` from the `bedrock-agentcore` SDK, providing the required `POST /invocations` and `GET /ping` endpoints with automatic SSE streaming support.
+
+```python
+from llama_index.llms.bedrock_converse import BedrockConverse
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.tools.aws_bedrock_agentcore import (
+    AgentCoreBrowserToolSpec,
+    AgentCoreRuntime,
+)
+
+tool_spec = AgentCoreBrowserToolSpec(region="us-west-2")
+tools = tool_spec.to_tool_list()
+
+llm = BedrockConverse(
+    model="us.anthropic.claude-sonnet-4-6-v1",
+    region_name="us-west-2",
+)
+
+agent = FunctionAgent(tools=tools, llm=llm)
+
+# One-liner -- starts uvicorn on port 8080
+AgentCoreRuntime.serve(agent)
+```
+
+Or with more control:
+
+```python
+runtime = AgentCoreRuntime(
+    agent=agent,
+    stream=True,  # SSE streaming (default)
+    port=8080,  # Required port for AgentCore deployment
+    debug=False,  # Enable debug logging
+    memory=memory,  # Optional AgentCoreMemory instance
+)
+runtime.run()
+```
+
+Session IDs from the `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header are automatically propagated to `AgentCoreMemory` when provided.
+
+When streaming, the SSE stream emits these event types:
+
+| Event          | Fields                                 | Description               |
+| -------------- | -------------------------------------- | ------------------------- |
+| `agent_stream` | `delta`, `response`, `thinking_delta`? | Token-by-token LLM output |
+| `tool_call`    | `tool_name`, `tool_kwargs`             | Before tool execution     |
+| `tool_result`  | `tool_name`, `tool_output`             | After tool execution      |
+| `done`         | `response`                             | Final agent response      |
+| `error`        | `message`                              | Error during streaming    |
+
+## Browser Tools
+
+The `AgentCoreBrowserToolSpec` gives agents the ability to navigate websites, extract content, click elements, and interact with web pages in a secure sandboxed browser.
+
+**Available tools:** `navigate_browser`, `click_element`, `extract_text`, `extract_hyperlinks`, `get_elements`, `navigate_back`, `current_webpage`, `generate_live_view_url`, `take_control`, `release_control`
+
+**Lifecycle methods** (programmatic use): `list_browsers`, `create_browser`, `delete_browser`, `get_browser`
+
+```python
+import asyncio
+from llama_index.llms.bedrock_converse import BedrockConverse
+from llama_index.tools.aws_bedrock_agentcore import AgentCoreBrowserToolSpec
+from llama_index.core.agent.workflow import FunctionAgent
+
+
+async def main():
+    tool_spec = AgentCoreBrowserToolSpec(region="us-west-2")
+    tools = tool_spec.to_tool_list()
+
+    llm = BedrockConverse(
+        model="us.anthropic.claude-sonnet-4-6-v1",
+        region_name="us-west-2",
+    )
+
+    agent = FunctionAgent(tools=tools, llm=llm)
+
+    response = await agent.run(
+        "Go to https://news.ycombinator.com/ and tell me the titles of the top 5 posts."
+    )
+    print(str(response))
+
+    await tool_spec.cleanup()
+
+
+asyncio.run(main())
+```
+
+You can optionally pass a custom `identifier` for VPC-enabled browser resources:
+
+```python
+tool_spec = AgentCoreBrowserToolSpec(
+    region="us-west-2",
+    identifier="my-custom-browser-id",
+)
+```
+
+## Code Interpreter Tools
+
+The `AgentCoreCodeInterpreterToolSpec` gives agents the ability to execute Python code, run shell commands, and manage files in a secure sandbox with up to 8-hour sessions.
+
+**Available tools:** `execute_code`, `execute_command`, `read_files`, `list_files`, `delete_files`, `write_files`, `start_command`, `get_task`, `stop_task`, `upload_file`, `upload_files`, `install_packages`, `download_file`, `download_files`, `clear_context`
+
+**Lifecycle methods** (programmatic use): `list_code_interpreters`, `create_code_interpreter`, `delete_code_interpreter`, `get_code_interpreter`
+
+```python
+import asyncio
+from llama_index.llms.bedrock_converse import BedrockConverse
+from llama_index.tools.aws_bedrock_agentcore import (
+    AgentCoreCodeInterpreterToolSpec,
+)
+from llama_index.core.agent.workflow import FunctionAgent
+
+
+async def main():
+    tool_spec = AgentCoreCodeInterpreterToolSpec(region="us-west-2")
+    tools = tool_spec.to_tool_list()
+
+    llm = BedrockConverse(
+        model="us.anthropic.claude-sonnet-4-6-v1",
+        region_name="us-west-2",
+    )
+
+    agent = FunctionAgent(tools=tools, llm=llm)
+
+    response = await agent.run(
+        "Write a Python function that calculates the factorial of a number and test it."
+    )
+    print(str(response))
+
+    await tool_spec.cleanup()
+
+
+asyncio.run(main())
+```
+
+You can optionally pass a custom `identifier` for VPC-enabled code interpreter resources:
+
+```python
+tool_spec = AgentCoreCodeInterpreterToolSpec(
+    region="us-west-2",
+    identifier="my-custom-interpreter-id",
+)
+```
+
+## Memory
+
+The `AgentCoreMemory` class provides persistent, managed memory backed by Amazon Bedrock AgentCore. It supports short-term chat history via events and long-term memory via semantic search over memory records. Memory is isolated per user via `actor_id`, making it suitable for multi-tenant applications.
+
+> **Note:** You must first create a memory resource in the AgentCore console or via the AWS SDK to obtain a `memory_id`. See the [AgentCore documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html) for setup instructions.
+
+```python
+import asyncio
+from llama_index.llms.bedrock_converse import BedrockConverse
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.memory.bedrock_agentcore import (
+    AgentCoreMemory,
+    AgentCoreMemoryContext,
+)
+
+
+async def main():
+    memory = AgentCoreMemory(
+        context=AgentCoreMemoryContext(
+            memory_id="your-memory-id",  # from AgentCore console or API
+            actor_id="user-123",
+            session_id="session-456",
+            namespace="/",
+        ),
+        region_name="us-west-2",
+    )
+
+    llm = BedrockConverse(
+        model="us.anthropic.claude-sonnet-4-6-v1",
+        region_name="us-west-2",
+    )
+
+    agent = FunctionAgent(llm=llm, tools=[])
+
+    # Memory persists across agent runs
+    response = await agent.run("My name is Alice.", memory=memory)
+    print(str(response))
+
+    response = await agent.run("What is my name?", memory=memory)
+    print(str(response))
+
+
+asyncio.run(main())
+```
+
+## Example Notebooks
+
+- [Browser Tool Notebook](/python/examples/tools/bedrock_agentcore_browser)
+- [Code Interpreter Tool Notebook](/python/examples/tools/bedrock_agentcore_code_interpreter)
+
+## Resources
+
+- [AWS Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html)
+- [Tools Package on PyPI](https://pypi.org/project/llama-index-tools-aws-bedrock-agentcore/)
+- [Memory Package on PyPI](https://pypi.org/project/llama-index-memory-bedrock-agentcore/)

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [0.3.0] - 2026-03-14
+
+- Add `AgentCoreRuntime` adapter for deploying LlamaIndex agents to AWS Bedrock AgentCore Runtime
+- Supports streaming (SSE) and non-streaming JSON responses via `POST /invocations`
+- Automatic session ID propagation from `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header to `AgentCoreMemory`
+- One-liner deployment: `AgentCoreRuntime.serve(agent)`
+- Accepts `prompt`, `message`, or `input` as payload keys
+
 ## [0.2.0] - 2026-02-26
 
 - Add `upload_file`, `upload_files`, `install_packages`, `download_file`, `download_files` tools to Code Interpreter

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/README.md
@@ -1,6 +1,6 @@
-# AWS Bedrock AgentCore Tools
+# Amazon Bedrock AgentCore Runtime and Tools
 
-This module provides tools for interacting with [AWS Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/)'s browser and code interpreter sandbox tools.
+This module provides a runtime adapter and tools for deploying and extending LlamaIndex agents with [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) -- including managed compute via AgentCore Runtime, sandboxed browser automation, and code execution.
 
 ## Prerequisites
 
@@ -22,11 +22,101 @@ Install the main tools package:
 pip install llama-index-tools-aws-bedrock-agentcore
 ```
 
+## Runtime
+
+The `AgentCoreRuntime` adapter deploys any LlamaIndex agent to [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html) -- a managed compute platform for AI agents. It wraps `BedrockAgentCoreApp` from the `bedrock-agentcore` SDK, providing the required `POST /invocations` and `GET /ping` endpoints.
+
+### Quick Start
+
+```python
+from llama_index.llms.bedrock_converse import BedrockConverse
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.tools.aws_bedrock_agentcore import AgentCoreRuntime
+
+llm = BedrockConverse(
+    model="us.anthropic.claude-sonnet-4-6-v1",
+    region_name="us-west-2",
+)
+agent = FunctionAgent(llm=llm, tools=[])
+
+# One-liner -- starts uvicorn on port 8080
+AgentCoreRuntime.serve(agent)
+```
+
+### With Options
+
+```python
+runtime = AgentCoreRuntime(
+    agent=agent,
+    stream=True,  # SSE streaming (default)
+    port=8080,  # Required port for AgentCore deployment
+    debug=False,
+)
+runtime.run()
+```
+
+### With AgentCore Memory
+
+```python
+from llama_index.memory.bedrock_agentcore import (
+    AgentCoreMemory,
+    AgentCoreMemoryContext,
+)
+
+memory = AgentCoreMemory(
+    context=AgentCoreMemoryContext(
+        memory_id="your-memory-id",
+        actor_id="user-123",
+    ),
+    region_name="us-west-2",
+)
+
+# Session ID from the X-Amzn-Bedrock-AgentCore-Runtime-Session-Id header
+# is automatically wired to memory
+AgentCoreRuntime.serve(agent, memory=memory)
+```
+
+### Sending Requests
+
+```bash
+# Non-streaming
+curl -X POST http://localhost:8080/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Hello, what can you do?"}'
+
+# Streaming (SSE)
+curl -N -X POST http://localhost:8080/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Hello, what can you do?"}'
+```
+
+The adapter accepts `prompt`, `message`, or `input` as the payload key.
+
+### Streaming Event Types
+
+When `stream=True` (default), the SSE stream emits these event types:
+
+| Event          | Fields                                 | Description               |
+| -------------- | -------------------------------------- | ------------------------- |
+| `agent_stream` | `delta`, `response`, `thinking_delta`? | Token-by-token LLM output |
+| `tool_call`    | `tool_name`, `tool_kwargs`             | Before tool execution     |
+| `tool_result`  | `tool_name`, `tool_output`             | After tool execution      |
+| `done`         | `response`                             | Final agent response      |
+| `error`        | `message`                              | Error during streaming    |
+
+### Testing with ASGI
+
+```python
+runtime = AgentCoreRuntime(agent=agent)
+app = runtime.app  # BedrockAgentCoreApp (Starlette-based)
+# Use with httpx.AsyncClient for testing
+```
+
 ## Toolspecs
 
 ### Browser
 
-The Bedrock AgentCore `Browser` toolspec provides a set of tools for interacting with web browsers in a secure sandbox environment. It enables your LlamaIndex agents to navigate websites, extract content, click elements, and more.
+The AgentCore `Browser` toolspec provides a set of tools for interacting with web browsers in a secure sandbox environment. It enables your LlamaIndex agents to navigate websites, extract content, click elements, and more.
 
 Included tools:
 
@@ -72,7 +162,7 @@ async def main():
     tools = tool_spec.to_tool_list()
 
     llm = BedrockConverse(
-        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        model="us.anthropic.claude-sonnet-4-6-v1",
         region_name="us-west-2",
     )
 
@@ -95,7 +185,7 @@ if __name__ == "__main__":
 
 ### Code Interpreter
 
-The Bedrock AgentCore `code_interpreter` toolspec provides a set of tools interacting with a secure code interpreter sandbox environment. It enables your LlamaIndex agents to execute code, run shell commands, manage files, and perform computational task.
+The AgentCore `Code Interpreter` toolspec provides a set of tools for interacting with a secure code interpreter sandbox environment. It enables your LlamaIndex agents to execute code, run shell commands, manage files, and perform computational tasks.
 
 Included tools:
 
@@ -148,7 +238,7 @@ async def main():
     tools = tool_spec.to_tool_list()
 
     llm = BedrockConverse(
-        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        model="us.anthropic.claude-sonnet-4-6-v1",
         region_name="us-west-2",
     )
 

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/llama_index/tools/aws_bedrock_agentcore/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/llama_index/tools/aws_bedrock_agentcore/__init__.py
@@ -1,8 +1,13 @@
-"""AWS Bedrock AgentCore tools."""
+"""AWS Bedrock AgentCore tools and runtime."""
 
 from llama_index.tools.aws_bedrock_agentcore.browser import AgentCoreBrowserToolSpec
 from llama_index.tools.aws_bedrock_agentcore.code_interpreter import (
     AgentCoreCodeInterpreterToolSpec,
 )
+from llama_index.tools.aws_bedrock_agentcore.runtime import AgentCoreRuntime
 
-__all__ = ["AgentCoreBrowserToolSpec", "AgentCoreCodeInterpreterToolSpec"]
+__all__ = [
+    "AgentCoreBrowserToolSpec",
+    "AgentCoreCodeInterpreterToolSpec",
+    "AgentCoreRuntime",
+]

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/llama_index/tools/aws_bedrock_agentcore/runtime/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/llama_index/tools/aws_bedrock_agentcore/runtime/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.aws_bedrock_agentcore.runtime.base import AgentCoreRuntime
+
+__all__ = ["AgentCoreRuntime"]

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/llama_index/tools/aws_bedrock_agentcore/runtime/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/llama_index/tools/aws_bedrock_agentcore/runtime/base.py
@@ -1,0 +1,165 @@
+import copy
+import logging
+from collections.abc import Sequence
+from typing import Any, AsyncGenerator, Dict, Optional
+
+from starlette.exceptions import HTTPException
+from starlette.middleware import Middleware
+from starlette.types import Lifespan
+
+from bedrock_agentcore.runtime import BedrockAgentCoreApp, RequestContext
+from llama_index.core.agent.workflow.workflow_events import (
+    AgentOutput,
+    AgentStream,
+    ToolCall,
+    ToolCallResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AgentCoreRuntime:
+    """Serves a LlamaIndex agent via BedrockAgentCoreApp (POST /invocations, GET /ping)."""
+
+    def __init__(
+        self,
+        agent: Any,
+        stream: bool = True,
+        port: int = 8080,
+        host: Optional[str] = None,
+        debug: bool = False,
+        memory: Optional[Any] = None,
+        lifespan: Optional[Lifespan] = None,
+        middleware: Optional[Sequence[Middleware]] = None,
+    ):
+        self._agent = agent
+        self._stream = stream
+        self._port = port
+        self._host = host
+        self._memory = memory
+        self._app = BedrockAgentCoreApp(
+            debug=debug, lifespan=lifespan, middleware=middleware
+        )
+
+        # Register entrypoint using closure wrappers (not bound methods).
+        # entrypoint() sets func.run attr which fails on bound methods.
+        # Closures also preserve isasyncgenfunction() detection for streaming.
+        runtime = self
+        if stream:
+
+            async def streaming_entrypoint(
+                payload: dict, context: RequestContext
+            ) -> AsyncGenerator[dict, None]:
+                async for chunk in runtime._streaming_handler(payload, context):
+                    yield chunk
+
+            self._app.entrypoint(streaming_entrypoint)
+        else:
+
+            async def non_streaming_entrypoint(
+                payload: dict, context: RequestContext
+            ) -> dict:
+                return await runtime._non_streaming_handler(payload, context)
+
+            self._app.entrypoint(non_streaming_entrypoint)
+
+    @classmethod
+    def serve(cls, agent: Any, **kwargs: Any) -> None:
+        """Create runtime and start server in one call."""
+        runtime = cls(agent=agent, **kwargs)
+        runtime.run()
+
+    def run(self, **kwargs: Any) -> None:
+        """Start uvicorn server."""
+        self._app.run(port=self._port, host=self._host, **kwargs)
+
+    @property
+    def app(self) -> BedrockAgentCoreApp:
+        """Expose for ASGI mounting or testing."""
+        return self._app
+
+    @staticmethod
+    def _extract_prompt(payload: dict) -> str:
+        """Normalize payload to user message string."""
+        prompt = payload.get("prompt") or payload.get("message") or payload.get("input")
+        if isinstance(prompt, dict):
+            prompt = prompt.get("prompt")
+        if isinstance(prompt, str):
+            prompt = prompt.strip()
+        if not prompt or not isinstance(prompt, (str, int, float)):
+            raise HTTPException(
+                status_code=400,
+                detail="Request must include 'prompt', 'message', or 'input' field"
+                " with a string value",
+            )
+        return str(prompt)
+
+    def _get_memory(self, context: Optional[RequestContext] = None) -> Optional[Any]:
+        """Return per-request memory copy with session_id from AgentCore context."""
+        if self._memory is None:
+            return None
+        if context and context.session_id and hasattr(self._memory, "_context"):
+            if hasattr(self._memory._context, "session_id"):
+                memory = copy.copy(self._memory)
+                memory._context = copy.copy(self._memory._context)
+                memory._context.session_id = context.session_id
+                return memory
+        return self._memory
+
+    async def _non_streaming_handler(
+        self, payload: dict, context: RequestContext
+    ) -> dict:
+        """Handle non-streaming invocation. Returns JSON response."""
+        prompt = self._extract_prompt(payload)
+        memory = self._get_memory(context)
+        handler = self._agent.run(user_msg=prompt, memory=memory)
+        result = await handler
+        return {"response": str(result)}
+
+    async def _streaming_handler(
+        self, payload: dict, context: RequestContext
+    ) -> AsyncGenerator[dict, None]:
+        """Handle streaming invocation. Yields SSE event dicts."""
+        prompt = self._extract_prompt(payload)
+        memory = self._get_memory(context)
+        handler = self._agent.run(user_msg=prompt, memory=memory)
+
+        try:
+            async for event in handler.stream_events():
+                if isinstance(event, AgentStream):
+                    ev: Dict[str, Any] = {
+                        "event": "agent_stream",
+                        "delta": event.delta,
+                        "response": event.response,
+                    }
+                    if event.thinking_delta:
+                        ev["thinking_delta"] = event.thinking_delta
+                    yield ev
+                elif isinstance(event, ToolCall):
+                    yield {
+                        "event": "tool_call",
+                        "tool_name": event.tool_name,
+                        "tool_kwargs": event.tool_kwargs,
+                    }
+                elif isinstance(event, ToolCallResult):
+                    yield {
+                        "event": "tool_result",
+                        "tool_name": event.tool_name,
+                        "tool_output": str(event.tool_output),
+                    }
+                elif isinstance(event, AgentOutput):
+                    yield {"event": "done", "response": str(event.response)}
+                else:
+                    logger.debug(
+                        "Ignoring unknown event type: %s", type(event).__name__
+                    )
+        except Exception as e:
+            logger.exception("Error during streaming")
+            yield {"event": "error", "message": str(e)}
+            return
+
+        # Await handler to ensure background tasks complete (memory flush, etc.)
+        try:
+            await handler
+        except Exception:
+            logger.exception("Error awaiting handler completion")

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/pyproject.toml
@@ -27,8 +27,8 @@ dev = [
 
 [project]
 name = "llama-index-tools-aws-bedrock-agentcore"
-version = "0.2.0"
-description = "llama-index tools AWS Bedrock AgentCore integration"
+version = "0.3.0"
+description = "llama-index Amazon Bedrock AgentCore Runtime and Tools integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"
@@ -65,6 +65,7 @@ import_path = "llama_index.tools.aws_bedrock_agentcore"
 [tool.llamahub.class_authors]
 AgentCoreBrowserToolSpec = "michaelnchin"
 AgentCoreCodeInterpreterToolSpec = "michaelnchin"
+AgentCoreRuntime = "michaelnchin"
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/tests/test_runtime.py
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/tests/test_runtime.py
@@ -1,0 +1,479 @@
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.exceptions import HTTPException
+
+from llama_index.tools.aws_bedrock_agentcore.runtime.base import AgentCoreRuntime
+
+
+class MockWorkflowHandler:
+    """Mimics LlamaIndex WorkflowHandler: awaitable + stream_events()."""
+
+    def __init__(self, result="done", events=None, raise_on_await=None):
+        self._result = result
+        self._events = events or []
+        self._raise_on_await = raise_on_await
+
+    def __await__(self):
+        async def _resolve():
+            if self._raise_on_await:
+                raise self._raise_on_await
+            return self._result
+
+        return _resolve().__await__()
+
+    async def stream_events(self):
+        for event in self._events:
+            yield event
+
+
+class ErrorStreamWorkflowHandler(MockWorkflowHandler):
+    """Raises mid-stream after yielding some events."""
+
+    def __init__(self, events_before_error=None, error=None, **kwargs):
+        super().__init__(**kwargs)
+        self._events_before_error = events_before_error or []
+        self._error = error or RuntimeError("stream failed")
+
+    async def stream_events(self):
+        for event in self._events_before_error:
+            yield event
+        raise self._error
+
+
+class TestExtractPrompt:
+    def test_prompt_field(self):
+        assert AgentCoreRuntime._extract_prompt({"prompt": "hello"}) == "hello"
+
+    def test_message_field(self):
+        assert AgentCoreRuntime._extract_prompt({"message": "hello"}) == "hello"
+
+    def test_input_field(self):
+        assert AgentCoreRuntime._extract_prompt({"input": "hello"}) == "hello"
+
+    def test_nested_prompt(self):
+        assert (
+            AgentCoreRuntime._extract_prompt({"input": {"prompt": "hello"}}) == "hello"
+        )
+
+    def test_priority_order(self):
+        payload = {"prompt": "first", "message": "second", "input": "third"}
+        assert AgentCoreRuntime._extract_prompt(payload) == "first"
+
+    def test_missing_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            AgentCoreRuntime._extract_prompt({"foo": "bar"})
+        assert exc_info.value.status_code == 400
+
+    def test_empty_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            AgentCoreRuntime._extract_prompt({})
+        assert exc_info.value.status_code == 400
+
+    def test_empty_string_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            AgentCoreRuntime._extract_prompt({"prompt": ""})
+        assert exc_info.value.status_code == 400
+
+    def test_whitespace_only_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            AgentCoreRuntime._extract_prompt({"prompt": "   "})
+        assert exc_info.value.status_code == 400
+
+    def test_list_value_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            AgentCoreRuntime._extract_prompt({"prompt": ["a", "b"]})
+        assert exc_info.value.status_code == 400
+
+    def test_numeric_value_coerced(self):
+        assert AgentCoreRuntime._extract_prompt({"prompt": 42}) == "42"
+
+    def test_strips_whitespace(self):
+        assert AgentCoreRuntime._extract_prompt({"prompt": "  hello  "}) == "hello"
+
+
+class TestNonStreamingHandler:
+    @pytest.mark.asyncio
+    async def test_returns_response_dict(self):
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = MockWorkflowHandler(result="test response")
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(agent=mock_agent, stream=False)
+
+        mock_context = MagicMock()
+        mock_context.session_id = None
+
+        result = await runtime._non_streaming_handler({"prompt": "hello"}, mock_context)
+
+        assert result == {"response": "test response"}
+        mock_agent.run.assert_called_once_with(user_msg="hello", memory=None)
+
+
+class TestStreamingHandler:
+    @pytest.mark.asyncio
+    async def test_yields_events(self):
+        from llama_index.core.agent.workflow.workflow_events import (
+            AgentOutput,
+            AgentStream,
+            ToolCall,
+            ToolCallResult,
+        )
+        from llama_index.core.llms import ChatMessage
+        from llama_index.core.tools.types import ToolOutput
+
+        tool_output = ToolOutput(
+            tool_name="my_tool",
+            raw_input={"arg": "val"},
+            raw_output="result",
+        )
+        tool_output.content = "result"
+
+        events = [
+            AgentStream(
+                delta="hi",
+                response="hi",
+                current_agent_name="agent",
+                thinking_delta=None,
+            ),
+            ToolCall(
+                tool_name="my_tool",
+                tool_kwargs={"arg": "val"},
+                tool_id="t1",
+            ),
+            ToolCallResult(
+                tool_name="my_tool",
+                tool_kwargs={"arg": "val"},
+                tool_id="t1",
+                tool_output=tool_output,
+                return_direct=False,
+            ),
+            AgentOutput(
+                response=ChatMessage(role="assistant", content="done"),
+                current_agent_name="agent",
+                tool_calls=[],
+                raw={},
+            ),
+        ]
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = MockWorkflowHandler(events=events)
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(agent=mock_agent, stream=True)
+
+        mock_context = MagicMock()
+        mock_context.session_id = None
+
+        collected = []
+        async for chunk in runtime._streaming_handler(
+            {"message": "hello"}, mock_context
+        ):
+            collected.append(chunk)
+
+        assert len(collected) == 4
+        assert collected[0]["event"] == "agent_stream"
+        assert collected[0]["delta"] == "hi"
+        assert "thinking_delta" not in collected[0]
+        assert collected[1]["event"] == "tool_call"
+        assert collected[1]["tool_name"] == "my_tool"
+        assert collected[2]["event"] == "tool_result"
+        assert collected[2]["tool_output"] == "result"
+        assert collected[3]["event"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_thinking_delta_included(self):
+        from llama_index.core.agent.workflow.workflow_events import (
+            AgentOutput,
+            AgentStream,
+        )
+        from llama_index.core.llms import ChatMessage
+
+        events = [
+            AgentStream(
+                delta="",
+                response="",
+                current_agent_name="agent",
+                thinking_delta="Let me think...",
+            ),
+            AgentOutput(
+                response=ChatMessage(role="assistant", content="done"),
+                current_agent_name="agent",
+                tool_calls=[],
+                raw={},
+            ),
+        ]
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = MockWorkflowHandler(events=events)
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(agent=mock_agent, stream=True)
+
+        mock_context = MagicMock()
+        mock_context.session_id = None
+
+        collected = []
+        async for chunk in runtime._streaming_handler(
+            {"prompt": "think"}, mock_context
+        ):
+            collected.append(chunk)
+
+        assert collected[0]["thinking_delta"] == "Let me think..."
+
+
+class TestStreamingErrorHandling:
+    @pytest.mark.asyncio
+    async def test_error_mid_stream_yields_error_event(self):
+        from llama_index.core.agent.workflow.workflow_events import AgentStream
+
+        events_before = [
+            AgentStream(
+                delta="hi",
+                response="hi",
+                current_agent_name="agent",
+                thinking_delta=None,
+            ),
+        ]
+
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = ErrorStreamWorkflowHandler(
+            events_before_error=events_before,
+            error=RuntimeError("LLM connection lost"),
+        )
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(agent=mock_agent, stream=True)
+
+        mock_context = MagicMock()
+        mock_context.session_id = None
+
+        collected = []
+        async for chunk in runtime._streaming_handler(
+            {"prompt": "hello"}, mock_context
+        ):
+            collected.append(chunk)
+
+        assert len(collected) == 2
+        assert collected[0]["event"] == "agent_stream"
+        assert collected[1]["event"] == "error"
+        assert "LLM connection lost" in collected[1]["message"]
+
+    @pytest.mark.asyncio
+    async def test_error_before_any_events(self):
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = ErrorStreamWorkflowHandler(
+            error=ValueError("bad input"),
+        )
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(agent=mock_agent, stream=True)
+
+        mock_context = MagicMock()
+        mock_context.session_id = None
+
+        collected = []
+        async for chunk in runtime._streaming_handler(
+            {"prompt": "hello"}, mock_context
+        ):
+            collected.append(chunk)
+
+        assert len(collected) == 1
+        assert collected[0]["event"] == "error"
+        assert "bad input" in collected[0]["message"]
+
+    @pytest.mark.asyncio
+    async def test_await_handler_error_does_not_crash(self):
+        mock_agent = MagicMock()
+        mock_agent.run.return_value = MockWorkflowHandler(
+            events=[], raise_on_await=RuntimeError("flush failed")
+        )
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(agent=mock_agent, stream=True)
+
+        mock_context = MagicMock()
+        mock_context.session_id = None
+
+        collected = []
+        async for chunk in runtime._streaming_handler(
+            {"prompt": "hello"}, mock_context
+        ):
+            collected.append(chunk)
+
+        # Should complete without raising (error is logged, not propagated)
+        assert len(collected) == 0
+
+
+class TestSessionIdPropagation:
+    def test_session_id_set_on_copy(self):
+        mock_memory = MagicMock()
+        mock_memory._context = MagicMock()
+        mock_memory._context.session_id = "old-session"
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(
+                agent=MagicMock(), stream=False, memory=mock_memory
+            )
+
+        mock_context = MagicMock()
+        mock_context.session_id = "new-session-123"
+
+        result = runtime._get_memory(mock_context)
+
+        # Should return a copy, not the original
+        assert result is not mock_memory
+        assert result._context.session_id == "new-session-123"
+        # Original memory should be unchanged
+        assert mock_memory._context.session_id == "old-session"
+
+    def test_no_memory_returns_none(self):
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(agent=MagicMock(), stream=False)
+
+        assert runtime._get_memory(MagicMock()) is None
+
+    def test_no_session_id_returns_original(self):
+        mock_memory = MagicMock()
+        mock_memory._context = MagicMock()
+        mock_memory._context.session_id = "existing"
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            runtime = AgentCoreRuntime(
+                agent=MagicMock(), stream=False, memory=mock_memory
+            )
+
+        mock_context = MagicMock()
+        mock_context.session_id = None
+
+        result = runtime._get_memory(mock_context)
+        assert result is mock_memory
+
+
+class TestServe:
+    def test_serve_calls_run(self):
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ):
+            with patch.object(AgentCoreRuntime, "run") as mock_run:
+                AgentCoreRuntime.serve(MagicMock(), port=9090, debug=True)
+                mock_run.assert_called_once()
+
+
+class TestEntrypointClosure:
+    def test_streaming_entrypoint_is_async_gen_function(self):
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ) as MockApp:
+            mock_app = MagicMock()
+            MockApp.return_value = mock_app
+
+            AgentCoreRuntime(agent=MagicMock(), stream=True)
+
+            registered_handler = mock_app.entrypoint.call_args[0][0]
+            assert inspect.isasyncgenfunction(registered_handler)
+            assert not inspect.ismethod(registered_handler)
+
+    def test_non_streaming_entrypoint_is_coroutine_function(self):
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ) as MockApp:
+            mock_app = MagicMock()
+            MockApp.return_value = mock_app
+
+            AgentCoreRuntime(agent=MagicMock(), stream=False)
+
+            registered_handler = mock_app.entrypoint.call_args[0][0]
+            assert inspect.iscoroutinefunction(registered_handler)
+            assert not inspect.ismethod(registered_handler)
+
+
+class TestAppProperty:
+    def test_exposes_app(self):
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ) as MockApp:
+            mock_app = MagicMock()
+            MockApp.return_value = mock_app
+
+            runtime = AgentCoreRuntime(agent=MagicMock())
+            assert runtime.app is mock_app
+
+
+class TestConstructorPassthrough:
+    def test_lifespan_passed_to_app(self):
+        async def my_lifespan(app):
+            yield
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ) as MockApp:
+            mock_app = MagicMock()
+            MockApp.return_value = mock_app
+
+            AgentCoreRuntime(agent=MagicMock(), lifespan=my_lifespan)
+
+            MockApp.assert_called_once_with(
+                debug=False, lifespan=my_lifespan, middleware=None
+            )
+
+    def test_middleware_passed_to_app(self):
+        from starlette.middleware import Middleware
+        from starlette.middleware.gzip import GZipMiddleware
+
+        mw = [Middleware(GZipMiddleware)]
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ) as MockApp:
+            mock_app = MagicMock()
+            MockApp.return_value = mock_app
+
+            AgentCoreRuntime(agent=MagicMock(), middleware=mw)
+
+            MockApp.assert_called_once_with(debug=False, lifespan=None, middleware=mw)
+
+    def test_all_app_params_passed(self):
+        async def my_lifespan(app):
+            yield
+
+        from starlette.middleware import Middleware
+        from starlette.middleware.gzip import GZipMiddleware
+
+        mw = [Middleware(GZipMiddleware)]
+
+        with patch(
+            "llama_index.tools.aws_bedrock_agentcore.runtime.base.BedrockAgentCoreApp"
+        ) as MockApp:
+            mock_app = MagicMock()
+            MockApp.return_value = mock_app
+
+            AgentCoreRuntime(
+                agent=MagicMock(),
+                debug=True,
+                lifespan=my_lifespan,
+                middleware=mw,
+            )
+
+            MockApp.assert_called_once_with(
+                debug=True, lifespan=my_lifespan, middleware=mw
+            )

--- a/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/tests/test_runtime_e2e.py
+++ b/llama-index-integrations/tools/llama-index-tools-aws-bedrock-agentcore/tests/test_runtime_e2e.py
@@ -1,0 +1,239 @@
+"""
+Integration tests for AgentCoreRuntime.
+
+Tests the full HTTP round-trip through BedrockAgentCoreApp using httpx's ASGI
+transport (no real server needed, no AWS credentials needed). Uses
+MockFunctionCallingLLM from llama-index-core which echoes user messages.
+
+Validates:
+  - Non-streaming JSON response via POST /invocations
+  - Streaming SSE response via POST /invocations
+  - GET /ping health check
+  - 400 error for missing prompt
+  - Session ID header propagation to memory
+  - Various payload key formats (prompt, message, input)
+
+Run:
+    uv run pytest tests/test_runtime_e2e.py -v
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from llama_index.core.agent.workflow import FunctionAgent
+
+try:
+    from llama_index.core.llms.mock import MockFunctionCallingLLM
+except ImportError:
+    MockFunctionCallingLLM = None
+
+from llama_index.tools.aws_bedrock_agentcore.runtime.base import AgentCoreRuntime
+
+pytestmark = pytest.mark.skipif(
+    MockFunctionCallingLLM is None,
+    reason="MockFunctionCallingLLM not available in this llama-index-core version",
+)
+
+SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
+
+
+@pytest.fixture
+def agent():
+    llm = MockFunctionCallingLLM()
+    return FunctionAgent(llm=llm, tools=[])
+
+
+@pytest.fixture
+def non_streaming_client(agent):
+    runtime = AgentCoreRuntime(agent=agent, stream=False)
+    transport = httpx.ASGITransport(app=runtime.app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def streaming_client(agent):
+    runtime = AgentCoreRuntime(agent=agent, stream=True)
+    transport = httpx.ASGITransport(app=runtime.app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+class TestPing:
+    @pytest.mark.asyncio
+    async def test_ping(self, non_streaming_client):
+        resp = await non_streaming_client.get("/ping")
+        assert resp.status_code == 200
+
+
+class TestNonStreaming:
+    @pytest.mark.asyncio
+    async def test_prompt_key(self, non_streaming_client):
+        resp = await non_streaming_client.post(
+            "/invocations", json={"prompt": "hello world"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "response" in body
+        # MockFunctionCallingLLM echoes user message
+        assert "hello world" in body["response"]
+
+    @pytest.mark.asyncio
+    async def test_message_key(self, non_streaming_client):
+        resp = await non_streaming_client.post(
+            "/invocations", json={"message": "test message"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "test message" in body["response"]
+
+    @pytest.mark.asyncio
+    async def test_input_key(self, non_streaming_client):
+        resp = await non_streaming_client.post(
+            "/invocations", json={"input": "test input"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "test input" in body["response"]
+
+    @pytest.mark.asyncio
+    async def test_missing_prompt_returns_400(self, non_streaming_client):
+        resp = await non_streaming_client.post("/invocations", json={"foo": "bar"})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_empty_payload_returns_400(self, non_streaming_client):
+        resp = await non_streaming_client.post("/invocations", json={})
+        assert resp.status_code == 400
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_streaming_returns_sse(self, streaming_client):
+        resp = await streaming_client.post(
+            "/invocations", json={"prompt": "stream test"}
+        )
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers.get("content-type", "")
+
+        events = _parse_sse(resp.text)
+        assert len(events) > 0
+
+        event_types = [e.get("event") for e in events]
+        assert "done" in event_types
+
+        done_events = [e for e in events if e.get("event") == "done"]
+        assert len(done_events) == 1
+        assert "stream test" in done_events[0]["response"]
+
+    @pytest.mark.asyncio
+    async def test_streaming_agent_stream_events(self, streaming_client):
+        resp = await streaming_client.post(
+            "/invocations", json={"prompt": "token test"}
+        )
+        events = _parse_sse(resp.text)
+
+        stream_events = [e for e in events if e.get("event") == "agent_stream"]
+        assert len(stream_events) > 0
+        for se in stream_events:
+            assert "delta" in se
+            assert "response" in se
+
+    @pytest.mark.asyncio
+    async def test_streaming_missing_prompt_returns_error(self, streaming_client):
+        resp = await streaming_client.post("/invocations", json={"foo": "bar"})
+        # For streaming, BedrockAgentCoreApp returns 200 (SSE connection open)
+        # but includes an error event in the stream. The error is raised inside
+        # the generator after the response headers are sent.
+        assert resp.status_code == 200
+        # The response should contain an error indicator in the SSE stream
+        assert "error" in resp.text.lower() or "HTTPException" in resp.text
+
+
+class TestSessionIdPropagation:
+    @pytest.mark.asyncio
+    async def test_session_header_reaches_handler(self):
+        """Verify that session ID from header is accessible in the handler."""
+        captured_contexts = []
+
+        agent = FunctionAgent(llm=MockFunctionCallingLLM(), tools=[])
+        runtime = AgentCoreRuntime(agent=agent, stream=False)
+
+        original_get_memory = runtime._get_memory
+
+        def capturing_get_memory(context=None):
+            if context:
+                captured_contexts.append(context)
+            return original_get_memory(context)
+
+        runtime._get_memory = capturing_get_memory
+
+        transport = httpx.ASGITransport(app=runtime.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/invocations",
+                json={"prompt": "session test"},
+                headers={SESSION_HEADER: "test-session-abc"},
+            )
+
+        assert resp.status_code == 200
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0].session_id == "test-session-abc"
+
+    @pytest.mark.asyncio
+    async def test_session_id_wired_to_memory(self):
+        """Verify session ID from header is set on a copy of memory, not the original."""
+        mock_memory = AsyncMock()
+        mock_memory._context = MagicMock()
+        mock_memory._context.session_id = "old-session"
+        mock_memory.aput.return_value = None
+        mock_memory.aget.return_value = []
+        mock_memory.aget_all.return_value = []
+        mock_memory.aput_messages.return_value = None
+
+        agent = FunctionAgent(llm=MockFunctionCallingLLM(), tools=[])
+        runtime = AgentCoreRuntime(agent=agent, stream=False, memory=mock_memory)
+
+        # Capture the memory returned by _get_memory
+        captured_memories = []
+        original_get_memory = runtime._get_memory
+
+        def capturing_get_memory(context=None):
+            result = original_get_memory(context)
+            captured_memories.append(result)
+            return result
+
+        runtime._get_memory = capturing_get_memory
+
+        transport = httpx.ASGITransport(app=runtime.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/invocations",
+                json={"prompt": "memory test"},
+                headers={SESSION_HEADER: "new-session-xyz"},
+            )
+
+        assert resp.status_code == 200
+        assert len(captured_memories) == 1
+        # The returned memory should have the new session ID
+        assert captured_memories[0]._context.session_id == "new-session-xyz"
+        # Original memory should be unchanged (no race condition)
+        assert mock_memory._context.session_id == "old-session"
+
+
+def _parse_sse(text: str) -> list[dict]:
+    """Parse SSE text into list of JSON event dicts."""
+    events = []
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if line.startswith("data: "):
+            data = line[6:]
+            try:
+                events.append(json.loads(data))
+            except json.JSONDecodeError:
+                pass
+    return events


### PR DESCRIPTION
## Summary

Add `AgentCoreRuntime` adapter to `llama-index-tools-aws-bedrock-agentcore` for deploying LlamaIndex agents to [AWS Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html).

- Wraps `BedrockAgentCoreApp` from the `bedrock-agentcore` SDK, providing `POST /invocations` and `GET /ping` endpoints with automatic SSE streaming
- One-liner deployment: `AgentCoreRuntime.serve(agent)`
- Full `BedrockAgentCoreApp` constructor passthrough: `debug`, `lifespan`, `middleware`
- Session ID propagation from `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header to `AgentCoreMemory`
- Streaming maps LlamaIndex events (`AgentStream`, `ToolCall`, `ToolCallResult`, `AgentOutput`) to SSE, including `thinking_delta` for extended thinking
- Graceful error handling: mid-stream errors yield `{"event": "error"}` instead of crashing
- Accepts `prompt`, `message`, or `input` as payload keys

### Target API

```python
from llama_index.tools.aws_bedrock_agentcore import AgentCoreRuntime

agent = FunctionAgent(llm=llm, tools=tools)

# One-liner
AgentCoreRuntime.serve(agent)

# With options
runtime = AgentCoreRuntime(
    agent=agent,
    stream=True,        # SSE streaming (default)
    port=8080,          # default
    debug=False,
    memory=memory,      # AgentCoreMemory for session persistence
    lifespan=lifespan,  # Starlette lifespan handler
    middleware=[...],    # Starlette middleware stack
)
runtime.run()

# Or access the ASGI app directly for testing/mounting
app = runtime.app
```

### Files changed

| File | Change |
|------|--------|
| `runtime/__init__.py` | New submodule init |
| `runtime/base.py` | `AgentCoreRuntime` class (~165 lines) |
| `__init__.py` | Added `AgentCoreRuntime` export |
| `pyproject.toml` | Version bump 0.2.0 → 0.3.0, added class author |
| `CHANGELOG.md` | Added 0.3.0 entry |
| `tests/test_runtime.py` | 28 unit tests |
| `tests/test_runtime_e2e.py` | 11 E2E tests (full HTTP round-trip via ASGI) |
| `README.md` | Added Runtime section |
| `docs/.../aws_bedrock_agentcore.md` | Added Runtime section |

## Test plan

- [x] 28 unit tests pass — prompt extraction, streaming events, error handling, session ID propagation, closure entrypoint detection, `lifespan`/`middleware` constructor passthrough
- [x] 11 E2E tests pass (real ASGI round-trip with `MockFunctionCallingLLM`)
- [x] Ruff lint and format clean