### PR TITLE
fix(core): catch ValueError/TypeError in Refine structured output handling

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -246,7 +246,7 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
                         f"Validation error on structured response: {e}", exc_info=True
                     )
@@ -326,7 +326,7 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
                         f"Validation error on structured response: {e}", exc_info=True
                     )
@@ -435,7 +435,7 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
                         f"Validation error on structured response: {e}", exc_info=True
                     )
@@ -494,7 +494,7 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
                         f"Validation error on structured response: {e}", exc_info=True
                     )


### PR DESCRIPTION
## Description

The `Refine` response synthesizer only catches `ValidationError` when structured output programs fail. After #21036 introduced explicit `ValueError` and `TypeError` raises in the function-calling structured output path, these uncaught exceptions cause queries to crash instead of falling through to the existing warning + fallback behavior.

This expands the exception handling in all four response methods (`_give_response_single`, `_refine_response_single`, `_agive_response_single`, `_arefine_response_single`) to catch `ValueError` and `TypeError` alongside `ValidationError`, matching the graceful degradation pattern already in place.

Related issues: #19926, #19044

Fixes #21089

## Testing

Verified with the exact reproduction script from the issue:

```python
from unittest.mock import patch
from pydantic import BaseModel, Field
from llama_index.core import SummaryIndex, Document
from llama_index.core.response_synthesizers import Refine
from llama_index.core.program.function_program import FunctionCallingProgram
from llama_index.llms.openai import OpenAI

class Answer(BaseModel):
    response: str = Field(description="Answer to the question")
    confidence: float = Field(description="Confidence score between 0 and 1")

docs = [Document(text="Paris is the capital of France.")]
index = SummaryIndex.from_documents(docs)
query_engine = index.as_query_engine(
    response_synthesizer=Refine(llm=OpenAI(api_key="sk-fake"), output_cls=Answer)
)

with patch.object(FunctionCallingProgram, "__call__", side_effect=ValueError("LLM did not return any tool calls")):
    response = query_engine.query("What is the capital of France?")

print(response)  # "Empty Response" instead of crash
```

Before the fix: `ValueError: LLM did not return any tool calls` propagates and crashes.
After the fix: warning is logged and the query returns `"Empty Response"` gracefully.