### PR TITLE
fix(s3-vector-store): warn when _node_content exceeds S3 filterable metadata limit

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-s3/llama_index/vector_stores/s3/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-s3/llama_index/vector_stores/s3/base.py
@@ -40,6 +40,17 @@ class S3VectorStore(BasePydanticVectorStore):
 
     It is recommended to create a vector bucket in S3 first.
 
+    **Important**: LlamaIndex automatically stores the full node content in a
+    metadata field called ``_node_content``. AWS S3 Vectors enforces a 2048-byte
+    limit on *filterable* metadata fields, so ``_node_content`` and ``_node_type``
+    **must** be configured as non-filterable keys in your S3 Vectors index.
+
+    The easiest way to ensure correct configuration is to use
+    :meth:`create_index_from_bucket`, which sets these keys as non-filterable
+    automatically. If you create the index via the AWS console or another tool,
+    add ``_node_content`` and ``_node_type`` to the index's
+    ``metadataConfiguration.nonFilterableMetadataKeys`` before inserting vectors.
+
     Args:
         index_name (str): The name of the index.
         bucket_name_or_arn (str): The name or ARN of the vector bucket.
@@ -266,6 +277,7 @@ class S3VectorStore(BasePydanticVectorStore):
         start_time = time.time()
         available_requests = 5
         added_ids = []
+        _warned_about_node_content = False
         for node_batch in iter_batch(nodes, self.insert_batch_size):
             vectors = []
             for node in node_batch:
@@ -275,6 +287,25 @@ class S3VectorStore(BasePydanticVectorStore):
                 node_metadata.pop("document_id", None)
                 node_metadata.pop("doc_id", None)
                 node_metadata.pop("embedding", None)
+
+                # Warn once if _node_content may exceed S3 Vectors' 2048-byte
+                # filterable metadata limit.  The field is required for node
+                # reconstruction, so it must be configured as a non-filterable
+                # key in the index (done automatically by create_index_from_bucket).
+                if not _warned_about_node_content:
+                    node_content = node_metadata.get("_node_content", "")
+                    if len(node_content.encode("utf-8")) > 2048:
+                        logger.warning(
+                            "The '_node_content' metadata field is larger than "
+                            "2048 bytes. AWS S3 Vectors enforces a 2048-byte limit "
+                            "on filterable metadata fields. Ensure that "
+                            "'_node_content' and '_node_type' are configured as "
+                            "non-filterable keys in your S3 Vectors index to avoid "
+                            "a ValidationException. Use "
+                            "S3VectorStore.create_index_from_bucket() to create an "
+                            "index with the correct configuration automatically."
+                        )
+                        _warned_about_node_content = True
 
                 vectors.append(
                     {


### PR DESCRIPTION
Fixes #21062

## Problem

When users create an S3 Vectors index manually (e.g., via the AWS console) and use `S3VectorStore` to insert nodes, they receive:

```
ValidationException: Filterable metadata must have at most 2048 bytes
```

The root cause is that `node_to_metadata_dict()` always adds a `_node_content` field containing the serialized JSON of the entire node, which is typically much larger than 2048 bytes. AWS S3 Vectors enforces this limit only on *filterable* metadata fields, so the field must be configured as non-filterable in the index.

`create_index_from_bucket()` already handles this correctly by adding `_node_content` and `_node_type` to `metadataConfiguration.nonFilterableMetadataKeys`. However, users creating their index by other means had no guidance on this requirement.

## Solution

- Add a clear note to the class docstring explaining that `_node_content` and `_node_type` must be configured as non-filterable keys, with a recommendation to use `create_index_from_bucket()`.
- In `add()`, emit a `logger.warning` (once per call) when `_node_content` exceeds 2048 bytes, pointing users to the correct fix before the AWS API call fails.

## Testing

Existing tests continue to pass (they use `create_index_from_bucket()` which already configures the index correctly). The new warning path is triggered only when `_node_content` exceeds 2048 bytes in the metadata and index is not configured with non-filterable keys.