### PR TITLE
Add llama-index-tools-openregistry integration

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-openregistry/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## [0.1.0]
+
+- Initial release: `OpenRegistryToolSpec`, a thin convenience wrapper around `McpToolSpec` from `llama-index-tools-mcp` preconfigured for the hosted [OpenRegistry](https://openregistry.sophymarine.com) MCP server.
+- Anonymous tier supported with no API key. Optional OAuth bearer token for authenticated higher-rate tiers.
+- Optional `allowed_tools` allowlist and `url` override for staging / self-hosted endpoints.

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/README.md
@@ -1,0 +1,76 @@
+# OpenRegistry Tool
+
+This tool gives a LlamaIndex agent live, real-time access to **27 national company registries** through the hosted [OpenRegistry](https://openregistry.sophymarine.com) MCP server — UK Companies House, France RNE, Germany Handelsregister, Italy InfoCamere via EU BRIS, Spain BORME, Korea OpenDART, and 21 more.
+
+Every tool call is a real-time query against the upstream government API at the moment the agent asks. No data is cached or aggregated, so the agent always sees the registry's own response with all field names preserved.
+
+## Installation
+
+```bash
+pip install llama-index-tools-openregistry
+```
+
+## Usage
+
+Anonymous use — no signup, no API key:
+
+```python
+from llama_index.tools.openregistry import OpenRegistryToolSpec
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+tool_spec = OpenRegistryToolSpec()
+
+agent = FunctionAgent(
+    tools=tool_spec.to_tool_list(),
+    llm=OpenAI(model="gpt-4.1"),
+)
+
+await agent.run(
+    "Find Tesco PLC on Companies House and walk its corporate ownership chain"
+    " across jurisdictions until you reach the ultimate beneficial owner."
+)
+```
+
+## Authenticated tier
+
+The free anonymous tier allows 20 calls/min per IP and a cross-border fan-out of 3 countries / 60s. For higher limits, complete the OAuth 2.1 flow at [openregistry.sophymarine.com/account](https://openregistry.sophymarine.com/account) and pass the resulting bearer token:
+
+```python
+tool_spec = OpenRegistryToolSpec(oauth_token=OPENREGISTRY_TOKEN)
+```
+
+## Restricting tools
+
+OpenRegistry exposes ~30 tools (search, profile, officers, PSCs, charges, filings, document download, jurisdiction-specific specialised records, etc.). To keep the agent's tool list lean, allowlist just the ones you need:
+
+```python
+tool_spec = OpenRegistryToolSpec(
+    allowed_tools=[
+        "search_companies",
+        "get_company_profile",
+        "get_officers",
+        "get_persons_with_significant_control",
+    ],
+)
+```
+
+## Tools available
+
+The full per-jurisdiction capability matrix is published at [`list_jurisdictions`](https://openregistry.sophymarine.com/jurisdictions) — each registry advertises which subset of the tool surface it supports. Highlights:
+
+- `search_companies` — name / number / address search across any single jurisdiction
+- `get_company_profile` — statutory profile (status, address, incorporation date, accounting reference date, etc.)
+- `get_officers` — directors and secretaries with full appointment history
+- `get_persons_with_significant_control` — UK PSC Register and equivalents
+- `get_shareholders` — shareholder lists where the registry publishes them
+- `get_charges` — registered charges / mortgages
+- `list_filings` / `fetch_document` — raw XHTML iXBRL, PDF, or XBRL filing bytes
+- `get_financials` — latest statutory accounts as machine-readable XBRL where available
+- Jurisdiction-specific tools for KR (OpenDART), DE (Handelsregister), ES (BORME / actos inscritos), IT (InfoCamere via BRIS), and others
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+OpenRegistry is a platform by [Sophymarine](https://sophymarine.com). The hosted service is not affiliated with any of the national company registries it proxies.

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/examples/basic_usage.py
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/examples/basic_usage.py
@@ -1,0 +1,46 @@
+"""Walk a UK company's officers + persons with significant control via the
+OpenRegistry MCP server.
+
+Run with:
+
+    pip install llama-index-tools-openregistry llama-index-llms-openai
+    export OPENAI_API_KEY=sk-...
+    python examples/basic_usage.py
+
+The example uses the free anonymous tier — no OpenRegistry signup needed.
+"""
+
+import asyncio
+
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+from llama_index.tools.openregistry import OpenRegistryToolSpec
+
+
+async def main() -> None:
+    tool_spec = OpenRegistryToolSpec(
+        # For lower latency, allowlist just the tools the agent needs:
+        allowed_tools=[
+            "search_companies",
+            "get_company_profile",
+            "get_officers",
+            "get_persons_with_significant_control",
+        ],
+    )
+
+    agent = FunctionAgent(
+        tools=tool_spec.to_tool_list(),
+        llm=OpenAI(model="gpt-4.1"),
+    )
+
+    response = await agent.run(
+        "Find Tesco PLC on Companies House (jurisdiction gb). Pull its current"
+        " directors and persons with significant control, and quote the upstream"
+        " `nature_of_control` strings exactly as the registry returns them."
+    )
+    print(response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/llama_index/tools/openregistry/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/llama_index/tools/openregistry/__init__.py
@@ -1,0 +1,6 @@
+from llama_index.tools.openregistry.base import (
+    OPENREGISTRY_MCP_URL,
+    OpenRegistryToolSpec,
+)
+
+__all__ = ["OPENREGISTRY_MCP_URL", "OpenRegistryToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/llama_index/tools/openregistry/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/llama_index/tools/openregistry/base.py
@@ -1,0 +1,68 @@
+"""OpenRegistry tool spec for LlamaIndex.
+
+OpenRegistry is a hosted Streamable HTTP MCP server that proxies 27 national
+company registries (UK Companies House, France RNE, Germany Handelsregister,
+Italy InfoCamere via EU BRIS, Spain BORME, Korea OpenDART, etc.). Every tool
+call is a real-time query against the upstream government API; no data is
+cached or aggregated.
+
+This package is a thin convenience wrapper around ``McpToolSpec`` from
+``llama-index-tools-mcp`` — it preconfigures the LlamaIndex agent with the
+hosted endpoint and forwards any optional OAuth bearer token (for higher
+rate-limit tiers).
+"""
+
+from typing import List, Optional
+
+from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
+
+OPENREGISTRY_MCP_URL = "https://openregistry.sophymarine.com/mcp"
+
+
+class OpenRegistryToolSpec(McpToolSpec):
+    """LlamaIndex ToolSpec preconfigured for the OpenRegistry MCP server.
+
+    Use the free anonymous tier with no arguments. For per-user rate limits or
+    cross-border fan-out beyond 3 countries / 60s, complete the OAuth 2.1 flow
+    against ``openregistry.sophymarine.com`` and pass the resulting bearer
+    token to ``oauth_token``.
+
+    Example:
+        >>> from llama_index.tools.openregistry import OpenRegistryToolSpec
+        >>> from llama_index.core.agent.workflow import FunctionAgent
+        >>> from llama_index.llms.openai import OpenAI
+        >>>
+        >>> tool_spec = OpenRegistryToolSpec()
+        >>> agent = FunctionAgent(
+        ...     tools=tool_spec.to_tool_list(),
+        ...     llm=OpenAI(model="gpt-4.1"),
+        ... )
+        >>> # await agent.run("Find Tesco PLC on Companies House")
+
+    Args:
+        oauth_token: Optional OAuth 2.1 bearer token for authenticated tiers.
+            See https://openregistry.sophymarine.com/docs for the OAuth flow.
+        url: Override the MCP endpoint. Defaults to the hosted production URL.
+            Useful for staging / self-hosted setups.
+        allowed_tools: Optional allowlist of tool names. When set, only the
+            named tools are exposed to the agent. By default all ~30 tools are
+            exposed.
+        include_resources: Forwarded to ``McpToolSpec``; enable to surface
+            MCP resources alongside tools.
+
+    """
+
+    def __init__(
+        self,
+        oauth_token: Optional[str] = None,
+        url: str = OPENREGISTRY_MCP_URL,
+        allowed_tools: Optional[List[str]] = None,
+        include_resources: bool = False,
+    ) -> None:
+        headers = {"Authorization": f"Bearer {oauth_token}"} if oauth_token else None
+        client = BasicMCPClient(url, headers=headers)
+        super().__init__(
+            client=client,
+            allowed_tools=allowed_tools,
+            include_resources=include_resources,
+        )

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/pyproject.toml
@@ -1,0 +1,75 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "pytest-asyncio>=0.23.8",
+]
+
+[project]
+name = "llama-index-tools-openregistry"
+version = "0.1.0"
+description = "llama-index tools openregistry integration — live access to 27 national company registries via the hosted OpenRegistry MCP server"
+authors = [{name = "Sophymarine", email = "contact@sophymarine.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "sophymarine"}]
+keywords = [
+    "mcp",
+    "openregistry",
+    "company-registry",
+    "kyc",
+    "ubo",
+    "due-diligence",
+    "compliance",
+]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "llama-index-tools-mcp>=0.4.0,<0.5",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.openregistry"
+
+[tool.llamahub.class_authors]
+OpenRegistryToolSpec = "sophymarine"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"

--- a/llama-index-integrations/tools/llama-index-tools-openregistry/tests/test_openregistry.py
+++ b/llama-index-integrations/tools/llama-index-tools-openregistry/tests/test_openregistry.py
@@ -1,0 +1,41 @@
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.mcp import McpToolSpec
+
+from llama_index.tools.openregistry import (
+    OPENREGISTRY_MCP_URL,
+    OpenRegistryToolSpec,
+)
+
+
+def test_default_url() -> None:
+    assert OPENREGISTRY_MCP_URL == "https://openregistry.sophymarine.com/mcp"
+
+
+def test_subclass() -> None:
+    """OpenRegistryToolSpec must be drop-in compatible with McpToolSpec."""
+    assert issubclass(OpenRegistryToolSpec, McpToolSpec)
+    assert issubclass(OpenRegistryToolSpec, BaseToolSpec)
+
+
+def test_anonymous_init_sets_no_auth_header() -> None:
+    spec = OpenRegistryToolSpec()
+    assert spec.client.command_or_url == OPENREGISTRY_MCP_URL
+    assert spec.client.headers is None
+    assert spec.allowed_tools is None
+    assert spec.include_resources is False
+
+
+def test_token_init_sets_bearer_header() -> None:
+    spec = OpenRegistryToolSpec(oauth_token="test-token-123")
+    assert spec.client.headers == {"Authorization": "Bearer test-token-123"}
+
+
+def test_url_override() -> None:
+    spec = OpenRegistryToolSpec(url="https://staging.openregistry.sophymarine.com/mcp")
+    assert spec.client.command_or_url == "https://staging.openregistry.sophymarine.com/mcp"
+
+
+def test_allowed_tools_passthrough() -> None:
+    allow = ["search_companies", "get_company_profile"]
+    spec = OpenRegistryToolSpec(allowed_tools=allow)
+    assert spec.allowed_tools == allow


### PR DESCRIPTION
## Summary

Adds `llama-index-tools-openregistry`, a thin convenience wrapper around `McpToolSpec` (from `llama-index-tools-mcp`) preconfigured for the hosted [OpenRegistry](https://openregistry.sophymarine.com) MCP server.

OpenRegistry is a Streamable HTTP MCP server that proxies **27 national company registries** in real time — UK Companies House, France RNE, Germany Handelsregister, Italy InfoCamere via EU BRIS, Spain BORME, Korea OpenDART, plus 21 others. Every tool call is a live query against the upstream government API; no aggregation.

## Why a dedicated package

`llama-index-tools-mcp` already accepts any MCP URL. This package adds:

- The hosted endpoint baked in — no boilerplate on the user side
- One-arg authentication: `OpenRegistryToolSpec(oauth_token=...)` for paid tiers
- Discoverability via `pip install llama-index-tools-openregistry` and the LlamaHub catalogue

## Public API

```python
from llama_index.tools.openregistry import OpenRegistryToolSpec
from llama_index.core.agent.workflow import FunctionAgent
from llama_index.llms.openai import OpenAI

tool_spec = OpenRegistryToolSpec()  # free anonymous tier — no signup

agent = FunctionAgent(tools=tool_spec.to_tool_list(), llm=OpenAI(model="gpt-4.1"))
await agent.run("Find Tesco PLC and walk its corporate ownership chain.")
```

## Files added

- `pyproject.toml` — `llama-index-tools-openregistry==0.1.0`, deps on `llama-index-core` + `llama-index-tools-mcp`
- `llama_index/tools/openregistry/{__init__,base}.py` — `OpenRegistryToolSpec` (subclass of `McpToolSpec`)
- `tests/test_openregistry.py` — unit tests for URL/auth/allowlist
- `README.md`, `CHANGELOG.md`, `LICENSE` (MIT), `Makefile`, `.gitignore`
- `examples/basic_usage.py` — Tesco PLC walkthrough

Layout matches `llama-index-tools-mcp-discovery` (#20502) and `llama-index-tools-arxiv`.

## Notes for reviewers

- All registry data surfaced is statutorily public.
- I'll register the maintainer (`sophymarine`) on PyPI before the package is published — happy to follow whatever ownership-transfer convention the project prefers.
- The package is intentionally minimal (subclass + URL constant) so future MCP-toolkit improvements in `llama-index-tools-mcp` flow through automatically.
- Happy to iterate on naming, public-API surface, or split out OAuth helpers.
