### PR TITLE
fix(databricks): make doc_id column name configurable

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-databricks/llama_index/vector_stores/databricks/base.py
@@ -106,6 +106,7 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
     stores_text: bool = True
     text_column: Optional[str]
     columns: Optional[List[str]]
+    doc_id_column: str = "doc_id"
 
     _index: VectorSearchIndex = PrivateAttr()
     _primary_key: str = PrivateAttr()
@@ -119,8 +120,9 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
         index: VectorSearchIndex,
         text_column: Optional[str] = None,
         columns: Optional[List[str]] = None,
+        doc_id_column: str = "doc_id",
     ) -> None:
-        super().__init__(text_column=text_column, columns=columns)
+        super().__init__(text_column=text_column, columns=columns, doc_id_column=doc_id_column)
 
         try:
             from databricks.vector_search.client import VectorSearchIndex
@@ -149,8 +151,8 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
 
         if columns is None:
             columns = []
-        if "doc_id" not in columns:
-            columns = columns[:19] + ["doc_id"]
+        if doc_id_column not in columns:
+            columns = columns[:19] + [doc_id_column]
 
         # initialize the column name for the text column in the delta table
         if self._is_databricks_managed_embeddings():
@@ -216,8 +218,8 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
             metadata_columns = self.columns or []
 
             # explicitly record doc_id as metadata (for delete)
-            if "doc_id" not in metadata_columns:
-                metadata_columns.append("doc_id")
+            if self.doc_id_column not in metadata_columns:
+                metadata_columns.append(self.doc_id_column)
 
             entry = {
                 self._primary_key: node_id,
@@ -232,7 +234,7 @@ class DatabricksVectorSearch(BasePydanticVectorStore):
                     )
                 },
             }
-            doc_id = metadata.get("doc_id")
+            doc_id = metadata.get(self.doc_id_column)
             self._doc_id_to_pk[doc_id] = list(
                 set(self._doc_id_to_pk.get(doc_id, []) + [node_id])  # noqa: RUF005
             )  # associate this node_id with this doc_id


### PR DESCRIPTION
Fixes #19515

## Problem

`DatabricksVectorSearch` hardcodes `"doc_id"` as the column name used to track
LlamaIndex document IDs in the Databricks index. Users whose existing index
schema uses a different column name get a 400 error at query time:

```
Error querying: "Requested columns to fetch are not present in index: doc_id"
```

## Solution

Add a `doc_id_column` parameter to `DatabricksVectorSearch.__init__` that
defaults to `"doc_id"` (fully backward compatible). All internal references to
the hardcoded `"doc_id"` string are replaced with `self.doc_id_column`.

Users with a non-standard schema can now do:

```python
store = DatabricksVectorSearch(
    index=databricks_index,
    text_column="title",
    columns=["id", "organization_id"],
    doc_id_column="my_doc_id",  # maps to whatever column tracks document IDs
)
```

## Testing

No automated tests exist for this integration (requires a live Databricks
cluster). The change is minimal — a rename of a hardcoded literal to a
configurable field — and preserves all existing behavior when `doc_id_column`
is not specified.