### PR TITLE
fix: handle mmr_threshold=0 and None score in fusion retriever

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -115,7 +115,7 @@ def get_top_k_mmr_embeddings(
     A mmr_threshold of 1 will check similarity the query and ignore previous results.
 
     """
-    threshold = mmr_threshold or 0.5
+    threshold = mmr_threshold if mmr_threshold is not None else 0.5
     similarity_fn = similarity_fn or default_similarity_fn
 
     if embedding_ids is None or embedding_ids == []:

--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -183,9 +183,9 @@ class QueryFusionRetriever(BaseRetriever):
                 if max_score == min_score:
                     node_with_score.score = 1.0 if max_score > 0 else 0.0
                 else:
-                    node_with_score.score = (node_with_score.score - min_score) / (
-                        max_score - min_score
-                    )
+                    node_with_score.score = (
+                        (node_with_score.score or 0.0) - min_score
+                    ) / (max_score - min_score)
                 # Scale by the weight of the retriever
                 retriever_idx = query_tuple[1]
                 existing_score = node_with_score.score or 0.0


### PR DESCRIPTION
## Description

This PR fixes two bugs in llama-index-core:

### Bug 1: `mmr_threshold=0` silently ignored in MMR embedding search

**File:** `llama-index-core/llama_index/core/indices/query/embedding_utils.py`, line 118

The expression `mmr_threshold or 0.5` uses Python's `or` operator, which treats `0` as falsy. When a user explicitly passes `mmr_threshold=0` to request maximum diversity (as documented in the docstring: "A mmr_threshold of 0 will strongly avoid similarity to previous results"), the value silently falls back to `0.5`.

**Fix:** Replace `mmr_threshold or 0.5` with `mmr_threshold if mmr_threshold is not None else 0.5` to only apply the default when the parameter is genuinely unset.

### Bug 2: `TypeError` when node score is `None` in relative score fusion

**File:** `llama-index-core/llama_index/core/retrievers/fusion_retriever.py`, line 186

In `QueryFusionRetriever._relative_score_fusion`, the expression `node_with_score.score - min_score` will raise a `TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'` when a node's score is `None`. 

Line 164 already guards against this with `node_with_score.score or 0.0`, but line 186 omits the same guard.

**Fix:** Add the same `or 0.0` guard: `(node_with_score.score or 0.0) - min_score`.

## New Package?

No

## Changes

- `embedding_utils.py`: Use explicit `is not None` check for `mmr_threshold` default
- `fusion_retriever.py`: Add `or 0.0` guard for `None` scores in relative score normalization