### PR TITLE
fix: support both reasoning and reasoning_content fields for vLLM compatibility

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -570,7 +570,7 @@ class OpenAI(FunctionCallingLLM):
 
                 # Extract reasoning_content for chain-of-thought streaming.
                 # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                raw_reasoning = getattr(delta, "reasoning", None) or getattr(delta, "reasoning_content", None)
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )
@@ -866,7 +866,7 @@ class OpenAI(FunctionCallingLLM):
 
                 # Extract reasoning_content for chain-of-thought streaming.
                 # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                raw_reasoning = getattr(delta, "reasoning", None) or getattr(delta, "reasoning_content", None)
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -813,7 +813,7 @@ def from_openai_message(
 
     # Extract reasoning_content if present (used by many OpenAI-compatible
     # providers for chain-of-thought responses)
-    reasoning_content = getattr(openai_message, "reasoning_content", None)
+    reasoning_content = getattr(openai_message, "reasoning", None) or getattr(openai_message, "reasoning_content", None)
     if isinstance(reasoning_content, str) and reasoning_content:
         blocks.append(ThinkingBlock(content=reasoning_content))
 


### PR DESCRIPTION
## Summary
Fixes #21075.
**Root cause:** vLLM 0.17.0+ deprecated `reasoning_content` in favor of `reasoning` field (see vllm-project/vllm#36730), but the OpenAI LLM integration only reads `reasoning_content`, preventing extraction of thinking content when using vLLM.
**Fix:** Read both `reasoning` (new standard) and `reasoning_content` (legacy) fields, preferring the new field. This maintains backward compatibility with providers still using `reasoning_content`.
## Changes
- `llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py`: Updated `_stream_chat` and `_astream_chat` to check both `reasoning` and `reasoning_content` attributes
- `llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py`: Updated `from_openai_message` to check both fields
## Testing
- Verified fix addresses reported scenario (vLLM reasoning field now extracted)
- Change is minimal and follows existing code patterns
- Backward compatible with providers using reasoning_content

Made with [Cursor](https://cursor.com)