### PR TITLE
Add protected_params and DynamicValue to FunctionTool

### DIFF
--- a/llama-index-core/llama_index/core/tools/__init__.py
+++ b/llama-index-core/llama_index/core/tools/__init__.py
@@ -1,6 +1,6 @@
 """Tools."""
 
-from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.core.tools.function_tool import DynamicValue, FunctionTool
 from llama_index.core.tools.query_engine import QueryEngineTool
 from llama_index.core.tools.query_plan import QueryPlanTool
 from llama_index.core.tools.retriever_tool import RetrieverTool
@@ -21,6 +21,7 @@ __all__ = [
     "BaseTool",
     "adapt_to_async_tool",
     "AsyncBaseTool",
+    "DynamicValue",
     "QueryEngineTool",
     "RetrieverTool",
     "ToolMetadata",

--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -64,6 +64,28 @@ def async_to_sync(func_async: AsyncCallable) -> Callable:
 CallbackReturn = Optional[Union[ToolOutput, str]]
 
 
+class DynamicValue:
+    """
+    Wraps a callable factory for per-request parameter resolution in protected_params.
+
+    Use this when a protected parameter's value must be determined at call time
+    (e.g., from a ContextVar holding the current request's session ID) rather than
+    being fixed when the tool is created.
+
+    Example:
+        >>> from contextvars import ContextVar
+        >>> session_var: ContextVar[str] = ContextVar("session_var")
+        >>> tool = FunctionTool.from_defaults(
+        ...     fn=my_fn,
+        ...     protected_params={"user_id": DynamicValue(lambda: session_var.get())},
+        ... )
+
+    """
+
+    def __init__(self, factory: Callable[[], Any]) -> None:
+        self.factory = factory
+
+
 class FunctionTool(AsyncBaseTool):
     """
     Function Tool.
@@ -81,6 +103,7 @@ class FunctionTool(AsyncBaseTool):
         callback: Optional[Callable[..., Any]] = None,
         async_callback: Optional[Callable[..., Any]] = None,
         partial_params: Optional[Dict[str, Any]] = None,
+        protected_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         if fn is None and async_fn is None:
             raise ValueError("fn or async_fn must be provided.")
@@ -134,6 +157,7 @@ class FunctionTool(AsyncBaseTool):
             self._async_callback = sync_to_async(self._callback)
 
         self.partial_params = partial_params or {}
+        self.protected_params = protected_params or {}
 
         # Extract actual default values from FieldInfo defaults so they are
         # applied when the function is called without those arguments.
@@ -164,6 +188,13 @@ class FunctionTool(AsyncBaseTool):
             return ret
         return None
 
+    def _resolve_protected_params(self) -> Dict[str, Any]:
+        """Resolve protected_params, calling DynamicValue factories."""
+        resolved: Dict[str, Any] = {}
+        for k, v in self.protected_params.items():
+            resolved[k] = v.factory() if isinstance(v, DynamicValue) else v
+        return resolved
+
     @classmethod
     def from_defaults(
         cls,
@@ -177,8 +208,10 @@ class FunctionTool(AsyncBaseTool):
         callback: Optional[Callable[[Any], Any]] = None,
         async_callback: Optional[AsyncCallable] = None,
         partial_params: Optional[Dict[str, Any]] = None,
+        protected_params: Optional[Dict[str, Any]] = None,
     ) -> "FunctionTool":
         partial_params = partial_params or {}
+        protected_params = protected_params or {}
 
         if tool_metadata is None:
             fn_to_parse = fn or async_fn
@@ -206,13 +239,14 @@ class FunctionTool(AsyncBaseTool):
                     continue
                 filtered_params.append(param)
 
-            # 3. Remove FieldInfo defaults and partial_params
+            # 3. Remove FieldInfo defaults, partial_params, and protected_params
+            hidden_params = set(partial_params.keys()) | set(protected_params.keys())
             final_params = [
                 param.replace(default=inspect.Parameter.empty)
                 if isinstance(param.default, FieldInfo)
                 else param
                 for param in filtered_params
-                if param.name not in (partial_params or {})
+                if param.name not in hidden_params
             ]
 
             # 4. Replace signature in one go
@@ -234,6 +268,7 @@ class FunctionTool(AsyncBaseTool):
                 if has_self:
                     ignore_fields.append("self")
                 ignore_fields.extend(partial_params.keys())
+                ignore_fields.extend(protected_params.keys())
 
                 fn_schema = create_schema_from_function(
                     f"{name}",
@@ -259,6 +294,7 @@ class FunctionTool(AsyncBaseTool):
             callback=callback,
             async_callback=async_callback,
             partial_params=partial_params,
+            protected_params=protected_params,
         )
 
     @property
@@ -307,21 +343,32 @@ class FunctionTool(AsyncBaseTool):
             return [TextBlock(text=str(raw_output))]
 
     def __call__(self, *args: Any, **kwargs: Any) -> ToolOutput:
-        all_kwargs = {**self.partial_params, **kwargs}
+        all_kwargs = {
+            **self.partial_params,
+            **kwargs,
+            **self._resolve_protected_params(),
+        }
         return self.call(*args, **all_kwargs)
 
     def call(self, *args: Any, **kwargs: Any) -> ToolOutput:
         """Sync Call."""
-        all_kwargs = {**self._field_defaults, **self.partial_params, **kwargs}
+        resolved_protected = self._resolve_protected_params()
+        all_kwargs = {
+            **self._field_defaults,
+            **self.partial_params,
+            **kwargs,
+            **resolved_protected,
+        }
         if self.requires_context and self.ctx_param_name is not None:
             if self.ctx_param_name not in all_kwargs:
                 raise ValueError("Context is required for this tool")
 
         raw_output = self._fn(*args, **all_kwargs)
 
-        # Exclude the Context param from the tool output so that the Context can be serialized
+        # Exclude Context and protected params from the serialized tool output
+        excluded_keys = {self.ctx_param_name} | set(self.protected_params.keys())
         tool_output_kwargs = {
-            k: v for k, v in all_kwargs.items() if k != self.ctx_param_name
+            k: v for k, v in all_kwargs.items() if k not in excluded_keys
         }
 
         # Parse tool output into content blocks
@@ -351,16 +398,23 @@ class FunctionTool(AsyncBaseTool):
 
     async def acall(self, *args: Any, **kwargs: Any) -> ToolOutput:
         """Async Call."""
-        all_kwargs = {**self._field_defaults, **self.partial_params, **kwargs}
+        resolved_protected = self._resolve_protected_params()
+        all_kwargs = {
+            **self._field_defaults,
+            **self.partial_params,
+            **kwargs,
+            **resolved_protected,
+        }
         if self.requires_context and self.ctx_param_name is not None:
             if self.ctx_param_name not in all_kwargs:
                 raise ValueError("Context is required for this tool")
 
         raw_output = await self._async_fn(*args, **all_kwargs)
 
-        # Exclude the Context param from the tool output so that the Context can be serialized
+        # Exclude Context and protected params from the serialized tool output
+        excluded_keys = {self.ctx_param_name} | set(self.protected_params.keys())
         tool_output_kwargs = {
-            k: v for k, v in all_kwargs.items() if k != self.ctx_param_name
+            k: v for k, v in all_kwargs.items() if k not in excluded_keys
         }
 
         # Parse tool output into content blocks

--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -343,11 +343,7 @@ class FunctionTool(AsyncBaseTool):
             return [TextBlock(text=str(raw_output))]
 
     def __call__(self, *args: Any, **kwargs: Any) -> ToolOutput:
-        all_kwargs = {
-            **self.partial_params,
-            **kwargs,
-            **self._resolve_protected_params(),
-        }
+        all_kwargs = {**self.partial_params, **kwargs}
         return self.call(*args, **all_kwargs)
 
     def call(self, *args: Any, **kwargs: Any) -> ToolOutput:
@@ -366,7 +362,9 @@ class FunctionTool(AsyncBaseTool):
         raw_output = self._fn(*args, **all_kwargs)
 
         # Exclude Context and protected params from the serialized tool output
-        excluded_keys = {self.ctx_param_name} | set(self.protected_params.keys())
+        excluded_keys = set(self.protected_params.keys())
+        if self.ctx_param_name:
+            excluded_keys.add(self.ctx_param_name)
         tool_output_kwargs = {
             k: v for k, v in all_kwargs.items() if k not in excluded_keys
         }
@@ -412,7 +410,9 @@ class FunctionTool(AsyncBaseTool):
         raw_output = await self._async_fn(*args, **all_kwargs)
 
         # Exclude Context and protected params from the serialized tool output
-        excluded_keys = {self.ctx_param_name} | set(self.protected_params.keys())
+        excluded_keys = set(self.protected_params.keys())
+        if self.ctx_param_name:
+            excluded_keys.add(self.ctx_param_name)
         tool_output_kwargs = {
             k: v for k, v in all_kwargs.items() if k not in excluded_keys
         }

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -1,12 +1,13 @@
 """Test tools."""
 
 import json
+from contextvars import ContextVar
 from typing import List, Optional
 
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.llms import TextBlock, ImageBlock
-from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.core.tools.function_tool import DynamicValue, FunctionTool
 from llama_index.core.schema import Document, TextNode
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow import Context
@@ -237,6 +238,143 @@ async def test_function_tool_partial_params_async() -> None:
         "args": (),
         "kwargs": {"x": 1, "y": 3},
     }
+
+
+def test_function_tool_protected_params_schema() -> None:
+    """Protected params should be hidden from the tool schema."""
+
+    def test_function(x: int, y: int, secret: str) -> str:
+        return f"x: {x}, y: {y}, secret: {secret}"
+
+    tool = FunctionTool.from_defaults(
+        test_function, protected_params={"secret": "s3cret"}
+    )
+    assert tool.metadata.fn_schema is not None
+    actual_schema = tool.metadata.fn_schema.model_json_schema()
+    assert "x" in actual_schema["properties"]
+    assert "y" in actual_schema["properties"]
+    assert "secret" not in actual_schema["properties"]
+
+
+def test_function_tool_protected_params_override() -> None:
+    """Protected params must always win over LLM-provided kwargs."""
+
+    def test_function(x: int, user_id: str) -> str:
+        return f"x: {x}, user_id: {user_id}"
+
+    tool = FunctionTool.from_defaults(
+        test_function, protected_params={"user_id": "trusted_123"}
+    )
+    # Even if LLM provides user_id, protected value wins
+    result = tool(x=1, user_id="hallucinated_456")
+    assert result.raw_output == "x: 1, user_id: trusted_123"
+    # Protected params excluded from raw_input
+    assert "user_id" not in result.raw_input["kwargs"]
+    assert result.raw_input["kwargs"]["x"] == 1
+
+
+def test_function_tool_protected_params_with_partial() -> None:
+    """Protected params win over both partial_params and kwargs."""
+
+    def test_function(x: int, y: int, z: str) -> str:
+        return f"x: {x}, y: {y}, z: {z}"
+
+    tool = FunctionTool.from_defaults(
+        test_function,
+        partial_params={"y": 2},
+        protected_params={"z": "enforced"},
+    )
+    assert tool.metadata.fn_schema is not None
+    actual_schema = tool.metadata.fn_schema.model_json_schema()
+    assert "x" in actual_schema["properties"]
+    assert "y" not in actual_schema["properties"]
+    assert "z" not in actual_schema["properties"]
+
+    result = tool(x=1, z="overridden_by_llm")
+    assert result.raw_output == "x: 1, y: 2, z: enforced"
+    assert "z" not in result.raw_input["kwargs"]
+    assert result.raw_input["kwargs"] == {"x": 1, "y": 2}
+
+
+@pytest.mark.asyncio
+async def test_function_tool_protected_params_async() -> None:
+    """Protected params work correctly in async path."""
+
+    async def test_function(x: int, api_key: str) -> str:
+        return f"x: {x}, api_key: {api_key}"
+
+    tool = FunctionTool.from_defaults(
+        test_function, protected_params={"api_key": "real_key"}
+    )
+    result = await tool.acall(x=1, api_key="fake_key")
+    assert result.raw_output == "x: 1, api_key: real_key"
+    assert "api_key" not in result.raw_input["kwargs"]
+
+
+def test_function_tool_dynamic_value() -> None:
+    """DynamicValue factory is resolved at call time, not at creation time."""
+    call_count = 0
+    counter: ContextVar[int] = ContextVar("counter", default=0)
+
+    def test_function(x: int, req_id: int) -> str:
+        return f"x: {x}, req_id: {req_id}"
+
+    def get_req_id() -> int:
+        nonlocal call_count
+        call_count += 1
+        return counter.get()
+
+    tool = FunctionTool.from_defaults(
+        test_function,
+        protected_params={"req_id": DynamicValue(get_req_id)},
+    )
+
+    # First call
+    counter.set(42)
+    result1 = tool(x=1)
+    assert result1.raw_output == "x: 1, req_id: 42"
+
+    # Second call with different context value
+    counter.set(99)
+    result2 = tool(x=2)
+    assert result2.raw_output == "x: 2, req_id: 99"
+
+    # Factory was called twice (once per tool call)
+    assert call_count == 4  # 2 calls x 2 (__call__ resolves + call resolves)
+
+
+@pytest.mark.asyncio
+async def test_function_tool_dynamic_value_async() -> None:
+    """DynamicValue works correctly in the async path."""
+    session_var: ContextVar[str] = ContextVar("session_var", default="default")
+
+    async def test_function(x: int, session_id: str) -> str:
+        return f"x: {x}, session_id: {session_id}"
+
+    tool = FunctionTool.from_defaults(
+        test_function,
+        protected_params={"session_id": DynamicValue(lambda: session_var.get())},
+    )
+
+    session_var.set("sess_abc")
+    result = await tool.acall(x=1)
+    assert result.raw_output == "x: 1, session_id: sess_abc"
+    assert "session_id" not in result.raw_input["kwargs"]
+
+
+def test_function_tool_protected_params_same_key_as_partial() -> None:
+    """When both partial_params and protected_params have the same key, protected wins."""
+
+    def test_function(x: int, shared: str) -> str:
+        return f"x: {x}, shared: {shared}"
+
+    tool = FunctionTool.from_defaults(
+        test_function,
+        partial_params={"shared": "from_partial"},
+        protected_params={"shared": "from_protected"},
+    )
+    result = tool(x=1)
+    assert result.raw_output == "x: 1, shared: from_protected"
 
 
 def test_function_tool_ctx_param() -> None:

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -339,8 +339,8 @@ def test_function_tool_dynamic_value() -> None:
     result2 = tool(x=2)
     assert result2.raw_output == "x: 2, req_id: 99"
 
-    # Factory was called twice (once per tool call)
-    assert call_count == 4  # 2 calls x 2 (__call__ resolves + call resolves)
+    # Factory was called once per tool invocation (only call() resolves)
+    assert call_count == 2
 
 
 @pytest.mark.asyncio
@@ -360,6 +360,21 @@ async def test_function_tool_dynamic_value_async() -> None:
     result = await tool.acall(x=1)
     assert result.raw_output == "x: 1, session_id: sess_abc"
     assert "session_id" not in result.raw_input["kwargs"]
+
+
+def test_function_tool_dynamic_value_factory_error() -> None:
+    """DynamicValue factory errors propagate clearly."""
+    no_default: ContextVar[str] = ContextVar("no_default")
+
+    def test_function(x: int, val: str) -> str:
+        return f"{x}, {val}"
+
+    tool = FunctionTool.from_defaults(
+        test_function,
+        protected_params={"val": DynamicValue(lambda: no_default.get())},
+    )
+    with pytest.raises(LookupError):
+        tool(x=1)
 
 
 def test_function_tool_protected_params_same_key_as_partial() -> None:


### PR DESCRIPTION
# Description

Add `protected_params` and `DynamicValue` to `FunctionTool`, enabling deterministic tool parameter enforcement that LLM-generated kwargs cannot override.

Partially addresses #20386 (input enforcement only; output postprocessing and composable middleware tracked in follow-up)

## New Package?

- [x] No

## Version Bump?

- [x] No (this is `llama-index-core`, version bumps are handled by maintainers)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## What changed

- **`llama-index-core/llama_index/core/tools/function_tool.py`**:
  - Added `DynamicValue` class — wraps a callable factory for per-request parameter resolution (e.g., from `ContextVar`)
  - Added `protected_params: Optional[Dict[str, Any]]` to `FunctionTool.__init__()` and `from_defaults()`
  - Added `_resolve_protected_params()` method that resolves `DynamicValue` factories at call time
  - Modified `call()`, `acall()`, and `__call__()` to merge `protected_params` **last** so they always win over LLM kwargs
  - `protected_params` keys are hidden from `fn_schema` (LLM never sees them)
  - `protected_params` keys are excluded from `raw_input` in `ToolOutput` (security: no sensitive values in serialized output)

- **`llama-index-core/llama_index/core/tools/__init__.py`**:
  - Exported `DynamicValue` from the public API

- **`llama-index-core/tests/tools/test_base.py`**:
  - Added 8 new tests covering all `protected_params` and `DynamicValue` behaviors

## Why

`partial_params` merges as `{**partial_params, **kwargs}`, so LLM-provided kwargs silently override them. For parameters like `user_id` or `api_key` that **must** come from a trusted source, this is a security gap. Additionally, `partial_params` values are frozen at tool creation time, making per-request dynamic injection (e.g., session-scoped IDs) impossible without rebuilding the tool list.

`protected_params` solves both problems:
1. **Enforcement**: Always merged last → LLM cannot override
2. **Dynamic values**: `DynamicValue(factory)` resolves at call time, not creation time

## How it works

```python
from contextvars import ContextVar
from llama_index.core.tools import FunctionTool, DynamicValue

session_var: ContextVar[str] = ContextVar("session_var")

def billing_lookup(question: str, client_id: str) -> dict:
    return {"balance": 12.34, "client_id": client_id}

tool = FunctionTool.from_defaults(
    fn=billing_lookup,
    # Static protected value:
    # protected_params={"client_id": "cust_123"}
    #
    # Or dynamic per-request value:
    protected_params={"client_id": DynamicValue(lambda: session_var.get())},
)

# LLM can't override client_id — even if it tries:
session_var.set("cust_real_789")
result = tool(question="Why is my bill high?", client_id="hallucinated_id")
assert result.raw_output["client_id"] == "cust_real_789"  # protected wins
assert "client_id" not in result.raw_input["kwargs"]       # excluded from output
```

## Merge priority

```
field_defaults (lowest) < partial_params < kwargs < protected_params (highest)
```

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

```
pytest tests/tools/test_base.py -v — 28 passed, 3 skipped (langchain not installed)
ruff check — All checks passed
ruff format --check — 3 files already formatted
mypy — Success: no issues found in 1 source file
```

New tests:
- `test_function_tool_protected_params_schema` — hidden from schema
- `test_function_tool_protected_params_override` — wins over LLM kwargs
- `test_function_tool_protected_params_with_partial` — interaction with partial_params
- `test_function_tool_protected_params_async` — async path
- `test_function_tool_dynamic_value` — factory resolved at call time
- `test_function_tool_dynamic_value_async` — async dynamic resolution
- `test_function_tool_dynamic_value_factory_error` — error propagation from factory
- `test_function_tool_protected_params_same_key_as_partial` — protected wins over partial

## Tradeoffs / risks

- Zero behavior change when `protected_params` is not provided (backward compatible)
- `DynamicValue` is a simple wrapper class, not a protocol — keeps it explicit and avoids ambiguity with callable values (see PR discussion for design rationale)
- Protected params excluded from `raw_input` to prevent sensitive values leaking into serialized output

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods