### PR TITLE
fix(azureaisearch): store falsy metadata values instead of silently dropping them

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc


### PR DESCRIPTION
## Summary

Fixes #21385

The `_build_metadata_filter` loop in `_build_index_document` used a truthy check to decide whether to store a metadata value:

```python
if metadata_value:
    index_doc[index_field_name] = metadata_value
```

This silently drops falsy values: `0`, `0.0`, `False`, `""`, and `[]`. For example, a document with `page_number=0` or `is_draft=False` would lose those fields entirely when indexed, causing retrieval filters on those fields to return no results.

## Fix

Changed to `if metadata_value is not None:` so that only absent keys are skipped while all legitimate values (including falsy ones) are stored.

## Test

Existing unit tests pass. The change is a one-line guard replacement with no structural side effects.
