### PR TITLE
fix(instrumentation): avoid mutating response.raw in LLM event model_dump

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -143,10 +143,11 @@ class LLMCompletionInProgressEvent(BaseEvent):
         return "LLMCompletionInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            # Avoid mutating the original response object in-place.
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data
 
 
 class LLMCompletionEndEvent(BaseEvent):
@@ -168,10 +169,11 @@ class LLMCompletionEndEvent(BaseEvent):
         return "LLMCompletionEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            # Avoid mutating the original response object in-place.
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data
 
 
 class LLMChatStartEvent(BaseEvent):
@@ -215,10 +217,11 @@ class LLMChatInProgressEvent(BaseEvent):
         return "LLMChatInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            # Avoid mutating the original response object in-place.
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data
 
 
 class LLMChatEndEvent(BaseEvent):
@@ -240,7 +243,8 @@ class LLMChatEndEvent(BaseEvent):
         return "LLMChatEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if self.response is not None and isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            # Avoid mutating the original response object in-place.
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data


### PR DESCRIPTION
## Summary

Fixes #21422

Each `model_dump()` override in the LLM instrumentation events was silently mutating the caller's response object:

```python
# Before (mutates in-place)
if isinstance(self.response.raw, BaseModel):
    self.response.raw = self.response.raw.model_dump()
return super().model_dump(**kwargs)
```

After `model_dump()` is called, `response.raw` is permanently changed from a `BaseModel` to a plain `dict`. Any code that continues to use the response after the event fires (e.g., streaming handlers, callbacks) will see a `dict` where a typed model is expected.

## Fix

Serialize into the output dict directly instead of touching the original object:

```python
# After (no mutation)
data = super().model_dump(**kwargs)
if isinstance(self.response.raw, BaseModel):
    data["response"]["raw"] = self.response.raw.model_dump()
return data
```

Applied to all four affected event classes: `LLMCompletionInProgressEvent`, `LLMCompletionEndEvent`, `LLMChatInProgressEvent`, `LLMChatEndEvent`.
