### PR TITLE
fix(core): preserve non-ASCII characters in PydanticOutputParser schema

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/pydantic.py
+++ b/llama-index-core/llama_index/core/output_parsers/pydantic.py
@@ -50,7 +50,7 @@ class PydanticOutputParser(BaseOutputParser, Generic[Model]):
         for key in self._excluded_schema_keys_from_format:
             del schema_dict[key]
 
-        schema_str = json.dumps(schema_dict)
+        schema_str = json.dumps(schema_dict, ensure_ascii=False)
         output_str = self._pydantic_format_tmpl.format(schema=schema_str)
         if escape_json:
             return output_str.replace("{", "{{").replace("}", "}}")

--- a/llama-index-core/tests/output_parsers/test_pydantic.py
+++ b/llama-index-core/tests/output_parsers/test_pydantic.py
@@ -53,6 +53,21 @@ def test_pydantic_format() -> None:
     assert "hello world" in formatted_query
 
 
+class NonAsciiModel(BaseModel):
+    username: str = "用户名"
+    formula: str = "H₂O"
+
+
+def test_pydantic_format_preserves_non_ascii() -> None:
+    """Test that non-ASCII characters in schema descriptions are not escaped."""
+    parser = PydanticOutputParser(output_cls=NonAsciiModel)
+    format_str = parser.get_format_string(escape_json=False)
+    # Non-ASCII characters should be preserved, not escaped to \\uXXXX
+    assert "用户名" in format_str
+    assert "H₂O" in format_str
+    assert "\\u" not in format_str
+
+
 def test_pydantic_format_with_blocks() -> None:
     """Test pydantic format with blocks."""
     parser = PydanticOutputParser(output_cls=AttrDict)


### PR DESCRIPTION
## Bug

`PydanticOutputParser.get_format_string()` serializes the Pydantic model schema with `json.dumps(schema_dict)`, which defaults to `ensure_ascii=True`. This escapes non-ASCII characters to `\uXXXX` sequences in the prompt.

For example:
- `用户名` (Chinese for *username*) → `\u7528\u6237\u540d`
- `H₂O` → `H\u2082O`

This degrades prompt readability and can reduce model comprehension of field semantics.

Fixes #21015

## Fix

Pass `ensure_ascii=False` to `json.dumps()` so Unicode text is preserved as-is in the schema string embedded in prompts.

One-line change in `llama-index-core/llama_index/core/output_parsers/pydantic.py`.

## Test

Added `test_pydantic_format_preserves_non_ascii` — verifies that non-ASCII characters (CJK, subscript) appear in the format string without escaping. All 4 existing tests pass.