### PR TITLE
fix: correct typos, duplicate words and grammar across integrations

### DIFF
--- a/llama-index-core/llama_index/core/image_retriever.py
+++ b/llama-index-core/llama_index/core/image_retriever.py
@@ -44,7 +44,7 @@ class BaseImageRetriever(PromptMixin, DispatcherSpanMixin):
         Retrieve image nodes given single image input.
 
         Args:
-            str_or_query_bundle (QueryType): a image path
+            str_or_query_bundle (QueryType): an image path
             string or a QueryBundle object.
 
         """

--- a/llama-index-core/llama_index/core/query_engine/multi_modal.py
+++ b/llama-index-core/llama_index/core/query_engine/multi_modal.py
@@ -234,7 +234,7 @@ class SimpleMultiModalQueryEngine(BaseQueryEngine):
         return response
 
     def image_query(self, image_path: QueryType, prompt_str: str) -> RESPONSE_TYPE:
-        """Answer a image query."""
+        """Answer an image query."""
         with self.callback_manager.event(
             CBEventType.QUERY, payload={EventPayload.QUERY_STR: str(image_path)}
         ) as query_event:

--- a/llama-index-integrations/indices/llama-index-indices-managed-google/llama_index/indices/managed/google/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-google/llama_index/indices/managed/google/base.py
@@ -219,7 +219,7 @@ class GoogleIndex(BaseManagedIndex):
             will follow with the originally provided passages, which will have
             a score from the retrieval.
 
-            `Response`'s `metadata` may also have have an entry with key
+            `Response`'s `metadata` may also have an entry with key
             `answerable_probability`, which is the probability that the grounded
             answer is likely correct.
 

--- a/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/base.py
@@ -232,7 +232,7 @@ class Cohere(FunctionCallingLLM):
         # cohere SDK will fail loudly if both connectors and documents are provided
         if additional_kwargs.get("documents", []) and documents and len(documents) > 0:
             raise ValueError(
-                "Received documents both as a keyword argument and as an prompt additional keyword argument. Please choose only one option."
+                "Received documents both as a keyword argument and as a prompt additional keyword argument. Please choose only one option."
             )
 
         messages, documents = remove_documents_from_messages(messages)

--- a/llama-index-integrations/llms/llama-index-llms-qianfan/llama_index/llms/qianfan/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-qianfan/llama_index/llms/qianfan/base.py
@@ -355,7 +355,7 @@ class Qianfan(CustomLLM):
             and the previous messages are the historical chat information. The number of
             members must be odd, and the role value of the odd-numbered messages must be
             "user", while the role value of the even-numbered messages must be "assistant".
-        :return: A ChatResponseAsyncGen object, which is a asynchronous generator of ChatResponse.
+        :return: A ChatResponseAsyncGen object, which is an asynchronous generator of ChatResponse.
         """
         request = build_chat_request(stream=True, messages=messages, **kwargs)
 

--- a/llama-index-integrations/llms/llama-index-llms-sambanovasystems/llama_index/llms/sambanovasystems/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-sambanovasystems/llama_index/llms/sambanovasystems/base.py
@@ -279,7 +279,7 @@ class SambaNovaCloud(LLM):
         self, messages_dicts: List[Dict], stop: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         """
-        Performs a async post request to the LLM API.
+        Performs an async post request to the LLM API.
 
         Args:
             messages_dicts: List of role / content dicts to use as input.

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/agentql_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/agentql_web/base.py
@@ -18,7 +18,7 @@ REQUEST_ORIGIN = "llamaindex"
 
 class AgentQLWebReader(BasePydanticReader):
     """
-    Scrape a URL with or without a agentql query and returns document in json format.
+    Scrape a URL with or without an AgentQL query and returns document in json format.
 
     Args:
         api_key (str): The AgentQL API key, get one at https://dev.agentql.com

--- a/llama-index-integrations/response_synthesizers/llama-index-response-synthesizers-google/llama_index/response_synthesizers/google/base.py
+++ b/llama-index-integrations/response_synthesizers/llama-index-response-synthesizers-google/llama_index/response_synthesizers/google/base.py
@@ -195,7 +195,7 @@ class GoogleTextSynthesizer(BaseSynthesizer):
             will follow with the originally provided passages, which will have
             a score from the retrieval.
 
-            Response's `metadata` may also have have an entry with key
+            Response's `metadata` may also have an entry with key
             `answerable_probability`, which is the model's estimate of the
             probability that its answer is correct and grounded in the input
             passages.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lindorm/llama_index/vector_stores/lindorm/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lindorm/llama_index/vector_stores/lindorm/base.py
@@ -115,7 +115,7 @@ class LindormVectorClient:
 
         if filter_type not in ["post_filter", "pre_filter"]:
             raise ValueError(
-                f"Unsupported filter type: {filter_type}, only post_filter and pre_filter are suopported now."
+                f"Unsupported filter type: {filter_type}, only post_filter and pre_filter are supported now."
             )
 
         # initialize parameters

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -139,7 +139,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         upsert_mode (bool, optional): Whether to upsert documents into existing collection with same node id. Defaults to False.
         doc_id_field (str, optional): The name of the doc_id field for the collection,
             defaults to DEFAULT_DOC_ID_KEY.
-        text_key (str, optional): What key text is stored in in the passed collection.
+        text_key (str, optional): What key text is stored in the passed collection.
             Used when bringing your own collection. Defaults to DEFAULT_TEXT_KEY.
         scalar_field_names (list, optional): The names of the extra scalar fields to be included in the collection schema.
         scalar_field_types (list, optional): The types of the extra scalar fields.


### PR DESCRIPTION
## Summary
- Fix duplicate words: `in in` → `in` (milvus), `have have` → `have` (google managed index & response synthesizer)
- Fix typo: `suopported` → `supported` (lindorm)
- Fix article usage (a/an): 6 instances across cohere, sambanova, qianfan, agentql, multi_modal, image_retriever

## Test plan
- [ ] Docstring and comment changes only, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)