### PR TITLE
feat: introduce service_tier as a param for models.generate_content and chats.create in google-genai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -1,34 +1,36 @@
 """Google's hosted Gemini API."""
 
 import asyncio
-import inspect
 import functools
+import inspect
 import os
-from importlib.metadata import PackageNotFoundError, version
 import typing
+from importlib.metadata import PackageNotFoundError, version
 from typing import (
     TYPE_CHECKING,
-    cast,
     Any,
     AsyncGenerator,
+    Callable,
     Dict,
     Generator,
     List,
+    Literal,
     Optional,
     Sequence,
     Type,
     Union,
-    Callable,
-    Literal,
+    cast,
 )
 
-
+import google.auth
+import google.genai
+import google.genai.types as types
 import llama_index.core.instrumentation as instrument
 from llama_index.core.base.llms.generic_utils import (
-    chat_to_completion_decorator,
     achat_to_completion_decorator,
-    stream_chat_to_completion_decorator,
     astream_chat_to_completion_decorator,
+    chat_to_completion_decorator,
+    stream_chat_to_completion_decorator,
 )
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -44,27 +46,23 @@ from llama_index.core.base.llms.types import (
 )
 from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
-from llama_index.core.constants import DEFAULT_TEMPERATURE, DEFAULT_NUM_OUTPUTS
+from llama_index.core.constants import DEFAULT_NUM_OUTPUTS, DEFAULT_TEMPERATURE
 from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
 from llama_index.core.llms.function_calling import FunctionCallingLLM
-from llama_index.core.llms.llm import ToolSelection, Model
-from llama_index.core.prompts import PromptTemplate
+from llama_index.core.llms.llm import Model, ToolSelection
 from llama_index.core.program.utils import FlexibleModel, create_flexible_model
+from llama_index.core.prompts import PromptTemplate
 from llama_index.core.types import PydanticProgramMode
 from llama_index.llms.google_genai.utils import (
+    adelete_uploaded_files,
     chat_from_gemini_response,
     chat_message_to_gemini,
     convert_schema_to_function_declaration,
-    prepare_chat_params,
-    handle_streaming_flexible_model,
     create_retry_decorator,
-    adelete_uploaded_files,
     delete_uploaded_files,
+    handle_streaming_flexible_model,
+    prepare_chat_params,
 )
-
-import google.genai
-import google.auth
-import google.genai.types as types
 
 dispatcher = instrument.get_dispatcher(__name__)
 
@@ -163,6 +161,9 @@ class GoogleGenAI(FunctionCallingLLM):
         default="hybrid",
         description="Whether to use inline-only, FileAPI-only or both for handling files.",
     )
+    service_tier: Literal["flex", "standard", "priority"] = Field(
+        default="standard", description="Service tier for the Gemini API."
+    )
 
     _max_tokens: int = PrivateAttr()
     _client: google.genai.Client = PrivateAttr()
@@ -186,6 +187,7 @@ class GoogleGenAI(FunctionCallingLLM):
         cached_content: Optional[str] = None,
         built_in_tool: Optional[types.Tool] = None,
         file_mode: Literal["inline", "fileapi", "hybrid"] = "hybrid",
+        service_tier: Literal["flex", "standard", "priority"] = "standard",
         **kwargs: Any,
     ):
         if temperature is None:
@@ -258,6 +260,7 @@ class GoogleGenAI(FunctionCallingLLM):
             cached_content=cached_content,
             built_in_tool=built_in_tool,
             file_mode=file_mode,
+            service_tier=service_tier,
             **kwargs,
         )
 
@@ -352,7 +355,12 @@ class GoogleGenAI(FunctionCallingLLM):
         params = {**kwargs, "generation_config": generation_config}
         next_msg, chat_kwargs, file_api_names = asyncio.run(
             prepare_chat_params(
-                self.model, messages, self.file_mode, self._client, **params
+                self.model,
+                messages,
+                self.file_mode,
+                self._client,
+                self.service_tier,
+                **params,
             )
         )
         chat = self._client.chats.create(**chat_kwargs)
@@ -374,7 +382,12 @@ class GoogleGenAI(FunctionCallingLLM):
         }
         params = {**kwargs, "generation_config": generation_config}
         next_msg, chat_kwargs, file_api_names = await prepare_chat_params(
-            self.model, messages, self.file_mode, self._client, **params
+            self.model,
+            messages,
+            self.file_mode,
+            self._client,
+            self.service_tier,
+            **params,
         )
         chat = self._client.aio.chats.create(**chat_kwargs)
         try:
@@ -407,7 +420,12 @@ class GoogleGenAI(FunctionCallingLLM):
         params = {**kwargs, "generation_config": generation_config}
         next_msg, chat_kwargs, file_api_names = asyncio.run(
             prepare_chat_params(
-                self.model, messages, self.file_mode, self._client, **params
+                self.model,
+                messages,
+                self.file_mode,
+                self._client,
+                self.service_tier,
+                **params,
             )
         )
         chat = self._client.chats.create(**chat_kwargs)
@@ -613,6 +631,7 @@ class GoogleGenAI(FunctionCallingLLM):
     ) -> Model:
         """Structured predict."""
         llm_kwargs = llm_kwargs or {}
+        llm_kwargs.pop("service_tier")
 
         messages = prompt.format_messages(**prompt_args)
         contents_and_names = [
@@ -625,6 +644,7 @@ class GoogleGenAI(FunctionCallingLLM):
         response = self._client.models.generate_content(
             model=self.model,
             contents=contents,
+            service_tier=self.service_tier,
             **{
                 **llm_kwargs,
                 **{
@@ -679,6 +699,7 @@ class GoogleGenAI(FunctionCallingLLM):
                 model=self.model,
                 contents=contents,
                 config=generation_config,
+                service_tier=self.service_tier,
             )
 
             if self.file_mode in ("fileapi", "hybrid"):
@@ -730,6 +751,7 @@ class GoogleGenAI(FunctionCallingLLM):
                 model=self.model,
                 contents=contents,
                 config=generation_config,
+                service_tier=self.service_tier,
             )
 
             if self.file_mode in ("fileapi", "hybrid"):

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -1,47 +1,45 @@
 import asyncio
 import json
 import logging
+import typing
 from collections.abc import Sequence
 from io import IOBase
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    Union,
-    Optional,
-    Type,
-    Tuple,
     List,
     Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
     cast,
 )
-import typing
 
-import google.genai.types as types
 import google.genai
+import google.genai.types as types
 import httpx
-from google.genai import _transformers, Client
-from google.genai import errors
-
-from llama_index.core.bridge.pydantic import BaseModel, ValidationError
+from google.genai import Client, _transformers, errors
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
+    ContentBlock,
+    DocumentBlock,
     ImageBlock,
     MessageRole,
     TextBlock,
-    DocumentBlock,
-    VideoBlock,
     ThinkingBlock,
     ToolCallBlock,
-    ContentBlock,
+    VideoBlock,
 )
+from llama_index.core.bridge.pydantic import BaseModel, ValidationError
 from llama_index.core.program.utils import _repair_incomplete_json
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_exception_type,
     retry_if_exception,
+    retry_if_exception_type,
     stop_after_attempt,
     stop_after_delay,
     wait_exponential,
@@ -129,9 +127,11 @@ def _error_if_finished_early(candidate: types.Candidate) -> None:
             if finish_reason == types.FinishReason.SAFETY and candidate.safety_ratings:
                 relevant_safety = list(
                     filter(
-                        lambda sr: sr.probability
-                        and sr.probability.value
-                        > types.HarmProbability.NEGLIGIBLE.value,
+                        lambda sr: (
+                            sr.probability
+                            and sr.probability.value
+                            > types.HarmProbability.NEGLIGIBLE.value
+                        ),
                         candidate.safety_ratings,
                     )
                 )
@@ -476,6 +476,7 @@ class ChatParams(typing.TypedDict):
     model: str
     history: list[types.Content]
     config: types.GenerateContentConfig
+    service_tier: Literal["priority", "standard", "flex"]
 
 
 async def prepare_chat_params(
@@ -483,6 +484,7 @@ async def prepare_chat_params(
     messages: Sequence[ChatMessage],
     file_mode: Literal["inline", "fileapi", "hybrid"] = "hybrid",
     client: Optional[Client] = None,
+    service_tier: Literal["priority", "standard", "flex"] = "standard",
     **kwargs: Any,
 ) -> tuple[types.Content, ChatParams, list[str]]:
     """
@@ -583,6 +585,7 @@ async def prepare_chat_params(
             config["tools"] = tools
 
     chat_kwargs["config"] = types.GenerateContentConfig(**config)
+    chat_kwargs["service_tier"] = service_tier
 
     return next_msg, chat_kwargs, file_api_names
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.0"
+version = "0.9.1"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
Add a `service_tier` constructor arg and propagate it to chats.create and models.generate_content
