### PR TITLE
fix(memory): handle DocumentBlock in Memory._estimate_token_count

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -229,6 +229,10 @@ class Memory(BaseMemory):
         default=256,
         description="The token size estimate for video.",
     )
+    document_token_size_estimate: int = Field(
+        default=2048,
+        description="The token size estimate for documents (e.g. PDFs). Used when document data is not available for byte-based estimation.",
+    )
     tokenizer_fn: Callable[[str], List] = Field(
         default_factory=get_tokenizer,
         exclude=True,
@@ -423,6 +427,12 @@ class Memory(BaseMemory):
                 token_count += self.video_token_size_estimate
             elif isinstance(block, AudioBlock):
                 token_count += self.audio_token_size_estimate
+            elif isinstance(block, DocumentBlock):
+                if isinstance(block.data, bytes) and block.data:
+                    # data is base64-encoded; divide by 4 as a bytes-to-tokens heuristic
+                    token_count += len(block.data) // 4
+                else:
+                    token_count += self.document_token_size_estimate
 
         return token_count
 

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -428,11 +428,7 @@ class Memory(BaseMemory):
             elif isinstance(block, AudioBlock):
                 token_count += self.audio_token_size_estimate
             elif isinstance(block, DocumentBlock):
-                if isinstance(block.data, bytes) and block.data:
-                    # data is base64-encoded; divide by 4 as a bytes-to-tokens heuristic
-                    token_count += len(block.data) // 4
-                else:
-                    token_count += self.document_token_size_estimate
+                token_count += self.document_token_size_estimate
 
         return token_count
 

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -231,7 +231,7 @@ class Memory(BaseMemory):
     )
     document_token_size_estimate: int = Field(
         default=2048,
-        description="The token size estimate for documents (e.g. PDFs). Used when document data is not available for byte-based estimation.",
+        description="The token size estimate for documents (e.g. PDFs).",
     )
     tokenizer_fn: Callable[[str], List] = Field(
         default_factory=get_tokenizer,

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -1,5 +1,3 @@
-import base64
-
 import pytest
 
 from llama_index.core.base.llms.types import (
@@ -68,20 +66,8 @@ async def test_estimate_token_count_audio(memory):
 
 
 @pytest.mark.asyncio
-async def test_estimate_token_count_document_with_data(memory):
-    """Test token counting for a document with byte data uses byte-based estimate."""
-    raw = b"A" * 400
-    block = DocumentBlock(
-        data=base64.b64encode(raw), document_mimetype="application/pdf"
-    )
-    message = ChatMessage(role="user", blocks=[block])
-    count = memory._estimate_token_count(message)
-    assert count == len(base64.b64encode(raw)) // 4
-
-
-@pytest.mark.asyncio
-async def test_estimate_token_count_document_without_data(memory):
-    """Test token counting for a document with no data falls back to fixed estimate."""
+async def test_estimate_token_count_document(memory):
+    """Test token counting for a document uses the fixed estimate."""
     block = DocumentBlock(
         url="http://example.com/doc.pdf", document_mimetype="application/pdf"
     )

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -1,7 +1,10 @@
+import base64
+
 import pytest
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    DocumentBlock,
     ImageBlock,
     AudioBlock,
     VideoBlock,
@@ -62,6 +65,29 @@ async def test_estimate_token_count_audio(memory):
     message = ChatMessage(role="user", blocks=[block])
     count = memory._estimate_token_count(message)
     assert count == memory.audio_token_size_estimate
+
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_document_with_data(memory):
+    """Test token counting for a document with byte data uses byte-based estimate."""
+    raw = b"A" * 400
+    block = DocumentBlock(
+        data=base64.b64encode(raw), document_mimetype="application/pdf"
+    )
+    message = ChatMessage(role="user", blocks=[block])
+    count = memory._estimate_token_count(message)
+    assert count == len(base64.b64encode(raw)) // 4
+
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_document_without_data(memory):
+    """Test token counting for a document with no data falls back to fixed estimate."""
+    block = DocumentBlock(
+        url="http://example.com/doc.pdf", document_mimetype="application/pdf"
+    )
+    message = ChatMessage(role="user", blocks=[block])
+    count = memory._estimate_token_count(message)
+    assert count == memory.document_token_size_estimate
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`Memory._estimate_token_count` handled `ImageBlock`, `VideoBlock`, and `AudioBlock`, but had no case for `DocumentBlock` — so any document passed in a message (e.g. a PDF) contributed **zero tokens** to the count. This could cause the memory queue to retain far more content than intended when documents are present.

This PR adds a `DocumentBlock` branch that uses a flat configurable estimate (`document_token_size_estimate`, default: 2048), consistent with the fixed-estimate pattern used for all other non-text block types.

## Changes

- `memory.py`: adds `document_token_size_estimate` field (default 2048) and a `DocumentBlock` branch in `_estimate_token_count`
- `test_memory_base.py`: adds a test covering document token estimation

## Test plan

- [ ] `pytest llama-index-core/tests/memory/test_memory_base.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)