### PR TITLE
Fix `delete_nodes()` crash on invalid node IDs in DocumentSummaryIndex

### DIFF
--- a/llama-index-core/llama_index/core/data_structs/document_summary.py
+++ b/llama-index-core/llama_index/core/data_structs/document_summary.py
@@ -64,7 +64,9 @@ class IndexDocumentSummary(IndexStruct):
 
     def delete_nodes(self, node_ids: List[str]) -> None:
         for node_id in node_ids:
-            summary_id = self.node_id_to_summary_id[node_id]
+            summary_id = self.node_id_to_summary_id.get(node_id)
+            if summary_id is None:
+                continue
             self.summary_id_to_node_ids[summary_id].remove(node_id)
             del self.node_id_to_summary_id[node_id]
 

--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -257,12 +257,14 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
 
         """
         index_nodes = self._index_struct.node_id_to_summary_id.keys()
-        for node in node_ids:
-            if node not in index_nodes:
-                logger.warning(f"node_id {node} not found, will not be deleted.")
-                node_ids.remove(node)
+        valid_node_ids = []
+        for node_id in node_ids:
+            if node_id not in index_nodes:
+                logger.warning(f"node_id {node_id} not found, will not be deleted.")
+            else:
+                valid_node_ids.append(node_id)
 
-        self._index_struct.delete_nodes(node_ids)
+        self._index_struct.delete_nodes(valid_node_ids)
 
         remove_summary_ids = [
             summary_id


### PR DESCRIPTION
Fixes #21066

### Description

`delete_nodes()` crashes with `KeyError` when called with node IDs that don't exist in the index. Two bugs contribute:

1. **Mutating list during iteration** -- The method calls `node_ids.remove(node)` while iterating over `node_ids`, which skips elements and allows invalid IDs to pass through.
2. **Raw dict lookup** -- `IndexDocumentSummary.delete_nodes()` uses `self.node_id_to_summary_id[node_id]` which raises `KeyError` for any invalid ID that wasn't filtered.

### Changes

- **`base.py`**: Replace the mutate-during-iteration pattern with a separate `valid_node_ids` list built via a single pass, then pass only valid IDs to the struct.
- **`document_summary.py`**: Use `.get()` with a `None` check and `continue` as a defensive guard in `IndexDocumentSummary.delete_nodes()`, so it gracefully skips unknown node IDs.

### Testing

```python
from llama_index.core import Document, Settings
from llama_index.core.indices.document_summary import DocumentSummaryIndex
from llama_index.core.llms.mock import MockLLM
from llama_index.core.embeddings.mock_embed_model import MockEmbedding

Settings.llm = MockLLM()
Settings.embed_model = MockEmbedding(embed_dim=8)

index = DocumentSummaryIndex.from_documents([Document(text="Hello world")])
# Previously crashed with KeyError; now logs warnings and completes
index.delete_nodes(["does_not_exist_1", "does_not_exist_2"])
```