### PR TITLE
Fix/opensearch knn prefilter 14433

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -360,26 +360,20 @@ class OpensearchVectorClient:
         self,
         query_vector: List[float],
         k: int = 4,
-        filters: Optional[Union[Dict, List]] = None,
         vector_field: str = "embedding",
+        pre_filter: Optional[Union[Dict, List]] = None,
         excluded_source_fields: Optional[List[str]] = None,
     ) -> Dict:
         """For Approximate k-NN Search, this is the default query."""
-        query = {
-            "size": k,
-            "query": {
-                "knn": {
-                    vector_field: {
-                        "vector": query_vector,
-                        "k": k,
-                    }
-                }
-            },
+        knn_query: Dict[str, Any] = {
+            "field": vector_field,
+            "query_vector": query_vector,
+            "k": k,
         }
+        if pre_filter and pre_filter != MATCH_ALL_QUERY:
+            knn_query["filter"] = pre_filter
 
-        if filters:
-            # filter key must be added only when filtering to avoid "filter doesn't support values of type: START_ARRAY" exception
-            query["query"]["knn"][vector_field]["filter"] = filters
+        query: Dict[str, Any] = {"size": k, "query": {"knn": knn_query}}
         if excluded_source_fields:
             query["_source"] = {"exclude": excluded_source_fields}
         return query
@@ -531,8 +525,8 @@ class OpensearchVectorClient:
             search_query = self._default_approximate_search_query(
                 query_embedding,
                 k,
-                filters={"bool": {"filter": filters}},
                 vector_field=embedding_field,
+                pre_filter={"bool": {"filter": filters}},
                 excluded_source_fields=excluded_source_fields,
             )
         else:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_vector_stores_opensearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_vector_stores_opensearch.py
@@ -10,6 +10,42 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
+def test_default_approximate_search_query_includes_native_knn_filter_when_prefilter_present():
+    """Ensure ANN query uses native knn.filter when pre_filter is provided."""
+    client = OpensearchVectorClient.__new__(OpensearchVectorClient)
+
+    pre_filter = {"bool": {"filter": [{"term": {"metadata.foo": "bar"}}]}}
+    query = client._default_approximate_search_query(
+        query_vector=[0.1, 0.2, 0.3],
+        k=4,
+        vector_field="embedding",
+        pre_filter=pre_filter,
+    )
+
+    assert query["size"] == 4
+    assert query["query"]["knn"]["field"] == "embedding"
+    assert query["query"]["knn"]["query_vector"] == [0.1, 0.2, 0.3]
+    assert query["query"]["knn"]["k"] == 4
+    assert query["query"]["knn"]["filter"] == pre_filter
+
+
+def test_default_approximate_search_query_omits_filter_for_match_all_prefilter():
+    """Avoid adding knn.filter for MATCH_ALL_QUERY to keep query minimal."""
+    from llama_index.vector_stores.opensearch.base import MATCH_ALL_QUERY
+
+    client = OpensearchVectorClient.__new__(OpensearchVectorClient)
+
+    query = client._default_approximate_search_query(
+        query_vector=[0.1, 0.2, 0.3],
+        k=4,
+        vector_field="embedding",
+        pre_filter=MATCH_ALL_QUERY,
+    )
+
+    assert query["query"]["knn"]["field"] == "embedding"
+    assert "filter" not in query["query"]["knn"]
+
+
 def test_class():
     names_of_base_classes = [b.__name__ for b in OpensearchVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_vector_stores_opensearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_vector_stores_opensearch.py
@@ -104,8 +104,8 @@ def test_knn_search_query_routing_with_filters(
         client._default_scoring_script_query.assert_not_called()
 
         _, kwargs = client._default_approximate_search_query.call_args
-        assert kwargs.get("filters") == expected_filter_structure
-        assert "pre_filter" not in kwargs
+        assert kwargs.get("pre_filter") == expected_filter_structure
+        assert "filters" not in kwargs
 
     elif expected_path == "script_score":
         client._default_scoring_script_query.assert_called_once()


### PR DESCRIPTION
Summary
This PR updates OpensearchVectorClient to use OpenSearch’s native “efficient filtering” for ANN by passing pre-filters directly inside the knn query block (knn.filter) instead of falling back to script-based scoring / exhaustive exact search when filters are present (when efficient filtering is supported).

Motivation / Context
Today, applying metadata filters can force OpenSearch queries onto a Painless/script-score path, which prevents approximate k-NN (ANN) and scales poorly. OpenSearch supports efficient filters directly in the knn query for Lucene/Faiss engines, allowing ANN + filtering without scripting.

Issue fixed
Fixes #14433

Dependencies required
- Runtime: opensearch-py (already required to use the OpenSearch integration).
- Testing: opensearch-py is required to import/collect the OpenSearch vector store tests locally; integration tests that hit a real cluster still require an available OpenSearch instance

New Package?
Did I fill in the tool.llamahub section in the pyproject.toml and provide a detailed README.md for my new integration or package?
- [x] No


## Version Bump?
Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)
- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
