### PR TITLE
docs: add FuturMix AI provider example notebook

### DIFF
--- a/docs/examples/llm/futurmix.ipynb
+++ b/docs/examples/llm/futurmix.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7f7c3284",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/llm/futurmix.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a07f0af",
+   "metadata": {},
+   "source": [
+    "# FuturMix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc0d66a7",
+   "metadata": {},
+   "source": [
+    "FuturMix is a unified AI gateway that provides access to 22+ models from OpenAI, Anthropic, Google, and more through a single OpenAI-compatible API endpoint. You can find out more on their [homepage](https://futurmix.ai).\n",
+    "\n",
+    "Since FuturMix exposes an OpenAI-compatible API, you can use LlamaIndex's `OpenAILike` class to interact with it directly.\n",
+    "\n",
+    "Visit [futurmix.ai](https://futurmix.ai) to sign up and get an API key.\n",
+    "\n",
+    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex \ud83e\udd99."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ddc8c84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-llms-openai-like"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "425f649c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install llama-index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02bfb427",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms.openai_like import OpenAILike\n",
+    "from llama_index.core.llms import ChatMessage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3907f07b",
+   "metadata": {},
+   "source": [
+    "## Call `chat` with ChatMessage List\n",
+    "You need to set your FuturMix API key. You can either set the env var `FUTURMIX_API_KEY` or pass it directly in the constructor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0bec6d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# os.environ[\"FUTURMIX_API_KEY\"] = \"<your-futurmix-key>\"\n",
+    "\n",
+    "llm = OpenAILike(\n",
+    "    model=\"gpt-4o\",\n",
+    "    api_base=\"https://futurmix.ai/v1\",\n",
+    "    api_key=\"<your-futurmix-key>\",\n",
+    "    is_chat_model=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1135fe2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "message = ChatMessage(role=\"user\", content=\"Tell me a joke\")\n",
+    "resp = llm.chat([message])\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0515c6b2",
+   "metadata": {},
+   "source": [
+    "### Streaming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "099f51ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "message = ChatMessage(role=\"user\", content=\"Tell me a story in 250 words\")\n",
+    "resp = llm.stream_chat([message])\n",
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac92c80f",
+   "metadata": {},
+   "source": [
+    "## Call `complete` with Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1290c9b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.complete(\"Tell me a joke\")\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be1a7fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.stream_complete(\"Tell me a story in 250 words\")\n",
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc3a2018",
+   "metadata": {},
+   "source": [
+    "## Model Configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "model-info",
+   "metadata": {},
+   "source": [
+    "FuturMix supports models from multiple providers through a single API key:\n",
+    "\n",
+    "| Provider | Example Models |\n",
+    "|----------|---------------|\n",
+    "| OpenAI | `gpt-4o`, `gpt-4o-mini` |\n",
+    "| Anthropic | `claude-sonnet-4-20250514`, `claude-3-5-haiku-20241022` |\n",
+    "| Google | `gemini-2.5-flash-preview-04-17`, `gemini-2.0-flash` |\n",
+    "\n",
+    "View the full list of available models at [futurmix.ai](https://futurmix.ai)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88c2680d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using Claude\n",
+    "llm = OpenAILike(\n",
+    "    model=\"claude-sonnet-4-20250514\",\n",
+    "    api_base=\"https://futurmix.ai/v1\",\n",
+    "    api_key=\"<your-futurmix-key>\",\n",
+    "    is_chat_model=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24ebd16b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.complete(\"Explain quantum computing in simple terms\")\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_name": null,
+   "id": "gemini-example",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using Gemini\n",
+    "llm = OpenAILike(\n",
+    "    model=\"gemini-2.5-flash-preview-04-17\",\n",
+    "    api_base=\"https://futurmix.ai/v1\",\n",
+    "    api_key=\"<your-futurmix-key>\",\n",
+    "    is_chat_model=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gemini-complete",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = llm.complete(\"Write a haiku about programming\")\n",
+    "print(resp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add an example notebook showing how to use [FuturMix](https://futurmix.ai) with LlamaIndex via the `OpenAILike` class.

FuturMix is an enterprise AI agent platform providing access to 22+ models (OpenAI, Anthropic, Google) , similar to how the existing Grok notebook demonstrates using `OpenAILike` with xAI's API.

### Changes

- Add `docs/examples/llm/futurmix.ipynb` — example notebook covering:
 - Chat and completion calls
 - Streaming support
 - Multi-model configuration (GPT-4o, Claude, Gemini)

No existing files are modified.