### PR TITLE
Fix DashScope multimodal embedding response parsing

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
@@ -147,7 +147,13 @@ def get_multimodal_embedding(
         model=model, input=input, api_key=api_key, kwargs=kwargs
     )
     if response.status_code == HTTPStatus.OK:
-        return response.output["embedding"]
+        if "embedding" in response.output:
+            return response.output["embedding"]
+        embeddings = response.output.get("embeddings") or []
+        if embeddings:
+            return embeddings[0]["embedding"]
+        logger.error("Calling MultiModalEmbedding returned no embeddings, details: %s" % response)
+        return []
     else:
         logger.error("Calling MultiModalEmbedding failed, details: %s" % response)
         return []

--- a/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/tests/test_embeddings_dashscope.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/tests/test_embeddings_dashscope.py
@@ -1,7 +1,64 @@
+from http import HTTPStatus
+from types import SimpleNamespace
+import sys
+
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.embeddings.dashscope import DashScopeEmbedding
+from llama_index.embeddings.dashscope.base import get_multimodal_embedding
 
 
 def test_dashscope_embedding_class():
     names_of_base_classes = [b.__name__ for b in DashScopeEmbedding.__mro__]
     assert MultiModalEmbedding.__name__ in names_of_base_classes
+
+
+def test_get_multimodal_embedding_accepts_current_dashscope_shape(monkeypatch):
+    class FakeMultiModalEmbedding:
+        @staticmethod
+        def call(**_kwargs):
+            return SimpleNamespace(
+                status_code=HTTPStatus.OK,
+                output={
+                    "embeddings": [
+                        {
+                            "embedding": [0.1, 0.2, 0.3],
+                            "index": 0,
+                            "type": "text",
+                        }
+                    ]
+                },
+            )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "dashscope",
+        SimpleNamespace(MultiModalEmbedding=FakeMultiModalEmbedding),
+    )
+
+    assert get_multimodal_embedding("multimodal-embedding-v1", [{"text": "hello"}]) == [
+        0.1,
+        0.2,
+        0.3,
+    ]
+
+
+def test_get_multimodal_embedding_preserves_legacy_dashscope_shape(monkeypatch):
+    class FakeMultiModalEmbedding:
+        @staticmethod
+        def call(**_kwargs):
+            return SimpleNamespace(
+                status_code=HTTPStatus.OK,
+                output={"embedding": [0.4, 0.5, 0.6]},
+            )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "dashscope",
+        SimpleNamespace(MultiModalEmbedding=FakeMultiModalEmbedding),
+    )
+
+    assert get_multimodal_embedding("multimodal-embedding-v1", [{"text": "hello"}]) == [
+        0.4,
+        0.5,
+        0.6,
+    ]


### PR DESCRIPTION
## Summary

Fixes DashScope multimodal embedding parsing for the current API response shape, where embeddings are returned under `output.embeddings[0].embedding` instead of the older `output.embedding` field.

The adapter still accepts the legacy singular response shape so existing older DashScope clients do not regress.

Fixes #21532.

## Validation

- `uv run --directory llama-index-integrations/embeddings/llama-index-embeddings-dashscope pytest tests/test_embeddings_dashscope.py -q`
- `uv run --directory llama-index-integrations/embeddings/llama-index-embeddings-dashscope ruff check llama_index/embeddings/dashscope/base.py tests/test_embeddings_dashscope.py`
- `git diff --check`
