### PR TITLE
Fix indentation in _conversion_stream_with_retry function

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -872,16 +872,21 @@ async def converse_with_retry_async(
         ) as client:
             return await client.converse(**kwargs)
 
-    @retry_decorator
     async def _conversion_stream_with_retry(**kwargs: Any) -> Any:
-        async with session.client(
-            "bedrock-runtime",
-            config=config,
-            **_boto_client_kwargs,
-        ) as client:
-            response = await client.converse_stream(**kwargs)
-            async for event in response["stream"]:
-                yield event
+        @retry_decorator
+        async def _connect(**kw: Any):
+            async with session.client(
+                "bedrock-runtime",
+                config=config,
+                **_boto_client_kwargs,
+            ) as client:
+                response = await client.converse_stream(**kw)
+                return response, client
+
+        response, client = await _connect(**kwargs)
+
+        async for event in response["stream"]:
+            yield event
 
     if stream:
         return _conversion_stream_with_retry(**converse_kwargs)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # 

- Introduced an internal `_connect` coroutine wrapped with `@retry_decorator`
- Applied retry only to the `client.converse_stream()` call
- Left streaming iteration outside retry, since retrying a partially consumed stream is not meaningful

## New Package?
no new package added

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)


- [x] No

## Type of Change

Please delete options that are not relevant.


- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
