### PR TITLE
fix(core): remove incorrect per-node delete calls in index helpers

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -414,7 +414,6 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
             if ref_doc_info is not None:
                 for node_id in ref_doc_info.node_ids:
                     self._index_struct.delete(node_id)
-                    self._vector_store.delete(node_id)
 
     def _delete_from_docstore(self, ref_doc_id: str) -> None:
         # delete from docstore only if needed
@@ -438,7 +437,6 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
             if ref_doc_info is not None:
                 for node_id in ref_doc_info.node_ids:
                     self._index_struct.delete(node_id)
-                    self._vector_store.delete(node_id)
 
     async def _adelete_from_docstore(self, ref_doc_id: str) -> None:
         """Delete from docstore only if needed."""

--- a/llama-index-core/tests/indices/vector_store/test_simple.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple.py
@@ -258,6 +258,34 @@ def test_simple_insert_save(
     assert index.index_struct == loaded_index.index_struct
 
 
+def test_delete_ref_doc_calls_vector_store_with_ref_doc_id_only(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    delete_log: List[str] = []
+
+    class TrackingVectorStore(SimpleVectorStore):
+        def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
+            delete_log.append(ref_doc_id)
+            super().delete(ref_doc_id, **kwargs)
+
+        @property
+        def client(self) -> Any:
+            return None
+
+    store = TrackingVectorStore()
+    index = VectorStoreIndex.from_documents(
+        [Document(text="Hello world.", id_="my-doc-id")],
+        storage_context=StorageContext.from_defaults(vector_store=store),
+        embed_model=mock_embed_model,
+    )
+
+    index.delete_ref_doc("my-doc-id")
+
+    assert delete_log == ["my-doc-id"], (
+        f"Expected delete() called once with ref_doc_id only, got: {delete_log}"
+    )
+
+
 def test_simple_pickle(
     patch_llm_predictor,
     patch_token_text_splitter,

--- a/llama-index-core/tests/indices/vector_store/test_simple_async.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple_async.py
@@ -1,8 +1,9 @@
 import pytest
-from typing import List
+from typing import Any, List
 from llama_index.core.indices.vector_store.base import VectorStoreIndex
 from llama_index.core.indices.keyword_table.simple_base import SimpleKeywordTableIndex
 from llama_index.core.schema import Document
+from llama_index.core.storage.storage_context import StorageContext
 from llama_index.core.vector_stores.simple import SimpleVectorStore
 
 
@@ -199,3 +200,32 @@ async def test_adelete_ref_doc_nodes_removed_from_docstore(
     for node_id in ref_doc_info_2.node_ids:
         node = index.docstore.get_node(node_id, raise_error=False)
         assert node is not None
+
+
+@pytest.mark.asyncio
+async def test_adelete_ref_doc_calls_vector_store_with_ref_doc_id_only(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    delete_log: List[str] = []
+
+    class TrackingVectorStore(SimpleVectorStore):
+        def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
+            delete_log.append(ref_doc_id)
+            super().delete(ref_doc_id, **kwargs)
+
+        @property
+        def client(self) -> Any:
+            return None
+
+    store = TrackingVectorStore()
+    index = VectorStoreIndex.from_documents(
+        [Document(text="Hello world.", id_="my-doc-id")],
+        storage_context=StorageContext.from_defaults(vector_store=store),
+        embed_model=mock_embed_model,
+    )
+
+    await index.adelete_ref_doc("my-doc-id")
+
+    assert delete_log == ["my-doc-id"], (
+        f"Expected delete() called once with ref_doc_id only, got: {delete_log}"
+    )


### PR DESCRIPTION
# Description

Removes the extra `vector_store.delete(node_id)` calls from `VectorStoreIndex` delete helpers, since ref-doc cleanup is already handled by the top-level delete path. This would also remove the synchronous delete call from the async path.

Fixes #21049

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
