### PR TITLE
fix: Handle None .text in AnthropicCompletionResponse

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -376,7 +376,7 @@ class Anthropic(FunctionCallingLLM):
         self, chat_response: AnthropicChatResponse
     ) -> AnthropicCompletionResponse:
         return AnthropicCompletionResponse(
-            text=chat_response.message.content,
+            text=chat_response.message.content or "",
             delta=chat_response.delta,
             additional_kwargs=chat_response.additional_kwargs,
             raw=chat_response.raw,

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
@@ -1074,3 +1074,44 @@ def test_structured_output_failure_mock() -> None:
         match="It was not possible to produce a structured response because of max_tokens",
     ):
         sllm.chat(STRUCT_MESSAGES)
+
+
+def test_completion_response_from_chat_response_with_none_content():
+    """
+    Test that _completion_response_from_chat_response handles None content.
+
+    Regression test for issue #21026 - Pydantic validation error when
+    chat_response.message.content is None (e.g., when message only has blocks).
+    """
+    from llama_index.llms.anthropic.base import (
+        AnthropicChatResponse,
+        AnthropicCompletionResponse,
+    )
+    from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+    # Create an Anthropic instance (no API key needed for this test)
+    llm = Anthropic(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+    )
+
+    # Create a ChatMessage with no content (just empty blocks)
+    # This simulates the case where message.content is None
+    chat_msg = ChatMessage(role=MessageRole.ASSISTANT, blocks=[])
+
+    # Create an AnthropicChatResponse with None content
+    chat_response = AnthropicChatResponse(
+        message=chat_msg,
+        citations=[],
+    )
+
+    # This should NOT raise a Pydantic validation error
+    # The fix ensures text defaults to "" when content is None
+    completion_response = llm._completion_response_from_chat_response(chat_response)
+
+    # Verify the response
+    assert isinstance(completion_response, AnthropicCompletionResponse)
+    assert completion_response.text == "", (
+        "text should be empty string when content is None"
+    )
+    assert completion_response.citations == []


### PR DESCRIPTION
Fixes #21026

## Bug Description

When using Anthropic LLM integration, `stream_complete` could trigger a ValidationError when `chat_response.message.content` is `None` (e.g., when the chat message contains blocks instead of text content).

## Root Cause

The `_completion_response_from_chat_response` method was passing `chat_response.message.content` directly to `AnthropicCompletionResponse`, but when the message only has blocks (no text content), the `content` field is `None`. The `CompletionResponse` class expects `text` to be a string, causing a Pydantic validation error.

## Fix

Changed `text=chat_response.message.content` to `text=chat_response.message.content or ""` to handle None values by defaulting to an empty string. This pattern is consistent with other LLM integrations in the codebase (e.g., zhipuai, huggingface-api, mistralai, ollama, langchain, siliconflow, premai).

## Testing

Added a regression test `test_completion_response_from_chat_response_with_none_content` that verifies the fix works correctly when content is None.

## Changes

- `llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py`: Added null check for content
- `llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py`: Added regression test