### PR TITLE
fix: add encoding="utf-8" to graph store persist/load methods

### DIFF
--- a/llama-index-core/llama_index/core/graph_stores/simple.py
+++ b/llama-index-core/llama_index/core/graph_stores/simple.py
@@ -147,7 +147,7 @@ class SimpleGraphStore(GraphStore):
         if not fs.exists(dirpath):
             fs.makedirs(dirpath)
 
-        with fs.open(persist_path, "w") as f:
+        with fs.open(persist_path, "w", encoding="utf-8") as f:
             json.dump(self._data.to_dict(), f)
 
     def get_schema(self, refresh: bool = False) -> str:
@@ -172,7 +172,7 @@ class SimpleGraphStore(GraphStore):
             return cls()
 
         logger.debug(f"Loading {__name__} from {persist_path}.")
-        with fs.open(persist_path, "rb") as f:
+        with fs.open(persist_path, "r", encoding="utf-8") as f:
             data_dict = json.load(f)
             data = SimpleGraphStoreData.from_dict(data_dict)
         return cls(data)

--- a/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
+++ b/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
@@ -167,7 +167,7 @@ class SimplePropertyGraphStore(PropertyGraphStore):
         """Persist the graph store to a file."""
         if fs is None:
             fs = fsspec.filesystem("file")
-        with fs.open(persist_path, "w") as f:
+        with fs.open(persist_path, "w", encoding="utf-8") as f:
             f.write(self.graph.model_dump_json())
 
     @classmethod
@@ -180,7 +180,7 @@ class SimplePropertyGraphStore(PropertyGraphStore):
         if fs is None:
             fs = fsspec.filesystem("file")
 
-        with fs.open(persist_path, "r") as f:
+        with fs.open(persist_path, "r", encoding="utf-8") as f:
             data = json.loads(f.read())
 
         return cls.from_dict(data)


### PR DESCRIPTION
## Description

Fixes #21109

`SimplePropertyGraphStore.persist()` / `from_persist_path()` and `SimpleGraphStore.persist()` / `from_persist_path()` open files without specifying `encoding="utf-8"`. On Windows, Python's `open()` defaults to the system encoding (often `cp1252`), which causes `UnicodeDecodeError` / `UnicodeEncodeError` when the graph data contains non-ASCII characters.

### Changes

- Added `encoding="utf-8"` to all `fs.open()` calls in `persist()` and `from_persist_path()` for both `SimplePropertyGraphStore` and `SimpleGraphStore`
- Fixed `SimpleGraphStore.from_persist_path()` using binary mode (`"rb"`) instead of text mode — `json.load()` expects a text stream, and binary mode is inconsistent with the write path which uses `"w"`

### Files changed

- `llama-index-core/llama_index/core/graph_stores/simple_labelled.py` (SimplePropertyGraphStore)
- `llama-index-core/llama_index/core/graph_stores/simple.py` (SimpleGraphStore)

## Related issue

Closes #21109 — same root cause as PR #21111 (stale since March 2025), but this PR also fixes the older `SimpleGraphStore` class and the `"rb"` mode inconsistency.