### PR TITLE
fix(embeddings): do not clutter stdout when turning off embeddings

### DIFF
--- a/llama-index-core/llama_index/core/embeddings/utils.py
+++ b/llama-index-core/llama_index/core/embeddings/utils.py
@@ -1,5 +1,6 @@
 """Embedding utils for LlamaIndex."""
 
+import logging
 import os
 from typing import TYPE_CHECKING, List, Optional, Union
 
@@ -11,6 +12,9 @@ from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.utils import get_cache_dir
 
 EmbedType = Union[BaseEmbedding, "LCEmbeddings", str]
+
+
+logger = logging.getLogger(__name__)
 
 
 def save_embedding(embedding: List[float], file_path: str) -> None:
@@ -129,7 +133,7 @@ def resolve_embed_model(
             )
 
     if embed_model is None:
-        print("Embeddings have been explicitly disabled. Using MockEmbedding.")
+        logger.warning("Embeddings have been explicitly disabled. Using MockEmbedding.")
         embed_model = MockEmbedding(embed_dim=1)
 
     assert isinstance(embed_model, BaseEmbedding)


### PR DESCRIPTION
Hi. First things first: Thanks a stack for conceiving and maintaining this excellent package.

# Description

We found when using the NLSQL components without needing any embeddings, a `print` statement caused stray output on stdout which makes it impossible to print other clean output to stdout within a Python program, for example JSON or YAML that needs to be parsed by downstream programs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
