### PR TITLE
fix(pgvector): use isinstance check for numeric filter values instead of float()

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -50,6 +50,7 @@ from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection, Model
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.program.utils import FlexibleModel, create_flexible_model
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.types import PydanticProgramMode
 from llama_index.llms.google_genai.utils import (
     chat_from_gemini_response,
@@ -350,7 +351,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs, file_api_names = asyncio.run(
+        next_msg, chat_kwargs, file_api_names = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.file_mode, self._client, **params
             )
@@ -405,7 +406,7 @@ class GoogleGenAI(FunctionCallingLLM):
             **kwargs.pop("generation_config", {}),
         }
         params = {**kwargs, "generation_config": generation_config}
-        next_msg, chat_kwargs, file_api_names = asyncio.run(
+        next_msg, chat_kwargs, file_api_names = asyncio_run(
             prepare_chat_params(
                 self.model, messages, self.file_mode, self._client, **params
             )
@@ -616,7 +617,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
         messages = prompt.format_messages(**prompt_args)
         contents_and_names = [
-            asyncio.run(chat_message_to_gemini(message, self.file_mode, self._client))
+            asyncio_run(chat_message_to_gemini(message, self.file_mode, self._client))
             for message in messages
         ]
         contents = [it[0] for it in contents_and_names]
@@ -667,7 +668,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents_and_names = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.file_mode, self._client)
                 )
                 for message in messages
@@ -769,7 +770,7 @@ class GoogleGenAI(FunctionCallingLLM):
 
             messages = prompt.format_messages(**prompt_args)
             contents_and_names = [
-                asyncio.run(
+                asyncio_run(
                     chat_message_to_gemini(message, self.file_mode, self._client)
                 )
                 for message in messages

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -735,16 +735,21 @@ class PGVectorStore(BasePydanticVectorStore):
                 f"{self._to_postgres_operator(filter_.operator)}"
             )
         else:
-            # Check if value is a number. If so, cast the metadata value to a float
-            # This is necessary because the metadata is stored as a string
-            try:
+            # If the filter value is a numeric type (int or float), cast the
+            # metadata JSON text to float for the comparison.  We check the
+            # Python type explicitly rather than trying float(value) because
+            # Python's float() accepts underscore-separated strings like
+            # "2024_123" (returning 2024123.0) while PostgreSQL's ::float cast
+            # does not, which would produce a DataError at query time.
+            if isinstance(filter_.value, (int, float)) and not isinstance(
+                filter_.value, bool
+            ):
                 return text(
                     f"(metadata_->>'{filter_.key}')::float "
                     f"{self._to_postgres_operator(filter_.operator)} "
                     f"{float(filter_.value)}"
                 )
-            except ValueError:
-                # If not a number, then treat it as a string
+            else:
                 return text(
                     f"metadata_->>'{filter_.key}' "
                     f"{self._to_postgres_operator(filter_.operator)} "

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_vector_stores_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_vector_stores_postgres.py
@@ -1,7 +1,66 @@
-from llama_index.core.vector_stores.types import BasePydanticVectorStore
+from unittest.mock import MagicMock
+
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    FilterOperator,
+    MetadataFilter,
+)
 from llama_index.vector_stores.postgres import PGVectorStore
+from llama_index.vector_stores.postgres.base import PGVectorStore as _PGVectorStore
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in PGVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+def _make_store() -> PGVectorStore:
+    """Create a minimal PGVectorStore using __new__ so no DB connection is needed."""
+    store = _PGVectorStore.__new__(_PGVectorStore)
+    # _to_postgres_operator only needs the operator enum, so we delegate to the
+    # real implementation; we just avoid touching any DB-related attributes.
+    return store
+
+
+def test_build_filter_clause_string_with_underscores():
+    """String values that look like numbers (e.g., '2024_123') must use string
+    comparison, not a ::float cast.  Python's float() accepts underscores, but
+    PostgreSQL's ::float cast does not, so using float() as the type check
+    caused DataError for such values (issue #15962)."""
+    store = _make_store()
+    f = MetadataFilter(key="file_name", value="2024_123", operator=FilterOperator.EQ)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" not in sql, f"string value should not use ::float cast; got: {sql}"
+    assert "'2024_123'" in sql
+
+
+def test_build_filter_clause_int_value():
+    """Integer filter values should use the ::float cast for numeric comparison."""
+    store = _make_store()
+    f = MetadataFilter(key="year", value=2024, operator=FilterOperator.EQ)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" in sql, f"int value should use ::float cast; got: {sql}"
+    assert "2024" in sql
+
+
+def test_build_filter_clause_float_value():
+    """Float filter values should use the ::float cast."""
+    store = _make_store()
+    f = MetadataFilter(key="score", value=0.9, operator=FilterOperator.GT)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" in sql, f"float value should use ::float cast; got: {sql}"
+
+
+def test_build_filter_clause_plain_number_string():
+    """A string value that happens to be a plain decimal number (e.g., '123')
+    should still use string comparison because the user explicitly provided a
+    string type."""
+    store = _make_store()
+    f = MetadataFilter(key="year", value="123", operator=FilterOperator.EQ)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" not in sql, f"string '123' should not use ::float cast; got: {sql}"
+    assert "'123'" in sql


### PR DESCRIPTION
Fixes #15962

> **Two related fixes in this PR** (per @VANDRANKI review): the pgvector cast bug below, plus a small `google_genai/base.py` change that swaps `asyncio.run()` for `asyncio_run()` in 5 spots so the LLM works when called from inside an already-running event loop. Both are short and independently safe — happy to split into two PRs if reviewers prefer.

## Problem (pgvector)

`PGVectorStore._build_filter_clause` used `try: float(filter_.value)` to decide whether to cast the metadata JSON text to `::float` in the SQL query. This heuristic fails for string metadata values that Python'''s `float()` can parse but PostgreSQL'''s `::float` cast cannot.

Concretely, Python 3.6+ allows underscores as visual separators in numeric literals, so `float("2024_123")` succeeds and returns `2024123.0`. The generated SQL then becomes:

Error:
No DBURL given

sql [-hnr] [--table-size] [--db-size] [-p pass-through] [-s string] dburl [command]

But when PostgreSQL tries to cast the stored string `"2024_123"` to `double precision`, it raises:



## Solution (pgvector)

Replace the `try/except float()` heuristic with an explicit `isinstance` check on the Python type of `filter_.value`. `MetadataFilter.value` uses Pydantic'''s `StrictInt`/`StrictFloat`/`StrictStr`, so the type is always exact:

- `filter_.value` is `int` or `float` → use `::float` cast (numeric comparison)
- `filter_.value` is a `str` → use string comparison (even if the string looks like a number)
- `bool` is excluded from the int branch because `bool` is a subclass of `int` in Python, and `True`/`False` should use string comparison.

This correctly handles both the bug case (`"2024_123"` stays a string comparison) and the intentional numeric case (`value=2024` uses the float path).

## Secondary fix (google_genai)

In `llama-index-llms-google-genai/.../base.py`, replace 5 `asyncio.run()` calls with the project'''s `asyncio_run()` helper. `asyncio.run()` raises `RuntimeError` if called from inside a running event loop (e.g. from a Jupyter kernel or another async framework calling `_chat`/`_stream_chat`/`_acomplete` synchronously). `asyncio_run` already exists in `llama_index.core.async_utils` for exactly this case.

## Testing

Added four unit tests in `tests/test_vector_stores_postgres.py` that exercise `_build_filter_clause` directly without requiring a database connection (uses `__new__` to bypass the DB connect path):
- string value with underscores (`"2024_123"`) → no `::float` cast
- integer value (`2024`) → `::float` cast applied
- float value (`0.9`) → `::float` cast applied
- plain numeric string (`"123"`) → no `::float` cast (explicit string type)