### PR TITLE
fix: use removeprefix instead of strip in RedisVectorStore

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -356,7 +356,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         )
         logger.info(f"Added {len(keys)} documents to index {self._async_index.name}")
         return [
-            key.strip(self._async_index.prefix + self._async_index.key_separator)
+            key.removeprefix(self._async_index.prefix + self._async_index.key_separator)
             for key in keys
         ]
 
@@ -408,7 +408,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         keys = self._index.load(data, id_field=NODE_ID_FIELD_NAME, **add_kwargs)
         logger.info(f"Added {len(keys)} documents to index {self._index.name}")
         return [
-            key.strip(self._index.prefix + self._index.key_separator) for key in keys
+            key.removeprefix(self._index.prefix + self._index.key_separator) for key in keys
         ]
 
     def _build_node_id_filter_expression(self, node_ids: list[str]) -> FilterExpression:


### PR DESCRIPTION
Fixes #21483

### Root Cause

`RedisVectorStore.add()` and `async_add()` use `key.strip(prefix + separator)` to remove the Redis key prefix from returned node IDs. However, Python's `str.strip(chars)` treats its argument as a **set of individual characters** to trim from both ends — not a literal substring.

For a prefix like `"semantic_cache_doc"` + separator `":"`, the character set includes `s`, `e`, `m`, `a`, `n`, `t`, `i`, `c`, `_`, `d`, `o`, `:`, etc. Any UUID node ID whose leading/trailing hex characters overlap (e.g., `e7b95ae7-...`, `...d0ce`) will be silently corrupted.

### Fix

Replace `.strip(...)` with `.removeprefix(...)` (Python 3.9+), which removes only the exact leading substring.