### PR TITLE
fix(core): preserve CTE names during schema prefixing in SQLDatabase.run_sql

### DIFF
--- a/llama-index-core/llama_index/core/utilities/sql_wrapper.py
+++ b/llama-index-core/llama_index/core/utilities/sql_wrapper.py
@@ -1,7 +1,7 @@
 """SQL wrapper around SQLDatabase in langchain."""
 
 import re
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from sqlalchemy import MetaData, create_engine, insert, inspect, text
 from sqlalchemy.engine import Engine
@@ -221,7 +221,7 @@ class SQLDatabase:
         schema-qualified identifiers so they are not double-prefixed.
         """
         # Collect CTE names defined in WITH clauses
-        cte_names: set[str] = set()
+        cte_names: Set[str] = set()
         # First CTE: WITH [RECURSIVE] name AS (
         for m in re.finditer(
             r"\bWITH\s+(?:RECURSIVE\s+)?(\w+)\s+AS\s*\(", command, re.IGNORECASE

--- a/llama-index-core/tests/utilities/test_sql_wrapper.py
+++ b/llama-index-core/tests/utilities/test_sql_wrapper.py
@@ -164,6 +164,38 @@ def test_schema_prefix_skips_already_qualified(sql_database: SQLDatabase) -> Non
     assert "myschema.other_schema" not in result
 
 
+def test_schema_prefix_left_join(sql_database: SQLDatabase) -> None:
+    sql_database._schema = "myschema"
+    result = sql_database._add_schema_prefix(
+        "SELECT * FROM users LEFT JOIN orders ON users.id = orders.user_id"
+    )
+    assert "FROM myschema.users" in result
+    assert "JOIN myschema.orders" in result
+
+
+def test_schema_prefix_subquery_not_prefixed(sql_database: SQLDatabase) -> None:
+    sql_database._schema = "myschema"
+    result = sql_database._add_schema_prefix(
+        "SELECT * FROM (SELECT id FROM users) AS sub"
+    )
+    # The subquery opener '(' should not be treated as a table name
+    assert "FROM myschema.users" in result
+    assert "myschema.(SELECT" not in result
+
+
+def test_schema_prefix_cte_join_inside_body(sql_database: SQLDatabase) -> None:
+    sql_database._schema = "myschema"
+    cmd = (
+        "WITH active AS (SELECT * FROM users WHERE active = 1) "
+        "SELECT * FROM active JOIN orders ON active.id = orders.user_id"
+    )
+    result = sql_database._add_schema_prefix(cmd)
+    assert "FROM myschema.users" in result
+    assert "JOIN myschema.orders" in result
+    assert "FROM active " in result
+    assert "myschema.active" not in result
+
+
 def test_schema_prefix_case_insensitive(sql_database: SQLDatabase) -> None:
     sql_database._schema = "myschema"
     result = sql_database._add_schema_prefix("select * from users join orders on 1=1")


### PR DESCRIPTION
# Description

Fix naive `str.replace("FROM ", ...)` in `SQLDatabase.run_sql()` that incorrectly schema-prefixes CTE (Common Table Expression) names, breaking queries like:

```sql
WITH my_cte AS (SELECT * FROM users) SELECT * FROM my_cte
-- Before (broken): ... SELECT * FROM myschema.my_cte
-- After (fixed):   ... SELECT * FROM my_cte
```

Replace with regex-based `_add_schema_prefix()` method that:
1. Extracts CTE names from `WITH [RECURSIVE] name AS (` clauses (including comma-separated CTEs)
2. Uses regex to match `FROM`/`JOIN` table references
3. Skips CTE names and already schema-qualified identifiers when prefixing

Fixes #19889

## Version Bump?

- [x] No (llama-index-core is exempt per PR template)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

10 new tests covering:
- Simple FROM/JOIN prefixing
- Single CTE name preservation
- Multiple CTEs (`WITH a AS (...), b AS (...)`)
- Recursive CTEs (`WITH RECURSIVE`)
- Already schema-qualified names (`other_schema.table`)
- Multi-word JOINs (`LEFT JOIN`)
- Subqueries (`FROM (SELECT ...)`)
- CTE + real table in same query
- Case-insensitive matching

All 16 tests pass (6 existing + 10 new). Pre-commit hooks, ruff, mypy all pass.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods