### PR TITLE
fix(openai): JSON-serialize `ToolCallBlock.tool_kwargs` in Chat Completions path

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -495,11 +495,14 @@ def to_openai_message_dict(
             continue
         elif isinstance(block, ToolCallBlock):
             try:
+                arguments = block.tool_kwargs
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments)
                 function_dict = {
                     "type": "function",
                     "function": {
                         "name": block.tool_name,
-                        "arguments": block.tool_kwargs,
+                        "arguments": arguments,
                     },
                     "id": block.tool_call_id,
                 }

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -756,3 +756,64 @@ def test_responses_api_tool_kwargs_string_passthrough() -> None:
         if isinstance(item, dict) and item.get("type") == "function_call"
     ][0]
     assert tool_item["arguments"] == '{"q": "test"}'
+
+
+def _extract_chat_tool_call(message_dict: dict) -> dict:
+    """Pull the single tool_call dict out of a Chat Completions message dict."""
+    if message_dict.get("tool_calls"):
+        return message_dict["tool_calls"][0]
+    content = message_dict.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("tool_calls"):
+                return item["tool_calls"][0]
+    raise AssertionError(f"No tool_calls found in message: {message_dict!r}")
+
+
+def test_chat_completions_tool_kwargs_dict_serialized_to_json_string() -> None:
+    """`function.arguments` must be a JSON string for the Chat Completions API.
+
+    Regression test for the cross-provider workflow where an Anthropic
+    assistant message (whose `ToolCallBlock.tool_kwargs` is a dict) is fed
+    into an OpenAI agent. Previously, `to_openai_message_dict` placed the
+    raw dict into `function.arguments`, triggering a 400 from OpenAI.
+    """
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_name="get_weather",
+                tool_call_id="call_dict",
+                tool_kwargs={"location": "Boston", "unit": "celsius"},
+            ),
+        ],
+    )
+
+    openai_message = to_openai_message_dicts([msg])[0]
+    tool_call = _extract_chat_tool_call(openai_message)
+
+    assert tool_call["function"]["name"] == "get_weather"
+    assert isinstance(tool_call["function"]["arguments"], str)
+    assert json.loads(tool_call["function"]["arguments"]) == {
+        "location": "Boston",
+        "unit": "celsius",
+    }
+
+
+def test_chat_completions_tool_kwargs_string_passthrough() -> None:
+    """Already-serialized `tool_kwargs` strings must pass through unchanged."""
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_name="search",
+                tool_call_id="call_str",
+                tool_kwargs='{"q": "test"}',
+            ),
+        ],
+    )
+
+    openai_message = to_openai_message_dicts([msg])[0]
+    tool_call = _extract_chat_tool_call(openai_message)
+
+    assert tool_call["function"]["arguments"] == '{"q": "test"}'


### PR DESCRIPTION
Closes #21378

---

`to_openai_message_dict` (the Chat Completions API converter) placed `ToolCallBlock.tool_kwargs` directly into `function.arguments`. When the tool call originated from a provider that stores arguments as a Python dict — Anthropic being the canonical example — forwarding the message into an OpenAI agent returned `400 BadRequestError: Invalid type for 'messages[*].tool_calls[*].function.arguments': expected a string, but got an object instead`.

This blocks any cross-provider `AgentWorkflow` where an Anthropic orchestrator hands off to an OpenAI sub-agent.

The Responses API converter (`to_openai_responses_message_dict`) already handles this by dumping non-string `tool_kwargs` via `json.dumps` and passing strings through unchanged. This PR mirrors that exact pattern in `to_openai_message_dict`.

Backward-compatible: callers already supplying serialized JSON strings see no behavior change.

Two regression tests added next to the existing Responses-API ones in `test_openai_utils.py` cover the dict and string branches for the Chat Completions path.

_Disclaimer: this contribution was prepared with AI-agent assistance._