### PR TITLE
docs: fixed a typo in LlamaParse section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ from llama_index.llms.openai import OpenAI
 - **Extract** — Structured data extraction from documents. [Docs](https://developers.llamaindex.ai/python/cloud/llamaextract/)
 - **Index** — Ingest, index, and RAG pipelines. [Docs](https://developers.llamaindex.ai/python/cloud/llamacloud/) · [Web UI](https://cloud.llamaindex.ai/)
 - **Split** - Split large documents into subcategories. [Docs](https://developers.llamaindex.ai/python/cloud/split/getting_started/)
-- **Agents** - Builde end-to-end document agents with `Workflows` and Agent Builder. [Docs](https://developers.llamaindex.ai/python/llamaagents/overview/)
+- **Agents** - Build end-to-end document agents with `Workflows` and Agent Builder. [Docs](https://developers.llamaindex.ai/python/llamaagents/overview/)
 
 ### Important Links
 


### PR DESCRIPTION
Corrected a small typo in the LlamaParse subsection of the README.

# Description
Corrected "Builde" to "Build" in the LlamaParse subsection for better clarity.

## Type of Change
- [x] This change requires a documentation update

## How Has This Been Tested?
N/A - Documentation typo fix.

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation