### PR TITLE
fix(core): prevent KeyError in DocumentSummaryIndex.delete_nodes() with invalid IDs

### DIFF
--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -257,12 +257,14 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
 
         """
         index_nodes = self._index_struct.node_id_to_summary_id.keys()
+        valid_node_ids = []
         for node in node_ids:
             if node not in index_nodes:
                 logger.warning(f"node_id {node} not found, will not be deleted.")
-                node_ids.remove(node)
+            else:
+                valid_node_ids.append(node)
 
-        self._index_struct.delete_nodes(node_ids)
+        self._index_struct.delete_nodes(valid_node_ids)
 
         remove_summary_ids = [
             summary_id

--- a/llama-index-core/tests/indices/document_summary/test_index.py
+++ b/llama-index-core/tests/indices/document_summary/test_index.py
@@ -60,3 +60,25 @@ def test_delete_nodes(
     assert len(index.index_struct.summary_id_to_node_ids) == 2
 
     assert len(index.vector_store._data.embedding_dict) == 2  # type: ignore
+
+
+def test_delete_nodes_with_invalid_ids(
+    docs: List[Document],
+    index: DocumentSummaryIndex,
+) -> None:
+    """Test that delete_nodes gracefully handles invalid node IDs.
+
+    Regression test for https://github.com/run-llama/llama_index/issues/21066
+    Previously, this would raise a KeyError due to mutating the list during
+    iteration and then passing invalid IDs to _index_struct.delete_nodes().
+    """
+    nodes = list(index.index_struct.node_id_to_summary_id.keys())
+    original_count = len(nodes)
+
+    # Should not raise KeyError when all IDs are invalid
+    index.delete_nodes(["does_not_exist_1", "does_not_exist_2"])
+    assert len(index.index_struct.node_id_to_summary_id) == original_count
+
+    # Should not raise when mixing valid and invalid IDs
+    index.delete_nodes([nodes[0], "does_not_exist_3"])
+    assert len(index.index_struct.node_id_to_summary_id) == original_count - 1


### PR DESCRIPTION
## Summary
- Fixes list mutation during iteration in `DocumentSummaryIndex.delete_nodes()` that caused `KeyError` when invalid node IDs were passed
- Builds a filtered list of valid IDs instead of removing items from the input list while iterating
- Adds regression test covering both all-invalid and mixed valid/invalid ID scenarios

## Root Cause
The original code called `node_ids.remove(node)` while iterating over `node_ids`, which can skip elements. Surviving invalid IDs then reached `_index_struct.delete_nodes()` which performs a raw dict lookup, raising `KeyError`.

## Test Plan
- [x] New test `test_delete_nodes_with_invalid_ids` passes
- [x] Existing `test_delete_nodes` unchanged and still passes
- [x] No changes to `IndexDocumentSummary.delete_nodes()` — fix is entirely in the caller

Fixes #21066