### PR TITLE
fix(azureaisearch): preserve falsy metadata values (0, empty string, [])

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc


### PR DESCRIPTION
## Problem

Falsy metadata values like `0`, `""`, and `[]` are silently dropped when indexing nodes into Azure AI Search. The condition on line 899 of `base.py`:

```python
if metadata_value:
```

evaluates to `False` for valid falsy values, so they are never written to the index document, effectively stored as `None`.

## Fix

Change the truthy check to an explicit `None` check:

```python
if metadata_value is not None:
```

This preserves all valid values — including `0`, `""`, and `[]` — while still skipping fields that are genuinely absent (i.e., `metadata.get()` returned `None`).

Fixes #21385