### PR TITLE
fix(instrumentation): let SparseEmbeddingStartEvent inherit EmbeddingStartEvent

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/events/embedding.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/embedding.py
@@ -41,17 +41,19 @@ class EmbeddingEndEvent(BaseEvent):
         return "EmbeddingEndEvent"
 
 
-class SparseEmbeddingStartEvent(BaseEvent):
+class SparseEmbeddingStartEvent(EmbeddingStartEvent):
     """
-    EmbeddingStartEvent.
+    SparseEmbeddingStartEvent.
+
+    Inherits from EmbeddingStartEvent so that observability integrations using
+    singledispatch (e.g. openinference-instrumentation-llama-index) route this
+    event to the existing EmbeddingStartEvent handler instead of logging an
+    "Unhandled event" warning.
 
     Args:
         model_dict (dict): Model dictionary containing details about the embedding model.
 
     """
-
-    model_config = ConfigDict(protected_namespaces=("pydantic_model_",))
-    model_dict: dict
 
     @classmethod
     def class_name(cls) -> str:
@@ -61,11 +63,11 @@ class SparseEmbeddingStartEvent(BaseEvent):
 
 class SparseEmbeddingEndEvent(BaseEvent):
     """
-    EmbeddingEndEvent.
+    SparseEmbeddingEndEvent.
 
     Args:
         chunks (List[str]): List of chunks.
-        embeddings (List[List[float]]): List of embeddings.
+        embeddings (List[Dict[int, float]]): List of sparse embeddings (token-id to weight).
 
     """
 


### PR DESCRIPTION
# Description

The `openinference-instrumentation-llama-index` package uses singledispatch to route instrumentation events to type-specific handlers. When it encounters an event type with no registered handler it walks the MRO — if none is found, it falls back to the default which logs:
- WARNING - Unhandled event of type SparseEmbeddingStartEvent

`SparseEmbeddingStartEvent` has the exact same interface as `EmbeddingStartEvent` (both carry `model_dict: dict`), so making it a subclass is both semantically correct and allows singledispatch to route it to the existing EmbeddingStartEvent handler, eliminating the spurious warning.

`SparseEmbeddingEndEvent` is intentionally left as a direct BaseEvent subclass because its embeddings field (List[Dict[int, float]]) is incompatible with the List[List[float]] that the EmbeddingEndEvent handler serialises into OTel span attributes. 

The [companion fix in openinference-instrumentation-llama-index](https://github.com/Arize-ai/openinference/pull/2908) is necessary to register a handler that understands the sparse vector format.


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
