### PR TITLE
core/node_parser: add CodeSplitter.from_filename and EXTENSION_TO_LAN…

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/__init__.py
+++ b/llama-index-core/llama_index/core/node_parser/__init__.py
@@ -25,7 +25,7 @@ from llama_index.core.node_parser.relational.unstructured_element import (
 from llama_index.core.node_parser.relational.llama_parse_json_element import (
     LlamaParseJsonNodeParser,
 )
-from llama_index.core.node_parser.text.code import CodeSplitter
+from llama_index.core.node_parser.text.code import CodeSplitter, EXTENSION_TO_LANGUAGE
 from llama_index.core.node_parser.text.langchain import LangchainNodeParser
 from llama_index.core.node_parser.text.semantic_splitter import (
     SemanticSplitterNodeParser,
@@ -47,6 +47,7 @@ __all__ = [
     "TokenTextSplitter",
     "SentenceSplitter",
     "CodeSplitter",
+    "EXTENSION_TO_LANGUAGE",
     "SimpleFileNodeParser",
     "HTMLNodeParser",
     "MarkdownNodeParser",

--- a/llama-index-core/llama_index/core/node_parser/text/code.py
+++ b/llama-index-core/llama_index/core/node_parser/text/code.py
@@ -1,6 +1,7 @@
 """Code splitter."""
 
-from typing import Any, Callable, List, Literal, Optional
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks.base import CallbackManager
@@ -14,6 +15,52 @@ DEFAULT_CHUNK_LINES = 40
 DEFAULT_LINES_OVERLAP = 15
 DEFAULT_MAX_CHARS = 1500
 DEFAULT_MAX_TOKENS = 512
+
+# Mapping of file extensions to tree-sitter language names.
+# Covers the most common languages supported by tree-sitter-language-pack.
+EXTENSION_TO_LANGUAGE: Dict[str, str] = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".c": "c",
+    ".h": "c",
+    ".cpp": "cpp",
+    ".cc": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".cs": "c_sharp",
+    ".rb": "ruby",
+    ".php": "php",
+    ".swift": "swift",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".scala": "scala",
+    ".r": "r",
+    ".lua": "lua",
+    ".ex": "elixir",
+    ".exs": "elixir",
+    ".hs": "haskell",
+    ".ml": "ocaml",
+    ".sh": "bash",
+    ".bash": "bash",
+    ".zsh": "bash",
+    ".toml": "toml",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".json": "json",
+    ".html": "html",
+    ".htm": "html",
+    ".css": "css",
+    ".sql": "sql",
+    ".md": "markdown",
+    ".markdown": "markdown",
+}
 
 
 class CodeSplitter(TextSplitter):
@@ -160,6 +207,75 @@ class CodeSplitter(TextSplitter):
         )
 
     @classmethod
+    def from_filename(
+        cls,
+        filename: str,
+        chunk_lines: int = DEFAULT_CHUNK_LINES,
+        chunk_lines_overlap: int = DEFAULT_LINES_OVERLAP,
+        max_chars: int = DEFAULT_MAX_CHARS,
+        count_mode: Literal["token", "char"] = "char",
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        tokenizer: Optional[Callable] = None,
+        callback_manager: Optional[CallbackManager] = None,
+        parser: Any = None,
+    ) -> "CodeSplitter":
+        """
+        Create a CodeSplitter by inferring the language from a file extension.
+
+        This is a convenience constructor that removes the need to manually
+        specify the ``language`` parameter when the programming language can
+        be determined from the file name.
+
+        Args:
+            filename: Path or file name whose extension is used to infer the
+                programming language (e.g. ``"main.py"``, ``"/src/app.ts"``).
+            chunk_lines: The number of lines to include in each chunk.
+            chunk_lines_overlap: How many lines of code each chunk overlaps with.
+            max_chars: Maximum number of characters per chunk.
+            count_mode: Mode for counting chunk size: ``'char'`` for characters,
+                ``'token'`` for tokens.
+            max_tokens: Maximum number of tokens per chunk (used when
+                ``count_mode='token'``).
+            tokenizer: Optional tokenizer function for token-based counting.
+            callback_manager: Optional callback manager.
+            parser: Optional tree-sitter Parser object.
+
+        Returns:
+            CodeSplitter: A configured ``CodeSplitter`` instance.
+
+        Raises:
+            ValueError: If the file extension is not recognised.  See
+                :data:`EXTENSION_TO_LANGUAGE` for the list of supported
+                extensions, or pass the ``language`` argument to
+                :meth:`from_defaults` directly.
+
+        Example:
+            >>> splitter = CodeSplitter.from_filename("app.py")
+            >>> splitter = CodeSplitter.from_filename("/project/src/index.ts")
+
+        """
+        suffix = Path(filename).suffix.lower()
+        language = EXTENSION_TO_LANGUAGE.get(suffix)
+        if language is None:
+            raise ValueError(
+                f"Could not infer language from file extension '{suffix}'. "
+                f"Supported extensions: {sorted(EXTENSION_TO_LANGUAGE)}. "
+                "Pass the language explicitly via CodeSplitter(language=...) "
+                "or CodeSplitter.from_defaults(language=...)."
+            )
+        return cls(
+            language=language,
+            chunk_lines=chunk_lines,
+            chunk_lines_overlap=chunk_lines_overlap,
+            max_chars=max_chars,
+            count_mode=count_mode,
+            max_tokens=max_tokens,
+            tokenizer=tokenizer,
+            callback_manager=callback_manager,
+            parser=parser,
+        )
+
+    @classmethod
     def class_name(cls) -> str:
         return "CodeSplitter"
 
@@ -262,4 +378,3 @@ class CodeSplitter(TextSplitter):
             else:
                 raise ValueError(f"Could not parse code with language {self.language}.")
 
-        # TODO: set up auto-language detection using something like https://github.com/yoeo/guesslang.

--- a/llama-index-core/llama_index/core/node_parser/text/code.py
+++ b/llama-index-core/llama_index/core/node_parser/text/code.py
@@ -255,10 +255,16 @@ class CodeSplitter(TextSplitter):
 
         """
         suffix = Path(filename).suffix.lower()
+        if not suffix:
+            raise ValueError(
+                f"'{filename}' has no file extension — cannot infer language. "
+                "Pass the language explicitly via CodeSplitter(language=...) "
+                "or CodeSplitter.from_defaults(language=...)."
+            )
         language = EXTENSION_TO_LANGUAGE.get(suffix)
         if language is None:
             raise ValueError(
-                f"Could not infer language from file extension '{suffix}'. "
+                f"Unrecognised file extension '{suffix}'. "
                 f"Supported extensions: {sorted(EXTENSION_TO_LANGUAGE)}. "
                 "Pass the language explicitly via CodeSplitter(language=...) "
                 "or CodeSplitter.from_defaults(language=...)."
@@ -377,4 +383,3 @@ class CodeSplitter(TextSplitter):
                 return chunks
             else:
                 raise ValueError(f"Could not parse code with language {self.language}.")
-

--- a/llama-index-core/tests/text_splitter/test_code_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_code_splitter.py
@@ -459,8 +459,18 @@ def test_from_filename_unknown_extension() -> None:
     if "CI" in os.environ:
         return
 
-    with pytest.raises(ValueError, match="Could not infer language"):
+    with pytest.raises(ValueError, match="Unrecognised file extension"):
         CodeSplitter.from_filename("unknown.xyz")
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_from_filename_no_extension() -> None:
+    """Test that from_filename raises ValueError for files with no extension."""
+    if "CI" in os.environ:
+        return
+
+    with pytest.raises(ValueError, match="has no file extension"):
+        CodeSplitter.from_filename("Makefile")
 
 
 @pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")

--- a/llama-index-core/tests/text_splitter/test_code_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_code_splitter.py
@@ -406,3 +406,71 @@ def complex_function():
     assert len(nodes) >= 1
     assert isinstance(nodes[0], TextNode)
     assert "def complex_function():" in nodes[0].text
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_from_filename_python() -> None:
+    """Test that from_filename correctly infers Python from .py extension."""
+    if "CI" in os.environ:
+        return
+
+    splitter = CodeSplitter.from_filename(
+        "main.py", chunk_lines=4, chunk_lines_overlap=1, max_chars=30
+    )
+    assert splitter.language == "python"
+
+    text = """\
+def foo():
+    print("bar")
+
+def baz():
+    print("bbq")"""
+
+    chunks = splitter.split_text(text)
+    assert chunks[0].startswith("def foo():")
+    assert chunks[1].startswith("def baz():")
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_from_filename_typescript() -> None:
+    """Test that from_filename correctly infers TypeScript from .ts extension."""
+    if "CI" in os.environ:
+        return
+
+    splitter = CodeSplitter.from_filename(
+        "/project/src/index.ts", chunk_lines=4, chunk_lines_overlap=1, max_chars=50
+    )
+    assert splitter.language == "typescript"
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_from_filename_full_path() -> None:
+    """Test that from_filename works with full file paths."""
+    if "CI" in os.environ:
+        return
+
+    splitter = CodeSplitter.from_filename("/home/user/project/utils.py")
+    assert splitter.language == "python"
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_from_filename_unknown_extension() -> None:
+    """Test that from_filename raises ValueError for unrecognised extension."""
+    if "CI" in os.environ:
+        return
+
+    with pytest.raises(ValueError, match="Could not infer language"):
+        CodeSplitter.from_filename("unknown.xyz")
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_extension_to_language_map() -> None:
+    """Test that EXTENSION_TO_LANGUAGE covers common languages."""
+    from llama_index.core.node_parser.text.code import EXTENSION_TO_LANGUAGE
+
+    assert EXTENSION_TO_LANGUAGE[".py"] == "python"
+    assert EXTENSION_TO_LANGUAGE[".ts"] == "typescript"
+    assert EXTENSION_TO_LANGUAGE[".js"] == "javascript"
+    assert EXTENSION_TO_LANGUAGE[".go"] == "go"
+    assert EXTENSION_TO_LANGUAGE[".rs"] == "rust"
+    assert EXTENSION_TO_LANGUAGE[".java"] == "java"


### PR DESCRIPTION
…GUAGE

Add a convenience constructor that infers the tree-sitter language from a file extension, removing the need for callers to maintain their own extension-to-language mapping when splitting code files.

Changes:
- Add EXTENSION_TO_LANGUAGE dict mapping 40+ common file extensions to their tree-sitter language names (.py, .ts, .rs, .go, .java, etc.)
- Add CodeSplitter.from_filename(filename, ...) classmethod that looks up the extension and delegates to the existing constructor
- Raise ValueError with a descriptive message for unrecognised extensions
- Remove the resolved TODO comment about language detection
- Add 5 tests covering .py/.ts inference, full paths, unknown extension error, and the EXTENSION_TO_LANGUAGE map contents

Addresses the TODO in split_text: 'set up auto-language detection'.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
