### PR TITLE
feat: add HeaderAwareMarkdownSplitter node parser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/__init__.py
+++ b/llama-index-core/llama_index/core/node_parser/__init__.py
@@ -1,5 +1,8 @@
 """Node parsers."""
 
+from llama_index.core.node_parser.file.header_aware_markdown import (
+    HeaderAwareMarkdownSplitter,
+)
 from llama_index.core.node_parser.file.html import HTMLNodeParser
 from llama_index.core.node_parser.file.json import JSONNodeParser
 from llama_index.core.node_parser.file.markdown import MarkdownNodeParser
@@ -48,6 +51,7 @@ __all__ = [
     "SentenceSplitter",
     "CodeSplitter",
     "SimpleFileNodeParser",
+    "HeaderAwareMarkdownSplitter",
     "HTMLNodeParser",
     "MarkdownNodeParser",
     "JSONNodeParser",

--- a/llama-index-core/llama_index/core/node_parser/file/__init__.py
+++ b/llama-index-core/llama_index/core/node_parser/file/__init__.py
@@ -1,3 +1,6 @@
+from llama_index.core.node_parser.file.header_aware_markdown import (
+    HeaderAwareMarkdownSplitter,
+)
 from llama_index.core.node_parser.file.html import HTMLNodeParser
 from llama_index.core.node_parser.file.json import JSONNodeParser
 from llama_index.core.node_parser.file.markdown import MarkdownNodeParser
@@ -6,6 +9,7 @@ from llama_index.core.node_parser.file.simple_file import SimpleFileNodeParser
 __all__ = [
     "SimpleFileNodeParser",
     "HTMLNodeParser",
+    "HeaderAwareMarkdownSplitter",
     "MarkdownNodeParser",
     "JSONNodeParser",
 ]

--- a/llama-index-core/llama_index/core/node_parser/file/header_aware_markdown.py
+++ b/llama-index-core/llama_index/core/node_parser/file/header_aware_markdown.py
@@ -1,0 +1,312 @@
+"""Header-aware Markdown node parser with token-limit enforcement."""
+
+import re
+from typing import Any, Callable, List, Optional, Sequence
+
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.callbacks.base import CallbackManager
+from llama_index.core.node_parser.interface import NodeParser
+from llama_index.core.node_parser.node_utils import build_nodes_from_splits
+from llama_index.core.schema import BaseNode, MetadataMode, TextNode
+from llama_index.core.utils import get_tokenizer, get_tqdm_iterable
+
+_DEFAULT_CHUNK_SIZE = 1024
+_HEADER_RE = re.compile(r"^(#+)\s(.*)")
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
+
+class HeaderAwareMarkdownSplitter(NodeParser):
+    """Markdown node parser that respects header groupings *and* enforces token limits.
+
+    Unlike :class:`MarkdownNodeParser` (which has no size constraint) or
+    :class:`SentenceSplitter` (which has no markdown awareness), this parser
+    keeps each header together with its body text whenever the section fits
+    within ``chunk_size``.  Sections that exceed the limit are split at
+    paragraph / sentence boundaries with the header context **prepended** to
+    every sub-chunk so retrieval never loses the structural context.
+
+    Args:
+        chunk_size: Maximum number of tokens per chunk.
+        header_path_separator: Separator for the ``header_path`` metadata value.
+        include_header_in_chunks: Prepend the header hierarchy to each sub-chunk
+            when a section must be split.
+        sub_splitter: Optional callable ``(text, chunk_size) -> list[str]`` used
+            to split oversized section bodies.  Defaults to a simple
+            paragraph-then-sentence splitter.  Swap this out for e.g. a semantic
+            splitter to get embedding-aware splits.
+    """
+
+    chunk_size: int = Field(
+        default=_DEFAULT_CHUNK_SIZE,
+        description="Maximum number of tokens per chunk.",
+        gt=0,
+    )
+    header_path_separator: str = Field(
+        default="/",
+        description="Separator for the header_path metadata value.",
+    )
+    include_header_in_chunks: bool = Field(
+        default=True,
+        description="Prepend the header hierarchy to each sub-chunk when a section is split.",
+    )
+
+    _tokenizer: Callable = PrivateAttr()
+    _sub_splitter: Optional[Callable[..., List[str]]] = PrivateAttr()
+
+    def __init__(
+        self,
+        chunk_size: int = _DEFAULT_CHUNK_SIZE,
+        header_path_separator: str = "/",
+        include_header_in_chunks: bool = True,
+        tokenizer: Optional[Callable] = None,
+        sub_splitter: Optional[Callable[..., List[str]]] = None,
+        include_metadata: bool = True,
+        include_prev_next_rel: bool = True,
+        callback_manager: Optional[CallbackManager] = None,
+        id_func: Optional[Callable] = None,
+    ) -> None:
+        callback_manager = callback_manager or CallbackManager([])
+        super().__init__(
+            chunk_size=chunk_size,
+            header_path_separator=header_path_separator,
+            include_header_in_chunks=include_header_in_chunks,
+            include_metadata=include_metadata,
+            include_prev_next_rel=include_prev_next_rel,
+            callback_manager=callback_manager,
+            id_func=id_func,
+        )
+        self._tokenizer = tokenizer or get_tokenizer()
+        self._sub_splitter = sub_splitter
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_nodes_from_node(self, node: BaseNode) -> List[TextNode]:
+        """Split a single document node into header-aware chunks."""
+        text = node.get_content(metadata_mode=MetadataMode.NONE)
+        sections = self._parse_markdown_sections(text)
+        result: List[TextNode] = []
+
+        for header_line, body, header_path in sections:
+            section_text = (header_line + "\n" + body).strip() if header_line else body.strip()
+            if not section_text:
+                continue
+
+            token_count = len(self._tokenizer(section_text))
+
+            if token_count <= self.chunk_size:
+                result.append(self._build_node(section_text, node, header_path))
+            else:
+                # Section exceeds chunk_size — sub-split the body.
+                sub_chunks = self._split_oversized_section(
+                    header_line, body.strip(), header_path
+                )
+                for chunk in sub_chunks:
+                    result.append(self._build_node(chunk, node, header_path))
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Markdown parsing
+    # ------------------------------------------------------------------
+
+    def _parse_markdown_sections(
+        self, text: str
+    ) -> List[tuple[str, str, str]]:
+        """Parse markdown into ``(header_line, body_text, header_path)`` tuples.
+
+        Returns one tuple per section.  ``header_line`` is the raw ``## Foo``
+        line (empty string for content before the first header).
+        ``header_path`` is the slash-separated ancestor path *excluding* the
+        current header (matching :class:`MarkdownNodeParser` convention).
+        """
+        lines = text.split("\n")
+        sections: List[tuple[str, str, str]] = []
+        header_stack: List[tuple[int, str]] = []
+        current_header_line = ""
+        current_body_lines: List[str] = []
+        code_block = False
+
+        def _flush() -> None:
+            body = "\n".join(current_body_lines)
+            path = self.header_path_separator.join(h[1] for h in header_stack[:-1]) if header_stack else ""
+            sections.append((current_header_line, body, path))
+
+        for line in lines:
+            # Track code blocks to avoid treating ```# Foo``` as a header.
+            if _FENCE_RE.match(line.lstrip()):
+                code_block = not code_block
+                current_body_lines.append(line)
+                continue
+
+            if not code_block:
+                header_match = _HEADER_RE.match(line)
+                if header_match:
+                    # Flush previous section.  Must happen BEFORE modifying
+                    # header_stack because _flush reads header_stack[:-1]
+                    # to build the ancestor path for the previous section.
+                    if current_header_line or current_body_lines:
+                        _flush()
+
+                    level = len(header_match.group(1))
+                    header_text = header_match.group(2)
+
+                    while header_stack and header_stack[-1][0] >= level:
+                        header_stack.pop()
+                    header_stack.append((level, header_text))
+
+                    current_header_line = line
+                    current_body_lines = []
+                    continue
+
+            current_body_lines.append(line)
+
+        # Final section.
+        if current_header_line or current_body_lines:
+            _flush()
+
+        return sections
+
+    # ------------------------------------------------------------------
+    # Sub-splitting
+    # ------------------------------------------------------------------
+
+    def _split_oversized_section(
+        self, header_line: str, body: str, header_path: str
+    ) -> List[str]:
+        """Split an oversized section body into chunks, prepending header context."""
+        prefix = ""
+        if self.include_header_in_chunks and header_line:
+            prefix = header_line + "\n"
+
+        prefix_tokens = len(self._tokenizer(prefix)) if prefix else 0
+        available = self.chunk_size - prefix_tokens
+        if available < 1:
+            available = 1
+
+        if self._sub_splitter is not None:
+            raw_chunks = self._sub_splitter(body, available)
+        else:
+            raw_chunks = self._default_split(body, available)
+
+        return [(prefix + chunk).strip() for chunk in raw_chunks if chunk.strip()]
+
+    def _default_split(self, text: str, max_tokens: int) -> List[str]:
+        """Split text by paragraphs first, then sentences, respecting max_tokens."""
+        paragraphs = re.split(r"\n\s*\n", text)
+        chunks: List[str] = []
+        current_chunk = ""
+
+        for para in paragraphs:
+            para = para.strip()
+            if not para:
+                continue
+
+            candidate = (current_chunk + "\n\n" + para).strip() if current_chunk else para
+
+            if len(self._tokenizer(candidate)) <= max_tokens:
+                current_chunk = candidate
+            else:
+                # Flush what we have.
+                if current_chunk:
+                    chunks.append(current_chunk)
+
+                # If this single paragraph fits, start a new chunk.
+                if len(self._tokenizer(para)) <= max_tokens:
+                    current_chunk = para
+                else:
+                    # Paragraph itself is too big — split by sentences.
+                    sentence_chunks = self._split_by_sentences(para, max_tokens)
+                    if not sentence_chunks:
+                        # Fallback: emit the paragraph even if oversized.
+                        chunks.append(para)
+                        current_chunk = ""
+                    else:
+                        chunks.extend(sentence_chunks[:-1])
+                        current_chunk = sentence_chunks[-1]
+
+        if current_chunk:
+            chunks.append(current_chunk)
+
+        return chunks
+
+    def _split_by_sentences(self, text: str, max_tokens: int) -> List[str]:
+        """Last-resort split by sentence boundaries.
+
+        Uses a simple regex that handles ``. ``, ``! ``, ``? `` and newlines.
+        Sentences that still exceed *max_tokens* are further split on word
+        boundaries so the chunk-size guarantee is never silently violated.
+        """
+        sentences = re.split(r"(?<=[.!?])\s+|\n", text)
+        chunks: List[str] = []
+        current = ""
+
+        for sent in sentences:
+            sent = sent.strip()
+            if not sent:
+                continue
+
+            # If a single sentence exceeds the limit, split on whitespace.
+            if len(self._tokenizer(sent)) > max_tokens:
+                if current:
+                    chunks.append(current)
+                    current = ""
+                for word in sent.split():
+                    candidate = (current + " " + word).strip() if current else word
+                    if len(self._tokenizer(candidate)) <= max_tokens:
+                        current = candidate
+                    else:
+                        if current:
+                            chunks.append(current)
+                        current = word
+                continue
+
+            candidate = (current + " " + sent).strip() if current else sent
+            if len(self._tokenizer(candidate)) <= max_tokens:
+                current = candidate
+            else:
+                if current:
+                    chunks.append(current)
+                current = sent
+
+        if current:
+            chunks.append(current)
+
+        return chunks
+
+    # ------------------------------------------------------------------
+    # Node construction
+    # ------------------------------------------------------------------
+
+    def _build_node(
+        self, text: str, source_node: BaseNode, header_path: str
+    ) -> TextNode:
+        """Build a TextNode with header_path metadata."""
+        node = build_nodes_from_splits([text], source_node, id_func=self.id_func)[0]
+
+        if self.include_metadata:
+            sep = self.header_path_separator
+            node.metadata["header_path"] = (
+                sep + header_path + sep if header_path else sep
+            )
+
+        return node
+
+    # ------------------------------------------------------------------
+    # NodeParser interface
+    # ------------------------------------------------------------------
+
+    def _parse_nodes(
+        self,
+        nodes: Sequence[BaseNode],
+        show_progress: bool = False,
+        **kwargs: Any,
+    ) -> List[BaseNode]:
+        all_nodes: List[BaseNode] = []
+        nodes_with_progress = get_tqdm_iterable(nodes, show_progress, "Parsing nodes")
+
+        for node in nodes_with_progress:
+            all_nodes.extend(self.get_nodes_from_node(node))
+
+        return all_nodes

--- a/llama-index-core/tests/node_parser/test_header_aware_markdown.py
+++ b/llama-index-core/tests/node_parser/test_header_aware_markdown.py
@@ -1,0 +1,189 @@
+"""Tests for HeaderAwareMarkdownSplitter."""
+
+from llama_index.core.node_parser.file.header_aware_markdown import (
+    HeaderAwareMarkdownSplitter,
+)
+from llama_index.core.schema import Document
+
+
+def _split(text: str, **kwargs) -> list:
+    """Helper — split a markdown string and return the resulting nodes."""
+    parser = HeaderAwareMarkdownSplitter(**kwargs)
+    return parser.get_nodes_from_documents([Document(text=text)])
+
+
+# ------------------------------------------------------------------
+# Basic behaviour
+# ------------------------------------------------------------------
+
+
+def test_single_section_within_limit():
+    """A short section stays as one node."""
+    nodes = _split("# Hello\n\nWorld", chunk_size=1024)
+    assert len(nodes) == 1
+    assert nodes[0].text == "# Hello\n\nWorld"
+    assert nodes[0].metadata["header_path"] == "/"
+
+
+def test_multiple_sections_within_limit():
+    """Multiple headers produce one node each when they fit."""
+    md = "# A\n\nContent A\n\n# B\n\nContent B"
+    nodes = _split(md, chunk_size=1024)
+    assert len(nodes) == 2
+    assert "Content A" in nodes[0].text
+    assert "Content B" in nodes[1].text
+
+
+def test_nested_headers_path():
+    """Header path metadata reflects the ancestor hierarchy."""
+    md = "# Top\n\nIntro\n\n## Sub\n\nSub content\n\n### Deep\n\nDeep content"
+    nodes = _split(md, chunk_size=1024)
+    assert len(nodes) == 3
+    assert nodes[0].metadata["header_path"] == "/"
+    assert nodes[1].metadata["header_path"] == "/Top/"
+    assert nodes[2].metadata["header_path"] == "/Top/Sub/"
+
+
+# ------------------------------------------------------------------
+# Oversized section splitting
+# ------------------------------------------------------------------
+
+
+def test_oversized_section_splits():
+    """A section exceeding chunk_size is split into multiple nodes."""
+    # Build a section with many paragraphs that exceeds a tiny chunk_size.
+    paragraphs = [f"Paragraph {i}. " * 10 for i in range(10)]
+    body = "\n\n".join(paragraphs)
+    md = f"# Big Section\n\n{body}"
+
+    nodes = _split(md, chunk_size=50)
+    assert len(nodes) > 1
+    # Every chunk should start with the header when include_header_in_chunks=True.
+    for node in nodes:
+        assert node.text.startswith("# Big Section")
+
+
+def test_oversized_section_no_header_prepend():
+    """When include_header_in_chunks=False, sub-chunks don't get the header."""
+    paragraphs = [f"Paragraph {i}. " * 10 for i in range(10)]
+    body = "\n\n".join(paragraphs)
+    md = f"# Big Section\n\n{body}"
+
+    nodes = _split(md, chunk_size=50, include_header_in_chunks=False)
+    assert len(nodes) > 1
+    # First node has the header (it's part of the original section),
+    # but subsequent nodes should NOT start with "#".
+    non_first = [n for n in nodes if not n.text.startswith("# Big Section")]
+    assert len(non_first) > 0
+
+
+def test_oversized_single_paragraph_splits_by_sentences():
+    """A single giant paragraph is split at sentence boundaries."""
+    sentences = [f"Sentence number {i}." for i in range(50)]
+    md = "# Title\n\n" + " ".join(sentences)
+
+    nodes = _split(md, chunk_size=30)
+    assert len(nodes) > 1
+
+
+# ------------------------------------------------------------------
+# Code blocks
+# ------------------------------------------------------------------
+
+
+def test_headers_in_code_blocks_ignored():
+    """Headers inside backtick code blocks should not be treated as section boundaries."""
+    md = "# Real Header\n\nSome text\n\n```python\n# This is a comment\ndef foo():\n    pass\n```\n\nMore text"
+    nodes = _split(md, chunk_size=1024)
+    assert len(nodes) == 1
+    assert "# This is a comment" in nodes[0].text
+
+
+def test_headers_in_tilde_code_blocks_ignored():
+    """Headers inside tilde-fenced code blocks should not be treated as section boundaries."""
+    md = "# Real Header\n\nSome text\n\n~~~python\n# This is a comment\ndef foo():\n    pass\n~~~\n\nMore text"
+    nodes = _split(md, chunk_size=1024)
+    assert len(nodes) == 1
+    assert "# This is a comment" in nodes[0].text
+
+
+# ------------------------------------------------------------------
+# Edge cases
+# ------------------------------------------------------------------
+
+
+def test_empty_document():
+    """Empty input produces no nodes."""
+    nodes = _split("", chunk_size=1024)
+    assert len(nodes) == 0
+
+
+def test_no_headers():
+    """Text without any headers is returned as a single node."""
+    md = "Just some plain text\n\nWith paragraphs"
+    nodes = _split(md, chunk_size=1024)
+    assert len(nodes) == 1
+    assert "Just some plain text" in nodes[0].text
+
+
+def test_header_with_no_body():
+    """A header followed immediately by another header produces a node with just the header."""
+    md = "# First\n\n# Second\n\nContent"
+    nodes = _split(md, chunk_size=1024)
+    assert len(nodes) == 2
+    assert nodes[0].text == "# First"
+    assert "Content" in nodes[1].text
+
+
+def test_oversized_single_sentence_word_fallback():
+    """A single sentence exceeding chunk_size is split at word boundaries."""
+    # One very long sentence with no periods in the middle.
+    long_sentence = " ".join([f"word{i}" for i in range(200)])
+    md = f"# Title\n\n{long_sentence}"
+
+    nodes = _split(md, chunk_size=20)
+    assert len(nodes) > 1
+    # Every chunk should be non-empty.
+    for node in nodes:
+        assert node.text.strip()
+
+
+def test_determinism():
+    """Same input always produces the same splits."""
+    md = "# A\n\nText A\n\n## B\n\nText B\n\n# C\n\nText C"
+    nodes_1 = _split(md, chunk_size=1024)
+    nodes_2 = _split(md, chunk_size=1024)
+    assert [n.text for n in nodes_1] == [n.text for n in nodes_2]
+
+
+# ------------------------------------------------------------------
+# Custom separator
+# ------------------------------------------------------------------
+
+
+def test_custom_header_path_separator():
+    """Custom separator is reflected in header_path metadata."""
+    md = "# Top\n\nIntro\n\n## Sub\n\nContent"
+    nodes = _split(md, chunk_size=1024, header_path_separator="›")
+    assert nodes[1].metadata["header_path"] == "›Top›"
+
+
+# ------------------------------------------------------------------
+# Sub-splitter extensibility
+# ------------------------------------------------------------------
+
+
+def test_custom_sub_splitter():
+    """A custom sub_splitter callable is used for oversized sections."""
+    calls = []
+
+    def my_splitter(text: str, max_tokens: int) -> list[str]:
+        calls.append((text, max_tokens))
+        return [text[:50], text[50:]]
+
+    paragraphs = ["Word " * 100 for _ in range(5)]
+    md = "# Big\n\n" + "\n\n".join(paragraphs)
+
+    nodes = _split(md, chunk_size=20, sub_splitter=my_splitter)
+    assert len(calls) > 0  # Our custom splitter was invoked
+    assert len(nodes) >= 2


### PR DESCRIPTION
## Summary

Partial fix for #21213 — implements the `HeaderAwareMarkdownSplitter` component. The `VerificationQueryEngine` component is being handled separately by @DYNOSuprovo.

### Problem

LlamaIndex has two markdown-related parsers with complementary gaps:
- **`MarkdownNodeParser`** — respects headers but has no token size limit (a 50k-token section becomes one node)
- **`SentenceSplitter`** — enforces token limits but has no markdown awareness (severs headers from their content)

### Solution

`HeaderAwareMarkdownSplitter` fills the gap: it keeps each header grouped with its body text when the section fits within `chunk_size`, and splits oversized sections at paragraph/sentence/word boundaries with the **header context prepended** to every sub-chunk.

### Usage

```python
from llama_index.core.node_parser import HeaderAwareMarkdownSplitter

splitter = HeaderAwareMarkdownSplitter(chunk_size=512)
nodes = splitter.get_nodes_from_documents(documents)

# Each node has header_path metadata: "/Introduction/Setup/"
```

### Key features

- **Header hierarchy** tracked in `header_path` metadata (same convention as `MarkdownNodeParser`)
- **Deterministic** — same input always produces same splits (no embedding model needed)
- **Code fence handling** — both backtick (`` ``` ``) and tilde (`~~~`) fences
- **Multi-level fallback** — paragraph → sentence → word boundaries for oversized content
- **Pluggable `sub_splitter`** parameter for custom split strategies (e.g. semantic splitting)

### Changes

| File | Change |
|---|---|
| `node_parser/file/header_aware_markdown.py` | New `HeaderAwareMarkdownSplitter` class (~250 lines) |
| `node_parser/file/__init__.py` | Export registration |
| `node_parser/__init__.py` | Top-level export |
| `tests/node_parser/test_header_aware_markdown.py` | 15 tests |

## Test plan

- [x] 15 new tests pass covering:
  - Basic single/multiple section splits
  - Nested header path metadata
  - Oversized section splitting (paragraph, sentence, word boundaries)
  - Code blocks (backtick and tilde fences)
  - Edge cases (empty doc, no headers, header with no body)
  - Determinism
  - Custom separator and custom sub_splitter
- [x] All 7 existing `MarkdownNodeParser` tests still pass