### PR TITLE
fix: use Filter.by_id() for node_ids query in WeaviateVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -619,7 +619,7 @@ class WeaviateVectorStore(BasePydanticVectorStore):
             filters = wvc.query.Filter.by_property("doc_id").contains_any(query.doc_ids)
 
         if query.node_ids:
-            filters = wvc.query.Filter.by_property("id").contains_any(query.node_ids)
+            filters = wvc.query.Filter.by_id().contains_any(query.node_ids)
 
         return_metatada = wvc.query.MetadataQuery(distance=True, score=True)
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -59,6 +59,29 @@ def test_custom_batch_validation_checks_wrapped_writer_interface():
     assert not _is_valid_batch_context_manager(_WrappedBatchManager(object()))
 
 
+def test_get_query_parameters_with_node_ids_uses_by_id_filter():
+    """Regression test for #15743: node_ids must produce Filter.by_id() targeting the Weaviate UUID."""
+    import uuid
+
+    vs = object.__new__(WeaviateVectorStore)
+    object.__setattr__(vs, "_is_self_created_weaviate_client", False)
+
+    node_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    query = VectorStoreQuery(
+        query_embedding=[0.1, 0.2, 0.3],
+        node_ids=node_ids,
+        similarity_top_k=5,
+    )
+
+    params = vs.get_query_parameters(query)
+    filters = params["filters"]
+
+    assert filters is not None
+    assert filters.target == "_id"
+    assert filters.operator == "ContainsAny"
+    assert list(filters.value) == node_ids
+
+
 def test_no_weaviate_client_instance_provided():
     """Tests that the creation of a Weaviate client within the WeaviateVectorStore constructor works."""
     vector_store = WeaviateVectorStore(


### PR DESCRIPTION
Fixes #15743

## Problem

When querying `WeaviateVectorStore` with `node_ids`, the code uses `Filter.by_property("id")` which tries to filter on a Weaviate property named `"id"`. However, `"id"` is not a property in the default Weaviate schema — it is the internal Weaviate object UUID.

This causes an error from the Weaviate server:
```
no such prop with name 'id' found in class '...'
```

## Solution

Changed `Filter.by_property("id")` to `Filter.by_id()`, which correctly filters by the internal Weaviate object UUID.

This is consistent with how node IDs are already handled in the `delete` and `adelete` methods (lines 506 and 540), which also use `Filter.by_id()`.

**Before:**
```python
filters = wvc.query.Filter.by_property("id").contains_any(query.node_ids)
```

**After:**
```python
filters = wvc.query.Filter.by_id().contains_any(query.node_ids)
```

## Testing

Manually verified that `Filter.by_id()` is the correct Weaviate API for filtering by object UUID, and that the existing `delete`/`adelete` methods in the same file already use `Filter.by_id()` consistently.