### PR TITLE
fix: use apostprocess_nodes() in async retrieval paths (fixes #20973)

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -218,7 +218,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         """Generate context information from a message."""
         nodes = await self._retriever.aretrieve(message)
         for postprocessor in self._node_postprocessors:
-            nodes = postprocessor.postprocess_nodes(
+            nodes = await postprocessor.apostprocess_nodes(
                 nodes, query_bundle=QueryBundle(message)
             )
 

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -151,7 +151,7 @@ class ContextChatEngine(BaseChatEngine):
         """Generate context information from a message."""
         nodes = await self._retriever.aretrieve(message)
         for postprocessor in self._node_postprocessors:
-            nodes = postprocessor.postprocess_nodes(
+            nodes = await postprocessor.apostprocess_nodes(
                 nodes, query_bundle=QueryBundle(message)
             )
 

--- a/llama-index-core/llama_index/core/chat_engine/multi_modal_condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/multi_modal_condense_plus_context.py
@@ -176,7 +176,7 @@ class MultiModalCondensePlusContextChatEngine(BaseChatEngine):
         """Generate context information from a message."""
         nodes = await self._retriever.aretrieve(message)
         for postprocessor in self._node_postprocessors:
-            nodes = postprocessor.postprocess_nodes(
+            nodes = await postprocessor.apostprocess_nodes(
                 nodes, query_bundle=QueryBundle(message)
             )
 

--- a/llama-index-core/llama_index/core/chat_engine/multi_modal_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/multi_modal_context.py
@@ -146,13 +146,22 @@ class MultiModalContextChatEngine(BaseChatEngine):
             )
         return nodes
 
+    async def _async_apply_node_postprocessors(
+        self, nodes: List[NodeWithScore], query_bundle: QueryBundle
+    ) -> List[NodeWithScore]:
+        for node_postprocessor in self._node_postprocessors:
+            nodes = await node_postprocessor.apostprocess_nodes(
+                nodes, query_bundle=query_bundle
+            )
+        return nodes
+
     def _get_nodes(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         nodes = self._retriever.retrieve(query_bundle)
         return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)
 
     async def _aget_nodes(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         nodes = await self._retriever.aretrieve(query_bundle)
-        return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)
+        return await self._async_apply_node_postprocessors(nodes, query_bundle=query_bundle)
 
     def synthesize(
         self,

--- a/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
@@ -245,7 +245,9 @@ class CitationQueryEngine(BaseQueryEngine):
         nodes = await self._retriever.aretrieve(query_bundle)
 
         for postprocessor in self._node_postprocessors:
-            nodes = postprocessor.postprocess_nodes(nodes, query_bundle=query_bundle)
+            nodes = await postprocessor.apostprocess_nodes(
+                nodes, query_bundle=query_bundle
+            )
 
         return nodes
 

--- a/llama-index-core/llama_index/core/query_engine/multi_modal.py
+++ b/llama-index-core/llama_index/core/query_engine/multi_modal.py
@@ -100,13 +100,22 @@ class SimpleMultiModalQueryEngine(BaseQueryEngine):
             )
         return nodes
 
+    async def _async_apply_node_postprocessors(
+        self, nodes: List[NodeWithScore], query_bundle: QueryBundle
+    ) -> List[NodeWithScore]:
+        for node_postprocessor in self._node_postprocessors:
+            nodes = await node_postprocessor.apostprocess_nodes(
+                nodes, query_bundle=query_bundle
+            )
+        return nodes
+
     def retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         nodes = self._retriever.retrieve(query_bundle)
         return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)
 
     async def aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         nodes = await self._retriever.aretrieve(query_bundle)
-        return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)
+        return await self._async_apply_node_postprocessors(nodes, query_bundle=query_bundle)
 
     def synthesize(
         self,

--- a/llama-index-core/llama_index/core/tools/retriever_tool.py
+++ b/llama-index-core/llama_index/core/tools/retriever_tool.py
@@ -110,7 +110,7 @@ class RetrieverTool(AsyncBaseTool):
             raise ValueError("Cannot call query engine without inputs")
         docs = await self._retriever.aretrieve(query_str)
         content = ""
-        docs = self._apply_node_postprocessors(docs, QueryBundle(query_str))
+        docs = await self._async_apply_node_postprocessors(docs, QueryBundle(query_str))
         for doc in docs:
             assert isinstance(doc.node, (Node, TextNode))
             node_copy = doc.node.model_copy()
@@ -130,6 +130,15 @@ class RetrieverTool(AsyncBaseTool):
     ) -> List[NodeWithScore]:
         for node_postprocessor in self._node_postprocessors:
             nodes = node_postprocessor.postprocess_nodes(
+                nodes, query_bundle=query_bundle
+            )
+        return nodes
+
+    async def _async_apply_node_postprocessors(
+        self, nodes: List[NodeWithScore], query_bundle: QueryBundle
+    ) -> List[NodeWithScore]:
+        for node_postprocessor in self._node_postprocessors:
+            nodes = await node_postprocessor.apostprocess_nodes(
                 nodes, query_bundle=query_bundle
             )
         return nodes


### PR DESCRIPTION
## Summary

Several async methods call the sync `postprocess_nodes()` instead of awaiting the async `apostprocess_nodes()`. This silently skips async-specific postprocessor implementations in all async retrieval paths.

`RetrieverQueryEngine` already uses the correct pattern through `_async_apply_node_postprocessors` — this PR applies the same fix to the remaining 7 files.

## Problem

When using `achat()`, `astream_chat()`, `aretrieve()`, or `acall()` with a custom `BaseNodePostprocessor` that overrides `_apostprocess_nodes()`, the async implementation is never called. Instead, the sync `_postprocess_nodes()` is called, which may have different behavior or be a no-op.

## Fix

For each affected file, replace `postprocessor.postprocess_nodes(...)` with `await postprocessor.apostprocess_nodes(...)` in async methods. For classes that use a `_apply_node_postprocessors()` helper, add a matching `_async_apply_node_postprocessors()` method (following the existing pattern in `RetrieverQueryEngine`).

### Files changed (7):

| File | Change |
|---|---|
| `chat_engine/context.py` | `_aget_nodes`: sync → async call |
| `chat_engine/condense_plus_context.py` | `_aget_nodes`: sync → async call |
| `chat_engine/multi_modal_context.py` | Add `_async_apply_node_postprocessors`, use in `_aget_nodes` |
| `chat_engine/multi_modal_condense_plus_context.py` | `_aget_nodes`: sync → async call |
| `query_engine/citation_query_engine.py` | `aretrieve`: sync → async call |
| `query_engine/multi_modal.py` | Add `_async_apply_node_postprocessors`, use in `aretrieve` |
| `tools/retriever_tool.py` | Add `_async_apply_node_postprocessors`, use in `acall` |

## Reproduction

```python
class TrackingPostprocessor(BaseNodePostprocessor):
    called_sync: bool = False
    called_async: bool = False

    def _postprocess_nodes(self, nodes, query_bundle=None):
        self.called_sync = True
        return nodes

    async def _apostprocess_nodes(self, nodes, query_bundle=None):
        self.called_async = True
        return nodes

# Before fix: called_async is always False in async paths
# After fix: called_async is True as expected
```

Fixes #20973