### PR TITLE
docs: Add Windows setup note for uv installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,11 @@ get started.
 
 We use `uv` as the package and project manager for all the Python packages in this repository. Before contributing, make sure you have `uv` installed (see [installation guide](https://docs.astral.sh/uv/getting-started/installation/)).
 
+> **Note for Windows users:** If you encounter issues with `uv` on Windows, you may need to:
+> - Install via `pip install uv` or download from [GitHub releases](https://github.com/astral-sh/uv/releases)
+> - Use `uv` commands in PowerShell or Command Prompt
+> - Ensure Python is in your system PATH
+
 If you're ready to dive in, here’s a quick setup guide to get you going:
 
 1. **Fork** the GitHub repo, clone your fork and open a terminal at the root of the git repository `llama_index`.


### PR DESCRIPTION
Hey team,

I noticed the CONTRIBUTING.md doesn't mention Windows-specific setup for `uv`. I ran into some issues setting up the dev environment on Windows and thought this might help other contributors.

Changes:
- Added Windows setup note for uv installation
- Included common troubleshooting tips (pip install, PowerShell usage, PATH setup)

This is a small docs improvement to make onboarding easier for Windows users. Let me know if you want any changes!

Thanks for maintaining this awesome project 🙏