### PR TITLE
fix(core): populate source_nodes in TreeSelectLeafRetriever._query() (#21441)

### DIFF
--- a/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
+++ b/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
@@ -113,12 +113,17 @@ class TreeSelectLeafRetriever(BaseRetriever):
         query_bundle: QueryBundle,
         prev_response: Optional[str] = None,
         level: int = 0,
+        selected_leaf_nodes: Optional[List[BaseNode]] = None,
     ) -> str:
         """
         Get response for selected node.
 
         If not leaf node, it will recursively call _query on the child nodes.
         If prev_response is provided, we will update prev_response with the answer.
+
+        If ``selected_leaf_nodes`` is provided, any leaf node synthesized into the
+        final answer is appended to it so callers can surface retrieval
+        provenance on the returned ``Response`` (see issue #21441).
 
         """
         query_str = query_bundle.query_str
@@ -136,12 +141,15 @@ class TreeSelectLeafRetriever(BaseRetriever):
                 query_str, [node_text], prev_response=prev_response
             )
             cur_response = str(cur_response)
+            if selected_leaf_nodes is not None:
+                selected_leaf_nodes.append(selected_node)
             logger.debug(f">[Level {level}] Current answer response: {cur_response} ")
         else:
             cur_response = self._query_level(
                 self._index_struct.get_children(selected_node),
                 query_bundle,
                 level=level + 1,
+                selected_leaf_nodes=selected_leaf_nodes,
             )
 
         if prev_response is None:
@@ -163,6 +171,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
         cur_node_ids: Dict[int, str],
         query_bundle: QueryBundle,
         level: int = 0,
+        selected_leaf_nodes: Optional[List[BaseNode]] = None,
     ) -> str:
         """Answer a query recursively."""
         query_str = query_bundle.query_str
@@ -175,7 +184,10 @@ class TreeSelectLeafRetriever(BaseRetriever):
         if len(cur_node_list) == 1:
             logger.debug(f">[Level {level}] Only one node left. Querying node.")
             return self._query_with_selected_node(
-                cur_node_list[0], query_bundle, level=level
+                cur_node_list[0],
+                query_bundle,
+                level=level,
+                selected_leaf_nodes=selected_leaf_nodes,
             )
         elif self.child_branch_factor == 1:
             query_template = self.query_template.partial_format(
@@ -266,6 +278,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
                 query_bundle,
                 prev_response=result_response,
                 level=level,
+                selected_leaf_nodes=selected_leaf_nodes,
             )
         # result_response should not be None
         return cast(str, result_response)
@@ -277,13 +290,24 @@ class TreeSelectLeafRetriever(BaseRetriever):
         logger.info(info_str)
         if self._verbose:
             print_text(info_str, end="\n")
+        selected_leaf_nodes: List[BaseNode] = []
         response_str = self._query_level(
             self._index_struct.root_nodes,
             query_bundle,
             level=0,
+            selected_leaf_nodes=selected_leaf_nodes,
         ).strip()
-        # TODO: fix source nodes
-        return Response(response_str, source_nodes=[])
+        # Deduplicate while preserving traversal order so the same leaf is not
+        # surfaced twice when it is visited along multiple selected branches.
+        seen: set = set()
+        unique_leaf_nodes: List[BaseNode] = []
+        for node in selected_leaf_nodes:
+            if node.node_id in seen:
+                continue
+            seen.add(node.node_id)
+            unique_leaf_nodes.append(node)
+        source_nodes = [NodeWithScore(node=node) for node in unique_leaf_nodes]
+        return Response(response_str, source_nodes=source_nodes)
 
     def _select_nodes(
         self,

--- a/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
+++ b/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
@@ -284,7 +284,18 @@ class TreeSelectLeafRetriever(BaseRetriever):
         return cast(str, result_response)
 
     def _query(self, query_bundle: QueryBundle) -> Response:
-        """Answer a query."""
+        """
+        Answer a query.
+
+        The ``Response.source_nodes`` returned here are the leaf
+        ``BaseNode``\\s the LLM-driven traversal selected on the way to the
+        final answer, deduplicated while preserving traversal order. They are
+        wrapped in ``NodeWithScore`` with ``score=None`` because tree
+        traversal uses LLM selection rather than a numeric ranking — there is
+        no relevance score to attach. Downstream rerankers / weighted fusion
+        consumers that expect a non-``None`` score should treat unscored
+        source nodes as a tie and rank them by a fallback signal.
+        """
         # NOTE: this overrides the _query method in the base class
         info_str = f"> Starting query: {query_bundle.query_str}"
         logger.info(info_str)

--- a/llama-index-core/tests/indices/tree/test_select_leaf_source_nodes.py
+++ b/llama-index-core/tests/indices/tree/test_select_leaf_source_nodes.py
@@ -1,0 +1,55 @@
+"""
+Regression test for https://github.com/run-llama/llama_index/issues/21441.
+
+TreeSelectLeafRetriever._query() used to return Response(source_nodes=[]),
+dropping all retrieval provenance. After the fix, the selected leaf nodes
+should be surfaced via Response.source_nodes.
+"""
+
+from typing import Dict, Tuple
+
+import pytest
+from llama_index.core.indices.query.schema import QueryBundle
+from llama_index.core.indices.tree.base import TreeIndex
+from llama_index.core.indices.tree.select_leaf_retriever import (
+    TreeSelectLeafRetriever,
+)
+from llama_index.core.schema import Document
+
+
+@pytest.fixture()
+def single_doc():
+    # Matches the fixture used in the other tree tests.
+    doc_text = (
+        "Hello world.\nThis is a test.\nThis is another test.\nThis is a test v2."
+    )
+    return [Document(text=doc_text)]
+
+
+def _split_kwargs(struct_kwargs: Tuple[Dict, Dict]) -> Tuple[Dict, Dict]:
+    index_kwargs, query_kwargs = struct_kwargs
+    return index_kwargs, query_kwargs
+
+
+def test_select_leaf_retriever_query_populates_source_nodes(
+    single_doc,
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    struct_kwargs,
+) -> None:
+    """_query() must return the selected leaf nodes as Response.source_nodes."""
+    index_kwargs, query_kwargs = _split_kwargs(struct_kwargs)
+    tree = TreeIndex.from_documents(single_doc, **index_kwargs)
+    retriever = TreeSelectLeafRetriever(
+        index=tree,
+        child_branch_factor=1,
+        **query_kwargs,
+    )
+
+    response = retriever._query(QueryBundle("What is?"))
+
+    assert response.source_nodes, (
+        "TreeSelectLeafRetriever._query() dropped source nodes (#21441)."
+    )
+    for node_with_score in response.source_nodes:
+        assert node_with_score.node is not None


### PR DESCRIPTION
## Summary

Fixes #21441. `TreeSelectLeafRetriever._query()` previously returned `Response(source_nodes=[])` with an inline `# TODO: fix source nodes`, discarding all retrieval provenance so downstream citation, evaluation and debug workflows could not see which leaf(s) produced the answer.

## Root cause

`_query()` called `_query_level(...)`, which called `_query_with_selected_node(...)` recursively, but those methods only returned the synthesized response string — the selected leaf `BaseNode`(s) were never captured. The final `Response` was hard-coded to an empty list.

## Fix

Thread an optional `selected_leaf_nodes: List[BaseNode]` accumulator through `_query_level` and `_query_with_selected_node`. In `_query_with_selected_node`, when a leaf node (no children) is synthesized into the answer, append it to the accumulator. `_query()` now:

1. creates the accumulator and passes it into `_query_level`,
2. deduplicates by `node.node_id` while preserving traversal order (so the same leaf visited along multiple selected branches is only surfaced once),
3. wraps each leaf in `NodeWithScore` and passes them into `Response(source_nodes=...)`.

No change to behavior when callers ignore `source_nodes`: the new parameter defaults to `None`, the accumulator is opt-in, and existing method signatures remain source-compatible for external callers.

## Verification

- Added `tests/indices/tree/test_select_leaf_source_nodes.py` — asserts `response.source_nodes` is non-empty and every entry has a real node. Fails on `main` (confirms the bug), passes after the fix.
- `uv run --` equivalent: `python -m pytest llama-index-core/tests/indices/tree/` — all 10 tree tests pass.
- Broader sanity: `python -m pytest llama-index-core/tests/indices/` — all 291 tests pass.
- `ruff check` passes for both modified files.

Before:
```
response: Response(response='What is?:Hello world.', source_nodes=[], metadata=None)
```

After:
```
response: Response(response='What is?:Hello world.', source_nodes=[NodeWithScore(node=TextNode(...), score=None)], metadata=None)
```

## Test plan

- [x] New regression test fails on `main`, passes on this branch
- [x] Existing tree retriever tests still pass (`tests/indices/tree/`)
- [x] Broader `tests/indices/` tests unaffected
- [x] `ruff check` clean on changed files

---
*Contributed by [kcolbchain](https://kcolbchain.com) / [Abhishek Krishna](https://abhishekkrishna.com)*