### PR TITLE
security: add minimal sandboxing to local CodeInterpreterToolSpec

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-code-interpreter/llama_index/tools/code_interpreter/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-code-interpreter/llama_index/tools/code_interpreter/base.py
@@ -31,5 +31,10 @@ class CodeInterpreterToolSpec(BaseToolSpec):
 
         It is not possible to return graphics or other complicated data from this function. If the user cannot see the output, save it to a file and tell the user.
         """
-        result = subprocess.run([sys.executable, "-c", code], capture_output=True)
+        result = subprocess.run(
+            [sys.executable, "-I", "-c", code],
+            capture_output=True,
+            timeout=60,
+            env={},
+        )
         return f"StdOut:\n{result.stdout}\nStdErr:\n{result.stderr}"


### PR DESCRIPTION
## Summary

Addresses critical security finding: **Local code interpreter without sandbox** (security audit 2026-04-28).

`CodeInterpreterToolSpec.code_interpreter()` previously executed arbitrary LLM-generated Python via `subprocess.run([sys.executable, "-c", code])` with no restrictions on execution time, environment access, or Python import path.

## Changes

- **Isolated mode**: Added `-I` flag to ignore `PYTHON*` environment variables and user site-packages.
- **Timeout**: Added 60-second `timeout` to prevent resource exhaustion / infinite loops.
- **Empty environment**: Pass `env={}` to `subprocess.run` to prevent secret exfiltration via `os.environ`.

## Scope

Minimal surgical fix on `llama_index/tools/code_interpreter/base.py`.

## Testing

- Existing test `test_tools_code_interpreter.py::test_class` passes.
- Verified basic code execution still works.
- Verified timeout and env restrictions are applied.

## Caveats

This does not provide full containment (filesystem/network access remains possible). Production use still requires proper sandboxing (containers, VMs, or remote interpreters such as the AWS Bedrock AgentCore variant).