### PR TITLE
fix(core): persist chat store with utf-8 and non-ascii JSON

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -168,8 +168,10 @@ class BaseComponent(BaseModel):
         return data
 
     def to_json(self, **kwargs: Any) -> str:
+        # Keep default json.dumps behavior (ensure_ascii=True) unless overridden.
+        ensure_ascii = kwargs.pop("ensure_ascii", True)
         data = self.to_dict(**kwargs)
-        return json.dumps(data)
+        return json.dumps(data, ensure_ascii=ensure_ascii)
 
     # TODO: return type here not supported by current mypy version
     @classmethod

--- a/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
@@ -83,27 +83,30 @@ class SimpleChatStore(BaseChatStore):
         self,
         persist_path: str = "chat_store.json",
         fs: Optional[fsspec.AbstractFileSystem] = None,
+        encoding: str = "utf-8",
     ) -> None:
         """Persist the docstore to a file."""
         fs = fs or fsspec.filesystem("file")
         dirpath = os.path.dirname(persist_path)
-        if not fs.exists(dirpath):
+        if dirpath and not fs.exists(dirpath):
             fs.makedirs(dirpath)
 
-        with fs.open(persist_path, "w") as f:
-            f.write(self.json())
+        with fs.open(persist_path, "w", encoding=encoding) as f:
+            # Use ensure_ascii=False to avoid bloating persisted files with unicode escape sequences.
+            f.write(json.dumps(self.dict(), ensure_ascii=False))
 
     @classmethod
     def from_persist_path(
         cls,
         persist_path: str = "chat_store.json",
         fs: Optional[fsspec.AbstractFileSystem] = None,
+        encoding: str = "utf-8",
     ) -> "SimpleChatStore":
         """Create a SimpleChatStore from a persist path."""
         fs = fs or fsspec.filesystem("file")
         if not fs.exists(persist_path):
             return cls()
-        with fs.open(persist_path, "r") as f:
+        with fs.open(persist_path, "r", encoding=encoding) as f:
             data = json.load(f)
 
         if isinstance(data, str):

--- a/llama-index-core/tests/storage/chat_store/test_simple_chat_store.py
+++ b/llama-index-core/tests/storage/chat_store/test_simple_chat_store.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from llama_index.core.llms import ChatMessage
 from llama_index.core.storage.chat_store import SimpleChatStore
 
@@ -74,3 +76,31 @@ def test_delete_chat_message_idx() -> None:
     assert chat_store.get_messages("user1") == [
         ChatMessage(role="user", content="world"),
     ]
+
+
+def test_persist_uses_utf8_and_no_ascii_escaping(tmp_path: pathlib.Path) -> None:
+    chat_store = SimpleChatStore()
+    chat_store.add_message("k", ChatMessage(role="user", content="café 你好"))
+
+    persist_path = str(tmp_path / "chat_store.json")
+    chat_store.persist(persist_path=persist_path)
+
+    raw = (tmp_path / "chat_store.json").read_text(encoding="utf-8")
+    assert "café 你好" in raw
+    assert "\\u" not in raw
+
+    loaded = SimpleChatStore.from_persist_path(persist_path=persist_path)
+    assert loaded.get_messages("k")[0].content == "café 你好"
+
+
+def test_persist_and_load_with_custom_encoding(tmp_path: pathlib.Path) -> None:
+    chat_store = SimpleChatStore()
+    chat_store.add_message("k", ChatMessage(role="user", content="Olá こんにちは"))
+
+    persist_path = str(tmp_path / "nested" / "chat_store.json")
+    chat_store.persist(persist_path=persist_path, encoding="utf-16")
+
+    loaded = SimpleChatStore.from_persist_path(
+        persist_path=persist_path, encoding="utf-16"
+    )
+    assert loaded.get_messages("k")[0].content == "Olá こんにちは"


### PR DESCRIPTION
Add an encoding parameter to SimpleChatStore persistence and disable ASCII escaping to avoid bloated \uXXXX sequences in persisted chat stores.

Description
This PR addresses the issue where persisting a SimpleChatStore containing non-ASCII characters (e.g., Persian, Arabic) results in significantly bloated file sizes and unreadable raw JSON files due to the default ensure_ascii=True behavior of json.dumps.

Changes made:
Added an encoding: str = "utf-8" parameter to SimpleChatStore.persist() and SimpleChatStore.from_persist_path().

Updated the file writing logic in persist() to use ensure_ascii=False during JSON serialization, which writes actual UTF-8 characters to the file instead of \uXXXX escape sequences.

Fixes #15055

New Package?
Did I fill in the tool.llamahub section in the pyproject.toml and provide a detailed README.md for my new integration or package?
- [ ] Yes
- [x] No

Version Bump?
Did I bump the version in the pyproject.toml file of the package I am updating? (Except for the llama-index-core package)
- [ ] Yes
- [x] No

Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

How Has This Been Tested?
Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.
- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran uv run make format; uv run make lint to appease the lint gods