### PR TITLE
fix(mcp): add parsing methods for CallToolResult and ReadResourceResult

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -120,9 +120,7 @@ class McpToolSpec(
             if isinstance(item, mcp_types.TextContent):
                 blocks.append(TextBlock(text=item.text))
             elif isinstance(item, mcp_types.ImageContent):
-                blocks.append(
-                    ImageBlock(image=item.data, image_mimetype=item.mimeType)
-                )
+                blocks.append(ImageBlock(image=item.data, image_mimetype=item.mimeType))
             elif hasattr(mcp_types, "AudioContent") and isinstance(
                 item, mcp_types.AudioContent
             ):
@@ -150,14 +148,17 @@ class McpToolSpec(
             elif isinstance(item, mcp_types.BlobResourceContents):
                 mime = item.mimeType or ""
                 if mime.startswith("image/"):
-                    blocks.append(
-                        ImageBlock(image=item.blob, image_mimetype=mime)
-                    )
+                    blocks.append(ImageBlock(image=item.blob, image_mimetype=mime))
                 elif mime.startswith("audio/"):
                     fmt = mime.split("/")[-1]
                     blocks.append(AudioBlock(audio=item.blob, format=fmt))
                 else:
-                    blocks.append(TextBlock(text=item.blob))
+                    blocks.append(
+                        TextBlock(
+                            text=f"[Binary resource: {mime or 'unknown type'}, "
+                            f"{len(item.blob)} bytes (base64)]"
+                        )
+                    )
             else:
                 blocks.append(TextBlock(text=str(item)))
         return blocks

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -2,10 +2,17 @@ import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional, Set
 
+from mcp import types as mcp_types
 from mcp.client.session import ClientSession
 from mcp.types import Resource
 from pydantic import BaseModel, create_model
 
+from llama_index.core.base.llms.types import (
+    AudioBlock,
+    ContentBlock,
+    ImageBlock,
+    TextBlock,
+)
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.core.tools.types import ToolMetadata
@@ -103,13 +110,66 @@ class McpToolSpec(
         )
         return []
 
+    @staticmethod
+    def _parse_call_tool_result(
+        result: mcp_types.CallToolResult,
+    ) -> List[ContentBlock]:
+        """Convert MCP CallToolResult content to llama_index ContentBlock list."""
+        blocks: List[ContentBlock] = []
+        for item in result.content:
+            if isinstance(item, mcp_types.TextContent):
+                blocks.append(TextBlock(text=item.text))
+            elif isinstance(item, mcp_types.ImageContent):
+                blocks.append(
+                    ImageBlock(image=item.data, image_mimetype=item.mimeType)
+                )
+            elif hasattr(mcp_types, "AudioContent") and isinstance(
+                item, mcp_types.AudioContent
+            ):
+                # Extract format from mimeType, e.g. "audio/mp3" -> "mp3"
+                fmt = (
+                    item.mimeType.split("/")[-1]
+                    if getattr(item, "mimeType", None)
+                    else None
+                )
+                blocks.append(AudioBlock(audio=item.data, format=fmt))
+            else:
+                # EmbeddedResource or other unknown content types
+                blocks.append(TextBlock(text=str(item)))
+        return blocks
+
+    @staticmethod
+    def _parse_read_resource_result(
+        result: mcp_types.ReadResourceResult,
+    ) -> List[ContentBlock]:
+        """Convert MCP ReadResourceResult content to llama_index ContentBlock list."""
+        blocks: List[ContentBlock] = []
+        for item in result.contents:
+            if isinstance(item, mcp_types.TextResourceContents):
+                blocks.append(TextBlock(text=item.text))
+            elif isinstance(item, mcp_types.BlobResourceContents):
+                mime = item.mimeType or ""
+                if mime.startswith("image/"):
+                    blocks.append(
+                        ImageBlock(image=item.blob, image_mimetype=mime)
+                    )
+                elif mime.startswith("audio/"):
+                    fmt = mime.split("/")[-1]
+                    blocks.append(AudioBlock(audio=item.blob, format=fmt))
+                else:
+                    blocks.append(TextBlock(text=item.blob))
+            else:
+                blocks.append(TextBlock(text=str(item)))
+        return blocks
+
     def _create_tool_fn(self, tool_name: str) -> Callable:
         """
         Create a tool call function for a specified MCP tool name. The function internally wraps the call_tool call to the MCP Client.
         """
 
         async def async_tool_fn(**kwargs):
-            return await self.client.call_tool(tool_name, kwargs)
+            result = await self.client.call_tool(tool_name, kwargs)
+            return McpToolSpec._parse_call_tool_result(result)
 
         return async_tool_fn
 
@@ -119,7 +179,8 @@ class McpToolSpec(
         """
 
         async def async_resource_fn():
-            return await self.client.read_resource(resource_uri)
+            result = await self.client.read_resource(resource_uri)
+            return McpToolSpec._parse_read_resource_result(result)
 
         return async_resource_fn
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.4.9"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -86,15 +86,13 @@ async def test_pydantic_models_tool(client: BasicMCPClient):
     tool = tools[0]
     assert tool.metadata.name == "test_pydantic"
 
-    result = await tool.async_fn(
+    result = await tool.acall(
         name={"name": "John Doe"},
         method={"method": "POST"},
         lst={"lst": [1, 2, 3, 4, 5]},
     )
 
-    assert (
-        "Name: John Doe, Method: POST, List: [1, 2, 3, 4, 5]" in result.content[0].text
-    )
+    assert "Name: John Doe, Method: POST, List: [1, 2, 3, 4, 5]" in result.content
 
 
 def test_pydantic_models_schema_structure(client: BasicMCPClient):

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -95,6 +95,31 @@ async def test_pydantic_models_tool(client: BasicMCPClient):
     assert "Name: John Doe, Method: POST, List: [1, 2, 3, 4, 5]" in result.content
 
 
+@pytest.mark.asyncio
+async def test_image_tool_returns_image_block(client: BasicMCPClient):
+    """Test that generate_image tool returns an ImageBlock in ToolOutput."""
+    from llama_index.core.base.llms.types import ImageBlock
+
+    tool_spec = McpToolSpec(client, allowed_tools=["generate_image"])
+    tools = await tool_spec.to_tool_list_async()
+
+    tool = tools[0]
+    assert tool.metadata.name == "generate_image"
+
+    result = await tool.acall(width=8, height=8, color="red")
+
+    # ToolOutput.blocks should contain an ImageBlock
+    assert result.blocks is not None
+    image_blocks = [b for b in result.blocks if isinstance(b, ImageBlock)]
+    assert len(image_blocks) == 1
+
+    img = image_blocks[0]
+    assert img.image_mimetype == "image/png"
+    # image field should be populated (base64-encoded PNG bytes)
+    assert img.image is not None
+    assert len(img.image) > 0
+
+
 def test_pydantic_models_schema_structure(client: BasicMCPClient):
     """Test that the test_pydantic tool generates correct schema structure."""
     tool = McpToolSpec(client, allowed_tools=["test_pydantic"]).to_tool_list()[0]


### PR DESCRIPTION
Currently, MCP Tool is a direct wrapper for MCP Client, but FunctionTool requires it to be a Block, which prevents any MCP that supports multimodal input from working.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
