### PR TITLE
fix: use removeprefix() instead of strip() for Redis key prefix removal

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -356,7 +356,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         )
         logger.info(f"Added {len(keys)} documents to index {self._async_index.name}")
         return [
-            key.strip(self._async_index.prefix + self._async_index.key_separator)
+            key.removeprefix(self._async_index.prefix + self._async_index.key_separator)
             for key in keys
         ]
 
@@ -408,7 +408,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         keys = self._index.load(data, id_field=NODE_ID_FIELD_NAME, **add_kwargs)
         logger.info(f"Added {len(keys)} documents to index {self._index.name}")
         return [
-            key.strip(self._index.prefix + self._index.key_separator) for key in keys
+            key.removeprefix(self._index.prefix + self._index.key_separator) for key in keys
         ]
 
     def _build_node_id_filter_expression(self, node_ids: list[str]) -> FilterExpression:


### PR DESCRIPTION
## Summary

Fixes #21483

`str.strip(chars)` removes any combination of the provided characters from both ends, not the exact substring. When Redis key prefixes share characters with UUID hex (e.g., prefix `semantic_cache_doc` shares `e`, `c`, `a`, `d` with hex), `.strip()` inadvertently deletes valid starting characters of the node ID.

## Changes

Replace two instances of `.strip()` with `.removeprefix()`:

```python
# Before (buggy):
key.strip(self._async_index.prefix + self._async_index.key_separator)
key.strip(self._index.prefix + self._index.key_separator)

# After (fixed):
key.removeprefix(self._async_index.prefix + self._async_index.key_separator)
key.removeprefix(self._index.prefix + self._index.key_separator)
```

`.removeprefix()` was added in Python 3.9 and removes only the exact prefix substring, preserving the node ID intact.

Closes #21483
