### PR TITLE
fix: preserve falsy metadata values in Azure AI Search vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc


### PR DESCRIPTION
## Problem

Falsy metadata values (`0`, `""`, `[]`, `False`) are silently dropped when building the Azure AI Search index document.

The current truthiness check on [line 899](https://github.com/run-llama/llama_index/blob/91fe33e75ce31d3ca447c017a5ea153ed8b38700/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py#L899):

```python
if metadata_value:
```

skips any value that evaluates to `False` in a boolean context, which includes valid values like integer `0`, empty strings, and empty lists.

## Fix

Replace the truthiness check with an explicit `None` check:

```python
if metadata_value is not None:
```

This ensures only truly absent metadata keys are skipped, while all valid falsy values are preserved in the index.

## Reproducing

1. Create an Azure AI Search index with an integer metadata field
2. Add a node with that metadata field set to `0`
3. Retrieve the node — the value comes back as `None` instead of `0`

Fixes #21385