### PR TITLE
fix(google-genai): replace asyncio.run() with asyncio_run() to support nested event loops

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -50,6 +50,7 @@ from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.program.utils import FlexibleModel, create_flexible_model
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.types import PydanticProgramMode
 from llama_index.llms.google_genai.utils import (
     chat_from_gemini_response,
@@ -350,7 +351,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs, file_api_names = asyncio.run(
+        next_msg, chat_kwargs, file_api_names = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.file_mode, self._client, **params
             )
@@ -405,7 +406,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs, file_api_names = asyncio.run(
+        next_msg, chat_kwargs, file_api_names = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.file_mode, self._client, **params
             )
@@ -616,7 +617,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
         messages = prompt.format_messages(**prompt_args)
         contents_and_names = [
-            asyncio.run(chat_message_to_gemini(message, self.file_mode, self._client))
+            asyncio_run(chat_message_to_gemini(message, self.file_mode, self._client))
             for message in messages
         ]
         contents = [it[0] for it in contents_and_names]
@@ -667,7 +668,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents_and_names = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.file_mode, self._client)
                 )
                 for message in messages
@@ -769,7 +770,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents_and_names = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.file_mode, self._client)
                 )
                 for message in messages


### PR DESCRIPTION
Fixes #20782

## Problem

Sync methods `_chat()`, `_stream_chat()`, and `structured_predict()` in the GoogleGenAI LLM integration call `asyncio.run()` to invoke the async helper `prepare_chat_params()` and `chat_message_to_gemini()`. When these sync methods are called from within an already-running event loop (e.g., the RAG CLI's `async def start_chat_repl()` or any `asyncio`-based app), Python raises:

```
RuntimeError: This event loop is already running.
```

## Solution

Replace all `asyncio.run(...)` calls in sync methods with `asyncio_run(...)` from `llama_index.core.async_utils`. This helper detects whether an event loop is already running and, if so, executes the coroutine in a separate thread — avoiding the `RuntimeError` while preserving correct behavior in purely synchronous contexts.

## Testing

- Syntax check: `ast.parse()` passes on the modified file.
- The fix applies to all five `asyncio.run()` call sites in `base.py` that are reachable from sync code paths.