### PR TITLE
fix: cohere reranker sdk v5 compat

### DIFF
--- a/llama-index-finetuning/llama_index/finetuning/rerankers/cohere_reranker.py
+++ b/llama-index-finetuning/llama_index/finetuning/rerankers/cohere_reranker.py
@@ -2,10 +2,17 @@
 
 import importlib.util
 import os
+import time
 from typing import Optional
 
+from cohere.finetuning import (  # pyright: ignore[reportMissingImports]
+    BaseModel,
+    FinetunedModel,
+    Settings,
+)
+
 from llama_index.finetuning.types import BaseCohereRerankerFinetuningEngine
-from llama_index.postprocessor.cohere_rerank import CohereRerank
+from llama_index.postprocessor.cohere_rerank import CohereRerank  # pyright: ignore[reportMissingImports]
 
 
 class CohereRerankerFinetuneEngine(BaseCohereRerankerFinetuningEngine):
@@ -25,7 +32,7 @@ class CohereRerankerFinetuneEngine(BaseCohereRerankerFinetuningEngine):
         cohere_spec = importlib.util.find_spec("cohere")
 
         if cohere_spec is not None:
-            import cohere
+            import cohere  # pyright: ignore[reportMissingImports]
         else:
             # Raise an ImportError if 'cohere' is not installed
             raise ImportError(
@@ -49,22 +56,36 @@ class CohereRerankerFinetuneEngine(BaseCohereRerankerFinetuningEngine):
 
     def finetune(self) -> None:
         """Finetune model."""
-        from cohere.custom_model_dataset import JsonlDataset
-
+        dataset_kwargs = {
+            "name": self._model_name,
+            "type": "rerank-finetune-input",
+            "data": open(self._train_file_name, "rb"),
+        }
         if self._val_file_name:
-            # Uploading both train file and eval file
-            dataset = JsonlDataset(
-                train_file=self._train_file_name, eval_file=self._val_file_name
-            )
-        else:
-            # Single Train File Upload:
-            dataset = JsonlDataset(train_file=self._train_file_name)
+            dataset_kwargs["eval_data"] = open(self._val_file_name, "rb")
 
-        self._finetune_model = self._model.create_custom_model(
-            name=self._model_name,
-            dataset=dataset,
-            model_type=self._model_type,
-            base_model=self._base_model,
+        dataset = self._model.datasets.create(**dataset_kwargs)
+
+        while True:
+            current_dataset = self._model.datasets.get(dataset.dataset.id)
+            validation_status = current_dataset.dataset.validation_status
+            if validation_status == "validated":
+                break
+            if validation_status == "failed":
+                raise ValueError("Cohere dataset validation failed.")
+            time.sleep(5)
+
+        self._finetune_model = self._model.finetuning.create_finetuned_model(
+            request=FinetunedModel(
+                name=self._model_name,
+                settings=Settings(
+                    dataset_id=dataset.dataset.id,
+                    base_model=BaseModel(
+                        base_type="BASE_TYPE_RERANK",
+                        name=self._base_model,
+                    ),
+                ),
+            )
         )
 
     def get_finetuned_model(self, top_n: int = 5) -> CohereRerank:

--- a/llama-index-finetuning/pyproject.toml
+++ b/llama-index-finetuning/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "llama-index-core>=0.13.0,<0.15",
     "llama-index-llms-azure-openai>=0.4.0,<0.5",
     "llama-index-llms-mistralai>=0.7.0,<0.8",
+    "cohere>=5.0.0,<6",
     "llama-index-postprocessor-cohere-rerank>=0.5.0,<0.6",
     "llama-index-embeddings-adapter>=0.4.0,<0.5",
     "mistralai>=1.7.0",

--- a/llama-index-finetuning/tests/test_cohere_reranker.py
+++ b/llama-index-finetuning/tests/test_cohere_reranker.py
@@ -1,0 +1,111 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+MODULE_PATH = Path(
+    "/Users/lalakiya/Desktop/Opensource/llama-Index/llama_index/"
+    "llama-index-finetuning/llama_index/finetuning/rerankers/cohere_reranker.py"
+)
+
+
+def _load_module():
+    cohere_module = ModuleType("cohere")
+    cohere_module.Client = MagicMock()
+    cohere_finetuning = ModuleType("cohere.finetuning")
+
+    class BaseModel:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class Settings:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class FinetunedModel:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    cohere_finetuning.BaseModel = BaseModel
+    cohere_finetuning.FinetunedModel = FinetunedModel
+    cohere_finetuning.Settings = Settings
+    cohere_module.finetuning = cohere_finetuning
+
+    types_module = ModuleType("llama_index.finetuning.types")
+    types_module.BaseCohereRerankerFinetuningEngine = object
+    postprocessor_module = ModuleType("llama_index.postprocessor.cohere_rerank")
+
+    class CohereRerank:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    postprocessor_module.CohereRerank = CohereRerank
+
+    sys.modules["cohere"] = cohere_module
+    sys.modules["cohere.finetuning"] = cohere_finetuning
+    sys.modules["llama_index.finetuning.types"] = types_module
+    sys.modules["llama_index.postprocessor.cohere_rerank"] = postprocessor_module
+
+    spec = importlib.util.spec_from_file_location("cohere_reranker_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.importlib.util.find_spec = lambda _name: object()
+    return module
+
+
+def _mock_dataset(dataset_id: str, validation_status: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        dataset=SimpleNamespace(id=dataset_id, validation_status=validation_status)
+    )
+
+
+def test_finetune_uses_cohere_v5_flow() -> None:
+    module = _load_module()
+    engine = module.CohereRerankerFinetuneEngine(api_key="test_key")
+
+    train_dataset = _mock_dataset("dataset-123", "pending")
+    validated_dataset = _mock_dataset("dataset-123", "validated")
+    finetuned_model = SimpleNamespace(id="finetuned-456")
+
+    engine._model.datasets.create.return_value = train_dataset
+    engine._model.datasets.get.side_effect = [train_dataset, validated_dataset]
+    engine._model.finetuning.create_finetuned_model.return_value = finetuned_model
+
+    with patch("builtins.open", mock_open()), patch.object(module.time, "sleep"):
+        engine.finetune()
+
+    engine._model.datasets.create.assert_called_once()
+    create_kwargs = engine._model.datasets.create.call_args.kwargs
+    assert create_kwargs["name"] == "exp_finetune"
+    assert create_kwargs["type"] == "rerank-finetune-input"
+    assert "data" in create_kwargs
+
+    engine._model.datasets.get.assert_any_call("dataset-123")
+    engine._model.finetuning.create_finetuned_model.assert_called_once()
+    request = engine._model.finetuning.create_finetuned_model.call_args.kwargs[
+        "request"
+    ]
+    assert request.name == "exp_finetune"
+    assert request.settings.dataset_id == "dataset-123"
+    assert request.settings.base_model.base_type == "BASE_TYPE_RERANK"
+    assert request.settings.base_model.name == "english"
+    assert engine._finetune_model == finetuned_model
+
+
+def test_finetune_raises_on_dataset_validation_failure() -> None:
+    module = _load_module()
+    engine = module.CohereRerankerFinetuneEngine(api_key="test_key")
+
+    failed_dataset = _mock_dataset("dataset-123", "failed")
+    engine._model.datasets.create.return_value = failed_dataset
+    engine._model.datasets.get.return_value = failed_dataset
+
+    with patch("builtins.open", mock_open()), patch.object(module.time, "sleep"):
+        with pytest.raises(ValueError, match="Cohere dataset validation failed"):
+            engine.finetune()
+
+    engine._model.finetuning.create_finetuned_model.assert_not_called()


### PR DESCRIPTION
# Description

This PR updates the CohereRerankerFinetuneEngine in llama-index-finetuning to be compatible with the Cohere Python SDK v5.

Motivation and Context:
The previous implementation relied on from cohere.custom_model_dataset import JsonlDataset, which was removed in the Cohere v5.0.0 SDK release, resulting in a ModuleNotFoundError when users attempted to call .finetune().

Fixes #14720 

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Leave unchecked if no doc pages needed updating)
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran uv run make format; uv run make lint to appease the lint gods
