### PR TITLE
fix: use async adelete in _adelete_from_index_struct

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -438,7 +438,7 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
             if ref_doc_info is not None:
                 for node_id in ref_doc_info.node_ids:
                     self._index_struct.delete(node_id)
-                    self._vector_store.delete(node_id)
+                    await self._vector_store.adelete(node_id)
 
     async def _adelete_from_docstore(self, ref_doc_id: str) -> None:
         """Delete from docstore only if needed."""


### PR DESCRIPTION
Fixes #21049

## Summary

`_adelete_from_index_struct()` was calling the synchronous `self._vector_store.delete(node_id)` instead of `await self._vector_store.adelete(node_id)` in an async context. This bypasses the async code path and can cause issues in async environments.

## Changes
- Changed sync `self._vector_store.delete()` call to `await self._vector_store.adelete()` in `_adelete_from_index_struct`