### PR TITLE
docs: add asqav as observability integration

### DIFF
--- a/docs/src/content/docs/framework/module_guides/observability/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/index.md
@@ -922,6 +922,44 @@ from llama_index.core import set_global_handler
 set_global_handler("agentops")
 ```
 
+### Asqav
+
+[Asqav](https://github.com/jagmarques/asqav-sdk) is an AI agent governance platform that provides audit trails, policy enforcement, and compliance tracking for LLM applications. With the asqav integration, every LLM call, retrieval, query, and embedding event in your LlamaIndex pipeline is cryptographically signed for governance and audit purposes.
+
+Uses `CallbackManager` directly (not `set_global_handler`).
+
+#### Install
+
+```shell
+pip install asqav[llamaindex]
+```
+
+#### Usage Pattern
+
+```python
+import asqav
+from asqav.extras.llamaindex import AsqavCallbackHandler
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core import Settings, VectorStoreIndex, SimpleDirectoryReader
+
+asqav.init("your_api_key")
+
+handler = AsqavCallbackHandler(agent_name="my-rag-app")
+callback_manager = CallbackManager([handler])
+Settings.callback_manager = callback_manager
+
+# All LlamaIndex operations are now signed for governance
+documents = SimpleDirectoryReader("data").load_data()
+index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
+response = query_engine.query("What is in the data?")
+```
+
+#### Guides
+
+- [Asqav Documentation](https://asqav.com/docs)
+- [Asqav SDK on GitHub](https://github.com/jagmarques/asqav-sdk)
+
 ### Simple (LLM Inputs/Outputs)
 
 This simple observability tool prints every LLM input/output pair to the terminal. Most useful for when you need to quickly enable debug logging on your LLM application.


### PR DESCRIPTION
## Summary

- Adds [asqav](https://github.com/jagmarques/asqav-sdk) to the observability integrations documentation page
- Asqav is an AI agent governance platform that provides cryptographic audit trails, policy enforcement, and compliance tracking for LLM applications
- The integration uses `CallbackManager` directly (not `set_global_handler`) and is installed via `pip install asqav[llamaindex]`
- Follows the existing format used by other third-party integrations on the page (Argilla, Langfuse, etc.)

This is a docs-only change. The integration package lives in the [asqav-sdk repo](https://github.com/jagmarques/asqav-sdk) and is published on [PyPI](https://pypi.org/project/asqav/).

## Test plan

- [ ] Verify the docs page builds correctly with `poetry run serve --skip-notebooks --skip-reference`
- [ ] Confirm links to asqav documentation and GitHub are valid