### PR TITLE
docs(observability): add Respan integration

### DIFF
--- a/docs/src/content/docs/framework/module_guides/observability/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/index.md
@@ -726,7 +726,6 @@ export OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
 Initialize Respan with the LlamaIndex instrumentor and run your application as usual:
 
 ```python
-import os
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -796,6 +795,8 @@ respan.flush()
 Respan also provides an [AI gateway](https://respan.ai/docs/integrations/llama-index) that lets you route LLM calls through an OpenAI-compatible endpoint. You can use it with LlamaIndex by pointing the `api_base` to Respan:
 
 ```python
+import os
+
 from llama_index.llms.openai import OpenAI
 
 llm = OpenAI(


### PR DESCRIPTION
## Summary

- Adds [Respan](https://respan.ai) to the observability integrations page alongside existing providers (Langfuse, MLflow, W&B Weave, etc.)
- Covers tracing via OpenInference instrumentation with `respan-ai` package
- Includes structured tracing with `@workflow`/`@task` decorators and `propagate_attributes` context manager
- Documents gateway-based LLM routing through Respan's OpenAI-compatible endpoint

## Test plan

- [x] Verify the docs page renders correctly (markdown formatting, code blocks, links)
- [x] Confirm all external links resolve (respan.ai docs pages)
- [x] Validate code examples match Respan's current SDK API

🤖 Generated with [Claude Code](https://claude.com/claude-code)