### PR TITLE
fix: correct docstring typos in integration packages

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/llama_index/llms/ipex_llm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/llama_index/llms/ipex_llm/base.py
@@ -496,7 +496,7 @@ class IpexLLM(CustomLLM):
             kwargs: Other kwargs for complete.
 
         Returns:
-            CompletionReponse after generation.
+            CompletionResponse after generation.
 
         """
         if not formatted:
@@ -532,7 +532,7 @@ class IpexLLM(CustomLLM):
             kwargs: Other kwargs for complete.
 
         Returns:
-            CompletionReponse after generation.
+            CompletionResponse after generation.
 
         """
         from transformers import TextIteratorStreamer

--- a/llama-index-integrations/readers/llama-index-readers-faiss/llama_index/readers/faiss/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-faiss/llama_index/readers/faiss/base.py
@@ -13,7 +13,7 @@ class FaissReader(BaseReader):
 
     Retrieves documents through an existing in-memory Faiss index.
     These documents can then be used in a downstream LlamaIndex data structure.
-    If you wish use Faiss itself as an index to to organize documents,
+    If you wish use Faiss itself as an index to organize documents,
     insert documents, and perform queries on them, please use VectorStoreIndex
     with FaissVectorStore.
 

--- a/llama-index-integrations/readers/llama-index-readers-txtai/llama_index/readers/txtai/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-txtai/llama_index/readers/txtai/base.py
@@ -13,7 +13,7 @@ class TxtaiReader(BaseReader):
 
     Retrieves documents through an existing in-memory txtai index.
     These documents can then be used in a downstream LlamaIndex data structure.
-    If you wish use txtai itself as an index to to organize documents,
+    If you wish use txtai itself as an index to organize documents,
     insert documents, and perform queries on them, please use VectorStoreIndex
     with TxtaiVectorStore.
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-awsdocdb/llama_index/vector_stores/awsdocdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-awsdocdb/llama_index/vector_stores/awsdocdb/base.py
@@ -1,7 +1,7 @@
 """
 AWS Document DB Vector store index.
 
-An index that that is built on top of an existing vector store.
+An index that is built on top of an existing vector store.
 
 """
 


### PR DESCRIPTION
## Summary
- Fix duplicate words: `that that` → `that` in awsdocdb, `to to` → `to` in faiss and txtai readers
- Fix typo `CompletionReponse` → `CompletionResponse` in ipex-llm docstrings

## Test plan
- [ ] Docstring-only changes, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)