### PR TITLE
docs: add Hindsight memory integration

### DIFF
--- a/docs/src/content/docs/framework/community/integrations.md
+++ b/docs/src/content/docs/framework/community/integrations.md
@@ -46,6 +46,10 @@ for full tracing integrations.
 - [Vector Stores](/python/framework/community/integrations/vector_stores)
 - [Managed Indices](/python/framework/community/integrations/managed_indices)
 
+## Memory
+
+- [Hindsight](/python/framework/community/integrations/hindsight)
+
 ## Application Frameworks
 
 - [Streamlit](https://blog.streamlit.io/build-a-chatbot-with-custom-data-sources-powered-by-llamaindex/)

--- a/docs/src/content/docs/framework/community/integrations/hindsight.md
+++ b/docs/src/content/docs/framework/community/integrations/hindsight.md
@@ -1,0 +1,100 @@
+---
+title: Hindsight
+---
+
+[Hindsight](https://github.com/vectorize-io/hindsight) is an open-source (MIT) long-term memory engine for AI agents. It automatically extracts facts from conversations, builds entity graphs, and retrieves relevant context using four parallel strategies (semantic, BM25, graph traversal, temporal).
+
+The `hindsight-llamaindex` package provides two integration patterns:
+
+- **Tools** (`HindsightToolSpec`): Agent-driven memory via `BaseToolSpec`. The agent decides when to retain, recall, or reflect.
+- **Memory** (`HindsightMemory`): Automatic memory via `BaseMemory`. Messages are stored on every turn and recalled as context.
+
+## Installation and setup
+
+```bash
+pip install hindsight-llamaindex
+```
+
+Hindsight runs locally via Docker, pip, or embedded in Python. See the [quick start guide](https://github.com/vectorize-io/hindsight#quick-start) for setup instructions.
+
+## Agent tools
+
+Give your agent retain/recall/reflect tools and let it decide when to use memory.
+
+```python
+import asyncio
+
+from hindsight_client import Hindsight
+from hindsight_llamaindex import HindsightToolSpec
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+
+
+async def main():
+    client = Hindsight(base_url="http://localhost:8888")
+
+    spec = HindsightToolSpec(
+        client=client,
+        bank_id="user-123",
+        mission="Track user preferences",
+    )
+    tools = spec.to_tool_list()
+
+    agent = ReActAgent(tools=tools, llm=OpenAI(model="gpt-4o"))
+
+    response = await agent.run("Remember that I prefer dark mode")
+    print(response)
+
+    response = await agent.run("What do you know about my preferences?")
+    print(response)
+
+
+asyncio.run(main())
+```
+
+The agent gets three tools: `retain_memory` (store), `recall_memory` (search), and `reflect_on_memory` (synthesize). Use `create_hindsight_tools()` to select which tools to include.
+
+## Automatic memory
+
+For automatic memory without explicit tool calls, use `HindsightMemory`. On every turn, it retains messages to Hindsight and recalls relevant context before the LLM responds.
+
+```python
+import asyncio
+
+from hindsight_client import Hindsight
+from hindsight_llamaindex import HindsightMemory
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+
+
+async def main():
+    client = Hindsight(base_url="http://localhost:8888")
+
+    memory = HindsightMemory.from_client(
+        client=client,
+        bank_id="user-123",
+        mission="Track user preferences",
+    )
+
+    agent = ReActAgent(tools=[], llm=OpenAI(model="gpt-4o"))
+
+    # Memory is passed per-run, not to the constructor
+    response = await agent.run("I work at Acme Corp on the platform team", memory=memory)
+    print(response)
+
+    # On subsequent runs, memories from prior turns are recalled automatically
+    response = await agent.run("What team do I work on?", memory=memory)
+    print(response)
+
+
+asyncio.run(main())
+```
+
+`HindsightMemory` maintains a local chat history buffer for the current session, while Hindsight provides cross-session long-term memory via semantic recall.
+
+## Resources
+
+- [Hindsight GitHub](https://github.com/vectorize-io/hindsight)
+- [hindsight-llamaindex on PyPI](https://pypi.org/project/hindsight-llamaindex/)
+- [Integration documentation](https://docs.hindsight.vectorize.io/sdks/integrations/llamaindex)
+- [Configuration and advanced usage](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/llamaindex)


### PR DESCRIPTION
## Summary

Adds a community integration documentation page for [Hindsight](https://github.com/vectorize-io/hindsight), an open-source (MIT) long-term memory engine for AI agents.

The `hindsight-llamaindex` package ([PyPI](https://pypi.org/project/hindsight-llamaindex/)) provides two integration patterns:

- **`HindsightToolSpec`** (`BaseToolSpec`): Agent-driven memory with retain/recall/reflect tools
- **`HindsightMemory`** (`BaseMemory`): Automatic per-turn memory injection and storage

### Changes

- Added `docs/src/content/docs/framework/community/integrations/hindsight.md` with installation, tools quickstart, and memory quickstart
- Added "Memory" section to the community integrations index with a link to the new page

### Package details

- PyPI: [hindsight-llamaindex](https://pypi.org/project/hindsight-llamaindex/)
- GitHub: [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight)
- License: MIT
- Runs locally (Docker, pip, embedded) or as a managed service

🤖 Generated with [Claude Code](https://claude.com/claude-code)