### PR TITLE
fix(ingestion): merge worker cache entries back into parent IngestionPipeline on multi-worker run

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -182,6 +182,62 @@ def arun_transformations_wrapper(
     return nodes
 
 
+def _run_transformations_with_cache_snapshot(
+    nodes: Sequence[BaseNode],
+    transformations: Sequence[TransformComponent],
+    in_place: bool = True,
+    cache: Optional[IngestionCache] = None,
+    cache_collection: Optional[str] = None,
+) -> tuple:
+    """Run transformations and return (nodes, cache_data) for multi-worker use.
+
+    Returning the cache snapshot lets the parent process merge new entries back
+    into its own cache after the worker exits, so subsequent runs (or persist())
+    can use those entries.  Without this, spawned worker processes mutate their
+    own in-memory cache copies which are discarded on exit.  See issue #21300.
+    """
+    result_nodes = run_transformations(
+        nodes, transformations, in_place, cache, cache_collection
+    )
+    cache_data: dict = {}
+    if cache is not None:
+        effective_collection = cache_collection or cache.collection
+        cache_data = cache.cache.get_all(collection=effective_collection)
+    return result_nodes, cache_data
+
+
+def _arun_transformations_wrapper_with_cache_snapshot(
+    nodes: Sequence[BaseNode],
+    transformations: Sequence[TransformComponent],
+    in_place: bool = True,
+    cache: Optional[IngestionCache] = None,
+    cache_collection: Optional[str] = None,
+    **kwargs: Any,
+) -> tuple:
+    """Async-wrapper variant of _run_transformations_with_cache_snapshot.
+
+    Mirrors arun_transformations_wrapper but also returns the cache snapshot so
+    the parent process can merge new entries after all workers finish.
+    """
+    loop = asyncio.new_event_loop()
+    result_nodes = loop.run_until_complete(
+        arun_transformations(
+            nodes=nodes,
+            transformations=transformations,
+            in_place=in_place,
+            cache=cache,
+            cache_collection=cache_collection,
+            **kwargs,
+        )
+    )
+    loop.close()
+    cache_data: dict = {}
+    if cache is not None:
+        effective_collection = cache_collection or cache.collection
+        cache_data = cache.cache.get_all(collection=effective_collection)
+    return result_nodes, cache_data
+
+
 class DocstoreStrategy(str, Enum):
     """
     Document de-duplication de-deduplication strategies work by comparing the hashes or ids stored in the document store.
@@ -560,8 +616,8 @@ class IngestionPipeline(BaseModel):
                 node_batches = self._node_batcher(
                     num_batches=num_workers, nodes=nodes_to_run
                 )
-                nodes_parallel = p.starmap(
-                    run_transformations,
+                results_with_cache = p.starmap(
+                    _run_transformations_with_cache_snapshot,
                     zip(
                         node_batches,
                         repeat(self.transformations),
@@ -570,7 +626,17 @@ class IngestionPipeline(BaseModel):
                         repeat(cache_collection),
                     ),
                 )
-                nodes = reduce(lambda x, y: x + y, nodes_parallel, [])  # type: ignore
+                nodes = reduce(lambda x, y: x + y, [r[0] for r in results_with_cache], [])  # type: ignore
+                # Merge cache entries written inside worker processes back into
+                # the parent's IngestionCache so subsequent runs and persist()
+                # include them.  Workers receive a pickled snapshot of the cache
+                # but their in-memory writes are discarded on exit; returning the
+                # snapshot and merging here is the fix for issue #21300.
+                if not self.disable_cache and self.cache is not None:
+                    effective_collection = cache_collection or self.cache.collection
+                    for _, worker_cache_data in results_with_cache:
+                        for key, val in worker_cache_data.items():
+                            self.cache.cache.put(key, val, collection=effective_collection)
         else:
             nodes = run_transformations(
                 nodes_to_run,
@@ -772,7 +838,7 @@ class IngestionPipeline(BaseModel):
                     loop.run_in_executor(
                         p,
                         partial(
-                            arun_transformations_wrapper,
+                            _arun_transformations_wrapper_with_cache_snapshot,
                             transformations=self.transformations,
                             in_place=in_place,
                             cache=self.cache if not self.disable_cache else None,
@@ -782,8 +848,16 @@ class IngestionPipeline(BaseModel):
                     )
                     for batch in node_batches
                 ]
-                result: Sequence[Sequence[BaseNode]] = await asyncio.gather(*tasks)
-                nodes: Sequence[BaseNode] = reduce(lambda x, y: x + y, result, [])  # type: ignore
+                results_with_cache: list = await asyncio.gather(*tasks)
+                nodes: Sequence[BaseNode] = reduce(lambda x, y: x + y, [r[0] for r in results_with_cache], [])  # type: ignore
+                # Merge cache entries written inside worker processes back into
+                # the parent's IngestionCache so subsequent runs and persist()
+                # include them.  See issue #21300.
+                if not self.disable_cache and self.cache is not None:
+                    effective_collection = cache_collection or self.cache.collection
+                    for _, worker_cache_data in results_with_cache:
+                        for key, val in worker_cache_data.items():
+                            self.cache.cache.put(key, val, collection=effective_collection)
         else:
             nodes = await arun_transformations(  # type: ignore
                 nodes_to_run,

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -501,3 +501,50 @@ async def test_docstore_strategy_not_mutated_on_arun_without_vector_store() -> N
             await pipeline.arun(documents=[Document.example()])
 
         assert pipeline.docstore_strategy is strategy
+
+def _cache_entry_count(pipeline: IngestionPipeline) -> int:
+    """Return the number of entries in the pipeline's in-memory cache."""
+    return len(
+        pipeline.cache.cache.get_all(collection=pipeline.cache.collection)
+    )
+
+
+@pytest.mark.skipif(cpu_count() < 2, reason="requires at least 2 CPUs for multi-worker test")
+def test_multiworker_run_merges_cache_into_parent() -> None:
+    """Cache entries written in worker processes must be visible in the parent.
+
+    Regression test for https://github.com/run-llama/llama_index/issues/21300.
+
+    Before the fix, spawned workers mutated their own in-memory copies of
+    IngestionCache (received via pickle) and those writes were discarded on
+    exit.  The parent's cache stayed empty so subsequent multi-worker runs
+    re-executed every transformation even when a cache hit was expected.
+    """
+    docs = [Document(text=f"Sample document {i}. " * 10) for i in range(4)]
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(chunk_size=50, chunk_overlap=0)]
+    )
+
+    # First run: cache is empty; workers should process and the parent should
+    # receive the resulting cache entries.
+    nodes_first = pipeline.run(documents=docs, num_workers=2)
+    assert len(nodes_first) > 0, "First multi-worker run produced no nodes"
+
+    cache_after_first = _cache_entry_count(pipeline)
+    assert cache_after_first > 0, (
+        "Parent cache is empty after the first multi-worker run. "
+        "Worker cache writes were not merged back into the parent. "
+        "See issue #21300."
+    )
+
+    # Second run: all entries should be cache hits; same nodes, same count.
+    nodes_second = pipeline.run(documents=docs, num_workers=2)
+    assert len(nodes_second) == len(nodes_first), (
+        "Second multi-worker run returned a different number of nodes than the "
+        "first run, which suggests the cache was not used."
+    )
+    cache_after_second = _cache_entry_count(pipeline)
+    assert cache_after_second == cache_after_first, (
+        "Cache grew on the second run; entries were re-written rather than hit."
+    )


### PR DESCRIPTION
## Summary

When `IngestionPipeline.run(num_workers>1)` is called with the default in-memory `IngestionCache`, each spawned worker process receives a pickled copy of `self.cache`. Transformations run and write new entries to those copies, but the parent only collects the transformed nodes - the per-worker cache mutations are silently discarded when the workers exit.

Effect:
- Subsequent `pipeline.run(num_workers>1)` calls re-execute every transformation even though they should be cache hits
- `pipeline.persist()` does not include any of the multi-worker cache entries

## Root cause

In the sync path (`Pool.starmap`) and async path (`ProcessPoolExecutor`), `run_transformations` / `arun_transformations_wrapper` only return `nodes`. The parent has no way to see what the worker wrote to its copy of the cache.

## Fix

Add two module-level snapshot wrappers (`_run_transformations_with_cache_snapshot` and `_arun_transformations_wrapper_with_cache_snapshot`) that run transformations and return `(nodes, cache_data)` where `cache_data = cache.cache.get_all()` is the full state of the worker's cache after the run.

After all workers complete, the parent iterates the snapshots and writes each entry back into `self.cache.cache.put()`. Both the sync `Pool.starmap` path and the async `ProcessPoolExecutor` path are updated.

## Test

Added `test_multiworker_run_merges_cache_into_parent` that:
- Runs a 4-document pipeline with `num_workers=2`
- Asserts the parent cache is non-empty after the first run
- Runs a second time and asserts the cache count is unchanged (all hits)

Fixes #21300