### PR TITLE
fix(openai): serialize ToolCallBlock.tool_kwargs to JSON string in to_openai_message_dict

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -495,11 +495,20 @@ def to_openai_message_dict(
             continue
         elif isinstance(block, ToolCallBlock):
             try:
+                # OpenAI Chat Completions API requires function.arguments to be a
+                # JSON string, not a dict.  When ToolCallBlock originates from the
+                # Anthropic provider, tool_kwargs is a Python dict (Anthropic returns
+                # tool_input as an object).  Serialize to string if needed.
+                # This is already done in to_openai_responses_message_dict.
+                # See issue #21378.
+                arguments = block.tool_kwargs
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments)
                 function_dict = {
                     "type": "function",
                     "function": {
                         "name": block.tool_name,
-                        "arguments": block.tool_kwargs,
+                        "arguments": arguments,
                     },
                     "id": block.tool_call_id,
                 }


### PR DESCRIPTION
## Summary

When an `AgentWorkflow` uses mixed LLM providers (e.g. Anthropic orchestrator handing off to an OpenAI sub-agent), the OpenAI Chat Completions API returns `400 BadRequestError` because `function.arguments` is sent as a JSON object instead of a JSON string.

## Root cause

In `to_openai_message_dict`, `ToolCallBlock.tool_kwargs` is placed directly into `"arguments"` without serialization:

```python
"arguments": block.tool_kwargs,  # dict when from Anthropic
```

The Anthropic provider stores `tool_kwargs` as a Python `dict` (Anthropic returns tool input as an object).  The OpenAI Chat Completions API requires `function.arguments` to be a JSON string, not an object.

## Fix

`to_openai_responses_message_dict` (Responses API path) already handles this correctly:

```python
arguments = block.tool_kwargs
if not isinstance(arguments, str):
    arguments = json.dumps(arguments)
```

Apply the same fix to `to_openai_message_dict` (Chat Completions API path).

Fixes #21378