### PR TITLE
fix(azure-openai): use deployment name in AzureOpenAIResponses structured predict

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/responses.py
@@ -1,15 +1,17 @@
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 import httpx
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.base.llms.generic_utils import get_from_param_or_env
+from llama_index.core import PromptTemplate
+from llama_index.core.llms.llm import Model
 from llama_index.llms.azure_openai.utils import (
     refresh_openai_azuread_token,
     resolve_from_aliases,
 )
-from llama_index.llms.openai.responses import OpenAIResponses
+from llama_index.llms.openai.responses import OpenAIResponses, to_openai_message_dicts
 from openai import AsyncAzureOpenAI
 from openai import AzureOpenAI as SyncAzureOpenAI
 from openai.lib.azure import AzureADTokenProvider
@@ -203,6 +205,68 @@ class AzureOpenAIResponses(OpenAIResponses):
 
         self._http_client = http_client
         self._async_http_client = async_http_client
+
+    def structured_predict(
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Model:
+        """
+        Structured predict using responses.parse with the Azure deployment name.
+
+        Overrides OpenAIResponses.structured_predict to pass ``self.engine``
+        (the Azure deployment name) instead of ``self.model`` (the model family
+        name) to ``responses.parse``.  Azure routes requests by deployment name;
+        using the model family name results in a 404 DeploymentNotFound error.
+        """
+        messages = prompt.format_messages(**prompt_args)
+        message_dicts = to_openai_message_dicts(
+            messages, model=self.model, is_responses_api=True
+        )
+        response = self._client.responses.parse(
+            model=self.engine,
+            input=message_dicts,
+            text_format=output_cls,
+            tool_choice="none",
+            store=self.store,
+            **(llm_kwargs or {}),
+        )
+        if response.output_parsed is not None:
+            return response.output_parsed
+        raise ValueError("Failed to produce a structured response from the model.")
+
+    async def astructured_predict(
+        self,
+        output_cls: Type[Model],
+        prompt: PromptTemplate,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        **prompt_args: Any,
+    ) -> Model:
+        """
+        Async structured predict using responses.parse with the Azure deployment name.
+
+        Overrides OpenAIResponses.astructured_predict to pass ``self.engine``
+        (the Azure deployment name) instead of ``self.model`` (the model family
+        name) to ``responses.parse``.  Azure routes requests by deployment name;
+        using the model family name results in a 404 DeploymentNotFound error.
+        """
+        messages = prompt.format_messages(**prompt_args)
+        message_dicts = to_openai_message_dicts(
+            messages, model=self.model, is_responses_api=True
+        )
+        response = await self._aclient.responses.parse(
+            model=self.engine,
+            input=message_dicts,
+            text_format=output_cls,
+            tool_choice="none",
+            store=self.store,
+            **(llm_kwargs or {}),
+        )
+        if response.output_parsed is not None:
+            return response.output_parsed
+        raise ValueError("Failed to produce a structured response from the model.")
 
     def _get_credential_kwargs(
         self, is_async: bool = False, **kwargs: Any

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/llama_index/llms/azure_openai/responses.py
@@ -1,17 +1,15 @@
 import os
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional
 
 import httpx
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.base.llms.generic_utils import get_from_param_or_env
-from llama_index.core import PromptTemplate
-from llama_index.core.llms.llm import Model
 from llama_index.llms.azure_openai.utils import (
     refresh_openai_azuread_token,
     resolve_from_aliases,
 )
-from llama_index.llms.openai.responses import OpenAIResponses, to_openai_message_dicts
+from llama_index.llms.openai.responses import OpenAIResponses
 from openai import AsyncAzureOpenAI
 from openai import AzureOpenAI as SyncAzureOpenAI
 from openai.lib.azure import AzureADTokenProvider
@@ -206,67 +204,9 @@ class AzureOpenAIResponses(OpenAIResponses):
         self._http_client = http_client
         self._async_http_client = async_http_client
 
-    def structured_predict(
-        self,
-        output_cls: Type[Model],
-        prompt: PromptTemplate,
-        llm_kwargs: Optional[Dict[str, Any]] = None,
-        **prompt_args: Any,
-    ) -> Model:
-        """
-        Structured predict using responses.parse with the Azure deployment name.
-
-        Overrides OpenAIResponses.structured_predict to pass ``self.engine``
-        (the Azure deployment name) instead of ``self.model`` (the model family
-        name) to ``responses.parse``.  Azure routes requests by deployment name;
-        using the model family name results in a 404 DeploymentNotFound error.
-        """
-        messages = prompt.format_messages(**prompt_args)
-        message_dicts = to_openai_message_dicts(
-            messages, model=self.model, is_responses_api=True
-        )
-        response = self._client.responses.parse(
-            model=self.engine,
-            input=message_dicts,
-            text_format=output_cls,
-            tool_choice="none",
-            store=self.store,
-            **(llm_kwargs or {}),
-        )
-        if response.output_parsed is not None:
-            return response.output_parsed
-        raise ValueError("Failed to produce a structured response from the model.")
-
-    async def astructured_predict(
-        self,
-        output_cls: Type[Model],
-        prompt: PromptTemplate,
-        llm_kwargs: Optional[Dict[str, Any]] = None,
-        **prompt_args: Any,
-    ) -> Model:
-        """
-        Async structured predict using responses.parse with the Azure deployment name.
-
-        Overrides OpenAIResponses.astructured_predict to pass ``self.engine``
-        (the Azure deployment name) instead of ``self.model`` (the model family
-        name) to ``responses.parse``.  Azure routes requests by deployment name;
-        using the model family name results in a 404 DeploymentNotFound error.
-        """
-        messages = prompt.format_messages(**prompt_args)
-        message_dicts = to_openai_message_dicts(
-            messages, model=self.model, is_responses_api=True
-        )
-        response = await self._aclient.responses.parse(
-            model=self.engine,
-            input=message_dicts,
-            text_format=output_cls,
-            tool_choice="none",
-            store=self.store,
-            **(llm_kwargs or {}),
-        )
-        if response.output_parsed is not None:
-            return response.output_parsed
-        raise ValueError("Failed to produce a structured response from the model.")
+    @property
+    def _responses_model(self) -> str:
+        return self.engine
 
     def _get_credential_kwargs(
         self, is_async: bool = False, **kwargs: Any

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-azure-openai"
-version = "0.5.4"
+version = "0.5.5"
 description = "llama-index llms azure openai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py
@@ -4,6 +4,8 @@ from openai import AsyncAzureOpenAI
 from typing import Any, Generator, AsyncGenerator
 from unittest.mock import MagicMock, AsyncMock, patch
 import httpx
+from pydantic import BaseModel, Field
+from llama_index.core import PromptTemplate
 from llama_index.llms.azure_openai import AzureOpenAI, AzureOpenAIResponses
 from llama_index.core.base.llms.types import ChatMessage
 from openai.types.chat.chat_completion import (
@@ -248,3 +250,79 @@ async def test_async_chat_completion_with_filter_results(
     chat_response_gen = await llm.astream_chat([message])
     chat_responses = [item async for item in chat_response_gen]
     assert chat_responses[-1].message.content == "Hello from\nAzure"
+
+
+@patch("llama_index.llms.azure_openai.responses.AsyncAzureOpenAI")
+@patch("llama_index.llms.azure_openai.responses.SyncAzureOpenAI")
+def test_structured_predict_uses_engine_not_model(
+    sync_azure_mock: MagicMock, async_azure_mock: MagicMock
+) -> None:
+    """
+    AzureOpenAIResponses.structured_predict must pass self.engine to responses.parse.
+
+    The parent OpenAIResponses.structured_predict uses self.model, which is the
+    model family name (e.g. 'gpt-4o').  Azure routes by deployment name, so
+    passing self.model raises a 404 DeploymentNotFound.
+    """
+
+    class Answer(BaseModel):
+        value: int = Field(description="The answer")
+
+    llm = AzureOpenAIResponses(
+        engine="my-deployment",
+        model="gpt-4o",
+        api_key="mock-key",
+        azure_endpoint="https://test.openai.azure.com/",
+        api_version="2025-03-01-preview",
+    )
+
+    mock_response = MagicMock()
+    mock_response.output_parsed = Answer(value=42)
+    llm._client.responses.parse = MagicMock(return_value=mock_response)
+
+    result = llm.structured_predict(
+        output_cls=Answer,
+        prompt=PromptTemplate("What is 6 times 7?"),
+    )
+
+    assert isinstance(result, Answer)
+    assert result.value == 42
+    assert llm._client.responses.parse.call_args.kwargs["model"] == "my-deployment"
+
+
+@pytest.mark.asyncio
+@patch("llama_index.llms.azure_openai.responses.AsyncAzureOpenAI")
+@patch("llama_index.llms.azure_openai.responses.SyncAzureOpenAI")
+async def test_astructured_predict_uses_engine_not_model(
+    sync_azure_mock: MagicMock, async_azure_mock: MagicMock
+) -> None:
+    """
+    AzureOpenAIResponses.astructured_predict must pass self.engine to responses.parse.
+
+    Same as the sync variant: the inherited OpenAIResponses implementation uses
+    self.model, which is the model family name and not a valid Azure deployment.
+    """
+
+    class Answer(BaseModel):
+        value: int = Field(description="The answer")
+
+    llm = AzureOpenAIResponses(
+        engine="my-deployment",
+        model="gpt-4o",
+        api_key="mock-key",
+        azure_endpoint="https://test.openai.azure.com/",
+        api_version="2025-03-01-preview",
+    )
+
+    mock_response = MagicMock()
+    mock_response.output_parsed = Answer(value=42)
+    llm._aclient.responses.parse = AsyncMock(return_value=mock_response)
+
+    result = await llm.astructured_predict(
+        output_cls=Answer,
+        prompt=PromptTemplate("What is 6 times 7?"),
+    )
+
+    assert isinstance(result, Answer)
+    assert result.value == 42
+    assert llm._aclient.responses.parse.call_args.kwargs["model"] == "my-deployment"

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -956,6 +956,11 @@ class OpenAIResponses(FunctionCallingLLM):
 
         return tool_selections
 
+    @property
+    def _responses_model(self) -> str:
+        """Model name passed to the Responses API. Subclasses may override (e.g. Azure uses a deployment name)."""
+        return self.model
+
     @dispatcher.span
     def structured_predict(
         self,
@@ -974,7 +979,7 @@ class OpenAIResponses(FunctionCallingLLM):
             messages, model=self.model, is_responses_api=True
         )
         response = self._client.responses.parse(
-            model=self.model,
+            model=self._responses_model,
             input=message_dicts,
             text_format=output_cls,
             tool_choice="none",
@@ -1003,7 +1008,7 @@ class OpenAIResponses(FunctionCallingLLM):
             messages, model=self.model, is_responses_api=True
         )
         response = await self._aclient.responses.parse(
-            model=self.model,
+            model=self._responses_model,
             input=message_dicts,
             text_format=output_cls,
             tool_choice="none",

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.7"
+version = "0.7.8"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
## Summary

`AzureOpenAIResponses.structured_predict` (and the async variant) were inherited from `OpenAIResponses`, which passes `model=self.model` (e.g. `"gpt-4o"`) to `responses.parse`. Azure routes requests by deployment name, not model family name, so this produces a 404 `DeploymentNotFound` error.

## Changes

**`openai/responses.py`**
- Adds a `_responses_model` property (returns `self.model`) as a hook point for subclasses

**`azure_openai/responses.py`**
- Overrides `_responses_model` to return `self.engine` (the Azure deployment name)
- No method duplication needed — the parent's `structured_predict` / `astructured_predict` pick up the correct value through the property

This follows the same pattern already used by `_get_model_kwargs` in `AzureOpenAIResponses`.

## Test plan

- [ ] `pytest llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py::test_structured_predict_uses_engine_not_model`
- [ ] `pytest llama-index-integrations/llms/llama-index-llms-azure-openai/tests/test_azure_openai.py::test_astructured_predict_uses_engine_not_model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)