### PR TITLE
fix: img_2_b64 returns bytes instead of str due to cast bypass

### DIFF
--- a/llama-index-core/llama_index/core/img_utils.py
+++ b/llama-index-core/llama_index/core/img_utils.py
@@ -22,7 +22,7 @@ def img_2_b64(image: ImageFile, format: str = "JPEG") -> str:
     """
     buff = BytesIO()
     image.save(buff, format=format)
-    return cast(str, base64.b64encode(buff.getvalue()))
+    return base64.b64encode(buff.getvalue()).decode("ascii")
 
 
 def b64_2_img(data: str) -> ImageFile:


### PR DESCRIPTION
Fixes #21186

## Problem

`img_2_b64()` calls `base64.b64encode()` which returns `bytes`, but wraps it with `typing.cast(str, ...)\). The cast only satisfies the static type checker — at runtime the return value is still `bytes`. Downstream code that concatenates the result (e.g. `f"data:image/jpeg;base64,{img}"`) or serializes it to JSON will crash with `TypeError: Object of type bytes is not JSON serializable`.

## Fix

Replace `cast(str, base64.b64encode(buff.getvalue()))` with `base64.b64encode(buff.getvalue()).decode("ascii")`.

The unused `cast` import can also be removed (it's still used by `b64_2_img`, so it stays).