### PR TITLE
fix(FunctionAgent): fall back to ThinkingBlock content when response content is empty

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -8,7 +8,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentStream,
     ToolCallResult,
 )
-from llama_index.core.base.llms.types import ChatResponse
+from llama_index.core.base.llms.types import ChatResponse, ThinkingBlock
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.llms import ChatMessage
 from llama_index.core.memory import BaseMemory
@@ -128,6 +128,31 @@ class FunctionAgent(BaseWorkflowAgent):
         tool_calls = self.llm.get_tool_calls_from_response(  # type: ignore
             last_chat_response, error_on_no_tool_call=False
         )
+
+        # Fallback: some OpenAI-compatible models (e.g. Kimi-K2.5) may put the final
+        # answer in `reasoning_content` instead of `content`. When there are no tool
+        # calls and the response content is empty, promote the ThinkingBlock content
+        # to be the text response so the agent doesn't silently return an empty answer.
+        if not tool_calls and not last_chat_response.message.content:
+            thinking_content = next(
+                (
+                    block.content
+                    for block in last_chat_response.message.blocks
+                    if isinstance(block, ThinkingBlock) and block.content
+                ),
+                None,
+            )
+            if thinking_content:
+                last_chat_response = ChatResponse(
+                    message=ChatMessage(
+                        role=last_chat_response.message.role,
+                        content=thinking_content,
+                        additional_kwargs=last_chat_response.message.additional_kwargs,
+                    ),
+                    delta=thinking_content,
+                    raw=last_chat_response.raw,
+                    additional_kwargs=last_chat_response.additional_kwargs,
+                )
 
         # only add to scratchpad if we didn't select the handoff tool
         scratchpad.append(last_chat_response.message)


### PR DESCRIPTION
Fixes #21337

## Problem

Some OpenAI-compatible models (e.g. Kimi-K2.5) occasionally return the final answer in `reasoning_content` instead of `content`. Because `FunctionAgent` doesn't validate that the response content is non-empty (unlike `ReActAgent`, which raises `ValueError("Got empty message")`), it silently returns an empty answer even though the model produced a valid response.

The streaming code in the OpenAI LLM already captures `reasoning_content` and stores it in a `ThinkingBlock` inside `ChatMessage.blocks`. However, `ChatMessage.content` only aggregates `TextBlock` text, so the `ThinkingBlock` content is invisible to the caller.

## Solution

In `FunctionAgent.take_step`, after extracting tool calls, add a fallback: when there are **no tool calls** and **content is empty**, scan the response blocks for a `ThinkingBlock` with non-empty content and, if found, reconstruct the `ChatResponse` using that content as the text response.

This handles both streaming and non-streaming paths (the check is in `take_step`, which is called for both).

Conditions for the fallback to trigger — all must be true:
- No tool calls in the response
- `message.content` is empty / `None`
- At least one `ThinkingBlock` in `message.blocks` has non-empty content

This does not change behaviour for models that behave correctly.

## Testing

The fix can be validated by mocking an LLM that returns a `ChatMessage` with only a `ThinkingBlock` (no `TextBlock` content) and verifying that `FunctionAgent` returns the thinking content as its response rather than an empty string.

Existing tests in `tests/agent/workflow/test_single_agent_workflow.py` continue to pass unchanged.