### PR TITLE
fix(openai): preserve assistant text alongside tool calls and serialize tool kwargs to JSON

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
@@ -659,11 +660,14 @@ def to_openai_responses_message_dict(
                         }
                     )
         elif isinstance(block, ToolCallBlock):
+            arguments = block.tool_kwargs
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments)
             tool_calls.extend(
                 [
                     {
                         "type": "function_call",
-                        "arguments": block.tool_kwargs,
+                        "arguments": arguments,
                         "call_id": block.tool_call_id,
                         "name": block.tool_name,
                     }
@@ -679,9 +683,17 @@ def to_openai_responses_message_dict(
             for tool_call in message.additional_kwargs["tool_calls"]
         ]
 
-        return [*reasoning, *message_dicts]
+        items = [*reasoning]
+        if content_txt not in (None, "", []):
+            items.append({"role": message.role.value, "content": content_txt})
+        items.extend(message_dicts)
+        return items
     elif tool_calls:
-        return [*reasoning, *tool_calls]
+        items = [*reasoning]
+        if content_txt not in (None, "", []):
+            items.append({"role": message.role.value, "content": content_txt})
+        items.extend(tool_calls)
+        return items
 
     # NOTE: Sending a null value (None) for Tool Message to OpenAI will cause error
     # It's only Allowed to send None if it's an Assistant Message and either a function call or tool calls were performed

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -628,3 +628,131 @@ def test_gpt_5_4_pro_responses_api_only() -> None:
     assert is_json_schema_supported(model_name) is True, (
         f"{model_name} should support JSON schema"
     )
+
+
+def test_responses_api_assistant_text_preserved_with_tool_calls() -> None:
+    """Test that assistant text content is included alongside tool calls.
+
+    When an assistant message contains both text blocks and tool calls,
+    the text must not be silently dropped.
+    Ref: https://github.com/run-llama/llama_index/issues/21124 (bug #1)
+    """
+    from llama_index.llms.openai.utils import to_openai_responses_message_dict
+
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            TextBlock(text="I'll search for that information now."),
+            ToolCallBlock(
+                tool_name="search",
+                tool_call_id="call_1",
+                tool_kwargs='{"q": "test"}',
+            ),
+        ],
+    )
+
+    result = to_openai_responses_message_dict(msg, model="o3-mini")
+    assert isinstance(result, list)
+
+    text_items = [
+        item
+        for item in result
+        if isinstance(item, dict) and item.get("role") == "assistant"
+    ]
+    tool_items = [
+        item
+        for item in result
+        if isinstance(item, dict) and item.get("type") == "function_call"
+    ]
+
+    assert len(text_items) == 1, "Assistant text content should be preserved"
+    assert text_items[0]["content"] == "I'll search for that information now."
+    assert len(tool_items) == 1, "Tool call should be preserved"
+    assert tool_items[0]["name"] == "search"
+
+
+def test_responses_api_tool_only_no_empty_text() -> None:
+    """Test that tool-call-only messages don't include an empty text item."""
+    from llama_index.llms.openai.utils import to_openai_responses_message_dict
+
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_name="search",
+                tool_call_id="call_1",
+                tool_kwargs='{"q": "test"}',
+            ),
+        ],
+    )
+
+    result = to_openai_responses_message_dict(msg, model="o3-mini")
+    assert isinstance(result, list)
+
+    text_items = [
+        item
+        for item in result
+        if isinstance(item, dict) and item.get("role") == "assistant"
+    ]
+    assert len(text_items) == 0, "No text item should be emitted for tool-only messages"
+
+
+def test_responses_api_tool_kwargs_serialized_to_json_string() -> None:
+    """Test that dict tool_kwargs are serialized to JSON strings.
+
+    The OpenAI Responses API expects 'arguments' to be a JSON string,
+    but ToolCallBlock.tool_kwargs can be a dict.
+    Ref: https://github.com/run-llama/llama_index/issues/21124 (bug #6)
+    """
+    from llama_index.llms.openai.utils import to_openai_responses_message_dict
+
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_name="get_weather",
+                tool_call_id="call_2",
+                tool_kwargs={"location": "Boston", "unit": "celsius"},
+            ),
+        ],
+    )
+
+    result = to_openai_responses_message_dict(msg, model="gpt-5.4")
+    assert isinstance(result, list)
+
+    tool_item = [
+        item
+        for item in result
+        if isinstance(item, dict) and item.get("type") == "function_call"
+    ][0]
+    assert isinstance(tool_item["arguments"], str), "arguments must be a JSON string"
+    assert json.loads(tool_item["arguments"]) == {
+        "location": "Boston",
+        "unit": "celsius",
+    }
+
+
+def test_responses_api_tool_kwargs_string_passthrough() -> None:
+    """Test that string tool_kwargs are passed through unchanged."""
+    from llama_index.llms.openai.utils import to_openai_responses_message_dict
+
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_name="search",
+                tool_call_id="call_3",
+                tool_kwargs='{"q": "test"}',
+            ),
+        ],
+    )
+
+    result = to_openai_responses_message_dict(msg, model="gpt-5.4")
+    assert isinstance(result, list)
+
+    tool_item = [
+        item
+        for item in result
+        if isinstance(item, dict) and item.get("type") == "function_call"
+    ][0]
+    assert tool_item["arguments"] == '{"q": "test"}'


### PR DESCRIPTION
## Summary

Fixes two bugs in `to_openai_responses_message_dict()` that break multi-turn tool-calling workflows with the Responses API:

- **Assistant text silently dropped alongside tool calls** — when an assistant message contains both text blocks *and* tool calls, the serializer returned only the tool call items, discarding the text content entirely. This degrades follow-up quality since the model's pre-tool-call commentary (e.g. "I'll search for that information now.") is stripped from conversation history.

- **Tool call arguments not consistently serialized to JSON strings** — `ToolCallBlock.tool_kwargs` can be either a `str` or a `dict`, but the Responses API expects `arguments` to always be a JSON string. Dict values were being passed through as-is, causing API errors.

## Changes

**`llama_index/llms/openai/utils.py`:**
- When tool calls are present, include the assistant text `message_dict` in the returned list if content is non-empty
- Serialize `ToolCallBlock.tool_kwargs` to a JSON string when it's a dict via `json.dumps()`

**`tests/test_openai_utils.py`:**
- `test_responses_api_assistant_text_preserved_with_tool_calls` — verifies text + tool call round-trip
- `test_responses_api_tool_only_no_empty_text` — verifies tool-only messages don't emit empty text
- `test_responses_api_tool_kwargs_serialized_to_json_string` — verifies dict kwargs become JSON strings
- `test_responses_api_tool_kwargs_string_passthrough` — verifies string kwargs pass through unchanged

Fixes #21124

## Test plan

- [x] All 4 new tests pass locally
- [x] All 31 existing tests in `test_openai_utils.py` pass (no regressions)
- [ ] CI should confirm cross-platform compatibility