### PR TITLE
fix(core): extract kwargs before loop in refresh_ref_docs

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -438,14 +438,16 @@ class BaseIndex(Generic[IS], ABC):
         """
         with self._callback_manager.as_trace("refresh_ref_docs"):
             refreshed_documents = [False] * len(documents)
+            insert_kwargs = update_kwargs.pop("insert_kwargs", {})
+            update_kwargs_internal = update_kwargs.pop("update_kwargs", {})
             for i, document in enumerate(documents):
                 existing_doc_hash = self._docstore.get_document_hash(document.id_)
                 if existing_doc_hash is None:
-                    self.insert(document, **update_kwargs.pop("insert_kwargs", {}))
+                    self.insert(document, **insert_kwargs)
                     refreshed_documents[i] = True
                 elif existing_doc_hash != document.hash:
                     self.update_ref_doc(
-                        document, **update_kwargs.pop("update_kwargs", {})
+                        document, **update_kwargs_internal
                     )
                     refreshed_documents[i] = True
 
@@ -463,18 +465,20 @@ class BaseIndex(Generic[IS], ABC):
         """
         with self._callback_manager.as_trace("arefresh_ref_docs"):
             refreshed_documents = [False] * len(documents)
+            insert_kwargs = update_kwargs.pop("insert_kwargs", {})
+            update_kwargs_internal = update_kwargs.pop("update_kwargs", {})
             for i, document in enumerate(documents):
                 existing_doc_hash = await self._docstore.aget_document_hash(
                     document.id_
                 )
                 if existing_doc_hash is None:
                     await self.ainsert(
-                        document, **update_kwargs.pop("insert_kwargs", {})
+                        document, **insert_kwargs
                     )
                     refreshed_documents[i] = True
                 elif existing_doc_hash != document.hash:
                     await self.aupdate_ref_doc(
-                        document, **update_kwargs.pop("update_kwargs", {})
+                        document, **update_kwargs_internal
                     )
                     refreshed_documents[i] = True
             return refreshed_documents

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -36,9 +36,14 @@ from llama_index.vector_stores.weaviate._exceptions import (
 import weaviate
 import weaviate.classes as wvc
 
-from weaviate.collections.batch.batch_wrapper import (
-    _ContextManagerWrapper as BatchWrapper,
-)
+try:
+    from weaviate.collections.batch.batch_wrapper import (
+        _BatchWrapper as BatchWrapper,
+    )
+except ImportError:
+    from weaviate.collections.batch.batch_wrapper import (
+        _ContextManagerWrapper as BatchWrapper,
+    )
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #21518 - Prevent kwargs from being dropped after first document in refresh_ref_docs.

The bug: `insert_kwargs` and `update_kwargs` are extracted via `.pop()` inside the document loop, so only the first document receives them. Subsequent documents get `{}`.

The fix: Extract kwargs before the loop using `.pop()` once and reuse the same values for all documents.