### PR TITLE
fix: llamacpp context window

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-llama-cpp/llama_index/llms/llama_cpp/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-llama-cpp/llama_index/llms/llama_cpp/base.py
@@ -27,7 +27,10 @@ from llama_index.core.types import BaseOutputParser, PydanticProgramMode
 from llama_index.core.utils import get_cache_dir
 from tqdm import tqdm
 
-from llama_cpp import Llama
+try:
+    from llama_cpp import Llama  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    Llama = None  # type: ignore[assignment]
 
 DEFAULT_LLAMA_CPP_GGML_MODEL = (
     "https://huggingface.co/TheBloke/Llama-2-13B-chat-GGML/resolve"
@@ -116,7 +119,7 @@ class LlamaCPP(CustomLLM):
     context_window: int = Field(
         default=DEFAULT_CONTEXT_WINDOW,
         description="The maximum number of context tokens for the model.",
-        gt=0,
+        ge=0,
     )
     generate_kwargs: Dict[str, Any] = Field(
         default_factory=dict, description="Kwargs used for generation."
@@ -148,10 +151,19 @@ class LlamaCPP(CustomLLM):
         pydantic_program_mode: PydanticProgramMode = PydanticProgramMode.DEFAULT,
         output_parser: Optional[BaseOutputParser] = None,
     ) -> None:
+        # If llama-cpp-python isn't installed, allow tests to monkeypatch `Llama`
+        # on this module before instantiation.
+        if Llama is None:
+            raise ModuleNotFoundError(
+                "The 'llama-cpp-python' package is required to use LlamaCPP. "
+                "Please install it with `pip install llama-cpp-python`."
+            )
+
         model_kwargs = {
             **{"n_ctx": context_window, "verbose": verbose},
             **(model_kwargs or {}),  # Override defaults via model_kwargs
         }
+        using_model_default_context = model_kwargs.get("n_ctx", context_window) == 0
 
         # check if model is cached
         if model_path is not None:
@@ -179,6 +191,8 @@ class LlamaCPP(CustomLLM):
         generate_kwargs.update(
             {"temperature": temperature, "max_tokens": max_new_tokens}
         )
+        if using_model_default_context:
+            context_window = model.n_ctx()
 
         super().__init__(
             model_path=model_path,
@@ -197,6 +211,8 @@ class LlamaCPP(CustomLLM):
             output_parser=output_parser,
         )
         self._model = model
+        if using_model_default_context:
+            object.__setattr__(self, "context_window", model.n_ctx())
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/llms/llama-index-llms-llama-cpp/tests/test_llms_llama_cpp.py
+++ b/llama-index-integrations/llms/llama-index-llms-llama-cpp/tests/test_llms_llama_cpp.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.llms.llama_cpp import LlamaCPP
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
@@ -48,3 +50,26 @@ def test_messages_to_prompt_v3_instruct():
         "<|start_header_id|>assistant<|end_header_id|>\n\n"
     )
     assert messages_to_prompt_v3_instruct(messages, "SYSTEM PROMPT") == output
+
+
+def test_context_window_uses_model_default_when_zero(monkeypatch, tmp_path):
+    import llama_index.llms.llama_cpp.base as llama_cpp_base
+
+    class FakeLlama:
+        last_kwargs = None
+
+        def __init__(self, model_path: str, **kwargs):
+            FakeLlama.last_kwargs = kwargs
+            self.context_params = SimpleNamespace(n_ctx=8192)
+
+        def n_ctx(self) -> int:
+            return 8192
+
+    monkeypatch.setattr(llama_cpp_base, "Llama", FakeLlama)
+
+    model_path = tmp_path / "model.gguf"
+    model_path.write_bytes(b"")
+
+    llm = LlamaCPP(model_path=str(model_path), context_window=0)
+    assert FakeLlama.last_kwargs["n_ctx"] == 0
+    assert llm.context_window == 8192


### PR DESCRIPTION
# Description

This PR updates the `LlamaCPP` LLM integration to properly respect and resolve the native model context window when initialized with `n_ctx=0` or `context_window=0`. 

Previously, LlamaIndex retained its own default of 3900 tokens even when the developer intended to use the model's native context window by passing the `0` flag. This artificially truncated models with larger context limits. With this change, if the context is set to `0`, the integration dynamically retrieves the actual context size from the underlying `llama_cpp.Llama` client (via `self._client.n_ctx()`) and updates `self.context_window` accordingly. 

Fixes #14727

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods