### PR TITLE
fix(security): block numpy.memmap in safe_eval/safe_exec sandbox

### DIFF
--- a/llama-index-experimental/llama_index/experimental/exec_utils.py
+++ b/llama-index-experimental/llama_index/experimental/exec_utils.py
@@ -78,9 +78,14 @@ _DANGEROUS_ATTR_CALLS = frozenset(
         "genfromtxt",
         "fromfile",
         "tofile",
+        "memmap",
+        "open",
         # general dangerous calls
         "system",
         "popen",
+        "subprocess",
+        "exec",
+        "eval",
     }
 )
 

--- a/llama-index-experimental/tests/test_exec_utils.py
+++ b/llama-index-experimental/tests/test_exec_utils.py
@@ -77,8 +77,10 @@ def test_blocks_pandas_io(code: str) -> None:
         'np.genfromtxt("data.csv")',
         'np.fromfile("raw.bin")',
         'arr.tofile("out.bin")',
+        "np.memmap('/etc/passwd', dtype='uint8', mode='r')",
+        "bytes(np.memmap('/etc/passwd', dtype='uint8', mode='r')[:1000])",
     ],
-    ids=["load", "save", "loadtxt", "savetxt", "genfromtxt", "fromfile", "tofile"],
+    ids=["load", "save", "loadtxt", "savetxt", "genfromtxt", "fromfile", "tofile", "memmap", "memmap_bytes"],
 )
 def test_blocks_numpy_io(code: str) -> None:
     assert _contains_protected_access(code)


### PR DESCRIPTION
## Summary

The `_DANGEROUS_ATTR_CALLS` blocklist in `exec_utils.py` blocks `np.load`, `np.fromfile`, and other numpy I/O methods but misses `np.memmap`. Since numpy is explicitly available in the PandasQueryEngine and PolarsQueryEngine sandbox via `global_vars={"np": np}`, this allows reading arbitrary files on the host filesystem.

## Changes

- Added `memmap` and `open` to `_DANGEROUS_ATTR_CALLS` in `exec_utils.py`
- Added `subprocess`, `exec`, `eval` as additional hardening
- Added test cases for `np.memmap` blocking in `test_exec_utils.py`

## Testing

- Existing tests pass (all previously blocked I/O methods still blocked)
- New test verifies `np.memmap('/etc/passwd', dtype='uint8', mode='r')` is blocked
- New test verifies `bytes(np.memmap(...))` wrapper pattern is also blocked
- Verified safe DataFrame operations remain unaffected

## Checklist
- [x] Tests pass locally
- [x] No breaking changes
- [x] DCO signed