### PR TITLE
update import mistralai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
@@ -56,7 +56,7 @@ from llama_index.llms.mistralai.utils import (
 from mistralai_azure import MistralAzure
 import mistralai_azure.models as mistral_azure_models
 
-from mistralai import Mistral
+from mistralai.client import Mistral
 import mistralai.models as mistral_models
 
 if TYPE_CHECKING:


### PR DESCRIPTION
# Description

I have made on my own a RAG with llama-index and mistralai (more specifically with llama-index-llms-mistralai, see https://pypi.org/project/llama-index-llms-mistralai/0.10.0.post2/) a few months ago.

But I have noticed recently that my chatbot AI does'nt work anymore because with the new version of mistralai (v1 => v2)  released in March 2026, I had an error of import because :
- in v1 it's `from mistralai import Mistral`.
- in v2 it's `from mistralai.client import Mistral`.

see this : https://pypi.org/project/mistralai/2.0.0/

Fixes # (issue)
I have juste changed the manner to import the Mistral module to match with the version v2 of mistralai.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


