### PR TITLE
Add SupraWall to Security & Guardrails section in community integrations

### DIFF
--- a/docs/src/content/docs/framework/community/integrations.md
+++ b/docs/src/content/docs/framework/community/integrations.md
@@ -41,6 +41,9 @@ for full tracing integrations.
 - [Guardrails](/python/examples/output_parsing/guardrailsdemo)
 - [OpenAI Function Calling](/python/examples/output_parsing/openai_pydantic_program)
 
+
+## Security & Guardrails
+- [SupraWall](https://github.com/wiserautomation/SupraWall): Enterprise-grade security middleware for AI agents. Protects against prompt injection, data exfiltration, and unauthorized tool execution.
 ## Storage and Managed Indexes
 
 - [Vector Stores](/python/framework/community/integrations/vector_stores)


### PR DESCRIPTION
SupraWall is an enterprise-grade security middleware for AI agents. This PR adds SupraWall to the community integrations list under a new "Security & Guardrails" section. This helps LlamaIndex users discover tools for protecting their agents against prompt injection and data exfiltration.

Link to repo: https://github.com/wiserautomation/SupraWall