### PR TITLE
fix: preserve Redis vector store node ids

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -58,6 +58,10 @@ NO_INDEXED_FILTERS = (
 )
 
 
+def _node_id_from_redis_key(key: str, prefix: str, key_separator: str) -> str:
+    return key.removeprefix(f"{prefix}{key_separator}")
+
+
 class TokenEscaper:
     """
     Escape punctuation within an input string. Taken from RedisOM Python.
@@ -356,7 +360,9 @@ class RedisVectorStore(BasePydanticVectorStore):
         )
         logger.info(f"Added {len(keys)} documents to index {self._async_index.name}")
         return [
-            key.strip(self._async_index.prefix + self._async_index.key_separator)
+            _node_id_from_redis_key(
+                key, self._async_index.prefix, self._async_index.key_separator
+            )
             for key in keys
         ]
 
@@ -408,7 +414,8 @@ class RedisVectorStore(BasePydanticVectorStore):
         keys = self._index.load(data, id_field=NODE_ID_FIELD_NAME, **add_kwargs)
         logger.info(f"Added {len(keys)} documents to index {self._index.name}")
         return [
-            key.strip(self._index.prefix + self._index.key_separator) for key in keys
+            _node_id_from_redis_key(key, self._index.prefix, self._index.key_separator)
+            for key in keys
         ]
 
     def _build_node_id_filter_expression(self, node_ids: list[str]) -> FilterExpression:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/tests/test_vector_stores_redis.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/tests/test_vector_stores_redis.py
@@ -10,7 +10,25 @@ from llama_index.core.vector_stores.types import (
     VectorStoreQuery,
 )
 from llama_index.vector_stores.redis import RedisVectorStore
+from llama_index.vector_stores.redis.base import _node_id_from_redis_key
 from llama_index.vector_stores.redis.schema import RedisVectorStoreSchema
+
+
+def test_node_id_from_redis_key_removes_exact_prefix():
+    node_id = "e7b95ae7-6369-404d-8287-1f4504121563"
+    redis_key = f"semantic_cache_doc:{node_id}"
+
+    assert (
+        _node_id_from_redis_key(redis_key, "semantic_cache_doc", ":")
+        == "e7b95ae7-6369-404d-8287-1f4504121563"
+    )
+
+
+def test_node_id_from_redis_key_preserves_suffix_characters_from_prefix():
+    node_id = "e7b95ae7-6369-404d-8287-1f4504121563-doc"
+    redis_key = f"semantic_cache_doc:{node_id}"
+
+    assert _node_id_from_redis_key(redis_key, "semantic_cache_doc", ":") == node_id
 
 
 def _build_filterable_schema(index_name: str) -> RedisVectorStoreSchema:


### PR DESCRIPTION
## Summary

- replace character-set based Redis key stripping with exact prefix removal for `RedisVectorStore.add()` and `async_add()`
- add regression coverage for node IDs that begin or end with characters present in the Redis key prefix

Fixes #21483.

## Validation

- `uv run ruff check llama_index/vector_stores/redis/base.py tests/test_vector_stores_redis.py`
- `uv run python - <<'PY' ...` direct regression check for `_node_id_from_redis_key`

I also attempted `uv run pytest tests/test_vector_stores_redis.py -q -k node_id_from_redis_key`, but local collection requires Docker because `tests/conftest.py` starts `redis/redis-stack:latest` at import time, and Docker is not available in this environment.
