### PR TITLE
fix: preserve non-ASCII schema descriptions in `PydanticOutputParser`

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/pydantic.py
+++ b/llama-index-core/llama_index/core/output_parsers/pydantic.py
@@ -50,7 +50,7 @@ class PydanticOutputParser(BaseOutputParser, Generic[Model]):
         for key in self._excluded_schema_keys_from_format:
             del schema_dict[key]
 
-        schema_str = json.dumps(schema_dict)
+        schema_str = json.dumps(schema_dict, ensure_ascii=False)
         output_str = self._pydantic_format_tmpl.format(schema=schema_str)
         if escape_json:
             return output_str.replace("{", "{{").replace("}", "}}")

--- a/llama-index-core/tests/output_parsers/test_pydantic.py
+++ b/llama-index-core/tests/output_parsers/test_pydantic.py
@@ -1,7 +1,7 @@
 """Test pydantic output parser."""
 
 import pytest
-from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.output_parsers.pydantic import PydanticOutputParser
 from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
 
@@ -15,6 +15,13 @@ class TestModel(BaseModel):
     __test__ = False
     title: str
     attr_dict: AttrDict
+
+
+class TestNonAsciiDescriptionModel(BaseModel):
+    __test__ = False
+    name: str = Field(description="用户名")  # Chinese for "username"
+    formula: str = Field(..., examples=["H₂O"])
+    currency: str = Field(..., examples=["€"])
 
 
 def test_pydantic() -> None:
@@ -70,3 +77,17 @@ def test_pydantic_format_with_blocks() -> None:
     ]
     formatted_messages = parser.format_messages(messages)
     assert "hello world" in formatted_messages[0].blocks[-1].text
+
+
+def test_pydantic_format_preserves_non_ascii_schema_descriptions() -> None:
+    """Test pydantic format keeps non-ASCII schema descriptions readable."""
+    query = "test"
+    parser = PydanticOutputParser(output_cls=TestNonAsciiDescriptionModel)
+    formatted_query = parser.format(query)
+
+    assert "用户名" in formatted_query
+    assert "\\u7528\\u6237\\u540d" not in formatted_query
+    assert "H₂O" in formatted_query
+    assert "H\\u2082O" not in formatted_query
+    assert "€" in formatted_query
+    assert "\\u20ac" not in formatted_query


### PR DESCRIPTION
# Description

This PR fixes a bug in `PydanticOutputParser.get_format_string()` where the generated schema prompt escaped non-ASCII characters using the default `json.dumps(...)` behavior. This may reduce how well the model understands field semantics, when descriptions contain Unicode.

The implementation now uses `json.dumps(schema_dict, ensure_ascii=False)` so schema descriptions remain readable in the prompt.

A regression test was added to cover Pydantic models with non-ASCII field descriptions.

Fixes #21015

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No new package

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No, updating llama-index-core

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
