### PR TITLE
docs: fix typos and broken anchor links in contribution guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/issue-form.yml
@@ -32,6 +32,6 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Relevant Logs/Tracbacks
+      label: Relevant Logs/Tracebacks
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ uv run -- pytest
 
 **That’s it!** The package you're working on is already installed in editable mode, so you can go on, change the code and run the tests!
 
-Once you get familiar with the project, scroll down to the [Development Guidelines](#-Development-Guidelines) for more details.
+Once you get familiar with the project, scroll down to the [Development Guidelines](#development-guidelines) for more details.
 
 ---
 
@@ -78,7 +78,7 @@ We also do not recommend working on these areas:
    ```bash
    git checkout -b your-feature-branch
    ```
-4. **Set up your environment** (follow the [Quick Start Guide](#-quick-start-guide)).
+4. **Set up your environment** (follow the [Quick Start Guide](#quick-start-guide)).
 5. **Work on your feature or bugfix**, ensuring you have unit tests covering your code.
 6. **Commit** your changes, then push them to your fork.
    ```bash


### PR DESCRIPTION
# Description

This PR fixes a few minor documentation issues to improve the experience for first-time contributors:
- Corrected a "Tracbacks" typo to "Tracebacks" in the bug report issue template (issue-form.yml).
- Fixed broken anchor links referencing #development-guidelines and #quick-start-guide in CONTRIBUTING.md that were previously failing to navigate correctly on GitHub.

These are documentation-only updates mapped directly to the repository's contributing resources.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No


## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
