### PR TITLE
Fix synchronous streaming in SiliconFlow LLM integration

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/llama_index/llms/siliconflow/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/llama_index/llms/siliconflow/base.py
@@ -464,6 +464,7 @@ class SiliconFlow(FunctionCallingLLM):
                     json=input_json,
                     headers=self._headers,
                     timeout=self.timeout,
+                    stream=True,
                 )
                 response.raise_for_status()
                 response_txt = ""

--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
@@ -189,6 +189,7 @@ def test_stream_chat():
             },
             headers=llm._headers,
             timeout=llm.timeout,
+            stream=True,
         )
 
 


### PR DESCRIPTION
## Summary

This fixes synchronous streaming for the SiliconFlow LLM integration.

`stream_chat()` was already sending `"stream": true` in the request payload, but the underlying synchronous `requests` call did not set `stream=True`. As a result, `response.iter_lines()` could end up reading a buffered response instead of yielding chunks as they arrived.

## What changed

- add `stream=True` to the synchronous `requests.Session.post(...)` call in `SiliconFlow.stream_chat()`
- update the sync streaming unit test to assert that `stream=True` is passed to `requests`

## Why this matters

The async path already behaves like a true stream, but the sync path was not aligned with that behavior.

With this change, the synchronous `stream_chat()` path can yield incremental chunks properly and behaves consistently with the async implementation.

## Validation

I verified this in two ways:

1. Local real-world check against the SiliconFlow API
   - before this change, the sync path appeared buffered and the full answer was printed at once
   - after this change, the sync path started yielding incremental chunks as expected

2. Package tests
   - `uv run --group dev pytest tests/test_llms_siliconflow.py -q`
   - result: `6 passed`

## Scope

This is a minimal bugfix with no API surface change.