### PR TITLE
fix(core): short-circuit Refine on `query_satisfied` when `structured_answer_filtering` is enabled

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -5,6 +5,7 @@ from typing import (
     Generator,
     Optional,
     Sequence,
+    Tuple,
     Type,
     cast,
     AsyncGenerator,
@@ -176,15 +177,17 @@ class Refine(BaseSynthesizer):
             if prev_response is None:
                 # if this is the first chunk, and text chunk already
                 # is an answer, then return it
-                response = self._give_response_single(
+                response, query_satisfied = self._give_response_single(
                     query_str, text_chunk, **response_kwargs
                 )
             else:
                 # refine response if possible
-                response = self._refine_response_single(
+                response, query_satisfied = self._refine_response_single(
                     prev_response, query_str, text_chunk, **response_kwargs
                 )
             prev_response = response
+            if self._structured_answer_filtering and query_satisfied:
+                break
         if isinstance(response, str):
             if self._output_cls is not None:
                 try:
@@ -222,7 +225,7 @@ class Refine(BaseSynthesizer):
         query_str: str,
         text_chunk: str,
         **response_kwargs: Any,
-    ) -> RESPONSE_TEXT_TYPE:
+    ) -> Tuple[RESPONSE_TEXT_TYPE, bool]:
         """Give response given a query and a corresponding text chunk."""
         text_qa_template = self._text_qa_template.partial_format(query_str=query_str)
         text_chunks = self._prompt_helper.repack(
@@ -230,10 +233,10 @@ class Refine(BaseSynthesizer):
         )
 
         response: Optional[RESPONSE_TEXT_TYPE] = None
+        query_satisfied = False
         program = self._program_factory(text_qa_template)
         # TODO: consolidate with loop in get_response_default
         for cur_text_chunk in text_chunks:
-            query_satisfied = False
             if response is None and not self._streaming:
                 try:
                     structured_response = cast(
@@ -246,6 +249,8 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
+                        if self._structured_answer_filtering:
+                            break
                 except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(f"Structured response error: {e}", exc_info=True)
             elif response is None and self._streaming:
@@ -256,7 +261,7 @@ class Refine(BaseSynthesizer):
                 )
                 query_satisfied = True
             else:
-                response = self._refine_response_single(
+                response, query_satisfied = self._refine_response_single(
                     cast(RESPONSE_TEXT_TYPE, response),
                     query_str,
                     cur_text_chunk,
@@ -268,7 +273,7 @@ class Refine(BaseSynthesizer):
             response = response or "Empty Response"
         else:
             response = cast(Generator, response)
-        return response
+        return response, query_satisfied
 
     def _refine_response_single(
         self,
@@ -276,7 +281,7 @@ class Refine(BaseSynthesizer):
         query_str: str,
         text_chunk: str,
         **response_kwargs: Any,
-    ) -> Optional[RESPONSE_TEXT_TYPE]:
+    ) -> Tuple[RESPONSE_TEXT_TYPE, bool]:
         """Refine response."""
         # TODO: consolidate with logic in response/schema.py
         if isinstance(response, Generator):
@@ -302,16 +307,16 @@ class Refine(BaseSynthesizer):
         if avail_chunk_size < 0:
             # if the available chunk size is negative, then the refine template
             # is too big and we just return the original response
-            return response
+            return response, False
 
         # obtain text chunks to add to the refine template
         text_chunks = self._prompt_helper.repack(
             refine_template, text_chunks=[text_chunk], llm=self._llm
         )
 
+        query_satisfied = False
         program = self._program_factory(refine_template)
         for cur_text_chunk in text_chunks:
-            query_satisfied = False
             if not self._streaming:
                 try:
                     structured_response = cast(
@@ -324,6 +329,8 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
+                        if self._structured_answer_filtering:
+                            break
                 except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(f"Structured response error: {e}", exc_info=True)
             else:
@@ -341,7 +348,7 @@ class Refine(BaseSynthesizer):
                     **response_kwargs,
                 )
 
-        return response
+        return response, query_satisfied
 
     @dispatcher.span
     async def aget_response(
@@ -359,14 +366,16 @@ class Refine(BaseSynthesizer):
             if prev_response is None:
                 # if this is the first chunk, and text chunk already
                 # is an answer, then return it
-                response = await self._agive_response_single(
+                response, query_satisfied = await self._agive_response_single(
                     query_str, text_chunk, **response_kwargs
                 )
             else:
-                response = await self._arefine_response_single(
+                response, query_satisfied = await self._arefine_response_single(
                     prev_response, query_str, text_chunk, **response_kwargs
                 )
             prev_response = response
+            if self._structured_answer_filtering and query_satisfied:
+                break
         if response is None:
             response = "Empty Response"
         if isinstance(response, str):
@@ -385,7 +394,7 @@ class Refine(BaseSynthesizer):
         query_str: str,
         text_chunk: str,
         **response_kwargs: Any,
-    ) -> Optional[RESPONSE_TEXT_TYPE]:
+    ) -> Tuple[RESPONSE_TEXT_TYPE, bool]:
         """Refine response."""
         # TODO: consolidate with logic in response/schema.py
         if isinstance(response, AsyncGenerator):
@@ -409,16 +418,16 @@ class Refine(BaseSynthesizer):
         if avail_chunk_size < 0:
             # if the available chunk size is negative, then the refine template
             # is too big and we just return the original response
-            return response
+            return response, False
 
         # obtain text chunks to add to the refine template
         text_chunks = self._prompt_helper.repack(
             refine_template, text_chunks=[text_chunk], llm=self._llm
         )
 
+        query_satisfied = False
         program = self._program_factory(refine_template)
         for cur_text_chunk in text_chunks:
-            query_satisfied = False
             if not self._streaming:
                 try:
                     structured_response = await program.acall(
@@ -431,6 +440,8 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
+                        if self._structured_answer_filtering:
+                            break
                 except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(f"Structured response error: {e}", exc_info=True)
             else:
@@ -453,19 +464,14 @@ class Refine(BaseSynthesizer):
                     **response_kwargs,
                 )
 
-            if query_satisfied:
-                refine_template = self._refine_template.partial_format(
-                    query_str=query_str, existing_answer=response
-                )
-
-        return response
+        return response, query_satisfied
 
     async def _agive_response_single(
         self,
         query_str: str,
         text_chunk: str,
         **response_kwargs: Any,
-    ) -> RESPONSE_TEXT_TYPE:
+    ) -> Tuple[RESPONSE_TEXT_TYPE, bool]:
         """Give response given a query and a corresponding text chunk."""
         text_qa_template = self._text_qa_template.partial_format(query_str=query_str)
         text_chunks = self._prompt_helper.repack(
@@ -473,6 +479,7 @@ class Refine(BaseSynthesizer):
         )
 
         response: Optional[RESPONSE_TEXT_TYPE] = None
+        query_satisfied = False
         program = self._program_factory(text_qa_template)
         # TODO: consolidate with loop in get_response_default
         for cur_text_chunk in text_chunks:
@@ -488,6 +495,8 @@ class Refine(BaseSynthesizer):
                     query_satisfied = structured_response.query_satisfied
                     if query_satisfied:
                         response = structured_response.answer
+                        if self._structured_answer_filtering:
+                            break
                 except (ValidationError, ValueError, TypeError) as e:
                     logger.warning(f"Structured response error: {e}", exc_info=True)
             elif response is None and self._streaming:
@@ -498,7 +507,7 @@ class Refine(BaseSynthesizer):
                 )
                 query_satisfied = True
             else:
-                response = await self._arefine_response_single(
+                response, query_satisfied = await self._arefine_response_single(
                     cast(RESPONSE_TEXT_TYPE, response),
                     query_str,
                     cur_text_chunk,
@@ -510,4 +519,4 @@ class Refine(BaseSynthesizer):
             response = response or "Empty Response"
         else:
             response = cast(AsyncGenerator, response)
-        return response
+        return response, query_satisfied

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -481,6 +481,10 @@ class Refine(BaseSynthesizer):
             program = self._program_factory(prompt_template)
             if resp := self._update_response(program, prompt_kwargs, response_kwargs):
                 response = resp
+                if self._structured_answer_filtering:
+                    if isinstance(response, Generator):
+                        response = get_response_text(response)
+                    break
 
         if isinstance(response, str):
             if self._output_cls is not None:
@@ -563,6 +567,10 @@ class Refine(BaseSynthesizer):
                 program, prompt_kwargs, response_kwargs
             ):
                 response = resp
+                if self._structured_answer_filtering:
+                    if isinstance(response, AsyncGenerator):
+                        response = await aget_response_text(response)
+                    break
 
         if isinstance(response, str):
             if self._output_cls is not None:

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from typing import Any, Dict, Optional, Type, cast
+from unittest.mock import MagicMock
 
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel
@@ -165,3 +166,94 @@ async def test_answer_filtering_no_answers() -> None:
         "question", list(input_to_query_satisfied.keys())
     )
     assert res == "Empty Response"
+
+
+def test_inner_loop_short_circuits_sync() -> None:
+    call_count = [0]
+
+    def program_factory(*args: Any, **kwargs: Any) -> Any:
+        def prog(*a: Any, **kw: Any) -> StructuredRefineResponse:
+            call_count[0] += 1
+            s = kw.get("context_str") or kw.get("context_msg")
+            return StructuredRefineResponse(answer=s, query_satisfied=True)
+
+        return prog
+
+    refine = Refine(structured_answer_filtering=True, program_factory=program_factory)
+    mock_helper = MagicMock()
+    mock_helper.repack.return_value = ["sub1", "sub2"]
+    refine._prompt_helper = mock_helper
+
+    res = refine.get_response("question", ["outer_chunk"])
+    assert call_count[0] == 1
+    assert res == "sub1"
+
+
+@pytest.mark.asyncio
+async def test_inner_loop_short_circuits_async() -> None:
+    call_count = [0]
+
+    def program_factory(*args: Any, **kwargs: Any) -> Any:
+        async def prog(*a: Any, **kw: Any) -> StructuredRefineResponse:
+            call_count[0] += 1
+            s = kw.get("context_str") or kw.get("context_msg")
+            return StructuredRefineResponse(answer=s, query_satisfied=True)
+
+        prog.acall = prog
+        return prog
+
+    refine = Refine(structured_answer_filtering=True, program_factory=program_factory)
+    mock_helper = MagicMock()
+    mock_helper.repack.return_value = ["sub1", "sub2"]
+    refine._prompt_helper = mock_helper
+
+    res = await refine.aget_response("question", ["outer_chunk"])
+    assert call_count[0] == 1
+    assert res == "sub1"
+
+
+def test_structured_filtering_short_circuits_sync() -> None:
+    call_count = [0]
+    chunks = ["chunk1", "chunk2", "chunk3"]
+
+    def program_factory(*args: Any, **kwargs: Any) -> MockRefineProgram:
+        call_count[0] += 1
+        return MockRefineProgram({"chunk1": True, "chunk2": True, "chunk3": True})
+
+    refine = Refine(structured_answer_filtering=True, program_factory=program_factory)
+    res = refine.get_response("question", chunks)
+    assert call_count[0] == 1
+    assert res == "chunk1"
+
+
+@pytest.mark.asyncio
+async def test_structured_filtering_short_circuits_async() -> None:
+    call_count = [0]
+    chunks = ["chunk1", "chunk2", "chunk3"]
+
+    def program_factory(*args: Any, **kwargs: Any) -> MockRefineProgram:
+        call_count[0] += 1
+        return MockRefineProgram({"chunk1": True, "chunk2": True, "chunk3": True})
+
+    refine = Refine(structured_answer_filtering=True, program_factory=program_factory)
+    res = await refine.aget_response("question", chunks)
+    assert call_count[0] == 1
+    assert res == "chunk1"
+
+
+def test_no_filtering_does_not_short_circuit_sync() -> None:
+    call_count = [0]
+
+    def program_factory(*args: Any, **kwargs: Any) -> MockRefineProgram:
+        call_count[0] += 1
+        return MockRefineProgram({"chunk1": True, "chunk2": True, "chunk3": True})
+
+    refine = Refine(structured_answer_filtering=False)
+    refine._program_factory = program_factory
+    mock_helper = MagicMock()
+    mock_helper.repack.return_value = ["chunk1"]
+    mock_helper._get_available_chunk_size.return_value = 100
+    refine._prompt_helper = mock_helper
+
+    refine.get_response("question", ["chunk1", "chunk2", "chunk3"])
+    assert call_count[0] == 3

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -144,8 +144,7 @@ def input_to_query_satisfied(png_1px_b64) -> OrderedDict[str | None, bool]:
                 input2_value=True,
                 expected_response="input2",
                 expected_last_llm_message_prefix=(
-                    # Refine template is used after first query satisfied results in a temporary answer
-                    "You are an expert Q&A system that strictly operates in two modes when refining existing answers:"
+                    "You are an expert Q&A system that is trusted around the world"
                 ),
             ),
             id="one query satisfied",
@@ -588,7 +587,7 @@ class TestRefine:
         if llm_case.chat_function is not None:
             assert llm.last_called_chat_function.count(llm_case.chat_function) == len(
                 nodes
-            )
+            ) - int(query_satisfied_case.input2_value)
             assert llm.last_chat_messages[0].content.startswith(
                 query_satisfied_case.expected_last_llm_message_prefix
             )
@@ -632,7 +631,7 @@ class TestRefine:
         if llm_case.async_chat_function is not None:
             assert llm.last_called_chat_function.count(
                 llm_case.async_chat_function
-            ) == len(nodes)
+            ) == len(nodes) - int(query_satisfied_case.input2_value)
             assert llm.last_chat_messages[0].content.startswith(
                 query_satisfied_case.expected_last_llm_message_prefix
             )
@@ -660,15 +659,15 @@ class TestRefine:
             response = synthesizer.synthesize(query="test", nodes=multimodal_nodes)
         assert isinstance(response, Response)
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function == ["chat", "chat", "chat"], "One per node"
+        assert llm.last_called_chat_function == ["chat"] * (
+            len(multimodal_nodes) - int(query_satisfied_case.input2_value)
+        )
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )
-        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == [
-            "text",
-            "image",
-            "text",
-        ]
+        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == (
+            ["text"] if query_satisfied_case.input2_value else ["text", "image", "text"]
+        )
 
     @pytest.mark.asyncio
     async def test_asynthesize__multimodal_structured_answer_filtering_default_text_completion_refine_program(
@@ -693,17 +692,15 @@ class TestRefine:
             )
         assert isinstance(response, Response)
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function == ["achat", "achat", "achat"], (
-            "One per node, no sync call for mock"
+        assert llm.last_called_chat_function == ["achat"] * (
+            len(multimodal_nodes) - int(query_satisfied_case.input2_value)
         )
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )
-        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == [
-            "text",
-            "image",
-            "text",
-        ]
+        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == (
+            ["text"] if query_satisfied_case.input2_value else ["text", "image", "text"]
+        )
 
     def test_synthesize__structured_answer_filtering_with_streaming_default_text_completion_refine_program(
         self,
@@ -742,7 +739,7 @@ class TestRefine:
         if llm_case.streaming_chat_function is not None:
             assert llm.last_called_chat_function.count(
                 llm_case.streaming_chat_function
-            ) == len(nodes)
+            ) == len(nodes) - int(query_satisfied_case.input2_value)
             assert llm.last_chat_messages[0].content.startswith(
                 query_satisfied_case.expected_last_llm_message_prefix
             )
@@ -788,7 +785,7 @@ class TestRefine:
         if llm_case.async_streaming_chat_function is not None:
             assert llm.last_called_chat_function.count(
                 llm_case.async_streaming_chat_function
-            ) == len(nodes)
+            ) == len(nodes) - int(query_satisfied_case.input2_value)
             assert llm.last_chat_messages[0].content.startswith(
                 query_satisfied_case.expected_last_llm_message_prefix
             )
@@ -814,7 +811,9 @@ class TestRefine:
         response = synthesizer.synthesize(query="test", nodes=nodes)
         assert isinstance(response, Response)
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function.count("chat") == len(nodes)
+        assert llm.last_called_chat_function.count("chat") == len(nodes) - int(
+            query_satisfied_case.input2_value
+        )
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )
@@ -838,7 +837,9 @@ class TestRefine:
         response = await synthesizer.asynthesize(query="test", nodes=nodes)
         assert isinstance(response, Response)
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function.count("achat") == len(nodes)
+        assert llm.last_called_chat_function.count("achat") == len(nodes) - int(
+            query_satisfied_case.input2_value
+        )
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )
@@ -861,15 +862,15 @@ class TestRefine:
         response = synthesizer.synthesize(query="test", nodes=multimodal_nodes)
         assert isinstance(response, Response)
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function == ["chat", "chat", "chat"], "One per node"
+        assert llm.last_called_chat_function == ["chat"] * (
+            len(multimodal_nodes) - int(query_satisfied_case.input2_value)
+        )
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )
-        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == [
-            "text",
-            "image",
-            "text",
-        ]
+        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == (
+            ["text"] if query_satisfied_case.input2_value else ["text", "image", "text"]
+        )
 
     @pytest.mark.asyncio
     async def test_asynthesize__multimodal_structured_answer_filtering_default_function_calling_refine_program(
@@ -890,18 +891,18 @@ class TestRefine:
         response = await synthesizer.asynthesize(query="test", nodes=multimodal_nodes)
         assert isinstance(response, Response)
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function.count("achat") == 3, "One per node"
-        assert llm.last_called_chat_function.count("chat") == 3, (
-            "Async calls sync under hood"
-        )
+        assert llm.last_called_chat_function.count("achat") == len(
+            multimodal_nodes
+        ) - int(query_satisfied_case.input2_value)
+        assert llm.last_called_chat_function.count("chat") == len(
+            multimodal_nodes
+        ) - int(query_satisfied_case.input2_value)
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )
-        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == [
-            "text",
-            "image",
-            "text",
-        ]
+        assert [block.block_type for block in llm.last_chat_messages[-1].blocks] == (
+            ["text"] if query_satisfied_case.input2_value else ["text", "image", "text"]
+        )
 
     def test_synthesize__structured_answer_filtering_with_streaming_default_function_calling_refine_program(
         self,
@@ -923,7 +924,9 @@ class TestRefine:
             "Not a generator since the tokens were consumed as part of the last refine call"
         )
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function.count("stream_chat") == len(nodes)
+        assert llm.last_called_chat_function.count("stream_chat") == len(nodes) - int(
+            query_satisfied_case.input2_value
+        )
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )
@@ -949,7 +952,9 @@ class TestRefine:
             "Not a generator since the tokens were consumed as part of the last refine call"
         )
         assert str(response) == query_satisfied_case.expected_response
-        assert llm.last_called_chat_function.count("astream_chat") == len(nodes)
+        assert llm.last_called_chat_function.count("astream_chat") == len(nodes) - int(
+            query_satisfied_case.input2_value
+        )
         assert llm.last_chat_messages[0].content.startswith(
             query_satisfied_case.expected_last_llm_message_prefix
         )


### PR DESCRIPTION
Closed as stale by the bot. Superseded by #22567 — identical change, rebased onto current main.

---

# Description

Added early-exit breaks to both the outer chunk loops and the inner repacked-subchunk loops in `get_response`, `aget_response`, and their helper methods. Also updated the helper methods to return `(response, query_satisfied)` so the outer loops can act on the satisfaction signal and stop processing additional chunks.

Fixes #21397

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods