### PR TITLE
fix(elasticsearch): forward metadata_keyword_suffix in sync query

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -495,7 +495,13 @@ class ElasticsearchStore(BasePydanticVectorStore):
 
         """
         return asyncio.get_event_loop().run_until_complete(
-            self.aquery(query, custom_query, es_filter, **kwargs)
+            self.aquery(
+                query,
+                custom_query,
+                es_filter,
+                metadata_keyword_suffix=metadata_keyword_suffix,
+                **kwargs,
+            )
         )
 
     async def aquery(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
@@ -1,3 +1,4 @@
+import asyncio
 import aiohttp  # noqa
 import logging
 import os
@@ -590,6 +591,45 @@ def test_metadata_filter_to_es_filter() -> None:
             ]
         }
     }
+
+
+def test_query_forwards_metadata_keyword_suffix() -> None:
+    captured = {}
+
+    class DummyStore:
+        async def aquery(
+            self,
+            query: VectorStoreQuery,
+            custom_query=None,
+            es_filter=None,
+            metadata_keyword_suffix: str = ".keyword",
+            **kwargs,
+        ):
+            captured["query"] = query
+            captured["custom_query"] = custom_query
+            captured["es_filter"] = es_filter
+            captured["metadata_keyword_suffix"] = metadata_keyword_suffix
+            captured["kwargs"] = kwargs
+            return "ok"
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        query = VectorStoreQuery(query_embedding=[1.0], similarity_top_k=1)
+        result = ElasticsearchStore.query(
+            DummyStore(),
+            query,
+            metadata_keyword_suffix="",
+            extra_option=True,
+        )
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+    assert result == "ok"
+    assert captured["query"] == query
+    assert captured["metadata_keyword_suffix"] == ""
+    assert captured["kwargs"] == {"extra_option": True}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

This fixes the synchronous `ElasticsearchStore.query()` wrapper so it forwards `metadata_keyword_suffix` to `aquery()` instead of silently dropping it.

Without this, custom metadata suffix support only works on the async path, while normal sync retrieval/query flows still behave as if the default `.keyword` suffix is in use.

No new dependencies are required.

Fixes #21328

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

## Local Validation

- `uv --cache-dir /tmp/uv-cache run pytest tests/test_vector_stores_elasticsearch.py`
  Result: `3 passed, 28 skipped`
- `uv --cache-dir /tmp/uv-cache run pytest tests/test_vector_stores_elasticsearch.py -k "metadata_filter_to_es_filter or query_forwards_metadata_keyword_suffix"`
  Result: `2 passed`
- `uv --cache-dir /tmp/uv-cache run pre-commit run --show-diff-on-failure --files llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py`
  Result: passed
