### PR TITLE
fix(retrievers): apply retriever_weights in reciprocal_rerank_fusion mode

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -123,8 +123,10 @@ class QueryFusionRetriever(BaseRetriever):
         fused_scores = {}
         hash_to_node = {}
 
-        # compute reciprocal rank scores
-        for nodes_with_scores in results.values():
+        # compute reciprocal rank scores weighted by retriever weight
+        for query_tuple, nodes_with_scores in results.items():
+            retriever_idx = query_tuple[1]
+            weight = self._retriever_weights[retriever_idx]
             for rank, node_with_score in enumerate(
                 sorted(nodes_with_scores, key=lambda x: x.score or 0.0, reverse=True)
             ):
@@ -132,7 +134,7 @@ class QueryFusionRetriever(BaseRetriever):
                 hash_to_node[hash] = node_with_score
                 if hash not in fused_scores:
                     fused_scores[hash] = 0.0
-                fused_scores[hash] += 1.0 / (rank + k)
+                fused_scores[hash] += weight / (rank + k)
 
         # sort results
         reranked_results = dict(


### PR DESCRIPTION
## Summary

Setting `retriever_weights` on a `QueryFusionRetriever` with `mode="reciprocal_rerank"` has no effect — all retrievers are weighted equally. The weights are silently ignored.

## Root cause

`_reciprocal_rerank_fusion` iterates over `results.values()`, discarding the `(query_str, retriever_idx)` key. Each node always gets `1.0 / (rank + k)` regardless of its retriever's weight:

```python
# Before (broken)
for nodes_with_scores in results.values():  # key discarded
    ...
    fused_scores[hash] += 1.0 / (rank + k)  # no weight applied
```

`_relative_score_fusion` already does this correctly with `retriever_idx = query_tuple[1]` and `self._retriever_weights[retriever_idx]`.

## Fix

Switch to `results.items()`, extract `retriever_idx` from the key, and scale the RRF contribution by `self._retriever_weights[retriever_idx]`:

```python
for query_tuple, nodes_with_scores in results.items():
    retriever_idx = query_tuple[1]
    weight = self._retriever_weights[retriever_idx]
    ...
    fused_scores[hash] += weight / (rank + k)
```

This mirrors the weight application in `_relative_score_fusion` and was introduced in PR #11667 but not carried through to the RRF path.

Fixes #21444