### PR TITLE
fix(core): use async query generation in `QueryFusionRetriever._aretrieve`

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -80,6 +80,19 @@ class QueryFusionRetriever(BaseRetriever):
                 PromptTemplate, prompts["query_gen_prompt"]
             ).template
 
+    async def _aget_queries(self, original_query: str) -> List[QueryBundle]:
+        prompt_str = self.query_gen_prompt.format(
+            num_queries=self.num_queries - 1,
+            query=original_query,
+        )
+        response = await self._llm.acomplete(prompt_str)
+        queries = response.text.strip("`").split("\n")
+        queries = [q.strip() for q in queries if q.strip()]
+        if self._verbose:
+            queries_str = "\n".join(queries)
+            print(f"Generated queries:\n{queries_str}")
+        return [QueryBundle(q) for q in queries[: self.num_queries - 1]]
+
     def _get_queries(self, original_query: str) -> List[QueryBundle]:
         prompt_str = self.query_gen_prompt.format(
             num_queries=self.num_queries - 1,
@@ -286,7 +299,7 @@ class QueryFusionRetriever(BaseRetriever):
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         queries: List[QueryBundle] = [query_bundle]
         if self.num_queries > 1:
-            queries.extend(self._get_queries(query_bundle.query_str))
+            queries.extend(await self._aget_queries(query_bundle.query_str))
 
         results = await self._run_async_queries(queries)
 

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -1,0 +1,35 @@
+import pytest
+
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.base.llms.types import CompletionResponse
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.retrievers import QueryFusionRetriever
+from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
+
+
+class MockRetriever(BaseRetriever):
+    def _retrieve(self, query_bundle: QueryBundle):
+        return [NodeWithScore(node=TextNode(text="result"), score=1.0)]
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_uses_async_query_generation():
+    async_called = []
+
+    class AsyncTrackingLLM(MockLLM):
+        def complete(self, prompt: str, formatted: bool = False, **kwargs):
+            raise AssertionError("sync complete() must not be called from _aretrieve")
+
+        async def acomplete(self, prompt: str, formatted: bool = False, **kwargs):
+            async_called.append(True)
+            return CompletionResponse(text="q1\nq2\nq3")
+
+    retriever = QueryFusionRetriever(
+        retrievers=[MockRetriever()],
+        llm=AsyncTrackingLLM(),
+        num_queries=4,
+    )
+
+    await retriever.aretrieve("test query")
+
+    assert async_called


### PR DESCRIPTION
# Description

Added `_aget_queries()` using `await self._llm.acomplete()` and updated `_aretrieve` to call it instead of the blocking `_get_queries()`.

Fixes #21159

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
