### PR TITLE
fix: apply retriever_weights in reciprocal rerank fusion

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -124,7 +124,8 @@ class QueryFusionRetriever(BaseRetriever):
         hash_to_node = {}
 
         # compute reciprocal rank scores
-        for nodes_with_scores in results.values():
+        for (query_str, retriever_idx), nodes_with_scores in results.items():
+            weight = self._retriever_weights[retriever_idx]
             for rank, node_with_score in enumerate(
                 sorted(nodes_with_scores, key=lambda x: x.score or 0.0, reverse=True)
             ):
@@ -132,7 +133,7 @@ class QueryFusionRetriever(BaseRetriever):
                 hash_to_node[hash] = node_with_score
                 if hash not in fused_scores:
                     fused_scores[hash] = 0.0
-                fused_scores[hash] += 1.0 / (rank + k)
+                fused_scores[hash] += weight / (rank + k)
 
         # sort results
         reranked_results = dict(


### PR DESCRIPTION
## Summary

Fixes #21444.

### Root Cause

`_reciprocal_rerank_fusion` iterated over `results.values()`, discarding the tuple key `(query_str, retriever_idx)`. As a result, the `retriever_idx` needed to look up the configured `retriever_weights` was never used. Every retriever contributed equally to the fused score (`1.0 / (rank + k)`), silently ignoring any weights passed via `retriever_weights`.

### Fix

Changed the iteration to unpack the key:

```python
# before
for nodes_with_scores in results.values():
    ...
    fused_scores[hash] += 1.0 / (rank + k)

# after
for (query_str, retriever_idx), nodes_with_scores in results.items():
    weight = self._retriever_weights[retriever_idx]
    ...
    fused_scores[hash] += weight / (rank + k)
```

This aligns `reciprocal_rerank` fusion with the `relative_score` and `dist_based_score` fusion modes, which already unpack the key and apply `retriever_weights` correctly.

## Test plan

- [ ] Instantiate `QueryFusionRetriever` with two retrievers and unequal `retriever_weights` (e.g. `[0.9, 0.1]`) in `reciprocal_rerank` mode
- [ ] Verify that nodes from the higher-weighted retriever receive proportionally higher fused scores
- [ ] Confirm existing unit tests for `QueryFusionRetriever` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)