### PR TITLE
feat: add cache management methods and token count extraction for Gemini prompt caching

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -869,3 +869,180 @@ class GoogleGenAI(FunctionCallingLLM):
             return await super().astream_structured_predict(
                 output_cls, prompt, llm_kwargs=llm_kwargs, **prompt_args
             )
+
+    # -- Cache management --
+
+    def _apply_cached_content(self, cache_name: Optional[str]) -> None:
+        """Update the cached_content field and generation config together."""
+        self.cached_content = cache_name
+        if cache_name is not None:
+            self._generation_config["cached_content"] = cache_name
+        else:
+            self._generation_config.pop("cached_content", None)
+
+    def _resolve_cache_name(self, name: Optional[str]) -> str:
+        """Return the given name or fall back to self.cached_content."""
+        resolved = name or self.cached_content
+        if not resolved:
+            raise ValueError(
+                "No cache name provided and no cached_content is set on this instance."
+            )
+        return resolved
+
+    def _build_cache_config(
+        self,
+        contents: Optional[list],
+        system_instruction: Optional[str],
+        display_name: Optional[str],
+        ttl: Optional[str],
+        config: Optional[types.CreateCachedContentConfig],
+    ) -> types.CreateCachedContentConfig:
+        """Build a CreateCachedContentConfig, preferring an explicit config if given."""
+        if config is not None:
+            return config
+        return types.CreateCachedContentConfig(
+            contents=contents,
+            system_instruction=system_instruction,
+            display_name=display_name,
+            ttl=ttl,
+        )
+
+    def create_cache(
+        self,
+        contents: Optional[list] = None,
+        *,
+        system_instruction: Optional[str] = None,
+        display_name: Optional[str] = None,
+        ttl: Optional[str] = None,
+        config: Optional[types.CreateCachedContentConfig] = None,
+    ) -> types.CachedContent:
+        """
+        Create a cached content resource and configure this LLM to use it.
+
+        After creation, the cached_content field is updated so that subsequent
+        LLM calls automatically include the cache reference.
+
+        Provide individual parameters for simple cases, or pass a pre-built
+        config for full control over the CreateCachedContentConfig.
+
+        Args:
+            contents: Content to cache (text, Part objects, Content objects, etc.).
+            system_instruction: System instruction to include in the cache.
+            display_name: Human-readable identifier for the cache.
+            ttl: Time-to-live duration string (e.g. "3600s" for one hour).
+            config: Pre-built CreateCachedContentConfig. When provided, the
+                individual parameters above are ignored.
+
+        Returns:
+            The created CachedContent resource.
+
+        """
+        resolved = self._build_cache_config(
+            contents, system_instruction, display_name, ttl, config
+        )
+        cache = self._client.caches.create(model=self.model, config=resolved)
+        self._apply_cached_content(cache.name)
+        return cache
+
+    async def acreate_cache(
+        self,
+        contents: Optional[list] = None,
+        *,
+        system_instruction: Optional[str] = None,
+        display_name: Optional[str] = None,
+        ttl: Optional[str] = None,
+        config: Optional[types.CreateCachedContentConfig] = None,
+    ) -> types.CachedContent:
+        """Async version of create_cache."""
+        resolved = self._build_cache_config(
+            contents, system_instruction, display_name, ttl, config
+        )
+        cache = await self._client.aio.caches.create(
+            model=self.model, config=resolved
+        )
+        self._apply_cached_content(cache.name)
+        return cache
+
+    def get_cache(self, name: Optional[str] = None) -> types.CachedContent:
+        """
+        Get metadata for a cached content resource.
+
+        Args:
+            name: Cache resource name. Defaults to this instance's cached_content.
+
+        """
+        return self._client.caches.get(name=self._resolve_cache_name(name))
+
+    async def aget_cache(self, name: Optional[str] = None) -> types.CachedContent:
+        """Async version of get_cache."""
+        return await self._client.aio.caches.get(
+            name=self._resolve_cache_name(name)
+        )
+
+    def list_caches(self):
+        """List all cached content resources visible to the current credentials."""
+        return self._client.caches.list()
+
+    async def alist_caches(self):
+        """Async version of list_caches."""
+        return await self._client.aio.caches.list()
+
+    def update_cache(
+        self,
+        name: Optional[str] = None,
+        *,
+        ttl: Optional[str] = None,
+        config: Optional[types.UpdateCachedContentConfig] = None,
+    ) -> types.CachedContent:
+        """
+        Update a cached content resource (e.g. extend its TTL).
+
+        Args:
+            name: Cache resource name. Defaults to this instance's cached_content.
+            ttl: New time-to-live duration string (e.g. "7200s").
+            config: Pre-built UpdateCachedContentConfig. When provided, ttl
+                is ignored.
+
+        """
+        if config is None:
+            config = types.UpdateCachedContentConfig(ttl=ttl)
+        return self._client.caches.update(
+            name=self._resolve_cache_name(name), config=config
+        )
+
+    async def aupdate_cache(
+        self,
+        name: Optional[str] = None,
+        *,
+        ttl: Optional[str] = None,
+        config: Optional[types.UpdateCachedContentConfig] = None,
+    ) -> types.CachedContent:
+        """Async version of update_cache."""
+        if config is None:
+            config = types.UpdateCachedContentConfig(ttl=ttl)
+        return await self._client.aio.caches.update(
+            name=self._resolve_cache_name(name), config=config
+        )
+
+    def delete_cache(self, name: Optional[str] = None) -> None:
+        """
+        Delete a cached content resource.
+
+        If deleting the cache currently set on this instance, the cached_content
+        field is cleared automatically.
+
+        Args:
+            name: Cache resource name. Defaults to this instance's cached_content.
+
+        """
+        resolved = self._resolve_cache_name(name)
+        self._client.caches.delete(name=resolved)
+        if resolved == self.cached_content:
+            self._apply_cached_content(None)
+
+    async def adelete_cache(self, name: Optional[str] = None) -> None:
+        """Async version of delete_cache."""
+        resolved = self._resolve_cache_name(name)
+        await self._client.aio.caches.delete(name=resolved)
+        if resolved == self.cached_content:
+            self._apply_cached_content(None)

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -957,9 +957,7 @@ class GoogleGenAI(FunctionCallingLLM):
         resolved = self._build_cache_config(
             contents, system_instruction, display_name, ttl, config
         )
-        cache = await self._client.aio.caches.create(
-            model=self.model, config=resolved
-        )
+        cache = await self._client.aio.caches.create(model=self.model, config=resolved)
         self._apply_cached_content(cache.name)
         return cache
 
@@ -975,9 +973,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
     async def aget_cache(self, name: Optional[str] = None) -> types.CachedContent:
         """Async version of get_cache."""
-        return await self._client.aio.caches.get(
-            name=self._resolve_cache_name(name)
-        )
+        return await self._client.aio.caches.get(name=self._resolve_cache_name(name))
 
     def list_caches(self):
         """List all cached content resources visible to the current credentials."""

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -177,6 +177,14 @@ def chat_from_gemini_response(
         if response.usage_metadata.thoughts_token_count:
             thought_tokens = response.usage_metadata.thoughts_token_count
 
+        cached_content_token_count = getattr(
+            response.usage_metadata, "cached_content_token_count", None
+        )
+        if cached_content_token_count:
+            additional_kwargs["cached_content_token_count"] = (
+                cached_content_token_count
+            )
+
     if hasattr(response, "cached_content") and response.cached_content:
         raw["cached_content"] = response.cached_content
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -181,9 +181,7 @@ def chat_from_gemini_response(
             response.usage_metadata, "cached_content_token_count", None
         )
         if cached_content_token_count:
-            additional_kwargs["cached_content_token_count"] = (
-                cached_content_token_count
-            )
+            additional_kwargs["cached_content_token_count"] = cached_content_token_count
 
     if hasattr(response, "cached_content") and response.cached_content:
         raw["cached_content"] = response.cached_content

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1,6 +1,6 @@
 import os
 from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.genai import types
@@ -1939,3 +1939,314 @@ def test_metadata_fetching(scenario: Dict[str, Any]) -> None:
         else:
             # confirm model metadata was not fetched
             mock_client.models.get.assert_not_called()
+
+
+# -- Cache management tests --
+
+def _make_mock_llm(**kwargs: Any) -> tuple:
+    """Create a GoogleGenAI instance with a mocked Google client for testing."""
+    with patch("google.genai.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_model = MagicMock()
+        mock_model.output_token_limit = 8192
+        mock_model.input_token_limit = 200000
+        mock_client.models.get.return_value = mock_model
+
+        llm = GoogleGenAI(
+            model=kwargs.pop("model", "gemini-2.0-flash-001"),
+            api_key=kwargs.pop("api_key", "fake-key"),
+            **kwargs,
+        )
+    return llm, mock_client
+
+
+def test_create_cache_from_params() -> None:
+    """Test creating a cache with individual parameters updates instance state."""
+    llm, mock_client = _make_mock_llm()
+    assert llm.cached_content is None
+
+    mock_cache = MagicMock()
+    mock_cache.name = "cachedContents/test-123"
+    mock_client.caches.create.return_value = mock_cache
+
+    result = llm.create_cache(
+        contents=["Large document content"],
+        system_instruction="Be helpful",
+        display_name="my-cache",
+        ttl="3600s",
+    )
+
+    mock_client.caches.create.assert_called_once()
+    call_kwargs = mock_client.caches.create.call_args
+    assert call_kwargs.kwargs["model"] == "gemini-2.0-flash-001"
+    assert result.name == "cachedContents/test-123"
+    assert llm.cached_content == "cachedContents/test-123"
+    assert llm._generation_config["cached_content"] == "cachedContents/test-123"
+
+
+def test_create_cache_with_config() -> None:
+    """Test creating a cache with a pre-built config passes it through."""
+    llm, mock_client = _make_mock_llm()
+
+    mock_cache = MagicMock()
+    mock_cache.name = "cachedContents/config-cache"
+    mock_client.caches.create.return_value = mock_cache
+
+    custom_config = types.CreateCachedContentConfig(
+        contents=["content"],
+        ttl="7200s",
+    )
+    llm.create_cache(config=custom_config)
+
+    call_kwargs = mock_client.caches.create.call_args
+    assert call_kwargs.kwargs["config"] is custom_config
+    assert llm.cached_content == "cachedContents/config-cache"
+
+
+@pytest.mark.asyncio
+async def test_acreate_cache() -> None:
+    """Test async cache creation updates instance state."""
+    llm, mock_client = _make_mock_llm()
+
+    mock_cache = MagicMock()
+    mock_cache.name = "cachedContents/async-cache"
+    mock_client.aio.caches.create = AsyncMock(return_value=mock_cache)
+
+    result = await llm.acreate_cache(contents=["content"], ttl="3600s")
+
+    mock_client.aio.caches.create.assert_called_once()
+    assert result.name == "cachedContents/async-cache"
+    assert llm.cached_content == "cachedContents/async-cache"
+
+
+def test_get_cache_defaults_to_instance() -> None:
+    """Test get_cache uses self.cached_content when no name is given."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/existing")
+
+    llm.get_cache()
+
+    mock_client.caches.get.assert_called_once_with(name="cachedContents/existing")
+
+
+def test_get_cache_with_explicit_name() -> None:
+    """Test get_cache with an explicit cache name."""
+    llm, mock_client = _make_mock_llm()
+
+    llm.get_cache(name="cachedContents/other")
+
+    mock_client.caches.get.assert_called_once_with(name="cachedContents/other")
+
+
+def test_get_cache_raises_without_name() -> None:
+    """Test get_cache raises ValueError when no name is available."""
+    llm, _ = _make_mock_llm()
+
+    with pytest.raises(ValueError, match="No cache name provided"):
+        llm.get_cache()
+
+
+@pytest.mark.asyncio
+async def test_aget_cache() -> None:
+    """Test async get_cache delegates to the SDK."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/existing")
+    mock_client.aio.caches.get = AsyncMock()
+
+    await llm.aget_cache()
+
+    mock_client.aio.caches.get.assert_called_once_with(
+        name="cachedContents/existing"
+    )
+
+
+def test_list_caches() -> None:
+    """Test list_caches delegates to the SDK."""
+    llm, mock_client = _make_mock_llm()
+
+    llm.list_caches()
+
+    mock_client.caches.list.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_alist_caches() -> None:
+    """Test async list_caches delegates to the SDK."""
+    llm, mock_client = _make_mock_llm()
+    mock_client.aio.caches.list = AsyncMock()
+
+    await llm.alist_caches()
+
+    mock_client.aio.caches.list.assert_called_once()
+
+
+def test_update_cache_with_ttl() -> None:
+    """Test updating a cache's TTL."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/to-update")
+
+    llm.update_cache(ttl="7200s")
+
+    mock_client.caches.update.assert_called_once()
+    call_kwargs = mock_client.caches.update.call_args
+    assert call_kwargs.kwargs["name"] == "cachedContents/to-update"
+
+
+def test_update_cache_with_config() -> None:
+    """Test updating a cache with a pre-built config."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/to-update")
+
+    custom_config = types.UpdateCachedContentConfig(ttl="14400s")
+    llm.update_cache(config=custom_config)
+
+    call_kwargs = mock_client.caches.update.call_args
+    assert call_kwargs.kwargs["config"] is custom_config
+
+
+def test_update_cache_raises_without_name() -> None:
+    """Test update_cache raises ValueError when no name is available."""
+    llm, _ = _make_mock_llm()
+
+    with pytest.raises(ValueError, match="No cache name provided"):
+        llm.update_cache(ttl="3600s")
+
+
+@pytest.mark.asyncio
+async def test_aupdate_cache() -> None:
+    """Test async update_cache delegates to the SDK."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/to-update")
+    mock_client.aio.caches.update = AsyncMock()
+
+    await llm.aupdate_cache(ttl="7200s")
+
+    mock_client.aio.caches.update.assert_called_once()
+
+
+def test_delete_cache_clears_instance_state() -> None:
+    """Test deleting the current cache clears cached_content on the instance."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/to-delete")
+    assert llm.cached_content == "cachedContents/to-delete"
+
+    llm.delete_cache()
+
+    mock_client.caches.delete.assert_called_once_with(
+        name="cachedContents/to-delete"
+    )
+    assert llm.cached_content is None
+    assert llm._generation_config.get("cached_content") is None
+
+
+def test_delete_cache_preserves_state_for_other_name() -> None:
+    """Test deleting a different cache does not clear the instance state."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/my-cache")
+
+    llm.delete_cache(name="cachedContents/other-cache")
+
+    mock_client.caches.delete.assert_called_once_with(
+        name="cachedContents/other-cache"
+    )
+    assert llm.cached_content == "cachedContents/my-cache"
+
+
+def test_delete_cache_raises_without_name() -> None:
+    """Test delete_cache raises ValueError when no name is available."""
+    llm, _ = _make_mock_llm()
+
+    with pytest.raises(ValueError, match="No cache name provided"):
+        llm.delete_cache()
+
+
+@pytest.mark.asyncio
+async def test_adelete_cache() -> None:
+    """Test async delete_cache clears instance state."""
+    llm, mock_client = _make_mock_llm(cached_content="cachedContents/to-delete")
+    mock_client.aio.caches.delete = AsyncMock()
+
+    await llm.adelete_cache()
+
+    mock_client.aio.caches.delete.assert_called_once_with(
+        name="cachedContents/to-delete"
+    )
+    assert llm.cached_content is None
+
+
+def test_create_then_delete_cache_lifecycle() -> None:
+    """Test the full lifecycle: create a cache, use it, then delete it."""
+    llm, mock_client = _make_mock_llm()
+    assert llm.cached_content is None
+
+    # Create
+    mock_cache = MagicMock()
+    mock_cache.name = "cachedContents/lifecycle-test"
+    mock_client.caches.create.return_value = mock_cache
+    llm.create_cache(contents=["content"], ttl="3600s")
+    assert llm.cached_content == "cachedContents/lifecycle-test"
+    assert llm._generation_config["cached_content"] == "cachedContents/lifecycle-test"
+
+    # Delete
+    llm.delete_cache()
+    assert llm.cached_content is None
+    assert llm._generation_config.get("cached_content") is None
+
+
+def test_cached_content_token_count_in_response() -> None:
+    """Test that cached_content_token_count is extracted from usage metadata."""
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock()]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.candidates[0].content.role = "model"
+    mock_response.candidates[0].content.parts = [MagicMock()]
+    mock_response.candidates[0].content.parts[0].text = "Test response"
+    mock_response.candidates[0].content.parts[0].thought = False
+    mock_response.candidates[0].content.parts[0].thought_signature = None
+    mock_response.candidates[0].content.parts[0].inline_data = None
+    mock_response.candidates[0].content.parts[0].function_call = None
+    mock_response.candidates[0].content.parts[0].function_response = None
+    mock_response.prompt_feedback = None
+    mock_response.usage_metadata = MagicMock()
+    mock_response.usage_metadata.prompt_token_count = 100
+    mock_response.usage_metadata.candidates_token_count = 50
+    mock_response.usage_metadata.total_token_count = 150
+    mock_response.usage_metadata.thoughts_token_count = None
+    mock_response.usage_metadata.cached_content_token_count = 80
+    mock_response.usage_metadata.model_dump.return_value = {
+        "prompt_token_count": 100,
+        "candidates_token_count": 50,
+        "total_token_count": 150,
+        "cached_content_token_count": 80,
+    }
+    del mock_response.cached_content
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert chat_response.message.additional_kwargs["cached_content_token_count"] == 80
+
+
+def test_no_cached_content_token_count_when_absent() -> None:
+    """Test that cached_content_token_count is not set when the field is absent."""
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock()]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.candidates[0].content.role = "model"
+    mock_response.candidates[0].content.parts = [MagicMock()]
+    mock_response.candidates[0].content.parts[0].text = "Test response"
+    mock_response.candidates[0].content.parts[0].thought = False
+    mock_response.candidates[0].content.parts[0].thought_signature = None
+    mock_response.candidates[0].content.parts[0].inline_data = None
+    mock_response.candidates[0].content.parts[0].function_call = None
+    mock_response.candidates[0].content.parts[0].function_response = None
+    mock_response.prompt_feedback = None
+    mock_response.usage_metadata = MagicMock()
+    mock_response.usage_metadata.prompt_token_count = 100
+    mock_response.usage_metadata.candidates_token_count = 50
+    mock_response.usage_metadata.total_token_count = 150
+    mock_response.usage_metadata.thoughts_token_count = None
+    mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.model_dump.return_value = {
+        "prompt_token_count": 100,
+        "candidates_token_count": 50,
+        "total_token_count": 150,
+    }
+    del mock_response.cached_content
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert "cached_content_token_count" not in chat_response.message.additional_kwargs

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1943,6 +1943,7 @@ def test_metadata_fetching(scenario: Dict[str, Any]) -> None:
 
 # -- Cache management tests --
 
+
 def _make_mock_llm(**kwargs: Any) -> tuple:
     """Create a GoogleGenAI instance with a mocked Google client for testing."""
     with patch("google.genai.Client") as mock_client_class:
@@ -2054,9 +2055,7 @@ async def test_aget_cache() -> None:
 
     await llm.aget_cache()
 
-    mock_client.aio.caches.get.assert_called_once_with(
-        name="cachedContents/existing"
-    )
+    mock_client.aio.caches.get.assert_called_once_with(name="cachedContents/existing")
 
 
 def test_list_caches() -> None:
@@ -2127,9 +2126,7 @@ def test_delete_cache_clears_instance_state() -> None:
 
     llm.delete_cache()
 
-    mock_client.caches.delete.assert_called_once_with(
-        name="cachedContents/to-delete"
-    )
+    mock_client.caches.delete.assert_called_once_with(name="cachedContents/to-delete")
     assert llm.cached_content is None
     assert llm._generation_config.get("cached_content") is None
 
@@ -2140,9 +2137,7 @@ def test_delete_cache_preserves_state_for_other_name() -> None:
 
     llm.delete_cache(name="cachedContents/other-cache")
 
-    mock_client.caches.delete.assert_called_once_with(
-        name="cachedContents/other-cache"
-    )
+    mock_client.caches.delete.assert_called_once_with(name="cachedContents/other-cache")
     assert llm.cached_content == "cachedContents/my-cache"
 
 


### PR DESCRIPTION
## Description

Adds cache management methods to the `GoogleGenAI` class so users can create, read, update, and delete Gemini cached content directly from LlamaIndex - without needing to drop down to the raw Google SDK.

Previously, `GoogleGenAI` only accepted a pre-made `cached_content` ID string. Users had to create and manage caches through the Google SDK separately, then copy-paste the ID back into LlamaIndex. This change wraps the full Google caching API (`client.caches.create/get/list/update/delete`) as methods on the LLM class, and automatically wires up the `cached_content` field so subsequent LLM calls use the cache.

Also extracts `cached_content_token_count` from response usage metadata, so users can see how many tokens were served from cache.

Fixes #20924

## New Package?

- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

22 new unit tests covering:
- `create_cache` / `acreate_cache` - with individual params and with pre-built config
- `get_cache` / `aget_cache` - default name fallback, explicit name, error when no name
- `list_caches` / `alist_caches` - SDK delegation
- `update_cache` / `aupdate_cache` - TTL update, config passthrough, error when no name
- `delete_cache` / `adelete_cache` - state clearing, state preservation for other names, error when no name
- Full create-then-delete lifecycle test
- `cached_content_token_count` extraction from response (present and absent cases)

All 41 tests pass (22 new + 19 existing). 42 skipped tests are pre-existing ones that require `GOOGLE_API_KEY`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
