### PR TITLE
docs: add Doubleword LLM and embedding integration

### DIFF
--- a/docs/examples/embeddings/doubleword.ipynb
+++ b/docs/examples/embeddings/doubleword.ipynb
@@ -18,10 +18,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "setup-heading",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "install-heading",
    "metadata": {},
    "source": [
-    "## Installation"
+    "### Installation"
    ]
   },
   {
@@ -39,13 +47,7 @@
    "id": "auth-heading",
    "metadata": {},
    "source": [
-    "## Authentication\n",
-    "\n",
-    "You can authenticate in three ways (checked in this order):\n",
-    "\n",
-    "1. Pass `api_key` directly to the constructor\n",
-    "2. Set the `DOUBLEWORD_API_KEY` environment variable\n",
-    "3. Store your key in `~/.dw/credentials.toml`"
+    "### Authentication\n\nYou can authenticate in three ways (checked in this order):\n\n1. Pass `api_key` directly to the constructor\n2. Set the `DOUBLEWORD_API_KEY` environment variable\n3. Store your key in `~/.dw/credentials.toml`"
    ]
   },
   {
@@ -70,11 +72,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "basic-init",
+   "id": "import-embed",
    "metadata": {},
    "outputs": [],
-   "source": "from llamaindex_doubleword import DoublewordEmbedding\n\nembed_model = DoublewordEmbedding(model_name=\"Qwen/Qwen3-Embedding-8B\")\n\n# Get a single embedding\nembedding = embed_model.get_text_embedding(\"Doubleword routes AI requests.\")\nprint(f\"Embedding dimension: {len(embedding)}\")\nprint(f\"First 5 values: {embedding[:5]}\")"
+   "execution_count": null,
+   "source": [
+    "from llamaindex_doubleword import DoublewordEmbedding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "init-embed",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "embed_model = DoublewordEmbedding(model_name=\"Qwen/Qwen3-Embedding-8B\")\n",
+    "\n",
+    "# Get a single embedding\n",
+    "embedding = embed_model.get_text_embedding(\"Doubleword routes AI requests.\")\n",
+    "print(f\"Embedding dimension: {len(embedding)}\")\n",
+    "print(f\"First 5 values: {embedding[:5]}\")"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/embeddings/doubleword.ipynb
+++ b/docs/examples/embeddings/doubleword.ipynb
@@ -12,7 +12,9 @@
    "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
-   "source": "# Doubleword Embeddings\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers.\n\nThe `llamaindex-doubleword` package provides two embedding classes:\n\n- **`DoublewordEmbedding`** — real-time embedding requests\n- **`DoublewordEmbeddingBatch`** — transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\n**Note:** `DoublewordEmbeddingBatch` is async-only. Sync methods will raise `NotImplementedError`. Use the async equivalents (e.g., `aget_text_embedding()`) instead.\n\nFor more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
+   "source": [
+    "# Doubleword Embeddings\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers.\n\nThe `llamaindex-doubleword` package provides two embedding classes:\n\n- **`DoublewordEmbedding`** \u2014 real-time embedding requests\n- **`DoublewordEmbeddingBatch`** \u2014 transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\n**Note:** `DoublewordEmbeddingBatch` is async-only. Sync methods will raise `NotImplementedError`. Use the async equivalents (e.g., `aget_text_embedding()`) instead.\n\nSee the [available models](https://docs.doubleword.ai/inference-api/models) for a full list, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards. For more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -121,7 +123,7 @@
    "cell_type": "markdown",
    "id": "batch-class-heading",
    "metadata": {},
-   "source": "## Batch API with DoublewordEmbeddingBatch\n\n`DoublewordEmbeddingBatch` transparently submits embedding requests through the batch API using [autobatcher](https://pypi.org/project/autobatcher/), which can provide up to 90% cost savings. It has the same interface as `DoublewordEmbedding`, but is **async-only** — sync methods will raise `NotImplementedError`."
+   "source": "## Batch API with DoublewordEmbeddingBatch\n\n`DoublewordEmbeddingBatch` transparently submits embedding requests through the batch API using [autobatcher](https://pypi.org/project/autobatcher/), which can provide up to 90% cost savings. It has the same interface as `DoublewordEmbedding`, but is **async-only** \u2014 sync methods will raise `NotImplementedError`."
   },
   {
    "cell_type": "code",

--- a/docs/examples/embeddings/doubleword.ipynb
+++ b/docs/examples/embeddings/doubleword.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "header-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/embeddings/doubleword.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Doubleword Embeddings\n",
+    "\n",
+    "[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers.\n",
+    "\n",
+    "The `llamaindex-doubleword` package provides two embedding classes:\n",
+    "\n",
+    "- **`DoublewordEmbedding`** — real-time embedding requests\n",
+    "- **`DoublewordEmbeddingBatch`** — transparent batch API submissions via [autobatcher](https://github.com/doublewordai/llamaindex-doubleword) for reduced cost\n",
+    "\n",
+    "For more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "install-heading",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llamaindex-doubleword llama-index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auth-heading",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "You can authenticate in three ways (checked in this order):\n",
+    "\n",
+    "1. Pass `api_key` directly to the constructor\n",
+    "2. Set the `DOUBLEWORD_API_KEY` environment variable\n",
+    "3. Store your key in `~/.dw/credentials.toml`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auth-env",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"DOUBLEWORD_API_KEY\"] = \"your-api-key\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "basic-heading",
+   "metadata": {},
+   "source": [
+    "## Basic Usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "basic-init",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llamaindex_doubleword import DoublewordEmbedding\n",
+    "\n",
+    "embed_model = DoublewordEmbedding(model=\"text-embedding-3-small\")\n",
+    "\n",
+    "# Get a single embedding\n",
+    "embedding = embed_model.get_text_embedding(\"Doubleword routes AI requests.\")\n",
+    "print(f\"Embedding dimension: {len(embedding)}\")\n",
+    "print(f\"First 5 values: {embedding[:5]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batch-embed-heading",
+   "metadata": {},
+   "source": [
+    "### Batch Embeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batch-embed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embeddings = embed_model.get_text_embedding_batch(\n",
+    "    [\n",
+    "        \"First document about AI gateways.\",\n",
+    "        \"Second document about model routing.\",\n",
+    "    ]\n",
+    ")\n",
+    "print(f\"Number of embeddings: {len(embeddings)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "query-heading",
+   "metadata": {},
+   "source": [
+    "### Query Embedding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "query-embed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_embedding = embed_model.get_query_embedding(\"What is an AI gateway?\")\n",
+    "print(f\"Query embedding dimension: {len(query_embedding)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batch-class-heading",
+   "metadata": {},
+   "source": [
+    "## Batch API with DoublewordEmbeddingBatch\n",
+    "\n",
+    "`DoublewordEmbeddingBatch` transparently submits embedding requests through the batch API using [autobatcher](https://github.com/doublewordai/llamaindex-doubleword), which can reduce costs significantly. It has the same interface as `DoublewordEmbedding`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batch-class",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llamaindex_doubleword import DoublewordEmbeddingBatch\n",
+    "\n",
+    "embed_batch = DoublewordEmbeddingBatch(model=\"text-embedding-3-small\")\n",
+    "\n",
+    "embedding = embed_batch.get_text_embedding(\"Cost-effective embeddings via batch API.\")\n",
+    "print(f\"Embedding dimension: {len(embedding)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "settings-heading",
+   "metadata": {},
+   "source": [
+    "## Using with LlamaIndex Settings\n",
+    "\n",
+    "Set Doubleword as the default embedding model globally:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "settings",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Settings, VectorStoreIndex, SimpleDirectoryReader\n",
+    "\n",
+    "Settings.embed_model = DoublewordEmbedding(model=\"text-embedding-3-small\")\n",
+    "\n",
+    "# Now all index operations will use Doubleword embeddings\n",
+    "# documents = SimpleDirectoryReader(\"./data\").load_data()\n",
+    "# index = VectorStoreIndex.from_documents(documents)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 5,
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/embeddings/doubleword.ipynb
+++ b/docs/examples/embeddings/doubleword.ipynb
@@ -12,18 +12,7 @@
    "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
-   "source": [
-    "# Doubleword Embeddings\n",
-    "\n",
-    "[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers.\n",
-    "\n",
-    "The `llamaindex-doubleword` package provides two embedding classes:\n",
-    "\n",
-    "- **`DoublewordEmbedding`** — real-time embedding requests\n",
-    "- **`DoublewordEmbeddingBatch`** — transparent batch API submissions via [autobatcher](https://github.com/doublewordai/llamaindex-doubleword) for reduced cost\n",
-    "\n",
-    "For more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
-   ]
+   "source": "# Doubleword Embeddings\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers.\n\nThe `llamaindex-doubleword` package provides two embedding classes:\n\n- **`DoublewordEmbedding`** — real-time embedding requests\n- **`DoublewordEmbeddingBatch`** — transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\n**Note:** `DoublewordEmbeddingBatch` is async-only. Sync methods will raise `NotImplementedError`. Use the async equivalents (e.g., `aget_text_embedding()`) instead.\n\nFor more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
   },
   {
    "cell_type": "markdown",
@@ -83,16 +72,7 @@
    "id": "basic-init",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llamaindex_doubleword import DoublewordEmbedding\n",
-    "\n",
-    "embed_model = DoublewordEmbedding(model=\"text-embedding-3-small\")\n",
-    "\n",
-    "# Get a single embedding\n",
-    "embedding = embed_model.get_text_embedding(\"Doubleword routes AI requests.\")\n",
-    "print(f\"Embedding dimension: {len(embedding)}\")\n",
-    "print(f\"First 5 values: {embedding[:5]}\")"
-   ]
+   "source": "from llamaindex_doubleword import DoublewordEmbedding\n\nembed_model = DoublewordEmbedding(model_name=\"Qwen/Qwen3-Embedding-8B\")\n\n# Get a single embedding\nembedding = embed_model.get_text_embedding(\"Doubleword routes AI requests.\")\nprint(f\"Embedding dimension: {len(embedding)}\")\nprint(f\"First 5 values: {embedding[:5]}\")"
   },
   {
    "cell_type": "markdown",
@@ -141,11 +121,7 @@
    "cell_type": "markdown",
    "id": "batch-class-heading",
    "metadata": {},
-   "source": [
-    "## Batch API with DoublewordEmbeddingBatch\n",
-    "\n",
-    "`DoublewordEmbeddingBatch` transparently submits embedding requests through the batch API using [autobatcher](https://github.com/doublewordai/llamaindex-doubleword), which can reduce costs significantly. It has the same interface as `DoublewordEmbedding`."
-   ]
+   "source": "## Batch API with DoublewordEmbeddingBatch\n\n`DoublewordEmbeddingBatch` transparently submits embedding requests through the batch API using [autobatcher](https://pypi.org/project/autobatcher/), which can provide up to 90% cost savings. It has the same interface as `DoublewordEmbedding`, but is **async-only** — sync methods will raise `NotImplementedError`."
   },
   {
    "cell_type": "code",
@@ -153,14 +129,7 @@
    "id": "batch-class",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llamaindex_doubleword import DoublewordEmbeddingBatch\n",
-    "\n",
-    "embed_batch = DoublewordEmbeddingBatch(model=\"text-embedding-3-small\")\n",
-    "\n",
-    "embedding = embed_batch.get_text_embedding(\"Cost-effective embeddings via batch API.\")\n",
-    "print(f\"Embedding dimension: {len(embedding)}\")"
-   ]
+   "source": "from llamaindex_doubleword import DoublewordEmbeddingBatch\n\nembed_batch = DoublewordEmbeddingBatch(model_name=\"Qwen/Qwen3-Embedding-8B\")\n\nembedding = await embed_batch.aget_text_embedding(\"Cost-effective embeddings via batch API.\")\nprint(f\"Embedding dimension: {len(embedding)}\")"
   },
   {
    "cell_type": "markdown",
@@ -178,15 +147,7 @@
    "id": "settings",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llama_index.core import Settings, VectorStoreIndex, SimpleDirectoryReader\n",
-    "\n",
-    "Settings.embed_model = DoublewordEmbedding(model=\"text-embedding-3-small\")\n",
-    "\n",
-    "# Now all index operations will use Doubleword embeddings\n",
-    "# documents = SimpleDirectoryReader(\"./data\").load_data()\n",
-    "# index = VectorStoreIndex.from_documents(documents)"
-   ]
+   "source": "from llama_index.core import Settings, VectorStoreIndex, SimpleDirectoryReader\n\nSettings.embed_model = DoublewordEmbedding(model_name=\"Qwen/Qwen3-Embedding-8B\")\n\n# Now all index operations will use Doubleword embeddings\n# documents = SimpleDirectoryReader(\"./data\").load_data()\n# index = VectorStoreIndex.from_documents(documents)"
   }
  ],
  "metadata": {

--- a/docs/examples/embeddings/doubleword.ipynb
+++ b/docs/examples/embeddings/doubleword.ipynb
@@ -12,9 +12,7 @@
    "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
-   "source": [
-    "# Doubleword Embeddings\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers.\n\nThe `llamaindex-doubleword` package provides two embedding classes:\n\n- **`DoublewordEmbedding`** \u2014 real-time embedding requests\n- **`DoublewordEmbeddingBatch`** \u2014 transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\n**Note:** `DoublewordEmbeddingBatch` is async-only. Sync methods will raise `NotImplementedError`. Use the async equivalents (e.g., `aget_text_embedding()`) instead.\n\nSee the [available models](https://docs.doubleword.ai/inference-api/models) for a full list, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards. For more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
-   ]
+   "source": "# Doubleword Embeddings\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers.\n\nThe `llamaindex-doubleword` package provides three embedding classes, one per Doubleword pricing tier:\n\n- **`DoublewordEmbedding`** \u2014 real-time embedding requests\n- **`DoublewordEmbeddingBatch`** \u2014 transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) on the 24-hour batch tier (deepest discount, up to 90% cost savings)\n- **`DoublewordEmbeddingAsync`** \u2014 same machinery, pinned to the 1-hour flex tier for indexing jobs with hourly deadlines\n\n**Note:** Both `DoublewordEmbeddingBatch` and `DoublewordEmbeddingAsync` are async-only. Sync methods will raise `NotImplementedError`. Use the async equivalents (e.g., `aget_text_embedding()`) instead.\n\nSee the [available models](https://docs.doubleword.ai/inference-api/models) for a full list, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards. For more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
   },
   {
    "cell_type": "markdown",
@@ -151,6 +149,20 @@
    "metadata": {},
    "outputs": [],
    "source": "from llamaindex_doubleword import DoublewordEmbeddingBatch\n\nembed_batch = DoublewordEmbeddingBatch(model_name=\"Qwen/Qwen3-Embedding-8B\")\n\nembedding = await embed_batch.aget_text_embedding(\"Cost-effective embeddings via batch API.\")\nprint(f\"Embedding dimension: {len(embedding)}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "async-embed-heading",
+   "metadata": {},
+   "source": "## Async (1-hour flex) API with DoublewordEmbeddingAsync\n\n`DoublewordEmbeddingAsync` is the same machinery as `DoublewordEmbeddingBatch`, but pinned to Doubleword's **1-hour flex completion window** instead of the 24-hour batch window. Use this when you need vectors back within an hour rather than next-day \u2014 for example, an index refresh that has to land before a daily report. Backed by `autobatcher.AsyncOpenAI`.\n\nLike `DoublewordEmbeddingBatch`, it's **async-only** \u2014 sync methods raise."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "async-embed-code",
+   "metadata": {},
+   "outputs": [],
+   "source": "from llamaindex_doubleword import DoublewordEmbeddingAsync\n\nembed_async = DoublewordEmbeddingAsync(model_name=\"Qwen/Qwen3-Embedding-8B\")\n\nembedding = await embed_async.aget_text_embedding(\"Flex embeddings \u2014 minutes, not days.\")\nprint(f\"Embedding dimension: {len(embedding)}\")"
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -192,6 +192,17 @@
    "metadata": {},
    "outputs": [],
    "source": "from llama_index.core import Settings\n\nSettings.llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "examples-heading",
+   "metadata": {},
+   "source": [
+    "## More Examples\n",
+    "\n",
+    "- [`examples/agent-basic/`](https://github.com/doublewordai/llamaindex-doubleword/tree/main/examples/agent-basic) \u2014 minimal tool-calling agent with real-time and batched variants\n",
+    "- [`examples/async-agents-research/`](https://github.com/doublewordai/llamaindex-doubleword/tree/main/examples/async-agents-research) \u2014 recursive multi-agent research orchestrator that spawns parallel sub-agents, searches the web, reads pages, and compiles a report\u2014all LLM calls batched via `DoublewordLLMBatch`"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -73,7 +73,7 @@
    "id": "basic-init",
    "metadata": {},
    "outputs": [],
-   "source": "from llamaindex_doubleword import DoublewordLLM\n\nllm = DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\")\n\n# Or pass the key directly:\n# llm = DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\", api_key=\"your-api-key\")"
+   "source": "from llamaindex_doubleword import DoublewordLLM\n\nllm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")\n\n# Or pass the key directly:\n# llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\", api_key=\"your-api-key\")"
   },
   {
    "cell_type": "markdown",
@@ -157,7 +157,7 @@
    "id": "tools",
    "metadata": {},
    "outputs": [],
-   "source": "from llama_index.core.agent.workflow import AgentWorkflow\n\n\ndef multiply(a: float, b: float) -> float:\n    \"\"\"Multiply two numbers and return the result.\"\"\"\n    return a * b\n\n\nagent = AgentWorkflow.from_tools_or_functions(\n    [multiply],\n    llm=DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\"),\n)\n\nresp = await agent.run(\"What is 7 times 6?\")\nprint(resp)"
+   "source": "from llama_index.core.agent.workflow import AgentWorkflow\n\n\ndef multiply(a: float, b: float) -> float:\n    \"\"\"Multiply two numbers and return the result.\"\"\"\n    return a * b\n\n\nagent = AgentWorkflow.from_tools_or_functions(\n    [multiply],\n    llm=DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\"),\n)\n\nresp = await agent.run(\"What is 7 times 6?\")\nprint(resp)"
   },
   {
    "cell_type": "markdown",
@@ -171,7 +171,7 @@
    "id": "batch",
    "metadata": {},
    "outputs": [],
-   "source": "from llamaindex_doubleword import DoublewordLLMBatch\n\nllm_batch = DoublewordLLMBatch(model=\"Qwen/Qwen3-30B-A3B\")\n\nresp = await llm_batch.acomplete(\"Summarize the benefits of batch processing.\")\nprint(resp)"
+   "source": "from llamaindex_doubleword import DoublewordLLMBatch\n\nllm_batch = DoublewordLLMBatch(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")\n\nresp = await llm_batch.acomplete(\"Summarize the benefits of batch processing.\")\nprint(resp)"
   },
   {
    "cell_type": "markdown",
@@ -189,7 +189,7 @@
    "id": "settings",
    "metadata": {},
    "outputs": [],
-   "source": "from llama_index.core import Settings\n\nSettings.llm = DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\")"
+   "source": "from llama_index.core import Settings\n\nSettings.llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")"
   }
  ],
  "metadata": {

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -99,10 +99,10 @@
    "outputs": [],
    "execution_count": null,
    "source": [
-    "llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")\n",
+    "llm = DoublewordLLM(model=\"Qwen/Qwen3.5-397B-A17B-FP8\")\n",
     "\n",
     "# Or pass the key directly:\n",
-    "# llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\", api_key=\"your-api-key\")"
+    "# llm = DoublewordLLM(model=\"Qwen/Qwen3.5-397B-A17B-FP8\", api_key=\"your-api-key\")"
    ]
   },
   {
@@ -187,7 +187,7 @@
    "id": "tools",
    "metadata": {},
    "outputs": [],
-   "source": "from llama_index.core.agent.workflow import AgentWorkflow\n\n\ndef multiply(a: float, b: float) -> float:\n    \"\"\"Multiply two numbers and return the result.\"\"\"\n    return a * b\n\n\nagent = AgentWorkflow.from_tools_or_functions(\n    [multiply],\n    llm=DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\"),\n)\n\nresp = await agent.run(\"What is 7 times 6?\")\nprint(resp)"
+   "source": "from llama_index.core.agent.workflow import AgentWorkflow\n\n\ndef multiply(a: float, b: float) -> float:\n    \"\"\"Multiply two numbers and return the result.\"\"\"\n    return a * b\n\n\nagent = AgentWorkflow.from_tools_or_functions(\n    [multiply],\n    llm=DoublewordLLM(model=\"Qwen/Qwen3.5-397B-A17B-FP8\"),\n)\n\nresp = await agent.run(\"What is 7 times 6?\")\nprint(resp)"
   },
   {
    "cell_type": "markdown",
@@ -201,7 +201,7 @@
    "id": "batch",
    "metadata": {},
    "outputs": [],
-   "source": "from llamaindex_doubleword import DoublewordLLMBatch\n\nllm_batch = DoublewordLLMBatch(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")\n\nresp = await llm_batch.acomplete(\"Summarize the benefits of batch processing.\")\nprint(resp)"
+   "source": "from llamaindex_doubleword import DoublewordLLMBatch\n\nllm_batch = DoublewordLLMBatch(model=\"Qwen/Qwen3.5-397B-A17B-FP8\")\n\nresp = await llm_batch.acomplete(\"Summarize the benefits of batch processing.\")\nprint(resp)"
   },
   {
    "cell_type": "markdown",
@@ -219,7 +219,7 @@
    "id": "settings",
    "metadata": {},
    "outputs": [],
-   "source": "from llama_index.core import Settings\n\nSettings.llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")"
+   "source": "from llama_index.core import Settings\n\nSettings.llm = DoublewordLLM(model=\"Qwen/Qwen3.5-397B-A17B-FP8\")"
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "header-badge",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/llm/doubleword.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Doubleword\n",
+    "\n",
+    "[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.\n",
+    "\n",
+    "The `llamaindex-doubleword` package provides two LLM classes:\n",
+    "\n",
+    "- **`DoublewordLLM`** — real-time chat and completion requests\n",
+    "- **`DoublewordLLMBatch`** — transparent batch API submissions via [autobatcher](https://github.com/doublewordai/llamaindex-doubleword) for reduced cost\n",
+    "\n",
+    "Both support streaming, tool calling, and all models routed through Doubleword.\n",
+    "\n",
+    "For more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "install-heading",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llamaindex-doubleword llama-index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auth-heading",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "You can authenticate in three ways (checked in this order):\n",
+    "\n",
+    "1. Pass `api_key` directly to the constructor\n",
+    "2. Set the `DOUBLEWORD_API_KEY` environment variable\n",
+    "3. Store your key in `~/.dw/credentials.toml`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auth-env",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Option 1: environment variable\n",
+    "os.environ[\"DOUBLEWORD_API_KEY\"] = \"your-api-key\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "basic-heading",
+   "metadata": {},
+   "source": [
+    "## Basic Usage with DoublewordLLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "basic-init",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llamaindex_doubleword import DoublewordLLM\n",
+    "\n",
+    "llm = DoublewordLLM(model=\"gpt-4o\")\n",
+    "\n",
+    "# Or pass the key directly:\n",
+    "# llm = DoublewordLLM(model=\"gpt-4o\", api_key=\"your-api-key\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "complete-heading",
+   "metadata": {},
+   "source": [
+    "### Call `complete`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "complete",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.complete(\"What is an AI gateway?\")\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "chat-heading",
+   "metadata": {},
+   "source": [
+    "### Call `chat`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "chat",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.llms import ChatMessage\n",
+    "\n",
+    "messages = [\n",
+    "    ChatMessage(role=\"system\", content=\"You are a helpful assistant.\"),\n",
+    "    ChatMessage(role=\"user\", content=\"Explain AI model routing in one paragraph.\"),\n",
+    "]\n",
+    "resp = llm.chat(messages)\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "streaming-heading",
+   "metadata": {},
+   "source": [
+    "### Streaming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "streaming",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.stream_chat(\n",
+    "    [ChatMessage(role=\"user\", content=\"Tell me a short story about a router.\")]\n",
+    ")\n",
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tools-heading",
+   "metadata": {},
+   "source": [
+    "### Tool Calling\n",
+    "\n",
+    "`DoublewordLLM` supports tool calling through LlamaIndex's `AgentWorkflow`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tools",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import AgentWorkflow\n",
+    "\n",
+    "\n",
+    "def multiply(a: float, b: float) -> float:\n",
+    "    \"\"\"Multiply two numbers and return the result.\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "agent = AgentWorkflow.from_tools_or_functions(\n",
+    "    [multiply],\n",
+    "    llm=DoublewordLLM(model=\"gpt-4o\"),\n",
+    ")\n",
+    "\n",
+    "resp = await agent.run(\"What is 7 times 6?\")\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batch-heading",
+   "metadata": {},
+   "source": [
+    "## Batch Usage with DoublewordLLMBatch\n",
+    "\n",
+    "`DoublewordLLMBatch` transparently submits requests through the batch API using [autobatcher](https://github.com/doublewordai/llamaindex-doubleword), which can reduce costs significantly. It has the same interface as `DoublewordLLM`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batch",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llamaindex_doubleword import DoublewordLLMBatch\n",
+    "\n",
+    "llm_batch = DoublewordLLMBatch(model=\"gpt-4o\")\n",
+    "\n",
+    "resp = llm_batch.complete(\"Summarize the benefits of batch processing.\")\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "settings-heading",
+   "metadata": {},
+   "source": [
+    "## Using with LlamaIndex Settings\n",
+    "\n",
+    "You can set Doubleword as the default LLM globally:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "settings",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Settings\n",
+    "\n",
+    "Settings.llm = DoublewordLLM(model=\"gpt-4o\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 5,
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -12,7 +12,9 @@
    "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
-   "source": "# Doubleword\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.\n\nThe `llamaindex-doubleword` package provides two LLM classes:\n\n- **`DoublewordLLM`** — real-time chat and completion requests\n- **`DoublewordLLMBatch`** — transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\nBoth support streaming, tool calling, and all models routed through Doubleword.\n\n**Note:** `DoublewordLLMBatch` is async-only. Sync methods like `complete()` will raise `NotImplementedError`. Use `acomplete()` instead.\n\nFor more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
+   "source": [
+    "# Doubleword\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.\n\nThe `llamaindex-doubleword` package provides two LLM classes:\n\n- **`DoublewordLLM`** \u2014 real-time chat and completion requests\n- **`DoublewordLLMBatch`** \u2014 transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\nBoth support streaming, tool calling, and all models routed through Doubleword. See the [available models](https://docs.doubleword.ai/inference-api/models) for a full list, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards. Feature support depends on the underlying model.\n\n**Note:** `DoublewordLLMBatch` is async-only. Sync methods like `complete()` will raise `NotImplementedError`. Use `acomplete()` instead.\n\nFor more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -163,7 +165,7 @@
    "cell_type": "markdown",
    "id": "batch-heading",
    "metadata": {},
-   "source": "## Batch Usage with DoublewordLLMBatch\n\n`DoublewordLLMBatch` transparently submits requests through the batch API using [autobatcher](https://pypi.org/project/autobatcher/), which can provide up to 90% cost savings. It has the same interface as `DoublewordLLM`, but is **async-only** — sync methods will raise `NotImplementedError`."
+   "source": "## Batch Usage with DoublewordLLMBatch\n\n`DoublewordLLMBatch` transparently submits requests through the batch API using [autobatcher](https://pypi.org/project/autobatcher/), which can provide up to 90% cost savings. It has the same interface as `DoublewordLLM`, but is **async-only** \u2014 sync methods will raise `NotImplementedError`."
   },
   {
    "cell_type": "code",

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -18,10 +18,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "setup-heading",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "install-heading",
    "metadata": {},
    "source": [
-    "## Installation"
+    "### Installation"
    ]
   },
   {
@@ -39,13 +47,7 @@
    "id": "auth-heading",
    "metadata": {},
    "source": [
-    "## Authentication\n",
-    "\n",
-    "You can authenticate in three ways (checked in this order):\n",
-    "\n",
-    "1. Pass `api_key` directly to the constructor\n",
-    "2. Set the `DOUBLEWORD_API_KEY` environment variable\n",
-    "3. Store your key in `~/.dw/credentials.toml`"
+    "### Authentication\n\nYou can authenticate in three ways (checked in this order):\n\n1. Pass `api_key` directly to the constructor\n2. Set the `DOUBLEWORD_API_KEY` environment variable\n3. Store your key in `~/.dw/credentials.toml`"
    ]
   },
   {
@@ -63,6 +65,17 @@
   },
   {
    "cell_type": "markdown",
+   "id": "models-ref",
+   "metadata": {},
+   "source": [
+    "### Available Models\n",
+    "\n",
+    "See the [available models](https://docs.doubleword.ai/inference-api/models) for a full list of models you can use with Doubleword, ",
+    "or visit the [Doubleword console](https://doubleword.ai) for detailed model cards."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "basic-heading",
    "metadata": {},
    "source": [
@@ -71,11 +84,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "basic-init",
+   "id": "import-llm",
    "metadata": {},
    "outputs": [],
-   "source": "from llamaindex_doubleword import DoublewordLLM\n\nllm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")\n\n# Or pass the key directly:\n# llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\", api_key=\"your-api-key\")"
+   "execution_count": null,
+   "source": [
+    "from llamaindex_doubleword import DoublewordLLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "init-llm",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\")\n",
+    "\n",
+    "# Or pass the key directly:\n",
+    "# llm = DoublewordLLM(model=\"Qwen/Qwen3.5-35B-A3B-FP8\", api_key=\"your-api-key\")"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -12,20 +12,7 @@
    "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
-   "source": [
-    "# Doubleword\n",
-    "\n",
-    "[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.\n",
-    "\n",
-    "The `llamaindex-doubleword` package provides two LLM classes:\n",
-    "\n",
-    "- **`DoublewordLLM`** — real-time chat and completion requests\n",
-    "- **`DoublewordLLMBatch`** — transparent batch API submissions via [autobatcher](https://github.com/doublewordai/llamaindex-doubleword) for reduced cost\n",
-    "\n",
-    "Both support streaming, tool calling, and all models routed through Doubleword.\n",
-    "\n",
-    "For more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
-   ]
+   "source": "# Doubleword\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.\n\nThe `llamaindex-doubleword` package provides two LLM classes:\n\n- **`DoublewordLLM`** — real-time chat and completion requests\n- **`DoublewordLLMBatch`** — transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\nBoth support streaming, tool calling, and all models routed through Doubleword.\n\n**Note:** `DoublewordLLMBatch` is async-only. Sync methods like `complete()` will raise `NotImplementedError`. Use `acomplete()` instead.\n\nFor more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
   },
   {
    "cell_type": "markdown",
@@ -86,14 +73,7 @@
    "id": "basic-init",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llamaindex_doubleword import DoublewordLLM\n",
-    "\n",
-    "llm = DoublewordLLM(model=\"gpt-4o\")\n",
-    "\n",
-    "# Or pass the key directly:\n",
-    "# llm = DoublewordLLM(model=\"gpt-4o\", api_key=\"your-api-key\")"
-   ]
+   "source": "from llamaindex_doubleword import DoublewordLLM\n\nllm = DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\")\n\n# Or pass the key directly:\n# llm = DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\", api_key=\"your-api-key\")"
   },
   {
    "cell_type": "markdown",
@@ -177,33 +157,13 @@
    "id": "tools",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llama_index.core.agent.workflow import AgentWorkflow\n",
-    "\n",
-    "\n",
-    "def multiply(a: float, b: float) -> float:\n",
-    "    \"\"\"Multiply two numbers and return the result.\"\"\"\n",
-    "    return a * b\n",
-    "\n",
-    "\n",
-    "agent = AgentWorkflow.from_tools_or_functions(\n",
-    "    [multiply],\n",
-    "    llm=DoublewordLLM(model=\"gpt-4o\"),\n",
-    ")\n",
-    "\n",
-    "resp = await agent.run(\"What is 7 times 6?\")\n",
-    "print(resp)"
-   ]
+   "source": "from llama_index.core.agent.workflow import AgentWorkflow\n\n\ndef multiply(a: float, b: float) -> float:\n    \"\"\"Multiply two numbers and return the result.\"\"\"\n    return a * b\n\n\nagent = AgentWorkflow.from_tools_or_functions(\n    [multiply],\n    llm=DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\"),\n)\n\nresp = await agent.run(\"What is 7 times 6?\")\nprint(resp)"
   },
   {
    "cell_type": "markdown",
    "id": "batch-heading",
    "metadata": {},
-   "source": [
-    "## Batch Usage with DoublewordLLMBatch\n",
-    "\n",
-    "`DoublewordLLMBatch` transparently submits requests through the batch API using [autobatcher](https://github.com/doublewordai/llamaindex-doubleword), which can reduce costs significantly. It has the same interface as `DoublewordLLM`."
-   ]
+   "source": "## Batch Usage with DoublewordLLMBatch\n\n`DoublewordLLMBatch` transparently submits requests through the batch API using [autobatcher](https://pypi.org/project/autobatcher/), which can provide up to 90% cost savings. It has the same interface as `DoublewordLLM`, but is **async-only** — sync methods will raise `NotImplementedError`."
   },
   {
    "cell_type": "code",
@@ -211,14 +171,7 @@
    "id": "batch",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llamaindex_doubleword import DoublewordLLMBatch\n",
-    "\n",
-    "llm_batch = DoublewordLLMBatch(model=\"gpt-4o\")\n",
-    "\n",
-    "resp = llm_batch.complete(\"Summarize the benefits of batch processing.\")\n",
-    "print(resp)"
-   ]
+   "source": "from llamaindex_doubleword import DoublewordLLMBatch\n\nllm_batch = DoublewordLLMBatch(model=\"Qwen/Qwen3-30B-A3B\")\n\nresp = await llm_batch.acomplete(\"Summarize the benefits of batch processing.\")\nprint(resp)"
   },
   {
    "cell_type": "markdown",
@@ -236,11 +189,7 @@
    "id": "settings",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from llama_index.core import Settings\n",
-    "\n",
-    "Settings.llm = DoublewordLLM(model=\"gpt-4o\")"
-   ]
+   "source": "from llama_index.core import Settings\n\nSettings.llm = DoublewordLLM(model=\"Qwen/Qwen3-30B-A3B\")"
   }
  ],
  "metadata": {

--- a/docs/examples/llm/doubleword.ipynb
+++ b/docs/examples/llm/doubleword.ipynb
@@ -12,9 +12,7 @@
    "cell_type": "markdown",
    "id": "intro",
    "metadata": {},
-   "source": [
-    "# Doubleword\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.\n\nThe `llamaindex-doubleword` package provides two LLM classes:\n\n- **`DoublewordLLM`** \u2014 real-time chat and completion requests\n- **`DoublewordLLMBatch`** \u2014 transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) with up to 90% cost savings\n\nBoth support streaming, tool calling, and all models routed through Doubleword. See the [available models](https://docs.doubleword.ai/inference-api/models) for a full list, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards. Feature support depends on the underlying model.\n\n**Note:** `DoublewordLLMBatch` is async-only. Sync methods like `complete()` will raise `NotImplementedError`. Use `acomplete()` instead.\n\nFor more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
-   ]
+   "source": "# Doubleword\n\n[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API at `https://api.doubleword.ai/v1`.\n\nThe `llamaindex-doubleword` package provides three LLM classes, one per Doubleword pricing tier:\n\n- **`DoublewordLLM`** \u2014 real-time chat and completion requests\n- **`DoublewordLLMBatch`** \u2014 transparent batch API submissions via [autobatcher](https://pypi.org/project/autobatcher/) on the 24-hour batch tier (deepest discount, up to 90% cost savings)\n- **`DoublewordLLMAsync`** \u2014 same machinery, pinned to the 1-hour flex tier for fan-out workflows that need results within an hour\n\nBoth support streaming, tool calling, and all models routed through Doubleword. See the [available models](https://docs.doubleword.ai/inference-api/models) for a full list, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards. Feature support depends on the underlying model.\n\n**Note:** Both `DoublewordLLMBatch` and `DoublewordLLMAsync` are async-only. Sync methods like `complete()` will raise `NotImplementedError`. Use `acomplete()` instead.\n\nFor more information, see the [Doubleword docs](https://docs.doubleword.ai) and the [package repository](https://github.com/doublewordai/llamaindex-doubleword)."
   },
   {
    "cell_type": "markdown",
@@ -202,6 +200,20 @@
    "metadata": {},
    "outputs": [],
    "source": "from llamaindex_doubleword import DoublewordLLMBatch\n\nllm_batch = DoublewordLLMBatch(model=\"Qwen/Qwen3.5-397B-A17B-FP8\")\n\nresp = await llm_batch.acomplete(\"Summarize the benefits of batch processing.\")\nprint(resp)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "async-usage-heading",
+   "metadata": {},
+   "source": "## Async (1-hour flex) Usage with DoublewordLLMAsync\n\n`DoublewordLLMAsync` is the same machinery as `DoublewordLLMBatch`, but pinned to Doubleword's **1-hour flex completion window** instead of the 24-hour batch window. Use this when 24-hour turnaround is too slow but realtime cost is too high \u2014 typical for fan-out workflows that need results within minutes-to-an-hour at significant cost savings over realtime inference.\n\nLike `DoublewordLLMBatch`, it's **async-only** \u2014 sync methods raise. Backed by `autobatcher.AsyncOpenAI`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "async-usage-code",
+   "metadata": {},
+   "outputs": [],
+   "source": "from llamaindex_doubleword import DoublewordLLMAsync\n\nllm_async = DoublewordLLMAsync(model=\"Qwen/Qwen3.5-397B-A17B-FP8\")\n\nresp = await llm_async.acomplete(\"Summarize the benefits of flex (1h) inference.\")\nprint(resp)"
   },
   {
    "cell_type": "markdown",

--- a/docs/src/content/docs/framework/module_guides/models/embeddings.md
+++ b/docs/src/content/docs/framework/module_guides/models/embeddings.md
@@ -389,6 +389,7 @@ We support integrations with OpenAI, Azure, and anything LangChain offers.
 - [Cohere](/python/examples/embeddings/cohereai)
 - [Custom](/python/examples/embeddings/custom_embeddings)
 - [Dashscope](/python/examples/embeddings/dashscope_embeddings)
+- [Doubleword](/python/examples/embeddings/doubleword)
 - [ElasticSearch](/python/examples/embeddings/elasticsearch)
 - [FastEmbed](/python/examples/embeddings/fastembed)
 - [Google Palm](/python/examples/embeddings/google_palm)

--- a/docs/src/content/docs/framework/module_guides/models/llms/modules.md
+++ b/docs/src/content/docs/framework/module_guides/models/llms/modules.md
@@ -18,6 +18,7 @@ We support integrations with OpenAI, Anthropic, Google, Hugging Face, and more.
 - [CometAPI](/python/examples/llm/cometapi)
 - [Dashscope](/python/examples/llm/dashscope)
 - [Dashscope Multi-Modal](/python/examples/multi_modal/dashscope_multi_modal)
+- [Doubleword](/python/examples/llm/doubleword)
 - [EverlyAI](/python/examples/llm/everlyai)
 - [Featherless AI](/python/examples/llm/featherlessai)
 - [Fireworks](/python/examples/llm/fireworks)


### PR DESCRIPTION
## Summary

- Add documentation notebooks for the [llamaindex-doubleword](https://pypi.org/project/llamaindex-doubleword/) package ([GitHub](https://github.com/doublewordai/llamaindex-doubleword))
- Add Doubleword to the LLM and embedding module lists in the docs

[Doubleword](https://doubleword.ai) is an AI model gateway providing unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API.

The `llamaindex-doubleword` package provides:

- **`DoublewordLLM`** / **`DoublewordLLMBatch`** — LLM classes (real-time and batch)
- **`DoublewordEmbedding`** / **`DoublewordEmbeddingBatch`** — Embedding classes (real-time and batch)

The batched variants use `autobatcher` for transparent batch API submissions at reduced cost.

### Files changed

- `docs/examples/llm/doubleword.ipynb` — LLM usage notebook (chat, streaming, tool calling, batch)
- `docs/examples/embeddings/doubleword.ipynb` — Embedding usage notebook
- `docs/src/content/docs/framework/module_guides/models/llms/modules.md` — Added to LLM list
- `docs/src/content/docs/framework/module_guides/models/embeddings.md` — Added to embeddings list

## Test plan

- [ ] Verify notebook renders correctly in the docs site
- [ ] Verify links in module lists point to the correct notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)