### PR TITLE
fix: QueryFusionRetriever._aretrieve blocks event loop during query generation

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -86,9 +86,21 @@ class QueryFusionRetriever(BaseRetriever):
             query=original_query,
         )
         response = self._llm.complete(prompt_str)
+        return self._parse_query_response(response.text)
 
+    async def _aget_queries(self, original_query: str) -> List[QueryBundle]:
+        """Async version of _get_queries that doesn't block the event loop."""
+        prompt_str = self.query_gen_prompt.format(
+            num_queries=self.num_queries - 1,
+            query=original_query,
+        )
+        response = await self._llm.acomplete(prompt_str)
+        return self._parse_query_response(response.text)
+
+    def _parse_query_response(self, text: str) -> List[QueryBundle]:
+        """Parse LLM response text into query bundles."""
         # Strip code block and assume LLM properly put each query on a newline
-        queries = response.text.strip("`").split("\n")
+        queries = text.strip("`").split("\n")
         queries = [q.strip() for q in queries if q.strip()]
         if self._verbose:
             queries_str = "\n".join(queries)
@@ -286,7 +298,7 @@ class QueryFusionRetriever(BaseRetriever):
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         queries: List[QueryBundle] = [query_bundle]
         if self.num_queries > 1:
-            queries.extend(self._get_queries(query_bundle.query_str))
+            queries.extend(await self._aget_queries(query_bundle.query_str))
 
         results = await self._run_async_queries(queries)
 


### PR DESCRIPTION
## Description
Fix `QueryFusionRetriever._aretrieve` blocking the event loop during query generation.

## Problem
`_aretrieve()` calls the synchronous `_get_queries()`, which calls `self._llm.complete()` synchronously. When `num_queries > 1` (the default), this blocks the current event loop during query expansion and prevents other coroutines from making progress.

## Solution
- Added `_aget_queries()` that uses `await self._llm.acomplete()` instead of `self._llm.complete()`
- Updated `_aretrieve()` to `await self._aget_queries()` instead of calling `_get_queries()`
- Extracted `_parse_query_response()` to avoid code duplication between sync and async versions

## Testing
Verified syntax is valid. The async path now properly yields control during LLM calls.

Fixes #21159
