### PR TITLE
fix(agent/workflow): project ToolCallResult to ToolSelection in AgentOutput.tool_calls

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -510,7 +510,14 @@ class BaseWorkflowAgent(
         cur_tool_calls: List[ToolCallResult] = await ctx.store.get(
             "current_tool_calls", default=[]
         )
-        output.tool_calls.extend(cur_tool_calls)  # type: ignore[arg-type]
+        output.tool_calls.extend(
+            ToolSelection(
+                tool_id=t.tool_id,
+                tool_name=t.tool_name,
+                tool_kwargs=t.tool_kwargs,
+            )
+            for t in cur_tool_calls
+        )
         await ctx.store.set("current_tool_calls", [])
 
         ctx.write_event_to_stream(output)
@@ -563,7 +570,14 @@ class BaseWorkflowAgent(
             cur_tool_calls: List[ToolCallResult] = await ctx.store.get(
                 "current_tool_calls", default=[]
             )
-            output.tool_calls.extend(cur_tool_calls)  # type: ignore
+            output.tool_calls.extend(
+                ToolSelection(
+                    tool_id=t.tool_id,
+                    tool_name=t.tool_name,
+                    tool_kwargs=t.tool_kwargs,
+                )
+                for t in cur_tool_calls
+            )
 
             if self.structured_output_fn is not None:
                 try:

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -513,7 +513,14 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         cur_tool_calls: List[ToolCallResult] = await ctx.store.get(
             "current_tool_calls", default=[]
         )
-        output.tool_calls.extend(cur_tool_calls)  # type: ignore[arg-type]
+        output.tool_calls.extend(
+            ToolSelection(
+                tool_id=t.tool_id,
+                tool_name=t.tool_name,
+                tool_kwargs=t.tool_kwargs,
+            )
+            for t in cur_tool_calls
+        )
         await ctx.store.set("current_tool_calls", [])
 
         ctx.write_event_to_stream(output)
@@ -572,7 +579,14 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             cur_tool_calls: List[ToolCallResult] = await ctx.store.get(
                 "current_tool_calls", default=[]
             )
-            output.tool_calls.extend(cur_tool_calls)  # type: ignore
+            output.tool_calls.extend(
+                ToolSelection(
+                    tool_id=t.tool_id,
+                    tool_name=t.tool_name,
+                    tool_kwargs=t.tool_kwargs,
+                )
+                for t in cur_tool_calls
+            )
             await ctx.store.set("current_tool_calls", [])
 
             if self.structured_output_fn is not None:

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -397,6 +397,81 @@ async def test_early_stopping_method_override_in_run():
 
 
 @pytest.mark.asyncio
+async def test_agent_output_tool_calls_are_tool_selections():
+    """
+    AgentOutput.tool_calls must be List[ToolSelection], not List[ToolCallResult].
+
+    Regression test for https://github.com/run-llama/llama_index/issues/20071 — both
+    on the standard finalize path and on the early-stopping ('generate') path,
+    `tool_calls` was being populated with `ToolCallResult` instances even though
+    the field is typed as `list[ToolSelection]`.
+    """
+    from llama_index.core.agent.workflow.workflow_events import ToolCallResult
+
+    def random_tool() -> str:
+        return "random"
+
+    tool_call_response = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        content="calling tool",
+        additional_kwargs={
+            "tool_calls": [
+                ToolSelection(
+                    tool_id="one",
+                    tool_name="random_tool",
+                    tool_kwargs={},
+                )
+            ]
+        },
+    )
+    final_response = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        content="done",
+    )
+
+    # 1) Standard finalize path: a tool call followed by a final assistant message.
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[random_tool],
+        llm=MockFunctionCallingLLM(
+            response_generator=_response_generator_from_list(
+                [tool_call_response, final_response]
+            )
+        ),
+    )
+
+    response = await agent.run(user_msg="test")
+    assert response is not None
+    for tc in response.tool_calls:
+        assert isinstance(tc, ToolSelection), (
+            f"tool_calls must contain ToolSelection, got {type(tc).__name__}"
+        )
+        assert not isinstance(tc, ToolCallResult)
+
+    # 2) Early-stopping 'generate' path.
+    agent_es = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[random_tool],
+        llm=MockFunctionCallingLLM(
+            response_generator=_response_generator_from_list(
+                [tool_call_response] * 5 + [final_response]
+            )
+        ),
+        early_stopping_method="generate",
+    )
+
+    response_es = await agent_es.run(user_msg="test", max_iterations=5)
+    assert response_es is not None
+    for tc in response_es.tool_calls:
+        assert isinstance(tc, ToolSelection), (
+            f"early-stopping tool_calls must contain ToolSelection, got {type(tc).__name__}"
+        )
+        assert not isinstance(tc, ToolCallResult)
+
+
+@pytest.mark.asyncio
 async def test_function_agent_with_mock_function_calling_llm():
     """Test that FunctionAgent works with MockFunctionCallingLLM."""
 


### PR DESCRIPTION
## Summary

Fixes #20071. `AgentOutput.tool_calls` is declared as `list[ToolSelection]`, but four finalize paths in the workflow agents do `output.tool_calls.extend(cur_tool_calls)` where `cur_tool_calls: List[ToolCallResult]`. `# type: ignore[arg-type]` comments silenced the mismatch, so `AgentOutput.tool_calls` ended up containing `ToolCallResult` objects (with full `tool_output` / `raw_output` payloads) instead of the lightweight `ToolSelection` view documented by the type. Inconsistent with the return-direct branch which already projected correctly.

## Fix

In all 4 sites (`base_agent.py` finalize + early-stopping; `multi_agent_workflow.py` finalize + early-stopping) replace the raw extend with a projection:

```python
output.tool_calls.extend(
    ToolSelection(tool_id=t.tool_id, tool_name=t.tool_name, tool_kwargs=t.tool_kwargs)
    for t in cur_tool_calls
)
```

`ToolSelection` was already imported in both files. Removed the `# type: ignore` since the call is now type-correct. ~14 LOC of production change across both files.

## Test

`tests/agent/workflow/test_single_agent_workflow.py::test_agent_output_tool_calls_are_tool_selections` covers both the standard finalize path and the early-stopping `generate` path, asserting `isinstance(tc, ToolSelection)` and `not isinstance(tc, ToolCallResult)` for every element. RED before, GREEN after.

`pytest tests/agent/workflow/` → 61 passed, 3 skipped. `pytest tests/agent/` → 86 passed, 3 skipped. `ruff` clean.

## Risk notes

- Behaviour change for downstream consumers: code that pulled `tool_output` / `raw_output` off entries in `AgentOutput.tool_calls` will now find them absent. Per the issue this is desired — they should be reading from `current_tool_calls` / `ToolCallResult` events.
- Different from prior user PRs (ZeroDivisionError, mutable defaults, stacklevel) — this is a type-contract / data-model leak in the agent workflow finalization path.

Refs #20071