### PR TITLE
fix(deps): replace archived nest-asyncio with maintained nest-asyncio2 fork

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -72,7 +72,7 @@ def asyncio_run(coro: Coroutine) -> Any:
             return asyncio.run(coro)
         except RuntimeError as e:
             raise RuntimeError(
-                "Detected nested async. Please use nest_asyncio.apply() to allow nested event loops."
+                "Detected nested async. Please use nest_asyncio.apply() (via nest-asyncio2) to allow nested event loops."
                 "Or, use async entry methods like `aquery()`, `aretriever`, `achat`, etc."
             )
 

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "deprecated>=1.2.9.3",
     "fsspec>=2023.5.0",
     "httpx",
-    "nest-asyncio>=1.5.8,<2",
+    "nest-asyncio2>=1.6.0",
     "nltk>=3.9.3",
     "numpy",
     "tenacity>=8.2.0,!=8.4.0,<10.0.0",


### PR DESCRIPTION
## Description

The `nest-asyncio` package has been archived by its author for over a year and does not support Python 3.12+'s new `loop_factory` parameter in `asyncio.run()`. Any code passing `loop_factory` to `asyncio.run()` will hit `TypeError: _patch_asyncio.<locals>.run() got an unexpected keyword argument 'loop_factory'` because nest-asyncio patches `asyncio.run` without forwarding unknown kwargs.

This replaces the archived `nest-asyncio` dependency with `nest-asyncio2`, a maintained community fork that is backward-compatible and fixes the Python 3.12+ `loop_factory` compatibility issue. The `nest-asyncio2` package installs under the same `nest_asyncio` module name, so no code changes beyond the dependency declaration are needed. The one usage in `llama-index-core/llama_index/core/async_utils.py::run_async_tasks` (`import nest_asyncio` / `nest_asyncio.apply()`) continues to work unchanged.

## Fixes

Fixes #19812

## Type of Change

- [x] Bug fix

## Testing

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` and resolved any issues
