### PR TITLE
fix(postprocessor-rerank): catch KeyError not IndexError on missing API key

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/llama_index/postprocessor/aimon_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/llama_index/postprocessor/aimon_rerank/base.py
@@ -39,7 +39,7 @@ class AIMonRerank(BaseNodePostprocessor):
         )
         try:
             api_key = api_key or os.environ["AIMON_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in AIMon API key or specify via AIMON_API_KEY environment variable"
             )

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -70,7 +70,7 @@ class CohereRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model, max_retries=max_retries)
         try:
             api_key = api_key or os.environ["COHERE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in cohere api key or "
                 "specify via COHERE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/llama_index/postprocessor/contextual_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/llama_index/postprocessor/contextual_rerank/base.py
@@ -43,7 +43,7 @@ class ContextualRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model)
         try:
             api_key = api_key or os.environ["CONTEXTUAL_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in contextual api key or "
                 "specify via CONTEXTUAL_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
@@ -33,7 +33,7 @@ class DashScopeRerank(BaseNodePostprocessor):
     ):
         try:
             api_key = api_key or os.environ["DASHSCOPE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in dashscope api key or "
                 "specify via DASHSCOPE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/llama_index/postprocessor/pinecone_native_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/llama_index/postprocessor/pinecone_native_rerank/base.py
@@ -36,7 +36,7 @@ class PineconeNativeRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model)
         try:
             api_key = api_key or os.environ["PINECONE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in pinecone api key or "
                 "specify via PINECONE_API_KEY environment variable "


### PR DESCRIPTION
## Summary

Five postprocessor reranker integrations
(`aimon`, `cohere`, `contextual`, `dashscope`, `pinecone-native`)
wrap `os.environ[\"<PROVIDER>_API_KEY\"]` in
`try/except IndexError` to surface a helpful
`ValueError(\"Must pass in ... API key or specify via ... environment variable\")`.

`os.environ` is a dict-like mapping, so the missing-key case raises
`KeyError`, **not** `IndexError`. As a result, the helpful message was
never shown - users got a raw `KeyError: 'COHERE_API_KEY'` (etc.) at
import time and had to dig into the constructor to find out what was wrong.

This PR replaces `except IndexError` with `except KeyError` in all five
integrations.

This is the same fix that #21363 (and issue #21362) applies to
`llama-index-core/llama_index/core/evaluation/retrieval/metrics.py`,
extending coverage to the integration packages that share the bug.

## Files changed (5, one line each)

- `llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/.../base.py`
- `llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/.../base.py`
- `llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/.../base.py`
- `llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/.../base.py`
- `llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/.../base.py`

## How to test

```python
import os
os.environ.pop(\"COHERE_API_KEY\", None)
from llama_index.postprocessor.cohere_rerank import CohereRerank
CohereRerank()
# Before: raises raw KeyError: 'COHERE_API_KEY'
# After:  raises ValueError(\"Must pass in cohere api key ...\")
```

Same logic for the other four providers (`AIMON_API_KEY`, `CONTEXTUAL_API_KEY`, `DASHSCOPE_API_KEY`, `PINECONE_API_KEY`).

## Notes

- No public API change. No behavior change in the success path.
- All five files are integration packages with their own pyproject; CI
  already covers each integration, so the change should pass each
  package's existing test matrix.
- Closes / extends #21362 for the integration packages.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>