### PR TITLE
fix: correct typo 'similarites' in knowledge graph retriever

### DIFF
--- a/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
@@ -263,7 +263,7 @@ class KGTableRetriever(BaseRetriever):
                 embedding_ids=all_rel_texts,
             )
             logger.debug(
-                f"Found the following rel_texts+query similarites: {similarities!s}"
+                f"Found the following rel_texts+query similarities: {similarities!s}"
             )
             logger.debug(f"Found the following top_k rel_texts: {rel_texts!s}")
             rel_texts.extend(top_rel_texts)


### PR DESCRIPTION
Typo in debug log message at \`llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py\` line 266:

\`similarites\` → \`similarities\`