### PR TITLE
fix(llms-openai): unknown models return default context window instead of raising

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -3,20 +3,6 @@ import os
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from deprecated import deprecated
-from tenacity import (
-    RetryCallState,
-    before_sleep_log,
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    stop_after_delay,
-    wait_exponential,
-    wait_random_exponential,
-)
-from tenacity.stop import stop_base
-from tenacity.wait import wait_base
-
-import openai
 from llama_index.core.base.llms.generic_utils import get_from_param_or_env
 from llama_index.core.base.llms.types import (
     AudioBlock,
@@ -31,6 +17,20 @@ from llama_index.core.base.llms.types import (
     ToolCallBlock,
 )
 from llama_index.core.bridge.pydantic import BaseModel
+from tenacity import (
+    RetryCallState,
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_exponential,
+    wait_random_exponential,
+)
+from tenacity.stop import stop_base
+from tenacity.wait import wait_base
+
+import openai
 from openai.types.chat import ChatCompletionMessageParam, ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
@@ -40,6 +40,11 @@ from openai.types.completion_choice import Logprobs
 DEFAULT_OPENAI_API_TYPE = "open_ai"
 DEFAULT_OPENAI_API_BASE = "https://api.openai.com/v1"
 DEFAULT_OPENAI_API_VERSION = ""
+
+# Fallback context window used when the model name is not in ALL_AVAILABLE_MODELS.
+# This allows OpenAI-compatible proxies (e.g. LiteLLM, AWS Bedrock Gateway,
+# vLLM, Ollama) to work without hard-coding every possible model name here.
+DEFAULT_CONTEXT_WINDOW = 4096
 
 O1_MODELS: Dict[str, int] = {
     "o1": 200000,
@@ -376,14 +381,24 @@ def openai_modelname_to_contextsize(modelname: str) -> int:
             "Please choose another model."
         )
     if modelname not in ALL_AVAILABLE_MODELS:
-        raise ValueError(
-            f"Unknown model {modelname!r}. Please provide a valid OpenAI model name in:"
-            f" {', '.join(ALL_AVAILABLE_MODELS.keys())}"
+        logger.warning(
+            "Unknown model %r. This model is not in the known OpenAI model list. "
+            "If you are using an OpenAI-compatible proxy (e.g. LiteLLM, AWS Bedrock "
+            "Gateway, vLLM, Ollama), this is expected. Falling back to a default "
+            "context window of %d tokens. Set `context_window` explicitly on your "
+            "LLM to avoid this warning.",
+            modelname,
+            DEFAULT_CONTEXT_WINDOW,
         )
+        return DEFAULT_CONTEXT_WINDOW
     return ALL_AVAILABLE_MODELS[modelname]
 
 
 def is_chat_model(model: str) -> bool:
+    # Default to True for unknown models so that OpenAI-compatible proxies
+    # (e.g. LiteLLM, AWS Bedrock Gateway, vLLM, Ollama) work out of the box.
+    if model not in CHAT_MODELS and model not in ALL_AVAILABLE_MODELS:
+        return True
     return model in CHAT_MODELS
 
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -1,7 +1,18 @@
 import json
+import logging
 from typing import List
 
 import pytest
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    ImageBlock,
+    LogProb,
+    MessageRole,
+    TextBlock,
+    ToolCallBlock,
+)
+from llama_index.core.bridge.pydantic import BaseModel
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.chat_completion_message_param import (
     ChatCompletionMessageParam,
@@ -13,16 +24,6 @@ from openai.types.chat.chat_completion_message_tool_call import (
 from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
 from openai.types.completion_choice import Logprobs
 
-from llama_index.core.base.llms.types import (
-    ChatMessage,
-    ChatResponse,
-    ImageBlock,
-    LogProb,
-    MessageRole,
-    TextBlock,
-    ToolCallBlock,
-)
-from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.llms.openai import OpenAI
 from llama_index.llms.openai.utils import (
     ALL_AVAILABLE_MODELS,
@@ -628,3 +629,67 @@ def test_gpt_5_4_pro_responses_api_only() -> None:
     assert is_json_schema_supported(model_name) is True, (
         f"{model_name} should support JSON schema"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for OpenAI-compatible proxy / unknown model behaviour (issue #18691)
+# ---------------------------------------------------------------------------
+
+
+def test_openai_modelname_to_contextsize_unknown_model_returns_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown models must not raise; they should log a warning and return the
+    default context window so OpenAI-compatible proxies work out of the box."""
+    from llama_index.llms.openai.utils import DEFAULT_CONTEXT_WINDOW
+
+    proxy_model = "us.meta.llama3-3-70b-instruct-v1:0"
+
+    with caplog.at_level(logging.WARNING, logger="llama_index.llms.openai.utils"):
+        result = openai_modelname_to_contextsize(proxy_model)
+
+    assert result == DEFAULT_CONTEXT_WINDOW
+    assert any(proxy_model in record.message for record in caplog.records), (
+        "Expected a warning mentioning the unknown model name"
+    )
+
+
+def test_openai_modelname_to_contextsize_litellm_proxy_model(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """LiteLLM-style model names (e.g. 'bedrock/anthropic.claude-3') should
+    return the default context size instead of raising."""
+    from llama_index.llms.openai.utils import DEFAULT_CONTEXT_WINDOW
+
+    litellm_model = "bedrock/anthropic.claude-3-sonnet-20240229-v1:0"
+
+    with caplog.at_level(logging.WARNING, logger="llama_index.llms.openai.utils"):
+        result = openai_modelname_to_contextsize(litellm_model)
+
+    assert result == DEFAULT_CONTEXT_WINDOW
+
+
+def test_openai_modelname_to_contextsize_discontinued_model_still_raises() -> None:
+    """Discontinued models must still raise so users get a clear message."""
+    with pytest.raises(ValueError, match="discontinued"):
+        openai_modelname_to_contextsize("code-davinci-002")
+
+
+def test_is_chat_model_unknown_model_returns_true() -> None:
+    """Unknown models should be treated as chat models (proxy-friendly default)."""
+    assert is_chat_model("some-custom-proxy-model") is True
+    assert is_chat_model("us.meta.llama3-3-70b-instruct-v1:0") is True
+
+
+def test_is_function_calling_model_unknown_model_returns_true() -> None:
+    """Unknown models already default to True; confirm this is still the case."""
+    assert is_function_calling_model("some-custom-proxy-model") is True
+
+
+def test_known_models_unaffected_by_proxy_fallback() -> None:
+    """Existing known-model lookups must still return the correct context size."""
+    assert openai_modelname_to_contextsize("gpt-4o") == 128000
+    assert openai_modelname_to_contextsize("gpt-4") == 8192
+    assert openai_modelname_to_contextsize("o1") == 200000
+    assert is_chat_model("gpt-4o") is True
+    assert is_chat_model("gpt-3.5-turbo") is True


### PR DESCRIPTION
Description:
openai_modelname_to_contextsize() raised a ValueError for any model not in ALL_AVAILABLE_MODELS, crashing before making a single API call. This broke every OpenAI-compatible proxy (LiteLLM, AWS Bedrock Gateway, vLLM, Ollama) using custom model names. Unknown models now log a warning and return DEFAULT_CONTEXT_WINDOW (4096). is_chat_model() is also fixed to default to True for unknown models, consistent with is_function_calling_model(). Discontinued models still raise as before.
Fixes #18691
New Package? — N/A
Version Bump?
 No
Type of Change:
 Bug fix (non-breaking change which fixes an issue)
How Has This Been Tested?
 I added new unit tests to cover this change
6 new tests added to tests/test_openai_utils.py covering: AWS Bedrock proxy model names, LiteLLM-style model names, discontinued model still raises, unknown model treated as chat model, unknown model treated as function-calling capable, and existing known models unaffected. Full suite: 33 passed.
Checklist:
 I have performed a self-review of my own code
 I have commented my code, particularly in hard-to-understand areas
 My changes generate no new warnings
 I have added tests that prove my fix is effective or that my feature works
 New and existing unit tests pass locally with my changes