### PR TITLE
fix: exclude volatile metadata from Node/TextNode hashing and IngestionCache keys to prevent unnecessary re-embeds

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -60,7 +60,7 @@ def get_transformation_hash(
 ) -> str:
     """Get the hash of a transformation."""
     nodes_str = "".join(
-        [str(node.get_content(metadata_mode=MetadataMode.ALL)) for node in nodes]
+        [str(node.get_content(metadata_mode=MetadataMode.EMBED)) for node in nodes]
     )
 
     transformation_dict = transformation.to_dict()

--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -746,7 +746,7 @@ class Node(BaseNode):
         The hash is generated based on the available resources (audio, image, text or video) and its metadata.
         """
         doc_identities = []
-        metadata_str = self.get_metadata_str(mode=MetadataMode.ALL)
+        metadata_str = self.get_metadata_str(mode=MetadataMode.EMBED)
         if metadata_str:
             doc_identities.append(metadata_str)
         if self.audio_resource is not None:
@@ -799,7 +799,8 @@ class TextNode(BaseNode):
 
     @property
     def hash(self) -> str:
-        doc_identity = str(self.text) + str(self.metadata)
+        metadata_str = self.get_metadata_str(mode=MetadataMode.EMBED)
+        doc_identity = str(self.text) + metadata_str
         return str(sha256(doc_identity.encode("utf-8", "surrogatepass")).hexdigest())
 
     @classmethod

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -227,6 +227,63 @@ def test_pipeline_update_metadata() -> None:
         assert node.metadata == new_metadata
 
 
+def test_pipeline_does_not_re_embed_on_volatile_metadata_change() -> None:
+    """Regression test: fields listed in `excluded_embed_metadata_keys` must
+    NOT trigger re-embedding on upsert. This covers the churn scenario where
+    volatile metadata such as file-stat timestamps or sizes would otherwise
+    force redundant embedding API calls for byte-identical content.
+
+    Companion to `test_pipeline_update_metadata`, which verifies the inverse:
+    a change to a content-relevant (non-excluded) metadata field DOES trigger
+    re-processing.
+    """
+    from unittest.mock import MagicMock
+
+    embed_model = MockEmbedding(embed_dim=4)
+    # Wrap the batch method so we can count invocations.
+    embed_model.get_text_embedding_batch = MagicMock(  # type: ignore[method-assign]
+        wraps=embed_model.get_text_embedding_batch
+    )
+
+    pipeline = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=256, chunk_overlap=0),
+            embed_model,
+        ],
+        docstore=SimpleDocumentStore(),
+    )
+
+    doc = Document(
+        id_="0",
+        text="hello world, this is a short test document for the pipeline",
+        metadata={"tag": "v1", "last_modified_date": "2026-04-22"},
+        excluded_embed_metadata_keys=["last_modified_date"],
+    )
+
+    # Phase 1: first ingest (should embed).
+    pipeline.run(documents=[doc])
+    embed_calls_after_phase1 = embed_model.get_text_embedding_batch.call_count
+    assert embed_calls_after_phase1 >= 1
+
+    # Phase 2: mutate only the volatile field, which is in
+    # `excluded_embed_metadata_keys`. This must NOT re-embed.
+    doc.metadata["last_modified_date"] = "2026-04-23"
+    pipeline.run(documents=[doc])
+    assert embed_model.get_text_embedding_batch.call_count == embed_calls_after_phase1, (
+        "Re-embedding was triggered by a change to metadata listed in "
+        "excluded_embed_metadata_keys. This re-introduces the churn bug."
+    )
+
+    # Phase 3: mutate a non-excluded (content-relevant) field. This SHOULD
+    # re-embed, preserving the behavior added in #18303 for #17871.
+    doc.metadata["tag"] = "v2"
+    pipeline.run(documents=[doc])
+    assert embed_model.get_text_embedding_batch.call_count > embed_calls_after_phase1, (
+        "Content-relevant metadata change was not detected. The fix must still "
+        "invalidate the cache when a non-excluded field changes."
+    )
+
+
 def test_pipeline_dedup_duplicates_only() -> None:
     documents = [
         Document(text="one", doc_id="1"),

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -228,22 +228,14 @@ def test_pipeline_update_metadata() -> None:
 
 
 def test_pipeline_does_not_re_embed_on_volatile_metadata_change() -> None:
-    """Regression test: fields listed in `excluded_embed_metadata_keys` must
-    NOT trigger re-embedding on upsert. This covers the churn scenario where
-    volatile metadata such as file-stat timestamps or sizes would otherwise
-    force redundant embedding API calls for byte-identical content.
-
-    Companion to `test_pipeline_update_metadata`, which verifies the inverse:
-    a change to a content-relevant (non-excluded) metadata field DOES trigger
-    re-processing.
+    """A change to a field listed in `excluded_embed_metadata_keys` must
+    not trigger re-embedding. This covers the scenario where volatile
+    metadata such as file-stat timestamps or sizes would otherwise force
+    redundant embedding API calls for byte-identical content.
     """
-    from unittest.mock import MagicMock
+    from unittest.mock import patch
 
     embed_model = MockEmbedding(embed_dim=4)
-    # Wrap the batch method so we can count invocations.
-    embed_model.get_text_embedding_batch = MagicMock(  # type: ignore[method-assign]
-        wraps=embed_model.get_text_embedding_batch
-    )
 
     pipeline = IngestionPipeline(
         transformations=[
@@ -260,28 +252,51 @@ def test_pipeline_does_not_re_embed_on_volatile_metadata_change() -> None:
         excluded_embed_metadata_keys=["last_modified_date"],
     )
 
-    # Phase 1: first ingest (should embed).
-    pipeline.run(documents=[doc])
-    embed_calls_after_phase1 = embed_model.get_text_embedding_batch.call_count
-    assert embed_calls_after_phase1 >= 1
+    # Class-level patch (not instance attribute assignment): MockEmbedding
+    # is a Pydantic BaseModel, so `embed_model.method = mock` is rejected
+    # by strict-field validation. `wraps=` forwards calls to the real
+    # method so the pipeline keeps working while the spy records them.
+    # Do not simplify to instance assignment, it will fail at runtime.
+    with patch.object(
+        MockEmbedding,
+        "get_text_embedding_batch",
+        wraps=embed_model.get_text_embedding_batch,
+    ) as embed_spy:
 
-    # Phase 2: mutate only the volatile field, which is in
-    # `excluded_embed_metadata_keys`. This must NOT re-embed.
-    doc.metadata["last_modified_date"] = "2026-04-23"
-    pipeline.run(documents=[doc])
-    assert embed_model.get_text_embedding_batch.call_count == embed_calls_after_phase1, (
-        "Re-embedding was triggered by a change to metadata listed in "
-        "excluded_embed_metadata_keys. This re-introduces the churn bug."
-    )
+        def texts_embedded() -> int:
+            """Count the real texts embedded so far, ignoring empty-batch calls.
 
-    # Phase 3: mutate a non-excluded (content-relevant) field. This SHOULD
-    # re-embed, preserving the behavior added in #18303 for #17871.
-    doc.metadata["tag"] = "v2"
-    pipeline.run(documents=[doc])
-    assert embed_model.get_text_embedding_batch.call_count > embed_calls_after_phase1, (
-        "Content-relevant metadata change was not detected. The fix must still "
-        "invalidate the cache when a non-excluded field changes."
-    )
+            The pipeline always invokes the embedding transform once per
+            `pipeline.run(...)`, even when dedup produced an empty
+            `nodes_to_run` and the batch is `[]`. Counting raw invocations
+            would therefore report a re-embed every time we re-run, which
+            is the opposite of what we want to assert.
+            """
+            return sum(
+                len(call.args[0]) if call.args else 0
+                for call in embed_spy.call_args_list
+            )
+
+        # Phase 1: first ingest; should embed.
+        pipeline.run(documents=[doc])
+        embedded_after_phase1 = texts_embedded()
+        assert embedded_after_phase1 >= 1
+
+        # Phase 2: change a volatile (excluded) field; must not re-embed.
+        doc.metadata["last_modified_date"] = "2026-04-23"
+        pipeline.run(documents=[doc])
+        assert texts_embedded() == embedded_after_phase1, (
+            "Re-embedding was triggered by a change to metadata listed in "
+            "excluded_embed_metadata_keys."
+        )
+
+        # Phase 3: change a non-excluded field; should re-embed.
+        doc.metadata["tag"] = "v2"
+        pipeline.run(documents=[doc])
+        assert texts_embedded() > embedded_after_phase1, (
+            "A change to a content-relevant (non-excluded) metadata field "
+            "did not trigger re-embedding."
+        )
 
 
 def test_pipeline_dedup_duplicates_only() -> None:

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -76,6 +76,52 @@ def test_text_node_hash() -> None:
     assert node3.hash != node.hash
 
 
+def test_text_node_hash_ignores_excluded_embed_metadata() -> None:
+    """Regression test for the embedding churn fix (#21461, #21462).
+
+    `TextNode.hash` must be computed from `MetadataMode.EMBED`, not `ALL`.
+    Fields listed in `excluded_embed_metadata_keys` (e.g. the
+    `last_modified_date` field that `SimpleDirectoryReader` populates from
+    the filesystem stat) are volatile: they change across runs even when
+    the document content is byte-identical. If the hash included them,
+    every ingestion run would produce a new hash for the same content,
+    forcing the cache to miss and the embedding model to re-embed
+    unchanged text.
+    """
+    node_a = TextNode(
+        text="hello world",
+        metadata={
+            "source": "docs/readme.md",
+            "last_modified_date": "2026-04-22",
+        },
+        excluded_embed_metadata_keys=["last_modified_date"],
+    )
+    node_b = TextNode(
+        text="hello world",
+        metadata={
+            "source": "docs/readme.md",
+            "last_modified_date": "2026-04-23",
+        },
+        excluded_embed_metadata_keys=["last_modified_date"],
+    )
+    # Volatile metadata changed but embedded content is byte-identical,
+    # so the hashes must match.
+    assert node_a.hash == node_b.hash
+
+    # Sanity check: a non-excluded metadata field still affects the hash.
+    # Without this assertion, a future regression that ignored ALL metadata
+    # would make the main assert above pass trivially.
+    node_c = TextNode(
+        text="hello world",
+        metadata={
+            "source": "docs/CHANGED.md",
+            "last_modified_date": "2026-04-22",
+        },
+        excluded_embed_metadata_keys=["last_modified_date"],
+    )
+    assert node_c.hash != node_a.hash
+
+
 def test_text_node_with_text_resource():
     tr = MediaResource(text="This is a test")
     text_node = TextNode(text_resource=tr)

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -59,16 +59,16 @@ def test_node_with_score_passthrough(node_with_score: NodeWithScore) -> None:
 def test_text_node_hash() -> None:
     node = TextNode(text="hello", metadata={"foo": "bar"})
     assert (
-        node.hash == "aa158bf3388f103cef4bd85b2ca93f343ad8f5e50f58ae4141a35d75a2f21fb0"
+        node.hash == "a98c32b3bf66d9514ee252ac7d7031e43a9c800620f25876095152b2640080cc"
     )
     node.set_content("world")
     assert (
-        node.hash == "ce6a3cefc3451ecb1ff41ec41a7d7e24354983520d8b2d6f5447be0b6b9b6b99"
+        node.hash == "546b28d61bae0226e30fb638ceb11f51a45966b14ca70ec341c4054bac69150a"
     )
 
     node.text = "new"
     assert (
-        node.hash == "bef8ff82498c9aa7d9f9751f441da9a1a1c4e9941bd03c57caa4a602cd5cadd0"
+        node.hash == "da8cebc17ab289e53fa89602bf0b00e7b4291ac8d986ee2b9bf4a34f9b7bcc17"
     )
     node2 = TextNode(text="new", metadata={"foo": "bar"})
     assert node2.hash == node.hash
@@ -77,16 +77,12 @@ def test_text_node_hash() -> None:
 
 
 def test_text_node_hash_ignores_excluded_embed_metadata() -> None:
-    """Regression test for the embedding churn fix (#21461, #21462).
-
-    `TextNode.hash` must be computed from `MetadataMode.EMBED`, not `ALL`.
-    Fields listed in `excluded_embed_metadata_keys` (e.g. the
-    `last_modified_date` field that `SimpleDirectoryReader` populates from
-    the filesystem stat) are volatile: they change across runs even when
-    the document content is byte-identical. If the hash included them,
-    every ingestion run would produce a new hash for the same content,
-    forcing the cache to miss and the embedding model to re-embed
-    unchanged text.
+    """`TextNode.hash` must ignore metadata fields listed in
+    `excluded_embed_metadata_keys`. These fields are volatile (e.g.
+    `last_modified_date` populated by `SimpleDirectoryReader` from the
+    filesystem stat); including them in the hash would produce a new
+    hash for byte-identical content on every run, forcing the cache to
+    miss and the embedding model to re-embed unchanged text.
     """
     node_a = TextNode(
         text="hello world",
@@ -104,13 +100,10 @@ def test_text_node_hash_ignores_excluded_embed_metadata() -> None:
         },
         excluded_embed_metadata_keys=["last_modified_date"],
     )
-    # Volatile metadata changed but embedded content is byte-identical,
-    # so the hashes must match.
     assert node_a.hash == node_b.hash
 
-    # Sanity check: a non-excluded metadata field still affects the hash.
-    # Without this assertion, a future regression that ignored ALL metadata
-    # would make the main assert above pass trivially.
+    # Sanity check: a non-excluded field must still affect the hash,
+    # otherwise the main assertion would pass trivially.
     node_c = TextNode(
         text="hello world",
         metadata={


### PR DESCRIPTION

### Description

Fixes the unnecessary re-embed behavior described in #21461.

Three parallel hashing code paths in `llama-index-core` include metadata without respecting `excluded_embed_metadata_keys`. The combined effect is that any volatile metadata change (file-stat timestamps, sizes, etc.) invalidates caches and re-triggers embedding for byte-identical content.

This PR changes all three sites to use `MetadataMode.EMBED`, which respects `excluded_embed_metadata_keys`. The mechanism already exists in the codebase for exactly the purpose of marking fields as not-content-relevant.

Meaningful metadata changes (user-added tags, custom enrichments, any field not explicitly excluded by the reader) are still tracked. The fix preserves the intent of #18303 (detect content-relevant metadata changes) while eliminating the churn on fields that were explicitly excluded from embedding.

Fixes #21461

### The three changes

1. **`Node.hash`** in `llama-index-core/llama_index/core/schema.py`:
   ```diff
   -        metadata_str = self.get_metadata_str(mode=MetadataMode.ALL)
   +        metadata_str = self.get_metadata_str(mode=MetadataMode.EMBED)
   ```

2. **`TextNode.hash`** in `llama-index-core/llama_index/core/schema.py`. Previously built `doc_identity` as `str(self.text) + str(self.metadata)`, which included all metadata regardless of exclusions. Updated to use `get_metadata_str(mode=MetadataMode.EMBED)` so volatile fields do not participate:
   ```diff
   -        doc_identity = str(self.text) + str(self.metadata)
   +        metadata_str = self.get_metadata_str(mode=MetadataMode.EMBED)
   +        doc_identity = str(self.text) + metadata_str
   ```

3. **`get_transformation_hash`** in `llama-index-core/llama_index/core/ingestion/pipeline.py`. This is the key used by `IngestionCache` to skip transformations on repeated input. Previously used `MetadataMode.ALL`, causing cache misses on volatile metadata change. Updated to `MetadataMode.EMBED`:
   ```diff
   -        [str(node.get_content(metadata_mode=MetadataMode.ALL)) for node in nodes]
   +        [str(node.get_content(metadata_mode=MetadataMode.EMBED)) for node in nodes]
   ```

Without change #3, even with #1 and #2 applied, `IngestionCache` would still miss on the volatile-metadata change and re-run the whole transformation chain including the embedder. The three changes together are the minimal set.

### Test coverage

Adds two regression tests:

1. **Unit test** in `llama-index-core/tests/schema/test_schema.py` (`test_text_node_hash_ignores_excluded_embed_metadata`) that asserts the invariant directly on `TextNode.hash`: two nodes with identical text but different values for a field listed in `excluded_embed_metadata_keys` must produce the same hash. Includes a sanity assertion that a change to a non-excluded field still affects the hash, to guard against an over-correction that would silently drop all metadata from the hash.

2. **Integration test** in `llama-index-core/tests/ingestion/test_pipeline.py` (`test_pipeline_does_not_re_embed_on_volatile_metadata_change`) that runs an `IngestionPipeline` end-to-end and verifies the user-facing symptom: a change to an excluded field does not trigger re-embedding, while a change to a non-excluded field does. Companion to `test_pipeline_update_metadata`, which still passes unchanged.

Together they cover the contract in both directions at both levels.

### Incidental test maintenance

A second commit (`test: fix existing tests that broke against the hash computation change`) updates two pre-existing artifacts that would otherwise fail CI:

1. `test_text_node_hash` had three hardcoded golden hash values computed against the pre-fix `str(self.text) + str(self.metadata)` doc_identity. Updated to match the new formatted `metadata_str` concatenation.
2. The integration test above also refactors `MockEmbedding` instrumentation away from direct instance assignment (rejected by Pydantic's strict field validation) and switches the invocation metric from `call_count` to a `texts_embedded()` helper that sums batch lengths, which avoids false positives on empty-batch calls.

Verified locally: the regression tests still correctly fail when `schema.py` and `pipeline.py` are reverted to main.

### Why `MetadataMode.EMBED` is the right choice

- It respects `excluded_embed_metadata_keys`, which readers already use to mark fields that should not participate in the embedded text.
- The intent of excluding a field from embedding is, by construction, that the field is not content-relevant. By the same reasoning, it should not invalidate the cached embedding.
- `SimpleDirectoryReader` and other readers (`S3Reader`, `GCSReader`, etc.) already populate `excluded_embed_metadata_keys` with volatile file-stat and API-datetime fields by default. These changes make the hashing paths align with that existing intent, without any reader-side modifications.
- Users who want a particular field to always participate in the hash can simply keep it out of `excluded_embed_metadata_keys`.

### Potential concerns and responses

**"This changes hash semantics and could break users depending on the old behavior."**
The change makes these hashes less aggressive at invalidation. They only flip on fields the reader hasn't marked excluded. Any previously-valid invalidation (on non-excluded fields) still occurs. The only change in behavior is that excluded-from-embed fields no longer cause unnecessary re-embeds. If a deployment relied on the old churn behavior as a form of time-based re-embedding, they can opt back in by removing specific fields from `excluded_embed_metadata_keys`.

**"Why not just document the current behavior?"**
The current behavior silently charges real API tokens to the embedding provider on every cross-day ingestion run that touches any file. Documentation doesn't fix the cost; it just explains it. The reproducer repo demonstrates real OpenAI billed usage under realistic workflows.

**"What about custom `file_metadata` callables that don't set `excluded_embed_metadata_keys`?"**
Those callers retain full control. Any field they include in metadata without excluding it will still participate in the hash. The fix is opt-in by virtue of respecting the existing exclusion mechanism.

### Reproducer

External reproducer repo with 5 progressive levels of evidence (hash comparison, counting embedder, real OpenAI API end-to-end, reader format families, S3 end-to-end): https://github.com/stirelli/llamaindex-embedding-churn

Level 3 (the real-OpenAI E2E test) goes from 100% overhead to 0% overhead after this PR is applied. Verified locally with `llama-index-core==0.14.21`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review
- [x] I added regression tests
- [x] Existing tests still pass (`test_pipeline_update_metadata` was the existing coverage for the inverse behavior, which still passes since its metadata fields are not in `excluded_embed_metadata_keys`)
- [x] Verified locally with the external reproducer
- [ ] I ran `uv run make format; uv run make lint` (blocked on this macOS x86_64 machine by an unrelated `tree-sitter-language-pack` wheel availability issue; CI will cover lint/format)

