### PR TITLE
fix(ollama): preserve thinking-only chunks in stream_chat/astream_chat

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -472,7 +472,7 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             for r in response:
-                if r["message"]["content"] is None:
+                if r["message"]["content"] is None and not r["message"].get("thinking"):
                     continue
 
                 r = dict(r)
@@ -556,7 +556,7 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             async for r in response:
-                if r["message"]["content"] is None:
+                if r["message"]["content"] is None and not r["message"].get("thinking"):
                     continue
 
                 r = dict(r)


### PR DESCRIPTION
## Summary
- Fix the `content is None` guard in both `stream_chat` and `astream_chat` to also check for thinking content before skipping a chunk
- Previously, chunks where `content=None` but `thinking` was present were silently dropped, losing all reasoning tokens during the thinking phase

## Test plan
- Run `stream_chat` with an Ollama model that supports thinking (e.g., `deepseek-r1`) and `thinking=True`
- Verify that `thinking_delta` values appear in `additional_kwargs` during the thinking phase
- Verify that `ThinkingBlock` is included in the final message blocks
- Confirm non-thinking streaming still works as before (truly empty chunks are still skipped)

Fixes #21232