### PR TITLE
fix(callbacks): Ensure TokenCountingHandler tracks embedding tokens in ingestion pipelines

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -369,6 +369,13 @@ class IngestionPipeline(BaseModel):
             Settings.embed_model,
         ]
 
+    def _propagate_callback_manager(self) -> None:
+        """Propagate Settings.callback_manager to transformations that support it."""
+        callback_manager = Settings.callback_manager
+        for transform in self.transformations:
+            if hasattr(transform, "callback_manager"):
+                transform.callback_manager = callback_manager
+
     def _prepare_inputs(
         self,
         documents: Optional[Sequence[Document]],
@@ -513,6 +520,10 @@ class IngestionPipeline(BaseModel):
 
         """
         input_nodes = self._prepare_inputs(documents, nodes)
+
+        # Propagate Settings.callback_manager to transformations so that
+        # handlers such as TokenCountingHandler receive embedding events.
+        self._propagate_callback_manager()
 
         effective_strategy = self.docstore_strategy
         if (
@@ -714,6 +725,10 @@ class IngestionPipeline(BaseModel):
 
         """
         input_nodes = self._prepare_inputs(documents, nodes)
+
+        # Propagate Settings.callback_manager to transformations so that
+        # handlers such as TokenCountingHandler receive embedding events.
+        self._propagate_callback_manager()
 
         effective_strategy = self.docstore_strategy
         if (

--- a/llama-index-core/tests/callbacks/test_token_counter.py
+++ b/llama-index-core/tests/callbacks/test_token_counter.py
@@ -1,7 +1,13 @@
 """Embeddings."""
 
+from llama_index.core.callbacks import CallbackManager
 from llama_index.core.callbacks.schema import CBEventType
 from llama_index.core.callbacks.token_counting import TokenCountingHandler
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.ingestion import IngestionPipeline
+from llama_index.core.node_parser import SentenceSplitter
+from llama_index.core.schema import Document
+from llama_index.core.settings import Settings
 
 TEST_PAYLOAD = {"chunks": ["one"], "formatted_prompt": "two", "response": "three"}
 TEST_ID = "my id"
@@ -48,3 +54,24 @@ def test_on_event_end() -> None:
     # Embedding should be one (single token chunk)
     assert handler.total_llm_token_count == 2
     assert handler.total_embedding_token_count == 1
+
+
+def test_token_counter_with_ingestion_pipeline() -> None:
+    """Test that TokenCountingHandler tracks embedding tokens in an IngestionPipeline."""
+    token_counter = TokenCountingHandler()
+    callback_manager = CallbackManager([token_counter])
+
+    Settings.callback_manager = callback_manager
+
+    embed_model = MockEmbedding(embed_dim=128)
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=512, chunk_overlap=0),
+            embed_model,
+        ],
+    )
+
+    documents = [Document(text="This is a test document for token counting.")]
+    pipeline.run(documents=documents)
+
+    assert token_counter.total_embedding_token_count > 0


### PR DESCRIPTION
This PR addresses an issue where the `TokenCountingHandler` fails to count embedding tokens when documents are processed through an ingestion pipeline that includes transformations.

The root cause was that the callback manager was not being correctly utilized during the embedding phase within the pipeline. This change ensures the callback events for embedding are properly dispatched, leading to accurate token counts.

**Changes**:
- Modified the `IngestionPipeline` to correctly propagate the `callback_manager`.
- Added a new unit test to replicate the original bug and verify the fix, ensuring embedding token counts are now accurately tracked.

This fix improves the observability of ingestion pipelines, allowing for better cost and performance tracking.