### PR TITLE
fix: avoid mutating response.raw in LLM event model_dump methods

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -144,8 +144,13 @@ class LLMCompletionInProgressEvent(BaseEvent):
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
+            return self.model_copy(
+                update={
+                    "response": self.response.model_copy(
+                        update={"raw": self.response.raw.model_dump()}
+                    )
+                }
+            ).model_dump(**kwargs)
         return super().model_dump(**kwargs)
 
 
@@ -169,8 +174,13 @@ class LLMCompletionEndEvent(BaseEvent):
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
+            return self.model_copy(
+                update={
+                    "response": self.response.model_copy(
+                        update={"raw": self.response.raw.model_dump()}
+                    )
+                }
+            ).model_dump(**kwargs)
         return super().model_dump(**kwargs)
 
 
@@ -216,8 +226,13 @@ class LLMChatInProgressEvent(BaseEvent):
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
+            return self.model_copy(
+                update={
+                    "response": self.response.model_copy(
+                        update={"raw": self.response.raw.model_dump()}
+                    )
+                }
+            ).model_dump(**kwargs)
         return super().model_dump(**kwargs)
 
 
@@ -241,6 +256,11 @@ class LLMChatEndEvent(BaseEvent):
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
         if self.response is not None and isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
+            return self.model_copy(
+                update={
+                    "response": self.response.model_copy(
+                        update={"raw": self.response.raw.model_dump()}
+                    )
+                }
+            ).model_dump(**kwargs)
         return super().model_dump(**kwargs)


### PR DESCRIPTION
## What this fixes

Closes #21422.

The `model_dump()` overrides in `LLMCompletionInProgressEvent`, `LLMCompletionEndEvent`, `LLMChatInProgressEvent`, and `LLMChatEndEvent` were mutating `self.response.raw` in-place:

```python
# Before — corrupts the original object
self.response.raw = self.response.raw.model_dump()
return super().model_dump(**kwargs)
```

Because `self.response` is the same object held by the caller, this permanently replaced the Pydantic model with a plain `dict`. Any code that accessed `response.raw` after the span handler fired would get a `dict` instead of the expected model — silent data corruption that only surfaces when the raw response is later inspected or passed to another layer (e.g. retries, streaming handlers, structured output parsers).

## Fix

Use `model_copy()` to create a throwaway copy of the event with `raw` pre-serialised, dump that copy, and leave the original response object untouched:

```python
# After — original response is never modified
def model_dump(self, **kwargs):
    if isinstance(self.response.raw, BaseModel):
        return self.model_copy(
            update={
                "response": self.response.model_copy(
                    update={"raw": self.response.raw.model_dump()}
                )
            }
        ).model_dump(**kwargs)
    return super().model_dump(**kwargs)
```

The same pattern is applied to all four affected event classes.

## Testing

The bug is reproducible by calling `model_dump()` on any of the four event classes and then checking that `event.response.raw` is still a `BaseModel` instance afterwards. Without this fix, it would be a `dict`.

Happy to add a unit test if that would help — let me know if there's a preferred location for instrumentation event tests.