### PR TITLE
fix(core): preserve refresh_ref_docs kwargs across batch documents

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -441,11 +441,11 @@ class BaseIndex(Generic[IS], ABC):
             for i, document in enumerate(documents):
                 existing_doc_hash = self._docstore.get_document_hash(document.id_)
                 if existing_doc_hash is None:
-                    self.insert(document, **update_kwargs.pop("insert_kwargs", {}))
+                    self.insert(document, **update_kwargs.get("insert_kwargs", {}))
                     refreshed_documents[i] = True
                 elif existing_doc_hash != document.hash:
                     self.update_ref_doc(
-                        document, **update_kwargs.pop("update_kwargs", {})
+                        document, **update_kwargs.get("update_kwargs", {})
                     )
                     refreshed_documents[i] = True
 
@@ -469,12 +469,12 @@ class BaseIndex(Generic[IS], ABC):
                 )
                 if existing_doc_hash is None:
                     await self.ainsert(
-                        document, **update_kwargs.pop("insert_kwargs", {})
+                        document, **update_kwargs.get("insert_kwargs", {})
                     )
                     refreshed_documents[i] = True
                 elif existing_doc_hash != document.hash:
                     await self.aupdate_ref_doc(
-                        document, **update_kwargs.pop("update_kwargs", {})
+                        document, **update_kwargs.get("update_kwargs", {})
                     )
                     refreshed_documents[i] = True
             return refreshed_documents

--- a/llama-index-core/tests/indices/vector_store/test_simple.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple.py
@@ -3,10 +3,10 @@
 import pickle
 from typing import Any, List, cast
 
+from llama_index.core.indices.keyword_table.simple_base import SimpleKeywordTableIndex
 from llama_index.core.indices.loading import load_index_from_storage
 from llama_index.core.indices.vector_store.base import VectorStoreIndex
-from llama_index.core.indices.keyword_table.simple_base import SimpleKeywordTableIndex
-from llama_index.core.schema import Document
+from llama_index.core.schema import BaseNode, Document, TransformComponent
 from llama_index.core.storage.storage_context import StorageContext
 from llama_index.core.vector_stores.simple import SimpleVectorStore
 
@@ -321,3 +321,34 @@ def test_simple_pickle(
     all_ref_doc_info = new_index.ref_doc_info
     for idx, ref_doc_id in enumerate(all_ref_doc_info.keys()):
         assert documents[idx].node_id == ref_doc_id
+
+
+def test_refresh_ref_docs_kwargs_applied_to_all_documents(
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    mock_embed_model,
+) -> None:
+    received_kwargs: List[dict] = []
+
+    class KwargsRecorder(TransformComponent):
+        def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+            received_kwargs.append(dict(kwargs))
+            return nodes
+
+    docs = [
+        Document(id_="1", text="doc one"),
+        Document(id_="2", text="doc two"),
+        Document(id_="3", text="doc three"),
+    ]
+    index = VectorStoreIndex(
+        [], transformations=[KwargsRecorder()], embed_model=mock_embed_model
+    )
+
+    refreshed = index.refresh_ref_docs(docs, insert_kwargs={"my_flag": True})
+
+    assert refreshed == [True, True, True]
+    assert len(received_kwargs) == 3
+    for i, kw in enumerate(received_kwargs):
+        assert kw.get("my_flag") is True, (
+            f"doc {i + 1}: expected my_flag=True, got {kw}"
+        )

--- a/llama-index-core/tests/indices/vector_store/test_simple_async.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple_async.py
@@ -1,8 +1,9 @@
 import pytest
 from typing import Any, List
-from llama_index.core.indices.vector_store.base import VectorStoreIndex
+
 from llama_index.core.indices.keyword_table.simple_base import SimpleKeywordTableIndex
-from llama_index.core.schema import Document
+from llama_index.core.indices.vector_store.base import VectorStoreIndex
+from llama_index.core.schema import BaseNode, Document, TransformComponent
 from llama_index.core.storage.storage_context import StorageContext
 from llama_index.core.vector_stores.simple import SimpleVectorStore
 
@@ -229,3 +230,35 @@ async def test_adelete_ref_doc_calls_vector_store_with_ref_doc_id_only(
     assert delete_log == ["my-doc-id"], (
         f"Expected delete() called once with ref_doc_id only, got: {delete_log}"
     )
+
+
+@pytest.mark.asyncio
+async def test_arefresh_ref_docs_kwargs_applied_to_all_documents(
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    mock_embed_model,
+) -> None:
+    received_kwargs: List[dict] = []
+
+    class KwargsRecorder(TransformComponent):
+        def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+            received_kwargs.append(dict(kwargs))
+            return nodes
+
+    docs = [
+        Document(id_="1", text="doc one"),
+        Document(id_="2", text="doc two"),
+        Document(id_="3", text="doc three"),
+    ]
+    index = VectorStoreIndex(
+        [], transformations=[KwargsRecorder()], embed_model=mock_embed_model
+    )
+
+    refreshed = await index.arefresh_ref_docs(docs, insert_kwargs={"my_flag": True})
+
+    assert refreshed == [True, True, True]
+    assert len(received_kwargs) == 3
+    for i, kw in enumerate(received_kwargs):
+        assert kw.get("my_flag") is True, (
+            f"doc {i + 1}: expected my_flag=True, got {kw}"
+        )


### PR DESCRIPTION
# Description

Replaced `.pop()` with `.get()` in the `refresh_ref_docs()` / `arefresh_ref_docs()` document loops so `insert_kwargs` and `update_kwargs` are forwarded to every matching document in the batch, not just the first.

Fixes #21518

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
