### PR TITLE
fix(instrumentation): avoid mutating ChatResponse.raw in LLM event model_dump

### DIFF
--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -143,10 +143,17 @@ class LLMCompletionInProgressEvent(BaseEvent):
         return "LLMCompletionInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+        result = super().model_dump(**kwargs)
+        # Serialize raw without mutating the original response object.
+        # The original code did self.response.raw = self.response.raw.model_dump()
+        # which permanently converted the field from a Pydantic model to a dict,
+        # corrupting ChatResponse.raw for all callers.  See issue #21422.
+        if (
+            isinstance(self.response.raw, BaseModel)
+            and isinstance(result.get("response"), dict)
+        ):
+            result["response"]["raw"] = self.response.raw.model_dump()
+        return result
 
 
 class LLMCompletionEndEvent(BaseEvent):
@@ -168,10 +175,17 @@ class LLMCompletionEndEvent(BaseEvent):
         return "LLMCompletionEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+        result = super().model_dump(**kwargs)
+        # Serialize raw without mutating the original response object.
+        # The original code did self.response.raw = self.response.raw.model_dump()
+        # which permanently converted the field from a Pydantic model to a dict,
+        # corrupting ChatResponse.raw for all callers.  See issue #21422.
+        if (
+            isinstance(self.response.raw, BaseModel)
+            and isinstance(result.get("response"), dict)
+        ):
+            result["response"]["raw"] = self.response.raw.model_dump()
+        return result
 
 
 class LLMChatStartEvent(BaseEvent):
@@ -215,10 +229,17 @@ class LLMChatInProgressEvent(BaseEvent):
         return "LLMChatInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+        result = super().model_dump(**kwargs)
+        # Serialize raw without mutating the original response object.
+        # The original code did self.response.raw = self.response.raw.model_dump()
+        # which permanently converted the field from a Pydantic model to a dict,
+        # corrupting ChatResponse.raw for all callers.  See issue #21422.
+        if (
+            isinstance(self.response.raw, BaseModel)
+            and isinstance(result.get("response"), dict)
+        ):
+            result["response"]["raw"] = self.response.raw.model_dump()
+        return result
 
 
 class LLMChatEndEvent(BaseEvent):
@@ -240,7 +261,13 @@ class LLMChatEndEvent(BaseEvent):
         return "LLMChatEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if self.response is not None and isinstance(self.response.raw, BaseModel):
-            self.response.raw = self.response.raw.model_dump()
-
-        return super().model_dump(**kwargs)
+        result = super().model_dump(**kwargs)
+        # Serialize raw without mutating the original response object.
+        # See issue #21422.
+        if (
+            self.response is not None
+            and isinstance(self.response.raw, BaseModel)
+            and isinstance(result.get("response"), dict)
+        ):
+            result["response"]["raw"] = self.response.raw.model_dump()
+        return result


### PR DESCRIPTION
## Summary

`LLMChatEndEvent.model_dump()` (and `LLMCompletionEndEvent`, `LLMChatInProgressEvent`, `LLMCompletionInProgressEvent`) mutate `ChatResponse.raw` in-place when serializing for telemetry. This corrupts the response object for the caller.

## Root cause

All four event classes override `model_dump()` with:

```python
def model_dump(self, **kwargs):
    if isinstance(self.response.raw, BaseModel):
        self.response.raw = self.response.raw.model_dump()  # mutates original!
    return super().model_dump(**kwargs)
```

`self.response` is the same `ChatResponse` object returned to the caller. After `model_dump()` fires (triggered by any OTel subscriber), `ChatResponse.raw` is permanently a plain `dict` instead of the Pydantic model. Any caller that accesses fields on `raw` (e.g. `StructuredLLM.achat()`) gets `AttributeError: 'dict' object has no attribute '...'`. The bug is silent in local dev (no telemetry subscriber) and only manifests in instrumented environments.

## Fix

Call `super().model_dump()` first to get the serialized dict, then overwrite `result["response"]["raw"]` in the returned dict using `self.response.raw.model_dump()`. `self.response.raw` is never touched:

```python
def model_dump(self, **kwargs):
    result = super().model_dump(**kwargs)
    if isinstance(self.response.raw, BaseModel) and isinstance(result.get("response"), dict):
        result["response"]["raw"] = self.response.raw.model_dump()
    return result
```

Applied to all four affected event classes.

Fixes #21422