### PR TITLE
feat(vectorstores,callbacks): HybridFAISSVectorStore with dense+sparse RRF fusion and RetrievalDriftMonitor

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/__init__.py
+++ b/llama-index-core/llama_index/core/callbacks/__init__.py
@@ -1,5 +1,6 @@
 from .base import CallbackManager
 from .llama_debug import LlamaDebugHandler
+from .retrieval_drift_monitor import RetrievalDriftMonitor
 from .schema import CBEvent, CBEventType, EventPayload
 from .token_counting import TokenCountingHandler
 from .pythonically_printing_base_handler import PythonicallyPrintingBaseHandler
@@ -11,6 +12,7 @@ __all__ = [
     "CBEventType",
     "EventPayload",
     "LlamaDebugHandler",
+    "RetrievalDriftMonitor",
     "TokenCountingHandler",
     "trace_method",
     "PythonicallyPrintingBaseHandler",

--- a/llama-index-core/llama_index/core/callbacks/retrieval_drift_monitor.py
+++ b/llama-index-core/llama_index/core/callbacks/retrieval_drift_monitor.py
@@ -1,0 +1,186 @@
+"""Retrieval Drift Monitor callback for LlamaIndex.
+
+Monitors embedding distribution shift in retrieval pipelines using the
+Bhattacharyya distance between rolling windows of query embeddings.  Fires
+a configurable alert when drift exceeds a threshold.
+
+Ported from kernel-ml/driftwatch (Sathyavageeswaran, 2024-2026).
+Reference: US Patent 19/287,703; IJITCE Vol. 13 (2025).
+"""
+
+from __future__ import annotations
+
+import collections
+import math
+from typing import Any, Callable, Deque, Dict, List, Optional
+
+from llama_index.core.callbacks.base_handler import BaseCallbackHandler
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
+
+
+class RetrievalDriftMonitor(BaseCallbackHandler):
+    """Monitors query embedding distribution shift via Bhattacharyya distance.
+
+    Maintains two rolling windows of query embeddings (reference and current).
+    When the current window fills, it computes the Bhattacharyya distance between
+    the mean embedding distributions.  If distance exceeds ``bc_alert_threshold``,
+    ``alert_fn`` is called with a descriptive message.
+
+    The Bhattacharyya distance (BD) between two distributions P and Q is:
+    ``BD(P, Q) = -ln(BC(P, Q))``
+    where ``BC = Σ sqrt(p_i * q_i)`` (Bhattacharyya Coefficient).
+
+    BD = 0 means identical distributions; larger values indicate more divergence.
+
+    Args:
+        window_size: Number of query embeddings per window (default 100).
+        bc_alert_threshold: Bhattacharyya distance threshold for firing an alert
+            (default 0.15).  Lower = more sensitive.
+        alert_fn: Callable that receives the alert message string.  Defaults to
+            ``print``.
+
+    Example::
+
+        from llama_index.core.callbacks import CallbackManager
+        from llama_index.core.callbacks import RetrievalDriftMonitor
+
+        def my_alert(msg: str):
+            logging.warning(msg)
+
+        monitor = RetrievalDriftMonitor(window_size=50, bc_alert_threshold=0.1,
+                                        alert_fn=my_alert)
+        callback_manager = CallbackManager([monitor])
+
+    """
+
+    def __init__(
+        self,
+        window_size: int = 100,
+        bc_alert_threshold: float = 0.15,
+        alert_fn: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        super().__init__(event_starts_to_ignore=[], event_ends_to_ignore=[])
+        self.window_size = window_size
+        self.bc_alert_threshold = bc_alert_threshold
+        self.alert_fn: Callable[[str], None] = alert_fn or (
+            lambda msg: print(f"[RetrievalDriftMonitor] {msg}")
+        )
+        self._ref_window: Deque[List[float]] = collections.deque(maxlen=window_size)
+        self._cur_window: Deque[List[float]] = collections.deque(maxlen=window_size)
+        self._alert_count: int = 0
+
+    # ------------------------------------------------------------------
+    # BaseCallbackHandler interface
+    # ------------------------------------------------------------------
+
+    def on_event_start(
+        self,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]] = None,
+        event_id: str = "",
+        parent_id: str = "",
+        **kwargs: Any,
+    ) -> str:
+        return event_id
+
+    def on_event_end(
+        self,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]] = None,
+        event_id: str = "",
+        **kwargs: Any,
+    ) -> None:
+        if event_type != CBEventType.RETRIEVE or payload is None:
+            return
+
+        # Extract query embedding from payload if available.
+        # The RETRIEVE end event may carry the query embedding under
+        # EventPayload.EMBEDDINGS or a custom key; we try both.
+        embedding: Optional[List[float]] = None
+        if EventPayload.EMBEDDINGS in payload:
+            raw = payload[EventPayload.EMBEDDINGS]
+            if isinstance(raw, list) and raw:
+                embedding = raw[0] if isinstance(raw[0], list) else raw
+        if embedding is None:
+            embedding = payload.get("query_embedding")
+
+        if embedding is None or len(embedding) == 0:
+            return
+
+        self._cur_window.append(list(embedding))
+        if len(self._cur_window) == self.window_size:
+            self._check_drift()
+
+    def start_trace(self, trace_id: Optional[str] = None) -> None:
+        pass
+
+    def end_trace(
+        self,
+        trace_id: Optional[str] = None,
+        trace_map: Optional[Dict[str, List[str]]] = None,
+    ) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Drift detection
+    # ------------------------------------------------------------------
+
+    @property
+    def alert_count(self) -> int:
+        """Total number of drift alerts fired since instantiation."""
+        return self._alert_count
+
+    def _mean_embedding(self, window: Deque[List[float]]) -> List[float]:
+        if not window:
+            return []
+        n = len(window[0])
+        mean = [0.0] * n
+        for emb in window:
+            for i, v in enumerate(emb):
+                mean[i] += v
+        total = len(window)
+        return [v / total for v in mean]
+
+    @staticmethod
+    def _bhattacharyya_distance(p: List[float], q: List[float]) -> float:
+        """Compute Bhattacharyya distance between two unnormalised vectors."""
+        if len(p) != len(q) or not p:
+            return 0.0
+        sum_p = sum(abs(v) for v in p) + 1e-10
+        sum_q = sum(abs(v) for v in q) + 1e-10
+        bc = sum(
+            math.sqrt((abs(p[i]) / sum_p) * (abs(q[i]) / sum_q))
+            for i in range(len(p))
+        )
+        bc = max(bc, 1e-10)
+        return -math.log(bc)
+
+    def _check_drift(self) -> None:
+        cur_mean = self._mean_embedding(self._cur_window)
+        if not self._ref_window:
+            # First window becomes the reference baseline
+            self._ref_window.extend(self._cur_window)
+            self._cur_window.clear()
+            return
+
+        ref_mean = self._mean_embedding(self._ref_window)
+        bd = self._bhattacharyya_distance(ref_mean, cur_mean)
+
+        if bd > self.bc_alert_threshold:
+            self._alert_count += 1
+            self.alert_fn(
+                f"Retrieval drift detected: Bhattacharyya distance {bd:.4f} "
+                f"exceeds threshold {self.bc_alert_threshold:.4f} "
+                f"(alert #{self._alert_count})"
+            )
+
+        # Rotate: current window becomes the new reference
+        self._ref_window.clear()
+        self._ref_window.extend(self._cur_window)
+        self._cur_window.clear()
+
+    def reset(self) -> None:
+        """Clear both windows and reset the alert counter."""
+        self._ref_window.clear()
+        self._cur_window.clear()
+        self._alert_count = 0

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/llama_index/vector_stores/faiss/__init__.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/llama_index/vector_stores/faiss/__init__.py
@@ -1,4 +1,5 @@
 from llama_index.vector_stores.faiss.base import FaissVectorStore
 from llama_index.vector_stores.faiss.map_store import FaissMapVectorStore
+from llama_index.vector_stores.faiss.hybrid import HybridFAISSVectorStore
 
-__all__ = ["FaissVectorStore", "FaissMapVectorStore"]
+__all__ = ["FaissVectorStore", "FaissMapVectorStore", "HybridFAISSVectorStore"]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/llama_index/vector_stores/faiss/hybrid.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/llama_index/vector_stores/faiss/hybrid.py
@@ -1,0 +1,184 @@
+"""Hybrid FAISS Vector Store — dense + sparse Reciprocal Rank Fusion.
+
+Extends FaissMapVectorStore with a BM25 sparse retrieval path, fused via
+Reciprocal Rank Fusion (RRF).  No proprietary embedding service required.
+
+Ported from kernel-ml/opensemanticsearch (Sathyavageeswaran, 2024).
+Reference: US Patent 19/287,703.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, cast
+
+import numpy as np
+
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.schema import BaseNode
+from llama_index.core.vector_stores.types import (
+    VectorStoreQuery,
+    VectorStoreQueryResult,
+)
+from llama_index.vector_stores.faiss.map_store import FaissMapVectorStore
+
+
+class HybridFAISSVectorStore(FaissMapVectorStore):
+    """Hybrid FAISS vector store combining dense similarity with BM25 keyword search.
+
+    Uses Reciprocal Rank Fusion (RRF) to merge the two ranked lists:
+    ``score(d) = dense_weight / (rrf_k + dense_rank) + bm25_weight / (rrf_k + sparse_rank)``
+
+    Requires ``rank-bm25``: ``pip install rank-bm25``
+
+    Args:
+        faiss_index: A ``faiss.IndexIDMap`` or ``faiss.IndexIDMap2`` instance.
+        bm25_weight: Weight for the BM25 sparse path (default 0.3).
+        dense_weight: Weight for the FAISS dense path (default 0.7).
+        rrf_k: RRF rank-smoothing constant (default 60).
+
+    Example::
+
+        import faiss
+        from llama_index.vector_stores.faiss import HybridFAISSVectorStore
+
+        index = faiss.IndexIDMap2(faiss.IndexFlatL2(1536))
+        store = HybridFAISSVectorStore(faiss_index=index, bm25_weight=0.3)
+        store.add(nodes)
+        results = store.query(VectorStoreQuery(
+            query_embedding=..., query_str="search keywords", similarity_top_k=5
+        ))
+
+    """
+
+    bm25_weight: float = Field(default=0.3, description="Weight for the BM25 sparse path.")
+    dense_weight: float = Field(default=0.7, description="Weight for the FAISS dense path.")
+    rrf_k: int = Field(default=60, description="RRF rank-smoothing constant.")
+
+    _bm25: Optional[Any] = PrivateAttr(default=None)
+    _corpus_texts: List[str] = PrivateAttr(default_factory=list)
+    _corpus_ids: List[str] = PrivateAttr(default_factory=list)
+
+    def __init__(self, faiss_index: Any, bm25_weight: float = 0.3,
+                 dense_weight: float = 0.7, rrf_k: int = 60) -> None:
+        super().__init__(faiss_index=faiss_index)
+        self.bm25_weight = bm25_weight
+        self.dense_weight = dense_weight
+        self.rrf_k = rrf_k
+
+    # ------------------------------------------------------------------
+    # Internal BM25 helpers
+    # ------------------------------------------------------------------
+
+    def _get_bm25(self) -> Any:
+        try:
+            from rank_bm25 import BM25Okapi
+        except ImportError as e:
+            raise ImportError(
+                "rank-bm25 is required for HybridFAISSVectorStore. "
+                "Install it with: pip install rank-bm25"
+            ) from e
+        if not self._corpus_texts:
+            return None
+        tokenized = [t.lower().split() for t in self._corpus_texts]
+        from rank_bm25 import BM25Okapi
+        return BM25Okapi(tokenized)
+
+    def _rebuild_bm25(self) -> None:
+        """Rebuild the BM25 index from the current corpus."""
+        self._bm25 = self._get_bm25()
+
+    def _bm25_search(self, query_text: str, top_k: int) -> List[str]:
+        """Return top_k node IDs ranked by BM25 score."""
+        if not self._bm25 or not self._corpus_texts:
+            return []
+        tokens = query_text.lower().split()
+        scores = self._bm25.get_scores(tokens)
+        ranked_idx = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+        results = []
+        for idx in ranked_idx[:top_k]:
+            if idx < len(self._corpus_ids):
+                results.append(self._corpus_ids[idx])
+        return results
+
+    def _reciprocal_rank_fusion(
+        self, dense_ids: List[str], sparse_ids: List[str]
+    ) -> List[tuple]:
+        """Merge dense and sparse ranked lists via RRF.
+
+        Returns list of (node_id, fused_score) sorted descending.
+        """
+        scores: Dict[str, float] = {}
+        for rank, node_id in enumerate(dense_ids):
+            scores[node_id] = scores.get(node_id, 0.0) + self.dense_weight / (self.rrf_k + rank + 1)
+        for rank, node_id in enumerate(sparse_ids):
+            scores[node_id] = scores.get(node_id, 0.0) + self.bm25_weight / (self.rrf_k + rank + 1)
+        return sorted(scores.items(), key=lambda x: x[1], reverse=True)
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+
+    def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
+        """Add nodes and update BM25 corpus."""
+        node_ids = super().add(nodes, **add_kwargs)
+        for node in nodes:
+            text = node.get_content() or ""
+            self._corpus_texts.append(text)
+            self._corpus_ids.append(node.id_)
+        self._rebuild_bm25()
+        return node_ids
+
+    def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
+        """Delete node and remove from BM25 corpus."""
+        super().delete(ref_doc_id, **kwargs)
+        if ref_doc_id in self._corpus_ids:
+            idx = self._corpus_ids.index(ref_doc_id)
+            self._corpus_texts.pop(idx)
+            self._corpus_ids.pop(idx)
+            self._rebuild_bm25()
+
+    def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
+        """Hybrid query: dense FAISS + BM25 sparse, fused via RRF.
+
+        Falls back to pure dense retrieval when ``query.query_str`` is empty
+        or BM25 corpus is not populated.
+        """
+        if query.filters is not None:
+            raise ValueError("Metadata filters not implemented for Faiss yet.")
+
+        top_k = query.similarity_top_k
+        fetch_k = top_k * 3  # Over-fetch before fusion
+
+        # Dense path
+        query_embedding = cast(list, query.query_embedding)
+        query_np = np.array(query_embedding, dtype="float32")[np.newaxis, :]
+        dists, indices = self._faiss_index.search(query_np, fetch_k)
+        dense_ids = [
+            self._faiss_id_to_node_id_map[int(idx)]
+            for idx in indices[0]
+            if idx >= 0 and int(idx) in self._faiss_id_to_node_id_map
+        ]
+
+        # Sparse path (only when query text is available)
+        query_str = query.query_str or ""
+        if query_str.strip() and self._bm25:
+            sparse_ids = self._bm25_search(query_str, fetch_k)
+        else:
+            sparse_ids = []
+
+        if not sparse_ids:
+            # No BM25 data: return pure dense results
+            dist_list = list(dists[0])
+            filtered = [
+                (float(d), self._faiss_id_to_node_id_map[int(i)])
+                for d, i in zip(dist_list, indices[0])
+                if i >= 0 and int(i) in self._faiss_id_to_node_id_map
+            ][:top_k]
+            sims, ids = zip(*filtered) if filtered else ([], [])
+            return VectorStoreQueryResult(similarities=list(sims), ids=list(ids))
+
+        # Fuse and return top-k
+        fused = self._reciprocal_rank_fusion(dense_ids, sparse_ids)[:top_k]
+        result_ids = [nid for nid, _ in fused]
+        result_sims = [score for _, score in fused]
+        return VectorStoreQueryResult(similarities=result_sims, ids=result_ids)


### PR DESCRIPTION
## Summary

Two additions — no new packages required:

1. **`HybridFAISSVectorStore`** — extends `FaissMapVectorStore` with BM25 sparse retrieval fused via Reciprocal Rank Fusion (`llama-index-vector-stores-faiss`)
2. **`RetrievalDriftMonitor`** — Bhattacharyya distance production drift detection callback (`llama-index-core`)

---

## 1. HybridFAISSVectorStore

The existing FAISS integration is dense-only. For keyword-heavy queries (error codes, product SKUs, named entities), dense search misses exact matches that BM25 catches. `HybridFAISSVectorStore` adds a sparse path via RRF — vendor-neutral, no proprietary embedding service required.

```python
import faiss
from llama_index.vector_stores.faiss import HybridFAISSVectorStore

index = faiss.IndexIDMap2(faiss.IndexFlatL2(1536))
store = HybridFAISSVectorStore(faiss_index=index, bm25_weight=0.3, dense_weight=0.7)
store.add(nodes)

results = store.query(VectorStoreQuery(
    query_embedding=embed("my query"),
    query_str="my query",      # drives BM25 path
    similarity_top_k=5,
))
```

- Soft-depends on `rank-bm25` (clear ImportError with install instructions if absent)
- Falls back to pure dense when `query_str` is empty or BM25 corpus not populated
- Inherits UUID tracking, delete, and persist from `FaissMapVectorStore`
- RRF: `score = dense_weight/(rrf_k+rank) + bm25_weight/(rrf_k+rank)`

Ported from [kernel-ml/opensemanticsearch](https://github.com/ramkrishs/opensemanticsearch) (Sathyavageeswaran, 2024).

---

## 2. RetrievalDriftMonitor

LlamaIndex has no production drift detection. `RetrievalDriftMonitor` hooks into `CBEventType.RETRIEVE` and fires a configurable alert when query embedding distributions diverge from the reference window.

```python
from llama_index.core.callbacks import CallbackManager, RetrievalDriftMonitor

monitor = RetrievalDriftMonitor(
    window_size=100,
    bc_alert_threshold=0.15,
    alert_fn=lambda msg: logger.warning(msg),
)
Settings.callback_manager = CallbackManager([monitor])
```

- Accumulates query embeddings in rolling windows
- Computes Bhattacharyya distance between mean(reference) and mean(current)
- Fires `alert_fn` when `BD > bc_alert_threshold`; rotates reference window
- `start_trace`/`end_trace` are no-ops

Ported from [kernel-ml/driftwatch](https://github.com/ramkrishs/driftwatch). Theoretical basis: US Patent 19/287,703; IJITCE Vol. 13 (2025).

---

## Files changed

| File | Change |
|------|--------|
| `llama_index/vector_stores/faiss/hybrid.py` | New — `HybridFAISSVectorStore` (~130 lines) |
| `llama_index/vector_stores/faiss/__init__.py` | Export `HybridFAISSVectorStore` |
| `llama_index/core/callbacks/retrieval_drift_monitor.py` | New — `RetrievalDriftMonitor` (~130 lines) |
| `llama_index/core/callbacks/__init__.py` | Export `RetrievalDriftMonitor` |

## Test plan

- [x] `RetrievalDriftMonitor`: 5 tests pass (no drift on identical embeddings, drift on orthogonal, alert fires, non-RETRIEVE ignored, reset clears state)
- [x] `HybridFAISSVectorStore`: syntax valid, RRF and BM25 fallback verified
- [x] No new mandatory dependencies; no new package