### PR TITLE
fix(azureaisearch): preserve falsy metadata values in index mapping

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -150,6 +150,48 @@ def test_azureaisearch_add_one_batch() -> None:
 @pytest.mark.skipif(
     not azureaisearch_installed, reason="azure-search-documents package not installed"
 )
+def test_default_index_mapping_preserves_falsy_metadata_values() -> None:
+    search_client = mock_client_with_user_agent("search")
+    vector_store = AzureAISearchVectorStore(
+        search_or_index_client=search_client,
+        id_field_key="id",
+        chunk_field_key="content",
+        embedding_field_key="embedding",
+        metadata_string_field_key="metadata",
+        doc_id_field_key="doc_id",
+        filterable_metadata_field_keys=["count", "text_value", "list_value"],
+        hidden_field_keys=["embedding"],
+        index_management=IndexManagement.NO_VALIDATION,
+        embedding_dimensionality=2,
+        semantic_configuration_name="default",
+    )
+
+    enriched_doc = {
+        "id": "1",
+        "chunk": "chunk",
+        "embedding": [0.1, 0.2],
+        "metadata": "{}",
+        "doc_id": "doc-1",
+    }
+
+    assert vector_store._default_index_mapping(enriched_doc, {"count": 0})["count"] == 0
+    assert (
+        vector_store._default_index_mapping(enriched_doc, {"text_value": ""})[
+            "text_value"
+        ]
+        == ""
+    )
+    assert (
+        vector_store._default_index_mapping(enriched_doc, {"list_value": []})[
+            "list_value"
+        ]
+        == []
+    )
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
 def test_invalid_index_management_for_searchclient() -> None:
     search_client = mock_client_with_user_agent("search")
 


### PR DESCRIPTION
# PR Title

fix(azureaisearch): preserve falsy metadata values in index mapping

# PR Body

## Description

Preserves falsy metadata values when mapping metadata fields into Azure AI Search index documents.

Previously, `_default_index_mapping()` only wrote metadata fields when the value was truthy, which caused valid values like `0`, `""`, and `[]` to be dropped before indexing. This change updates the check to preserve all values except `None` and adds a regression test covering those falsy cases.

Fixes #21385

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Targeted test run:

```bash
uv run --directory llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch pytest tests/test_azureaisearch.py -k preserves_falsy_metadata_values
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods