### PR TITLE
fix(mcp): handle AudioContent, EmbeddedResource, and ResourceLink in get_prompt()

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,6 +1,7 @@
 import warnings
 import logging
 import io
+import base64
 
 from contextlib import asynccontextmanager
 from datetime import timedelta
@@ -27,7 +28,7 @@ from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthClientInformat
 from mcp import types
 from pydantic import AnyUrl
 
-from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.core.llms import AudioBlock, ChatMessage, ImageBlock, TextBlock
 
 
 class StreamingHandler(logging.Handler):
@@ -398,9 +399,80 @@ class BasicMCPClient(ClientSession):
                             ],
                         )
                     )
+                elif isinstance(message.content, types.AudioContent):
+                    llama_messages.append(
+                        ChatMessage(
+                            role=message.role,
+                            blocks=[
+                                AudioBlock(
+                                    audio=base64.b64decode(
+                                        message.content.data
+                                    ),
+                                    format=message.content.mimeType.split(
+                                        "/"
+                                    )[-1]
+                                    if message.content.mimeType
+                                    else None,
+                                )
+                            ],
+                        )
+                    )
                 elif isinstance(message.content, types.EmbeddedResource):
-                    raise NotImplementedError(
-                        "Embedded resources are not supported yet"
+                    resource = message.content.resource
+                    if isinstance(resource, types.TextResourceContents):
+                        llama_messages.append(
+                            ChatMessage(
+                                role=message.role,
+                                blocks=[TextBlock(text=resource.text)],
+                            )
+                        )
+                    elif isinstance(resource, types.BlobResourceContents):
+                        mime = resource.mimeType or ""
+                        if mime.startswith("image/"):
+                            llama_messages.append(
+                                ChatMessage(
+                                    role=message.role,
+                                    blocks=[
+                                        ImageBlock(
+                                            image=resource.blob,
+                                            image_mimetype=mime or None,
+                                        )
+                                    ],
+                                )
+                            )
+                        elif mime.startswith("audio/"):
+                            llama_messages.append(
+                                ChatMessage(
+                                    role=message.role,
+                                    blocks=[
+                                        AudioBlock(
+                                            audio=base64.b64decode(
+                                                resource.blob
+                                            ),
+                                            format=mime.split("/")[-1],
+                                        )
+                                    ],
+                                )
+                            )
+                        else:
+                            llama_messages.append(
+                                ChatMessage(
+                                    role=message.role,
+                                    blocks=[
+                                        TextBlock(
+                                            text=f"[Binary resource ({mime or 'unknown type'}): {resource.uri}]"
+                                        )
+                                    ],
+                                )
+                            )
+                elif isinstance(message.content, types.ResourceLink):
+                    llama_messages.append(
+                        ChatMessage(
+                            role=message.role,
+                            blocks=[
+                                TextBlock(text=str(message.content.uri))
+                            ],
+                        )
                     )
                 else:
                     raise ValueError(

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,10 +1,16 @@
+import base64
 import os
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
 from httpx import AsyncClient
 import pytest
 
+from llama_index.core.llms import AudioBlock, ImageBlock, TextBlock
 from llama_index.tools.mcp import BasicMCPClient
 from llama_index.tools.mcp.client import enable_sse
 from mcp import types
+from pydantic import AnyUrl
 
 
 # Path to the test server script - adjust as needed
@@ -259,3 +265,147 @@ def test_enable_sse():
     # Test command-style inputs (non-URL)
     assert enable_sse("python") is False
     assert enable_sse("/usr/bin/python") is False
+
+
+def _make_mock_client() -> BasicMCPClient:
+    return BasicMCPClient("python", args=["server.py"], timeout=5)
+
+
+def _make_prompt_result(role: str, content) -> types.GetPromptResult:
+    return types.GetPromptResult(
+        messages=[types.PromptMessage(role=role, content=content)]
+    )
+
+
+@asynccontextmanager
+async def _mock_session(prompt_result: types.GetPromptResult):
+    session = AsyncMock()
+    session.get_prompt = AsyncMock(return_value=prompt_result)
+    yield session
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_embedded_text_resource():
+    """EmbeddedResource with TextResourceContents yields a TextBlock."""
+    resource = types.TextResourceContents(
+        uri=AnyUrl("file:///hello.txt"), text="hello from resource"
+    )
+    embedded = types.EmbeddedResource(type="resource", resource=resource)
+    prompt_result = _make_prompt_result("user", embedded)
+    client = _make_mock_client()
+
+    with patch.object(
+        client, "_run_session", return_value=_mock_session(prompt_result)
+    ):
+        messages = await client.get_prompt("test_prompt")
+
+    assert len(messages) == 1
+    assert isinstance(messages[0].blocks[0], TextBlock)
+    assert messages[0].blocks[0].text == "hello from resource"
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_embedded_image_blob_resource():
+    """EmbeddedResource with BlobResourceContents (image) yields an ImageBlock."""
+    fake_png = base64.b64encode(b"\x89PNG\r\n").decode()
+    resource = types.BlobResourceContents(
+        uri=AnyUrl("file:///photo.png"),
+        blob=fake_png,
+        mimeType="image/png",
+    )
+    embedded = types.EmbeddedResource(type="resource", resource=resource)
+    prompt_result = _make_prompt_result("user", embedded)
+    client = _make_mock_client()
+
+    with patch.object(
+        client, "_run_session", return_value=_mock_session(prompt_result)
+    ):
+        messages = await client.get_prompt("test_prompt")
+
+    assert len(messages) == 1
+    assert isinstance(messages[0].blocks[0], ImageBlock)
+    assert messages[0].blocks[0].image_mimetype == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_embedded_audio_blob_resource():
+    """EmbeddedResource with BlobResourceContents (audio) yields an AudioBlock."""
+    fake_mp3 = base64.b64encode(b"ID3\x03").decode()
+    resource = types.BlobResourceContents(
+        uri=AnyUrl("file:///clip.mp3"),
+        blob=fake_mp3,
+        mimeType="audio/mpeg",
+    )
+    embedded = types.EmbeddedResource(type="resource", resource=resource)
+    prompt_result = _make_prompt_result("user", embedded)
+    client = _make_mock_client()
+
+    with patch.object(
+        client, "_run_session", return_value=_mock_session(prompt_result)
+    ):
+        messages = await client.get_prompt("test_prompt")
+
+    assert len(messages) == 1
+    assert isinstance(messages[0].blocks[0], AudioBlock)
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_embedded_unknown_blob_resource():
+    """EmbeddedResource with BlobResourceContents (unknown type) yields a TextBlock."""
+    fake_data = base64.b64encode(b"\x00\x01\x02").decode()
+    resource = types.BlobResourceContents(
+        uri=AnyUrl("file:///data.bin"),
+        blob=fake_data,
+        mimeType="application/octet-stream",
+    )
+    embedded = types.EmbeddedResource(type="resource", resource=resource)
+    prompt_result = _make_prompt_result("user", embedded)
+    client = _make_mock_client()
+
+    with patch.object(
+        client, "_run_session", return_value=_mock_session(prompt_result)
+    ):
+        messages = await client.get_prompt("test_prompt")
+
+    assert len(messages) == 1
+    assert isinstance(messages[0].blocks[0], TextBlock)
+    assert "application/octet-stream" in messages[0].blocks[0].text
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_audio_content():
+    """AudioContent yields an AudioBlock."""
+    fake_wav = base64.b64encode(b"RIFF").decode()
+    audio = types.AudioContent(type="audio", data=fake_wav, mimeType="audio/wav")
+    prompt_result = _make_prompt_result("user", audio)
+    client = _make_mock_client()
+
+    with patch.object(
+        client, "_run_session", return_value=_mock_session(prompt_result)
+    ):
+        messages = await client.get_prompt("test_prompt")
+
+    assert len(messages) == 1
+    assert isinstance(messages[0].blocks[0], AudioBlock)
+    assert messages[0].blocks[0].format == "wav"
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_resource_link():
+    """ResourceLink yields a TextBlock containing the URI."""
+    link = types.ResourceLink(
+        type="resource_link",
+        uri=AnyUrl("file:///docs/readme.md"),
+        name="README",
+    )
+    prompt_result = _make_prompt_result("user", link)
+    client = _make_mock_client()
+
+    with patch.object(
+        client, "_run_session", return_value=_mock_session(prompt_result)
+    ):
+        messages = await client.get_prompt("test_prompt")
+
+    assert len(messages) == 1
+    assert isinstance(messages[0].blocks[0], TextBlock)
+    assert "readme.md" in messages[0].blocks[0].text


### PR DESCRIPTION
## Summary

`BasicMCPClient.get_prompt()` previously raised `NotImplementedError` for `EmbeddedResource` and `ValueError` for any other MCP `ContentBlock` type beyond `TextContent` and `ImageContent`. This meant any MCP server that returns `AudioContent`, `EmbeddedResource`, or `ResourceLink` (all spec-valid prompt message content types) would crash the call.

Fixes #21270.

## Changes

**`llama_index/tools/mcp/client.py`**
- Add `import base64`
- Import `AudioBlock` alongside the existing `ChatMessage`, `ImageBlock`, `TextBlock`
- In `get_prompt()`, add handlers for all remaining MCP `ContentBlock` variants:
  - `AudioContent` → `AudioBlock` (base64-decoded bytes, format derived from MIME type)
  - `EmbeddedResource` / `TextResourceContents` → `TextBlock`
  - `EmbeddedResource` / `BlobResourceContents` (image/*) → `ImageBlock`
  - `EmbeddedResource` / `BlobResourceContents` (audio/*) → `AudioBlock`
  - `EmbeddedResource` / `BlobResourceContents` (other) → `TextBlock` with URI and MIME type
  - `ResourceLink` → `TextBlock` with the resource URI

**`tests/test_client.py`**
- Six new unit tests that mock `_run_session` and verify each new content-type branch converts correctly to the expected LlamaIndex block type.

## Test plan

- [x] `test_get_prompt_embedded_text_resource` — `EmbeddedResource` with `TextResourceContents` → `TextBlock` with resource text
- [x] `test_get_prompt_embedded_image_blob_resource` — `EmbeddedResource` with image blob → `ImageBlock` with correct MIME type
- [x] `test_get_prompt_embedded_audio_blob_resource` — `EmbeddedResource` with audio blob → `AudioBlock`
- [x] `test_get_prompt_embedded_unknown_blob_resource` — `EmbeddedResource` with unknown MIME → `TextBlock` containing MIME type and URI
- [x] `test_get_prompt_audio_content` — `AudioContent` → `AudioBlock` with `format="wav"`
- [x] `test_get_prompt_resource_link` — `ResourceLink` → `TextBlock` containing the URI
- [x] All 6 new tests pass; `ruff` clean

https://claude.ai/code/session_01UcPuV2p6eNWoMCm9fQMJsZ