### PR TITLE
docs: replace placeholder docstrings in finetuning abstract base classes

### DIFF
--- a/llama-index-finetuning/llama_index/finetuning/types.py
+++ b/llama-index-finetuning/llama_index/finetuning/types.py
@@ -14,11 +14,25 @@ class BaseLLMFinetuneEngine(ABC):
 
     @abstractmethod
     def finetune(self) -> None:
-        """Goes off and does stuff."""
+        """Run the finetuning process.
+
+        This method should initiate the full finetuning loop, including
+        loading training data, configuring the model, and saving the
+        resulting checkpoint. Implementations may block until training
+        is complete or launch an async job depending on the backend.
+        """
 
     @abstractmethod
     def get_finetuned_model(self, **model_kwargs: Any) -> LLM:
-        """Gets finetuned model."""
+        """Return the finetuned LLM.
+
+        Args:
+            **model_kwargs: Additional keyword arguments passed to the
+                underlying model constructor.
+
+        Returns:
+            An LLM instance loaded from the finetuned checkpoint.
+        """
 
 
 class BaseEmbeddingFinetuneEngine(ABC):
@@ -26,11 +40,24 @@ class BaseEmbeddingFinetuneEngine(ABC):
 
     @abstractmethod
     def finetune(self) -> None:
-        """Goes off and does stuff."""
+        """Run the finetuning process.
+
+        This method should initiate the full finetuning loop, including
+        loading training data, configuring the embedding model, and saving
+        the resulting checkpoint.
+        """
 
     @abstractmethod
     def get_finetuned_model(self, **model_kwargs: Any) -> BaseEmbedding:
-        """Gets finetuned model."""
+        """Return the finetuned embedding model.
+
+        Args:
+            **model_kwargs: Additional keyword arguments passed to the
+                underlying embedding model constructor.
+
+        Returns:
+            A BaseEmbedding instance loaded from the finetuned checkpoint.
+        """
 
 
 class BaseCrossEncoderFinetuningEngine(ABC):
@@ -38,13 +65,26 @@ class BaseCrossEncoderFinetuningEngine(ABC):
 
     @abstractmethod
     def finetune(self) -> None:
-        """Goes off and does stuff."""
+        """Run the cross-encoder finetuning process.
+
+        This method should initiate the full finetuning loop for a
+        cross-encoder re-ranker, including loading pairwise training data
+        and saving the resulting checkpoint.
+        """
 
     @abstractmethod
     def get_finetuned_model(
         self, model_name: str, top_n: int = 3
     ) -> SentenceTransformerRerank:
-        """Gets fine-tuned Cross-Encoder model as re-ranker."""
+        """Return the finetuned cross-encoder model as a re-ranker.
+
+        Args:
+            model_name: Name or path of the finetuned model.
+            top_n: Number of top results to return during re-ranking.
+
+        Returns:
+            A SentenceTransformerRerank instance using the finetuned checkpoint.
+        """
 
 
 class BaseCohereRerankerFinetuningEngine(ABC):
@@ -52,8 +92,20 @@ class BaseCohereRerankerFinetuningEngine(ABC):
 
     @abstractmethod
     def finetune(self) -> None:
-        """Goes off and does stuff."""
+        """Run the Cohere reranker finetuning process.
+
+        This method should initiate the full finetuning loop against the
+        Cohere finetuning API, including uploading training data and
+        waiting for the finetuned model to be ready.
+        """
 
     @abstractmethod
     def get_finetuned_model(self, top_n: int = 5) -> CohereRerank:
-        """Gets finetuned model."""
+        """Return the finetuned Cohere reranker model.
+
+        Args:
+            top_n: Number of top results to return during re-ranking.
+
+        Returns:
+            A CohereRerank instance using the finetuned model.
+        """


### PR DESCRIPTION
Replaces the `"Goes off and does stuff."` placeholder in `finetune()` across all four abstract base classes in `llama-index-finetuning/llama_index/finetuning/types.py` with proper docstrings describing expected behavior, blocking semantics, and return values.

Fixes #21188