### PR TITLE
fix(openai): handle deprecated reasoning_content in vLLM

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -568,9 +568,13 @@ class OpenAI(FunctionCallingLLM):
                 content_delta = delta.content or ""
                 content += content_delta
 
-                # Extract reasoning_content for chain-of-thought streaming.
+                # Extract reasoning/reasoning_content for chain-of-thought streaming.
                 # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # vLLM deprecated reasoning_content in favor of reasoning (see vllm#36730),
+                # so we check "reasoning" first, then fall back to "reasoning_content".
+                raw_reasoning = getattr(delta, "reasoning", None) or getattr(
+                    delta, "reasoning_content", None
+                )
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )
@@ -864,9 +868,13 @@ class OpenAI(FunctionCallingLLM):
                 content_delta = delta.content or ""
                 content += content_delta
 
-                # Extract reasoning_content for chain-of-thought streaming.
+                # Extract reasoning/reasoning_content for chain-of-thought streaming.
                 # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # vLLM deprecated reasoning_content in favor of reasoning (see vllm#36730),
+                # so we check "reasoning" first, then fall back to "reasoning_content".
+                raw_reasoning = getattr(delta, "reasoning", None) or getattr(
+                    delta, "reasoning_content", None
+                )
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
@@ -861,3 +861,54 @@ def test_from_openai_message_without_reasoning_content() -> None:
     assert len(thinking_blocks) == 0
     assert len(result.blocks) == 1
     assert result.blocks[0].text == "Hello!"
+
+
+def _make_reasoning_stream_chunks_vllm_new() -> list[ChatCompletionChunk]:
+    """Simulate vLLM streaming with new 'reasoning' field (vllm#36730).
+
+    vLLM deprecated reasoning_content in favor of reasoning.
+    """
+    return [
+        _make_chunk({"role": "assistant"}),
+        _make_chunk({"content": None, "__extra__": {"reasoning": "Let me think"}}),
+        _make_chunk({"content": None, "__extra__": {"reasoning": " about this."}}),
+        _make_chunk({"content": "The answer"}),
+        _make_chunk({"content": " is 42."}),
+        _make_chunk({}, finish_reason="stop"),
+    ]
+
+
+@patch("llama_index.llms.openai.base.SyncOpenAI")
+def test_stream_chat_reasoning_vllm_new_field(MockSyncOpenAI: MagicMock) -> None:
+    """Test that new vLLM 'reasoning' field is captured as ThinkingBlock.
+
+    vLLM deprecated reasoning_content in favor of reasoning (vllm#36730).
+    This test ensures the new field works correctly.
+    """
+    with CachedOpenAIApiKeys(set_fake_key=True):
+        mock_instance = MockSyncOpenAI.return_value
+        mock_instance.chat.completions.create.return_value = iter(
+            _make_reasoning_stream_chunks_vllm_new()
+        )
+
+        llm = OpenAI(model="gpt-4o", api_key="test-key")
+        responses = list(llm.stream_chat([ChatMessage(role="user", content="test")]))
+
+        final = responses[-1]
+        thinking_blocks = [
+            b for b in final.message.blocks if isinstance(b, ThinkingBlock)
+        ]
+        text_blocks = [b for b in final.message.blocks if isinstance(b, TextBlock)]
+
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0].content == "Let me think about this."
+        assert len(text_blocks) == 1
+        assert text_blocks[0].text == "The answer is 42."
+
+        # Exactly 2 chunks carry thinking_delta (the two reasoning chunks)
+        reasoning_chunks = [
+            r for r in responses if r.additional_kwargs.get("thinking_delta")
+        ]
+        assert len(reasoning_chunks) == 2
+        assert reasoning_chunks[0].additional_kwargs["thinking_delta"] == "Let me think"
+        assert reasoning_chunks[1].additional_kwargs["thinking_delta"] == " about this."


### PR DESCRIPTION
## Summary

The `reasoning_content` field is deprecated in vLLM (see vllm-project/vllm#36730). This fix updates the OpenAI LLM integration to handle the new `reasoning` field while maintaining backward compatibility with the old `reasoning_content` field.

## Changes

- Updated `raw_reasoning` extraction to check `reasoning` field first (new vLLM format), then fall back to `reasoning_content` (old format)
- Applied the fix in both `_stream_chat` and `_astream_chat` methods
- Added test `test_stream_chat_reasoning_vllm_new_field` to verify the new field works correctly

## Testing

- All existing tests pass (103 passed, 14 skipped)
- New test verifies the new vLLM `reasoning` field is correctly captured as ThinkingBlock
- Backward compatibility maintained - old `reasoning_content` field still works

Fixes run-llama/llama_index#21075