### PR TITLE
fix(azureaisearch): preserve falsy-but-not-None metadata values

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -503,3 +503,50 @@ def test_close_does_not_call_external_client_close() -> None:
 
     # Verify close was NOT called on the external search client
     search_client.close.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
+def test_default_index_mapping_preserves_falsy_metadata_values() -> None:
+    """Falsy-but-not-None metadata values (0, "", [], False) must be indexed,
+    not dropped. Previously the mapper used a truthiness check which treated
+    0 as absent."""
+    search_client = mock_client_with_user_agent("search")
+    vector_store = create_mock_vector_store(search_client)
+
+    vector_store._metadata_to_index_field_map = {
+        "zero_int": ("zero_int_field", "Edm.Int64"),
+        "empty_string": ("empty_string_field", "Edm.String"),
+        "empty_list": ("empty_list_field", "Collection(Edm.String)"),
+        "false_bool": ("false_bool_field", "Edm.Boolean"),
+        "none_value": ("none_value_field", "Edm.String"),
+        "truthy": ("truthy_field", "Edm.String"),
+    }
+
+    metadata = {
+        "zero_int": 0,
+        "empty_string": "",
+        "empty_list": [],
+        "false_bool": False,
+        "none_value": None,
+        "truthy": "hello",
+    }
+
+    index_doc = vector_store._default_index_mapping(
+        enriched_doc={
+            "id": "x",
+            "chunk": "x",
+            "embedding": [0.0, 0.0],
+            "metadata": "{}",
+            "doc_id": "x",
+        },
+        metadata=metadata,
+    )
+
+    assert index_doc["zero_int_field"] == 0
+    assert index_doc["empty_string_field"] == ""
+    assert index_doc["empty_list_field"] == []
+    assert index_doc["false_bool_field"] is False
+    assert index_doc["truthy_field"] == "hello"
+    assert "none_value_field" not in index_doc


### PR DESCRIPTION
## Summary

Fixes #21385. The Azure AI Search vector store dropped legitimate falsy metadata values (\`0\`, \`\"\"\`, \`[]\`, \`False\`) when building the index document, so round-tripping a node through the vector store returned \`None\` for those fields instead of the original value.

## Root cause

\`_default_index_mapping\` in \`llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py\` used a truthiness check:

\`\`\`python
metadata_value = metadata.get(metadata_field_name)
if metadata_value:
    index_doc[index_field_name] = metadata_value
\`\`\`

For any \`0\`, \`\"\"\`, \`[]\`, or \`False\` metadata, the branch was skipped and the field was omitted from the index document. Azure AI Search then returned \`None\` on retrieval.

## Fix

One-character semantic change — compare against \`None\` explicitly:

\`\`\`python
if metadata_value is not None:
    index_doc[index_field_name] = metadata_value
\`\`\`

This matches the reporter's suggestion. \`None\` is still skipped (emitting \`null\` for a configured field would fail the Azure schema), but falsy-but-present values now round-trip correctly.

## Test plan

- [x] Added \`test_default_index_mapping_preserves_falsy_metadata_values\` covering \`0\`, \`\"\"\`, \`[]\`, \`False\`, and \`None\`.
- [x] \`pytest tests/test_azureaisearch.py\` — 15 passed (14 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)