### PR TITLE
fix: bump llama-index-llms-cerebras openai-like dependency to >=0.7.0

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cerebras/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/pyproject.toml
@@ -34,7 +34,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "llama-index-core>=0.13.0,<0.15",
-    "llama-index-llms-openai-like>=0.5.0,<0.6",
+    "llama-index-llms-openai-like>=0.7.0,<0.8",
 ]
 
 [tool.codespell]


### PR DESCRIPTION
## Summary

Fixes #21100

`llama-index-llms-cerebras` pins `llama-index-llms-openai-like>=0.5.0,<0.6`, but `llama-index 0.14.18` requires `llama-index-llms-openai>=0.7.0` which pulls in `llama-index-llms-openai-like 0.7.x`. This creates an impossible dependency resolution.

Same pattern as #19944 — bump the upper bound so cerebras is compatible with the current openai-like release.

## Change

`llama-index-llms-cerebras/pyproject.toml`: `llama-index-llms-openai-like>=0.5.0,<0.6` → `>=0.7.0,<0.8`