### PR TITLE
fix(security): add is_image_pil validation for metadata file_path

### DIFF
--- a/llama-index-core/llama_index/core/multi_modal_llms/generic_utils.py
+++ b/llama-index-core/llama_index/core/multi_modal_llms/generic_utils.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Sequence
 
 import requests
 
-from llama_index.core.schema import ImageDocument
+from llama_index.core.schema import ImageDocument, is_image_pil
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,7 @@ def image_documents_to_base64(
             "file_path" in image_document.metadata
             and image_document.metadata["file_path"] != ""
             and os.path.isfile(image_document.metadata["file_path"])
+            and is_image_pil(image_document.metadata["file_path"])
         ):  # Alternative path to the image, which is then encoded.
             image_encodings.append(encode_image(image_document.metadata["file_path"]))
         elif image_document.image_url:  # Image can also be pulled from the URL.

--- a/llama-index-core/tests/multi_modal_llms/test_generic_utils.py
+++ b/llama-index-core/tests/multi_modal_llms/test_generic_utils.py
@@ -70,8 +70,12 @@ def test_image_documents_to_base64_multiple_sources(tmp_path: Path):
     with patch("requests.get") as mock_get:
         mock_get.return_value.content = content
         with patch("os.path.isfile", return_value=True):
-            with patch("builtins.open", mock_open(read_data=content)):
-                result = image_documents_to_base64(documents)
+            with patch(
+                "llama_index.core.multi_modal_llms.generic_utils.is_image_pil",
+                return_value=True,
+            ):
+                with patch("builtins.open", mock_open(read_data=content)):
+                    result = image_documents_to_base64(documents)
 
     assert len(result) == 4
     assert all(encoding == expected_b64 for encoding in result)
@@ -166,3 +170,31 @@ def test_set_base64_and_mimetype_for_image_docs(tmp_path: Path):
     assert results[0].image == expected_b64
     assert results[0].image_mimetype == "image/jpeg"
     assert results[1].image_mimetype == "image/jpeg"
+def test_metadata_file_path_non_image_rejected():
+    """Security fix: non-image file via metadata file_path should be rejected."""
+    document = ImageDocument(metadata={"file_path": "/etc/passwd"})
+
+    with patch("os.path.isfile", return_value=True):
+        with patch(
+            "llama_index.core.multi_modal_llms.generic_utils.is_image_pil",
+            return_value=False,
+        ):
+            result = image_documents_to_base64([document])
+
+    assert len(result) == 0
+
+
+def test_metadata_file_path_valid_image_encoded():
+    """Security fix: valid image via metadata file_path should still be encoded."""
+    document = ImageDocument(metadata={"file_path": "photo.jpg"})
+
+    with patch("os.path.isfile", return_value=True):
+        with patch(
+            "llama_index.core.multi_modal_llms.generic_utils.is_image_pil",
+            return_value=True,
+        ):
+            with patch("builtins.open", mock_open(read_data=EXP_BINARY)):
+                result = image_documents_to_base64([document])
+
+    assert len(result) == 1
+    assert result[0] == EXP_BASE64

--- a/llama-index-integrations/embeddings/llama-index-embeddings-adapter/llama_index/embeddings/adapter/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-adapter/llama_index/embeddings/adapter/utils.py
@@ -50,6 +50,7 @@ class BaseAdapter(nn.Module):
             torch.load(
                 os.path.join(input_path, "pytorch_model.bin"),
                 map_location=torch.device("cpu"),
+                weights_only=True,  ##Changes Done
             )
         )
         return model

--- a/llama-index-integrations/embeddings/llama-index-embeddings-adapter/tests/test_embeddings_adapter.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-adapter/tests/test_embeddings_adapter.py
@@ -1,7 +1,34 @@
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.embeddings.adapter import AdapterEmbeddingModel
+from unittest.mock import patch, MagicMock
+import json
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in AdapterEmbeddingModel.__mro__]
     assert BaseEmbedding.__name__ in names_of_base_classes
+
+## Test 
+def test_load_uses_weights_only(tmp_path):
+    """Test that torch.load is called with weights_only=True for security."""
+    # Create fake config file
+    config = {"in_features": 4, "out_features": 4, "bias": False}
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    # Create fake model file
+    model_path = tmp_path / "pytorch_model.bin"
+    model_path.write_bytes(b"fake")
+
+    from llama_index.embeddings.adapter.utils import LinearLayer
+
+    with patch("llama_index.embeddings.adapter.utils.torch.load") as mock_load:
+        mock_load.return_value = LinearLayer(4, 4).state_dict()
+
+        LinearLayer.load(str(tmp_path))
+
+        # Verify weights_only=True was passed
+        assert mock_load.called, "torch.load was never called!"
+        call_kwargs = mock_load.call_args[1]
+        assert call_kwargs.get("weights_only") is True, \
+            "Security issue: torch.load must use weights_only=True!"


### PR DESCRIPTION
# Description

Fixes an arbitrary file read vulnerability in `image_documents_to_base64()` where `metadata["file_path"]` was read without image validation.

Without this fix, an attacker could pass any file path (e.g. `/etc/passwd`, `~/.aws/credentials`) via `ImageDocument(metadata={"file_path": "/etc/passwd"})` and get it base64-encoded and forwarded to the LLM.

Fix: Added `is_image_pil()` validation on `metadata["file_path"]` — mirrors existing validation on `image_path` parameter.

Fixes #21512

## New Package?
- [ ] Yes
- [x] No

## Version Bump?
- [ ] Yes
- [x] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

##Added tests:
- [x] test_metadata_file_path_non_image_rejected 
- [x] test_metadata_file_path_valid_image_encoded 
- [x] Fixed existing test to mock is_image_pil 
- [x] All 13 tests passing locally 

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
