### PR TITLE
docs: add Kelly Intelligence example notebook for OpenAILike

### DIFF
--- a/docs/examples/llm/kelly_intelligence.ipynb
+++ b/docs/examples/llm/kelly_intelligence.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-0",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/llm/kelly_intelligence.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-1",
+   "metadata": {},
+   "source": [
+    "# Kelly Intelligence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-2",
+   "metadata": {},
+   "source": [
+    "[Kelly Intelligence](https://api.thedailylesson.com) is an OpenAI-compatible API with a built-in 162,000-word vocabulary RAG layer, operated by [Lesson of the Day, PBC](https://lotdpbc.com). It exposes `/v1/chat/completions` at `https://api.thedailylesson.com/v1`, so you can use it with LlamaIndex via the existing [`llama-index-llms-openai-like`](https://github.com/run-llama/llama_index/tree/main/llama-index-integrations/llms/llama-index-llms-openai-like) integration.\n",
+    "\n",
+    "This notebook does not introduce a new integration package. It shows how to point the existing `OpenAILike` class at a Kelly Intelligence endpoint."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-3",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-4",
+   "metadata": {},
+   "source": [
+    "1. Get a free `KELLY_API_KEY` from [api.thedailylesson.com](https://api.thedailylesson.com). No credit card required for the free tier.\n",
+    "2. Install `llama-index` and the `openai-like` integration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-core llama-index llama-index-llms-openai-like"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-6",
+   "metadata": {},
+   "source": [
+    "Fix for \"RuntimeError: This event loop is already running\" if you run this notebook inside Jupyter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from llama_index.llms.openai_like import OpenAILike\n",
+    "from llama_index.core.base.llms.types import ChatMessage, MessageRole"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-9",
+   "metadata": {},
+   "source": [
+    "## Create the LLM\n",
+    "\n",
+    "Kelly Intelligence exposes six model ids: `kelly-haiku`, `kelly-sonnet`, `kelly-opus`, `claude-haiku`, `claude-sonnet`, and `claude-opus`. The free tier includes `kelly-haiku` and `claude-haiku`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = OpenAILike(\n",
+    "    model=\"kelly-haiku\",\n",
+    "    api_base=\"https://api.thedailylesson.com/v1\",\n",
+    "    api_key=os.environ.get(\"KELLY_API_KEY\", \"your-key-here\"),\n",
+    "    context_window=200000,\n",
+    "    is_chat_model=True,\n",
+    "    is_function_calling_model=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-11",
+   "metadata": {},
+   "source": [
+    "## Complete"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = llm.complete(\"Define the word 'ephemeral' for an intermediate English learner.\")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-13",
+   "metadata": {},
+   "source": [
+    "## Stream complete"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = llm.stream_complete(\"Use 'ephemeral' in two short example sentences.\")\n",
+    "for r in response:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kelly-cell-15",
+   "metadata": {},
+   "source": [
+    "## Chat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "messages = [\n",
+    "    ChatMessage(\n",
+    "        role=MessageRole.SYSTEM,\n",
+    "        content=\"You are a friendly vocabulary tutor. Keep answers short and learner-appropriate.\",\n",
+    "    ),\n",
+    "    ChatMessage(\n",
+    "        role=MessageRole.USER,\n",
+    "        content=\"What is the difference between 'ephemeral' and 'transient'?\",\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = llm.chat(messages=messages)\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kelly-cell-18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = llm.stream_chat(messages=messages)\n",
+    "for r in response:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llama_index_v3",
+   "language": "python",
+   "name": "llama_index_v3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds a single example notebook at `docs/examples/llm/kelly_intelligence.ipynb` that shows how to use the **existing** [`llama-index-llms-openai-like`](https://github.com/run-llama/llama_index/tree/main/llama-index-integrations/llms/llama-index-llms-openai-like) integration with [Kelly Intelligence](https://api.thedailylesson.com), an OpenAI-compatible API with a built-in 162,000-word vocabulary RAG layer operated by [Lesson of the Day, PBC](https://lotdpbc.com).

**This is a docs-only addition.** No new integration package, no new `pyproject.toml`, no changes to `llama-index-integrations/`. The notebook only imports `OpenAILike` from the existing `llama_index.llms.openai_like` package and points it at `https://api.thedailylesson.com/v1`. The structure mirrors the existing [`docs/examples/llm/lmstudio.ipynb`](https://github.com/run-llama/llama_index/blob/main/docs/examples/llm/lmstudio.ipynb) notebook.

## What the notebook covers

- `pip install llama-index-core llama-index llama-index-llms-openai-like`
- Creating an `OpenAILike` instance pointed at the Kelly endpoint
- `complete()`, `stream_complete()`, `chat()`, and `stream_chat()` patterns

```python
from llama_index.llms.openai_like import OpenAILike

llm = OpenAILike(
    model="kelly-haiku",
    api_base="https://api.thedailylesson.com/v1",
    api_key=os.environ["KELLY_API_KEY"],
    context_window=200000,
    is_chat_model=True,
    is_function_calling_model=False,
)
```

## Compliance with `CONTRIBUTING.md`

`CONTRIBUTING.md` notes: *"we are no longer accepting new integration packages in this repository. New integrations should be maintained in their own repositories and published to PyPI independently. PRs that add a new pyproject.toml will be automatically closed."*

This PR is **not** a new integration. It is a docs-only example for an **existing** integration (`llama-index-llms-openai-like`). It adds zero `pyproject.toml` files and zero source files.

## Why this notebook is useful

The free tier of Kelly Intelligence (`kelly-haiku`, `claude-haiku`) requires no credit card and is intended for vocabulary tutoring and language learning use cases. LlamaIndex users building education-focused agents (RAG over learner content, vocabulary lookups) may find a worked example valuable.

## Testing

- Notebook JSON validated locally with `python -c "import json; json.load(open(...))"`.
- The notebook does **not** execute on the docs build pipeline (it's a static example like all other `docs/examples/llm/*.ipynb`).
- Endpoint health verified live before opening this PR: `curl https://api.thedailylesson.com/v1/models` returns the expected list of six model ids.

## AI disclosure

This notebook was drafted with Claude Code. The author (operator of Kelly Intelligence) reviewed every cell, validated the JSON, and verified the live endpoint before opening this PR. Conventions (cell structure, badge, `nest_asyncio` fix, ChatMessage usage) were copied from the existing `lmstudio.ipynb` for consistency.