### PR TITLE
fix: preserve empty strings in DocumentBlock validation

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -697,9 +697,10 @@ class DocumentBlock(BaseContentBlock):
 
     @model_validator(mode="after")
     def document_validation(self) -> Self:
-        self.document_mimetype = self.document_mimetype or self._guess_mimetype()
+        if self.document_mimetype is None:
+            self.document_mimetype = self._guess_mimetype()
 
-        if not self.title:
+        if self.title is None:
             self.title = "input_document"
 
         # skip data validation if no byte is provided


### PR DESCRIPTION
## Summary

- Fix `DocumentBlock.document_validation()` incorrectly coercing empty string (`""`) fields to `None` or default values due to falsy checks
- Replace `self.document_mimetype or self._guess_mimetype()` with explicit `if self.document_mimetype is None` check
- Replace `if not self.title` with `if self.title is None` check

## Problem

The validator used Python falsy checks (`or` and `not`) which treat `""` the same as `None`. This means explicitly passing `title=""` or `document_mimetype=""` would silently overwrite those values with `"input_document"` or a guessed mimetype, respectively.

This is the same class of bug fixed in PR #19302 for `ChatMessage` content handling.

Fixes #20462

## Test plan

- [ ] `DocumentBlock(title="")` preserves `title=""` instead of coercing to `"input_document"`
- [ ] `DocumentBlock(document_mimetype="")` preserves `document_mimetype=""` instead of guessing

🤖 Generated with [Claude Code](https://claude.com/claude-code)