### PR TITLE
fix: DocumentSummaryIndex.delete_nodes() crashes on invalid node IDs

### DIFF
--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -257,12 +257,14 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
 
         """
         index_nodes = self._index_struct.node_id_to_summary_id.keys()
+        valid_node_ids = []
         for node in node_ids:
-            if node not in index_nodes:
+            if node in index_nodes:
+                valid_node_ids.append(node)
+            else:
                 logger.warning(f"node_id {node} not found, will not be deleted.")
-                node_ids.remove(node)
 
-        self._index_struct.delete_nodes(node_ids)
+        self._index_struct.delete_nodes(valid_node_ids)
 
         remove_summary_ids = [
             summary_id


### PR DESCRIPTION
## Summary

`DocumentSummaryIndex.delete_nodes()` was mutating the input list while iterating over it to filter out invalid node IDs, causing some invalid IDs to be skipped. Those IDs were then passed to `_index_struct.delete_nodes()`, which raised `KeyError` on the raw dict lookup.

## Changes

- Fixed list mutation during iteration in `delete_nodes()`
- Invalid node IDs are now properly filtered before being passed to `_index_struct.delete_nodes()`

## Testing

- Created and ran a test script that reproduces the issue
- Verified the fix handles multiple invalid IDs correctly
- Edge cases tested: empty list, all invalid IDs, all valid IDs, single invalid ID, single valid ID

Fixes #21066