### PR TITLE
fix(openai): serialize tool call arguments as JSON string

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -499,7 +499,7 @@ def to_openai_message_dict(
                     "type": "function",
                     "function": {
                         "name": block.tool_name,
-                        "arguments": block.tool_kwargs,
+                        "arguments": json.dumps(block.tool_kwargs),
                     },
                     "id": block.tool_call_id,
                 }

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.5"
+version = "0.7.6"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -756,3 +756,39 @@ def test_responses_api_tool_kwargs_string_passthrough() -> None:
         if isinstance(item, dict) and item.get("type") == "function_call"
     ][0]
     assert tool_item["arguments"] == '{"q": "test"}'
+
+
+def test_tool_call_block_with_no_args_serializes_arguments_as_json_string() -> None:
+    """Regression test for issue #18928.
+
+    When a FunctionTool has no parameters, the 'arguments' field in the
+    serialized tool_calls message must be a JSON string ("{}"), not a dict ({}).
+    Strict OpenAI-spec servers like vLLM reject a bare dict with a 400 error.
+    """
+    messages = [
+        ChatMessage(
+            role=MessageRole.ASSISTANT,
+            blocks=[
+                ToolCallBlock(
+                    block_type="tool_call",
+                    tool_call_id="call_001",
+                    tool_name="no_arg_tool",
+                    tool_kwargs={},  # no parameters
+                )
+            ],
+        )
+    ]
+    openai_dicts = to_openai_message_dicts(messages)
+
+    tool_calls = openai_dicts[0]["tool_calls"]
+    assert len(tool_calls) == 1
+
+    arguments = tool_calls[0]["function"]["arguments"]
+
+    # Must be a string, not a dict
+    assert isinstance(arguments, str), (
+        f"'arguments' must be a JSON string per OpenAI spec, got {type(arguments)}"
+    )
+    # Must be valid JSON
+    parsed = json.loads(arguments)
+    assert parsed == {}


### PR DESCRIPTION
fix(openai): serialize tool call arguments as JSON string (fixes #18928)

# Description

Fixes #18928

When a `FunctionTool` has no parameters, the `arguments` field in tool call messages was being sent as a Python dict `{}` instead of a JSON-encoded string `"{}"`. The OpenAI spec requires `arguments` to always be a JSON string. Strict spec-compliant servers like vLLM reject the bare dict with a 400 validation error.
**Root cause:** In `to_openai_message_dict()`, `block.tool_kwargs` was passed directly without serialization. Fixed by wrapping it with `json.dumps()`.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
