### PR TITLE
docs: fix query engine link typo

### DIFF
--- a/docs/src/content/docs/framework/module_guides/deploying/query_engine/modules.md
+++ b/docs/src/content/docs/framework/module_guides/deploying/query_engine/modules.md
@@ -20,7 +20,7 @@ Then check out the rest of the sections below.
 - [JSONalyze Query Engine](/python/examples/query_engine/jsonalyze_query_engine)
 - [Knowledge Graph Query Engine](/python/examples/query_engine/knowledge_graph_query_engine)
 - [KG RAG Retriever](/python/examples/query_engine/knowledge_graph_rag_query_engine)
-- [Multi-Docment Auto Retrieval](/python/examples/query_engine/multi_doc_auto_retrieval/multi_doc_auto_retrieval)
+- [Multi-Document Auto Retrieval](/python/examples/query_engine/multi_doc_auto_retrieval/multi_doc_auto_retrieval)
 
 ## Advanced
 


### PR DESCRIPTION
Fixes a typo in the query engine modules list: `Multi-Docment Auto Retrieval` -> `Multi-Document Auto Retrieval`.