### PR TITLE
fix: make QueryFusionRetriever._aretrieve use async query generation

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -97,6 +97,23 @@ class QueryFusionRetriever(BaseRetriever):
         # The LLM often returns more queries than we asked for, so trim the list.
         return [QueryBundle(q) for q in queries[: self.num_queries - 1]]
 
+    async def _aget_queries(self, original_query: str) -> List[QueryBundle]:
+        prompt_str = self.query_gen_prompt.format(
+            num_queries=self.num_queries - 1,
+            query=original_query,
+        )
+        response = await self._llm.acomplete(prompt_str)
+
+        # Strip code block and assume LLM properly put each query on a newline
+        queries = response.text.strip("`").split("\n")
+        queries = [q.strip() for q in queries if q.strip()]
+        if self._verbose:
+            queries_str = "\n".join(queries)
+            print(f"Generated queries:\n{queries_str}")
+
+        # The LLM often returns more queries than we asked for, so trim the list.
+        return [QueryBundle(q) for q in queries[: self.num_queries - 1]]
+
     def _reciprocal_rerank_fusion(
         self, results: Dict[Tuple[str, int], List[NodeWithScore]]
     ) -> List[NodeWithScore]:
@@ -286,7 +303,7 @@ class QueryFusionRetriever(BaseRetriever):
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         queries: List[QueryBundle] = [query_bundle]
         if self.num_queries > 1:
-            queries.extend(self._get_queries(query_bundle.query_str))
+            queries.extend(await self._aget_queries(query_bundle.query_str))
 
         results = await self._run_async_queries(queries)
 


### PR DESCRIPTION
## Summary

Fixes #21159

The `_aretrieve()` method was calling the synchronous `_get_queries()` which blocks on `self._llm.complete()`. When `num_queries > 1` (the default), this blocks the current event loop during query generation and prevents other coroutines from making progress.

## Changes

- Added `_aget_queries()` async method that uses `self._llm.acomplete()`
- Updated `_aretrieve()` to await `_aget_queries()` instead of calling `_get_queries()`

## Testing

The fix ensures that when using `aretrieve()`, the LLM calls are properly awaited, allowing other coroutines to run during query generation.

The synchronous `_retrieve()` method continues to use `_get_queries()` as before, maintaining backward compatibility.