### PR TITLE
callbacks: add CONTEXT_COMPACTION event type and payload keys to CBEventType

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/schema.py
+++ b/llama-index-core/llama_index/core/callbacks/schema.py
@@ -27,6 +27,10 @@ class CBEventType(str, Enum):
         SYNTHESIZE: Logs for the result for synthesize calls.
         TREE: Logs for the summary and level of summaries generated.
         SUB_QUESTION: Logs for a generated sub question and answer.
+        CONTEXT_COMPACTION: Fires when the agent compacts its context window
+            (summarizes and drops older messages). Carries pre/post token counts
+            and the summary text so observability tools can compare agent behavior
+            across the compaction boundary.
 
     """
 
@@ -44,6 +48,7 @@ class CBEventType(str, Enum):
     RERANKING = "reranking"
     EXCEPTION = "exception"
     AGENT_STEP = "agent_step"
+    CONTEXT_COMPACTION = "context_compaction"
 
 
 class EventPayload(str, Enum):
@@ -69,6 +74,11 @@ class EventPayload(str, Enum):
     SYSTEM_PROMPT = "system_prompt"  # system prompt used in LLM call
     QUERY_WRAPPER_PROMPT = "query_wrapper_prompt"  # query wrapper prompt used in LLM
     EXCEPTION = "exception"  # exception raised in an event
+    # CONTEXT_COMPACTION payloads
+    PRE_COMPACTION_TOKEN_COUNT = "pre_compaction_token_count"  # tokens before compaction
+    POST_COMPACTION_TOKEN_COUNT = "post_compaction_token_count"  # tokens after compaction
+    COMPACTION_SUMMARY = "compaction_summary"  # summary text produced by compaction
+    DROPPED_MESSAGE_COUNT = "dropped_message_count"  # number of messages removed
 
 
 # events that will never have children events


### PR DESCRIPTION
## Summary

Adds `CONTEXT_COMPACTION` to `CBEventType` and four matching `EventPayload` keys:

- `PRE_COMPACTION_TOKEN_COUNT`
- `POST_COMPACTION_TOKEN_COUNT`
- `COMPACTION_SUMMARY`
- `DROPPED_MESSAGE_COUNT`

This is a pure schema addition: no existing behaviour changes, no breaking changes, fully backward-compatible.

## Motivation

When a long-running agent compacts its context window (summarizes + drops older messages), the compaction event is invisible to the callback system today. Observability tools, monitors, and production operators have no standard hook to:

- Record what was dropped and what summary was produced
- Compare agent behaviour before and after the boundary
- Alert on or roll back from unexpected behavioural drift

This addition follows the request in Issue #21207 and mirrors the `CBEventType`/`EventPayload` patterns already established for `AGENT_STEP`, `RERANKING`, and others.

## Usage

```python
from llama_index.core.callbacks import CallbackManager, CBEventType
from llama_index.core.callbacks.schema import EventPayload

class CompactionMonitor(BaseCallbackHandler):
    def on_event_start(self, event_type, payload=None, **kwargs):
        if event_type == CBEventType.CONTEXT_COMPACTION:
            pre = payload.get(EventPayload.PRE_COMPACTION_TOKEN_COUNT, 0)
            print(f"Compaction starting: {pre} tokens in context")

    def on_event_end(self, event_type, payload=None, **kwargs):
        if event_type == CBEventType.CONTEXT_COMPACTION:
            post = payload.get(EventPayload.POST_COMPACTION_TOKEN_COUNT, 0)
            summary = payload.get(EventPayload.COMPACTION_SUMMARY, "")
            dropped = payload.get(EventPayload.DROPPED_MESSAGE_COUNT, 0)
            print(f"Compaction done: {post} tokens, {dropped} messages dropped")
            # attach behavioral fingerprint here for drift detection
```

## Scope

- `llama-index-core/llama_index/core/callbacks/schema.py` only
- Docstring updated; no logic changes
- Existing `LEAF_EVENTS` tuple unchanged (compaction is not a leaf event)

Closes #21207 (partial — schema foundation; emit-side wiring in compaction paths is a follow-up)
