### PR TITLE
fix(core): avoid mutating list during iteration in delete_nodes

### DIFF
--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -256,13 +256,15 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
             node_ids (List[str]): A list of node_ids from the nodes to delete
 
         """
-        index_nodes = self._index_struct.node_id_to_summary_id.keys()
+        index_nodes = set(self._index_struct.node_id_to_summary_id.keys())
+        valid_node_ids = []
         for node in node_ids:
             if node not in index_nodes:
                 logger.warning(f"node_id {node} not found, will not be deleted.")
-                node_ids.remove(node)
+            else:
+                valid_node_ids.append(node)
 
-        self._index_struct.delete_nodes(node_ids)
+        self._index_struct.delete_nodes(valid_node_ids)
 
         remove_summary_ids = [
             summary_id

--- a/llama-index-core/tests/indices/document_summary/test_index.py
+++ b/llama-index-core/tests/indices/document_summary/test_index.py
@@ -60,3 +60,16 @@ def test_delete_nodes(
     assert len(index.index_struct.summary_id_to_node_ids) == 2
 
     assert len(index.vector_store._data.embedding_dict) == 2  # type: ignore
+
+
+def test_delete_nodes_with_invalid_ids(
+    docs: List[Document],
+    index: DocumentSummaryIndex,
+) -> None:
+    """Regression test for #21066: invalid node_ids should not crash."""
+    nodes = list(index.index_struct.node_id_to_summary_id.keys())
+    initial_count = len(nodes)
+    index.delete_nodes([nodes[0], "nonexistent-id"])
+
+    remaining = len(index.index_struct.node_id_to_summary_id)
+    assert remaining == initial_count - 1


### PR DESCRIPTION
Fixes #21066

  DocumentSummaryIndex.delete_nodes() calls node_ids.remove() inside a for loop over node_ids, which skips elements and can raise KeyError. Replaced with a filtered list approach.

  Also converts dict_keys to set for O(1) lookups.

  ## Test plan
  - Added test_delete_nodes_with_invalid_ids regression test
  - uv run -- pytest tests/indices/document_summary/ -v passes