### PR TITLE
fix(openai): JSON-serialize tool_kwargs for function.arguments in to_openai_message_dict

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -499,7 +499,7 @@ def to_openai_message_dict(
                     "type": "function",
                     "function": {
                         "name": block.tool_name,
-                        "arguments": block.tool_kwargs,
+                        "arguments": json.dumps(block.tool_kwargs),
                     },
                     "id": block.tool_call_id,
                 }


### PR DESCRIPTION
## Summary

Fixes #21378

`to_openai_message_dict()` was passing `block.tool_kwargs` (a `dict`) directly as `function.arguments`:

```python
"function": {
    "name": block.tool_name,
    "arguments": block.tool_kwargs,   # dict - causes 400
},
```

The OpenAI API requires `function.arguments` to be a **JSON-encoded string**, not an object. This produced:

> `Invalid type for 'messages[...].tool_calls[...].function.arguments': expected a string, but got an object`

## Fix

```python
"arguments": json.dumps(block.tool_kwargs),
```

`json` is already imported at the top of the file.
