### PR TITLE
fix(vllm): filter None kwargs before passing to SamplingParams

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -254,7 +254,7 @@ class Vllm(LLM):
             "top_k": self.top_k,
             "top_p": self.top_p,
         }
-        return {**base_kwargs}
+        return {k: v for k, v in base_kwargs.items() if v is not None}
 
     @atexit.register
     def close():


### PR DESCRIPTION
## Summary

Fixes #21371

`llama-index-llms-vllm` hardcodes `best_of` in `_model_kwargs`, but vLLM >= 0.19.0 removed `best_of` from `SamplingParams`. Since `_model_kwargs` unconditionally included it, every `.complete()` call raised:

```
TypeError: Unexpected keyword argument 'best_of'
```

**Root cause** — `base.py` line 257:
```python
return {**base_kwargs}  # passes all keys including best_of=None
```

**Fix** — filter out `None`-valued keys before returning:
```python
return {k: v for k, v in base_kwargs.items() if v is not None}
```

This way any parameter whose default is `None` (including `best_of`) is simply omitted, making the integration robust to future vLLM API removals without breaking explicitly set values.

## Test plan

- [ ] `Vllm.complete()` no longer raises `TypeError` with vLLM >= 0.19.0
- [ ] Parameters explicitly set by the user (e.g. `temperature=0.7`) are still forwarded correctly
- [ ] `best_of` is still forwarded when explicitly set to a non-None value (for older vLLM versions)