### PR TITLE
fix(core): stop `LLM*Event.model_dump()` from mutating `response.raw`

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -143,10 +143,10 @@ class LLMCompletionInProgressEvent(BaseEvent):
         return "LLMCompletionInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data
 
 
 class LLMCompletionEndEvent(BaseEvent):
@@ -168,10 +168,10 @@ class LLMCompletionEndEvent(BaseEvent):
         return "LLMCompletionEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data
 
 
 class LLMChatStartEvent(BaseEvent):
@@ -215,10 +215,10 @@ class LLMChatInProgressEvent(BaseEvent):
         return "LLMChatInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data
 
 
 class LLMChatEndEvent(BaseEvent):
@@ -240,7 +240,7 @@ class LLMChatEndEvent(BaseEvent):
         return "LLMChatEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().model_dump(**kwargs)
         if self.response is not None and isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+            data["response"]["raw"] = self.response.raw.model_dump()
+        return data

--- a/llama-index-core/tests/llms/test_instrumentation_events.py
+++ b/llama-index-core/tests/llms/test_instrumentation_events.py
@@ -1,0 +1,71 @@
+from pydantic import BaseModel
+
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    CompletionResponse,
+)
+from llama_index.core.instrumentation.events.llm import (
+    LLMChatEndEvent,
+    LLMChatInProgressEvent,
+    LLMCompletionEndEvent,
+    LLMCompletionInProgressEvent,
+)
+
+
+class _RawModel(BaseModel):
+    answer: str
+
+
+def test_llm_chat_end_event_does_not_mutate_response_raw() -> None:
+    raw = _RawModel(answer="hi")
+    response = ChatResponse(message=ChatMessage.from_str("reply"), raw=raw)
+    event = LLMChatEndEvent(
+        messages=[ChatMessage.from_str("prompt")], response=response
+    )
+
+    dumped = event.model_dump()
+
+    assert dumped["response"]["raw"] == {"answer": "hi"}
+    assert isinstance(response.raw, _RawModel)
+    assert response.raw is raw
+
+
+def test_llm_chat_in_progress_event_does_not_mutate_response_raw() -> None:
+    raw = _RawModel(answer="hi")
+    response = ChatResponse(message=ChatMessage.from_str("reply"), raw=raw)
+    event = LLMChatInProgressEvent(
+        messages=[ChatMessage.from_str("prompt")], response=response
+    )
+
+    event.model_dump()
+
+    assert isinstance(response.raw, _RawModel)
+
+
+def test_llm_completion_end_event_does_not_mutate_response_raw() -> None:
+    raw = _RawModel(answer="hi")
+    response = CompletionResponse(text="reply", raw=raw)
+    event = LLMCompletionEndEvent(prompt="prompt", response=response)
+
+    event.model_dump()
+
+    assert isinstance(response.raw, _RawModel)
+
+
+def test_llm_completion_in_progress_event_does_not_mutate_response_raw() -> None:
+    raw = _RawModel(answer="hi")
+    response = CompletionResponse(text="reply", raw=raw)
+    event = LLMCompletionInProgressEvent(prompt="prompt", response=response)
+
+    event.model_dump()
+
+    assert isinstance(response.raw, _RawModel)
+
+
+def test_llm_chat_end_event_handles_none_response() -> None:
+    event = LLMChatEndEvent(messages=[ChatMessage.from_str("prompt")], response=None)
+
+    dumped = event.model_dump()
+
+    assert dumped["response"] is None


### PR DESCRIPTION
Closes #21422

## Description
`LLMChatEndEvent.model_dump()` (and the three sibling events — `LLMChatInProgressEvent`, `LLMCompletionEndEvent`, `LLMCompletionInProgressEvent`) converted `self.response.raw` from a Pydantic model to a plain dict **in place** before serializing. Because the event holds a reference to the same `ChatResponse` / `CompletionResponse` object returned to the caller, any code path with an active dispatcher subscriber (e.g. an OpenTelemetry integration) silently strips the Pydantic model off the caller's response, causing downstream `AttributeError` on field access.

The bug only surfaces when telemetry is wired up, which is why it ships unnoticed in local dev and only bites users like `StructuredLLM` consumers in production.

## Fix
The mutation was never necessary. Pydantic v2 already serializes nested `BaseModel` values inside an `Optional[Any]` field when the outer model is dumped. Build the dict from `super().model_dump(**kwargs)` and patch the `response.raw` entry only on the output — leave the original object untouched.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage
- [x] I added/updated unit tests

Added `tests/llms/test_instrumentation_events.py` covering all four event classes and the `response=None` path for `LLMChatEndEvent`. Each test dumps the event and then asserts the original `response.raw` is still a `BaseModel` instance.

_AI-assisted contribution._