### PR TITLE
fix(vllm): filter None kwargs before passing to SamplingParams

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -1,4 +1,6 @@
+import inspect
 import json
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from llama_index.core.base.llms.types import (
@@ -288,7 +290,23 @@ class Vllm(LLM):
 
         from vllm import SamplingParams
 
-        # build sampling parameters
+        # Drop params not accepted by the installed vLLM version so that
+        # fields removed in newer releases (e.g. best_of in vLLM >= 0.19.0)
+        # don't cause a TypeError.
+        valid_keys = (
+            set(inspect.signature(SamplingParams.__init__).parameters) - {"self"}
+        )
+        unsupported = set(params) - valid_keys
+        if unsupported:
+            warnings.warn(
+                f"The following sampling kwargs are not supported by the "
+                f"installed vLLM version and will be ignored: "
+                f"{sorted(unsupported)}",
+                UserWarning,
+                stacklevel=2,
+            )
+            params = {k: v for k, v in params.items() if k in valid_keys}
+
         sampling_params = SamplingParams(**params)
         outputs = self._client.generate([prompt], sampling_params)
         return CompletionResponse(text=outputs[0].outputs[0].text)

--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -254,7 +254,7 @@ class Vllm(LLM):
             "top_k": self.top_k,
             "top_p": self.top_p,
         }
-        return {**base_kwargs}
+        return {k: v for k, v in base_kwargs.items() if v is not None}
 
     @atexit.register
     def close():

--- a/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
@@ -1,5 +1,138 @@
+import sys
+import types
+import warnings
+
+import pytest
+from unittest.mock import MagicMock
+
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.core.callbacks import CallbackManager
+
+
+# ---------------------------------------------------------------------------
+# vLLM stubs
+# ---------------------------------------------------------------------------
+
+
+def _make_vllm_stub(*, accept_best_of: bool) -> types.ModuleType:
+    """Return a minimal vllm module stub.
+
+    When *accept_best_of* is False the SamplingParams signature omits
+    ``best_of``, reproducing the behaviour of vLLM >= 0.19.0.
+    """
+    vllm_mod = types.ModuleType("vllm")
+
+    if accept_best_of:
+
+        class FakeSamplingParams:
+            def __init__(
+                self,
+                temperature: float = 1.0,
+                max_tokens: int = 512,
+                n: int = 1,
+                top_p: float = 1.0,
+                top_k: int = -1,
+                frequency_penalty: float = 0.0,
+                presence_penalty: float = 0.0,
+                ignore_eos: bool = False,
+                stop=None,
+                logprobs=None,
+                best_of=None,
+            ) -> None:
+                self.kwargs = {k: v for k, v in locals().items() if k != "self"}
+
+    else:
+
+        class FakeSamplingParams:  # type: ignore[no-redef]
+            def __init__(
+                self,
+                temperature: float = 1.0,
+                max_tokens: int = 512,
+                n: int = 1,
+                top_p: float = 1.0,
+                top_k: int = -1,
+                frequency_penalty: float = 0.0,
+                presence_penalty: float = 0.0,
+                ignore_eos: bool = False,
+                stop=None,
+                logprobs=None,
+            ) -> None:
+                self.kwargs = {k: v for k, v in locals().items() if k != "self"}
+
+    class FakeLLM:
+        def __init__(self, model=None, tensor_parallel_size=1,
+                     trust_remote_code=False, dtype="auto",
+                     download_dir=None, **kw) -> None:
+            pass
+
+        def generate(self, prompts, sampling_params):
+            out = MagicMock()
+            out.outputs[0].text = "hello"
+            return [out]
+
+    vllm_mod.SamplingParams = FakeSamplingParams
+    vllm_mod.LLM = FakeLLM
+    return vllm_mod
+
+
+@pytest.fixture()
+def vllm_new(monkeypatch):
+    """Stub for vLLM >= 0.19.0: SamplingParams has no ``best_of``."""
+    stub = _make_vllm_stub(accept_best_of=False)
+    monkeypatch.setitem(sys.modules, "vllm", stub)
+    return stub
+
+
+@pytest.fixture()
+def vllm_old(monkeypatch):
+    """Stub for vLLM < 0.19.0: SamplingParams accepts ``best_of``."""
+    stub = _make_vllm_stub(accept_best_of=True)
+    monkeypatch.setitem(sys.modules, "vllm", stub)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# SamplingParams compatibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_complete_default_best_of_no_error(vllm_new):
+    """best_of=None (default) must not be passed to SamplingParams."""
+    from llama_index.llms.vllm import Vllm
+
+    llm = Vllm(model="stub")
+    result = llm.complete("Hello")
+    assert isinstance(result, CompletionResponse)
+    assert result.text == "hello"
+
+
+def test_complete_explicit_best_of_warns_and_succeeds(vllm_new):
+    """Explicitly set best_of should warn and be silently dropped on new vLLM."""
+    from llama_index.llms.vllm import Vllm
+
+    llm = Vllm(model="stub", best_of=3)
+    with pytest.warns(UserWarning, match="best_of"):
+        result = llm.complete("Hello")
+    assert isinstance(result, CompletionResponse)
+    assert result.text == "hello"
+
+
+def test_complete_best_of_forwarded_on_old_vllm(vllm_old):
+    """best_of is forwarded without a warning on vLLM versions that support it."""
+    from llama_index.llms.vllm import Vllm
+
+    llm = Vllm(model="stub", best_of=3)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = llm.complete("Hello")
+
+    assert isinstance(result, CompletionResponse)
+    assert result.text == "hello"
+    assert not any("best_of" in str(w.message) for w in caught)
+
+
+# ---------------------------------------------------------------------------
 
 
 def test_embedding_class():


### PR DESCRIPTION
# Description

llama-index-llms-vllm unconditionally included all sampling parameters (including best_of) in _model_kwargs, even when their value was None. These were then unpacked directly into SamplingParams(**params). Since vLLM ≥ 0.19.0 removed best_of from SamplingParams, every call to .complete() raised:


TypeError: Unexpected keyword argument 'best_of'
This fix filters out all None-valued keys from _model_kwargs before they reach SamplingParams, so any optional parameter that is unset is simply omitted. This handles best_of and makes the integration resilient to future vLLM removals of other optional kwargs.

Fixes #21371

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
