### PR TITLE
fix(llms-openai): fall back to `reasoning` field for vLLM compatibility

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -568,9 +568,13 @@ class OpenAI(FunctionCallingLLM):
                 content_delta = delta.content or ""
                 content += content_delta
 
-                # Extract reasoning_content for chain-of-thought streaming.
-                # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # Extract reasoning content for chain-of-thought streaming.
+                # `reasoning_content` is the legacy field name; vLLM >= 0.9 and
+                # other OpenAI-compatible providers use `reasoning` instead.
+                # See https://github.com/vllm-project/vllm/issues/36730
+                raw_reasoning = getattr(delta, "reasoning_content", None) or getattr(
+                    delta, "reasoning", None
+                )
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )
@@ -864,9 +868,13 @@ class OpenAI(FunctionCallingLLM):
                 content_delta = delta.content or ""
                 content += content_delta
 
-                # Extract reasoning_content for chain-of-thought streaming.
-                # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # Extract reasoning content for chain-of-thought streaming.
+                # `reasoning_content` is the legacy field name; vLLM >= 0.9 and
+                # other OpenAI-compatible providers use `reasoning` instead.
+                # See https://github.com/vllm-project/vllm/issues/36730
+                raw_reasoning = getattr(delta, "reasoning_content", None) or getattr(
+                    delta, "reasoning", None
+                )
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )


### PR DESCRIPTION
## Summary

Fixes #21075 — thinking content from Qwen3 / DeepSeek-R1 deployed via vLLM ≥ 0.9 is silently discarded because vLLM deprecated `reasoning_content` in favour of `reasoning`.

**Root cause:** Both streaming paths in `base.py` (lines 573 and 869) read chain-of-thought content exclusively via:
```python
raw_reasoning = getattr(delta, "reasoning_content", None)
```
vLLM ≥ 0.9 (see vllm-project/vllm#36730) no longer emits `reasoning_content` — it emits `reasoning`. `getattr` returns `None`, `reasoning_delta` stays `""`, and `ThinkingBlock` is never appended.

**Fix:** Add an `or` fallback to the new field name at both call sites:
```python
raw_reasoning = getattr(delta, "reasoning_content", None) or getattr(
    delta, "reasoning", None
)
```
Providers that still emit `reasoning_content` (OpenRouter, older vLLM, DeepSeek API) are unaffected.

## Test plan

- [ ] Deploy Qwen3-4B via vLLM ≥ 0.9, stream a completion, verify `ThinkingBlock` is present in response
- [ ] Verify existing `reasoning_content` providers (e.g. DeepSeek API) still populate `ThinkingBlock`
- [ ] Run `pytest llama-index-integrations/llms/llama-index-llms-openai/`