### PR TITLE
fix: prevent KeyError in DocumentSummaryIndex.delete_nodes with unknown IDs

### DIFF
--- a/llama-index-core/llama_index/core/data_structs/document_summary.py
+++ b/llama-index-core/llama_index/core/data_structs/document_summary.py
@@ -64,7 +64,9 @@ class IndexDocumentSummary(IndexStruct):
 
     def delete_nodes(self, node_ids: List[str]) -> None:
         for node_id in node_ids:
-            summary_id = self.node_id_to_summary_id[node_id]
+            summary_id = self.node_id_to_summary_id.get(node_id)
+            if summary_id is None:
+                continue
             self.summary_id_to_node_ids[summary_id].remove(node_id)
             del self.node_id_to_summary_id[node_id]
 

--- a/llama-index-core/llama_index/core/indices/document_summary/base.py
+++ b/llama-index-core/llama_index/core/indices/document_summary/base.py
@@ -257,12 +257,14 @@ class DocumentSummaryIndex(BaseIndex[IndexDocumentSummary]):
 
         """
         index_nodes = self._index_struct.node_id_to_summary_id.keys()
-        for node in node_ids:
-            if node not in index_nodes:
-                logger.warning(f"node_id {node} not found, will not be deleted.")
-                node_ids.remove(node)
+        valid_node_ids = []
+        for node_id in node_ids:
+            if node_id not in index_nodes:
+                logger.warning(f"node_id {node_id} not found, will not be deleted.")
+            else:
+                valid_node_ids.append(node_id)
 
-        self._index_struct.delete_nodes(node_ids)
+        self._index_struct.delete_nodes(valid_node_ids)
 
         remove_summary_ids = [
             summary_id


### PR DESCRIPTION
Fixes #21066

Calling `delete_nodes()` with any node ID that isn't in the index raises a KeyError. Two things were causing it: the code was calling `list.remove()` while iterating over the same list (classic bug that silently skips elements), and `IndexDocumentSummary.delete_nodes` did a raw dict lookup on `node_id_to_summary_id` instead of using `.get()`. Fixed by collecting valid IDs in a separate pass first, and using `.get()` with a None guard in the data struct so unknown node IDs are just skipped.