### PR TITLE
fix: catch ValueError and TypeError in Refine structured output handlers

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -189,7 +189,7 @@ class Refine(BaseSynthesizer):
             if self._output_cls is not None:
                 try:
                     response = self._output_cls.model_validate_json(response)
-                except ValidationError:
+                except (ValidationError, ValueError, TypeError):
                     pass
             else:
                 response = response or "Empty Response"


### PR DESCRIPTION
Fixes #21089

When using `output_cls` with a function-calling LLM, you can get a ValueError if the model returns no tool calls, or a TypeError if the output isn't a BaseModel subclass. These were crashing the query instead of falling back gracefully like ValidationError already does. Extended all five except blocks in `refine.py` (the sync and async versions of `_give_response_single` and `_refine_response_single`, plus the initial `model_validate_json` call) to catch all three exception types.