### PR TITLE
fix: correctly separate thinking from response in Mistral reasoning models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
@@ -378,25 +378,30 @@ class MistralAI(FunctionCallingLLM):
         self, response: Union[str, List["ContentChunk"]]
     ) -> Tuple[str, str]:
         """Separate the thinking from the response."""
-        content = ""
         if isinstance(response, str):
-            content = response
+            # For raw text responses, use regex to split thinking tags
+            match = THINKING_REGEX.search(response)
+            if match:
+                return match.group(1), response.replace(match.group(0), "")
+
+            match = THINKING_START_REGEX.search(response)
+            if match:
+                return match.group(0), ""
+
+            return "", response
         else:
+            # For structured responses, separate ThinkChunk and TextChunk directly
+            thinking_text = ""
+            response_text = ""
             for chunk in response:
                 if isinstance(chunk, self._models.ThinkChunk):
                     for c in chunk.thinking:
                         if isinstance(c, self._models.TextChunk):
-                            content += c.text + "\n"
+                            thinking_text += c.text + "\n"
+                elif isinstance(chunk, self._models.TextChunk):
+                    response_text += chunk.text
 
-        match = THINKING_REGEX.search(content)
-        if match:
-            return match.group(1), content.replace(match.group(0), "")
-
-        match = THINKING_START_REGEX.search(content)
-        if match:
-            return match.group(0), ""
-
-        return "", content
+            return thinking_text.rstrip("\n"), response_text
 
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:


### PR DESCRIPTION
## Summary
- Fix `_separate_thinking()` to correctly handle structured `ContentChunk` responses from Mistral reasoning models
- Thinking text was being returned as the response, while the actual response text was lost

## Root Cause
When the Mistral API returns structured `ContentChunk` objects (`ThinkChunk` + `TextChunk`), `_separate_thinking()` only extracted `ThinkChunk` text into a `content` variable, then tried to match `<think>` regex tags on it. Since structured chunks don't contain raw `<think>` tags, the regex never matched, causing:
1. Thinking text returned as the "response" (second return value)
2. Actual `TextChunk` response text ignored entirely

Verified with live Mistral API - `magistral-small-latest` returns:
```
ThinkChunk(thinking=[TextChunk(text="The question is asking...")])
TextChunk(text="4")
```

The old code only read ThinkChunk into `content`, missed TextChunk entirely, and regex failed on the structured text.

## Fix
Split parsing into two paths:
- **String responses** (streaming): regex-based `<think>` tag parsing (unchanged behavior)
- **Structured `List[ContentChunk]` responses** (non-streaming): direct separation of `ThinkChunk` and `TextChunk` objects without relying on regex

## Reproduction
```python
from llama_index.llms.mistralai import MistralAI
from llama_index.core.base.llms.types import ChatMessage, MessageRole, TextBlock

llm = MistralAI(model="magistral-small-latest", show_thinking=True)
response = llm.chat([ChatMessage(role=MessageRole.USER, blocks=[TextBlock(text="What is the capital of France?")])])
# Before fix: response.message.content contains thinking text, actual answer lost
# After fix: thinking in ThinkingBlock, response in TextBlock
```

## Changes
- `llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py`: Refactored `_separate_thinking()` to handle structured and string responses separately

Fixes #20456
