### PR TITLE
Fix Refine to catch ValueError/TypeError from structured outputs

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -246,9 +246,9 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
-                        f"Validation error on structured response: {e}", exc_info=True
+                        f"Error on structured response: {e}", exc_info=True
                     )
             elif response is None and self._streaming:
                 response = self._llm.stream(
@@ -326,9 +326,9 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
-                        f"Validation error on structured response: {e}", exc_info=True
+                        f"Error on structured response: {e}", exc_info=True
                     )
             else:
                 # TODO: structured response not supported for streaming
@@ -435,9 +435,9 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
-                        f"Validation error on structured response: {e}", exc_info=True
+                        f"Error on structured response: {e}", exc_info=True
                     )
             else:
                 if isinstance(response, Generator):
@@ -494,9 +494,9 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
-                except ValidationError as e:
+                except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(
-                        f"Validation error on structured response: {e}", exc_info=True
+                        f"Error on structured response: {e}", exc_info=True
                     )
             elif response is None and self._streaming:
                 response = await self._llm.astream(


### PR DESCRIPTION
Fixes #21089

### Description

When using `output_cls` or `structured_answer_filtering` with a function-calling LLM, the `Refine` response synthesizer only catches `ValidationError` from structured output programs. However, the function-calling path can also raise:

- **`ValueError`** when the LLM returns no tool calls
- **`TypeError`** when the tool output is not a `BaseModel` subclass

These are semantically equivalent to `ValidationError` (the structured output failed) and should follow the same warning-and-fallback path rather than crashing the query.

### Changes

In `refine.py`, extend all four `except ValidationError` blocks to also catch `ValueError` and `TypeError`:

1. `_give_response_single` (sync) -- line ~240
2. `_refine_response_single` (sync) -- line ~300
3. `_arefine_response_single` (async) -- line ~408
4. `_agive_response_single` (async) -- line ~448

Each change is identical: `except ValidationError as e:` becomes `except (ValidationError, ValueError, TypeError) as e:`.

The log message is also generalized from "Validation error" to "Error" since it now covers more exception types.

### Testing

```python
from unittest.mock import patch
from pydantic import BaseModel, Field
from llama_index.core import SummaryIndex, Document
from llama_index.core.response_synthesizers import Refine
from llama_index.core.program.function_program import FunctionCallingProgram
from llama_index.llms.openai import OpenAI

class Answer(BaseModel):
    response: str = Field(description="Answer to the question")
    confidence: float = Field(description="Confidence score between 0 and 1")

docs = [Document(text="Paris is the capital of France.")]
index = SummaryIndex.from_documents(docs)
query_engine = index.as_query_engine(
    response_synthesizer=Refine(llm=OpenAI(api_key="sk-fake"), output_cls=Answer)
)

# Previously crashed with ValueError; now falls back to "Empty Response"
with patch.object(FunctionCallingProgram, "__call__", side_effect=ValueError("LLM did not return any tool calls")):
    response = query_engine.query("What is the capital of France?")
print(response)  # "Empty Response"
```