### PR TITLE
fix: use (hash, ref_doc_id) as dedup key in sync recursive retrieval

### DIFF
--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -143,11 +143,15 @@ class BaseRetriever(PromptMixin, DispatcherSpanMixin):
             else:
                 retrieved_nodes.append(n)
 
+        # remove any duplicates based on hash and ref_doc_id
         seen = set()
         return [
             n
             for n in retrieved_nodes
-            if not (n.node.hash in seen or seen.add(n.node.hash))  # type: ignore[func-returns-value]
+            if not (
+                (n.node.hash, n.node.ref_doc_id) in seen
+                or seen.add((n.node.hash, n.node.ref_doc_id))  # type: ignore[func-returns-value]
+            )
         ]
 
     async def _ahandle_recursive_retrieval(


### PR DESCRIPTION
## Summary

- Fixes #21033
- `_handle_recursive_retrieval` (sync) was deduplicating nodes using `node.hash` alone, while `_ahandle_recursive_retrieval` (async) correctly uses `(node.hash, node.ref_doc_id)` as the dedup key (introduced in PR #14383)
- Two nodes with identical text content but originating from different source documents were incorrectly dropped in the sync retrieval path

## Changes

Changed the dedup key in `_handle_recursive_retrieval` from `node.hash` to `(node.hash, node.ref_doc_id)` to match the async counterpart.

**File:** `llama-index-core/llama_index/core/base/base_retriever.py`

Before:
```python
seen = set()
return [
    n
    for n in retrieved_nodes
    if not (n.node.hash in seen or seen.add(n.node.hash))
]
```

After:
```python
# remove any duplicates based on hash and ref_doc_id
seen = set()
return [
    n
    for n in retrieved_nodes
    if not (
        (n.node.hash, n.node.ref_doc_id) in seen
        or seen.add((n.node.hash, n.node.ref_doc_id))
    )
]
```

## Test plan

- [ ] Verify that two nodes with identical text but different `ref_doc_id` values are both returned by `_handle_recursive_retrieval`
- [ ] Verify that true duplicates (same hash AND same ref_doc_id) are still correctly deduplicated
- [ ] Run existing retriever tests: `uv run -- pytest llama-index-core/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)