### PR TITLE
feat: Add DNS-AID tool pack for agent discovery via DNS

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-dns-aid/llama_index/tools/dns_aid/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-dns-aid/llama_index/tools/dns_aid/__init__.py
@@ -1,0 +1,5 @@
+"""DNS-AID tools for LlamaIndex."""
+
+from llama_index.tools.dns_aid.base import DnsAidToolSpec
+
+__all__ = ["DnsAidToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-dns-aid/llama_index/tools/dns_aid/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-dns-aid/llama_index/tools/dns_aid/base.py
@@ -1,0 +1,98 @@
+"""DNS-AID tool specification for LlamaIndex.
+
+Provides discover, publish, and unpublish operations as LlamaIndex FunctionTool objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class DnsAidToolSpec:
+    """DNS-AID tool spec for LlamaIndex.
+
+    Example::
+
+        from llama_index_tools_dns_aid import DnsAidToolSpec
+
+        spec = DnsAidToolSpec(backend_name="route53")
+        tools = spec.to_tool_list()
+        # Use tools in a LlamaIndex agent
+    """
+
+    def __init__(
+        self,
+        backend_name: Optional[str] = None,
+        backend: Any = None,
+    ) -> None:
+        from dns_aid.integrations import DnsAidOperations
+
+        self._ops = DnsAidOperations(backend_name=backend_name, backend=backend)
+
+    def discover_agents(
+        self,
+        domain: str,
+        protocol: Optional[str] = None,
+        name: Optional[str] = None,
+        require_dnssec: bool = False,
+    ) -> str:
+        """Discover AI agents at a domain via DNS-AID SVCB records."""
+        return self._ops.discover_sync(
+            domain=domain, protocol=protocol, name=name, require_dnssec=require_dnssec
+        )
+
+    def publish_agent(
+        self,
+        name: str,
+        domain: str,
+        protocol: str = "mcp",
+        endpoint: str = "",
+        port: int = 443,
+        capabilities: Optional[list[str]] = None,
+        version: str = "1.0.0",
+        description: Optional[str] = None,
+        ttl: int = 3600,
+    ) -> str:
+        """Publish an AI agent to DNS via DNS-AID."""
+        return self._ops.publish_sync(
+            name=name,
+            domain=domain,
+            protocol=protocol,
+            endpoint=endpoint,
+            port=port,
+            capabilities=capabilities,
+            version=version,
+            description=description,
+            ttl=ttl,
+        )
+
+    def unpublish_agent(
+        self,
+        name: str,
+        domain: str,
+        protocol: str = "mcp",
+    ) -> str:
+        """Remove an AI agent from DNS via DNS-AID."""
+        return self._ops.unpublish_sync(name=name, domain=domain, protocol=protocol)
+
+    def to_tool_list(self) -> list:
+        """Convert to list of LlamaIndex FunctionTool objects."""
+        from llama_index.core.tools import FunctionTool
+
+        return [
+            FunctionTool.from_defaults(
+                fn=self.discover_agents,
+                name="dns_aid_discover",
+                description="Discover AI agents at a domain via DNS-AID SVCB records.",
+            ),
+            FunctionTool.from_defaults(
+                fn=self.publish_agent,
+                name="dns_aid_publish",
+                description="Publish an AI agent to DNS via DNS-AID.",
+            ),
+            FunctionTool.from_defaults(
+                fn=self.unpublish_agent,
+                name="dns_aid_unpublish",
+                description="Remove an AI agent from DNS via DNS-AID.",
+            ),
+        ]

--- a/llama-index-integrations/tools/llama-index-tools-dns-aid/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-dns-aid/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "llama-index-tools-dns-aid"
+version = "0.1.0"
+description = "DNS-AID tools for LlamaIndex - discover AI agents via DNS"
+license = "Apache-2.0"
+readme = "README.md"
+packages = [{include = "llama_index/"}]
+
+[tool.poetry.dependencies]
+python = ">=3.9,<4.0"
+llama-index-core = ">=0.12.0"
+dns-aid = ">=0.12.0"


### PR DESCRIPTION
## Summary

- Adds `llama-index-tools-dns-aid` tool pack with `DnsAidToolSpec`
- Provides `discover_agents`, `publish_agent`, `unpublish_agent` methods
- `to_tool_list()` converts to LlamaIndex `FunctionTool` objects

## Why

DNS-AID provides decentralized agent discovery via DNS SVCB records (IETF draft-mozleywilliams-dnsop-dnsaid-01). LlamaIndex agents and RAG pipelines can dynamically discover and route to specialized agents.

## Dependencies

- `dns-aid>=0.12.0`

## Test plan

- [ ] Unit tests with mocked DNS operations
- [ ] Verify FunctionTool creation via to_tool_list()
- [ ] Integration test with dns-aid mock backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)