### PR TITLE
fix(imdb-reader): assign re.sub and str.replace results back to variable

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-imdb-review/llama_index/readers/imdb_review/scraper.py
+++ b/llama-index-integrations/readers/llama-index-readers-imdb-review/llama_index/readers/imdb_review/scraper.py
@@ -90,9 +90,9 @@ def scrape_data(revs):
     except NoSuchElementException:
         rating = 0.0
 
-    re.sub("\n", " ", contents)
-    re.sub("\t", " ", contents)
-    contents.replace("//", "")
+    contents = re.sub("\n", " ", contents)
+    contents = re.sub("\t", " ", contents)
+    contents = contents.replace("//", "")
     date = revs.find_element(By.CLASS_NAME, "review-date").text
     contents = clean_text(contents)
     return date, contents, rating, title, link, spoiler


### PR DESCRIPTION
## Description

In `scraper.py`, three string cleaning operations have their return values discarded:

```python
re.sub("\n", " ", contents)      # result discarded
re.sub("\t", " ", contents)      # result discarded
contents.replace("//", "")       # result discarded
```

`re.sub()` and `str.replace()` return **new strings** — they don't modify in place. The review contents are passed to `clean_text()` on the next line with newlines, tabs, and double slashes still intact.

## Fix

Assign the results back to `contents`:

```python
contents = re.sub("\n", " ", contents)
contents = re.sub("\t", " ", contents)
contents = contents.replace("//", "")
```