### PR TITLE
docs: add Actian VectorAI vector store docs and notebook

### DIFF
--- a/docs/examples/vector_stores/ActianVectorAIVectorStoreDemo.ipynb
+++ b/docs/examples/vector_stores/ActianVectorAIVectorStoreDemo.ipynb
@@ -1,0 +1,247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "707ade95",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/vector_stores/ActianVectorAIVectorStoreDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb5fb177",
+   "metadata": {},
+   "source": [
+    "# Actian VectorAI Vector Store Demo\n",
+    "\n",
+    "> This notebook shows how to use Actian VectorAI as a LlamaIndex vector store for ingestion and retrieval.\n",
+    "\n",
+    "## Prerequisites\n",
+    "- A running Actian VectorAI instance (default: `localhost:6574`)\n",
+    "- An OpenAI API key for embeddings/LLM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad8e6201",
+   "metadata": {},
+   "source": [
+    "### 1. Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7c773f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q llama-index llama-index-llms-openai llama-index-embeddings-openai llama-index-vector-stores-actian-vectorai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "720772df",
+   "metadata": {},
+   "source": [
+    "### 2. Configure credentials and imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d616e900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import uuid\n",
+    "from getpass import getpass\n",
+    "\n",
+    "from llama_index.core import (\n",
+    "    Document,\n",
+    "    Settings,\n",
+    "    StorageContext,\n",
+    "    VectorStoreIndex,\n",
+    ")\n",
+    "from llama_index.core.vector_stores.types import (\n",
+    "    MetadataFilter,\n",
+    "    MetadataFilters,\n",
+    "    FilterOperator,\n",
+    "    VectorStoreQuery,\n",
+    ")\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.vector_stores.actian_vectorai import ActianVectorAIVectorStore\n",
+    "\n",
+    "if not os.getenv(\"OPENAI_API_KEY\"):\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass(\"Enter OPENAI_API_KEY: \")\n",
+    "\n",
+    "VECTORAI_SERVER_URL = os.getenv(\"VECTORAI_SERVER_URL\", \"localhost:6574\")\n",
+    "COLLECTION_NAME = f\"llama_index_actian_demo_{uuid.uuid4().hex[:8]}\"\n",
+    "\n",
+    "print(f\"Using Actian endpoint: {VECTORAI_SERVER_URL}\")\n",
+    "print(f\"Using collection: {COLLECTION_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65008f27",
+   "metadata": {},
+   "source": [
+    "### 3. Create sample documents and build an index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4be40f62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "documents = [\n",
+    "    Document(\n",
+    "        text=\"LlamaIndex helps orchestrate RAG pipelines and retrieval over unstructured data.\",\n",
+    "        metadata={\"topic\": \"rag\", \"year\": 2023},\n",
+    "    ),\n",
+    "    Document(\n",
+    "        text=\"Actian VectorAI is a vector database used for semantic search and filtering.\",\n",
+    "        metadata={\"topic\": \"database\", \"year\": 2024},\n",
+    "    ),\n",
+    "    Document(\n",
+    "        text=\"Metadata filters let you narrow retrieval results by fields like topic or year.\",\n",
+    "        metadata={\"topic\": \"rag\", \"year\": 2022},\n",
+    "    ),\n",
+    "    Document(\n",
+    "        text=\"Production systems often combine vector retrieval with re-ranking and tool usage.\",\n",
+    "        metadata={\"topic\": \"architecture\", \"year\": 2016},\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "Settings.embed_model = OpenAIEmbedding(model=\"text-embedding-3-small\")\n",
+    "Settings.llm = OpenAI(model=\"gpt-4o-mini\")\n",
+    "\n",
+    "vector_store = ActianVectorAIVectorStore(\n",
+    "    url=VECTORAI_SERVER_URL,\n",
+    "    collection_name=COLLECTION_NAME,\n",
+    "    stores_text=True,\n",
+    "    clear_existing_collection=True,\n",
+    ")\n",
+    "vector_store.connect()\n",
+    "\n",
+    "storage_context = StorageContext.from_defaults(vector_store=vector_store)\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    documents, storage_context=storage_context\n",
+    ")\n",
+    "\n",
+    "print(f\"Indexed {len(documents)} documents into {COLLECTION_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14e4f363",
+   "metadata": {},
+   "source": [
+    "### 4. Run a semantic query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdec272a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_engine = index.as_query_engine(similarity_top_k=2)\n",
+    "response = query_engine.query(\n",
+    "    \"What does this demo say about vector databases?\"\n",
+    ")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d46be4d",
+   "metadata": {},
+   "source": [
+    "### 5. Query with metadata filters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4249806c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_embedding = Settings.embed_model.get_query_embedding(\n",
+    "    \"Find content about retrieval architecture from 2016\"\n",
+    ")\n",
+    "\n",
+    "filters = MetadataFilters(\n",
+    "    filters=[\n",
+    "        MetadataFilter(\n",
+    "            key=\"topic\", operator=FilterOperator.EQ, value=\"architecture\"\n",
+    "        ),\n",
+    "        MetadataFilter(key=\"year\", operator=FilterOperator.GTE, value=2016),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "result = vector_store.query(\n",
+    "    VectorStoreQuery(\n",
+    "        query_embedding=query_embedding,\n",
+    "        similarity_top_k=3,\n",
+    "        filters=filters,\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "for i, node in enumerate(result.nodes, start=1):\n",
+    "    print(f\"Result {i}: {node.get_content()}\")\n",
+    "    print(f\"Metadata: {node.metadata}\")\n",
+    "    print(\"-\" * 80)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "779372ae",
+   "metadata": {},
+   "source": [
+    "### 6. Cleanup (optional but recommended)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e8d4c1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove demo data and close the client connection.\n",
+    "vector_store.clear()\n",
+    "vector_store.close()\n",
+    "print(f\"Cleared and closed collection: {COLLECTION_NAME}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/framework/community/integrations/vector_stores.md
+++ b/docs/src/content/docs/framework/community/integrations/vector_stores.md
@@ -12,6 +12,7 @@ LlamaIndex offers multiple integration points with vector stores / vector databa
 LlamaIndex also supports different vector stores
 as the storage backend for `VectorStoreIndex`.
 
+- Actian VectorAI DB (`ActianVectorAIVectorStore`). [Quickstart](https://docs.vectoraidb.actian.com/home/quickstart/quickstart).
 - Alibaba Cloud OpenSearch (`AlibabaCloudOpenSearchStore`). [QuickStart](https://help.aliyun.com/zh/open-search/vector-search-edition).
 - Amazon Neptune - Neptune Analytics (`NeptuneAnalyticsVectorStore`). [Working with vector similarity in Neptune Analytics](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/vector-similarity.html).
 - Apache Cassandra® and Astra DB through CQL (`CassandraVectorStore`). [Installation](https://cassandra.apache.org/doc/stable/cassandra/getting_started/installing.html) [Quickstart](https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html)
@@ -113,6 +114,27 @@ response = query_engine.query("What did the author do growing up?")
 ```
 
 Below we show more examples of how to construct various vector stores we support.
+
+**Actian VectorAI DB**
+
+```python
+from llama_index.vector_stores.actian_vectorai import ActianVectorAIVectorStore
+from llama_index.core.vector_stores.types import VectorStoreQuery
+
+with ActianVectorAIVectorStore() as vector_store:
+    # Add nodes
+    vector_store.add(nodes)
+
+    # Query
+    query = VectorStoreQuery(query_embedding=embedding, similarity_top_k=5)
+    result = vector_store.query(query)
+
+    # Delete by source document ID
+    vector_store.delete("doc_01")
+
+    # Delete the entire collection
+    vector_store.clear()
+```
 
 **Alibaba Cloud OpenSearch**
 
@@ -1208,6 +1230,7 @@ documents = reader.load_data(
 
 ## Vector Store Examples
 
+- [Actian VectorAI DB](/python/examples/vector_stores/actianvectoraivectorstoredemo)
 - [Alibaba Cloud OpenSearch](/python/examples/vector_stores/alibabacloudopensearchindexdemo)
 - [Amazon Neptune - Neptune Analytics](/python/examples/vector_stores/amazonneptunevectordemo)
 - [Astra DB](/python/examples/vector_stores/astradbindexdemo)

--- a/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
@@ -17,6 +17,7 @@ We are actively adding more integrations and improving feature coverage for each
 
 | Vector Store               | Type                    | Metadata Filtering | Hybrid Search | Delete | Store Documents | Async                         |
 | -------------------------- | ----------------------- | ------------------ | ------------- | ------ | --------------- | ----------------------------- |
+| Actian VectorAI DB         | self-hosted / cloud     | ✓                  |               | ✓      | ✓               | ✓                             |
 | Alibaba Cloud OpenSearch   | cloud                   | ✓                  |               | ✓      | ✓               | ✓                             |
 | Apache Cassandra®         | self-hosted / cloud     | ✓                  |               | ✓      | ✓               |                               |
 | Astra DB                   | cloud                   | ✓                  |               | ✓      | ✓               |                               |
@@ -74,6 +75,7 @@ For more details, see [Vector Store Integrations](/python/framework/community/in
 
 ## Example Notebooks
 
+- [Actian VectorAI DB](/python/examples/vector_stores/actianvectoraivectorstoredemo)
 - [Alibaba Cloud OpenSearch](/python/examples/vector_stores/alibabacloudopensearchindexdemo)
 - [Astra DB](/python/examples/vector_stores/astradbindexdemo)
 - [Async Index Creation](/python/examples/vector_stores/asyncindexcreationdemo)


### PR DESCRIPTION
# Description

[Actian VectorAI DB](https://docs.vectoraidb.actian.com/) is a modern vector database engine that delivers enterprise-grade AI features. 

This PR adds documentation and an example notebook for Actian VectorAI DB as a supported vector store in LlamaIndex.



## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
