### PR TITLE
Fix: base64 image encoding returns bytes instead of string (#21186)

### DIFF
--- a/llama-index-core/llama_index/core/img_utils.py
+++ b/llama-index-core/llama_index/core/img_utils.py
@@ -22,7 +22,7 @@ def img_2_b64(image: ImageFile, format: str = "JPEG") -> str:
     """
     buff = BytesIO()
     image.save(buff, format=format)
-    return cast(str, base64.b64encode(buff.getvalue()))
+    return base64.b64encode(buff.getvalue()).decode("utf-8")
 
 
 def b64_2_img(data: str) -> ImageFile:

--- a/llama-index-core/tests/test_img_utils.py
+++ b/llama-index-core/tests/test_img_utils.py
@@ -1,0 +1,41 @@
+"""Test img_utils."""
+
+import base64
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from llama_index.core.img_utils import b64_2_img, img_2_b64
+
+
+def test_img_2_b64_returns_string() -> None:
+    """Test that img_2_b64 returns a string, not bytes."""
+    # Create a simple test image
+    img = Image.new("RGB", (10, 10), color="red")
+
+    # Convert to base64
+    b64_str = img_2_b64(img)
+
+    # Assert it's a string
+    assert isinstance(b64_str, str)
+
+    # Verify it's valid base64 by decoding it back
+    decoded_bytes = base64.b64decode(b64_str)
+    assert isinstance(decoded_bytes, bytes)
+
+
+def test_b64_2_img_round_trip() -> None:
+    """Test that b64_2_img can decode what img_2_b64 produces."""
+    # Create a simple test image
+    original_img = Image.new("RGB", (10, 10), color="blue")
+
+    # Convert to base64 and back
+    b64_str = img_2_b64(original_img)
+    reconstructed_img = b64_2_img(b64_str)
+
+    # Check that the images are the same size
+    assert reconstructed_img.size == original_img.size
+
+    # Check that the mode is the same
+    assert reconstructed_img.mode == original_img.mode


### PR DESCRIPTION
# Description

This PR fixes issue #21186.

The function `img_2_b64` returned a base64-encoded value as `bytes`, which caused JSON serialization issues and inconsistent behavior across the library.

### Before
`img_2_b64(image)` returned:
b'/9j/4AAQSkZJRgABAQ...'

### After
`img_2_b64(image)` returns:
'/9j/4AAQSkZJRgABAQ...'

Fixes # (issue)
Added `.decode("utf-8")` to ensure the output is a string.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
