### PR TITLE
fix(weaviate): add import compatibility fallback for batch wrapper

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -36,9 +36,14 @@ from llama_index.vector_stores.weaviate._exceptions import (
 import weaviate
 import weaviate.classes as wvc
 
-from weaviate.collections.batch.batch_wrapper import (
-    _ContextManagerWrapper as BatchWrapper,
-)
+try:
+    from weaviate.collections.batch.batch_wrapper import (
+        _BatchWrapper as BatchWrapper,
+    )
+except ImportError:
+    from weaviate.collections.batch.batch_wrapper import (
+        _ContextManagerWrapper as BatchWrapper,
+    )
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #21495 - Add fallback import for `_BatchWrapper` class.

In weaviate-client v4.20.5, `_ContextManagerWrapper` was renamed to `_BatchWrapper`. This change adds a try/except fallback to support both versions, ensuring compatibility with newer and older versions of the weaviate-client library.