### PR TITLE
fix(core): avoid KeyError on missing VectorMemory sub_dicts

### DIFF
--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -147,7 +147,9 @@ class VectorMemory(BaseMemory):
         return [
             ChatMessage.model_validate(sub_dict)
             for node in nodes
-            for sub_dict in node.metadata["sub_dicts"]
+            for sub_dict in (
+                node.metadata.get("sub_dicts", []) if node.metadata else []
+            )
         ]
 
     def get_all(self) -> List[ChatMessage]:

--- a/llama-index-core/tests/memory/test_vector_memory_sub_dicts.py
+++ b/llama-index-core/tests/memory/test_vector_memory_sub_dicts.py
@@ -1,0 +1,77 @@
+"""Tests for VectorMemory.get() sub_dict parsing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.llms import ChatMessage
+from llama_index.core.memory import VectorMemory
+
+
+@dataclass
+class _MockNode:
+    metadata: Optional[Dict[str, Any]]
+
+
+class _MockRetriever:
+    def __init__(self, nodes: List[_MockNode]) -> None:
+        self._nodes = nodes
+
+    def retrieve(self, _query: str) -> List[_MockNode]:
+        return self._nodes
+
+
+def _make_memory_with_nodes(nodes: List[_MockNode]) -> VectorMemory:
+    # We don't exercise indexing/embeddings here; we only need a valid VectorMemory instance.
+    mem = VectorMemory.from_defaults(embed_model=MockEmbedding(embed_dim=1))
+    mem.vector_index.as_retriever = lambda **_kwargs: _MockRetriever(nodes)  # type: ignore[method-assign]
+    return mem
+
+
+def test_vector_memory_get_mixed_nodes_with_and_without_sub_dicts() -> None:
+    mem = _make_memory_with_nodes(
+        [
+            _MockNode(
+                metadata={
+                    "sub_dicts": [
+                        ChatMessage.from_str("hello", "user").model_dump(),
+                        ChatMessage.from_str("hi", "assistant").model_dump(),
+                    ]
+                }
+            ),
+            _MockNode(metadata={"source": "doc.txt"}),  # no sub_dicts
+            _MockNode(metadata=None),  # missing metadata entirely
+        ]
+    )
+
+    msgs = mem.get("query")
+
+    assert [m.content for m in msgs] == ["hello", "hi"]
+
+
+def test_vector_memory_get_nodes_with_only_document_metadata() -> None:
+    mem = _make_memory_with_nodes(
+        [
+            _MockNode(metadata={"source": "doc1.txt", "page": 1}),
+            _MockNode(metadata={"source": "doc2.txt", "page": 2}),
+        ]
+    )
+
+    msgs = mem.get("query")
+
+    assert msgs == []
+
+
+def test_vector_memory_get_nodes_with_empty_sub_dicts() -> None:
+    mem = _make_memory_with_nodes(
+        [
+            _MockNode(metadata={"sub_dicts": []}),
+            _MockNode(metadata={"sub_dicts": []}),
+        ]
+    )
+
+    msgs = mem.get("query")
+
+    assert msgs == []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/tests/test_vector_memory_chroma.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-chroma/tests/test_vector_memory_chroma.py
@@ -1,0 +1,77 @@
+import json
+import uuid
+from typing import Any, Dict
+
+import chromadb
+
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.llms import ChatMessage
+from llama_index.core.memory import VectorMemory
+from llama_index.core.schema import TextNode
+from llama_index.vector_stores.chroma import ChromaVectorStore
+
+
+def _node_to_chroma_metadata(node: TextNode) -> Dict[str, Any]:
+    """
+    Create Chroma-safe metadata while preserving full node in _node_content.
+
+    Chroma's metadata values must be scalars, but we still want node reconstruction
+    (including nested metadata like `sub_dicts`) via `_node_content`.
+    """
+    node_dict = node.model_dump(mode="json")
+    node_dict["text"] = ""
+    node_dict["embedding"] = None
+
+    return {
+        "_node_content": json.dumps(node_dict, ensure_ascii=False),
+        "_node_type": node.class_name(),
+        "document_id": node.ref_doc_id or "None",
+        "doc_id": node.ref_doc_id or "None",
+        "ref_doc_id": node.ref_doc_id or "None",
+    }
+
+
+def test_vector_memory_get_ignores_document_nodes_without_sub_dicts() -> None:
+    chroma_client = chromadb.EphemeralClient()
+    collection_name = f"vector-memory-{uuid.uuid4()}"
+    collection = chroma_client.get_or_create_collection(collection_name)
+
+    vector_store = ChromaVectorStore(chroma_collection=collection)
+    embed_model = MockEmbedding(embed_dim=3)
+
+    doc_node = TextNode(
+        id_="doc-node",
+        text="normal document chunk",
+        metadata={"source": "doc.txt"},
+        embedding=[0.0, 0.0, 1.0],
+    )
+
+    chat_msg = ChatMessage.from_str("hello from chat", "user")
+    chat_node = TextNode(
+        id_="chat-node",
+        text="hello from chat",
+        metadata={"sub_dicts": [chat_msg.model_dump()]},
+        embedding=[0.0, 1.0, 0.0],
+    )
+
+    collection.add(
+        ids=[doc_node.node_id, chat_node.node_id],
+        embeddings=[doc_node.get_embedding(), chat_node.get_embedding()],
+        documents=[doc_node.text, chat_node.text],
+        metadatas=[
+            _node_to_chroma_metadata(doc_node),
+            _node_to_chroma_metadata(chat_node),
+        ],
+    )
+
+    mem = VectorMemory.from_defaults(
+        vector_store=vector_store,
+        embed_model=embed_model,
+        retriever_kwargs={"similarity_top_k": 2},
+    )
+
+    # Should not raise KeyError even if a retrieved node lacks `sub_dicts`.
+    result = mem.get("any query")
+
+    assert len(result) == 1
+    assert result[0].content == "hello from chat"


### PR DESCRIPTION
VectorMemory.get() now safely handles nodes with missing metadata or missing/empty sub_dicts. Add unit tests covering mixed nodes and document-only metadata.

Description
This PR fixes a KeyError: 'sub_dicts' that occurs when VectorMemory.get() retrieves nodes that do not contain sub_dicts in their metadata. This issue commonly surfaces when using vector stores (such as ChromaDB) that have been populated with standard document chunks alongside chat messages.

The update ensures the list comprehension safely accesses the metadata dictionary using .get("sub_dicts", []) and includes a fallback in case the metadata itself is None. Furthermore, mocked unit tests were added directly to llama-index-core to verify that VectorMemory successfully handles a mix of nodes (with and without sub_dicts), document-only nodes, and nodes with empty sub-dictionaries, without relying on external integration dependencies.

Fixes #15681

New Package?
Did I fill in the tool.llamahub section in the pyproject.toml and provide a detailed README.md for my new integration or package?
- [ ] Yes
- [x] No

Version Bump?
Did I bump the version in the pyproject.toml file of the package I am updating? (Except for the llama-index-core package)

- [ ] Yes
- [x] No

Type of Change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.
- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran uv run make format; uv run make lint to appease the lint gods