### PR TITLE
fix: avoid list mutation during iteration in DocumentSummaryIndex.delete_nodes()

### DIFF
--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -257,10 +257,13 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
 
         """
         index_nodes = self._index_struct.node_id_to_summary_id.keys()
+        valid_node_ids = []
         for node in node_ids:
             if node not in index_nodes:
                 logger.warning(f"node_id {node} not found, will not be deleted.")
-                node_ids.remove(node)
+            else:
+                valid_node_ids.append(node)
+        node_ids = valid_node_ids
 
         self._index_struct.delete_nodes(node_ids)
 


### PR DESCRIPTION
## Summary
- Fix `DocumentSummaryIndex.delete_nodes()` crashing with `KeyError` when given invalid node IDs
- Replace in-place `list.remove()` during iteration with a filtered list approach

## Root Cause
The `delete_nodes()` method mutated `node_ids` with `remove()` while iterating over it - a classic Python antipattern. When an element is removed during iteration, the iterator skips the next element, allowing invalid node IDs to pass through to code that raises `KeyError`.

## Reproduction
```python
from llama_index.core.indices.document_summary import DocumentSummaryIndex

index.delete_nodes(["valid_id", "does_not_exist_1", "does_not_exist_2"])
# Before fix: does_not_exist_2 slips through -> KeyError
# After fix: both invalid IDs are filtered out with warnings
```

## Changes
- `llama-index-core/llama_index/core/indices/document_summary/base.py`: Build a filtered `valid_node_ids` list instead of mutating `node_ids` during iteration

Fixes #21066
