### PR TITLE
fix: fix extra bracket in data_sources and typo in data_sinks

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/data_sinks.py
+++ b/llama-index-core/llama_index/core/ingestion/data_sinks.py
@@ -49,7 +49,7 @@ class ConfigurableComponent(Enum):
         )
 
 
-def build_conifurable_data_sink_enum() -> ConfigurableComponent:
+def build_configurable_data_sink_enum() -> ConfigurableComponent:
     """
     Build an enum of configurable data sinks.
     But conditional on if the corresponding vector store is available.
@@ -144,7 +144,7 @@ def build_conifurable_data_sink_enum() -> ConfigurableComponent:
     return ConfigurableComponent("ConfigurableDataSinks", enum_members)  # type: ignore
 
 
-ConfigurableDataSinks = build_conifurable_data_sink_enum()
+ConfigurableDataSinks = build_configurable_data_sink_enum()
 
 
 T = TypeVar("T", bound=BasePydanticVectorStore)

--- a/llama-index-core/llama_index/core/ingestion/data_sources.py
+++ b/llama-index-core/llama_index/core/ingestion/data_sources.py
@@ -80,7 +80,7 @@ class ConfigurableComponent(Enum):
 
         if name is None:
             suffix = uuid.uuid1()
-            name = self.value.name + f" [{suffix}]]"
+            name = self.value.name + f" [{suffix}]"
         return ConfiguredDataSource[component_type](  # type: ignore
             component=component, name=name
         )


### PR DESCRIPTION
Two small fixes in llama-index-core ingestion module:

1. **data_sources.py line 83**: Extra closing bracket `]]` → `]`. Generated data source names produced `"DataSource [uuid]]"` instead of `"DataSource [uuid]"`.

2. **data_sinks.py lines 52, 147**: Function name typo `build_conifurable_data_sink_enum` → `build_configurable_data_sink_enum`. Only referenced internally, no external breakage.