### PR TITLE
Fix: Add encoding=utf-8 to SimplePropertyGraphStore for Windows compatibility

### DIFF
--- a/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
+++ b/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
@@ -167,7 +167,7 @@ class SimplePropertyGraphStore(PropertyGraphStore):
         """Persist the graph store to a file."""
         if fs is None:
             fs = fsspec.filesystem("file")
-        with fs.open(persist_path, "w") as f:
+        with fs.open(persist_path, "w", encoding='utf-8') as f:
             f.write(self.graph.model_dump_json())
 
     @classmethod
@@ -180,7 +180,7 @@ class SimplePropertyGraphStore(PropertyGraphStore):
         if fs is None:
             fs = fsspec.filesystem("file")
 
-        with fs.open(persist_path, "r") as f:
+        with fs.open(persist_path, "r", encoding='utf-8') as f:
             data = json.loads(f.read())
 
         return cls.from_dict(data)


### PR DESCRIPTION
## Description

Fixes #21109

On Windows, files are opened with cp1252 encoding by default, causing errors when persisting UTF-8 content.

## Changes

Added `encoding="utf-8"` parameter to file open operations in `simple_labelled.py`:

1. `persist()` method: `fs.open(persist_path, "w", encoding="utf-8")`
2. `from_persist_path()` method: `fs.open(persist_path, "r", encoding="utf-8")`

This ensures consistent UTF-8 encoding across all platforms, fixing the Windows compatibility issue described in #21109.