### PR TITLE
fix: preserve thinking-only chunks in Ollama streaming

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -472,7 +472,9 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             for r in response:
-                if r["message"]["content"] is None:
+                if r["message"]["content"] is None and not r["message"].get(
+                    "thinking"
+                ):
                     continue
 
                 r = dict(r)
@@ -556,7 +558,9 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             async for r in response:
-                if r["message"]["content"] is None:
+                if r["message"]["content"] is None and not r["message"].get(
+                    "thinking"
+                ):
                     continue
 
                 r = dict(r)


### PR DESCRIPTION
Don't skip chunks that have thinking content but no message content in stream_chat/astream_chat.

Fixes #21232