### PR TITLE
feat(readers/service-now): add OAuth2 Client Credentials Grant Flow s…

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-service-now/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## [0.4.0] - 2026-04-05
+
+### Added
+
+- Support for OAuth2 Client Credentials Grant Flow authentication (machine-to-machine, no username/password required)
+- Requires pysnc>=1.2.1 which includes `ServiceNowClientCredentialsFlow`
+
+### Changed
+
+- Authentication validation now supports three modes: basic auth, password grant flow, and client credentials flow
+- `username` and `password` parameters are no longer always required (only needed for basic/password grant flow)
+- Bumped minimum `pysnc` dependency from `>=1.0.0` to `>=1.2.1`
+
 ## [0.1.0] - 2025-07-15
 
 ### Added

--- a/llama-index-integrations/readers/llama-index-readers-service-now/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/README.md
@@ -6,27 +6,35 @@ pip install llama-index-readers-service-now
 
 This loader reads Knowledge Base articles from a ServiceNow instance. The user needs to specify the ServiceNow instance URL and authentication credentials to initialize the SnowKBReader.
 
-The loader uses the `pysnc` library to connect to ServiceNow and retrieve knowledge base articles. It supports authentication via username/password (basic auth) or with OAuth2 client credentials (password grant flow).
+The loader uses the `pysnc` library to connect to ServiceNow and retrieve knowledge base articles. It supports authentication via username/password (basic auth), OAuth2 password grant flow, or OAuth2 client credentials grant flow.
 
 **Important**: This reader requires custom parsers for processing different file types. At minimum, an HTML parser must be provided for processing article bodies.
 
 ## Authentication
 
-The reader requires the following authentication parameters:
+The reader supports three authentication methods:
 
-**Required:**
+### 1. Basic Auth (username/password)
 
 - `instance`: Your ServiceNow instance name (e.g., "dev12345" - without .service-now.com)
 - `username`: ServiceNow username
 - `password`: ServiceNow password
 - `custom_parsers`: Dictionary mapping FileType enum values to BaseReader instances (REQUIRED)
 
-**Optional (for OAuth2 password grant flow):**
+### 2. OAuth2 Password Grant Flow (username/password + client credentials)
 
-- `client_id`: OAuth2 client ID (if provided, client_secret is also required)
-- `client_secret`: OAuth2 client secret (if provided, client_id is also required)
+- `instance`, `username`, `password`, `custom_parsers` (as above)
+- `client_id`: OAuth2 client ID
+- `client_secret`: OAuth2 client secret
 
-If OAuth2 parameters are not provided, the reader will use basic authentication with username/password.
+### 3. OAuth2 Client Credentials Grant Flow (machine-to-machine, no username/password)
+
+- `instance`: Your ServiceNow instance name
+- `client_id`: OAuth2 client ID
+- `client_secret`: OAuth2 client secret
+- `custom_parsers`: Dictionary mapping FileType enum values to BaseReader instances (REQUIRED)
+
+This flow is ideal for machine-to-machine authentication where no user context is needed. Requires `pysnc>=1.2.1`.
 
 ## Event System
 
@@ -184,12 +192,31 @@ reader = SnowKBReader(
     custom_parsers=custom_parsers,  # REQUIRED parameter
     username="your_username",
     password="your_password",
-    # Optional OAuth2 parameters:
+    # Optional OAuth2 parameters for password grant flow:
     # client_id="your_client_id",
     # client_secret="your_client_secret",
 )
 
 # Load a specific article by sys_id
+documents = reader.load_data(article_sys_id="your_article_sys_id")
+```
+
+```python
+# Example using OAuth2 Client Credentials Grant Flow (machine-to-machine, no username/password)
+from llama_index.readers.service_now import SnowKBReader, FileType
+
+# Custom parsers are REQUIRED
+custom_parsers = {
+    FileType.HTML: HTMLParser()  # Required for article body processing
+}
+
+reader = SnowKBReader(
+    instance="dev12345",
+    custom_parsers=custom_parsers,
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+)
+
 documents = reader.load_data(article_sys_id="your_article_sys_id")
 ```
 

--- a/llama-index-integrations/readers/llama-index-readers-service-now/llama_index/readers/service_now/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/llama_index/readers/service_now/base.py
@@ -6,7 +6,7 @@ from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
 from llama_index.core.instrumentation import get_dispatcher
 from pysnc import GlideRecord, ServiceNowClient
-from pysnc.auth import ServiceNowPasswordGrantFlow
+from pysnc.auth import ServiceNowPasswordGrantFlow, ServiceNowClientCredentialsFlow
 import requests
 from pydantic import BaseModel, Field, model_validator, ConfigDict
 
@@ -240,7 +240,7 @@ class CustomParserManager(BaseModel):
 
 class SnowKBReader(BaseReader):
     """
-    ServiceNow Knowledge Base reader using PySNC with username/password or password grant flow.
+    ServiceNow Knowledge Base reader using PySNC with multiple authentication methods.
 
     This reader requires custom parsers for processing different file types. At minimum,
     an HTML parser must be provided for processing article bodies. Additional parsers
@@ -265,10 +265,10 @@ class SnowKBReader(BaseReader):
         custom_parsers: Dictionary mapping FileType enum values to BaseReader instances.
                        This is REQUIRED and must include at least FileType.HTML.
                        Each parser must implement the load_data method.
-        username: ServiceNow username for authentication (required)
-        password: ServiceNow password for authentication (required)
-        client_id: OAuth client ID for ServiceNow (optional, but if provided, client_secret is required)
-        client_secret: OAuth client secret for ServiceNow (optional, but if provided, client_id is required)
+        username: ServiceNow username for authentication (required for basic/password grant flow)
+        password: ServiceNow password for authentication (required for basic/password grant flow)
+        client_id: OAuth client ID for ServiceNow
+        client_secret: OAuth client secret for ServiceNow
         process_attachment_callback: Optional callback to filter attachments (content_type: str, size_bytes: int, file_name: str) -> tuple[bool, str]
         process_document_callback: Optional callback to filter documents (kb_number: str) -> bool
         custom_folder: Folder for temporary files during parsing
@@ -278,7 +278,9 @@ class SnowKBReader(BaseReader):
 
     Authentication:
         - Basic auth: Provide username and password only
-        - OAuth flow: Provide username, password, client_id, and client_secret
+        - Password grant flow (OAuth): Provide username, password, client_id, and client_secret
+        - Client credentials flow (OAuth): Provide client_id and client_secret only (no username/password).
+          Requires pysnc>=1.2.1.
 
     Events:
         The reader fires various events during processing using LlamaIndex's standard
@@ -344,17 +346,29 @@ class SnowKBReader(BaseReader):
                 )
 
         # Validate authentication parameters
-        # Username and password are always required
-        if not username:
-            raise ValueError("username parameter is required")
-        if not password:
-            raise ValueError("password parameter is required")
+        # Three valid authentication combinations:
+        # 1. Basic auth: username + password (no client_id/client_secret)
+        # 2. Password grant flow: username + password + client_id + client_secret
+        # 3. Client credentials flow: client_id + client_secret (no username/password)
 
-        # If client_id is provided, client_secret must also be provided (for OAuth flow)
-        if client_id is not None and client_secret is None:
-            raise ValueError("client_secret is required when client_id is provided")
-        if client_secret is not None and client_id is None:
-            raise ValueError("client_id is required when client_secret is provided")
+        # Check for partial credential pairs first to give specific error messages
+        if (username is not None) != (password is not None):
+            raise ValueError("Both username and password must be provided together.")
+
+        if (client_id is not None) != (client_secret is not None):
+            raise ValueError(
+                "Both client_id and client_secret must be provided together."
+            )
+
+        has_user_creds = username is not None and password is not None
+        has_client_creds = client_id is not None and client_secret is not None
+
+        if not has_user_creds and not has_client_creds:
+            raise ValueError(
+                "Authentication credentials required. Provide either "
+                "username/password (basic or password grant flow) or "
+                "client_id/client_secret (client credentials flow)."
+            )
 
         self.instance = instance
         self.username = username
@@ -408,22 +422,31 @@ class SnowKBReader(BaseReader):
         try:
             self.logger.info("Initializing ServiceNow client")
             instance = self.instance
-            user = self.username
-            password = self.password
 
-            # Use OAuth flow if client_id and client_secret are provided, otherwise use basic auth
-            if self.client_id and self.client_secret:
-                client_id = self.client_id
-                client_secret = self.client_secret
+            if (
+                self.client_id
+                and self.client_secret
+                and self.username
+                and self.password
+            ):
+                # Password grant flow: username + password + client_id + client_secret
                 self.pysnc_client = ServiceNowClient(
                     instance,
                     ServiceNowPasswordGrantFlow(
-                        user, password, client_id, client_secret
+                        self.username, self.password, self.client_id, self.client_secret
                     ),
+                )
+            elif self.client_id and self.client_secret:
+                # Client credentials flow: client_id + client_secret only
+                self.pysnc_client = ServiceNowClient(
+                    instance,
+                    ServiceNowClientCredentialsFlow(self.client_id, self.client_secret),
                 )
             else:
                 # Basic authentication with username and password
-                self.pysnc_client = ServiceNowClient(instance, (user, password))
+                self.pysnc_client = ServiceNowClient(
+                    instance, (self.username, self.password)
+                )
         except Exception as e:
             self.logger.error(f"Error initializing ServiceNow client: {e}")
             raise ValueError(f"Error initializing ServiceNow client: {e}")

--- a/llama-index-integrations/readers/llama-index-readers-service-now/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-service-now"
-version = "0.3.0"
+version = "0.4.0"
 description = "llama-index readers service-now integration"
 authors = [{name = "Ameetpal Singh", email = "ameetpal.singh@maersk.com"}]
 requires-python = ">=3.10,<4.0"
@@ -35,7 +35,7 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 maintainers = [{name = "ameetpal.singh"}]
 dependencies = [
-    "pysnc>=1.0.0,<2",
+    "pysnc>=1.2.1,<2",
     "requests>=2.25.0,<3",
     "llama-index-core>=0.13.0,<0.15",
 ]

--- a/llama-index-integrations/readers/llama-index-readers-service-now/tests/test_snow_kb_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/tests/test_snow_kb_reader.py
@@ -58,6 +58,14 @@ class MockPasswordGrantFlow:
         pass
 
 
+class MockClientCredentialsFlow:
+    """Mock client credentials grant flow for ServiceNow authentication."""
+
+    def __init__(self, client_id, client_secret):
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
 @pytest.fixture
 def mock_pysnc_imports():
     """Mock pysnc imports for testing."""
@@ -65,6 +73,9 @@ def mock_pysnc_imports():
         sys.modules["pysnc"].ServiceNowClient = MockServiceNowClient
         sys.modules["pysnc"].GlideRecord = MagicMock()
         sys.modules["pysnc.auth"].ServiceNowPasswordGrantFlow = MockPasswordGrantFlow
+        sys.modules[
+            "pysnc.auth"
+        ].ServiceNowClientCredentialsFlow = MockClientCredentialsFlow
         yield
 
 
@@ -78,21 +89,51 @@ def snow_reader(mock_pysnc_imports):
             "llama_index.readers.service_now.base.ServiceNowPasswordGrantFlow",
             MockPasswordGrantFlow,
         ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                MockClientCredentialsFlow,
+            ):
+                from llama_index.readers.service_now import SnowKBReader
+                from llama_index.readers.service_now.base import FileType
+
+                # Create custom parsers dictionary with mock parsers
+                custom_parsers = {
+                    FileType.HTML: MockCustomParser(),  # HTML parser is required
+                    FileType.PDF: MockCustomParser(),
+                    FileType.DOCUMENT: MockCustomParser(),
+                }
+
+                return SnowKBReader(
+                    instance="test.service-now.com",
+                    custom_parsers=custom_parsers,
+                    username="test_user",
+                    password="test_pass",
+                    client_id="test_client_id",
+                    client_secret="test_client_secret",
+                )
+
+
+@pytest.fixture
+def snow_reader_client_creds(mock_pysnc_imports):
+    """Fixture to create a SnowKBReader instance using client credentials flow."""
+    with patch(
+        "llama_index.readers.service_now.base.ServiceNowClient", MockServiceNowClient
+    ):
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+            MockClientCredentialsFlow,
+        ):
             from llama_index.readers.service_now import SnowKBReader
             from llama_index.readers.service_now.base import FileType
 
-            # Create custom parsers dictionary with mock parsers
             custom_parsers = {
-                FileType.HTML: MockCustomParser(),  # HTML parser is required
+                FileType.HTML: MockCustomParser(),
                 FileType.PDF: MockCustomParser(),
-                FileType.DOCUMENT: MockCustomParser(),
             }
 
             return SnowKBReader(
                 instance="test.service-now.com",
                 custom_parsers=custom_parsers,
-                username="test_user",
-                password="test_pass",
                 client_id="test_client_id",
                 client_secret="test_client_secret",
             )
@@ -138,7 +179,7 @@ class TestSnowKBReader:
                 assert reader.custom_parsers == custom_parsers
 
     def test_initialization_missing_credentials(self):
-        """Test that SnowKBReader raises error when missing required credentials."""
+        """Test that SnowKBReader raises error when missing all credentials."""
         from llama_index.readers.service_now import SnowKBReader
         from llama_index.readers.service_now.base import FileType
 
@@ -147,7 +188,7 @@ class TestSnowKBReader:
             FileType.PDF: MockCustomParser(),
         }
 
-        with pytest.raises(ValueError, match="username parameter is required"):
+        with pytest.raises(ValueError, match="Authentication credentials required"):
             SnowKBReader(instance="test.service-now.com", custom_parsers=custom_parsers)
 
     def test_load_data_by_sys_id(self, snow_reader):
@@ -599,3 +640,372 @@ class TestSnowKBReader:
                 pytest.fail(
                     f"Unexpected error during minimal SnowKBReader instantiation: {e}"
                 )
+
+
+class TestClientCredentialsFlow:
+    """Test class for Client Credentials Grant Flow authentication."""
+
+    def test_client_credentials_initialization(self, mock_pysnc_imports):
+        """Test SnowKBReader initializes correctly with client credentials only."""
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            MockServiceNowClient,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                MockClientCredentialsFlow,
+            ):
+                from llama_index.readers.service_now import SnowKBReader
+                from llama_index.readers.service_now.base import FileType
+
+                custom_parsers = {
+                    FileType.HTML: MockCustomParser(),
+                    FileType.PDF: MockCustomParser(),
+                }
+
+                reader = SnowKBReader(
+                    instance="test.service-now.com",
+                    custom_parsers=custom_parsers,
+                    client_id="test_client_id",
+                    client_secret="test_client_secret",
+                )
+
+                assert reader.instance == "test.service-now.com"
+                assert reader.username is None
+                assert reader.password is None
+                assert reader.client_id == "test_client_id"
+                assert reader.client_secret == "test_client_secret"
+                assert reader.kb_table == "kb_knowledge"
+                assert reader.pysnc_client is not None
+                assert reader.custom_parsers == custom_parsers
+
+    def test_client_credentials_uses_correct_flow(self, mock_pysnc_imports):
+        """Test that client credentials flow uses ServiceNowClientCredentialsFlow."""
+        mock_snow_client = MagicMock()
+        mock_cred_flow = MagicMock()
+
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            mock_snow_client,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                mock_cred_flow,
+            ):
+                from llama_index.readers.service_now import SnowKBReader
+                from llama_index.readers.service_now.base import FileType
+
+                custom_parsers = {FileType.HTML: MockCustomParser()}
+
+                SnowKBReader(
+                    instance="test.service-now.com",
+                    custom_parsers=custom_parsers,
+                    client_id="my_client_id",
+                    client_secret="my_client_secret",
+                )
+
+                # Verify ServiceNowClientCredentialsFlow was called with correct args
+                mock_cred_flow.assert_called_once_with(
+                    "my_client_id", "my_client_secret"
+                )
+                # Verify ServiceNowClient was called with the flow instance
+                mock_snow_client.assert_called_once_with(
+                    "test.service-now.com", mock_cred_flow.return_value
+                )
+
+    def test_password_grant_flow_still_used_when_all_creds_provided(
+        self, mock_pysnc_imports
+    ):
+        """Test that password grant flow is used when all four credentials are provided."""
+        mock_snow_client = MagicMock()
+        mock_pwd_flow = MagicMock()
+        mock_cred_flow = MagicMock()
+
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            mock_snow_client,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowPasswordGrantFlow",
+                mock_pwd_flow,
+            ):
+                with patch(
+                    "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                    mock_cred_flow,
+                ):
+                    from llama_index.readers.service_now import SnowKBReader
+                    from llama_index.readers.service_now.base import FileType
+
+                    custom_parsers = {FileType.HTML: MockCustomParser()}
+
+                    SnowKBReader(
+                        instance="test.service-now.com",
+                        custom_parsers=custom_parsers,
+                        username="test_user",
+                        password="test_pass",
+                        client_id="test_client_id",
+                        client_secret="test_client_secret",
+                    )
+
+                    # Password grant flow should be used, not client credentials
+                    mock_pwd_flow.assert_called_once_with(
+                        "test_user",
+                        "test_pass",
+                        "test_client_id",
+                        "test_client_secret",
+                    )
+                    mock_cred_flow.assert_not_called()
+
+    def test_basic_auth_used_when_only_username_password(self, mock_pysnc_imports):
+        """Test that basic auth is used when only username and password are provided."""
+        mock_snow_client = MagicMock()
+
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            mock_snow_client,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                MockClientCredentialsFlow,
+            ):
+                from llama_index.readers.service_now import SnowKBReader
+                from llama_index.readers.service_now.base import FileType
+
+                custom_parsers = {FileType.HTML: MockCustomParser()}
+
+                SnowKBReader(
+                    instance="test.service-now.com",
+                    custom_parsers=custom_parsers,
+                    username="test_user",
+                    password="test_pass",
+                )
+
+                # Basic auth should pass a tuple
+                mock_snow_client.assert_called_once_with(
+                    "test.service-now.com", ("test_user", "test_pass")
+                )
+
+    def test_client_credentials_load_data(self, snow_reader_client_creds):
+        """Test loading data using client credentials flow reader."""
+        with patch.object(snow_reader_client_creds, "load_data") as mock_load_data:
+            mock_doc = Document(
+                text="Test content",
+                metadata={
+                    "title": "Test KB Article",
+                    "page_id": "KB0010001",
+                    "status": "Published",
+                },
+            )
+            mock_load_data.return_value = [mock_doc]
+
+            result = snow_reader_client_creds.load_data(article_sys_id="test_sys_id")
+
+            assert len(result) == 1
+            assert result[0].text == "Test content"
+
+    def test_missing_client_secret_raises_error(self, mock_pysnc_imports):
+        """Test that providing client_id without client_secret raises error."""
+        from llama_index.readers.service_now import SnowKBReader
+        from llama_index.readers.service_now.base import FileType
+
+        custom_parsers = {FileType.HTML: MockCustomParser()}
+
+        with pytest.raises(
+            ValueError, match="Both client_id and client_secret must be provided"
+        ):
+            SnowKBReader(
+                instance="test.service-now.com",
+                custom_parsers=custom_parsers,
+                client_id="test_client_id",
+            )
+
+    def test_missing_client_id_raises_error(self, mock_pysnc_imports):
+        """Test that providing client_secret without client_id raises error."""
+        from llama_index.readers.service_now import SnowKBReader
+        from llama_index.readers.service_now.base import FileType
+
+        custom_parsers = {FileType.HTML: MockCustomParser()}
+
+        with pytest.raises(
+            ValueError, match="Both client_id and client_secret must be provided"
+        ):
+            SnowKBReader(
+                instance="test.service-now.com",
+                custom_parsers=custom_parsers,
+                client_secret="test_client_secret",
+            )
+
+    def test_username_without_password_raises_error(self, mock_pysnc_imports):
+        """Test that providing username without password raises error."""
+        from llama_index.readers.service_now import SnowKBReader
+        from llama_index.readers.service_now.base import FileType
+
+        custom_parsers = {FileType.HTML: MockCustomParser()}
+
+        with pytest.raises(
+            ValueError, match="Both username and password must be provided"
+        ):
+            SnowKBReader(
+                instance="test.service-now.com",
+                custom_parsers=custom_parsers,
+                username="test_user",
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+            )
+
+    def test_password_without_username_raises_error(self, mock_pysnc_imports):
+        """Test that providing password without username raises error."""
+        from llama_index.readers.service_now import SnowKBReader
+        from llama_index.readers.service_now.base import FileType
+
+        custom_parsers = {FileType.HTML: MockCustomParser()}
+
+        with pytest.raises(
+            ValueError, match="Both username and password must be provided"
+        ):
+            SnowKBReader(
+                instance="test.service-now.com",
+                custom_parsers=custom_parsers,
+                password="test_pass",
+                client_id="test_client_id",
+                client_secret="test_client_secret",
+            )
+
+    def test_no_credentials_raises_error(self, mock_pysnc_imports):
+        """Test that providing no credentials at all raises error."""
+        from llama_index.readers.service_now import SnowKBReader
+        from llama_index.readers.service_now.base import FileType
+
+        custom_parsers = {FileType.HTML: MockCustomParser()}
+
+        with pytest.raises(ValueError, match="Authentication credentials required"):
+            SnowKBReader(
+                instance="test.service-now.com",
+                custom_parsers=custom_parsers,
+            )
+
+    def test_client_credentials_with_callbacks(self, mock_pysnc_imports):
+        """Test client credentials flow with process callbacks."""
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            MockServiceNowClient,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                MockClientCredentialsFlow,
+            ):
+                from llama_index.readers.service_now import SnowKBReader
+                from llama_index.readers.service_now.base import FileType
+
+                def process_attachment_callback(
+                    file_name: str, size: int
+                ) -> tuple[bool, str]:
+                    return True, "Processing"
+
+                def process_document_callback(kb_number: str) -> bool:
+                    return True
+
+                custom_parsers = {FileType.HTML: MockCustomParser()}
+
+                reader = SnowKBReader(
+                    instance="test.service-now.com",
+                    custom_parsers=custom_parsers,
+                    client_id="test_client_id",
+                    client_secret="test_client_secret",
+                    process_attachment_callback=process_attachment_callback,
+                    process_document_callback=process_document_callback,
+                )
+
+                assert reader.process_attachment_callback is not None
+                assert reader.process_document_callback is not None
+                assert reader.username is None
+                assert reader.password is None
+
+    def test_client_credentials_with_custom_kb_table(self, mock_pysnc_imports):
+        """Test client credentials flow with custom KB table."""
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            MockServiceNowClient,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                MockClientCredentialsFlow,
+            ):
+                from llama_index.readers.service_now import SnowKBReader
+                from llama_index.readers.service_now.base import FileType
+
+                custom_parsers = {FileType.HTML: MockCustomParser()}
+
+                reader = SnowKBReader(
+                    instance="test.service-now.com",
+                    custom_parsers=custom_parsers,
+                    client_id="test_client_id",
+                    client_secret="test_client_secret",
+                    kb_table="custom_kb_table",
+                )
+
+                assert reader.kb_table == "custom_kb_table"
+
+    def test_backward_compatibility_basic_auth(self, mock_pysnc_imports):
+        """Test backward compatibility: basic auth still works as before."""
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            MockServiceNowClient,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                MockClientCredentialsFlow,
+            ):
+                from llama_index.readers.service_now import SnowKBReader
+                from llama_index.readers.service_now.base import FileType
+
+                custom_parsers = {FileType.HTML: MockCustomParser()}
+
+                reader = SnowKBReader(
+                    instance="test.service-now.com",
+                    custom_parsers=custom_parsers,
+                    username="test_user",
+                    password="test_pass",
+                )
+
+                assert reader.instance == "test.service-now.com"
+                assert reader.username == "test_user"
+                assert reader.password == "test_pass"
+                assert reader.client_id is None
+                assert reader.client_secret is None
+                assert reader.pysnc_client is not None
+
+    def test_backward_compatibility_password_grant_flow(self, mock_pysnc_imports):
+        """Test backward compatibility: password grant flow still works as before."""
+        with patch(
+            "llama_index.readers.service_now.base.ServiceNowClient",
+            MockServiceNowClient,
+        ):
+            with patch(
+                "llama_index.readers.service_now.base.ServiceNowPasswordGrantFlow",
+                MockPasswordGrantFlow,
+            ):
+                with patch(
+                    "llama_index.readers.service_now.base.ServiceNowClientCredentialsFlow",
+                    MockClientCredentialsFlow,
+                ):
+                    from llama_index.readers.service_now import SnowKBReader
+                    from llama_index.readers.service_now.base import FileType
+
+                    custom_parsers = {FileType.HTML: MockCustomParser()}
+
+                    reader = SnowKBReader(
+                        instance="test.service-now.com",
+                        custom_parsers=custom_parsers,
+                        username="test_user",
+                        password="test_pass",
+                        client_id="test_client_id",
+                        client_secret="test_client_secret",
+                    )
+
+                    assert reader.instance == "test.service-now.com"
+                    assert reader.username == "test_user"
+                    assert reader.password == "test_pass"
+                    assert reader.client_id == "test_client_id"
+                    assert reader.client_secret == "test_client_secret"
+                    assert reader.pysnc_client is not None

--- a/llama-index-integrations/readers/llama-index-readers-service-now/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-service-now/uv.lock
@@ -1760,7 +1760,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.14.19"
+version = "0.14.20"
 source = { directory = "../../../llama-index-core" }
 dependencies = [
     { name = "aiohttp" },
@@ -1855,6 +1855,7 @@ dev = [
     { name = "types-deprecated", specifier = ">=0.1.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.12,<7" },
     { name = "types-requests", specifier = ">=2.28.11.8" },
+    { name = "types-setuptools" },
 ]
 
 [[package]]
@@ -1872,7 +1873,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-service-now"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1906,7 +1907,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "llama-index-core", directory = "../../../llama-index-core" },
-    { name = "pysnc", specifier = ">=1.0.0,<2" },
+    { name = "pysnc", specifier = ">=1.2.1,<2" },
     { name = "requests", specifier = ">=2.25.0,<3" },
 ]
 


### PR DESCRIPTION
## Description

Add support for **OAuth2 Client Credentials Grant Flow** authentication to the ServiceNow Knowledge Base reader, enabling machine-to-machine auth without requiring username/password.

The `pysnc` library (v1.2.1) now includes `ServiceNowClientCredentialsFlow`. This PR integrates that new auth flow into `SnowKBReader` while keeping full backward compatibility with the existing basic auth and password grant flow.

### What changed

- Import and integrate `ServiceNowClientCredentialsFlow` from `pysnc>=1.2.1`
- `SnowKBReader` now supports three auth modes:
  - **Basic auth**: `username` + `password`
  - **Password grant flow**: `username` + `password` + `client_id` + `client_secret`
  - **Client credentials flow** *(new)*: `client_id` + `client_secret` only
- `username`/`password` are no longer required when using client credentials flow
- Validation reordered to give specific error messages for partial credentials
- Bumped `pysnc` minimum dependency from `>=1.0.0` to `>=1.2.1`
- Updated README with documentation and usage examples for all three auth modes
- Added 14 new tests covering the new flow and edge cases

### Dependencies

- `pysnc>=1.2.1` (was `>=1.0.0`)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes (`0.3.0` → `0.4.0`)
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

All 35 tests pass (21 existing + 14 new):

- [x] I added new unit tests to cover this change

New tests in `TestClientCredentialsFlow`:
- Client credentials initialization and property assertions
- Correct auth flow selection (client credentials vs password grant vs basic auth)
- Partial credential validation errors
- No credentials provided
- Client credentials flow with callbacks, custom KB table
- Backward compatibility for basic auth and password grant flow

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods