### PR TITLE
fix(openai): serialize ToolCallBlock.tool_kwargs to JSON string in Chat Completions API

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -495,11 +495,14 @@ def to_openai_message_dict(
             continue
         elif isinstance(block, ToolCallBlock):
             try:
+                arguments = block.tool_kwargs
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments)
                 function_dict = {
                     "type": "function",
                     "function": {
                         "name": block.tool_name,
-                        "arguments": block.tool_kwargs,
+                        "arguments": arguments,
                     },
                     "id": block.tool_call_id,
                 }

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -756,3 +756,52 @@ def test_responses_api_tool_kwargs_string_passthrough() -> None:
         if isinstance(item, dict) and item.get("type") == "function_call"
     ][0]
     assert tool_item["arguments"] == '{"q": "test"}'
+
+
+def test_chat_completions_tool_kwargs_serialized_to_json_string() -> None:
+    """Test that dict tool_kwargs are serialized to JSON strings in Chat Completions API.
+
+    The OpenAI Chat Completions API expects function.arguments to be a JSON string,
+    but ToolCallBlock.tool_kwargs can be a dict (e.g. from Anthropic provider).
+    Ref: https://github.com/run-llama/llama_index/issues/21378
+    """
+    from llama_index.llms.openai.utils import to_openai_message_dict
+
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_name="get_weather",
+                tool_call_id="call_1",
+                tool_kwargs={"location": "Boston", "unit": "celsius"},
+            ),
+        ],
+    )
+
+    result = to_openai_message_dict(msg)
+    tool_calls = result.get("tool_calls", [])
+    assert len(tool_calls) == 1
+    arguments = tool_calls[0]["function"]["arguments"]
+    assert isinstance(arguments, str), "arguments must be a JSON string"
+    assert json.loads(arguments) == {"location": "Boston", "unit": "celsius"}
+
+
+def test_chat_completions_tool_kwargs_string_passthrough() -> None:
+    """Test that string tool_kwargs are passed through unchanged in Chat Completions API."""
+    from llama_index.llms.openai.utils import to_openai_message_dict
+
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_name="search",
+                tool_call_id="call_2",
+                tool_kwargs='{"q": "test"}',
+            ),
+        ],
+    )
+
+    result = to_openai_message_dict(msg)
+    tool_calls = result.get("tool_calls", [])
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["arguments"] == '{"q": "test"}'


### PR DESCRIPTION
## Summary

- `to_openai_message_dict` passes `ToolCallBlock.tool_kwargs` directly as a dict into `function.arguments`, but the OpenAI Chat Completions API requires it to be a JSON string
- This causes `BadRequestError: 400` in cross-provider agent workflows (e.g. Anthropic orchestrator → OpenAI sub-agent) since Anthropic stores tool input as a Python dict
- Applied the same `json.dumps()` serialization pattern already used in `to_openai_responses_message_dict` (lines 666-668)

Fixes #21378

## Test plan

- [x] Added `test_chat_completions_tool_kwargs_serialized_to_json_string` — verifies dict kwargs are JSON-serialized
- [x] Added `test_chat_completions_tool_kwargs_string_passthrough` — verifies string kwargs pass through unchanged
- [x] Existing responses API tests continue to pass
- [x] All 4 tool_kwargs-related tests pass