### PR TITLE
feat: add support for deepseek v3 models in bedrock converse

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -100,6 +100,8 @@ BEDROCK_MODELS = {
     "ai21.jamba-1-5-mini-v1:0": 256000,
     "ai21.jamba-1-5-large-v1:0": 256000,
     "deepseek.r1-v1:0": 128000,
+    "deepseek.v3-v1:0": 128000,
+    "deepseek.v3.2": 128000,
 }
 
 BEDROCK_FUNCTION_CALLING_MODELS = (
@@ -137,6 +139,8 @@ BEDROCK_FUNCTION_CALLING_MODELS = (
     "meta.llama4-scout-17b-instruct-v1:0",
     "openai.gpt-oss-120b-1:0",
     "openai.gpt-oss-20b-1:0",
+    "deepseek.v3-v1:0",
+    "deepseek.v3.2",
 )
 
 BEDROCK_INFERENCE_PROFILE_SUPPORTED_MODELS = (
@@ -203,6 +207,7 @@ BEDROCK_REASONING_MODELS = (
     "anthropic.claude-sonnet-4-6",
     "anthropic.claude-haiku-4-5-20251001-v1:0",
     "deepseek.r1-v1:0",
+    "deepseek.v3-v1:0",
 )
 
 BEDROCK_ADAPTIVE_THINKING_SUPPORTED_MODELS = (

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.3"
+version = "0.14.4"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
@@ -17,12 +17,16 @@ from llama_index.core.base.llms.types import (
 )
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.bedrock_converse.utils import (
+    BEDROCK_MODELS,
     ThinkingDict,
     __get_img_format_from_image_mimetype,
     _content_block_to_bedrock_format,
+    bedrock_modelname_to_context_size,
     converse_with_retry,
     converse_with_retry_async,
     get_model_name,
+    is_bedrock_function_calling_model,
+    is_reasoning,
     messages_to_converse_messages,
     tools_to_converse_tools,
 )
@@ -127,6 +131,43 @@ def test_get_model_name_does_nottranslate_unsupported():
 def test_get_model_name_throws_inference_profile_exception():
     with pytest.raises(ValueError):
         assert get_model_name("us.cohere.command-r-plus-v1:0")
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected_context"),
+    [
+        ("deepseek.r1-v1:0", 128000),
+        ("deepseek.v3-v1:0", 128000),
+        ("deepseek.v3.2", 128000),
+    ],
+)
+def test_deepseek_models_registered(model_id, expected_context):
+    assert model_id in BEDROCK_MODELS
+    assert bedrock_modelname_to_context_size(model_id) == expected_context
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        ("deepseek.r1-v1:0", True),
+        ("deepseek.v3-v1:0", True),
+        ("deepseek.v3.2", False),
+    ],
+)
+def test_deepseek_reasoning_models(model_id, expected):
+    assert is_reasoning(model_id) == expected
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        ("deepseek.r1-v1:0", False),
+        ("deepseek.v3-v1:0", True),
+        ("deepseek.v3.2", True),
+    ],
+)
+def test_deepseek_function_calling_models(model_id, expected):
+    assert is_bedrock_function_calling_model(model_id) == expected
 
 
 def test_get_img_format_jpeg():

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -1830,7 +1830,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.2"
+version = "0.14.4"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

Add DeepSeek-V3.1 (`deepseek.v3-v1:0`) and DeepSeek V3.2 (`deepseek.v3.2`) to the Bedrock Converse model registry.

These models are fully managed on Amazon Bedrock (announced Feb 2026) but were missing from the utils whitelist, causing `Unknown model` errors when used.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

### Unit tests

9 parametrized tests covering model registration, reasoning detection, and function calling detection for all three DeepSeek models.

### Manual verification against live Bedrock API

All capabilities were verified by calling the Bedrock Converse API directly (`us-west-2`):

**Tool use (function calling):**

```
deepseek.v3-v1:0  → stopReason: tool_use  ✅
deepseek.v3.2     → stopReason: tool_use  ✅
deepseek.r1-v1:0  → "This model doesn't support tool use."  ❌ (correctly excluded)
```

**Reasoning mode:**

DeepSeek-V3.1 supports hybrid thinking mode (chain-of-thought reasoning), matching the existing `deepseek.r1-v1:0` behavior. DeepSeek V3.2 does not support reasoning mode.

### Summary of changes to each whitelist

| List | `deepseek.r1-v1:0` | `deepseek.v3-v1:0` | `deepseek.v3.2` |
|------|:---:|:---:|:---:|
| `BEDROCK_MODELS` | already present | **added** (128k) | **added** (128k) |
| `BEDROCK_FUNCTION_CALLING_MODELS` | ❌ | **added** | **added** |
| `BEDROCK_REASONING_MODELS` | already present | **added** | ❌ |
| `BEDROCK_INFERENCE_PROFILE_SUPPORTED_MODELS` | already present | ❌ | ❌ |

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
