### PR TITLE
fix: add missing f-string prefixes in moorcheh and dashscope integrations

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/base.py
@@ -169,7 +169,7 @@ class DashScopeCloudIndex(BaseManagedIndex):
             print(f"failed_docs: {failed_docs}")
 
         if ingestion_status == "FAILED":
-            print("Index {name} created failed!")
+            print(f"Index {name} creation failed!")
             return None
 
         if verbose:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-moorcheh/llama_index/vector_stores/moorcheh/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-moorcheh/llama_index/vector_stores/moorcheh/base.py
@@ -125,16 +125,16 @@ class MoorchehVectorStore(BasePydanticVectorStore):
             ]
             logger.debug("Found namespaces.")
         except Exception as e:
-            logger.debug("Failed to list namespaces: {e}")
+            logger.debug(f"Failed to list namespaces: {e}")
             raise
 
         # Check if the namespace exists
         if self.namespace in namespaces:
             logger.debug(
-                "Namespace '{self.namespace}' already exists. No action required."
+                f"Namespace '{self.namespace}' already exists. No action required."
             )
         else:
-            logger.debug("Namespace '{self.namespace}' not found. Creating it.")
+            logger.debug(f"Namespace '{self.namespace}' not found. Creating it.")
             # If the namespace doesn't exist, create it
             try:
                 self._client.create_namespace(
@@ -142,9 +142,9 @@ class MoorchehVectorStore(BasePydanticVectorStore):
                     type=self.namespace_type,
                     vector_dimension=self.vector_dimension,
                 )
-                logger.debug("Namespace '{self.namespace}' created.")
+                logger.debug(f"Namespace '{self.namespace}' created.")
             except Exception as e:
-                logger.debug("Failed to create namespace: {e}")
+                logger.debug(f"Failed to create namespace: {e}")
                 raise
 
     # _client: MoorchehClient = PrivateAttr()


### PR DESCRIPTION
## Summary
- Add missing `f` prefix to 5 log messages in moorcheh vector store where `{e}`, `{self.namespace}` are printed as literal text
- Add missing `f` prefix and fix grammar in dashscope index: `Index {name} created failed!` → `f"Index {name} creation failed!"`

## Motivation
Without the `f` prefix, debug log and print messages show literal `{variable}` text instead of actual values, making debugging impossible.

## Test plan
- [ ] Verify log messages correctly interpolate variable values

🤖 Generated with [Claude Code](https://claude.com/claude-code)