### PR TITLE
refactor(llama-index-core): base64 encode returns bytes instead of string, causing serialization crashes

### DIFF
--- a/llama-index-core/llama_index/core/img_utils.py
+++ b/llama-index-core/llama_index/core/img_utils.py
@@ -2,7 +2,6 @@
 
 import base64
 from io import BytesIO
-from typing import cast
 
 from PIL import Image
 from PIL.ImageFile import ImageFile
@@ -22,7 +21,7 @@ def img_2_b64(image: ImageFile, format: str = "JPEG") -> str:
     """
     buff = BytesIO()
     image.save(buff, format=format)
-    return cast(str, base64.b64encode(buff.getvalue()))
+    return base64.b64encode(buff.getvalue()).decode("utf-8")
 
 
 def b64_2_img(data: str) -> ImageFile:
@@ -37,4 +36,4 @@ def b64_2_img(data: str) -> ImageFile:
 
     """
     buff = BytesIO(base64.b64decode(data))
-    return cast(ImageFile, Image.open(buff))
+    return Image.open(buff)


### PR DESCRIPTION
## Code Quality

### Problem
`base64.b64encode()` returns a `bytes` object (e.g., `b"Zm9v"`). The function uses `typing.cast(str, ...)` which only satisfies the static type checker but does not actually convert the bytes to a string at runtime. Because the function signature advertises a `str` return type, downstream code will likely attempt to concatenate it with other strings (e.g., `f"data:image/jpeg;base64,{img}"`) or serialize it to JSON for API requests. This will result in runtime errors like `TypeError: Object of type bytes is not JSON serializable`.


**Severity**: `high`
**File**: `llama-index-core/llama_index/core/img_utils.py`

### Solution
Replace the `cast` with an actual decode call:

### Changes
- `llama-index-core/llama_index/core/img_utils.py` (modified)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #21186