### PR TITLE
MAIT-133: Add revision field to Page dataclass

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/.gitignore
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/.gitignore
@@ -1,0 +1,134 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/LICENSE
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 WikiTeq
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/Makefile
@@ -1,0 +1,14 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help: ## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format: ## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint: ## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test: ## Run tests via pytest (uses active Python; no uv required).
+	python -m pytest tests

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/Makefile
@@ -1,5 +1,7 @@
 GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
 
+.PHONY: help format lint test
+
 help: ## Show all Makefile targets.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/README.md
@@ -1,0 +1,82 @@
+# LlamaIndex Readers Integration: MediaWiki
+
+## Overview
+
+The MediaWiki Reader loads pages from any [MediaWiki](https://www.mediawiki.org/)-based wiki (Wikipedia, Wikiversity, or your own instance) and returns them as LlamaIndex `Document` objects. It uses the wiki’s [Action API](https://www.mediawiki.org/wiki/API:Main_page) via [mwclient](https://github.com/mwclient/mwclient): you provide the wiki **host** (and optionally **path** and **scheme**), and the reader fetches page list, metadata (URL, last-modified), and parsed text, with optional namespace filtering.
+
+### Features
+
+- **Any MediaWiki instance** — Use `host`, `path`, and `scheme` to point at any wiki (e.g. `host="en.wikipedia.org"` with default path `/w/`).
+- **Resource-based API** — Implements `load_resource` and `get_resource_info` for LlamaIndex ingestion and RAG pipelines.
+- **Efficient listing** — Batched API calls for page metadata; optional `namespaces` filter.
+- **HTML to text** — Converts wiki HTML to clean text via html2text (with regex fallback on failure).
+
+### Installation
+
+```bash
+pip install llama-index-readers-mediawiki
+```
+
+The reader depends on **mwclient** for MediaWiki API access; it is installed automatically with the package.
+
+### Usage
+
+**Load a single page by title (get metadata with get_resource_info, then load content):**
+
+```python
+from llama_index.readers.mediawiki import MediaWikiReader
+
+reader = MediaWikiReader(host="en.wikipedia.org")
+
+title = "Python (programming language)"
+info = reader.get_resource_info(title)
+if info.get("url"):
+    docs = reader.load_resource(
+        title,
+        resource_url=info["url"],
+        last_modified=info.get("last_modified"),
+    )
+# docs is a list of one Document with .text and .metadata (title, url, last_modified)
+```
+
+**Stream all pages (lazy):**
+
+```python
+for doc in reader.lazy_load_data():
+    print(doc.metadata.get("title"), len(doc.text))
+```
+
+**Optional: custom path/scheme, namespace filter, page limit:**
+
+```python
+reader = MediaWikiReader(
+    host="mywiki.example.com",
+    path="/w/",
+    scheme="https",
+    page_limit=100,
+    namespaces=[0],  # Main namespace only
+)
+```
+
+### Configuration
+
+| Parameter     | Type     | Default   | Description |
+|---------------|----------|-----------|-------------|
+| `host`        | `str`    | required  | MediaWiki site hostname (e.g. `en.wikipedia.org`). |
+| `path`        | `str`    | `"/w/"`   | MediaWiki script path (API at `{path}api.php`). |
+| `scheme`      | `"https" \| "http"` | `"https"` | URL scheme. |
+| `page_limit`  | `int`    | `500`     | Max page titles per allpages API call (pagination). |
+| `namespaces`  | `list[int] \| None` | `None` | Namespace IDs to list; `None` = wiki content namespaces from siteinfo API ([$wgContentNamespaces](https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces)). |
+| `logger`      | `logging.Logger` | module logger | Logger instance (injectable for tests or custom logging). Not serialized. |
+
+### Manual testing
+
+For manual testing, run the usage examples above with your wiki’s `host` (and `path`/`scheme` if not default). For a **private wiki**, set `host`, call `reader.login(username, password)` (or use a bot password), then use `load_resource` / `lazy_load_data` as usual.
+
+### License
+
+MIT.
+
+---
+
+This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index) and/or subsequently as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent.

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/README.md
@@ -60,14 +60,14 @@ reader = MediaWikiReader(
 
 ### Configuration
 
-| Parameter     | Type     | Default   | Description |
-|---------------|----------|-----------|-------------|
-| `host`        | `str`    | required  | MediaWiki site hostname (e.g. `en.wikipedia.org`). |
-| `path`        | `str`    | `"/w/"`   | MediaWiki script path (API at `{path}api.php`). |
-| `scheme`      | `"https" \| "http"` | `"https"` | URL scheme. |
-| `page_limit`  | `int`    | `500`     | Max page titles per allpages API call (pagination). |
-| `namespaces`  | `list[int] \| None` | `None` | Namespace IDs to list; `None` = wiki content namespaces from siteinfo API ([$wgContentNamespaces](https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces)). |
-| `logger`      | `logging.Logger` | module logger | Logger instance (injectable for tests or custom logging). Not serialized. |
+| Parameter    | Type                | Default       | Description                                                                                                                                                     |
+| ------------ | ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `host`       | `str`               | required      | MediaWiki site hostname (e.g. `en.wikipedia.org`).                                                                                                              |
+| `path`       | `str`               | `"/w/"`       | MediaWiki script path (API at `{path}api.php`).                                                                                                                 |
+| `scheme`     | `"https" \| "http"` | `"https"`     | URL scheme.                                                                                                                                                     |
+| `page_limit` | `int`               | `500`         | Max page titles per allpages API call (pagination).                                                                                                             |
+| `namespaces` | `list[int] \| None` | `None`        | Namespace IDs to list; `None` = wiki content namespaces from siteinfo API ([$wgContentNamespaces](https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces)). |
+| `logger`     | `logging.Logger`    | module logger | Logger instance (injectable for tests or custom logging). Not serialized.                                                                                       |
 
 ### Manual testing
 

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-The MediaWiki Reader loads pages from any [MediaWiki](https://www.mediawiki.org/)-based wiki (Wikipedia, Wikiversity, or your own instance) and returns them as LlamaIndex `Document` objects. It uses the wiki’s [Action API](https://www.mediawiki.org/wiki/API:Main_page) via [mwclient](https://github.com/mwclient/mwclient): you provide the wiki **host** (and optionally **path** and **scheme**), and the reader fetches page list, metadata (URL, last-modified), and parsed text, with optional namespace filtering.
+The MediaWiki Reader loads pages from any [MediaWiki](https://www.mediawiki.org/)-based wiki (Wikipedia, Wikiversity, or your own instance) and returns them as LlamaIndex `Document` objects. It uses the wiki's [Action API](https://www.mediawiki.org/wiki/API:Main_page) via [mwclient](https://github.com/mwclient/mwclient): you provide the wiki **host** (and optionally **path** and **scheme**), and the reader fetches page list, metadata (URL, last-modified), and parsed text, with optional namespace filtering.
 
 ### Features
 
 - **Any MediaWiki instance** — Use `host`, `path`, and `scheme` to point at any wiki (e.g. `host="en.wikipedia.org"` with default path `/w/`).
-- **Resource-based API** — Implements `load_resource` and `get_resource_info` for LlamaIndex ingestion and RAG pipelines.
 - **Efficient listing** — Batched API calls for page metadata; optional `namespaces` filter.
+- **Redirect filtering** — Redirect pages are excluded by default (configurable via `filter_redirects`).
 - **HTML to text** — Converts wiki HTML to clean text via html2text (with regex fallback on failure).
 
 ### Installation
@@ -21,27 +21,24 @@ The reader depends on **mwclient** for MediaWiki API access; it is installed aut
 
 ### Usage
 
-**Load a single page by title (get metadata with get_resource_info, then load content):**
+**Load all pages from a wiki:**
 
 ```python
 from llama_index.readers.mediawiki import MediaWikiReader
 
 reader = MediaWikiReader(host="en.wikipedia.org")
 
-title = "Python (programming language)"
-info = reader.get_resource_info(title)
-if info.get("url"):
-    docs = reader.load_resource(
-        title,
-        resource_url=info["url"],
-        last_modified=info.get("last_modified"),
-    )
-# docs is a list of one Document with .text and .metadata (title, url, last_modified)
+# Load all pages as a list of Documents
+documents = reader.load_data()
 ```
 
-**Stream all pages (lazy):**
+**Stream all pages (memory-efficient for large wikis):**
 
 ```python
+from llama_index.readers.mediawiki import MediaWikiReader
+
+reader = MediaWikiReader(host="en.wikipedia.org")
+
 for doc in reader.lazy_load_data():
     print(doc.metadata.get("title"), len(doc.text))
 ```
@@ -55,23 +52,34 @@ reader = MediaWikiReader(
     scheme="https",
     page_limit=100,
     namespaces=[0],  # Main namespace only
+    filter_redirects=True,  # Exclude redirects (default)
 )
+documents = reader.load_data()
+```
+
+**Private wiki with authentication:**
+
+```python
+reader = MediaWikiReader(host="my.private.wiki")
+reader.login("username", "password")  # or use a bot password
+documents = reader.load_data()
 ```
 
 ### Configuration
 
-| Parameter    | Type                | Default       | Description                                                                                                                                                     |
-| ------------ | ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `host`       | `str`               | required      | MediaWiki site hostname (e.g. `en.wikipedia.org`).                                                                                                              |
-| `path`       | `str`               | `"/w/"`       | MediaWiki script path (API at `{path}api.php`).                                                                                                                 |
-| `scheme`     | `"https" \| "http"` | `"https"`     | URL scheme.                                                                                                                                                     |
-| `page_limit` | `int`               | `500`         | Max page titles per allpages API call (pagination).                                                                                                             |
-| `namespaces` | `list[int] \| None` | `None`        | Namespace IDs to list; `None` = wiki content namespaces from siteinfo API ([$wgContentNamespaces](https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces)). |
-| `logger`     | `logging.Logger`    | module logger | Logger instance (injectable for tests or custom logging). Not serialized.                                                                                       |
+| Parameter         | Type                | Default       | Description                                                                                                                                                     |
+| ----------------- | ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `host`            | `str`               | required      | MediaWiki site hostname (e.g. `en.wikipedia.org`).                                                                                                              |
+| `path`            | `str`               | `"/w/"`       | MediaWiki script path (API at `{path}api.php`).                                                                                                                 |
+| `scheme`          | `"https" \| "http"` | `"https"`     | URL scheme.                                                                                                                                                     |
+| `page_limit`      | `int`               | `500`         | Max page titles per allpages API call (pagination).                                                                                                             |
+| `namespaces`      | `list[int] \| None` | `None`        | Namespace IDs to list; `None` = wiki content namespaces from siteinfo ([$wgContentNamespaces](https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces)). |
+| `filter_redirects`| `bool`              | `True`        | Exclude redirect pages from results when `True`.                                                                                                                |
+| `logger`          | `logging.Logger`    | module logger | Logger instance (injectable for tests or custom logging). Not serialized.                                                                                       |
 
 ### Manual testing
 
-For manual testing, run the usage examples above with your wiki’s `host` (and `path`/`scheme` if not default). For a **private wiki**, set `host`, call `reader.login(username, password)` (or use a bot password), then use `load_resource` / `lazy_load_data` as usual.
+For manual testing, run the usage examples above with your wiki's `host` (and `path`/`scheme` if not default). For a **private wiki**, set `host`, call `reader.login(username, password)` (or use a bot password), then use `load_data` / `lazy_load_data` as usual.
 
 ### License
 

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/__init__.py
@@ -1,0 +1,5 @@
+"""LlamaIndex MediaWiki Reader."""
+
+from llama_index.readers.mediawiki.base import MediaWikiReader
+
+__all__ = ["MediaWikiReader"]

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -270,7 +270,7 @@ class MediaWikiReader(BasePydanticReader):
                     "title": title,
                     "url": url,
                     "last_modified": last_modified,
-                    "pageid": page.revision,
+                    "pageid": page.pageid,
                     "namespace": page.namespace,
                 }
 
@@ -283,7 +283,7 @@ class MediaWikiReader(BasePydanticReader):
 
         """
         try:
-            result = self.site.get(
+            result = self.site.post(
                 "parse",
                 page=page_title,
                 prop="text",

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -1,0 +1,407 @@
+"""MediaWiki reader for LlamaIndex.
+
+Provides a LlamaIndex-compatible reader that fetches and converts pages from
+any MediaWiki instance into LlamaIndex Documents, using mwclient for all
+MediaWiki API interactions.
+"""
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple
+from urllib.parse import urlparse
+
+import html2text
+import mwclient
+
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.readers.base import BasePydanticReader
+from llama_index.core.schema import Document
+
+_internal_logger = logging.getLogger(__name__)
+
+
+class MediaWikiReader(BasePydanticReader):
+    """LlamaIndex reader for MediaWiki instances.
+
+    Fetches pages from a MediaWiki site, converts HTML content to clean text,
+    and returns LlamaIndex Documents with metadata (title, URL, last_modified).
+
+    Uses `mwclient` for all API interactions. Supports authentication via
+    :meth:`login`.
+
+    **Ingestion scale:** Full ingestion (e.g. :meth:`lazy_load_data`) lists
+    pages via the allpages API, then fetches parsed content with one
+    ``parse`` API call per page. MediaWiki's parse API does not support
+    batch requests, so large wikis require many HTTP requests. This is a
+    known limitation of the MediaWiki API.
+
+    Example::
+
+        reader = MediaWikiReader(host="en.wikipedia.org")
+        docs = list(reader.lazy_load_data())
+
+    With authentication::
+
+        reader = MediaWikiReader(host="my.private.wiki")
+        reader.login("username", "password")
+        docs = list(reader.lazy_load_data())
+
+    Implements BasePydanticReader (for serialization / LlamaHub compatibility)
+    and provides load_resource and get_resource_info for resource-based use.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    # -- Pydantic fields (serialisable config) --------------------------------
+
+    host: str = Field(
+        min_length=1,
+        description="MediaWiki site hostname (e.g. 'en.wikipedia.org')",
+    )
+    path: str = Field(
+        default="/w/",
+        description="MediaWiki script path (default '/w/')",
+    )
+    scheme: Literal["https", "http"] = Field(
+        default="https",
+        description="URL scheme: 'https' or 'http'",
+    )
+    page_limit: int = Field(
+        default=500,
+        gt=0,
+        description=(
+            "Max page titles per allpages API call. Pagination continues "
+            "until the wiki is fully listed."
+        ),
+    )
+    namespaces: Optional[List[int]] = Field(
+        default=None,
+        description=(
+            "Namespace IDs to list. None = wiki content namespaces from "
+            "siteinfo API (i.e. $wgContentNamespaces). Set explicitly to "
+            "override."
+        ),
+    )
+    logger: logging.Logger = Field(
+        default_factory=lambda: _internal_logger,
+        description="Logger instance (injectable for tests or custom logging)",
+        exclude=True,
+    )
+
+    # -- Non-serialised internal state ----------------------------------------
+    _site: Optional[mwclient.Site] = PrivateAttr(default=None)
+    _content_namespace_ids: Optional[List[int]] = PrivateAttr(default=None)
+
+    # -- Construction helpers -------------------------------------------------
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.logger.info(
+            "Initialized MediaWikiReader for %s://%s%s",
+            self.scheme,
+            self.host,
+            self.path,
+        )
+
+    # -- mwclient Site lifecycle ----------------------------------------------
+
+    @property
+    def site(self) -> mwclient.Site:
+        """Return the mwclient Site, creating one lazily if needed."""
+        if self._site is None:
+            self._site = mwclient.Site(
+                self.host,
+                path=self.path,
+                scheme=self.scheme,
+            )
+        return self._site
+
+    def login(self, username: str, password: str) -> None:
+        """Authenticate to the wiki using user credentials.
+
+        Uses ``clientlogin`` (MW 1.27+). For bot passwords, use the bot
+        password as the ``password`` argument with the full bot-username
+        (e.g. ``User@BotName``).
+
+        Args:
+            username: MediaWiki username.
+            password: MediaWiki password or bot password.
+
+        Raises:
+            mwclient.errors.LoginError: If login fails.
+        """
+        self.site.clientlogin(username=username, password=password)
+        self.logger.info("Logged in as %s", username)
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _fetch_content_namespace_ids(self) -> List[int]:
+        """Return namespace IDs marked as content ($wgContentNamespaces).
+
+        Uses ``action=query&meta=siteinfo&siprop=namespaces`` and filters for
+        the ``content`` attribute. Falls back to ``[0]`` on failure.
+        """
+        try:
+            result = self.site.get(
+                "query", meta="siteinfo", siprop="namespaces"
+            )
+        except mwclient.errors.APIError as exc:
+            self.logger.warning(
+                "Could not fetch siteinfo; defaulting to main namespace (0): %s",
+                exc,
+            )
+            return [0]
+
+        namespaces = result.get("query", {}).get("namespaces", {})
+        ids: List[int] = []
+        for ns_data in namespaces.values():
+            if not isinstance(ns_data, dict):
+                continue
+            if not ns_data.get("content"):
+                continue
+            ns_id = ns_data.get("id")
+            if ns_id is not None:
+                ids.append(int(ns_id))
+
+        if not ids:
+            self.logger.warning(
+                "No content namespaces in siteinfo; defaulting to main namespace (0)."
+            )
+            return [0]
+        return sorted(ids)
+
+    def _build_page_url(
+        self, title: str, url_base: Optional[Tuple[str, str]]
+    ) -> Optional[str]:
+        """Build canonical page URL from pre-parsed (origin, article_path)."""
+        if not url_base:
+            return None
+        origin, article_path = url_base
+        return origin + article_path.replace("$1", title.replace(" ", "_"))
+
+    def _extract_revision_time(self, page: Any, title: str) -> Optional[datetime]:
+        """Extract last_modified from page revision timestamp (struct_time)."""
+        try:
+            ts = page.last_rev_time
+            if ts:
+                return datetime(*ts[:6], tzinfo=timezone.utc)
+            return None
+        except Exception as e:
+            self.logger.debug(
+                "Revision timestamp extraction failed for page %r: %s",
+                title,
+                e,
+                exc_info=True,
+            )
+            return None
+
+    def _get_all_pages_generator(self) -> Iterator[Dict[str, Any]]:
+        """Yield rich dicts for all pages via mwclient's allpages.
+
+        Each yielded dict contains:
+            - title (str)
+            - url (str or None)
+            - last_modified (datetime or None)
+        """
+        if self.namespaces is None:
+            if self._content_namespace_ids is None:
+                self._content_namespace_ids = self._fetch_content_namespace_ids()
+            ns_list = self._content_namespace_ids
+        else:
+            ns_list = self.namespaces
+
+        # Parse site base URL once; origin + article_path are constant per site
+        url_base: Optional[Tuple[str, str]] = None
+        try:
+            site_info = self.site.site
+            base_url = site_info.get("base", "")
+            article_path = site_info.get("articlepath", "/wiki/$1")
+            if base_url:
+                parsed = urlparse(base_url)
+                origin = f"{parsed.scheme}://{parsed.netloc}"
+                url_base = (origin, article_path)
+        except Exception as e:
+            self.logger.debug(
+                "URL base from siteinfo failed: %s",
+                e,
+                exc_info=True,
+            )
+
+        for ns in ns_list:
+            for page in self.site.allpages(
+                namespace=ns,
+                generator=True,
+                api_chunk_size=self.page_limit,
+            ):
+                title = page.name
+                url = self._build_page_url(title, url_base)
+                last_modified = self._extract_revision_time(page, title)
+                yield {
+                    "title": title,
+                    "url": url,
+                    "last_modified": last_modified,
+                }
+
+    def _get_page_contents(self, page_title: str) -> Optional[str]:
+        """Fetch parsed HTML content for a page via mwclient's parse API.
+
+        Returns:
+            Raw HTML from the API, or ``None`` on failure.
+        """
+        try:
+            result = self.site.parse(
+                page=page_title, prop="text"
+            )
+        except mwclient.errors.APIError as exc:
+            self.logger.warning(
+                "Parse API failed for '%s': %s", page_title, exc
+            )
+            return None
+
+        if not result:
+            self.logger.warning("No parse result for page '%s'", page_title)
+            return None
+
+        html_content = result.get("text", {}).get("*", "")
+        if not html_content:
+            self.logger.warning(
+                "No content in parse result for page '%s'", page_title
+            )
+            return None
+
+        return html_content
+
+    @staticmethod
+    def _html_to_clean_text(html_content: str) -> str:
+        """Convert MediaWiki HTML to clean Markdown text."""
+        try:
+            h = html2text.HTML2Text()
+            h.ignore_links = True
+            h.ignore_images = True
+            h.body_width = 0
+            h.ul_item_mark = "-"
+            h.emphasis_mark = "*"
+            h.strong_mark = "**"
+            return h.handle(html_content).strip()
+        except Exception as e:
+            _internal_logger.debug(
+                "html2text failed, using tag-strip fallback: %s",
+                e,
+                exc_info=True,
+            )
+            clean_text = re.sub(r"<[^>]+>", "", html_content)
+            clean_text = re.sub(r"\s+", " ", clean_text).strip()
+            return clean_text
+
+    # -- Resource API (load_resource) -----------------------------------------
+
+    def load_resource(
+        self,
+        resource_id: str,
+        resource_url: str,
+        last_modified: Optional[datetime],
+    ) -> List[Document]:
+        """Load a single page as a list containing one Document.
+
+        Args:
+            resource_id: The page title.
+            resource_url: Pre-fetched canonical URL for the page.
+            last_modified: Pre-fetched last-modified timestamp (or None).
+
+        Returns:
+            A one-element list with the page Document, or empty on failure.
+        """
+        content = self._get_page_contents(resource_id)
+        if not content:
+            return []
+
+        content = self._html_to_clean_text(content)
+        doc = Document(
+            text=content,
+            id_=f"mediawiki:{resource_id}",
+            metadata={
+                "title": resource_id,
+                "url": resource_url,
+                "last_modified": (
+                    last_modified.isoformat() if last_modified else None
+                ),
+            },
+        )
+        return [doc]
+
+    # -- Resource info (single page) ------------------------------------------
+
+    def get_resource_info(self, resource_id: str) -> Dict[str, Any]:
+        """Return metadata for a single page (URL and last_modified).
+
+        Args:
+            resource_id: Page title.
+
+        Returns:
+            ``{"last_modified": datetime | None, "url": str | None}``.
+        """
+        try:
+            result = self.site.get(
+                "query",
+                titles=resource_id,
+                prop="info|revisions",
+                inprop="url",
+                rvprop="timestamp",
+            )
+        except mwclient.errors.APIError as exc:
+            self.logger.warning(
+                "Query API failed for '%s': %s", resource_id, exc
+            )
+            return {"last_modified": None, "url": None}
+
+        pages = result.get("query", {}).get("pages", {})
+        page_data = next(
+            (p for p in pages.values() if p.get("title")), None
+        )
+        last_modified = None
+        url = None
+        if page_data and "missing" not in page_data:
+            url = page_data.get("canonicalurl")
+            revisions = page_data.get("revisions", [])
+            if revisions:
+                ts_str = revisions[0].get("timestamp")
+                if ts_str:
+                    try:
+                        last_modified = datetime.fromisoformat(
+                            ts_str.replace("Z", "+00:00")
+                        )
+                    except (ValueError, TypeError):
+                        pass
+
+        return {"last_modified": last_modified, "url": url}
+
+    # -- BasePydanticReader / BaseReader interface -----------------------------
+
+    def lazy_load_data(self, *args: Any, **kwargs: Any) -> Iterator[Document]:
+        """Yield one Document per page in the wiki.
+
+        Iterates all pages via mwclient's allpages, then fetches parsed
+        content for each page with one parse API call per page (MediaWiki
+        has no batch parse API; see class docstring for scale notes).
+        """
+        for page_record in self._get_all_pages_generator():
+            url = page_record.get("url")
+            if not url:
+                # API-based URL construction failed; use guaranteed fallback
+                # so we never drop content due to missing siteinfo.
+                safe_title = page_record["title"].replace(" ", "_")
+                url = (
+                    f"{self.scheme}://{self.host}{self.path}"
+                    f"index.php?title={safe_title}"
+                )
+                self.logger.debug(
+                    "Using fallback URL for %s",
+                    page_record["title"],
+                )
+            docs = self.load_resource(
+                page_record["title"],
+                resource_url=url,
+                last_modified=page_record.get("last_modified"),
+            )
+            yield from docs

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -61,7 +61,6 @@ class MediaWikiReader(BasePydanticReader):
     FILTERREDIR_ALL: str = "all"
 
     is_remote: bool = True
-    model_config = {"arbitrary_types_allowed": True}
 
     # -- Pydantic fields (serialisable config) --------------------------------
 
@@ -143,7 +142,7 @@ class MediaWikiReader(BasePydanticReader):
 
         """
         self.site.login(username=username, password=password)
-        self.logger.info("Logged in as %s", username)
+        self.logger.info("Successfully logged into MediaWiki")
 
     # -- Internal helpers -----------------------------------------------------
 
@@ -336,6 +335,7 @@ class MediaWikiReader(BasePydanticReader):
 
         Returns:
             A Document, or None if the page content could not be fetched.
+
         """
         content = self._get_page_contents(title)
         if not content:
@@ -348,7 +348,9 @@ class MediaWikiReader(BasePydanticReader):
             metadata={
                 "title": title,
                 "url": url,
-                "last_modified": (last_modified.isoformat() if last_modified else None),
+                "last_modified": (
+                    last_modified.isoformat() if last_modified else None
+                ),
                 "pageid": pageid,
                 "namespace": namespace,
             },

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -8,18 +8,29 @@ MediaWiki API interactions.
 
 import logging
 import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple
+from typing import Any, Iterator, List, Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 import html2text
 import mwclient
-
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.readers.base import BasePydanticReader
 from llama_index.core.schema import Document
 
 _internal_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Page:
+    """Lightweight record for a single wiki page entry from allpages."""
+
+    title: str
+    url: Optional[str]
+    last_modified: Optional[datetime]
+    pageid: Optional[int]
+    namespace: Optional[int]
 
 
 class MediaWikiReader(BasePydanticReader):
@@ -30,26 +41,20 @@ class MediaWikiReader(BasePydanticReader):
     and returns LlamaIndex Documents with metadata (title, URL, last_modified).
 
     Uses `mwclient` for all API interactions. Supports authentication via
-    :meth:`login`.
+    `login`.
 
-    **Ingestion scale:** Full ingestion (e.g. :meth:`lazy_load_data`) lists
-    pages via the allpages API, then fetches parsed content with one
-    ``parse`` API call per page. MediaWiki's parse API does not support
-    batch requests, so large wikis require many HTTP requests. This is a
-    known limitation of the MediaWiki API.
-
-    Example::
-
+    Example:
         reader = MediaWikiReader(host="en.wikipedia.org")
         docs = reader.load_data()
 
-    With authentication::
+    With authentication:
 
         reader = MediaWikiReader(host="my.private.wiki")
         reader.login("username", "password")
         docs = reader.load_data()
 
     Implements BasePydanticReader (for serialization / LlamaHub compatibility).
+
     """
 
     FILTERREDIR_NONREDIRECTS: str = "nonredirects"
@@ -121,29 +126,23 @@ class MediaWikiReader(BasePydanticReader):
         """Return the mwclient Site, creating one lazily if needed."""
         if self._site is None:
             self._site = mwclient.Site(
-                self.host,
-                path=self.path,
-                scheme=self.scheme,
+                self.host, path=self.path, scheme=self.scheme
             )
         return self._site
 
     def login(self, username: str, password: str) -> None:
         """
-        Authenticate to the wiki using user credentials.
-
-        Uses ``clientlogin`` (MW 1.27+). For bot passwords, use the bot
-        password as the ``password`` argument with the full bot-username
-        (e.g. ``User@BotName``).
+        Authenticate to the wiki using a user or bot credentials.
 
         Args:
-            username: MediaWiki username.
+            username: MediaWiki username or bot username.
             password: MediaWiki password or bot password.
 
         Raises:
             mwclient.errors.LoginError: If login fails.
 
         """
-        self.site.clientlogin(username=username, password=password)
+        self.site.login(username=username, password=password)
         self.logger.info("Logged in as %s", username)
 
     # -- Internal helpers -----------------------------------------------------
@@ -154,10 +153,10 @@ class MediaWikiReader(BasePydanticReader):
 
         Queries ``action=query&meta=siteinfo&siprop=namespaces`` and filters
         for namespaces that carry the ``content`` flag.
-        Falls back to ``[0]`` (main namespace) if none are found.
 
         Raises:
             mwclient.errors.APIError: If the siteinfo query fails.
+            RuntimeError: If no content namespaces are found in siteinfo.
 
         """
         result = self.site.get("query", meta="siteinfo", siprop="namespaces")
@@ -171,10 +170,10 @@ class MediaWikiReader(BasePydanticReader):
         ]
 
         if not ids:
-            self.logger.warning(
-                "No content namespaces found in siteinfo; defaulting to main namespace (0)."
+            raise RuntimeError(
+                "No content namespaces found in siteinfo; "
+                "the MediaWiki API may be unreachable or misconfigured."
             )
-            return [0]
         return sorted(ids)
 
     def _resolve_namespace_list(self) -> List[int]:
@@ -189,6 +188,7 @@ class MediaWikiReader(BasePydanticReader):
 
         Raises:
             RuntimeError: If the URL base cannot be determined from siteinfo.
+
         """
         site_info = self.site.site
         base_url = site_info.get("base", "")
@@ -211,7 +211,9 @@ class MediaWikiReader(BasePydanticReader):
         origin, article_path = url_base
         return origin + article_path.replace("$1", title.replace(" ", "_"))
 
-    def _extract_revision_time(self, page: Any, title: str) -> Optional[datetime]:
+    def _extract_revision_time(
+        self, page: Any, title: str
+    ) -> Optional[datetime]:
         """Extract last_modified from page revision timestamp (struct_time)."""
         try:
             ts = page.touched
@@ -227,28 +229,12 @@ class MediaWikiReader(BasePydanticReader):
             )
             return None
 
-    def _get_all_pages_generator(self) -> Iterator[Dict[str, Any]]:
-        """
-        Yield rich dicts for all pages via mwclient's allpages.
-
-        Each yielded dict contains:
-            - title (str)
-            - url (str or None)
-            - last_modified (datetime or None)
-            - pageid (int or None)
-            - namespace (int or None)
-        """
+    def _get_all_pages_generator(self) -> Iterator[Page]:
+        """Yield a Page record for every page in the wiki via mwclient's allpages."""
         ns_list = self._resolve_namespace_list()
 
         # Parse site base URL once; origin + article_path are constant per site
-        url_base: Optional[Tuple[str, str]] = None
-        try:
-            url_base = self._get_url_base()
-        except RuntimeError as e:
-            raise RuntimeError(
-                "Cannot list pages: failed to determine site URL base. "
-                "Check that the MediaWiki API is reachable and siteinfo is accessible."
-            ) from e
+        url_base = self._get_url_base()
 
         filterredir = (
             self.FILTERREDIR_NONREDIRECTS
@@ -264,15 +250,13 @@ class MediaWikiReader(BasePydanticReader):
                 filterredir=filterredir,
             ):
                 title = page.name
-                url = self._build_page_url(title, url_base)
-                last_modified = self._extract_revision_time(page, title)
-                yield {
-                    "title": title,
-                    "url": url,
-                    "last_modified": last_modified,
-                    "pageid": page.pageid,
-                    "namespace": page.namespace,
-                }
+                yield Page(
+                    title=title,
+                    url=self._build_page_url(title, url_base),
+                    last_modified=self._extract_revision_time(page, title),
+                    pageid=page.pageid,
+                    namespace=page.namespace,
+                )
 
     def _get_page_contents(self, page_title: str) -> Optional[str]:
         """
@@ -292,7 +276,9 @@ class MediaWikiReader(BasePydanticReader):
                 disabletoc=True,
             )
         except mwclient.errors.APIError as exc:
-            self.logger.warning("Parse API failed for '%s': %s", page_title, exc)
+            self.logger.warning(
+                "Parse API failed for '%s': %s", page_title, exc
+            )
             return None
 
         if not result:
@@ -301,7 +287,9 @@ class MediaWikiReader(BasePydanticReader):
 
         html_content = result.get("parse", {}).get("text", {}).get("*", "")
         if not html_content:
-            self.logger.warning("No content in parse result for page '%s'", page_title)
+            self.logger.warning(
+                "No content in parse result for page '%s'", page_title
+            )
             return None
 
         return html_content
@@ -318,13 +306,15 @@ class MediaWikiReader(BasePydanticReader):
             h.emphasis_mark = "*"
             h.strong_mark = "**"
             return h.handle(html_content).strip()
-        except Exception as e:
+        except (AttributeError, TypeError, ValueError) as e:
             _internal_logger.debug(
                 "html2text failed, using tag-strip fallback: %s",
                 e,
                 exc_info=True,
             )
-            return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", html_content)).strip()
+            return re.sub(
+                r"\s+", " ", re.sub(r"<[^>]+>", "", html_content)
+            ).strip()
 
     def _page_to_document(
         self,
@@ -376,11 +366,11 @@ class MediaWikiReader(BasePydanticReader):
         """
         for page_record in self._get_all_pages_generator():
             doc = self._page_to_document(
-                title=page_record["title"],
-                url=page_record.get("url"),
-                last_modified=page_record.get("last_modified"),
-                pageid=page_record.get("pageid"),
-                namespace=page_record.get("namespace"),
+                title=page_record.title,
+                url=page_record.url,
+                last_modified=page_record.last_modified,
+                pageid=page_record.pageid,
+                namespace=page_record.namespace,
             )
             if doc is not None:
                 yield doc

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -1,4 +1,5 @@
-"""MediaWiki reader for LlamaIndex.
+"""
+MediaWiki reader for LlamaIndex.
 
 Provides a LlamaIndex-compatible reader that fetches and converts pages from
 any MediaWiki instance into LlamaIndex Documents, using mwclient for all
@@ -22,7 +23,8 @@ _internal_logger = logging.getLogger(__name__)
 
 
 class MediaWikiReader(BasePydanticReader):
-    """LlamaIndex reader for MediaWiki instances.
+    """
+    LlamaIndex reader for MediaWiki instances.
 
     Fetches pages from a MediaWiki site, converts HTML content to clean text,
     and returns LlamaIndex Documents with metadata (title, URL, last_modified).
@@ -118,7 +120,8 @@ class MediaWikiReader(BasePydanticReader):
         return self._site
 
     def login(self, username: str, password: str) -> None:
-        """Authenticate to the wiki using user credentials.
+        """
+        Authenticate to the wiki using user credentials.
 
         Uses ``clientlogin`` (MW 1.27+). For bot passwords, use the bot
         password as the ``password`` argument with the full bot-username
@@ -130,6 +133,7 @@ class MediaWikiReader(BasePydanticReader):
 
         Raises:
             mwclient.errors.LoginError: If login fails.
+
         """
         self.site.clientlogin(username=username, password=password)
         self.logger.info("Logged in as %s", username)
@@ -137,15 +141,14 @@ class MediaWikiReader(BasePydanticReader):
     # -- Internal helpers -----------------------------------------------------
 
     def _fetch_content_namespace_ids(self) -> List[int]:
-        """Return namespace IDs marked as content ($wgContentNamespaces).
+        """
+        Return namespace IDs marked as content ($wgContentNamespaces).
 
         Uses ``action=query&meta=siteinfo&siprop=namespaces`` and filters for
         the ``content`` attribute. Falls back to ``[0]`` on failure.
         """
         try:
-            result = self.site.get(
-                "query", meta="siteinfo", siprop="namespaces"
-            )
+            result = self.site.get("query", meta="siteinfo", siprop="namespaces")
         except mwclient.errors.APIError as exc:
             self.logger.warning(
                 "Could not fetch siteinfo; defaulting to main namespace (0): %s",
@@ -197,7 +200,8 @@ class MediaWikiReader(BasePydanticReader):
             return None
 
     def _get_all_pages_generator(self) -> Iterator[Dict[str, Any]]:
-        """Yield rich dicts for all pages via mwclient's allpages.
+        """
+        Yield rich dicts for all pages via mwclient's allpages.
 
         Each yielded dict contains:
             - title (str)
@@ -244,19 +248,17 @@ class MediaWikiReader(BasePydanticReader):
                 }
 
     def _get_page_contents(self, page_title: str) -> Optional[str]:
-        """Fetch parsed HTML content for a page via mwclient's parse API.
+        """
+        Fetch parsed HTML content for a page via mwclient's parse API.
 
         Returns:
             Raw HTML from the API, or ``None`` on failure.
+
         """
         try:
-            result = self.site.parse(
-                page=page_title, prop="text"
-            )
+            result = self.site.parse(page=page_title, prop="text")
         except mwclient.errors.APIError as exc:
-            self.logger.warning(
-                "Parse API failed for '%s': %s", page_title, exc
-            )
+            self.logger.warning("Parse API failed for '%s': %s", page_title, exc)
             return None
 
         if not result:
@@ -265,9 +267,7 @@ class MediaWikiReader(BasePydanticReader):
 
         html_content = result.get("text", {}).get("*", "")
         if not html_content:
-            self.logger.warning(
-                "No content in parse result for page '%s'", page_title
-            )
+            self.logger.warning("No content in parse result for page '%s'", page_title)
             return None
 
         return html_content
@@ -290,9 +290,7 @@ class MediaWikiReader(BasePydanticReader):
                 e,
                 exc_info=True,
             )
-            clean_text = re.sub(r"<[^>]+>", "", html_content)
-            clean_text = re.sub(r"\s+", " ", clean_text).strip()
-            return clean_text
+            return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", html_content)).strip()
 
     # -- Resource API (load_resource) -----------------------------------------
 
@@ -302,7 +300,8 @@ class MediaWikiReader(BasePydanticReader):
         resource_url: str,
         last_modified: Optional[datetime],
     ) -> List[Document]:
-        """Load a single page as a list containing one Document.
+        """
+        Load a single page as a list containing one Document.
 
         Args:
             resource_id: The page title.
@@ -311,6 +310,7 @@ class MediaWikiReader(BasePydanticReader):
 
         Returns:
             A one-element list with the page Document, or empty on failure.
+
         """
         content = self._get_page_contents(resource_id)
         if not content:
@@ -323,9 +323,7 @@ class MediaWikiReader(BasePydanticReader):
             metadata={
                 "title": resource_id,
                 "url": resource_url,
-                "last_modified": (
-                    last_modified.isoformat() if last_modified else None
-                ),
+                "last_modified": (last_modified.isoformat() if last_modified else None),
             },
         )
         return [doc]
@@ -333,13 +331,15 @@ class MediaWikiReader(BasePydanticReader):
     # -- Resource info (single page) ------------------------------------------
 
     def get_resource_info(self, resource_id: str) -> Dict[str, Any]:
-        """Return metadata for a single page (URL and last_modified).
+        """
+        Return metadata for a single page (URL and last_modified).
 
         Args:
             resource_id: Page title.
 
         Returns:
             ``{"last_modified": datetime | None, "url": str | None}``.
+
         """
         try:
             result = self.site.get(
@@ -350,15 +350,11 @@ class MediaWikiReader(BasePydanticReader):
                 rvprop="timestamp",
             )
         except mwclient.errors.APIError as exc:
-            self.logger.warning(
-                "Query API failed for '%s': %s", resource_id, exc
-            )
+            self.logger.warning("Query API failed for '%s': %s", resource_id, exc)
             return {"last_modified": None, "url": None}
 
         pages = result.get("query", {}).get("pages", {})
-        page_data = next(
-            (p for p in pages.values() if p.get("title")), None
-        )
+        page_data = next((p for p in pages.values() if p.get("title")), None)
         last_modified = None
         url = None
         if page_data and "missing" not in page_data:
@@ -379,7 +375,8 @@ class MediaWikiReader(BasePydanticReader):
     # -- BasePydanticReader / BaseReader interface -----------------------------
 
     def lazy_load_data(self, *args: Any, **kwargs: Any) -> Iterator[Document]:
-        """Yield one Document per page in the wiki.
+        """
+        Yield one Document per page in the wiki.
 
         Iterates all pages via mwclient's allpages, then fetches parsed
         content for each page with one parse API call per page (MediaWiki

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -52,6 +52,9 @@ class MediaWikiReader(BasePydanticReader):
     Implements BasePydanticReader (for serialization / LlamaHub compatibility).
     """
 
+    FILTERREDIR_NONREDIRECTS: str = "nonredirects"
+    FILTERREDIR_ALL: str = "all"
+
     is_remote: bool = True
     model_config = {"arbitrary_types_allowed": True}
 
@@ -150,8 +153,7 @@ class MediaWikiReader(BasePydanticReader):
         Return namespace IDs marked as content ($wgContentNamespaces).
 
         Queries ``action=query&meta=siteinfo&siprop=namespaces`` and filters
-        for namespaces that carry the ``content`` flag. mwclient fetches
-        siteinfo on Site init so this call hits the already-cached data.
+        for namespaces that carry the ``content`` flag.
         Falls back to ``[0]`` (main namespace) if none are found.
 
         Raises:
@@ -164,7 +166,7 @@ class MediaWikiReader(BasePydanticReader):
             int(ns_data["id"])
             for ns_data in namespaces.values()
             if isinstance(ns_data, dict)
-            and ns_data.get("content")
+            and "content" in ns_data
             and ns_data.get("id") is not None
         ]
 
@@ -212,7 +214,7 @@ class MediaWikiReader(BasePydanticReader):
     def _extract_revision_time(self, page: Any, title: str) -> Optional[datetime]:
         """Extract last_modified from page revision timestamp (struct_time)."""
         try:
-            ts = page.last_rev_time
+            ts = page.touched
             if ts:
                 return datetime(*ts[:6], tzinfo=timezone.utc)
             return None
@@ -233,6 +235,8 @@ class MediaWikiReader(BasePydanticReader):
             - title (str)
             - url (str or None)
             - last_modified (datetime or None)
+            - pageid (int or None)
+            - namespace (int or None)
         """
         ns_list = self._resolve_namespace_list()
 
@@ -246,7 +250,11 @@ class MediaWikiReader(BasePydanticReader):
                 "Check that the MediaWiki API is reachable and siteinfo is accessible."
             ) from e
 
-        filterredir = "nonredirects" if self.filter_redirects else "all"
+        filterredir = (
+            self.FILTERREDIR_NONREDIRECTS
+            if self.filter_redirects
+            else self.FILTERREDIR_ALL
+        )
 
         for ns in ns_list:
             for page in self.site.allpages(
@@ -262,6 +270,8 @@ class MediaWikiReader(BasePydanticReader):
                     "title": title,
                     "url": url,
                     "last_modified": last_modified,
+                    "pageid": page.revision,
+                    "namespace": page.namespace,
                 }
 
     def _get_page_contents(self, page_title: str) -> Optional[str]:
@@ -273,7 +283,8 @@ class MediaWikiReader(BasePydanticReader):
 
         """
         try:
-            result = self.site.parse(
+            result = self.site.get(
+                "parse",
                 page=page_title,
                 prop="text",
                 disablelimitreport=True,
@@ -288,7 +299,7 @@ class MediaWikiReader(BasePydanticReader):
             self.logger.warning("No parse result for page '%s'", page_title)
             return None
 
-        html_content = result.get("text", {}).get("*", "")
+        html_content = result.get("parse", {}).get("text", {}).get("*", "")
         if not html_content:
             self.logger.warning("No content in parse result for page '%s'", page_title)
             return None
@@ -320,6 +331,8 @@ class MediaWikiReader(BasePydanticReader):
         title: str,
         url: Optional[str],
         last_modified: Optional[datetime],
+        pageid: Optional[int] = None,
+        namespace: Optional[int] = None,
     ) -> Optional[Document]:
         """
         Fetch and convert a single wiki page into a Document.
@@ -328,6 +341,8 @@ class MediaWikiReader(BasePydanticReader):
             title: Page title.
             url: Canonical URL for the page (may be None).
             last_modified: Last-modified timestamp (may be None).
+            pageid: Numeric page ID (may be None).
+            namespace: Namespace ID for the page (may be None).
 
         Returns:
             A Document, or None if the page content could not be fetched.
@@ -344,6 +359,8 @@ class MediaWikiReader(BasePydanticReader):
                 "title": title,
                 "url": url,
                 "last_modified": (last_modified.isoformat() if last_modified else None),
+                "pageid": pageid,
+                "namespace": namespace,
             },
         )
 
@@ -362,6 +379,8 @@ class MediaWikiReader(BasePydanticReader):
                 title=page_record["title"],
                 url=page_record.get("url"),
                 last_modified=page_record.get("last_modified"),
+                pageid=page_record.get("pageid"),
+                namespace=page_record.get("namespace"),
             )
             if doc is not None:
                 yield doc

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterator, List, Literal, Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import html2text
 import mwclient
@@ -76,12 +76,14 @@ class MediaWikiReader(BasePydanticReader):
         default="https",
         description="URL scheme: 'https' or 'http'",
     )
-    page_limit: int = Field(
-        default=500,
+    page_limit: Optional[int] = Field(
+        default=None,
         gt=0,
         description=(
-            "Max page titles per allpages API call. Pagination continues "
-            "until the wiki is fully listed."
+            "Max pages to yield per namespace. None (default) means unlimited, "
+            "matching mwclient's own default for max_items. "
+            "When multiple namespaces are iterated, this limit applies to each "
+            "namespace independently."
         ),
     )
     namespaces: Optional[List[int]] = Field(
@@ -208,12 +210,13 @@ class MediaWikiReader(BasePydanticReader):
         if not url_base:
             return None
         origin, article_path = url_base
-        return origin + article_path.replace("$1", title.replace(" ", "_"))
+        encoded_title = quote(title.replace(" ", "_"), safe="/:")
+        return origin + article_path.replace("$1", encoded_title)
 
     def _extract_revision_time(
         self, page: Any, title: str
     ) -> Optional[datetime]:
-        """Extract last_modified from page revision timestamp (struct_time)."""
+        """Extract last_modified from page.touched (cache-invalidation timestamp, struct_time)."""
         try:
             ts = page.touched
             if ts:
@@ -245,7 +248,7 @@ class MediaWikiReader(BasePydanticReader):
             for page in self.site.allpages(
                 namespace=ns,
                 generator=True,
-                api_chunk_size=self.page_limit,
+                max_items=self.page_limit,
                 filterredir=filterredir,
             ):
                 title = page.name
@@ -315,44 +318,44 @@ class MediaWikiReader(BasePydanticReader):
                 r"\s+", " ", re.sub(r"<[^>]+>", "", html_content)
             ).strip()
 
-    def _page_to_document(
-        self,
-        title: str,
-        url: Optional[str],
-        last_modified: Optional[datetime],
-        pageid: Optional[int] = None,
-        namespace: Optional[int] = None,
-    ) -> Optional[Document]:
+    def _page_to_document(self, page: Page) -> Optional[Document]:
         """
         Fetch and convert a single wiki page into a Document.
 
         Args:
-            title: Page title.
-            url: Canonical URL for the page (may be None).
-            last_modified: Last-modified timestamp (may be None).
-            pageid: Numeric page ID (may be None).
-            namespace: Namespace ID for the page (may be None).
+            page: Page record with title, url, last_modified, pageid, namespace.
 
         Returns:
             A Document, or None if the page content could not be fetched.
 
         """
-        content = self._get_page_contents(title)
+        content = self._get_page_contents(page.title)
         if not content:
             return None
 
         text = self._html_to_clean_text(content)
+        if not text.strip():
+            self.logger.debug(
+                "Skipping page %r because extracted text is empty", page.title
+            )
+            return None
+        wiki_id = self.site.site.get("wikiid", f"{self.host}{self.path}")
+        doc_id = (
+            f"mediawiki:{wiki_id}:{page.pageid}"
+            if page.pageid is not None
+            else f"mediawiki:{wiki_id}:{page.title}"
+        )
         return Document(
             text=text,
-            id_=f"mediawiki:{title}",
+            id_=doc_id,
             metadata={
-                "title": title,
-                "url": url,
+                "title": page.title,
+                "url": page.url,
                 "last_modified": (
-                    last_modified.isoformat() if last_modified else None
+                    page.last_modified.isoformat() if page.last_modified else None
                 ),
-                "pageid": pageid,
-                "namespace": namespace,
+                "pageid": page.pageid,
+                "namespace": page.namespace,
             },
         )
 
@@ -367,12 +370,6 @@ class MediaWikiReader(BasePydanticReader):
         has no batch parse API; see class docstring for scale notes).
         """
         for page_record in self._get_all_pages_generator():
-            doc = self._page_to_document(
-                title=page_record.title,
-                url=page_record.url,
-                last_modified=page_record.last_modified,
-                pageid=page_record.pageid,
-                namespace=page_record.namespace,
-            )
+            doc = self._page_to_document(page_record)
             if doc is not None:
                 yield doc

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -31,6 +31,7 @@ class Page:
     last_modified: Optional[datetime]
     pageid: Optional[int]
     namespace: Optional[int]
+    revision: Optional[int] = None
 
 
 class MediaWikiReader(BasePydanticReader):
@@ -258,6 +259,9 @@ class MediaWikiReader(BasePydanticReader):
                     last_modified=self._extract_revision_time(page, title),
                     pageid=page.pageid,
                     namespace=page.namespace,
+                    # mwclient defaults revision to 0 when unavailable; coerce to None
+                    # so callers can use a simple truthiness check.
+                    revision=page.revision or None,
                 )
 
     def _get_page_contents(self, page_title: str) -> Optional[str]:

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/llama_index/readers/mediawiki/base.py
@@ -41,18 +41,18 @@ class MediaWikiReader(BasePydanticReader):
     Example::
 
         reader = MediaWikiReader(host="en.wikipedia.org")
-        docs = list(reader.lazy_load_data())
+        docs = reader.load_data()
 
     With authentication::
 
         reader = MediaWikiReader(host="my.private.wiki")
         reader.login("username", "password")
-        docs = list(reader.lazy_load_data())
+        docs = reader.load_data()
 
-    Implements BasePydanticReader (for serialization / LlamaHub compatibility)
-    and provides load_resource and get_resource_info for resource-based use.
+    Implements BasePydanticReader (for serialization / LlamaHub compatibility).
     """
 
+    is_remote: bool = True
     model_config = {"arbitrary_types_allowed": True}
 
     # -- Pydantic fields (serialisable config) --------------------------------
@@ -81,8 +81,14 @@ class MediaWikiReader(BasePydanticReader):
         default=None,
         description=(
             "Namespace IDs to list. None = wiki content namespaces from "
-            "siteinfo API (i.e. $wgContentNamespaces). Set explicitly to "
-            "override."
+            "siteinfo (i.e. $wgContentNamespaces). Set explicitly to override."
+        ),
+    )
+    filter_redirects: bool = Field(
+        default=True,
+        description=(
+            "If True (default), redirect pages are excluded from results. "
+            "Set to False to include redirect pages."
         ),
     )
     logger: logging.Logger = Field(
@@ -93,7 +99,6 @@ class MediaWikiReader(BasePydanticReader):
 
     # -- Non-serialised internal state ----------------------------------------
     _site: Optional[mwclient.Site] = PrivateAttr(default=None)
-    _content_namespace_ids: Optional[List[int]] = PrivateAttr(default=None)
 
     # -- Construction helpers -------------------------------------------------
 
@@ -140,39 +145,60 @@ class MediaWikiReader(BasePydanticReader):
 
     # -- Internal helpers -----------------------------------------------------
 
-    def _fetch_content_namespace_ids(self) -> List[int]:
+    def _get_content_namespace_ids(self) -> List[int]:
         """
         Return namespace IDs marked as content ($wgContentNamespaces).
 
-        Uses ``action=query&meta=siteinfo&siprop=namespaces`` and filters for
-        the ``content`` attribute. Falls back to ``[0]`` on failure.
-        """
-        try:
-            result = self.site.get("query", meta="siteinfo", siprop="namespaces")
-        except mwclient.errors.APIError as exc:
-            self.logger.warning(
-                "Could not fetch siteinfo; defaulting to main namespace (0): %s",
-                exc,
-            )
-            return [0]
+        Queries ``action=query&meta=siteinfo&siprop=namespaces`` and filters
+        for namespaces that carry the ``content`` flag. mwclient fetches
+        siteinfo on Site init so this call hits the already-cached data.
+        Falls back to ``[0]`` (main namespace) if none are found.
 
+        Raises:
+            mwclient.errors.APIError: If the siteinfo query fails.
+
+        """
+        result = self.site.get("query", meta="siteinfo", siprop="namespaces")
         namespaces = result.get("query", {}).get("namespaces", {})
-        ids: List[int] = []
-        for ns_data in namespaces.values():
-            if not isinstance(ns_data, dict):
-                continue
-            if not ns_data.get("content"):
-                continue
-            ns_id = ns_data.get("id")
-            if ns_id is not None:
-                ids.append(int(ns_id))
+        ids: List[int] = [
+            int(ns_data["id"])
+            for ns_data in namespaces.values()
+            if isinstance(ns_data, dict)
+            and ns_data.get("content")
+            and ns_data.get("id") is not None
+        ]
 
         if not ids:
             self.logger.warning(
-                "No content namespaces in siteinfo; defaulting to main namespace (0)."
+                "No content namespaces found in siteinfo; defaulting to main namespace (0)."
             )
             return [0]
         return sorted(ids)
+
+    def _resolve_namespace_list(self) -> List[int]:
+        """Return the effective list of namespace IDs to iterate."""
+        if self.namespaces is not None:
+            return self.namespaces
+        return self._get_content_namespace_ids()
+
+    def _get_url_base(self) -> Tuple[str, str]:
+        """
+        Return ``(origin, article_path)`` parsed from the site's siteinfo.
+
+        Raises:
+            RuntimeError: If the URL base cannot be determined from siteinfo.
+        """
+        site_info = self.site.site
+        base_url = site_info.get("base", "")
+        article_path = site_info.get("articlepath", "/wiki/$1")
+        if not base_url:
+            raise RuntimeError(
+                "Could not determine base URL from siteinfo; "
+                "the 'base' field is missing or empty."
+            )
+        parsed = urlparse(base_url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        return origin, article_path
 
     def _build_page_url(
         self, title: str, url_base: Optional[Tuple[str, str]]
@@ -190,7 +216,7 @@ class MediaWikiReader(BasePydanticReader):
             if ts:
                 return datetime(*ts[:6], tzinfo=timezone.utc)
             return None
-        except Exception as e:
+        except (AttributeError, TypeError) as e:
             self.logger.debug(
                 "Revision timestamp extraction failed for page %r: %s",
                 title,
@@ -208,35 +234,26 @@ class MediaWikiReader(BasePydanticReader):
             - url (str or None)
             - last_modified (datetime or None)
         """
-        if self.namespaces is None:
-            if self._content_namespace_ids is None:
-                self._content_namespace_ids = self._fetch_content_namespace_ids()
-            ns_list = self._content_namespace_ids
-        else:
-            ns_list = self.namespaces
+        ns_list = self._resolve_namespace_list()
 
         # Parse site base URL once; origin + article_path are constant per site
         url_base: Optional[Tuple[str, str]] = None
         try:
-            site_info = self.site.site
-            base_url = site_info.get("base", "")
-            article_path = site_info.get("articlepath", "/wiki/$1")
-            if base_url:
-                parsed = urlparse(base_url)
-                origin = f"{parsed.scheme}://{parsed.netloc}"
-                url_base = (origin, article_path)
-        except Exception as e:
-            self.logger.debug(
-                "URL base from siteinfo failed: %s",
-                e,
-                exc_info=True,
-            )
+            url_base = self._get_url_base()
+        except RuntimeError as e:
+            raise RuntimeError(
+                "Cannot list pages: failed to determine site URL base. "
+                "Check that the MediaWiki API is reachable and siteinfo is accessible."
+            ) from e
+
+        filterredir = "nonredirects" if self.filter_redirects else "all"
 
         for ns in ns_list:
             for page in self.site.allpages(
                 namespace=ns,
                 generator=True,
                 api_chunk_size=self.page_limit,
+                filterredir=filterredir,
             ):
                 title = page.name
                 url = self._build_page_url(title, url_base)
@@ -256,7 +273,13 @@ class MediaWikiReader(BasePydanticReader):
 
         """
         try:
-            result = self.site.parse(page=page_title, prop="text")
+            result = self.site.parse(
+                page=page_title,
+                prop="text",
+                disablelimitreport=True,
+                disableeditsection=True,
+                disabletoc=True,
+            )
         except mwclient.errors.APIError as exc:
             self.logger.warning("Parse API failed for '%s': %s", page_title, exc)
             return None
@@ -292,85 +315,37 @@ class MediaWikiReader(BasePydanticReader):
             )
             return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", html_content)).strip()
 
-    # -- Resource API (load_resource) -----------------------------------------
-
-    def load_resource(
+    def _page_to_document(
         self,
-        resource_id: str,
-        resource_url: str,
+        title: str,
+        url: Optional[str],
         last_modified: Optional[datetime],
-    ) -> List[Document]:
+    ) -> Optional[Document]:
         """
-        Load a single page as a list containing one Document.
+        Fetch and convert a single wiki page into a Document.
 
         Args:
-            resource_id: The page title.
-            resource_url: Pre-fetched canonical URL for the page.
-            last_modified: Pre-fetched last-modified timestamp (or None).
+            title: Page title.
+            url: Canonical URL for the page (may be None).
+            last_modified: Last-modified timestamp (may be None).
 
         Returns:
-            A one-element list with the page Document, or empty on failure.
-
+            A Document, or None if the page content could not be fetched.
         """
-        content = self._get_page_contents(resource_id)
+        content = self._get_page_contents(title)
         if not content:
-            return []
+            return None
 
-        content = self._html_to_clean_text(content)
-        doc = Document(
-            text=content,
-            id_=f"mediawiki:{resource_id}",
+        text = self._html_to_clean_text(content)
+        return Document(
+            text=text,
+            id_=f"mediawiki:{title}",
             metadata={
-                "title": resource_id,
-                "url": resource_url,
+                "title": title,
+                "url": url,
                 "last_modified": (last_modified.isoformat() if last_modified else None),
             },
         )
-        return [doc]
-
-    # -- Resource info (single page) ------------------------------------------
-
-    def get_resource_info(self, resource_id: str) -> Dict[str, Any]:
-        """
-        Return metadata for a single page (URL and last_modified).
-
-        Args:
-            resource_id: Page title.
-
-        Returns:
-            ``{"last_modified": datetime | None, "url": str | None}``.
-
-        """
-        try:
-            result = self.site.get(
-                "query",
-                titles=resource_id,
-                prop="info|revisions",
-                inprop="url",
-                rvprop="timestamp",
-            )
-        except mwclient.errors.APIError as exc:
-            self.logger.warning("Query API failed for '%s': %s", resource_id, exc)
-            return {"last_modified": None, "url": None}
-
-        pages = result.get("query", {}).get("pages", {})
-        page_data = next((p for p in pages.values() if p.get("title")), None)
-        last_modified = None
-        url = None
-        if page_data and "missing" not in page_data:
-            url = page_data.get("canonicalurl")
-            revisions = page_data.get("revisions", [])
-            if revisions:
-                ts_str = revisions[0].get("timestamp")
-                if ts_str:
-                    try:
-                        last_modified = datetime.fromisoformat(
-                            ts_str.replace("Z", "+00:00")
-                        )
-                    except (ValueError, TypeError):
-                        pass
-
-        return {"last_modified": last_modified, "url": url}
 
     # -- BasePydanticReader / BaseReader interface -----------------------------
 
@@ -383,22 +358,10 @@ class MediaWikiReader(BasePydanticReader):
         has no batch parse API; see class docstring for scale notes).
         """
         for page_record in self._get_all_pages_generator():
-            url = page_record.get("url")
-            if not url:
-                # API-based URL construction failed; use guaranteed fallback
-                # so we never drop content due to missing siteinfo.
-                safe_title = page_record["title"].replace(" ", "_")
-                url = (
-                    f"{self.scheme}://{self.host}{self.path}"
-                    f"index.php?title={safe_title}"
-                )
-                self.logger.debug(
-                    "Using fallback URL for %s",
-                    page_record["title"],
-                )
-            docs = self.load_resource(
-                page_record["title"],
-                resource_url=url,
+            doc = self._page_to_document(
+                title=page_record["title"],
+                url=page_record.get("url"),
                 last_modified=page_record.get("last_modified"),
             )
-            yield from docs
+            if doc is not None:
+                yield doc

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest==7.2.1",
+]
+
+[project]
+name = "llama-index-readers-mediawiki"
+version = "0.1.0"
+description = "LlamaIndex reader for MediaWiki instances"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.9,<4.0"
+authors = [{name = "WikiTeq"}]
+maintainers = [{name = "wikiteq"}]
+dependencies = [
+    "llama-index-core>=0.14,<0.15",
+    "mwclient>=0.11",
+    "html2text>=2024.2",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.9"
+
+[tool.llamahub]
+import_path = "llama_index.readers.mediawiki"
+contains_example = false
+
+[tool.llamahub.class_authors]
+MediaWikiReader = "wikiteq"

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "html2text>=2024.2",
 ]
 
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
 [tool.hatch.build.targets.sdist]
 include = ["llama_index/"]
 exclude = ["**/BUILD"]
@@ -30,20 +35,15 @@ exclude = ["**/BUILD"]
 include = ["llama_index/"]
 exclude = ["**/BUILD"]
 
-[tool.codespell]
-check-filenames = true
-check-hidden = true
-skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
-
-[tool.mypy]
-disallow_untyped_defs = true
-exclude = ["_static", "build", "examples", "notebooks", "venv"]
-ignore_missing_imports = true
-python_version = "3.9"
-
 [tool.llamahub]
 import_path = "llama_index.readers.mediawiki"
 contains_example = false
 
 [tool.llamahub.class_authors]
 MediaWikiReader = "wikiteq"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.9"

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -218,7 +218,7 @@ class TestGetAllPages:
         mock_site = _mock_site()
         mock_page = MagicMock()
         mock_page.name = "Page 1"
-        mock_page.revision = True
+        mock_page.revision = 98765
         mock_page.touched = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
         mock_site.allpages.return_value = [mock_page]
         mock_site_cls.return_value = mock_site
@@ -230,6 +230,7 @@ class TestGetAllPages:
         assert pages[0].title == "Page 1"
         assert pages[0].url == "https://example.com/wiki/Page_1"
         assert pages[0].last_modified.year == 2024
+        assert pages[0].revision == 98765
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_multiple_namespaces(self, mock_site_cls):

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -344,7 +344,7 @@ class TestGetPageContents:
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_success(self, mock_site_cls):
         mock_site = _mock_site()
-        mock_site.get.return_value = {"parse": {"text": {"*": "<p>Test page content.</p>"}}}
+        mock_site.post.return_value = {"parse": {"text": {"*": "<p>Test page content.</p>"}}}
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -353,7 +353,7 @@ class TestGetPageContents:
         assert result is not None
         assert "Test page content" in result
         assert "<p>" in result  # raw HTML
-        mock_site.get.assert_called_once_with(
+        mock_site.post.assert_called_once_with(
             "parse",
             page="Test Page",
             prop="text",
@@ -365,7 +365,7 @@ class TestGetPageContents:
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_empty_parse_result(self, mock_site_cls):
         mock_site = _mock_site()
-        mock_site.get.return_value = {}
+        mock_site.post.return_value = {}
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -376,7 +376,7 @@ class TestGetPageContents:
         import mwclient.errors
 
         mock_site = _mock_site()
-        mock_site.get.side_effect = mwclient.errors.APIError("error", "info", {})
+        mock_site.post.side_effect = mwclient.errors.APIError("error", "info", {})
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -442,7 +442,7 @@ class TestLazyLoadData:
         page.touched = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
         mock_site.allpages.return_value = [page]
 
-        mock_site.get.return_value = {"parse": {"text": {"*": "<p>Hello world</p>"}}}
+        mock_site.post.return_value = {"parse": {"text": {"*": "<p>Hello world</p>"}}}
 
         mock_site_cls.return_value = mock_site
 
@@ -482,7 +482,7 @@ class TestLazyLoadData:
         page_skip.touched = (2024, 1, 2, 12, 0, 0, 0, 0, 0)
 
         mock_site.allpages.return_value = [page_ok, page_skip]
-        mock_site.get.side_effect = [
+        mock_site.post.side_effect = [
             {"parse": {"text": {"*": "<p>Only this page has content</p>"}}},
             {},  # second page: no content
         ]

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -114,17 +114,17 @@ class TestSiteProperty:
 
 
 class TestLogin:
-    """Authentication via clientlogin."""
+    """Authentication via login (supports both user accounts and bot passwords)."""
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_login_calls_clientlogin(self, mock_site_cls):
+    def test_login_calls_login(self, mock_site_cls):
         mock_site = _mock_site()
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
         reader.login("testuser", "testpass")
 
-        mock_site.clientlogin.assert_called_once_with(
+        mock_site.login.assert_called_once_with(
             username="testuser", password="testpass"
         )
 
@@ -133,7 +133,7 @@ class TestLogin:
         import mwclient.errors
 
         mock_site = _mock_site()
-        mock_site.clientlogin.side_effect = mwclient.errors.LoginError(
+        mock_site.login.side_effect = mwclient.errors.LoginError(
             mock_site, "FAIL", "Bad credentials"
         )
         mock_site_cls.return_value = mock_site
@@ -151,7 +151,7 @@ class TestLogin:
         reader = _make_reader()
         reader.login("User@BotName", "bot-password-token")
 
-        mock_site.clientlogin.assert_called_once_with(
+        mock_site.login.assert_called_once_with(
             username="User@BotName", password="bot-password-token"
         )
 
@@ -183,13 +183,14 @@ class TestGetContentNamespaceIds:
         assert ids == [0, 4]
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_defaults_to_zero_on_empty(self, mock_site_cls):
+    def test_raises_on_empty(self, mock_site_cls):
         mock_site = _mock_site()
         mock_site.get.return_value = {"query": {"namespaces": {}}}
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
-        assert reader._get_content_namespace_ids() == [0]
+        with pytest.raises(RuntimeError, match="No content namespaces"):
+            reader._get_content_namespace_ids()
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_raises_on_api_error(self, mock_site_cls):
@@ -226,9 +227,9 @@ class TestGetAllPages:
         pages = list(reader._get_all_pages_generator())
 
         assert len(pages) == 1
-        assert pages[0]["title"] == "Page 1"
-        assert pages[0]["url"] == "https://example.com/wiki/Page_1"
-        assert pages[0]["last_modified"].year == 2024
+        assert pages[0].title == "Page 1"
+        assert pages[0].url == "https://example.com/wiki/Page_1"
+        assert pages[0].last_modified.year == 2024
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_multiple_namespaces(self, mock_site_cls):
@@ -250,8 +251,8 @@ class TestGetAllPages:
         pages = list(reader._get_all_pages_generator())
 
         assert len(pages) == 2
-        assert pages[0]["title"] == "Main Page"
-        assert pages[1]["title"] == "Project:About"
+        assert pages[0].title == "Main Page"
+        assert pages[1].title == "Project:About"
         assert mock_site.allpages.call_count == 2
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
@@ -312,7 +313,7 @@ class TestGetAllPages:
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader(namespaces=[0])
-        with pytest.raises(RuntimeError, match="site URL base"):
+        with pytest.raises(RuntimeError, match="base URL from siteinfo"):
             list(reader._get_all_pages_generator())
 
 
@@ -410,7 +411,7 @@ class TestHtmlToCleanText:
     @patch("llama_index.readers.mediawiki.base.html2text.HTML2Text")
     def test_fallback_when_html2text_raises(self, mock_html2text_cls):
         """When html2text raises, fallback strips tags with regex and normalizes space."""
-        mock_html2text_cls.return_value.handle.side_effect = RuntimeError(
+        mock_html2text_cls.return_value.handle.side_effect = ValueError(
             "html2text fail"
         )
         result = MediaWikiReader._html_to_clean_text("<p>Hello</p> <b>world</b>")
@@ -463,7 +464,7 @@ class TestLazyLoadData:
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader(host="wiki.example.com", namespaces=[0])
-        with pytest.raises(RuntimeError, match="site URL base"):
+        with pytest.raises(RuntimeError, match="base URL from siteinfo"):
             list(reader.lazy_load_data())
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, Mock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -13,6 +13,7 @@ from llama_index.readers.mediawiki import MediaWikiReader
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_reader(**overrides):
     """Create a MediaWikiReader with sensible defaults (mwclient.Site is mocked)."""
@@ -34,6 +35,7 @@ def _mock_site():
 # ---------------------------------------------------------------------------
 # Construction & Config
 # ---------------------------------------------------------------------------
+
 
 class TestMediaWikiReaderInit:
     """Construction and config validation."""
@@ -79,6 +81,7 @@ class TestMediaWikiReaderInit:
 # Site property (lazy creation)
 # ---------------------------------------------------------------------------
 
+
 class TestSiteProperty:
     """The .site property lazily creates an mwclient.Site."""
 
@@ -89,9 +92,7 @@ class TestSiteProperty:
 
         _ = reader.site
 
-        mock_site_cls.assert_called_once_with(
-            "example.com", path="/w/", scheme="https"
-        )
+        mock_site_cls.assert_called_once_with("example.com", path="/w/", scheme="https")
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_returns_same_instance(self, mock_site_cls):
@@ -105,6 +106,7 @@ class TestSiteProperty:
 # ---------------------------------------------------------------------------
 # Login
 # ---------------------------------------------------------------------------
+
 
 class TestLogin:
     """Authentication via clientlogin."""
@@ -153,6 +155,7 @@ class TestLogin:
 # Content namespace discovery
 # ---------------------------------------------------------------------------
 
+
 class TestFetchContentNamespaceIds:
     """_fetch_content_namespace_ids filters namespaces for content=True."""
 
@@ -188,9 +191,7 @@ class TestFetchContentNamespaceIds:
         import mwclient.errors
 
         mock_site = _mock_site()
-        mock_site.get.side_effect = mwclient.errors.APIError(
-            "error", "info", {}
-        )
+        mock_site.get.side_effect = mwclient.errors.APIError("error", "info", {})
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -200,6 +201,7 @@ class TestFetchContentNamespaceIds:
 # ---------------------------------------------------------------------------
 # All-pages generator
 # ---------------------------------------------------------------------------
+
 
 class TestGetAllPages:
     """Page listing via mwclient's allpages."""
@@ -300,6 +302,7 @@ class TestGetAllPages:
 # URL building
 # ---------------------------------------------------------------------------
 
+
 class TestBuildPageUrl:
     """_build_page_url builds canonical URLs from title and site base."""
 
@@ -316,15 +319,14 @@ class TestBuildPageUrl:
 # Page content retrieval
 # ---------------------------------------------------------------------------
 
+
 class TestGetPageContents:
     """Content retrieval via Site.parse()."""
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_success(self, mock_site_cls):
         mock_site = _mock_site()
-        mock_site.parse.return_value = {
-            "text": {"*": "<p>Test page content.</p>"}
-        }
+        mock_site.parse.return_value = {"text": {"*": "<p>Test page content.</p>"}}
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -349,9 +351,7 @@ class TestGetPageContents:
         import mwclient.errors
 
         mock_site = _mock_site()
-        mock_site.parse.side_effect = mwclient.errors.APIError(
-            "error", "info", {}
-        )
+        mock_site.parse.side_effect = mwclient.errors.APIError("error", "info", {})
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -362,13 +362,12 @@ class TestGetPageContents:
 # HTML-to-text conversion
 # ---------------------------------------------------------------------------
 
+
 class TestHtmlToCleanText:
     """HTML-to-text conversion (no mocking needed)."""
 
     def test_basic_html(self):
-        result = MediaWikiReader._html_to_clean_text(
-            "<p>Hello <b>world</b></p>"
-        )
+        result = MediaWikiReader._html_to_clean_text("<p>Hello <b>world</b></p>")
         assert "Hello" in result
         assert "world" in result
 
@@ -386,7 +385,9 @@ class TestHtmlToCleanText:
     @patch("llama_index.readers.mediawiki.base.html2text.HTML2Text")
     def test_fallback_when_html2text_raises(self, mock_html2text_cls):
         """When html2text raises, fallback strips tags with regex and normalizes space."""
-        mock_html2text_cls.return_value.handle.side_effect = RuntimeError("html2text fail")
+        mock_html2text_cls.return_value.handle.side_effect = RuntimeError(
+            "html2text fail"
+        )
         result = MediaWikiReader._html_to_clean_text("<p>Hello</p> <b>world</b>")
         assert result == "Hello world"
 
@@ -401,6 +402,7 @@ class TestHtmlToCleanText:
 # ---------------------------------------------------------------------------
 # Resource interface
 # ---------------------------------------------------------------------------
+
 
 class TestResourcesInterface:
     """Public resource-based API."""
@@ -465,9 +467,7 @@ class TestResourcesInterface:
                         "pageid": 123,
                         "title": "Page",
                         "canonicalurl": "https://example.com/wiki/Page",
-                        "revisions": [
-                            {"timestamp": "2024-06-01T00:00:00Z"}
-                        ],
+                        "revisions": [{"timestamp": "2024-06-01T00:00:00Z"}],
                     }
                 }
             }
@@ -535,9 +535,7 @@ class TestResourcesInterface:
         import mwclient.errors
 
         mock_site = _mock_site()
-        mock_site.get.side_effect = mwclient.errors.APIError(
-            "query-error", "code", {}
-        )
+        mock_site.get.side_effect = mwclient.errors.APIError("query-error", "code", {})
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -550,6 +548,7 @@ class TestResourcesInterface:
 # ---------------------------------------------------------------------------
 # lazy_load_data
 # ---------------------------------------------------------------------------
+
 
 class TestLazyLoadData:
     """End-to-end integration via lazy_load_data."""
@@ -566,9 +565,7 @@ class TestLazyLoadData:
         mock_site.allpages.return_value = [page]
 
         # parse returns HTML
-        mock_site.parse.return_value = {
-            "text": {"*": "<p>Hello world</p>"}
-        }
+        mock_site.parse.return_value = {"text": {"*": "<p>Hello world</p>"}}
 
         mock_site_cls.return_value = mock_site
 

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -47,6 +47,11 @@ class TestMediaWikiReaderInit:
         assert "BaseReader" in names_of_base_classes
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_is_remote(self, _mock_site_cls):
+        reader = _make_reader()
+        assert reader.is_remote is True
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_missing_host_raises(self, _mock_site_cls):
         with pytest.raises(ValidationError, match="host"):
             MediaWikiReader(host="")
@@ -69,6 +74,7 @@ class TestMediaWikiReaderInit:
         assert reader.scheme == "https"
         assert reader.page_limit == 500
         assert reader.namespaces is None
+        assert reader.filter_redirects is True
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_logger_injection(self, _mock_site_cls):
@@ -156,8 +162,8 @@ class TestLogin:
 # ---------------------------------------------------------------------------
 
 
-class TestFetchContentNamespaceIds:
-    """_fetch_content_namespace_ids filters namespaces for content=True."""
+class TestGetContentNamespaceIds:
+    """_get_content_namespace_ids filters namespaces for content flag."""
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_filters_content_namespaces(self, mock_site_cls):
@@ -174,7 +180,7 @@ class TestFetchContentNamespaceIds:
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
-        ids = reader._fetch_content_namespace_ids()
+        ids = reader._get_content_namespace_ids()
         assert ids == [0, 4]
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
@@ -184,10 +190,10 @@ class TestFetchContentNamespaceIds:
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
-        assert reader._fetch_content_namespace_ids() == [0]
+        assert reader._get_content_namespace_ids() == [0]
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_defaults_to_zero_on_api_error(self, mock_site_cls):
+    def test_raises_on_api_error(self, mock_site_cls):
         import mwclient.errors
 
         mock_site = _mock_site()
@@ -195,7 +201,8 @@ class TestFetchContentNamespaceIds:
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
-        assert reader._fetch_content_namespace_ids() == [0]
+        with pytest.raises(mwclient.errors.APIError):
+            reader._get_content_namespace_ids()
 
 
 # ---------------------------------------------------------------------------
@@ -273,29 +280,41 @@ class TestGetAllPages:
         assert len(pages) == 1
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_content_ns_cache(self, mock_site_cls):
-        """Content namespace IDs are cached after first call."""
+    def test_filter_redirects_default(self, mock_site_cls):
+        """filterredir='nonredirects' is passed by default."""
         mock_site = _mock_site()
-        mock_site.get.return_value = {
-            "query": {
-                "namespaces": {
-                    "0": {"id": 0, "*": "", "content": True},
-                }
-            }
-        }
-        page = MagicMock()
-        page.name = "A"
-        page.revision = True
-        page.last_rev_time = (2024, 1, 1, 0, 0, 0, 0, 0, 0)
-        mock_site.allpages.return_value = [page]
+        mock_site.allpages.return_value = []
         mock_site_cls.return_value = mock_site
 
-        reader = _make_reader(namespaces=None)
-        list(reader._get_all_pages_generator())
+        reader = _make_reader(namespaces=[0])
         list(reader._get_all_pages_generator())
 
-        # siteinfo should be called only once
-        assert mock_site.get.call_count == 1
+        call_kwargs = mock_site.allpages.call_args.kwargs
+        assert call_kwargs.get("filterredir") == "nonredirects"
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_filter_redirects_disabled(self, mock_site_cls):
+        """filterredir='all' is passed when filter_redirects=False."""
+        mock_site = _mock_site()
+        mock_site.allpages.return_value = []
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=[0], filter_redirects=False)
+        list(reader._get_all_pages_generator())
+
+        call_kwargs = mock_site.allpages.call_args.kwargs
+        assert call_kwargs.get("filterredir") == "all"
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_raises_when_siteinfo_base_missing(self, mock_site_cls):
+        """RuntimeError is raised when siteinfo has no base URL."""
+        mock_site = _mock_site()
+        mock_site.site = {}  # no "base" key
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=[0])
+        with pytest.raises(RuntimeError, match="site URL base"):
+            list(reader._get_all_pages_generator())
 
 
 # ---------------------------------------------------------------------------
@@ -335,7 +354,13 @@ class TestGetPageContents:
         assert result is not None
         assert "Test page content" in result
         assert "<p>" in result  # raw HTML
-        mock_site.parse.assert_called_once_with(page="Test Page", prop="text")
+        mock_site.parse.assert_called_once_with(
+            page="Test Page",
+            prop="text",
+            disablelimitreport=True,
+            disableeditsection=True,
+            disabletoc=True,
+        )
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_empty_parse_result(self, mock_site_cls):
@@ -400,152 +425,6 @@ class TestHtmlToCleanText:
 
 
 # ---------------------------------------------------------------------------
-# Resource interface
-# ---------------------------------------------------------------------------
-
-
-class TestResourcesInterface:
-    """Public resource-based API."""
-
-    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_load_resource(self, mock_site_cls):
-        mock_site = _mock_site()
-        mock_site.parse.return_value = {"text": {"*": "<p>Content</p>"}}
-        mock_site_cls.return_value = mock_site
-
-        reader = _make_reader()
-        timestamp = datetime(2024, 2, 1, 10, 0, 0, tzinfo=timezone.utc)
-        docs = reader.load_resource(
-            "P", resource_url="https://wiki.com/P", last_modified=timestamp
-        )
-
-        assert len(docs) == 1
-        assert docs[0].text == "Content"
-        assert docs[0].metadata["url"] == "https://wiki.com/P"
-        assert docs[0].metadata["last_modified"] == timestamp.isoformat()
-        mock_site.parse.assert_called_once()
-
-    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_load_resource_missing_page(self, mock_site_cls):
-        mock_site = _mock_site()
-        mock_site.parse.return_value = {}
-        mock_site_cls.return_value = mock_site
-
-        reader = _make_reader()
-        docs = reader.load_resource(
-            "Missing",
-            resource_url="https://example.com/wiki/Missing",
-            last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        )
-        assert docs == []
-
-    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_load_resource_last_modified_none(self, mock_site_cls):
-        """When last_modified is None, metadata["last_modified"] is None."""
-        mock_site = _mock_site()
-        mock_site.parse.return_value = {"text": {"*": "<p>Content</p>"}}
-        mock_site_cls.return_value = mock_site
-
-        reader = _make_reader()
-        docs = reader.load_resource(
-            "SomePage",
-            resource_url="https://example.com/wiki/SomePage",
-            last_modified=None,
-        )
-
-        assert len(docs) == 1
-        assert docs[0].metadata["last_modified"] is None
-        assert docs[0].metadata["url"] == "https://example.com/wiki/SomePage"
-
-    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_get_resource_info(self, mock_site_cls):
-        mock_site = _mock_site()
-        mock_site.get.return_value = {
-            "query": {
-                "pages": {
-                    "123": {
-                        "pageid": 123,
-                        "title": "Page",
-                        "canonicalurl": "https://example.com/wiki/Page",
-                        "revisions": [{"timestamp": "2024-06-01T00:00:00Z"}],
-                    }
-                }
-            }
-        }
-        mock_site_cls.return_value = mock_site
-
-        reader = _make_reader()
-        info = reader.get_resource_info("Page")
-
-        assert info["url"] == "https://example.com/wiki/Page"
-        assert info["last_modified"] is not None
-        assert info["last_modified"].year == 2024
-        mock_site.get.assert_called_once()
-
-    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_get_resource_info_empty_revisions(self, mock_site_cls):
-        """When page exists but revisions list is empty, last_modified is None."""
-        mock_site = _mock_site()
-        mock_site.get.return_value = {
-            "query": {
-                "pages": {
-                    "1": {
-                        "pageid": 1,
-                        "title": "Page",
-                        "canonicalurl": "https://example.com/wiki/Page",
-                        "revisions": [],
-                    }
-                }
-            }
-        }
-        mock_site_cls.return_value = mock_site
-
-        reader = _make_reader()
-        info = reader.get_resource_info("Page")
-
-        assert info["url"] == "https://example.com/wiki/Page"
-        assert info["last_modified"] is None
-
-    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_get_resource_info_missing_page(self, mock_site_cls):
-        """When the page does not exist, API returns 'missing'; url and last_modified are None."""
-        mock_site = _mock_site()
-        mock_site.get.return_value = {
-            "query": {
-                "pages": {
-                    "-1": {
-                        "ns": 0,
-                        "title": "NonExistent",
-                        "missing": "",
-                    }
-                }
-            }
-        }
-        mock_site_cls.return_value = mock_site
-
-        reader = _make_reader()
-        info = reader.get_resource_info("NonExistent")
-
-        assert info["url"] is None
-        assert info["last_modified"] is None
-
-    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_get_resource_info_api_error(self, mock_site_cls):
-        """When site.get raises APIError, return url and last_modified as None."""
-        import mwclient.errors
-
-        mock_site = _mock_site()
-        mock_site.get.side_effect = mwclient.errors.APIError("query-error", "code", {})
-        mock_site_cls.return_value = mock_site
-
-        reader = _make_reader()
-        info = reader.get_resource_info("Any")
-
-        assert info["url"] is None
-        assert info["last_modified"] is None
-
-
-# ---------------------------------------------------------------------------
 # lazy_load_data
 # ---------------------------------------------------------------------------
 
@@ -557,14 +436,12 @@ class TestLazyLoadData:
     def test_yields_documents(self, mock_site_cls):
         mock_site = _mock_site()
 
-        # allpages returns mwclient Page objects
         page = MagicMock()
         page.name = "Test Page"
         page.revision = True
         page.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
         mock_site.allpages.return_value = [page]
 
-        # parse returns HTML
         mock_site.parse.return_value = {"text": {"*": "<p>Hello world</p>"}}
 
         mock_site_cls.return_value = mock_site
@@ -578,27 +455,16 @@ class TestLazyLoadData:
         assert "example.com" in docs[0].metadata["url"]
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
-    def test_uses_fallback_url_when_siteinfo_has_no_base(self, mock_site_cls):
-        """When siteinfo has no base URL, lazy_load_data uses scheme/host/path fallback."""
+    def test_raises_when_siteinfo_base_missing(self, mock_site_cls):
+        """When siteinfo has no base URL, lazy_load_data raises RuntimeError."""
         mock_site = _mock_site()
-        mock_site.site = {}  # no "base" -> url_base is None in generator
-        page = MagicMock()
-        page.name = "NoURL Page"
-        page.revision = True
-        page.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
-        mock_site.allpages.return_value = [page]
-        mock_site.parse.return_value = {"text": {"*": "<p>Content</p>"}}
+        mock_site.site = {}  # no "base"
+        mock_site.allpages.return_value = []
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader(host="wiki.example.com", namespaces=[0])
-        docs = list(reader.lazy_load_data())
-
-        assert len(docs) == 1
-        assert docs[0].metadata["title"] == "NoURL Page"
-        # Fallback URL from reader config
-        assert docs[0].metadata["url"] == (
-            "https://wiki.example.com/w/index.php?title=NoURL_Page"
-        )
+        with pytest.raises(RuntimeError, match="site URL base"):
+            list(reader.lazy_load_data())
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_skips_page_when_get_page_contents_returns_none(self, mock_site_cls):
@@ -618,7 +484,7 @@ class TestLazyLoadData:
         mock_site.allpages.return_value = [page_ok, page_skip]
         mock_site.parse.side_effect = [
             {"text": {"*": "<p>Only this page has content</p>"}},
-            {},  # second page: no content -> load_resource returns []
+            {},  # second page: no content
         ]
         mock_site_cls.return_value = mock_site
 

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -1,0 +1,633 @@
+"""Tests for MediaWikiReader (mwclient-backed version)."""
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, Mock, patch, PropertyMock
+
+import pytest
+from pydantic import ValidationError
+
+from llama_index.readers.mediawiki import MediaWikiReader
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_reader(**overrides):
+    """Create a MediaWikiReader with sensible defaults (mwclient.Site is mocked)."""
+    kwargs = {"host": "example.com"}
+    kwargs.update(overrides)
+    return MediaWikiReader(**kwargs)
+
+
+def _mock_site():
+    """Create a mock mwclient.Site."""
+    site = MagicMock()
+    site.site = {
+        "base": "https://example.com/wiki/Main_Page",
+        "articlepath": "/wiki/$1",
+    }
+    return site
+
+
+# ---------------------------------------------------------------------------
+# Construction & Config
+# ---------------------------------------------------------------------------
+
+class TestMediaWikiReaderInit:
+    """Construction and config validation."""
+
+    def test_class(self):
+        """MediaWikiReader must inherit from the LlamaIndex base reader."""
+        names_of_base_classes = [b.__name__ for b in MediaWikiReader.__mro__]
+        assert "BasePydanticReader" in names_of_base_classes
+        assert "BaseReader" in names_of_base_classes
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_missing_host_raises(self, _mock_site_cls):
+        with pytest.raises(ValidationError, match="host"):
+            MediaWikiReader(host="")
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_zero_page_limit_raises(self, _mock_site_cls):
+        with pytest.raises(ValidationError, match="page_limit"):
+            _make_reader(page_limit=0)
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_negative_page_limit_raises(self, _mock_site_cls):
+        with pytest.raises(ValidationError, match="page_limit"):
+            _make_reader(page_limit=-1)
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_defaults(self, _mock_site_cls):
+        reader = _make_reader()
+        assert reader.host == "example.com"
+        assert reader.path == "/w/"
+        assert reader.scheme == "https"
+        assert reader.page_limit == 500
+        assert reader.namespaces is None
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_logger_injection(self, _mock_site_cls):
+        custom = logging.getLogger("custom.mediawiki")
+        reader = _make_reader(logger=custom)
+        assert reader.logger is custom
+
+
+# ---------------------------------------------------------------------------
+# Site property (lazy creation)
+# ---------------------------------------------------------------------------
+
+class TestSiteProperty:
+    """The .site property lazily creates an mwclient.Site."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_creates_site_lazily(self, mock_site_cls):
+        reader = _make_reader()
+        mock_site_cls.assert_not_called()
+
+        _ = reader.site
+
+        mock_site_cls.assert_called_once_with(
+            "example.com", path="/w/", scheme="https"
+        )
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_returns_same_instance(self, mock_site_cls):
+        reader = _make_reader()
+        site1 = reader.site
+        site2 = reader.site
+        assert site1 is site2
+        assert mock_site_cls.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Login
+# ---------------------------------------------------------------------------
+
+class TestLogin:
+    """Authentication via clientlogin."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_login_calls_clientlogin(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        reader.login("testuser", "testpass")
+
+        mock_site.clientlogin.assert_called_once_with(
+            username="testuser", password="testpass"
+        )
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_login_failure_raises(self, mock_site_cls):
+        import mwclient.errors
+
+        mock_site = _mock_site()
+        mock_site.clientlogin.side_effect = mwclient.errors.LoginError(
+            mock_site, "FAIL", "Bad credentials"
+        )
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        with pytest.raises(mwclient.errors.LoginError):
+            reader.login("bad", "creds")
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_login_with_bot_password_format(self, mock_site_cls):
+        """Bot password uses User@BotName as username; passes through to mwclient."""
+        mock_site = _mock_site()
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        reader.login("User@BotName", "bot-password-token")
+
+        mock_site.clientlogin.assert_called_once_with(
+            username="User@BotName", password="bot-password-token"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Content namespace discovery
+# ---------------------------------------------------------------------------
+
+class TestFetchContentNamespaceIds:
+    """_fetch_content_namespace_ids filters namespaces for content=True."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_filters_content_namespaces(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site.get.return_value = {
+            "query": {
+                "namespaces": {
+                    "0": {"id": 0, "*": "", "content": True},
+                    "1": {"id": 1, "*": "Talk", "content": False},
+                    "4": {"id": 4, "*": "Project", "content": True},
+                }
+            }
+        }
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        ids = reader._fetch_content_namespace_ids()
+        assert ids == [0, 4]
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_defaults_to_zero_on_empty(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site.get.return_value = {"query": {"namespaces": {}}}
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        assert reader._fetch_content_namespace_ids() == [0]
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_defaults_to_zero_on_api_error(self, mock_site_cls):
+        import mwclient.errors
+
+        mock_site = _mock_site()
+        mock_site.get.side_effect = mwclient.errors.APIError(
+            "error", "info", {}
+        )
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        assert reader._fetch_content_namespace_ids() == [0]
+
+
+# ---------------------------------------------------------------------------
+# All-pages generator
+# ---------------------------------------------------------------------------
+
+class TestGetAllPages:
+    """Page listing via mwclient's allpages."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_iterates_pages(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_page = MagicMock()
+        mock_page.name = "Page 1"
+        mock_page.revision = True
+        mock_page.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+        mock_site.allpages.return_value = [mock_page]
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=[0])
+        pages = list(reader._get_all_pages_generator())
+
+        assert len(pages) == 1
+        assert pages[0]["title"] == "Page 1"
+        assert pages[0]["url"] == "https://example.com/wiki/Page_1"
+        assert pages[0]["last_modified"].year == 2024
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_multiple_namespaces(self, mock_site_cls):
+        mock_site = _mock_site()
+        page_ns0 = MagicMock()
+        page_ns0.name = "Main Page"
+        page_ns0.revision = True
+        page_ns0.last_rev_time = (2024, 1, 1, 0, 0, 0, 0, 0, 0)
+
+        page_ns4 = MagicMock()
+        page_ns4.name = "Project:About"
+        page_ns4.revision = True
+        page_ns4.last_rev_time = (2024, 2, 1, 0, 0, 0, 0, 0, 0)
+
+        mock_site.allpages.side_effect = [[page_ns0], [page_ns4]]
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=[0, 4])
+        pages = list(reader._get_all_pages_generator())
+
+        assert len(pages) == 2
+        assert pages[0]["title"] == "Main Page"
+        assert pages[1]["title"] == "Project:About"
+        assert mock_site.allpages.call_count == 2
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_auto_discovers_content_namespaces(self, mock_site_cls):
+        """When namespaces is None, calls siteinfo to find content namespaces."""
+        mock_site = _mock_site()
+        mock_site.get.return_value = {
+            "query": {
+                "namespaces": {
+                    "0": {"id": 0, "*": "", "content": True},
+                }
+            }
+        }
+        page = MagicMock()
+        page.name = "Test"
+        page.revision = True
+        page.last_rev_time = (2024, 6, 1, 0, 0, 0, 0, 0, 0)
+        mock_site.allpages.return_value = [page]
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=None)
+        pages = list(reader._get_all_pages_generator())
+
+        mock_site.get.assert_called_once()
+        assert len(pages) == 1
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_content_ns_cache(self, mock_site_cls):
+        """Content namespace IDs are cached after first call."""
+        mock_site = _mock_site()
+        mock_site.get.return_value = {
+            "query": {
+                "namespaces": {
+                    "0": {"id": 0, "*": "", "content": True},
+                }
+            }
+        }
+        page = MagicMock()
+        page.name = "A"
+        page.revision = True
+        page.last_rev_time = (2024, 1, 1, 0, 0, 0, 0, 0, 0)
+        mock_site.allpages.return_value = [page]
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=None)
+        list(reader._get_all_pages_generator())
+        list(reader._get_all_pages_generator())
+
+        # siteinfo should be called only once
+        assert mock_site.get.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# URL building
+# ---------------------------------------------------------------------------
+
+class TestBuildPageUrl:
+    """_build_page_url builds canonical URLs from title and site base."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_special_characters_in_title(self, _mock_site_cls):
+        """Titles with & and spaces are normalized (spaces to underscores)."""
+        reader = _make_reader()
+        url_base = ("https://example.com", "/wiki/$1")
+        result = reader._build_page_url("Page & FAQ", url_base)
+        assert result == "https://example.com/wiki/Page_&_FAQ"
+
+
+# ---------------------------------------------------------------------------
+# Page content retrieval
+# ---------------------------------------------------------------------------
+
+class TestGetPageContents:
+    """Content retrieval via Site.parse()."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_success(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site.parse.return_value = {
+            "text": {"*": "<p>Test page content.</p>"}
+        }
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        result = reader._get_page_contents("Test Page")
+
+        assert result is not None
+        assert "Test page content" in result
+        assert "<p>" in result  # raw HTML
+        mock_site.parse.assert_called_once_with(page="Test Page", prop="text")
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_empty_parse_result(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site.parse.return_value = {}
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        assert reader._get_page_contents("Missing") is None
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_api_error_returns_none(self, mock_site_cls):
+        import mwclient.errors
+
+        mock_site = _mock_site()
+        mock_site.parse.side_effect = mwclient.errors.APIError(
+            "error", "info", {}
+        )
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        assert reader._get_page_contents("Broken") is None
+
+
+# ---------------------------------------------------------------------------
+# HTML-to-text conversion
+# ---------------------------------------------------------------------------
+
+class TestHtmlToCleanText:
+    """HTML-to-text conversion (no mocking needed)."""
+
+    def test_basic_html(self):
+        result = MediaWikiReader._html_to_clean_text(
+            "<p>Hello <b>world</b></p>"
+        )
+        assert "Hello" in result
+        assert "world" in result
+
+    def test_preserves_structure(self):
+        html = (
+            "<h1>Title</h1>"
+            "<p>Paragraph with <em>emphasis</em> and <strong>strong</strong>.</p>"
+            "<ul><li>Item 1</li><li>Item 2</li></ul>"
+        )
+        result = MediaWikiReader._html_to_clean_text(html)
+        assert "Title" in result
+        assert "Item 1" in result
+        assert "Item 2" in result
+
+    @patch("llama_index.readers.mediawiki.base.html2text.HTML2Text")
+    def test_fallback_when_html2text_raises(self, mock_html2text_cls):
+        """When html2text raises, fallback strips tags with regex and normalizes space."""
+        mock_html2text_cls.return_value.handle.side_effect = RuntimeError("html2text fail")
+        result = MediaWikiReader._html_to_clean_text("<p>Hello</p> <b>world</b>")
+        assert result == "Hello world"
+
+    def test_deeply_nested_malformed_html(self):
+        """Deeply nested or malformed HTML is handled by html2text or tag-strip fallback."""
+        html = "<div><div><p>Nested <span>text</span></p></div>"
+        result = MediaWikiReader._html_to_clean_text(html)
+        assert "Nested" in result
+        assert "text" in result
+
+
+# ---------------------------------------------------------------------------
+# Resource interface
+# ---------------------------------------------------------------------------
+
+class TestResourcesInterface:
+    """Public resource-based API."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_load_resource(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site.parse.return_value = {"text": {"*": "<p>Content</p>"}}
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        timestamp = datetime(2024, 2, 1, 10, 0, 0, tzinfo=timezone.utc)
+        docs = reader.load_resource(
+            "P", resource_url="https://wiki.com/P", last_modified=timestamp
+        )
+
+        assert len(docs) == 1
+        assert docs[0].text == "Content"
+        assert docs[0].metadata["url"] == "https://wiki.com/P"
+        assert docs[0].metadata["last_modified"] == timestamp.isoformat()
+        mock_site.parse.assert_called_once()
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_load_resource_missing_page(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site.parse.return_value = {}
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        docs = reader.load_resource(
+            "Missing",
+            resource_url="https://example.com/wiki/Missing",
+            last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        assert docs == []
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_load_resource_last_modified_none(self, mock_site_cls):
+        """When last_modified is None, metadata["last_modified"] is None."""
+        mock_site = _mock_site()
+        mock_site.parse.return_value = {"text": {"*": "<p>Content</p>"}}
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        docs = reader.load_resource(
+            "SomePage",
+            resource_url="https://example.com/wiki/SomePage",
+            last_modified=None,
+        )
+
+        assert len(docs) == 1
+        assert docs[0].metadata["last_modified"] is None
+        assert docs[0].metadata["url"] == "https://example.com/wiki/SomePage"
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_get_resource_info(self, mock_site_cls):
+        mock_site = _mock_site()
+        mock_site.get.return_value = {
+            "query": {
+                "pages": {
+                    "123": {
+                        "pageid": 123,
+                        "title": "Page",
+                        "canonicalurl": "https://example.com/wiki/Page",
+                        "revisions": [
+                            {"timestamp": "2024-06-01T00:00:00Z"}
+                        ],
+                    }
+                }
+            }
+        }
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        info = reader.get_resource_info("Page")
+
+        assert info["url"] == "https://example.com/wiki/Page"
+        assert info["last_modified"] is not None
+        assert info["last_modified"].year == 2024
+        mock_site.get.assert_called_once()
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_get_resource_info_empty_revisions(self, mock_site_cls):
+        """When page exists but revisions list is empty, last_modified is None."""
+        mock_site = _mock_site()
+        mock_site.get.return_value = {
+            "query": {
+                "pages": {
+                    "1": {
+                        "pageid": 1,
+                        "title": "Page",
+                        "canonicalurl": "https://example.com/wiki/Page",
+                        "revisions": [],
+                    }
+                }
+            }
+        }
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        info = reader.get_resource_info("Page")
+
+        assert info["url"] == "https://example.com/wiki/Page"
+        assert info["last_modified"] is None
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_get_resource_info_missing_page(self, mock_site_cls):
+        """When the page does not exist, API returns 'missing'; url and last_modified are None."""
+        mock_site = _mock_site()
+        mock_site.get.return_value = {
+            "query": {
+                "pages": {
+                    "-1": {
+                        "ns": 0,
+                        "title": "NonExistent",
+                        "missing": "",
+                    }
+                }
+            }
+        }
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        info = reader.get_resource_info("NonExistent")
+
+        assert info["url"] is None
+        assert info["last_modified"] is None
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_get_resource_info_api_error(self, mock_site_cls):
+        """When site.get raises APIError, return url and last_modified as None."""
+        import mwclient.errors
+
+        mock_site = _mock_site()
+        mock_site.get.side_effect = mwclient.errors.APIError(
+            "query-error", "code", {}
+        )
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader()
+        info = reader.get_resource_info("Any")
+
+        assert info["url"] is None
+        assert info["last_modified"] is None
+
+
+# ---------------------------------------------------------------------------
+# lazy_load_data
+# ---------------------------------------------------------------------------
+
+class TestLazyLoadData:
+    """End-to-end integration via lazy_load_data."""
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_yields_documents(self, mock_site_cls):
+        mock_site = _mock_site()
+
+        # allpages returns mwclient Page objects
+        page = MagicMock()
+        page.name = "Test Page"
+        page.revision = True
+        page.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+        mock_site.allpages.return_value = [page]
+
+        # parse returns HTML
+        mock_site.parse.return_value = {
+            "text": {"*": "<p>Hello world</p>"}
+        }
+
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=[0])
+        docs = list(reader.lazy_load_data())
+
+        assert len(docs) == 1
+        assert "Hello world" in docs[0].text
+        assert docs[0].metadata["title"] == "Test Page"
+        assert "example.com" in docs[0].metadata["url"]
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_uses_fallback_url_when_siteinfo_has_no_base(self, mock_site_cls):
+        """When siteinfo has no base URL, lazy_load_data uses scheme/host/path fallback."""
+        mock_site = _mock_site()
+        mock_site.site = {}  # no "base" -> url_base is None in generator
+        page = MagicMock()
+        page.name = "NoURL Page"
+        page.revision = True
+        page.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+        mock_site.allpages.return_value = [page]
+        mock_site.parse.return_value = {"text": {"*": "<p>Content</p>"}}
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(host="wiki.example.com", namespaces=[0])
+        docs = list(reader.lazy_load_data())
+
+        assert len(docs) == 1
+        assert docs[0].metadata["title"] == "NoURL Page"
+        # Fallback URL from reader config
+        assert docs[0].metadata["url"] == (
+            "https://wiki.example.com/w/index.php?title=NoURL_Page"
+        )
+
+    @patch("llama_index.readers.mediawiki.base.mwclient.Site")
+    def test_skips_page_when_get_page_contents_returns_none(self, mock_site_cls):
+        """When _get_page_contents returns None for a page, no document is yielded for it."""
+        mock_site = _mock_site()
+
+        page_ok = MagicMock()
+        page_ok.name = "PageWithContent"
+        page_ok.revision = True
+        page_ok.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+
+        page_skip = MagicMock()
+        page_skip.name = "PageWithoutContent"
+        page_skip.revision = True
+        page_skip.last_rev_time = (2024, 1, 2, 12, 0, 0, 0, 0, 0)
+
+        mock_site.allpages.return_value = [page_ok, page_skip]
+        mock_site.parse.side_effect = [
+            {"text": {"*": "<p>Only this page has content</p>"}},
+            {},  # second page: no content -> load_resource returns []
+        ]
+        mock_site_cls.return_value = mock_site
+
+        reader = _make_reader(namespaces=[0])
+        docs = list(reader.lazy_load_data())
+
+        assert len(docs) == 1
+        assert docs[0].metadata["title"] == "PageWithContent"
+        assert "Only this page has content" in docs[0].text

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -441,6 +441,8 @@ class TestLazyLoadData:
         page.name = "Test Page"
         page.revision = True
         page.touched = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+        page.pageid = 42
+        page.namespace = 0
         mock_site.allpages.return_value = [page]
 
         mock_site.post.return_value = {"parse": {"text": {"*": "<p>Hello world</p>"}}}
@@ -454,6 +456,8 @@ class TestLazyLoadData:
         assert "Hello world" in docs[0].text
         assert docs[0].metadata["title"] == "Test Page"
         assert "example.com" in docs[0].metadata["url"]
+        assert docs[0].metadata["pageid"] == 42
+        assert docs[0].metadata["namespace"] == 0
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_raises_when_siteinfo_base_missing(self, mock_site_cls):

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -71,7 +71,7 @@ class TestMediaWikiReaderInit:
         assert reader.host == "example.com"
         assert reader.path == "/w/"
         assert reader.scheme == "https"
-        assert reader.page_limit == 500
+        assert reader.page_limit is None
         assert reader.namespaces is None
         assert reader.filter_redirects is True
 
@@ -327,11 +327,11 @@ class TestBuildPageUrl:
 
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_special_characters_in_title(self, _mock_site_cls):
-        """Titles with & and spaces are normalized (spaces to underscores)."""
+        """Titles with & and spaces are URL-encoded."""
         reader = _make_reader()
         url_base = ("https://example.com", "/wiki/$1")
         result = reader._build_page_url("Page & FAQ", url_base)
-        assert result == "https://example.com/wiki/Page_&_FAQ"
+        assert result == "https://example.com/wiki/Page_%26_FAQ"
 
 
 # ---------------------------------------------------------------------------

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -1,7 +1,6 @@
 """Tests for MediaWikiReader (mwclient-backed version)."""
 
 import logging
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -171,9 +170,9 @@ class TestGetContentNamespaceIds:
         mock_site.get.return_value = {
             "query": {
                 "namespaces": {
-                    "0": {"id": 0, "*": "", "content": True},
-                    "1": {"id": 1, "*": "Talk", "content": False},
-                    "4": {"id": 4, "*": "Project", "content": True},
+                    "0": {"id": 0, "*": "", "content": ""},
+                    "1": {"id": 1, "*": "Talk"},
+                    "4": {"id": 4, "*": "Project", "content": ""},
                 }
             }
         }
@@ -219,7 +218,7 @@ class TestGetAllPages:
         mock_page = MagicMock()
         mock_page.name = "Page 1"
         mock_page.revision = True
-        mock_page.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+        mock_page.touched = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
         mock_site.allpages.return_value = [mock_page]
         mock_site_cls.return_value = mock_site
 
@@ -345,7 +344,7 @@ class TestGetPageContents:
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_success(self, mock_site_cls):
         mock_site = _mock_site()
-        mock_site.parse.return_value = {"text": {"*": "<p>Test page content.</p>"}}
+        mock_site.get.return_value = {"parse": {"text": {"*": "<p>Test page content.</p>"}}}
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -354,7 +353,8 @@ class TestGetPageContents:
         assert result is not None
         assert "Test page content" in result
         assert "<p>" in result  # raw HTML
-        mock_site.parse.assert_called_once_with(
+        mock_site.get.assert_called_once_with(
+            "parse",
             page="Test Page",
             prop="text",
             disablelimitreport=True,
@@ -365,7 +365,7 @@ class TestGetPageContents:
     @patch("llama_index.readers.mediawiki.base.mwclient.Site")
     def test_empty_parse_result(self, mock_site_cls):
         mock_site = _mock_site()
-        mock_site.parse.return_value = {}
+        mock_site.get.return_value = {}
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -376,7 +376,7 @@ class TestGetPageContents:
         import mwclient.errors
 
         mock_site = _mock_site()
-        mock_site.parse.side_effect = mwclient.errors.APIError("error", "info", {})
+        mock_site.get.side_effect = mwclient.errors.APIError("error", "info", {})
         mock_site_cls.return_value = mock_site
 
         reader = _make_reader()
@@ -439,10 +439,10 @@ class TestLazyLoadData:
         page = MagicMock()
         page.name = "Test Page"
         page.revision = True
-        page.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+        page.touched = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
         mock_site.allpages.return_value = [page]
 
-        mock_site.parse.return_value = {"text": {"*": "<p>Hello world</p>"}}
+        mock_site.get.return_value = {"parse": {"text": {"*": "<p>Hello world</p>"}}}
 
         mock_site_cls.return_value = mock_site
 
@@ -474,16 +474,16 @@ class TestLazyLoadData:
         page_ok = MagicMock()
         page_ok.name = "PageWithContent"
         page_ok.revision = True
-        page_ok.last_rev_time = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
+        page_ok.touched = (2024, 1, 1, 12, 0, 0, 0, 0, 0)
 
         page_skip = MagicMock()
         page_skip.name = "PageWithoutContent"
         page_skip.revision = True
-        page_skip.last_rev_time = (2024, 1, 2, 12, 0, 0, 0, 0, 0)
+        page_skip.touched = (2024, 1, 2, 12, 0, 0, 0, 0, 0)
 
         mock_site.allpages.return_value = [page_ok, page_skip]
-        mock_site.parse.side_effect = [
-            {"text": {"*": "<p>Only this page has content</p>"}},
+        mock_site.get.side_effect = [
+            {"parse": {"text": {"*": "<p>Only this page has content</p>"}}},
             {},  # second page: no content
         ]
         mock_site_cls.return_value = mock_site

--- a/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-mediawiki/tests/test_mediawiki_reader.py
@@ -236,12 +236,12 @@ class TestGetAllPages:
         page_ns0 = MagicMock()
         page_ns0.name = "Main Page"
         page_ns0.revision = True
-        page_ns0.last_rev_time = (2024, 1, 1, 0, 0, 0, 0, 0, 0)
+        page_ns0.touched = (2024, 1, 1, 0, 0, 0, 0, 0, 0)
 
         page_ns4 = MagicMock()
         page_ns4.name = "Project:About"
         page_ns4.revision = True
-        page_ns4.last_rev_time = (2024, 2, 1, 0, 0, 0, 0, 0, 0)
+        page_ns4.touched = (2024, 2, 1, 0, 0, 0, 0, 0, 0)
 
         mock_site.allpages.side_effect = [[page_ns0], [page_ns4]]
         mock_site_cls.return_value = mock_site
@@ -268,7 +268,7 @@ class TestGetAllPages:
         page = MagicMock()
         page.name = "Test"
         page.revision = True
-        page.last_rev_time = (2024, 6, 1, 0, 0, 0, 0, 0, 0)
+        page.touched = (2024, 6, 1, 0, 0, 0, 0, 0, 0)
         mock_site.allpages.return_value = [page]
         mock_site_cls.return_value = mock_site
 


### PR DESCRIPTION
## Summary

- Add `revision: Optional[int] = None` field to the `Page` dataclass
- Populate it from `page.revision` (mwclient's `lastrevid`) in `_get_all_pages_generator()`
- Update `test_iterates_pages` to assert `pages[0].revision` is correctly passed through
