### PR TITLE
feat(#21094): implement output schema validation in FunctionTool

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -172,6 +172,7 @@ class FunctionTool(AsyncBaseTool):
         description: Optional[str] = None,
         return_direct: bool = False,
         fn_schema: Optional[Type[BaseModel]] = None,
+        output_schema: Optional[Type[BaseModel]] = None,
         async_fn: Optional[AsyncCallable] = None,
         tool_metadata: Optional[ToolMetadata] = None,
         callback: Optional[Callable[[Any], Any]] = None,
@@ -251,6 +252,7 @@ class FunctionTool(AsyncBaseTool):
                 description=description,
                 fn_schema=fn_schema,
                 return_direct=return_direct,
+                output_schema=output_schema,
             )
         return cls(
             fn=fn,
@@ -318,6 +320,8 @@ class FunctionTool(AsyncBaseTool):
                 raise ValueError("Context is required for this tool")
 
         raw_output = self._fn(*args, **all_kwargs)
+        if self.metadata.output_schema is not None:
+            raw_output = self.metadata.output_schema.model_validate(raw_output)
 
         # Exclude the Context param from the tool output so that the Context can be serialized
         tool_output_kwargs = {
@@ -357,6 +361,8 @@ class FunctionTool(AsyncBaseTool):
                 raise ValueError("Context is required for this tool")
 
         raw_output = await self._async_fn(*args, **all_kwargs)
+        if self.metadata.output_schema is not None:
+            raw_output = self.metadata.output_schema.model_validate(raw_output)
 
         # Exclude the Context param from the tool output so that the Context can be serialized
         tool_output_kwargs = {

--- a/llama-index-core/llama_index/core/tools/types.py
+++ b/llama-index-core/llama_index/core/tools/types.py
@@ -26,6 +26,7 @@ class ToolMetadata:
     name: Optional[str] = None
     fn_schema: Optional[Type[BaseModel]] = DefaultToolFnSchema
     return_direct: bool = False
+    output_schema: Optional[Type[BaseModel]] = None
 
     def get_parameters_dict(self) -> dict:
         if self.fn_schema is None:

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -475,3 +475,81 @@ def test_function_tool_field_default() -> None:
     # Calling with an explicit arg should override the default
     result = tool.call(location="Munich")
     assert result.content == "weather in Munich"
+
+
+def test_function_tool_output_schema_validation() -> None:
+    """Test that FunctionTool validates output against output_schema."""
+
+    class OutputSchema(BaseModel):
+        name: str
+        age: int
+
+    def get_user_info() -> dict:
+        return {"name": "Alice", "age": 30}
+
+    tool = FunctionTool.from_defaults(get_user_info, output_schema=OutputSchema)
+    result = tool.call()
+
+    # The raw output should be evaluated into the OutputSchema instance
+    assert isinstance(result.raw_output, OutputSchema)
+    assert result.raw_output.name == "Alice"
+    assert result.raw_output.age == 30
+
+
+def test_function_tool_output_schema_validation_error() -> None:
+    """Test that FunctionTool raises ValidationError when output DOES NOT match output_schema."""
+    from pydantic import ValidationError
+
+    class OutputSchema(BaseModel):
+        name: str
+        age: int
+
+    def get_bad_user_info() -> dict:
+        return {"name": "Alice", "age": "thirty"}
+
+    tool = FunctionTool.from_defaults(get_bad_user_info, output_schema=OutputSchema)
+
+    with pytest.raises(ValidationError):
+        tool.call()
+
+
+@pytest.mark.asyncio
+async def test_function_tool_output_schema_validation_async() -> None:
+    """Test that FunctionTool validates output against output_schema asynchronously."""
+
+    class OutputSchema(BaseModel):
+        name: str
+        age: int
+
+    async def get_user_info() -> dict:
+        return {"name": "Alice", "age": 30}
+
+    tool = FunctionTool.from_defaults(
+        async_fn=get_user_info, output_schema=OutputSchema
+    )
+    result = await tool.acall()
+
+    # The raw output should be evaluated into the OutputSchema instance
+    assert isinstance(result.raw_output, OutputSchema)
+    assert result.raw_output.name == "Alice"
+    assert result.raw_output.age == 30
+
+
+@pytest.mark.asyncio
+async def test_function_tool_output_schema_validation_error_async() -> None:
+    """Test that FunctionTool raises ValidationError when async output DOES NOT match output_schema."""
+    from pydantic import ValidationError
+
+    class OutputSchema(BaseModel):
+        name: str
+        age: int
+
+    async def get_bad_user_info() -> dict:
+        return {"name": "Alice", "age": "thirty"}
+
+    tool = FunctionTool.from_defaults(
+        async_fn=get_bad_user_info, output_schema=OutputSchema
+    )
+
+    with pytest.raises(ValidationError):
+        await tool.acall()


### PR DESCRIPTION
# Description

This PR introduces output schema validation for `FunctionTool` by adding an optional `output_schema` to `ToolMetadata` and leveraging Pydantic validation across both the `call` and `acall` execution paths. 

*Note per AI guidelines:* I used AI initially to help review the architectural approaches discussed in the issue comments. Together we verified the decision to place the schema on `ToolMetadata`, scaffolded the asynchronous unit test paths, and ran local validation.

Fixes #21094

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No *(Change is contained within llama-index-core)*

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change *(Added async test paths to match your sync test paths)*
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
