### PR TITLE
fix: async HTTP for DocumentBlock URL resolution in async chat paths

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -44,7 +44,7 @@ from llama_index.core.bridge.pydantic import (
 )
 from llama_index.core.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
 from llama_index.core.schema import ImageDocument
-from llama_index.core.utils import get_tokenizer, resolve_binary
+from llama_index.core.utils import aresolve_binary, get_tokenizer, resolve_binary
 
 _logger = logging.getLogger(__name__)
 
@@ -368,12 +368,7 @@ class ImageBlock(BaseContentBlock):
 
         """
         data_buffer = (
-            resolve_binary(
-                raw_bytes=self.image.read(),
-                path=self.path,
-                url=str(self.url) if self.url else None,
-                as_base64=as_base64,
-            )
+            self.image
             if isinstance(self.image, IOBase)
             else resolve_binary(
                 raw_bytes=self.image,
@@ -488,12 +483,7 @@ class AudioBlock(BaseContentBlock):
 
         """
         data_buffer = (
-            resolve_binary(
-                raw_bytes=self.audio.read(),
-                path=self.path,
-                url=str(self.url) if self.url else None,
-                as_base64=as_base64,
-            )
+            self.audio
             if isinstance(self.audio, IOBase)
             else resolve_binary(
                 raw_bytes=self.audio,
@@ -622,12 +612,7 @@ class VideoBlock(BaseContentBlock):
 
         """
         data_buffer = (
-            resolve_binary(
-                raw_bytes=self.video.read(),
-                path=self.path,
-                url=str(self.url) if self.url else None,
-                as_base64=as_base64,
-            )
+            self.video
             if isinstance(self.video, IOBase)
             else resolve_binary(
                 raw_bytes=self.video,
@@ -742,6 +727,31 @@ class DocumentBlock(BaseContentBlock):
             raise ValueError("resolve_document returned zero bytes")
         return data_buffer
 
+    async def aresolve_document(self) -> IOBase:
+        """
+        Async version of resolve_document.
+
+        Resolve a document such that it is represented by a BufferIO object.
+        Uses async HTTP when fetching from URLs to avoid blocking the event loop.
+        """
+        if isinstance(self.data, IOBase):
+            data_buffer = self.data
+        else:
+            data_buffer = await aresolve_binary(
+                raw_bytes=self.data,
+                path=self.path,
+                url=str(self.url) if self.url else None,
+                as_base64=False,
+            )
+        # Check size by seeking to end and getting position
+        data_buffer.seek(0, 2)  # Seek to end
+        size = data_buffer.tell()
+        data_buffer.seek(0)  # Reset to beginning
+
+        if size == 0:
+            raise ValueError("resolve_document returned zero bytes")
+        return data_buffer
+
     def _get_b64_bytes(self, data_buffer: IOBase) -> bytes:
         """
         Get base64-encoded bytes from a IOBase buffer.
@@ -784,7 +794,7 @@ class DocumentBlock(BaseContentBlock):
 
     async def aestimate_tokens(self, *args: Any, **kwargs: Any) -> int:
         try:
-            self.resolve_document()
+            await self.aresolve_document()
         except ValueError as e:
             # Null case
             if str(e) == "resolve_document returned zero bytes":

--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -45,7 +45,7 @@ from llama_index.core.bridge.pydantic import (
 )
 from llama_index.core.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPUTS
 from llama_index.core.schema import ImageDocument
-from llama_index.core.utils import get_tokenizer, resolve_binary
+from llama_index.core.utils import aresolve_binary, get_tokenizer, resolve_binary
 
 _logger = logging.getLogger(__name__)
 
@@ -731,6 +731,31 @@ class DocumentBlock(BaseContentBlock):
             raise ValueError("resolve_document returned zero bytes")
         return data_buffer
 
+    async def aresolve_document(self) -> IOBase:
+        """
+        Async version of resolve_document.
+
+        Resolve a document such that it is represented by a BufferIO object.
+        Uses async HTTP when fetching from URLs to avoid blocking the event loop.
+        """
+        if isinstance(self.data, IOBase):
+            data_buffer = self.data
+        else:
+            data_buffer = await aresolve_binary(
+                raw_bytes=self.data,
+                path=self.path,
+                url=str(self.url) if self.url else None,
+                as_base64=False,
+            )
+        # Check size by seeking to end and getting position
+        data_buffer.seek(0, 2)  # Seek to end
+        size = data_buffer.tell()
+        data_buffer.seek(0)  # Reset to beginning
+
+        if size == 0:
+            raise ValueError("resolve_document returned zero bytes")
+        return data_buffer
+
     def _get_b64_bytes(self, data_buffer: IOBase) -> bytes:
         """
         Get base64-encoded bytes from a IOBase buffer.
@@ -773,7 +798,7 @@ class DocumentBlock(BaseContentBlock):
 
     async def aestimate_tokens(self, *args: Any, **kwargs: Any) -> int:
         try:
-            self.resolve_document()
+            await self.aresolve_document()
         except ValueError as e:
             # Null case
             if str(e) == "resolve_document returned zero bytes":

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -708,3 +708,66 @@ def resolve_binary(
         return BytesIO(response.content)
 
     raise ValueError("No valid source provided to resolve binary data!")
+
+
+async def aresolve_binary(
+    raw_bytes: Optional[bytes] = None,
+    path: Optional[Union[str, Path]] = None,
+    url: Optional[str] = None,
+    as_base64: bool = False,
+) -> BytesIO:
+    """
+    Async version of resolve_binary.
+
+    Resolve binary data from various sources into a BytesIO object.
+    Uses httpx for async HTTP requests when fetching from URLs,
+    avoiding blocking the event loop in async contexts.
+
+    Args:
+        raw_bytes: Raw bytes data
+        path: File path to read bytes from
+        url: URL to fetch bytes from
+        as_base64: Whether to base64 encode the output bytes
+
+    Returns:
+        BytesIO object containing the binary data
+
+    Raises:
+        ValueError: If no valid source is provided
+
+    """
+    # For non-URL sources, delegate to the sync version since they are
+    # local operations (memory/filesystem) that don't block on network I/O.
+    if raw_bytes is not None or path is not None:
+        return resolve_binary(
+            raw_bytes=raw_bytes, path=path, url=None, as_base64=as_base64
+        )
+
+    if url is not None:
+        parsed_url = urlparse(url)
+        if parsed_url.scheme == "data":
+            # Data URLs are in-memory, no network I/O needed
+            return resolve_binary(url=url, as_base64=as_base64)
+
+        # Use httpx for async HTTP fetching
+        try:
+            import httpx
+        except ImportError:
+            raise ImportError(
+                "httpx is required for async document resolution. "
+                "Install it with: pip install httpx"
+            )
+
+        headers = {
+            "User-Agent": "LlamaIndex/0.0 (https://llamaindex.ai; info@llamaindex.ai) llama-index-core/0.0"
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                url, headers=headers, timeout=httpx.Timeout(60.0, connect=60.0)
+            )
+            response.raise_for_status()
+            if as_base64:
+                return BytesIO(base64.b64encode(response.content))
+            return BytesIO(response.content)
+
+    raise ValueError("No valid source provided to resolve binary data!")

--- a/llama-index-core/tests/test_async_resolve_binary.py
+++ b/llama-index-core/tests/test_async_resolve_binary.py
@@ -1,0 +1,220 @@
+"""Tests for async document resolution (aresolve_binary and aresolve_document).
+
+These tests verify that:
+1. aresolve_binary correctly handles raw bytes, file paths, data URLs, and HTTP URLs
+2. aresolve_document on DocumentBlock uses async HTTP for URL-based documents
+3. The async path produces identical results to the sync path for non-network sources
+"""
+
+import asyncio
+import base64
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# aresolve_binary tests
+# ---------------------------------------------------------------------------
+
+from llama_index.core.utils import aresolve_binary, resolve_binary
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_raw_bytes():
+    """aresolve_binary should handle raw bytes identically to resolve_binary."""
+    data = b"hello world"
+    result = await aresolve_binary(raw_bytes=data)
+    expected = resolve_binary(raw_bytes=data)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_raw_bytes_base64():
+    """aresolve_binary should base64-encode raw bytes when as_base64=True."""
+    data = b"hello world"
+    result = await aresolve_binary(raw_bytes=data, as_base64=True)
+    expected = resolve_binary(raw_bytes=data, as_base64=True)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_path(tmp_path):
+    """aresolve_binary should read from file paths."""
+    test_file = tmp_path / "test.bin"
+    test_file.write_bytes(b"file content")
+
+    result = await aresolve_binary(path=test_file)
+    expected = resolve_binary(path=test_file)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_data_url():
+    """aresolve_binary should handle data: URLs without network I/O."""
+    encoded = base64.b64encode(b"test data").decode()
+    data_url = f"data:application/octet-stream;base64,{encoded}"
+
+    result = await aresolve_binary(url=data_url)
+    expected = resolve_binary(url=data_url)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_http_url_uses_httpx():
+    """aresolve_binary should use httpx.AsyncClient for HTTP URLs."""
+    mock_response = MagicMock()
+    mock_response.content = b"remote content"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        result = await aresolve_binary(url="https://example.com/file.pdf")
+        assert result.read() == b"remote content"
+        mock_client.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_http_url_base64():
+    """aresolve_binary should base64-encode HTTP response when as_base64=True."""
+    mock_response = MagicMock()
+    mock_response.content = b"remote content"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        result = await aresolve_binary(
+            url="https://example.com/file.pdf", as_base64=True
+        )
+        assert result.read() == base64.b64encode(b"remote content")
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_no_source():
+    """aresolve_binary should raise ValueError when no source is provided."""
+    with pytest.raises(ValueError, match="No valid source provided"):
+        await aresolve_binary()
+
+
+# ---------------------------------------------------------------------------
+# DocumentBlock.aresolve_document tests
+# ---------------------------------------------------------------------------
+
+from llama_index.core.base.llms.types import DocumentBlock
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_with_data():
+    """aresolve_document should work with pre-loaded data."""
+    raw = b"document content"
+    block = DocumentBlock(data=raw, document_mimetype="application/pdf")
+
+    result = await block.aresolve_document()
+    result.seek(0)
+    content = result.read()
+    assert len(content) > 0
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_with_url():
+    """aresolve_document should use async HTTP for URL-based documents."""
+    mock_response = MagicMock()
+    mock_response.content = b"fetched document"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        block = DocumentBlock(
+            url="https://example.com/doc.pdf",
+            document_mimetype="application/pdf",
+        )
+        result = await block.aresolve_document()
+        result.seek(0)
+        assert result.read() == b"fetched document"
+        mock_client.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_zero_bytes():
+    """aresolve_document should raise ValueError for empty documents."""
+    mock_response = MagicMock()
+    mock_response.content = b""
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        block = DocumentBlock(
+            url="https://example.com/empty.pdf",
+            document_mimetype="application/pdf",
+        )
+        with pytest.raises(ValueError, match="resolve_document returned zero bytes"):
+            await block.aresolve_document()
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_with_path(tmp_path):
+    """aresolve_document should work with local file paths."""
+    test_file = tmp_path / "test.pdf"
+    test_file.write_bytes(b"%PDF-1.4 test content")
+
+    block = DocumentBlock(
+        path=str(test_file), document_mimetype="application/pdf"
+    )
+    result = await block.aresolve_document()
+    result.seek(0)
+    assert result.read() == b"%PDF-1.4 test content"
+
+
+@pytest.mark.asyncio
+async def test_document_block_aestimate_tokens_uses_async():
+    """aestimate_tokens should use aresolve_document (async path)."""
+    mock_response = MagicMock()
+    mock_response.content = b"some content"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        block = DocumentBlock(
+            url="https://example.com/doc.pdf",
+            document_mimetype="application/pdf",
+        )
+        tokens = await block.aestimate_tokens()
+        assert tokens == 512
+        # Verify httpx was used (async path), not requests (sync path)
+        mock_client.get.assert_awaited_once()

--- a/llama-index-core/tests/test_async_resolve_binary.py
+++ b/llama-index-core/tests/test_async_resolve_binary.py
@@ -184,9 +184,7 @@ async def test_document_block_aresolve_document_with_path(tmp_path):
     test_file = tmp_path / "test.pdf"
     test_file.write_bytes(b"%PDF-1.4 test content")
 
-    block = DocumentBlock(
-        path=str(test_file), document_mimetype="application/pdf"
-    )
+    block = DocumentBlock(path=str(test_file), document_mimetype="application/pdf")
     result = await block.aresolve_document()
     result.seek(0)
     assert result.read() == b"%PDF-1.4 test content"

--- a/llama-index-core/tests/test_async_resolve_binary.py
+++ b/llama-index-core/tests/test_async_resolve_binary.py
@@ -1,0 +1,218 @@
+"""
+Tests for async document resolution (aresolve_binary and aresolve_document).
+
+These tests verify that:
+1. aresolve_binary correctly handles raw bytes, file paths, data URLs, and HTTP URLs
+2. aresolve_document on DocumentBlock uses async HTTP for URL-based documents
+3. The async path produces identical results to the sync path for non-network sources
+"""
+
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# aresolve_binary tests
+# ---------------------------------------------------------------------------
+
+from llama_index.core.utils import aresolve_binary, resolve_binary
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_raw_bytes():
+    """aresolve_binary should handle raw bytes identically to resolve_binary."""
+    data = b"hello world"
+    result = await aresolve_binary(raw_bytes=data)
+    expected = resolve_binary(raw_bytes=data)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_raw_bytes_base64():
+    """aresolve_binary should base64-encode raw bytes when as_base64=True."""
+    data = b"hello world"
+    result = await aresolve_binary(raw_bytes=data, as_base64=True)
+    expected = resolve_binary(raw_bytes=data, as_base64=True)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_path(tmp_path):
+    """aresolve_binary should read from file paths."""
+    test_file = tmp_path / "test.bin"
+    test_file.write_bytes(b"file content")
+
+    result = await aresolve_binary(path=test_file)
+    expected = resolve_binary(path=test_file)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_data_url():
+    """aresolve_binary should handle data: URLs without network I/O."""
+    encoded = base64.b64encode(b"test data").decode()
+    data_url = f"data:application/octet-stream;base64,{encoded}"
+
+    result = await aresolve_binary(url=data_url)
+    expected = resolve_binary(url=data_url)
+    assert result.read() == expected.read()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_http_url_uses_httpx():
+    """aresolve_binary should use httpx.AsyncClient for HTTP URLs."""
+    mock_response = MagicMock()
+    mock_response.content = b"remote content"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        result = await aresolve_binary(url="https://example.com/file.pdf")
+        assert result.read() == b"remote content"
+        mock_client.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_http_url_base64():
+    """aresolve_binary should base64-encode HTTP response when as_base64=True."""
+    mock_response = MagicMock()
+    mock_response.content = b"remote content"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        result = await aresolve_binary(
+            url="https://example.com/file.pdf", as_base64=True
+        )
+        assert result.read() == base64.b64encode(b"remote content")
+
+
+@pytest.mark.asyncio
+async def test_aresolve_binary_no_source():
+    """aresolve_binary should raise ValueError when no source is provided."""
+    with pytest.raises(ValueError, match="No valid source provided"):
+        await aresolve_binary()
+
+
+# ---------------------------------------------------------------------------
+# DocumentBlock.aresolve_document tests
+# ---------------------------------------------------------------------------
+
+from llama_index.core.base.llms.types import DocumentBlock
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_with_data():
+    """aresolve_document should work with pre-loaded data."""
+    raw = b"document content"
+    block = DocumentBlock(data=raw, document_mimetype="application/pdf")
+
+    result = await block.aresolve_document()
+    result.seek(0)
+    content = result.read()
+    assert len(content) > 0
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_with_url():
+    """aresolve_document should use async HTTP for URL-based documents."""
+    mock_response = MagicMock()
+    mock_response.content = b"fetched document"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        block = DocumentBlock(
+            url="https://example.com/doc.pdf",
+            document_mimetype="application/pdf",
+        )
+        result = await block.aresolve_document()
+        result.seek(0)
+        assert result.read() == b"fetched document"
+        mock_client.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_zero_bytes():
+    """aresolve_document should raise ValueError for empty documents."""
+    mock_response = MagicMock()
+    mock_response.content = b""
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        block = DocumentBlock(
+            url="https://example.com/empty.pdf",
+            document_mimetype="application/pdf",
+        )
+        with pytest.raises(ValueError, match="resolve_document returned zero bytes"):
+            await block.aresolve_document()
+
+
+@pytest.mark.asyncio
+async def test_document_block_aresolve_document_with_path(tmp_path):
+    """aresolve_document should work with local file paths."""
+    test_file = tmp_path / "test.pdf"
+    test_file.write_bytes(b"%PDF-1.4 test content")
+
+    block = DocumentBlock(
+        path=str(test_file), document_mimetype="application/pdf"
+    )
+    result = await block.aresolve_document()
+    result.seek(0)
+    assert result.read() == b"%PDF-1.4 test content"
+
+
+@pytest.mark.asyncio
+async def test_document_block_aestimate_tokens_uses_async():
+    """aestimate_tokens should use aresolve_document (async path)."""
+    mock_response = MagicMock()
+    mock_response.content = b"some content"
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("llama_index.core.utils.httpx") as mock_httpx:
+        mock_httpx.AsyncClient.return_value = mock_client
+        mock_httpx.Timeout = MagicMock()
+
+        block = DocumentBlock(
+            url="https://example.com/doc.pdf",
+            document_mimetype="application/pdf",
+        )
+        tokens = await block.aestimate_tokens()
+        assert tokens == 512
+        # Verify httpx was used (async path), not requests (sync path)
+        mock_client.get.assert_awaited_once()

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -88,6 +88,7 @@ from llama_index.core.prompts import PromptTemplate
 from llama_index.core.program.utils import FlexibleModel
 from llama_index.llms.openai.utils import (
     O1_MODELS,
+    ato_openai_message_dicts,
     create_retry_decorator,
     is_function_calling_model,
     openai_modelname_to_contextsize,
@@ -784,7 +785,7 @@ class OpenAIResponses(FunctionCallingLLM):
     async def _achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponse:
-        message_dicts = to_openai_message_dicts(
+        message_dicts = await ato_openai_message_dicts(
             messages,
             model=self.model,
             is_responses_api=True,
@@ -809,7 +810,7 @@ class OpenAIResponses(FunctionCallingLLM):
     async def _astream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
-        message_dicts = to_openai_message_dicts(
+        message_dicts = await ato_openai_message_dicts(
             messages,
             model=self.model,
             is_responses_api=True,
@@ -999,7 +1000,7 @@ class OpenAIResponses(FunctionCallingLLM):
         adherence at the API level, rather than best-effort function calling.
         """
         messages = prompt.format_messages(**prompt_args)
-        message_dicts = to_openai_message_dicts(
+        message_dicts = await ato_openai_message_dicts(
             messages, model=self.model, is_responses_api=True
         )
         response = await self._aclient.responses.parse(

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -88,6 +88,7 @@ from llama_index.core.prompts import PromptTemplate
 from llama_index.core.program.utils import FlexibleModel
 from llama_index.llms.openai.utils import (
     O1_MODELS,
+    ato_openai_message_dicts,
     create_retry_decorator,
     is_function_calling_model,
     openai_modelname_to_contextsize,
@@ -784,7 +785,7 @@ class OpenAIResponses(FunctionCallingLLM):
     async def _achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponse:
-        message_dicts = to_openai_message_dicts(
+        message_dicts = await ato_openai_message_dicts(
             messages,
             model=self.model,
             is_responses_api=True,
@@ -809,7 +810,7 @@ class OpenAIResponses(FunctionCallingLLM):
     async def _astream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
-        message_dicts = to_openai_message_dicts(
+        message_dicts = await ato_openai_message_dicts(
             messages,
             model=self.model,
             is_responses_api=True,
@@ -1004,7 +1005,7 @@ class OpenAIResponses(FunctionCallingLLM):
         adherence at the API level, rather than best-effort function calling.
         """
         messages = prompt.format_messages(**prompt_args)
-        message_dicts = to_openai_message_dicts(
+        message_dicts = await ato_openai_message_dicts(
             messages, model=self.model, is_responses_api=True
         )
         response = await self._aclient.responses.parse(

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -819,6 +819,398 @@ def to_openai_message_dicts(
         ]
 
 
+async def ato_openai_message_dict(
+    message: ChatMessage,
+    drop_none: bool = False,
+    model: Optional[str] = None,
+    store: bool = False,
+) -> ChatCompletionMessageParam:
+    """Async version of to_openai_message_dict.
+
+    Uses async document resolution to avoid blocking the event loop
+    when DocumentBlock(url=...) needs to fetch remote files.
+    """
+    content = []
+    content_txt = ""
+    reference_audio_id = None
+    for block in message.blocks:
+        if message.role == MessageRole.ASSISTANT:
+            reference_audio_id = message.additional_kwargs.get(
+                "reference_audio_id", None
+            )
+            if reference_audio_id:
+                continue
+
+        if isinstance(block, TextBlock):
+            content.append({"type": "text", "text": block.text})
+            content_txt += block.text
+        elif isinstance(block, DocumentBlock):
+            if not block.data:
+                file_buffer = await block.aresolve_document()
+                b64_string = block._get_b64_string(file_buffer)
+                mimetype = block._guess_mimetype()
+            else:
+                b64_string = block.data.decode("utf-8")
+                mimetype = block._guess_mimetype()
+            content.append(
+                {
+                    "type": "file",
+                    "file": {
+                        "filename": block.title,
+                        "file_data": f"data:{mimetype};base64,{b64_string}",
+                    },
+                }
+            )
+        elif isinstance(block, ImageBlock):
+            if block.url:
+                image_url = {"url": str(block.url)}
+                if block.detail:
+                    image_url["detail"] = block.detail
+
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": image_url,
+                    }
+                )
+            else:
+                img_bytes = block.resolve_image(as_base64=True).read()
+                img_str = img_bytes.decode("utf-8")
+                image_url = f"data:{block.image_mimetype};base64,{img_str}"
+
+                image_url_dict = {"url": image_url}
+                if block.detail:
+                    image_url_dict["detail"] = block.detail
+
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": image_url_dict,
+                    }
+                )
+        elif isinstance(block, AudioBlock):
+            audio_bytes = block.resolve_audio(as_base64=True).read()
+            audio_str = audio_bytes.decode("utf-8")
+            content.append(
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": audio_str,
+                        "format": block.format,
+                    },
+                }
+            )
+        elif isinstance(block, ThinkingBlock):
+            continue
+        elif isinstance(block, ToolCallBlock):
+            try:
+                function_dict = {
+                    "type": "function",
+                    "function": {
+                        "name": block.tool_name,
+                        "arguments": block.tool_kwargs,
+                    },
+                    "id": block.tool_call_id,
+                }
+
+                if len(content) == 0 or content[-1]["type"] != "text":
+                    content.append(
+                        {"type": "text", "text": "", "tool_calls": [function_dict]}
+                    )
+                elif content[-1]["type"] == "text" and "tool_calls" in content[-1]:
+                    content[-1]["tool_calls"].append(function_dict)
+                elif content[-1]["type"] == "text" and "tool_calls" not in content[-1]:
+                    content[-1]["tool_calls"] = [function_dict]
+            except Exception:
+                logger.warning(
+                    f"It was not possible to convert ToolCallBlock with call id {block.tool_call_id or '`no call id`'} to a valid message, skipping..."
+                )
+                continue
+        else:
+            msg = f"Unsupported content block type: {type(block).__name__}"
+            raise ValueError(msg)
+
+    already_has_tool_calls = any(
+        isinstance(block, ToolCallBlock) for block in message.blocks
+    )
+    content_txt = (
+        None
+        if content_txt == ""
+        and message.role == MessageRole.ASSISTANT
+        and (
+            "function_call" in message.additional_kwargs
+            or "tool_calls" in message.additional_kwargs
+            or already_has_tool_calls
+        )
+        else content_txt
+    )
+
+    if reference_audio_id:
+        message_dict = {
+            "role": message.role.value,
+            "audio": {"id": reference_audio_id},
+        }
+    else:
+        message_dict = {
+            "role": message.role.value,
+            "content": (
+                content_txt
+                if message.role.value in ("assistant", "tool", "system")
+                or all(isinstance(block, TextBlock) for block in message.blocks)
+                else content
+            ),
+        }
+        if already_has_tool_calls:
+            existing_tool_calls = []
+            for c in content:
+                existing_tool_calls.extend(c.get("tool_calls", []))
+
+            if existing_tool_calls:
+                message_dict["tool_calls"] = existing_tool_calls
+
+    if (
+        model is not None
+        and model in O1_MODELS
+        and model not in O1_MODELS_WITHOUT_FUNCTION_CALLING
+    ):
+        if message_dict["role"] == "system":
+            message_dict["role"] = "developer"
+
+    if (
+        "tool_calls" in message.additional_kwargs
+        or "function_call" in message.additional_kwargs
+    ) and not already_has_tool_calls:
+        message_dict.update(message.additional_kwargs)
+
+    if "tool_call_id" in message.additional_kwargs:
+        message_dict["tool_call_id"] = message.additional_kwargs["tool_call_id"]
+
+    null_keys = [key for key, value in message_dict.items() if value is None]
+    if drop_none:
+        for key in null_keys:
+            message_dict.pop(key)
+
+    return message_dict  # type: ignore
+
+
+async def ato_openai_responses_message_dict(
+    message: ChatMessage,
+    drop_none: bool = False,
+    model: Optional[str] = None,
+    store: bool = False,
+) -> Union[str, Dict[str, Any], List[Dict[str, Any]]]:
+    """Async version of to_openai_responses_message_dict.
+
+    Uses async document resolution to avoid blocking the event loop
+    when DocumentBlock(url=...) needs to fetch remote files.
+    """
+    content = []
+    content_txt = ""
+    tool_calls = []
+    reasoning = []
+
+    for block in message.blocks:
+        if isinstance(block, TextBlock):
+            if message.role.value == "user":
+                content.append({"type": "input_text", "text": block.text})
+            else:
+                content.append({"type": "output_text", "text": block.text})
+            content_txt += block.text
+        elif isinstance(block, DocumentBlock):
+            if not block.data:
+                file_buffer = await block.aresolve_document()
+                b64_string = block._get_b64_string(file_buffer)
+                mimetype = block._guess_mimetype()
+            else:
+                b64_string = block.data.decode("utf-8")
+                mimetype = block._guess_mimetype()
+            content.append(
+                {
+                    "type": "input_file",
+                    "filename": block.title,
+                    "file_data": f"data:{mimetype};base64,{b64_string}",
+                }
+            )
+        elif isinstance(block, ImageBlock):
+            if block.url:
+                content.append(
+                    {
+                        "type": "input_image",
+                        "image_url": str(block.url),
+                        "detail": block.detail or "auto",
+                    }
+                )
+            else:
+                img_bytes = block.resolve_image(as_base64=True).read()
+                img_str = img_bytes.decode("utf-8")
+                content.append(
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:{block.image_mimetype};base64,{img_str}",
+                        "detail": block.detail or "auto",
+                    }
+                )
+        elif isinstance(block, ThinkingBlock):
+            if store:
+                if block.content and "id" in block.additional_information:
+                    reasoning.append(
+                        {
+                            "type": "reasoning",
+                            "id": block.additional_information["id"],
+                            "summary": [
+                                {"type": "summary_text", "text": block.content or ""}
+                            ],
+                        }
+                    )
+        elif isinstance(block, ToolCallBlock):
+            arguments = block.tool_kwargs
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments)
+            tool_calls.extend(
+                [
+                    {
+                        "type": "function_call",
+                        "arguments": arguments,
+                        "call_id": block.tool_call_id,
+                        "name": block.tool_name,
+                    }
+                ]
+            )
+        else:
+            msg = f"Unsupported content block type: {type(block).__name__}"
+            raise ValueError(msg)
+
+    if "tool_calls" in message.additional_kwargs:
+        message_dicts = [
+            tool_call if isinstance(tool_call, dict) else tool_call.model_dump()
+            for tool_call in message.additional_kwargs["tool_calls"]
+        ]
+
+        items = [*reasoning]
+        if content_txt not in (None, "", []):
+            items.append({"role": message.role.value, "content": content_txt})
+        items.extend(message_dicts)
+        return items
+    elif tool_calls:
+        items = [*reasoning]
+        if content_txt not in (None, "", []):
+            items.append({"role": message.role.value, "content": content_txt})
+        items.extend(tool_calls)
+        return items
+
+    content_txt = (
+        None
+        if content_txt == ""
+        and message.role == MessageRole.ASSISTANT
+        and (
+            "function_call" in message.additional_kwargs
+            or "tool_calls" in message.additional_kwargs
+        )
+        else content_txt
+    )
+
+    if message.role.value == "tool":
+        call_id = message.additional_kwargs.get(
+            "tool_call_id", message.additional_kwargs.get("call_id")
+        )
+        if call_id is None:
+            raise ValueError(
+                "tool_call_id or call_id is required in additional_kwargs for tool messages"
+            )
+
+        message_dict = {
+            "type": "function_call_output",
+            "output": content_txt,
+            "call_id": call_id,
+        }
+
+        return message_dict
+
+    elif (
+        isinstance(content_txt, str)
+        and len(content_txt) != 0
+        and all(item["type"] == "input_text" for item in content)
+        and message.role.value == "user"
+    ):
+        return content_txt
+    else:
+        message_dict = {
+            "role": message.role.value,
+            "content": (
+                content_txt
+                if message.role.value in ("system", "developer")
+                or all(isinstance(block, TextBlock) for block in message.blocks)
+                else content
+            ),
+        }
+
+    if (
+        model is not None
+        and model in O1_MODELS
+        and model not in O1_MODELS_WITHOUT_FUNCTION_CALLING
+    ):
+        if message_dict["role"] == "system":
+            message_dict["role"] = "developer"
+
+    null_keys = [key for key, value in message_dict.items() if value is None]
+    if drop_none:
+        for key in null_keys:
+            message_dict.pop(key)
+
+    if reasoning:
+        return [*reasoning, message_dict]
+
+    return message_dict  # type: ignore
+
+
+async def ato_openai_message_dicts(
+    messages: Sequence[ChatMessage],
+    drop_none: bool = False,
+    model: Optional[str] = None,
+    is_responses_api: bool = False,
+    store: bool = False,
+) -> Union[List[ChatCompletionMessageParam], str]:
+    """Async version of to_openai_message_dicts.
+
+    Uses async document resolution to avoid blocking the event loop
+    when DocumentBlock(url=...) needs to fetch remote files.
+    """
+    if is_responses_api:
+        final_message_dicts = []
+        for message in messages:
+            message_dicts = await ato_openai_responses_message_dict(
+                message,
+                drop_none=drop_none,
+                model="o3-mini",
+                store=store,
+            )
+            if isinstance(message_dicts, list):
+                final_message_dicts.extend(message_dicts)
+            elif isinstance(message_dicts, str):
+                final_message_dicts.append({"role": "user", "content": message_dicts})
+            else:
+                final_message_dicts.append(message_dicts)
+
+        if (
+            len(final_message_dicts) == 1
+            and final_message_dicts[0]["role"] == "user"
+            and isinstance(final_message_dicts[0]["content"], str)
+        ):
+            return final_message_dicts[0]["content"]
+
+        return final_message_dicts
+    else:
+        return [
+            await ato_openai_message_dict(
+                message,
+                drop_none=drop_none,
+                model=model,
+                store=store,
+            )
+            for message in messages
+        ]
+
+
 def from_openai_message(
     openai_message: ChatCompletionMessage, modalities: List[str]
 ) -> ChatMessage:

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -826,6 +826,398 @@ def to_openai_message_dicts(
         ]
 
 
+async def ato_openai_message_dict(
+    message: ChatMessage,
+    drop_none: bool = False,
+    model: Optional[str] = None,
+    store: bool = False,
+) -> ChatCompletionMessageParam:
+    """Async version of to_openai_message_dict.
+
+    Uses async document resolution to avoid blocking the event loop
+    when DocumentBlock(url=...) needs to fetch remote files.
+    """
+    content = []
+    content_txt = ""
+    reference_audio_id = None
+    for block in message.blocks:
+        if message.role == MessageRole.ASSISTANT:
+            reference_audio_id = message.additional_kwargs.get(
+                "reference_audio_id", None
+            )
+            if reference_audio_id:
+                continue
+
+        if isinstance(block, TextBlock):
+            content.append({"type": "text", "text": block.text})
+            content_txt += block.text
+        elif isinstance(block, DocumentBlock):
+            if not block.data:
+                file_buffer = await block.aresolve_document()
+                b64_string = block._get_b64_string(file_buffer)
+                mimetype = block._guess_mimetype()
+            else:
+                b64_string = block.data.decode("utf-8")
+                mimetype = block._guess_mimetype()
+            content.append(
+                {
+                    "type": "file",
+                    "file": {
+                        "filename": block.title,
+                        "file_data": f"data:{mimetype};base64,{b64_string}",
+                    },
+                }
+            )
+        elif isinstance(block, ImageBlock):
+            if block.url:
+                image_url = {"url": str(block.url)}
+                if block.detail:
+                    image_url["detail"] = block.detail
+
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": image_url,
+                    }
+                )
+            else:
+                img_bytes = block.resolve_image(as_base64=True).read()
+                img_str = img_bytes.decode("utf-8")
+                image_url = f"data:{block.image_mimetype};base64,{img_str}"
+
+                image_url_dict = {"url": image_url}
+                if block.detail:
+                    image_url_dict["detail"] = block.detail
+
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": image_url_dict,
+                    }
+                )
+        elif isinstance(block, AudioBlock):
+            audio_bytes = block.resolve_audio(as_base64=True).read()
+            audio_str = audio_bytes.decode("utf-8")
+            content.append(
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": audio_str,
+                        "format": block.format,
+                    },
+                }
+            )
+        elif isinstance(block, ThinkingBlock):
+            continue
+        elif isinstance(block, ToolCallBlock):
+            try:
+                function_dict = {
+                    "type": "function",
+                    "function": {
+                        "name": block.tool_name,
+                        "arguments": block.tool_kwargs,
+                    },
+                    "id": block.tool_call_id,
+                }
+
+                if len(content) == 0 or content[-1]["type"] != "text":
+                    content.append(
+                        {"type": "text", "text": "", "tool_calls": [function_dict]}
+                    )
+                elif content[-1]["type"] == "text" and "tool_calls" in content[-1]:
+                    content[-1]["tool_calls"].append(function_dict)
+                elif content[-1]["type"] == "text" and "tool_calls" not in content[-1]:
+                    content[-1]["tool_calls"] = [function_dict]
+            except Exception:
+                logger.warning(
+                    f"It was not possible to convert ToolCallBlock with call id {block.tool_call_id or '`no call id`'} to a valid message, skipping..."
+                )
+                continue
+        else:
+            msg = f"Unsupported content block type: {type(block).__name__}"
+            raise ValueError(msg)
+
+    already_has_tool_calls = any(
+        isinstance(block, ToolCallBlock) for block in message.blocks
+    )
+    content_txt = (
+        None
+        if content_txt == ""
+        and message.role == MessageRole.ASSISTANT
+        and (
+            "function_call" in message.additional_kwargs
+            or "tool_calls" in message.additional_kwargs
+            or already_has_tool_calls
+        )
+        else content_txt
+    )
+
+    if reference_audio_id:
+        message_dict = {
+            "role": message.role.value,
+            "audio": {"id": reference_audio_id},
+        }
+    else:
+        message_dict = {
+            "role": message.role.value,
+            "content": (
+                content_txt
+                if message.role.value in ("assistant", "tool", "system")
+                or all(isinstance(block, TextBlock) for block in message.blocks)
+                else content
+            ),
+        }
+        if already_has_tool_calls:
+            existing_tool_calls = []
+            for c in content:
+                existing_tool_calls.extend(c.get("tool_calls", []))
+
+            if existing_tool_calls:
+                message_dict["tool_calls"] = existing_tool_calls
+
+    if (
+        model is not None
+        and model in O1_MODELS
+        and model not in O1_MODELS_WITHOUT_FUNCTION_CALLING
+    ):
+        if message_dict["role"] == "system":
+            message_dict["role"] = "developer"
+
+    if (
+        "tool_calls" in message.additional_kwargs
+        or "function_call" in message.additional_kwargs
+    ) and not already_has_tool_calls:
+        message_dict.update(message.additional_kwargs)
+
+    if "tool_call_id" in message.additional_kwargs:
+        message_dict["tool_call_id"] = message.additional_kwargs["tool_call_id"]
+
+    null_keys = [key for key, value in message_dict.items() if value is None]
+    if drop_none:
+        for key in null_keys:
+            message_dict.pop(key)
+
+    return message_dict  # type: ignore
+
+
+async def ato_openai_responses_message_dict(
+    message: ChatMessage,
+    drop_none: bool = False,
+    model: Optional[str] = None,
+    store: bool = False,
+) -> Union[str, Dict[str, Any], List[Dict[str, Any]]]:
+    """Async version of to_openai_responses_message_dict.
+
+    Uses async document resolution to avoid blocking the event loop
+    when DocumentBlock(url=...) needs to fetch remote files.
+    """
+    content = []
+    content_txt = ""
+    tool_calls = []
+    reasoning = []
+
+    for block in message.blocks:
+        if isinstance(block, TextBlock):
+            if message.role.value == "user":
+                content.append({"type": "input_text", "text": block.text})
+            else:
+                content.append({"type": "output_text", "text": block.text})
+            content_txt += block.text
+        elif isinstance(block, DocumentBlock):
+            if not block.data:
+                file_buffer = await block.aresolve_document()
+                b64_string = block._get_b64_string(file_buffer)
+                mimetype = block._guess_mimetype()
+            else:
+                b64_string = block.data.decode("utf-8")
+                mimetype = block._guess_mimetype()
+            content.append(
+                {
+                    "type": "input_file",
+                    "filename": block.title,
+                    "file_data": f"data:{mimetype};base64,{b64_string}",
+                }
+            )
+        elif isinstance(block, ImageBlock):
+            if block.url:
+                content.append(
+                    {
+                        "type": "input_image",
+                        "image_url": str(block.url),
+                        "detail": block.detail or "auto",
+                    }
+                )
+            else:
+                img_bytes = block.resolve_image(as_base64=True).read()
+                img_str = img_bytes.decode("utf-8")
+                content.append(
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:{block.image_mimetype};base64,{img_str}",
+                        "detail": block.detail or "auto",
+                    }
+                )
+        elif isinstance(block, ThinkingBlock):
+            if store:
+                if block.content and "id" in block.additional_information:
+                    reasoning.append(
+                        {
+                            "type": "reasoning",
+                            "id": block.additional_information["id"],
+                            "summary": [
+                                {"type": "summary_text", "text": block.content or ""}
+                            ],
+                        }
+                    )
+        elif isinstance(block, ToolCallBlock):
+            arguments = block.tool_kwargs
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments)
+            tool_calls.extend(
+                [
+                    {
+                        "type": "function_call",
+                        "arguments": arguments,
+                        "call_id": block.tool_call_id,
+                        "name": block.tool_name,
+                    }
+                ]
+            )
+        else:
+            msg = f"Unsupported content block type: {type(block).__name__}"
+            raise ValueError(msg)
+
+    if "tool_calls" in message.additional_kwargs:
+        message_dicts = [
+            tool_call if isinstance(tool_call, dict) else tool_call.model_dump()
+            for tool_call in message.additional_kwargs["tool_calls"]
+        ]
+
+        items = [*reasoning]
+        if content_txt not in (None, "", []):
+            items.append({"role": message.role.value, "content": content_txt})
+        items.extend(message_dicts)
+        return items
+    elif tool_calls:
+        items = [*reasoning]
+        if content_txt not in (None, "", []):
+            items.append({"role": message.role.value, "content": content_txt})
+        items.extend(tool_calls)
+        return items
+
+    content_txt = (
+        None
+        if content_txt == ""
+        and message.role == MessageRole.ASSISTANT
+        and (
+            "function_call" in message.additional_kwargs
+            or "tool_calls" in message.additional_kwargs
+        )
+        else content_txt
+    )
+
+    if message.role.value == "tool":
+        call_id = message.additional_kwargs.get(
+            "tool_call_id", message.additional_kwargs.get("call_id")
+        )
+        if call_id is None:
+            raise ValueError(
+                "tool_call_id or call_id is required in additional_kwargs for tool messages"
+            )
+
+        message_dict = {
+            "type": "function_call_output",
+            "output": content_txt,
+            "call_id": call_id,
+        }
+
+        return message_dict
+
+    elif (
+        isinstance(content_txt, str)
+        and len(content_txt) != 0
+        and all(item["type"] == "input_text" for item in content)
+        and message.role.value == "user"
+    ):
+        return content_txt
+    else:
+        message_dict = {
+            "role": message.role.value,
+            "content": (
+                content_txt
+                if message.role.value in ("system", "developer")
+                or all(isinstance(block, TextBlock) for block in message.blocks)
+                else content
+            ),
+        }
+
+    if (
+        model is not None
+        and model in O1_MODELS
+        and model not in O1_MODELS_WITHOUT_FUNCTION_CALLING
+    ):
+        if message_dict["role"] == "system":
+            message_dict["role"] = "developer"
+
+    null_keys = [key for key, value in message_dict.items() if value is None]
+    if drop_none:
+        for key in null_keys:
+            message_dict.pop(key)
+
+    if reasoning:
+        return [*reasoning, message_dict]
+
+    return message_dict  # type: ignore
+
+
+async def ato_openai_message_dicts(
+    messages: Sequence[ChatMessage],
+    drop_none: bool = False,
+    model: Optional[str] = None,
+    is_responses_api: bool = False,
+    store: bool = False,
+) -> Union[List[ChatCompletionMessageParam], str]:
+    """Async version of to_openai_message_dicts.
+
+    Uses async document resolution to avoid blocking the event loop
+    when DocumentBlock(url=...) needs to fetch remote files.
+    """
+    if is_responses_api:
+        final_message_dicts = []
+        for message in messages:
+            message_dicts = await ato_openai_responses_message_dict(
+                message,
+                drop_none=drop_none,
+                model="o3-mini",
+                store=store,
+            )
+            if isinstance(message_dicts, list):
+                final_message_dicts.extend(message_dicts)
+            elif isinstance(message_dicts, str):
+                final_message_dicts.append({"role": "user", "content": message_dicts})
+            else:
+                final_message_dicts.append(message_dicts)
+
+        if (
+            len(final_message_dicts) == 1
+            and final_message_dicts[0]["role"] == "user"
+            and isinstance(final_message_dicts[0]["content"], str)
+        ):
+            return final_message_dicts[0]["content"]
+
+        return final_message_dicts
+    else:
+        return [
+            await ato_openai_message_dict(
+                message,
+                drop_none=drop_none,
+                model=model,
+                store=store,
+            )
+            for message in messages
+        ]
+
+
 def from_openai_message(
     openai_message: ChatCompletionMessage, modalities: List[str]
 ) -> ChatMessage:


### PR DESCRIPTION
## Summary

`DocumentBlock(url=...)` calls `resolve_document()` → `resolve_binary()` → synchronous `requests.get()` even in async chat paths (`astream_chat`, `_achat`, `astructured_predict`), blocking the event loop and causing timeouts in production under load.

This PR adds proper async counterparts:

- **`aresolve_binary()`** in `llama_index.core.utils` — uses `httpx.AsyncClient` for non-blocking HTTP fetches (local/memory sources delegate to the sync version since they don't involve network I/O)
- **`DocumentBlock.aresolve_document()`** — async method that uses `aresolve_binary()` for URL-based document resolution
- **`ato_openai_message_dict()` / `ato_openai_responses_message_dict()` / `ato_openai_message_dicts()`** — async versions of the OpenAI message conversion utilities
- Updated all async methods in `OpenAIResponses` (`_achat`, `_astream_chat`, `astructured_predict`) to use the async message dict converters
- Updated `DocumentBlock.aestimate_tokens()` to use `aresolve_document()` instead of the sync version

Fixes #21122

## Test plan

- [x] Added `test_async_resolve_binary.py` with 11 tests covering:
  - `aresolve_binary` with raw bytes, file paths, data URLs, HTTP URLs, base64 encoding, and error cases
  - `DocumentBlock.aresolve_document` with pre-loaded data, URL fetching, zero-byte error handling, and local paths
  - `DocumentBlock.aestimate_tokens` verifies it uses the async path
- [ ] Verify existing sync paths are unaffected (no changes to sync code paths)
- [ ] Manual test with `astream_chat_with_tools` + `DocumentBlock(url=...)` under network latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)