### PR TITLE
Update llama-index-workflows dependency to >=2.14.0

### DIFF
--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "eval-type-backport>=0.2.0,<0.3 ; python_version < '3.10'",
     "banks>=2.3.0,<3",
     "aiosqlite",
-    "llama-index-workflows>=2,<3,!=2.9.0",
+    "llama-index-workflows>=2.14.0,<3",
     "setuptools>=80.9.0",
     "platformdirs",
     "tinytag>=2.2.0",

--- a/llama-index-core/uv.lock
+++ b/llama-index-core/uv.lock
@@ -1209,7 +1209,7 @@ requires-dist = [
     { name = "filetype", specifier = ">=1.2.0,<2" },
     { name = "fsspec", specifier = ">=2023.5.0" },
     { name = "httpx" },
-    { name = "llama-index-workflows", specifier = ">=2,!=2.9.0,<3" },
+    { name = "llama-index-workflows", specifier = ">=2.14.0,<3" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "nltk", specifier = ">=3.9.3" },


### PR DESCRIPTION
# Description

Updates the `llama-index-workflows` dependency constraint from `>=2,<3,!=2.9.0` to `>=2.14.0,<3`. Older versions did not have the `StateStore` protocol. Core now imports it, so is incompatible with versions prior to 2.14

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

The dependency update is a configuration change that will be validated through the existing test suite and CI/CD pipeline.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods