### PR TITLE
fix(ipex-llm): make trust_remote_code user-controlled, default to False

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ipex-llm/llama_index/llms/ipex_llm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ipex-llm/llama_index/llms/ipex_llm/base.py
@@ -232,8 +232,16 @@ class IpexLLM(CustomLLM):
                     tokenizer_name, **tokenizer_kwargs
                 )
             except Exception:
+                logger.warning(
+                    f"AutoTokenizer failed for '{tokenizer_name}'. "
+                    "Retrying with LlamaTokenizer. "
+                    "trust_remote_code is NOT enabled automatically; "
+                    "pass trust_remote_code=True in tokenizer_kwargs explicitly "
+                    "if you trust this model source."
+                )
                 tokenizer = LlamaTokenizer.from_pretrained(
-                    tokenizer_name, trust_remote_code=True
+                    tokenizer_name,
+                    trust_remote_code=tokenizer_kwargs.get("trust_remote_code", False),
                 )
 
         if tokenizer_name != model_name:
@@ -404,7 +412,14 @@ class IpexLLM(CustomLLM):
         """Attempts to load a model with AutoModelForCausalLM and falls back to AutoModel on failure."""
         from ipex_llm.transformers import AutoModelForCausalLM, AutoModel
 
-        load_kwargs = {"use_cache": True, "trust_remote_code": True}
+        trust_remote_code = model_kwargs.pop("trust_remote_code", False)
+        if trust_remote_code:
+            logger.warning(
+                "trust_remote_code=True is enabled. This allows execution of "
+                "arbitrary code from the model repository. Only use this if you "
+                "trust the model source."
+            )
+        load_kwargs = {"use_cache": True, "trust_remote_code": trust_remote_code}
 
         if not low_bit_model:
             if load_in_low_bit is not None:


### PR DESCRIPTION
## Summary

Fixes #21464

`trust_remote_code=True` was hardcoded in two places in `llama-index-llms-ipex-llm`, silently granting arbitrary code execution permission without user consent.

### Changes

**1. Tokenizer fallback (`~line 235`)**

Before:
```python
except Exception:
    tokenizer = LlamaTokenizer.from_pretrained(
        tokenizer_name, trust_remote_code=True  # hardcoded
    )
```

After:
```python
except Exception:
    logger.warning(
        f"AutoTokenizer failed for '{tokenizer_name}'. "
        "Retrying with LlamaTokenizer. "
        "trust_remote_code is NOT enabled automatically; "
        "pass trust_remote_code=True in tokenizer_kwargs explicitly "
        "if you trust this model source."
    )
    tokenizer = LlamaTokenizer.from_pretrained(
        tokenizer_name,
        trust_remote_code=tokenizer_kwargs.get("trust_remote_code", False),
    )
```

**2. Model loading (`~line 407`)**

Before:
```python
load_kwargs = {"use_cache": True, "trust_remote_code": True}  # unconditional
```

After:
```python
trust_remote_code = model_kwargs.pop("trust_remote_code", False)
if trust_remote_code:
    logger.warning(
        "trust_remote_code=True is enabled. This allows execution of "
        "arbitrary code from the model repository. Only use this if you "
        "trust the model source."
    )
load_kwargs = {"use_cache": True, "trust_remote_code": trust_remote_code}
```

### Behaviour

- Default is now `False` (safe) — no breaking change for users who trust the model and already pass `trust_remote_code=True` explicitly via `model_kwargs` or `tokenizer_kwargs`
- A `logger.warning()` is emitted whenever `trust_remote_code=True` is actually applied, consistent with the Gaudi and vLLM integrations