### PR TITLE
Add MultiModalContextChatEngine and supporting test utilities

### DIFF
--- a/llama-index-core/llama_index/core/__init__.py
+++ b/llama-index-core/llama_index/core/__init__.py
@@ -19,7 +19,7 @@ from llama_index.core.base.response.schema import Response
 # import global eval handler
 from llama_index.core.callbacks.global_handlers import set_global_handler
 from llama_index.core.data_structs.struct_type import IndexStructType
-from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding, MockMultiModalEmbedding
 
 # indices
 # loading
@@ -131,6 +131,7 @@ __all__ = [
     "Document",
     "SimpleDirectoryReader",
     "MockEmbedding",
+    "MockMultiModalEmbedding",
     "SQLDatabase",
     "SQLDocumentContextBuilder",
     "SQLContextBuilder",

--- a/llama-index-core/llama_index/core/chat_engine/__init__.py
+++ b/llama-index-core/llama_index/core/chat_engine/__init__.py
@@ -5,11 +5,8 @@ from llama_index.core.chat_engine.condense_question import (
     CondenseQuestionChatEngine,
 )
 from llama_index.core.chat_engine.context import ContextChatEngine
-from llama_index.core.chat_engine.simple import SimpleChatEngine
 from llama_index.core.chat_engine.multi_modal_context import MultiModalContextChatEngine
-from llama_index.core.chat_engine.multi_modal_condense_plus_context import (
-    MultiModalCondensePlusContextChatEngine,
-)
+from llama_index.core.chat_engine.simple import SimpleChatEngine
 
 __all__ = [
     "SimpleChatEngine",
@@ -17,5 +14,4 @@ __all__ = [
     "ContextChatEngine",
     "CondensePlusContextChatEngine",
     "MultiModalContextChatEngine",
-    "MultiModalCondensePlusContextChatEngine",
 ]

--- a/llama-index-core/llama_index/core/chat_engine/multi_modal.py
+++ b/llama-index-core/llama_index/core/chat_engine/multi_modal.py
@@ -1,0 +1,8 @@
+"""Compatibility shim — implementation lives in multi_modal_context.py."""
+
+from llama_index.core.chat_engine.multi_modal_context import (  # noqa: F401
+    DEFAULT_CONTEXT_TEMPLATE,
+    MultiModalContextChatEngine,
+)
+
+__all__ = ["MultiModalContextChatEngine", "DEFAULT_CONTEXT_TEMPLATE"]

--- a/llama-index-core/llama_index/core/chat_engine/multi_modal_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/multi_modal_context.py
@@ -1,318 +1,229 @@
-import asyncio
-from typing import Any, List, Optional, Sequence, Tuple, Union
+"""Multi-Modal Context Chat Engine."""
 
-from llama_index.core.base.response.schema import RESPONSE_TYPE, Response
-from llama_index.core.callbacks.base import CallbackManager
-from llama_index.core.callbacks import trace_method
+import base64
+import logging
+from typing import Any, List, Optional, Tuple, Union
+
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    ImageBlock,
+    MessageRole,
+    TextBlock,
+)
+from llama_index.core.callbacks import CallbackManager, trace_method
 from llama_index.core.chat_engine.types import (
     AgentChatResponse,
     BaseChatEngine,
     StreamingAgentChatResponse,
     ToolOutput,
 )
-from llama_index.core.base.llms.types import (
-    ChatMessage,
-    ChatResponse,
-    ChatResponseAsyncGen,
-    ChatResponseGen,
-    MessageRole,
-)
-from llama_index.core.base.response.schema import (
-    StreamingResponse,
-    AsyncStreamingResponse,
-)
-from llama_index.core.indices.query.schema import QueryBundle, QueryType
-from llama_index.core.llms import LLM, TextBlock, ChatMessage, ImageBlock
+from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
+from llama_index.core.multi_modal_llms.base import MultiModalLLM
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
-from llama_index.core.prompts import PromptTemplate
-from llama_index.core.schema import ImageNode, NodeWithScore, MetadataMode
-from llama_index.core.base.llms.generic_utils import image_node_to_image_block
-from llama_index.core.memory import BaseMemory, Memory
-from llama_index.core.types import Thread
-
-# from llama_index.core.query_engine.multi_modal import _get_image_and_text_nodes
-from llama_index.core.llms.llm import (
-    astream_chat_response_to_tokens,
-    stream_chat_response_to_tokens,
-)
-from llama_index.core.prompts.default_prompts import DEFAULT_TEXT_QA_PROMPT
+from llama_index.core.schema import ImageNode, NodeWithScore, QueryBundle
 from llama_index.core.settings import Settings
-from llama_index.core.base.base_retriever import BaseRetriever
 
+logger = logging.getLogger(__name__)
 
-def _get_image_and_text_nodes(
-    nodes: List[NodeWithScore],
-) -> Tuple[List[NodeWithScore], List[NodeWithScore]]:
-    image_nodes = []
-    text_nodes = []
-    for res_node in nodes:
-        if isinstance(res_node.node, ImageNode):
-            image_nodes.append(res_node)
-        else:
-            text_nodes.append(res_node)
-    return image_nodes, text_nodes
-
-
-def _ensure_query_bundle(str_or_query_bundle: QueryType) -> QueryBundle:
-    if isinstance(str_or_query_bundle, str):
-        return QueryBundle(str_or_query_bundle)
-    return str_or_query_bundle
+DEFAULT_CONTEXT_TEMPLATE = (
+    "Use the context information below to assist the user."
+    "\n--------------------\n"
+    "{context_str}"
+    "\n--------------------\n"
+)
 
 
 class MultiModalContextChatEngine(BaseChatEngine):
     """
-    Multimodal Context Chat Engine.
+    Multi-Modal Context Chat Engine.
 
-    Assumes that retrieved text context fits within context window of LLM, along with images.
-    This class closely relates to the non-multimodal version, ContextChatEngine.
+    Retrieves both text nodes and image nodes from a MultiModal index via a
+    ``MultiModalVectorIndexRetriever``, then builds a multi-modal chat message
+    containing:
 
-    Args:
-        retriever (MultiModalVectorIndexRetriever): A retriever object.
-        multi_modal_llm (LLM): A multimodal LLM model.
-        memory (BaseMemory): Chat memory buffer to store the history.
-        system_prompt (str): System prompt.
-        context_template (Optional[Union[str, PromptTemplate]]): Prompt Template to embed query and context.
-        node_postprocessors (Optional[List[BaseNodePostprocessor]]): Node Postprocessors.
-        callback_manager (Optional[CallbackManager]): A callback manager.
+    * A ``TextBlock`` with the retrieved text context and the user's question.
+    * One ``ImageBlock`` per retrieved ``ImageNode``.
 
+    The assembled message list (prefix messages + memory history + user message)
+    is sent to a ``MultiModalLLM``.
     """
 
     def __init__(
         self,
         retriever: BaseRetriever,
-        multi_modal_llm: LLM,
+        multi_modal_llm: MultiModalLLM,
         memory: BaseMemory,
-        system_prompt: str,
-        context_template: Optional[Union[str, PromptTemplate]] = None,
+        prefix_messages: List[ChatMessage],
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
+        context_template: str = DEFAULT_CONTEXT_TEMPLATE,
         callback_manager: Optional[CallbackManager] = None,
-        **kwargs: Any,
     ) -> None:
         self._retriever = retriever
         self._multi_modal_llm = multi_modal_llm
-        context_template = context_template or DEFAULT_TEXT_QA_PROMPT
-        if isinstance(context_template, str):
-            context_template = PromptTemplate(context_template)
-        self._context_template = context_template
-
         self._memory = memory
-        self._system_prompt = system_prompt
-
+        self._prefix_messages = prefix_messages
         self._node_postprocessors = node_postprocessors or []
+        self._context_template = context_template
         self.callback_manager = callback_manager or CallbackManager([])
-        for node_postprocessor in self._node_postprocessors:
-            node_postprocessor.callback_manager = self.callback_manager
+        for postprocessor in self._node_postprocessors:
+            postprocessor.callback_manager = self.callback_manager
 
     @classmethod
     def from_defaults(
         cls,
         retriever: BaseRetriever,
+        multi_modal_llm: Optional[MultiModalLLM] = None,
         chat_history: Optional[List[ChatMessage]] = None,
         memory: Optional[BaseMemory] = None,
         system_prompt: Optional[str] = None,
+        prefix_messages: Optional[List[ChatMessage]] = None,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
-        context_template: Optional[Union[str, PromptTemplate]] = None,
-        multi_modal_llm: Optional[LLM] = None,
+        context_template: Optional[str] = None,
         **kwargs: Any,
     ) -> "MultiModalContextChatEngine":
-        """Initialize a MultiModalContextChatEngine from default parameters."""
-        multi_modal_llm = multi_modal_llm or Settings.llm
+        """Create a ``MultiModalContextChatEngine`` from default parameters."""
+        mm_llm = multi_modal_llm or Settings.llm
+        if not isinstance(mm_llm, MultiModalLLM):
+            raise ValueError(
+                f"MultiModalContextChatEngine requires a MultiModalLLM, "
+                f"but got {type(mm_llm).__name__}. "
+                "Pass multi_modal_llm=<your MultiModalLLM instance>."
+            )
 
         chat_history = chat_history or []
-        memory = memory or Memory.from_defaults(
+        memory = memory or ChatMemoryBuffer.from_defaults(
             chat_history=chat_history,
-            token_limit=multi_modal_llm.metadata.context_window - 256,
+            token_limit=(mm_llm.metadata.context_window or 4096) - 256,
         )
 
-        system_prompt = system_prompt or ""
-        node_postprocessors = node_postprocessors or []
+        if system_prompt is not None:
+            if prefix_messages is not None:
+                raise ValueError(
+                    "Cannot specify both system_prompt and prefix_messages"
+                )
+            prefix_messages = [
+                ChatMessage(content=system_prompt, role=MessageRole.SYSTEM)
+            ]
 
         return cls(
-            retriever,
-            multi_modal_llm=multi_modal_llm,
+            retriever=retriever,
+            multi_modal_llm=mm_llm,
             memory=memory,
-            system_prompt=system_prompt,
-            node_postprocessors=node_postprocessors,
+            prefix_messages=prefix_messages or [],
+            node_postprocessors=node_postprocessors or [],
+            context_template=context_template or DEFAULT_CONTEXT_TEMPLATE,
             callback_manager=Settings.callback_manager,
-            context_template=context_template,
         )
 
-    def _apply_node_postprocessors(
-        self, nodes: List[NodeWithScore], query_bundle: QueryBundle
-    ) -> List[NodeWithScore]:
-        for node_postprocessor in self._node_postprocessors:
-            nodes = node_postprocessor.postprocess_nodes(
-                nodes, query_bundle=query_bundle
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_nodes(
+        self, message: str
+    ) -> Tuple[List[NodeWithScore], List[NodeWithScore]]:
+        """Retrieve nodes and split into text and image lists."""
+        nodes = self._retriever.retrieve(message)
+        for postprocessor in self._node_postprocessors:
+            nodes = postprocessor.postprocess_nodes(
+                nodes, query_bundle=QueryBundle(message)
             )
-        return nodes
+        text_nodes = [n for n in nodes if not isinstance(n.node, ImageNode)]
+        image_nodes = [n for n in nodes if isinstance(n.node, ImageNode)]
+        return text_nodes, image_nodes
 
-    async def _async_apply_node_postprocessors(
-        self, nodes: List[NodeWithScore], query_bundle: QueryBundle
-    ) -> List[NodeWithScore]:
-        for node_postprocessor in self._node_postprocessors:
-            nodes = await node_postprocessor.apostprocess_nodes(
-                nodes, query_bundle=query_bundle
+    async def _aget_nodes(
+        self, message: str
+    ) -> Tuple[List[NodeWithScore], List[NodeWithScore]]:
+        """Asynchronously retrieve nodes and split into text and image lists."""
+        nodes = await self._retriever.aretrieve(message)
+        for postprocessor in self._node_postprocessors:
+            nodes = postprocessor.postprocess_nodes(
+                nodes, query_bundle=QueryBundle(message)
             )
-        return nodes
+        text_nodes = [n for n in nodes if not isinstance(n.node, ImageNode)]
+        image_nodes = [n for n in nodes if isinstance(n.node, ImageNode)]
+        return text_nodes, image_nodes
 
-    def _get_nodes(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        nodes = self._retriever.retrieve(query_bundle)
-        return self._apply_node_postprocessors(nodes, query_bundle=query_bundle)
-
-    async def _aget_nodes(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
-        nodes = await self._retriever.aretrieve(query_bundle)
-        return await self._async_apply_node_postprocessors(
-            nodes, query_bundle=query_bundle
-        )
-
-    def synthesize(
+    def _build_for_llm_messages(
         self,
-        query_bundle: QueryBundle,
-        nodes: List[NodeWithScore],
-        additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
-        streaming: bool = False,
-    ) -> RESPONSE_TYPE:
-        image_nodes, text_nodes = _get_image_and_text_nodes(nodes)
-        context_str = "\n\n".join(
-            [r.get_content(metadata_mode=MetadataMode.LLM) for r in text_nodes]
-        )
-        fmt_prompt = self._context_template.format(
-            context_str=context_str, query_str=query_bundle.query_str
-        )
+        message: str,
+        text_nodes: List[NodeWithScore],
+        image_nodes: List[NodeWithScore],
+    ) -> List[ChatMessage]:
+        """Build the complete message list to pass to the MultiModalLLM.
 
-        blocks: List[Union[ImageBlock, TextBlock]] = [
-            image_node_to_image_block(image_node.node)
-            for image_node in image_nodes
-            if isinstance(image_node.node, ImageNode)
+        Layout:
+            prefix_messages
+            + memory chat history
+            + user message (TextBlock with context + question, ImageBlocks)
+        """
+        context_str = "\n\n".join(node.get_content() for node in text_nodes)
+        context_text = self._context_template.format(context_str=context_str)
+
+        blocks: List[Union[TextBlock, ImageBlock]] = [
+            TextBlock(text=f"{context_text}\n{message}")
         ]
 
-        blocks.append(TextBlock(text=fmt_prompt))
+        for node_with_score in image_nodes:
+            node = node_with_score.node
+            if isinstance(node, ImageNode):
+                if node.image_url:
+                    blocks.append(ImageBlock(url=node.image_url))
+                elif node.image_path:
+                    blocks.append(ImageBlock(path=node.image_path))
+                elif node.image:
+                    blocks.append(
+                        ImageBlock(
+                            image=base64.b64decode(node.image),
+                            image_mimetype=node.image_mimetype,
+                        )
+                    )
 
-        chat_history = self._memory.get(
-            input=str(query_bundle),
-        )
+        user_message = ChatMessage(role=MessageRole.USER, blocks=blocks)
+        chat_history = self._memory.get(input=message)
+        return self._prefix_messages + chat_history + [user_message]
 
-        if streaming:
-            llm_stream = self._multi_modal_llm.stream_chat(
-                [
-                    ChatMessage(role="system", content=self._system_prompt),
-                    *chat_history,
-                    ChatMessage(role="user", blocks=blocks),
-                ]
-            )
-            stream_tokens = stream_chat_response_to_tokens(llm_stream)
-            return StreamingResponse(
-                response_gen=stream_tokens,
-                source_nodes=nodes,
-                metadata={"text_nodes": text_nodes, "image_nodes": image_nodes},
-            )
-        else:
-            llm_response = self._multi_modal_llm.chat(
-                [
-                    ChatMessage(role="system", content=self._system_prompt),
-                    *chat_history,
-                    ChatMessage(role="user", blocks=blocks),
-                ]
-            )
-            output = llm_response.message.content or ""
-            return Response(
-                response=output,
-                source_nodes=nodes,
-                metadata={"text_nodes": text_nodes, "image_nodes": image_nodes},
-            )
-
-    async def asynthesize(
-        self,
-        query_bundle: QueryBundle,
-        nodes: List[NodeWithScore],
-        additional_source_nodes: Optional[Sequence[NodeWithScore]] = None,
-        streaming: bool = False,
-    ) -> RESPONSE_TYPE:
-        image_nodes, text_nodes = _get_image_and_text_nodes(nodes)
-        context_str = "\n\n".join(
-            [r.get_content(metadata_mode=MetadataMode.LLM) for r in text_nodes]
-        )
-        fmt_prompt = self._context_template.format(
-            context_str=context_str, query_str=query_bundle.query_str
-        )
-
-        blocks: List[Union[ImageBlock, TextBlock]] = [
-            image_node_to_image_block(image_node.node)
-            for image_node in image_nodes
-            if isinstance(image_node.node, ImageNode)
-        ]
-
-        blocks.append(TextBlock(text=fmt_prompt))
-
-        chat_history = await self._memory.aget(
-            input=str(query_bundle),
-        )
-
-        if streaming:
-            llm_stream = await self._multi_modal_llm.astream_chat(
-                [
-                    ChatMessage(role="system", content=self._system_prompt),
-                    *chat_history,
-                    ChatMessage(role="user", blocks=blocks),
-                ]
-            )
-            stream_tokens = await astream_chat_response_to_tokens(llm_stream)
-            return AsyncStreamingResponse(
-                response_gen=stream_tokens,
-                source_nodes=nodes,
-                metadata={"text_nodes": text_nodes, "image_nodes": image_nodes},
-            )
-        else:
-            llm_response = await self._multi_modal_llm.achat(
-                [
-                    ChatMessage(role="system", content=self._system_prompt),
-                    *chat_history,
-                    ChatMessage(role="user", blocks=blocks),
-                ]
-            )
-            output = llm_response.message.content or ""
-            return Response(
-                response=output,
-                source_nodes=nodes,
-                metadata={"text_nodes": text_nodes, "image_nodes": image_nodes},
-            )
+    # ------------------------------------------------------------------
+    # BaseChatEngine interface
+    # ------------------------------------------------------------------
 
     @trace_method("chat")
     def chat(
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        prev_chunks: Optional[List[NodeWithScore]] = None,
     ) -> AgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
 
-        # get nodes and postprocess them
-        nodes = self._get_nodes(_ensure_query_bundle(message))
-        if len(nodes) == 0 and prev_chunks is not None:
-            nodes = prev_chunks
+        text_nodes, image_nodes = self._get_nodes(message)
+        all_nodes = text_nodes + image_nodes
 
-        response = self.synthesize(
-            _ensure_query_bundle(message), nodes=nodes, streaming=False
+        messages = self._build_for_llm_messages(message, text_nodes, image_nodes)
+        response: ChatResponse = self._multi_modal_llm.chat(messages)
+        response_text = str(response.message.content or "")
+
+        self._memory.put(ChatMessage(content=message, role=MessageRole.USER))
+        self._memory.put(
+            ChatMessage(content=response_text, role=MessageRole.ASSISTANT)
         )
 
-        user_message = ChatMessage(content=str(message), role=MessageRole.USER)
-        ai_message = ChatMessage(content=str(response), role=MessageRole.ASSISTANT)
-
-        self._memory.put(user_message)
-        self._memory.put(ai_message)
-
         return AgentChatResponse(
-            response=str(response),
+            response=response_text,
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(nodes),
+                    content=str(all_nodes),
                     raw_input={"message": message},
-                    raw_output=response.metadata,
+                    raw_output=all_nodes,
                 )
             ],
-            source_nodes=response.source_nodes,
+            source_nodes=all_nodes,
         )
 
     @trace_method("chat")
@@ -320,89 +231,73 @@ class MultiModalContextChatEngine(BaseChatEngine):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        prev_chunks: Optional[List[NodeWithScore]] = None,
     ) -> StreamingAgentChatResponse:
         if chat_history is not None:
             self._memory.set(chat_history)
 
-        # get nodes and postprocess them
-        nodes = self._get_nodes(_ensure_query_bundle(message))
-        if len(nodes) == 0 and prev_chunks is not None:
-            nodes = prev_chunks
+        text_nodes, image_nodes = self._get_nodes(message)
+        all_nodes = text_nodes + image_nodes
 
-        response = self.synthesize(
-            _ensure_query_bundle(message), nodes=nodes, streaming=True
-        )
-        assert isinstance(response, StreamingResponse)
+        messages = self._build_for_llm_messages(message, text_nodes, image_nodes)
+        response_stream = self._multi_modal_llm.stream_chat(messages)
 
-        self._memory.put(ChatMessage(content=str(message), role=MessageRole.USER))
-
-        def wrapped_gen(response: StreamingResponse) -> ChatResponseGen:
+        def gen() -> ChatResponseGen:
             full_response = ""
-            for token in response.response_gen:
-                full_response += token
-                yield ChatResponse(
-                    message=ChatMessage(
-                        content=full_response, role=MessageRole.ASSISTANT
-                    ),
-                    delta=token,
-                )
+            for chunk in response_stream:
+                delta = chunk.delta or ""
+                full_response += delta
+                yield chunk
+            self._memory.put(ChatMessage(content=message, role=MessageRole.USER))
+            self._memory.put(
+                ChatMessage(content=full_response, role=MessageRole.ASSISTANT)
+            )
 
-        chat_response = StreamingAgentChatResponse(
-            chat_stream=wrapped_gen(response),
+        return StreamingAgentChatResponse(
+            chat_stream=gen(),
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(nodes),
+                    content=str(all_nodes),
                     raw_input={"message": message},
-                    raw_output=response.metadata,
+                    raw_output=all_nodes,
                 )
             ],
-            source_nodes=response.source_nodes,
+            source_nodes=all_nodes,
+            is_writing_to_memory=False,
         )
-        thread = Thread(
-            target=chat_response.write_response_to_history, args=(self._memory,)
-        )
-        chat_response.write_response_to_history_thread = thread
-        thread.start()
-        return chat_response
 
     @trace_method("chat")
     async def achat(
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        prev_chunks: Optional[List[NodeWithScore]] = None,
     ) -> AgentChatResponse:
         if chat_history is not None:
             await self._memory.aset(chat_history)
 
-        # get nodes and postprocess them
-        nodes = await self._aget_nodes(_ensure_query_bundle(message))
-        if len(nodes) == 0 and prev_chunks is not None:
-            nodes = prev_chunks
+        text_nodes, image_nodes = await self._aget_nodes(message)
+        all_nodes = text_nodes + image_nodes
 
-        response = await self.asynthesize(
-            _ensure_query_bundle(message), nodes=nodes, streaming=False
+        messages = self._build_for_llm_messages(message, text_nodes, image_nodes)
+        response: ChatResponse = await self._multi_modal_llm.achat(messages)
+        response_text = str(response.message.content or "")
+
+        await self._memory.aput(ChatMessage(content=message, role=MessageRole.USER))
+        await self._memory.aput(
+            ChatMessage(content=response_text, role=MessageRole.ASSISTANT)
         )
 
-        user_message = ChatMessage(content=str(message), role=MessageRole.USER)
-        ai_message = ChatMessage(content=str(response), role=MessageRole.ASSISTANT)
-
-        await self._memory.aput(user_message)
-        await self._memory.aput(ai_message)
-
         return AgentChatResponse(
-            response=str(response),
+            response=response_text,
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(nodes),
+                    content=str(all_nodes),
                     raw_input={"message": message},
-                    raw_output=response.metadata,
+                    raw_output=all_nodes,
                 )
             ],
-            source_nodes=response.source_nodes,
+            source_nodes=all_nodes,
         )
 
     @trace_method("chat")
@@ -410,57 +305,46 @@ class MultiModalContextChatEngine(BaseChatEngine):
         self,
         message: str,
         chat_history: Optional[List[ChatMessage]] = None,
-        prev_chunks: Optional[List[NodeWithScore]] = None,
     ) -> StreamingAgentChatResponse:
         if chat_history is not None:
             await self._memory.aset(chat_history)
 
-        # get nodes and postprocess them
-        nodes = await self._aget_nodes(_ensure_query_bundle(message))
-        if len(nodes) == 0 and prev_chunks is not None:
-            nodes = prev_chunks
+        text_nodes, image_nodes = await self._aget_nodes(message)
+        all_nodes = text_nodes + image_nodes
 
-        response = await self.asynthesize(
-            _ensure_query_bundle(message), nodes=nodes, streaming=True
-        )
-        assert isinstance(response, AsyncStreamingResponse)
+        messages = self._build_for_llm_messages(message, text_nodes, image_nodes)
+        response_stream = await self._multi_modal_llm.astream_chat(messages)
 
-        await self._memory.aput(
-            ChatMessage(content=str(message), role=MessageRole.USER)
-        )
-
-        async def wrapped_gen(response: AsyncStreamingResponse) -> ChatResponseAsyncGen:
+        async def async_gen() -> ChatResponseAsyncGen:
             full_response = ""
-            async for token in response.async_response_gen():
-                full_response += token
-                yield ChatResponse(
-                    message=ChatMessage(
-                        content=full_response, role=MessageRole.ASSISTANT
-                    ),
-                    delta=token,
-                )
+            async for chunk in response_stream:
+                delta = chunk.delta or ""
+                full_response += delta
+                yield chunk
+            await self._memory.aput(
+                ChatMessage(content=message, role=MessageRole.USER)
+            )
+            await self._memory.aput(
+                ChatMessage(content=full_response, role=MessageRole.ASSISTANT)
+            )
 
-        chat_response = StreamingAgentChatResponse(
-            achat_stream=wrapped_gen(response),
+        return StreamingAgentChatResponse(
+            achat_stream=async_gen(),
             sources=[
                 ToolOutput(
                     tool_name="retriever",
-                    content=str(nodes),
+                    content=str(all_nodes),
                     raw_input={"message": message},
-                    raw_output=response.metadata,
+                    raw_output=all_nodes,
                 )
             ],
-            source_nodes=response.source_nodes,
+            source_nodes=all_nodes,
+            is_writing_to_memory=False,
         )
-        chat_response.awrite_response_to_history_task = asyncio.create_task(
-            chat_response.awrite_response_to_history(self._memory)
-        )
-        return chat_response
 
     def reset(self) -> None:
         self._memory.reset()
 
     @property
     def chat_history(self) -> List[ChatMessage]:
-        """Get chat history."""
         return self._memory.get_all()

--- a/llama-index-core/llama_index/core/embeddings/__init__.py
+++ b/llama-index-core/llama_index/core/embeddings/__init__.py
@@ -1,6 +1,8 @@
 from llama_index.core.base.embeddings.base import BaseEmbedding
-from llama_index.core.embeddings.mock_embed_model import MockEmbedding
-from llama_index.core.embeddings.mock_embed_model import MockMultiModalEmbedding
+from llama_index.core.embeddings.mock_embed_model import (
+    MockEmbedding,
+    MockMultiModalEmbedding,
+)
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.core.embeddings.pooling import Pooling
 from llama_index.core.embeddings.utils import resolve_embed_model
@@ -8,8 +10,8 @@ from llama_index.core.embeddings.utils import resolve_embed_model
 __all__ = [
     "BaseEmbedding",
     "MockEmbedding",
-    "MultiModalEmbedding",
     "MockMultiModalEmbedding",
+    "MultiModalEmbedding",
     "Pooling",
     "resolve_embed_model",
 ]

--- a/llama-index-core/llama_index/core/embeddings/mock_embed_model.py
+++ b/llama-index-core/llama_index/core/embeddings/mock_embed_model.py
@@ -48,10 +48,9 @@ class MockEmbedding(BaseEmbedding):
 
 class MockMultiModalEmbedding(MultiModalEmbedding):
     """
-    Multi-Modal Mock embedding.
+    Mock multi-modal embedding model for testing.
 
-    Used to simulate a multi-modal embedding.
-    The reason this is used beside MockEmbedding to satisfy MultiModalVectorStoreIndex image embedding checks.
+    Returns a constant vector for both text and image inputs.
 
     Args:
         embed_dim (int): embedding dimension
@@ -61,11 +60,23 @@ class MockMultiModalEmbedding(MultiModalEmbedding):
     embed_dim: int
 
     def __init__(self, embed_dim: int, **kwargs: Any) -> None:
-        """Init params."""
         super().__init__(embed_dim=embed_dim, **kwargs)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "MockMultiModalEmbedding"
 
     def _get_vector(self) -> List[float]:
         return [0.5] * self.embed_dim
+
+    async def _aget_text_embedding(self, text: str) -> List[float]:
+        return self._get_vector()
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return self._get_vector()
+
+    def _get_query_embedding(self, query: str) -> List[float]:
+        return self._get_vector()
 
     def _get_text_embedding(self, text: str) -> List[float]:
         return self._get_vector()
@@ -74,10 +85,4 @@ class MockMultiModalEmbedding(MultiModalEmbedding):
         return self._get_vector()
 
     async def _aget_image_embedding(self, img_file_path: ImageType) -> List[float]:
-        return self._get_image_embedding(img_file_path)
-
-    def _get_query_embedding(self, query: str) -> List[float]:
-        return self._get_text_embedding(query)
-
-    async def _aget_query_embedding(self, query: str) -> List[float]:
-        return self._get_query_embedding(query)
+        return self._get_vector()

--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -10,6 +10,7 @@ from typing import Any, List, Optional, Sequence, cast
 
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.chat_engine.types import BaseChatEngine, ChatMode
 from llama_index.core.data_structs.data_structs import (
     IndexDict,
     MultiModelIndexDict,
@@ -26,7 +27,6 @@ from llama_index.core.indices.multi_modal.retriever import (
     MultiModalVectorIndexRetriever,
 )
 from llama_index.core.indices.vector_store.base import VectorStoreIndex
-from llama_index.core.llms import LLM
 from llama_index.core.llms.utils import LLMType
 from llama_index.core.multi_modal_llms.base import MultiModalLLM
 from llama_index.core.query_engine.multi_modal import SimpleMultiModalQueryEngine
@@ -38,7 +38,6 @@ from llama_index.core.vector_stores.simple import (
     SimpleVectorStore,
 )
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
-from llama_index.core.chat_engine.types import BaseChatEngine, ChatMode
 
 logger = logging.getLogger(__name__)
 
@@ -163,40 +162,55 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
         self,
         chat_mode: ChatMode = ChatMode.BEST,
         llm: Optional[LLMType] = None,
+        multi_modal_llm: Optional[MultiModalLLM] = None,
         **kwargs: Any,
     ) -> BaseChatEngine:
-        llm = llm or Settings.llm
-        assert isinstance(llm, (BaseLLM, MultiModalLLM))
-        llm = cast(LLM, llm)  # kludge. They don't actually inherit from these types.
-        class_name = llm.class_name()
-        if "multi" not in class_name:
-            logger.warning(
-                f"Warning: {class_name} does not appear to be a multi-modal LLM. This may not work as expected."
-            )
+        """
+        Convert the index to a chat engine.
 
+        For ``ChatMode.CONTEXT`` a :class:`MultiModalContextChatEngine` is
+        returned that retrieves both text and image nodes and sends a
+        multi-modal message list to a ``MultiModalLLM``.
+
+        All other chat modes fall back to the base ``VectorStoreIndex``
+        implementation.
+
+        Args:
+            chat_mode: The chat mode to use. ``ChatMode.CONTEXT`` (default
+                when explicitly requested) is handled natively; all other modes
+                are delegated to the parent class.
+            llm: A text-only LLM.  Accepted for other chat modes or as a
+                fallback; ignored when ``multi_modal_llm`` is provided.
+            multi_modal_llm: The ``MultiModalLLM`` to use for
+                ``ChatMode.CONTEXT``.  When *None* the global
+                ``Settings.llm`` is used (which must be a
+                ``MultiModalLLM``).
+            **kwargs: Additional keyword arguments forwarded to the retriever
+                and/or the chat engine ``from_defaults`` constructor.
+        """
         if chat_mode == ChatMode.CONTEXT:
             from llama_index.core.chat_engine.multi_modal_context import (
                 MultiModalContextChatEngine,
             )
 
+            mm_llm: Any = multi_modal_llm or (
+                llm if isinstance(llm, MultiModalLLM) else None
+            ) or Settings.llm
+
+            if not isinstance(mm_llm, MultiModalLLM):
+                raise ValueError(
+                    f"ChatMode.CONTEXT on a MultiModalVectorStoreIndex requires a "
+                    f"MultiModalLLM, but got {type(mm_llm).__name__}. "
+                    "Pass multi_modal_llm=<your MultiModalLLM instance>."
+                )
+
             return MultiModalContextChatEngine.from_defaults(
                 retriever=self.as_retriever(**kwargs),
-                multi_modal_llm=llm,
+                multi_modal_llm=mm_llm,
                 **kwargs,
             )
 
-        if chat_mode == ChatMode.CONDENSE_PLUS_CONTEXT:
-            from llama_index.core.chat_engine.multi_modal_condense_plus_context import (
-                MultiModalCondensePlusContextChatEngine,
-            )
-
-            return MultiModalCondensePlusContextChatEngine.from_defaults(
-                retriever=self.as_retriever(**kwargs),
-                multi_modal_llm=llm,
-                **kwargs,
-            )
-
-        return super().as_chat_engine(chat_mode, llm, **kwargs)
+        return super().as_chat_engine(chat_mode=chat_mode, llm=llm, **kwargs)
 
     @classmethod
     def from_vector_store(

--- a/llama-index-core/llama_index/core/llms/mock.py
+++ b/llama-index-core/llama_index/core/llms/mock.py
@@ -1,66 +1,32 @@
-from typing import (
-    Any,
-    Sequence,
-    List,
-    Literal,
-    Generator,
-    AsyncGenerator,
-    Callable,
-    Optional,
-    Union,
-    TYPE_CHECKING,
-)
-from typing_extensions import TypeAlias
-from base64 import b64decode
-from json import JSONDecodeError
+from typing import Any, List, Optional, Sequence, Union
 from llama_index.core.base.llms.types import (
-    ChatResponseGen,
-    CompletionResponse,
-    CompletionResponseGen,
-    CompletionResponseAsyncGen,
-    LLMMetadata,
     ChatMessage,
     ChatResponse,
     ChatResponseAsyncGen,
-    TextBlock,
-    DocumentBlock,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseAsyncGen,
+    CompletionResponseGen,
     ImageBlock,
-    AudioBlock,
-    ToolCallBlock,
-    ThinkingBlock,
-    CitableBlock,
-    CitationBlock,
-    VideoBlock,
-    ContentBlock,
+    LLMMetadata,
     MessageRole,
 )
+from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.custom import CustomLLM
-from llama_index.core.llms.function_calling import FunctionCallingLLM
-from llama_index.core.llms.llm import (
-    MessagesToPromptType,
-    CompletionToPromptType,
-    ToolSelection,
-)
-from llama_index.core.llms.utils import parse_partial_json
+from llama_index.core.llms.llm import MessagesToPromptType, CompletionToPromptType
+from llama_index.core.multi_modal_llms.base import MultiModalLLM, MultiModalLLMMetadata
+from llama_index.core.schema import ImageNode
 from llama_index.core.types import PydanticProgramMode
-
-from pydantic import Field, PrivateAttr
-import copy
-
-if TYPE_CHECKING:
-    from llama_index.core.tools import BaseTool
 
 
 class MockLLM(CustomLLM):
     max_tokens: Optional[int]
-    is_chat_model: Optional[bool] = False
 
     def __init__(
         self,
         max_tokens: Optional[int] = None,
-        is_chat_model: Optional[bool] = False,
         callback_manager: Optional[CallbackManager] = None,
         system_prompt: Optional[str] = None,
         messages_to_prompt: Optional[MessagesToPromptType] = None,
@@ -75,7 +41,6 @@ class MockLLM(CustomLLM):
             completion_to_prompt=completion_to_prompt,
             pydantic_program_mode=pydantic_program_mode,
         )
-        self.is_chat_model = is_chat_model
 
     @classmethod
     def class_name(cls) -> str:
@@ -83,9 +48,7 @@ class MockLLM(CustomLLM):
 
     @property
     def metadata(self) -> LLMMetadata:
-        return LLMMetadata(
-            num_output=self.max_tokens or -1, is_chat_model=self.is_chat_model
-        )
+        return LLMMetadata(num_output=self.max_tokens or -1)
 
     def _generate_text(self, length: int) -> str:
         return " ".join(["text" for _ in range(length)])
@@ -136,372 +99,112 @@ class MockLLMWithNonyieldingChatStream(MockLLM):
         yield from []
 
 
-class MockLLMWithChatMemoryOfLastCall(MockLLM):
+class MockLLMWithChatMemoryOfLastCall(MultiModalLLM):
     """
-    Mock LLM that keeps track of chat messages of function calls.
+    Mock MultiModalLLM for testing that records the messages from the most
+    recent ``chat`` / ``achat`` call.
 
-    The idea behind this is to be able to easily checks whether the right messages would have been passed to an actual LLM.
+    Access the captured messages via :attr:`last_messages_received`.
     """
 
-    last_chat_messages: Optional[Sequence[ChatMessage]] = Field(
-        default=None, exclude=True
-    )
-    last_called_chat_function: List[str] = Field(default=[], exclude=True)
-
-    @llm_chat_callback()
-    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
-        r = super().chat(copy.deepcopy(messages), **kwargs)
-        self.last_chat_messages = messages
-        self.last_called_chat_function.append("chat")
-        return r
-
-    @llm_chat_callback()
-    def stream_chat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponseGen:
-        r = super().stream_chat(copy.deepcopy(messages), **kwargs)
-        self.last_chat_messages = messages
-        self.last_called_chat_function.append("stream_chat")
-        return r
-
-    @llm_chat_callback()
-    async def achat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponse:
-        r = await super().achat(copy.deepcopy(messages), **kwargs)
-        self.last_chat_messages = messages
-        self.last_called_chat_function.append("achat")
-        return r
-
-    @llm_chat_callback()
-    async def astream_chat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponseAsyncGen:
-        r = await super().astream_chat(copy.deepcopy(messages), **kwargs)
-        self.last_chat_messages = messages
-        self.last_called_chat_function.append("astream_chat")
-        return r
-
-    def reset_memory(self) -> None:
-        self.last_chat_messages = None
-        self.last_called_chat_function = []
+    _last_messages: List[ChatMessage] = PrivateAttr(default_factory=list)
 
     @classmethod
     def class_name(cls) -> str:
         return "MockLLMWithChatMemoryOfLastCall"
 
-
-def _data_from_binary(
-    data: bytes, block_type: Literal["audio", "document", "image", "video"]
-) -> str:
-    try:
-        b64data = b64decode(data).decode("utf-8")
-    except Exception:
-        b64data = ""
-    return f"<{block_type}>{b64data}</{block_type}>"
-
-
-def _default_blocks_to_content_callback(
-    blocks: list[ContentBlock], tool_calls: Optional[list[ToolCallBlock]] = None
-) -> str:
-    content_parts: list[str] = []
-    for block in blocks:
-        if isinstance(block, DocumentBlock):
-            content_parts.append(
-                _data_from_binary(
-                    data=block.data if isinstance(block.data, bytes) else b"",
-                    block_type=block.block_type,
-                )
-            )
-        elif isinstance(block, ImageBlock):
-            content_parts.append(
-                _data_from_binary(
-                    data=block.image if isinstance(block.image, bytes) else b"",
-                    block_type=block.block_type,
-                )
-            )
-        elif isinstance(block, VideoBlock):
-            content_parts.append(
-                _data_from_binary(
-                    data=block.video if isinstance(block.video, bytes) else b"",
-                    block_type=block.block_type,
-                )
-            )
-        elif isinstance(block, AudioBlock):
-            content_parts.append(
-                _data_from_binary(
-                    data=block.audio if isinstance(block.audio, bytes) else b"",
-                    block_type=block.block_type,
-                )
-            )
-        elif isinstance(block, TextBlock):
-            content_parts.append(block.text)
-        elif isinstance(block, ThinkingBlock):
-            content_parts.append(block.content or "")
-        elif isinstance(block, CitableBlock):
-            for c in block.content:
-                if isinstance(c, TextBlock):
-                    content_parts.append(c.text)
-                elif isinstance(c, ImageBlock):
-                    content_parts.append(
-                        _data_from_binary(
-                            c.image if isinstance(c.image, bytes) else b"",
-                            block_type=c.block_type,
-                        )
-                    )
-                else:
-                    content_parts.append(
-                        _data_from_binary(
-                            c.data if isinstance(c.data, bytes) else b"",
-                            block_type=c.block_type,
-                        )
-                    )
-        elif isinstance(block, CitationBlock):
-            if isinstance(block.cited_content, TextBlock):
-                content_parts.append(block.cited_content.text)
-            else:
-                content_parts.append(
-                    _data_from_binary(
-                        data=block.cited_content.image
-                        if isinstance(block.cited_content.image, bytes)
-                        else b"",
-                        block_type=block.cited_content.block_type,
-                    )
-                )
-        elif isinstance(block, ToolCallBlock):
-            if tool_calls is not None:
-                tool_calls.append(block)
-        else:
-            pass
-    return "".join(content_parts)
-
-
-BlockToContentCallback: TypeAlias = Callable[
-    [list[ContentBlock], Optional[list[ToolCallBlock]]], str
-]
-
-ResponseGenerator: TypeAlias = Callable[[Sequence[ChatMessage]], ChatMessage]
-
-
-def _default_response_generator(messages: Sequence[ChatMessage]) -> ChatMessage:
-    """Default response generator that echoes the last message's content."""
-    if not messages:
-        return ChatMessage(role="assistant", content="<empty>")
-
-    tool_calls: List[ToolCallBlock] = []
-    content = _default_blocks_to_content_callback(messages[-1].blocks, tool_calls)
-    if not content:
-        content = "<empty>"
-    return ChatMessage(role="assistant", content=content)
-
-
-class MockFunctionCallingLLM(FunctionCallingLLM):
-    tool_calls: List[ToolCallBlock] = Field(default_factory=list)
-    blocks_to_content_callback: BlockToContentCallback = Field(
-        default=_default_blocks_to_content_callback
-    )
-
-    _response_generator: Optional[ResponseGenerator] = PrivateAttr(default=None)
-
-    def __init__(
-        self,
-        callback_manager: Optional[CallbackManager] = None,
-        system_prompt: Optional[str] = None,
-        messages_to_prompt: Optional[MessagesToPromptType] = None,
-        completion_to_prompt: Optional[CompletionToPromptType] = None,
-        pydantic_program_mode: PydanticProgramMode = PydanticProgramMode.DEFAULT,
-        blocks_to_content_callback: Optional[BlockToContentCallback] = None,
-        response_generator: Optional[ResponseGenerator] = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(
-            callback_manager=callback_manager or CallbackManager([]),
-            system_prompt=system_prompt,
-            messages_to_prompt=messages_to_prompt,
-            completion_to_prompt=completion_to_prompt,
-            pydantic_program_mode=pydantic_program_mode,
-            **kwargs,
-        )
-
-        if blocks_to_content_callback is not None:
-            self.blocks_to_content_callback = blocks_to_content_callback
-
-        if response_generator is not None:
-            self._response_generator = response_generator
-        # else: leave as None, will use _get_response_generator() method
-
-    @classmethod
-    def class_name(cls) -> str:
-        return "MockFunctionCallingLLM"
-
-    def _get_response_generator(self) -> ResponseGenerator:
-        """Get the active response generator, using default if none set."""
-        if self._response_generator is not None:
-            return self._response_generator
-
-        # Return a default generator that uses instance's blocks_to_content_callback
-        def default_generator(messages: Sequence[ChatMessage]) -> ChatMessage:
-            if not messages:
-                return ChatMessage(role="assistant", content="<empty>")
-
-            # Pass self.tool_calls to accumulate tool call blocks
-            content = self.blocks_to_content_callback(
-                messages[-1].blocks, self.tool_calls
-            )
-            if not content:
-                content = "<empty>"
-            return ChatMessage(role="assistant", content=content)
-
-        return default_generator
+    @property
+    def metadata(self) -> MultiModalLLMMetadata:
+        return MultiModalLLMMetadata(model_name="mock-multi-modal")
 
     @property
-    def response_generator(self) -> ResponseGenerator:
-        """Get the response generator function."""
-        return self._get_response_generator()
+    def last_messages_received(self) -> List[ChatMessage]:
+        """Return the messages passed to the most recent chat/achat call."""
+        return self._last_messages
 
-    @response_generator.setter
-    def response_generator(self, value: ResponseGenerator) -> None:
-        """Set the response generator function."""
-        self._response_generator = value
-
-    @property
-    def metadata(self) -> LLMMetadata:
-        return LLMMetadata(is_function_calling_model=True)
-
-    @llm_completion_callback()
     def complete(
-        self, prompt: str, formatted: bool = False, **kwargs: Any
+        self,
+        prompt: str,
+        image_documents: List[Union[ImageNode, ImageBlock]],
+        **kwargs: Any,
     ) -> CompletionResponse:
-        return CompletionResponse(text=prompt)
+        return CompletionResponse(text="mock response")
 
-    @llm_completion_callback()
     def stream_complete(
-        self, prompt: str, formatted: bool = False, **kwargs: Any
+        self,
+        prompt: str,
+        image_documents: List[Union[ImageNode, ImageBlock]],
+        **kwargs: Any,
     ) -> CompletionResponseGen:
-        def gen() -> CompletionResponseGen:
-            yield CompletionResponse(text=prompt, delta=prompt)
+        yield CompletionResponse(text="mock response", delta="mock response")
 
-        return gen()
-
-    @llm_completion_callback()
-    async def acomplete(
-        self, prompt: str, formatted: bool = False, **kwargs: Any
-    ) -> CompletionResponse:
-        return CompletionResponse(text=prompt)
-
-    @llm_completion_callback()
-    async def astream_complete(
-        self, prompt: str, formatted: bool = False, **kwargs: Any
-    ) -> CompletionResponseAsyncGen:
-        async def gen() -> AsyncGenerator[CompletionResponse, None]:
-            yield CompletionResponse(text=prompt, delta=prompt)
-
-        return gen()
-
-    @llm_chat_callback()
-    def stream_chat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponseGen:
-        response_msg = self._get_response_generator()(messages)
-        content = response_msg.content or ""
-
-        def _gen() -> Generator[ChatResponse, None, None]:
-            yield ChatResponse(
-                message=response_msg,
-                delta=content,
-                raw={"content": content},
-            )
-
-        return _gen()
-
-    @llm_chat_callback()
-    async def astream_chat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponseAsyncGen:
-        response_msg = self._get_response_generator()(messages)
-        content = response_msg.content or ""
-
-        async def _gen() -> AsyncGenerator[ChatResponse, None]:
-            yield ChatResponse(
-                message=response_msg,
-                delta=content,
-                raw={"content": content},
-            )
-
-        return _gen()
-
-    @llm_chat_callback()
-    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
-        response_msg = self._get_response_generator()(messages)
-        content = response_msg.content or ""
+    def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        **kwargs: Any,
+    ) -> ChatResponse:
+        self._last_messages = list(messages)
         return ChatResponse(
-            message=response_msg,
-            delta=content,
-            raw={"content": content},
+            message=ChatMessage(
+                content="mock multi-modal response", role=MessageRole.ASSISTANT
+            )
         )
 
-    @llm_chat_callback()
-    async def achat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponse:
-        return self.chat(messages=messages)
-
-    def _prepare_chat_with_tools(
+    def stream_chat(
         self,
-        tools: Sequence["BaseTool"],
-        user_msg: Optional[Union[str, ChatMessage]] = None,
-        chat_history: Optional[List[ChatMessage]] = None,
-        verbose: bool = False,
-        allow_parallel_tool_calls: bool = False,
-        tool_required: bool = False,
+        messages: Sequence[ChatMessage],
         **kwargs: Any,
-    ) -> dict:
-        """Prepare the arguments needed to let the LLM chat with tools."""
-        # Build the complete message list
-        messages = list(chat_history or [])
+    ) -> ChatResponseGen:
+        self._last_messages = list(messages)
+        delta = "mock multi-modal response"
+        yield ChatResponse(
+            message=ChatMessage(content=delta, role=MessageRole.ASSISTANT),
+            delta=delta,
+        )
 
-        # Add user message if provided
-        if user_msg:
-            if isinstance(user_msg, str):
-                messages.append(ChatMessage(role=MessageRole.USER, content=user_msg))
-            else:
-                messages.append(user_msg)
+    async def acomplete(
+        self,
+        prompt: str,
+        image_documents: List[Union[ImageNode, ImageBlock]],
+        **kwargs: Any,
+    ) -> CompletionResponse:
+        return CompletionResponse(text="mock response")
 
-        # For the mock implementation, we return the messages and tools
-        # The actual tools are not used since this is a mock
-        return {
-            "messages": messages,
-            "tools": tools,
-        }
+    async def astream_complete(
+        self,
+        prompt: str,
+        image_documents: List[Union[ImageNode, ImageBlock]],
+        **kwargs: Any,
+    ) -> CompletionResponseAsyncGen:
+        async def _gen() -> CompletionResponseAsyncGen:
+            yield CompletionResponse(text="mock response", delta="mock response")
 
-    def get_tool_calls_from_response(
-        self, response: ChatResponse, error_on_no_tool_call: bool = False, **kwargs: Any
-    ) -> List[ToolSelection]:
-        # First, check if tool calls are in additional_kwargs (for compatibility with test mocks)
-        if "tool_calls" in response.message.additional_kwargs:
-            return response.message.additional_kwargs.get("tool_calls", [])
+        return _gen()
 
-        # Otherwise, extract from blocks
-        tool_calls = [
-            block
-            for block in response.message.blocks
-            if isinstance(block, ToolCallBlock)
-        ]
-        tool_selections = []
-        for tool_call in tool_calls:
-            # this should handle both complete and partial jsons
-            try:
-                if isinstance(tool_call.tool_kwargs, str):
-                    argument_dict = parse_partial_json(tool_call.tool_kwargs)
-                else:
-                    argument_dict = tool_call.tool_kwargs
-            except (ValueError, TypeError, JSONDecodeError):
-                argument_dict = {}
-            tool_selections.append(
-                ToolSelection(
-                    tool_id=tool_call.tool_call_id or "",
-                    tool_name=tool_call.tool_name,
-                    tool_kwargs=argument_dict,
-                )
+    async def achat(
+        self,
+        messages: Sequence[ChatMessage],
+        **kwargs: Any,
+    ) -> ChatResponse:
+        self._last_messages = list(messages)
+        return ChatResponse(
+            message=ChatMessage(
+                content="mock multi-modal response", role=MessageRole.ASSISTANT
             )
-        return tool_selections
+        )
+
+    async def astream_chat(
+        self,
+        messages: Sequence[ChatMessage],
+        **kwargs: Any,
+    ) -> ChatResponseAsyncGen:
+        self._last_messages = list(messages)
+
+        async def _gen() -> ChatResponseAsyncGen:
+            delta = "mock multi-modal response"
+            yield ChatResponse(
+                message=ChatMessage(content=delta, role=MessageRole.ASSISTANT),
+                delta=delta,
+            )
+
+        return _gen()

--- a/llama-index-core/tests/chat_engine/test_multi_modal_context.py
+++ b/llama-index-core/tests/chat_engine/test_multi_modal_context.py
@@ -1,270 +1,470 @@
-import time
+"""Tests for MultiModalContextChatEngine, MockMultiModalEmbedding, and
+MockLLMWithChatMemoryOfLastCall."""
+
+from typing import List
 
 import pytest
 
-from llama_index.core import MockEmbedding
-from llama_index.core.embeddings import MockMultiModalEmbedding
-from llama_index.core.chat_engine.multi_modal_context import (
-    MultiModalContextChatEngine,
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ImageBlock,
+    MessageRole,
+    TextBlock,
 )
-from llama_index.core.indices import MultiModalVectorStoreIndex
-from llama_index.core.llms.mock import MockLLMWithChatMemoryOfLastCall
-from llama_index.core.schema import Document, ImageDocument, QueryBundle
-from llama_index.core.llms import TextBlock, ImageBlock, MessageRole
-from llama_index.core.memory import ChatMemoryBuffer
+from llama_index.core.chat_engine.multi_modal_context import MultiModalContextChatEngine
 from llama_index.core.chat_engine.types import ChatMode
+from llama_index.core.embeddings.mock_embed_model import MockMultiModalEmbedding
+from llama_index.core.llms.mock import MockLLMWithChatMemoryOfLastCall
+from llama_index.core.schema import (
+    ImageNode,
+    NodeWithScore,
+    QueryBundle,
+    TextNode,
+)
 
-SYSTEM_PROMPT = "Talk like a pirate."
+# ---------------------------------------------------------------------------
+# Minimal stub retriever
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = "You are a helpful multi-modal assistant."
+
+
+class _MockRetriever(BaseRetriever):
+    """Retriever that always returns a fixed list of nodes."""
+
+    def __init__(self, nodes: List[NodeWithScore]) -> None:
+        self._fixed_nodes = nodes
+        super().__init__()
+
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return list(self._fixed_nodes)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
-def chat_engine() -> MultiModalContextChatEngine:
-    # Base64 string for a 1×1 transparent PNG
-    base64_str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
-    img = ImageDocument(image=base64_str, metadata={"file_name": "tiny.png"})
-    embed_model_text = MockEmbedding(embed_dim=3)
-    embed_model_image = MockMultiModalEmbedding(embed_dim=3)
-    index = MultiModalVectorStoreIndex.from_documents(
-        [Document.example(), img],
-        image_embed_model=embed_model_image,
-        embed_model=embed_model_text,
-    )
-    fixture = index.as_chat_engine(
-        similarity_top_k=2,
-        image_similarity_top_k=1,
-        chat_mode=ChatMode.CONTEXT,
-        llm=MockLLMWithChatMemoryOfLastCall(),
+def mock_llm() -> MockLLMWithChatMemoryOfLastCall:
+    return MockLLMWithChatMemoryOfLastCall()
+
+
+@pytest.fixture()
+def text_nodes() -> List[NodeWithScore]:
+    return [
+        NodeWithScore(node=TextNode(text="Paris is the capital of France."), score=0.9),
+        NodeWithScore(node=TextNode(text="The Eiffel Tower is in Paris."), score=0.8),
+    ]
+
+
+@pytest.fixture()
+def image_nodes() -> List[NodeWithScore]:
+    return [
+        NodeWithScore(
+            node=ImageNode(image_url="http://example.com/eiffel.jpg"), score=0.7
+        ),
+    ]
+
+
+@pytest.fixture()
+def chat_engine(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+    text_nodes: List[NodeWithScore],
+    image_nodes: List[NodeWithScore],
+) -> MultiModalContextChatEngine:
+    retriever = _MockRetriever(text_nodes + image_nodes)
+    return MultiModalContextChatEngine.from_defaults(
+        retriever=retriever,
+        multi_modal_llm=mock_llm,
         system_prompt=SYSTEM_PROMPT,
     )
-    assert isinstance(fixture, MultiModalContextChatEngine)
-    return fixture
 
 
-def test_chat(chat_engine: MultiModalContextChatEngine):
-    response = chat_engine.chat("Hello World!")
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert len(response.source_nodes) == 2  # one image and one text
-    assert len(response.sources) == 1
-    assert response.sources[0].tool_name == "retriever"
-    assert len(response.sources[0].raw_output["image_nodes"]) == 1
-    assert len(response.sources[0].raw_output["text_nodes"]) == 1
-
-    llm = chat_engine._multi_modal_llm
-    assert len(llm.last_chat_messages) == 2  # system prompt and user message
-    assert (
-        len(llm.last_chat_messages[1].blocks) == 2
-    )  # user message consisting of text block containing text context and query and image block
-    assert (
-        isinstance(llm.last_chat_messages[1].blocks[0], ImageBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], TextBlock)
-    ) or (
-        isinstance(llm.last_chat_messages[1].blocks[0], TextBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], ImageBlock)
-    )
-    assert "chat" in llm.last_called_chat_function
-
-    response = chat_engine.chat("What is the capital of the moon?")
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert "What is the capital of the moon?" in str(response)
-    assert len(chat_engine.chat_history) == 4
-
-    chat_engine.reset()
-    q = QueryBundle("Hello World through QueryBundle")
-    response = chat_engine.chat(q)
-    assert str(q) in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert str(q) in str(chat_engine.chat_history[0])
+# ===========================================================================
+# MockMultiModalEmbedding
+# ===========================================================================
 
 
-def test_chat_stream(chat_engine: MultiModalContextChatEngine):
-    response = chat_engine.stream_chat("Hello World!")
+def test_mock_multi_modal_embedding_text() -> None:
+    emb = MockMultiModalEmbedding(embed_dim=8)
+    assert emb._get_text_embedding("hello") == [0.5] * 8
+    assert emb._get_query_embedding("query") == [0.5] * 8
 
-    num_iters = 0
-    for _ in response.response_gen:
-        num_iters += 1
 
-    assert num_iters > 10
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert len(response.source_nodes) == 2  # one image and one text
-    assert len(response.sources) == 1
-    assert response.sources[0].tool_name == "retriever"
-    assert len(response.sources[0].raw_output["image_nodes"]) == 1
-    assert len(response.sources[0].raw_output["text_nodes"]) == 1
+def test_mock_multi_modal_embedding_image() -> None:
+    emb = MockMultiModalEmbedding(embed_dim=4)
+    vec = emb._get_image_embedding("fake/path/to/image.jpg")
+    assert vec == [0.5] * 4
 
-    llm = chat_engine._multi_modal_llm
-    assert len(llm.last_chat_messages) == 2  # system prompt and user message
-    assert (
-        len(llm.last_chat_messages[1].blocks) == 2
-    )  # user message consisting of text block containing text context and query and image block
-    assert (
-        isinstance(llm.last_chat_messages[1].blocks[0], ImageBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], TextBlock)
-    ) or (
-        isinstance(llm.last_chat_messages[1].blocks[0], TextBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], ImageBlock)
-    )
-    assert "stream_chat" in llm.last_called_chat_function
 
-    response = chat_engine.stream_chat("What is the capital of the moon?")
-
-    num_iters = 0
-    for _ in response.response_gen:
-        num_iters += 1
-
-    assert num_iters > 10
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert "What is the capital of the moon?" in str(response)
-    assert len(chat_engine.chat_history) == 4
-
-    chat_engine.reset()
-    q = QueryBundle("Hello World through QueryBundle")
-    response = chat_engine.stream_chat(q)
-    num_iters = 0
-    for _ in response.response_gen:
-        num_iters += 1
-    assert num_iters > 10
-    assert str(q) in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert str(q) in str(chat_engine.chat_history[0])
+def test_mock_multi_modal_embedding_class_name() -> None:
+    emb = MockMultiModalEmbedding(embed_dim=2)
+    assert emb.class_name() == "MockMultiModalEmbedding"
 
 
 @pytest.mark.asyncio
-async def test_achat(chat_engine: MultiModalContextChatEngine):
-    response = await chat_engine.achat("Hello World!")
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert len(response.source_nodes) == 2  # one image and one text
-    assert len(response.sources) == 1
-    assert response.sources[0].tool_name == "retriever"
-    assert len(response.sources[0].raw_output["image_nodes"]) == 1
-    assert len(response.sources[0].raw_output["text_nodes"]) == 1
+async def test_mock_multi_modal_embedding_async() -> None:
+    emb = MockMultiModalEmbedding(embed_dim=3)
+    assert await emb._aget_text_embedding("hello") == [0.5] * 3
+    assert await emb._aget_query_embedding("q") == [0.5] * 3
+    assert await emb._aget_image_embedding("fake.png") == [0.5] * 3
 
-    llm = chat_engine._multi_modal_llm
-    assert len(llm.last_chat_messages) == 2  # system prompt and user message
-    assert (
-        len(llm.last_chat_messages[1].blocks) == 2
-    )  # user message consisting of text block containing text context and query and image block
-    assert (
-        isinstance(llm.last_chat_messages[1].blocks[0], ImageBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], TextBlock)
-    ) or (
-        isinstance(llm.last_chat_messages[1].blocks[0], TextBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], ImageBlock)
-    )
-    assert "achat" in llm.last_called_chat_function
 
-    response = await chat_engine.achat("What is the capital of the moon?")
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert "What is the capital of the moon?" in str(response)
-    assert len(chat_engine.chat_history) == 4
+# ===========================================================================
+# MockLLMWithChatMemoryOfLastCall
+# ===========================================================================
 
-    chat_engine.reset()
-    q = QueryBundle("Hello World through QueryBundle")
-    response = await chat_engine.achat(q)
-    assert str(q) in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert str(q) in str(chat_engine.chat_history[0])
+
+def test_mock_llm_metadata(mock_llm: MockLLMWithChatMemoryOfLastCall) -> None:
+    assert mock_llm.metadata.model_name == "mock-multi-modal"
+    assert mock_llm.class_name() == "MockLLMWithChatMemoryOfLastCall"
+
+
+def test_mock_llm_chat_records_messages(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    msgs = [ChatMessage(content="hello", role=MessageRole.USER)]
+    response = mock_llm.chat(msgs)
+    assert mock_llm.last_messages_received == msgs
+    assert response.message.content == "mock multi-modal response"
+
+
+def test_mock_llm_chat_overwrites_previous_messages(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    msgs1 = [ChatMessage(content="first", role=MessageRole.USER)]
+    msgs2 = [ChatMessage(content="second", role=MessageRole.USER)]
+    mock_llm.chat(msgs1)
+    mock_llm.chat(msgs2)
+    assert mock_llm.last_messages_received == msgs2
+
+
+def test_mock_llm_stream_chat_records_messages_after_consumption(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    msgs = [ChatMessage(content="stream test", role=MessageRole.USER)]
+    # stream_chat is a generator function; body runs on first next()
+    chunks = list(mock_llm.stream_chat(msgs))
+    assert mock_llm.last_messages_received == msgs
+    assert len(chunks) == 1
+    assert chunks[0].delta == "mock multi-modal response"
 
 
 @pytest.mark.asyncio
-async def test_chat_astream(chat_engine: MultiModalContextChatEngine):
-    response = await chat_engine.astream_chat("Hello World!")
-
-    num_iters = 0
-    async for _ in response.async_response_gen():
-        num_iters += 1
-
-    assert num_iters > 10
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert len(response.source_nodes) == 2  # one image and one text
-    assert len(response.sources) == 1
-    assert response.sources[0].tool_name == "retriever"
-    assert len(response.sources[0].raw_output["image_nodes"]) == 1
-    assert len(response.sources[0].raw_output["text_nodes"]) == 1
-
-    llm = chat_engine._multi_modal_llm
-    assert len(llm.last_chat_messages) == 2  # system prompt and user message
-    assert (
-        len(llm.last_chat_messages[1].blocks) == 2
-    )  # user message consisting of text block containing text context and query and image block
-    assert (
-        isinstance(llm.last_chat_messages[1].blocks[0], ImageBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], TextBlock)
-    ) or (
-        isinstance(llm.last_chat_messages[1].blocks[0], TextBlock)
-        and isinstance(llm.last_chat_messages[1].blocks[1], ImageBlock)
-    )
-    assert "astream_chat" in llm.last_called_chat_function
-
-    response = await chat_engine.astream_chat("What is the capital of the moon?")
-
-    num_iters = 0
-    async for _ in response.async_response_gen():
-        num_iters += 1
-
-    assert num_iters > 10
-    assert SYSTEM_PROMPT in str(response)
-    assert "Hello World!" in str(response)
-    assert "What is the capital of the moon?" in str(response)
-    assert len(chat_engine.chat_history) == 4
-
-    chat_engine.reset()
-    q = QueryBundle("Hello World through QueryBundle")
-    response = await chat_engine.astream_chat(q)
-    num_iters = 0
-    async for _ in response.async_response_gen():
-        num_iters += 1
-    assert num_iters > 10
-    assert str(q) in str(response)
-    assert len(chat_engine.chat_history) == 2
-    assert str(q) in str(chat_engine.chat_history[0])
+async def test_mock_llm_achat_records_messages(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    msgs = [ChatMessage(content="async hello", role=MessageRole.USER)]
+    response = await mock_llm.achat(msgs)
+    assert mock_llm.last_messages_received == msgs
+    assert response.message.content == "mock multi-modal response"
 
 
-def test_stream_chat_memory_not_lost_on_incomplete_consumption(
+@pytest.mark.asyncio
+async def test_mock_llm_astream_chat_records_messages(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    msgs = [ChatMessage(content="async stream", role=MessageRole.USER)]
+    stream = await mock_llm.astream_chat(msgs)
+    # messages are captured when astream_chat is awaited (not a generator func)
+    assert mock_llm.last_messages_received == msgs
+    chunks = [chunk async for chunk in stream]
+    assert len(chunks) == 1
+    assert chunks[0].delta == "mock multi-modal response"
+
+
+# ===========================================================================
+# MultiModalContextChatEngine — chat()
+# ===========================================================================
+
+
+def test_chat_returns_response(
     chat_engine: MultiModalContextChatEngine,
-):
-    # Use ChatMemoryBuffer to avoid per-event-loop aiosqlite isolation
-    # when the background thread writes memory.
-    chat_engine._memory = ChatMemoryBuffer.from_defaults()
-    response = chat_engine.stream_chat("Hello World!")
-    assert len(chat_engine.chat_history) >= 1
-    assert chat_engine.chat_history[0].role == MessageRole.USER
-    assert "Hello World!" in str(chat_engine.chat_history[0].content)
-    for i, _ in enumerate(response.response_gen):
-        if i >= 2:
-            break
-    deadline = time.time() + 2.0
-    while not response.is_done and time.time() < deadline:
-        time.sleep(0.01)
-    assert response.is_done
+) -> None:
+    response = chat_engine.chat("What is in the image?")
+    assert response.response == "mock multi-modal response"
     assert len(chat_engine.chat_history) == 2
-    assert chat_engine.chat_history[1].role == MessageRole.ASSISTANT
+
+
+def test_chat_message_contains_text_block_with_context(
+    chat_engine: MultiModalContextChatEngine,
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    chat_engine.chat("Describe what you see.")
+    user_msg = mock_llm.last_messages_received[-1]
+    text_blocks = [b for b in user_msg.blocks if isinstance(b, TextBlock)]
+    assert len(text_blocks) == 1
+    combined = text_blocks[0].text
+    assert "Paris is the capital of France." in combined
+    assert "Describe what you see." in combined
+
+
+def test_chat_message_contains_image_block(
+    chat_engine: MultiModalContextChatEngine,
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    chat_engine.chat("What is shown?")
+    user_msg = mock_llm.last_messages_received[-1]
+    image_blocks = [b for b in user_msg.blocks if isinstance(b, ImageBlock)]
+    assert len(image_blocks) == 1
+    assert "eiffel.jpg" in str(image_blocks[0].url)
+
+
+def test_chat_prefix_system_message_is_first(
+    chat_engine: MultiModalContextChatEngine,
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    chat_engine.chat("Hello")
+    messages = mock_llm.last_messages_received
+    assert messages[0].role == MessageRole.SYSTEM
+    assert messages[0].content == SYSTEM_PROMPT
+
+
+def test_chat_history_grows_across_turns(
+    chat_engine: MultiModalContextChatEngine,
+) -> None:
+    chat_engine.chat("First question")
+    assert len(chat_engine.chat_history) == 2
+    chat_engine.chat("Second question")
+    assert len(chat_engine.chat_history) == 4
+
+
+def test_reset_clears_history(chat_engine: MultiModalContextChatEngine) -> None:
+    chat_engine.chat("Something")
+    assert len(chat_engine.chat_history) == 2
+    chat_engine.reset()
+    assert len(chat_engine.chat_history) == 0
+
+
+def test_chat_with_explicit_history_overrides_memory(
+    chat_engine: MultiModalContextChatEngine,
+) -> None:
+    explicit_history = [
+        ChatMessage(content="Earlier question", role=MessageRole.USER),
+        ChatMessage(content="Earlier answer", role=MessageRole.ASSISTANT),
+    ]
+    chat_engine.chat("New question", chat_history=explicit_history)
+    # 2 explicit prior + 2 new from this turn
+    assert len(chat_engine.chat_history) == 4
+
+
+def test_chat_text_only_no_image_blocks(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    """When the retriever returns no image nodes, no ImageBlocks appear."""
+    retriever = _MockRetriever(
+        [NodeWithScore(node=TextNode(text="Some text."), score=1.0)]
+    )
+    engine = MultiModalContextChatEngine.from_defaults(
+        retriever=retriever,
+        multi_modal_llm=mock_llm,
+    )
+    engine.chat("Tell me about the text.")
+    user_msg = mock_llm.last_messages_received[-1]
+    image_blocks = [b for b in user_msg.blocks if isinstance(b, ImageBlock)]
+    assert len(image_blocks) == 0
+
+
+def test_from_defaults_raises_without_multimodal_llm() -> None:
+    """from_defaults raises ValueError when given a plain LLM."""
+    from llama_index.core.llms.mock import MockLLM
+
+    retriever = _MockRetriever([])
+    with pytest.raises(ValueError, match="MultiModalLLM"):
+        MultiModalContextChatEngine.from_defaults(
+            retriever=retriever,
+            multi_modal_llm=MockLLM(),  # type: ignore[arg-type]
+        )
+
+
+def test_from_defaults_raises_with_both_system_prompt_and_prefix_messages(
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    retriever = _MockRetriever([])
+    with pytest.raises(ValueError, match="system_prompt"):
+        MultiModalContextChatEngine.from_defaults(
+            retriever=retriever,
+            multi_modal_llm=mock_llm,
+            system_prompt="sys",
+            prefix_messages=[ChatMessage(content="x", role=MessageRole.SYSTEM)],
+        )
+
+
+# ===========================================================================
+# MultiModalContextChatEngine — stream_chat()
+# ===========================================================================
+
+
+def test_stream_chat_yields_delta(chat_engine: MultiModalContextChatEngine) -> None:
+    response = chat_engine.stream_chat("Describe this.")
+    tokens = list(response.response_gen)
+    assert tokens == ["mock multi-modal response"]
+
+
+def test_stream_chat_updates_history_after_consumption(
+    chat_engine: MultiModalContextChatEngine,
+) -> None:
+    response = chat_engine.stream_chat("Stream question")
+    list(response.response_gen)  # consume to trigger memory write
+    assert len(chat_engine.chat_history) == 2
+
+
+def test_stream_chat_records_messages_after_consumption(
+    chat_engine: MultiModalContextChatEngine,
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    response = chat_engine.stream_chat("Stream this.")
+    list(response.response_gen)  # generator body executes on consumption
+    user_msg = mock_llm.last_messages_received[-1]
+    text_blocks = [b for b in user_msg.blocks if isinstance(b, TextBlock)]
+    assert len(text_blocks) == 1
+    assert "Stream this." in text_blocks[0].text
+
+
+def test_stream_chat_contains_image_block_after_consumption(
+    chat_engine: MultiModalContextChatEngine,
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    response = chat_engine.stream_chat("Stream image.")
+    list(response.response_gen)
+    user_msg = mock_llm.last_messages_received[-1]
+    image_blocks = [b for b in user_msg.blocks if isinstance(b, ImageBlock)]
+    assert len(image_blocks) == 1
+
+
+# ===========================================================================
+# MultiModalContextChatEngine — achat()
+# ===========================================================================
 
 
 @pytest.mark.asyncio
-async def test_astream_chat_memory_not_lost_on_incomplete_consumption(
+async def test_achat_returns_response(
     chat_engine: MultiModalContextChatEngine,
-):
-    response = await chat_engine.astream_chat("Hello World!")
-    assert len(chat_engine.chat_history) == 1
-    assert chat_engine.chat_history[0].role == MessageRole.USER
-    assert "Hello World!" in str(chat_engine.chat_history[0].content)
-    i = 0
-    async for _ in response.async_response_gen():
-        i += 1
-        if i >= 2:
-            break
-    assert response.awrite_response_to_history_task is not None
-    await response.awrite_response_to_history_task
+) -> None:
+    response = await chat_engine.achat("Async question")
+    assert response.response == "mock multi-modal response"
     assert len(chat_engine.chat_history) == 2
-    assert chat_engine.chat_history[1].role == MessageRole.ASSISTANT
+
+
+@pytest.mark.asyncio
+async def test_achat_message_has_text_and_image_blocks(
+    chat_engine: MultiModalContextChatEngine,
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    await chat_engine.achat("Async describe")
+    user_msg = mock_llm.last_messages_received[-1]
+    text_blocks = [b for b in user_msg.blocks if isinstance(b, TextBlock)]
+    image_blocks = [b for b in user_msg.blocks if isinstance(b, ImageBlock)]
+    assert len(text_blocks) == 1
+    assert len(image_blocks) == 1
+    assert "Async describe" in text_blocks[0].text
+
+
+@pytest.mark.asyncio
+async def test_achat_history_grows(chat_engine: MultiModalContextChatEngine) -> None:
+    await chat_engine.achat("First async")
+    assert len(chat_engine.chat_history) == 2
+    await chat_engine.achat("Second async")
+    assert len(chat_engine.chat_history) == 4
+
+
+# ===========================================================================
+# MultiModalContextChatEngine — astream_chat()
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_yields_delta(
+    chat_engine: MultiModalContextChatEngine,
+) -> None:
+    response = await chat_engine.astream_chat("Async stream question")
+    tokens = [tok async for tok in response.async_response_gen()]
+    assert tokens == ["mock multi-modal response"]
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_updates_history_after_consumption(
+    chat_engine: MultiModalContextChatEngine,
+) -> None:
+    response = await chat_engine.astream_chat("Async stream")
+    async for _ in response.async_response_gen():
+        pass
+    assert len(chat_engine.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_messages_captured_before_consumption(
+    chat_engine: MultiModalContextChatEngine,
+    mock_llm: MockLLMWithChatMemoryOfLastCall,
+) -> None:
+    # astream_chat is a regular async def (not a generator func), so messages
+    # are stored when the coroutine is awaited, before consuming the stream.
+    await chat_engine.astream_chat("Async stream before consume")
+    assert len(mock_llm.last_messages_received) > 0
+    user_msg = mock_llm.last_messages_received[-1]
+    # blocks[0] is always the TextBlock (context + question)
+    text_blocks = [b for b in user_msg.blocks if isinstance(b, TextBlock)]
+    assert len(text_blocks) == 1
+    assert "Async stream before consume" in text_blocks[0].text
+
+
+# ===========================================================================
+# MultiModalVectorStoreIndex.as_chat_engine() wiring
+# ===========================================================================
+
+
+def test_as_chat_engine_context_mode_returns_multimodal_engine() -> None:
+    """as_chat_engine(ChatMode.CONTEXT) returns a MultiModalContextChatEngine."""
+    from llama_index.core.indices.multi_modal import MultiModalVectorStoreIndex
+
+    mm_llm = MockLLMWithChatMemoryOfLastCall()
+    mm_embed = MockMultiModalEmbedding(embed_dim=3)
+    index = MultiModalVectorStoreIndex(
+        nodes=[],
+        embed_model=mm_embed,
+        image_embed_model=mm_embed,
+    )
+    engine = index.as_chat_engine(
+        chat_mode=ChatMode.CONTEXT,
+        multi_modal_llm=mm_llm,
+    )
+    assert isinstance(engine, MultiModalContextChatEngine)
+
+
+def test_as_chat_engine_context_mode_raises_with_plain_llm() -> None:
+    """as_chat_engine(ChatMode.CONTEXT) raises ValueError for a plain text LLM."""
+    from llama_index.core.indices.multi_modal import MultiModalVectorStoreIndex
+    from llama_index.core.llms.mock import MockLLM
+
+    mm_embed = MockMultiModalEmbedding(embed_dim=3)
+    index = MultiModalVectorStoreIndex(
+        nodes=[],
+        embed_model=mm_embed,
+        image_embed_model=mm_embed,
+    )
+    with pytest.raises(ValueError, match="MultiModalLLM"):
+        index.as_chat_engine(
+            chat_mode=ChatMode.CONTEXT,
+            llm=MockLLM(),
+        )
+
+
+def test_as_chat_engine_context_llm_param_accepts_multimodal_llm() -> None:
+    """Passing a MultiModalLLM via the llm= kwarg also works."""
+    from llama_index.core.indices.multi_modal import MultiModalVectorStoreIndex
+
+    mm_llm = MockLLMWithChatMemoryOfLastCall()
+    mm_embed = MockMultiModalEmbedding(embed_dim=3)
+    index = MultiModalVectorStoreIndex(
+        nodes=[],
+        embed_model=mm_embed,
+        image_embed_model=mm_embed,
+    )
+    # Passing via llm= should also work if it's a MultiModalLLM instance
+    engine = index.as_chat_engine(
+        chat_mode=ChatMode.CONTEXT,
+        llm=mm_llm,
+    )
+    assert isinstance(engine, MultiModalContextChatEngine)


### PR DESCRIPTION
## Description

This PR adds multimodal context chat support for `MultiModalVectorStoreIndex` by introducing a dedicated chat engine and wiring it into `as_chat_engine(ChatMode.CONTEXT)`.

### What changed

- Added `MultiModalContextChatEngine` in `llama-index-core/llama_index/core/chat_engine/multi_modal_context.py`
  - retrieves both text and image nodes
  - builds multimodal chat messages with `TextBlock` and `ImageBlock`
  - sends messages to `MultiModalLLM`
  - supports sync/async + streaming variants
- Wired `MultiModalVectorStoreIndex.as_chat_engine()` to return `MultiModalContextChatEngine` for `ChatMode.CONTEXT`
- Added `MockMultiModalEmbedding` in `llama-index-core/llama_index/core/embeddings/mock_embed_model.py`
- Added `MockLLMWithChatMemoryOfLastCall` in `llama-index-core/llama_index/core/llms/mock.py`
- Exported `MockMultiModalEmbedding` from:
  - `llama-index-core/llama_index/core/embeddings/__init__.py`
  - `llama-index-core/llama_index/core/__init__.py`
- Added compatibility shim in `llama-index-core/llama_index/core/chat_engine/multi_modal.py`
- Added tests in `llama-index-core/tests/chat_engine/test_multi_modal_context.py`

### Motivation / context

`MultiModalVectorStoreIndex` previously fell back to base behavior for `as_chat_engine()`, which did not provide multimodal `ChatMode.CONTEXT` support. This change enables context chat with text+image retrieval and multimodal LLM message construction.

Fixes # (issue)

## New Package?

No

## Version Bump?

No (`llama-index-core` only)

## Type of Change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added new unit tests in `llama-index-core/tests/chat_engine/test_multi_modal_context.py`
- Ran:
  - `pytest llama-index-core/tests/chat_engine/test_multi_modal_context.py -v`

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods