### PR TITLE
fix(retriever): include ref_doc_id in sync recursive retrieval dedup key

### DIFF
--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -143,11 +143,15 @@ class BaseRetriever(PromptMixin, DispatcherSpanMixin):
             else:
                 retrieved_nodes.append(n)
 
+        # remove any duplicates based on hash and ref_doc_id (matches async counterpart)
         seen = set()
         return [
             n
             for n in retrieved_nodes
-            if not (n.node.hash in seen or seen.add(n.node.hash))  # type: ignore[func-returns-value]
+            if not (
+                (n.node.hash, n.node.ref_doc_id) in seen
+                or seen.add((n.node.hash, n.node.ref_doc_id))  # type: ignore[func-returns-value]
+            )
         ]
 
     async def _ahandle_recursive_retrieval(


### PR DESCRIPTION
## Summary

Fixes #21033

`_handle_recursive_retrieval()` deduplicated nodes using `node.hash` alone, while its async counterpart `_ahandle_recursive_retrieval()` correctly uses `(node.hash, node.ref_doc_id)` as the dedup key (introduced in PR #14383).

This mismatch caused two nodes with identical text/metadata but from different source documents to be **incorrectly dropped** in synchronous retrieval, while the same nodes would both be retained in async retrieval.

## Changes

Aligned the sync deduplication key with the async implementation:

```python
# Before (drops nodes with same hash from different source docs)
seen = set()
return [
    n for n in retrieved_nodes
    if not (n.node.hash in seen or seen.add(n.node.hash))
]

# After (matches async: composite key preserves nodes from different sources)
seen = set()
return [
    n for n in retrieved_nodes
    if not (
        (n.node.hash, n.node.ref_doc_id) in seen
        or seen.add((n.node.hash, n.node.ref_doc_id))
    )
]
```

## Testing

Add two nodes with identical content but different `ref_doc_id`. With `sync` retrieval, both should now be returned (matching async behavior).