### PR TITLE
Fix/gemini embedding 2 task types

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
@@ -122,7 +122,7 @@ class GoogleGenAIEmbedding(BaseEmbedding):
 
     Args:
         model_name (str): Model for embedding.
-            Defaults to "gemini-embedding-2-preview".
+            Defaults to "gemini-embedding-2".
         api_key (Optional[str]): API key to access the model. Defaults to None.
         embedding_config (Optional[types.EmbedContentConfigOrDict]): Embedding config to access the model. Defaults to None.
         vertexai_config (Optional[VertexAIConfig]): Vertex AI config to access the model. Defaults to None.
@@ -142,7 +142,7 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         ```python
         from llama_index.embeddings.google_genai import GoogleGenAIEmbedding
 
-        embed_model = GoogleGenAIEmbedding(model_name="gemini-embedding-2-preview", api_key="...")
+        embed_model = GoogleGenAIEmbedding(model_name="gemini-embedding-2", api_key="...")
         ```
 
     """
@@ -167,7 +167,7 @@ class GoogleGenAIEmbedding(BaseEmbedding):
 
     def __init__(
         self,
-        model_name: str = "gemini-embedding-2-preview",
+        model_name: str = "gemini-embedding-2",
         api_key: Optional[str] = None,
         embedding_config: Optional[types.EmbedContentConfigOrDict] = None,
         vertexai_config: Optional[VertexAIConfig] = None,
@@ -247,10 +247,52 @@ class GoogleGenAIEmbedding(BaseEmbedding):
     def class_name(cls) -> str:
         return "GeminiEmbedding"
 
+    def _format_texts_for_gemini_emb_2(
+        self, texts: List[str], task_type: str
+    ) -> List[str]:
+        """Format texts with specific task instructions required for gemini-embedding-2."""
+        task_prefix_map = {
+            "RETRIEVAL_QUERY": "task: search result | query: ",
+            "QUESTION_ANSWERING": "task: question answering | query: ",
+            "FACT_VERIFICATION": "task: fact checking | query: ",
+            "CODE_RETRIEVAL_QUERY": "task: code retrieval | query: ",
+            "SEMANTIC_SIMILARITY": "task: sentence similarity | query: ",
+            "CLASSIFICATION": "task: classification | query: ",
+            "CLUSTERING": "task: clustering | query: ",
+        }
+
+        formatted_texts = []
+        for text in texts:
+            if task_type == "RETRIEVAL_DOCUMENT":
+                if text.startswith("title: ") and " | text: " in text:
+                    formatted_texts.append(text)
+                else:
+                    formatted_texts.append(f"title: none | text: {text}")
+            elif task_type in task_prefix_map:
+                prefix = task_prefix_map[task_type]
+                if text.startswith(prefix):
+                    formatted_texts.append(text)
+                else:
+                    formatted_texts.append(f"{prefix}{text}")
+            else:
+                # fallback to RETRIEVAL_QUERY if task_type is unrecognised or None
+                formatted_texts.append(f"task: search result | query: {text}")
+
+        return formatted_texts
+
     def _embed_texts(
         self, texts: List[str], task_type: Optional[str] = None
     ) -> List[List[float]]:
         """Embed texts."""
+        is_gemini_emb_2 = "embedding-2" in self.model_name
+
+        if is_gemini_emb_2 and task_type:
+            texts_to_embed = self._format_texts_for_gemini_emb_2(texts, task_type)
+            # Nullify task_type so the standard config block below ignores it
+            task_type = None
+        else:
+            texts_to_embed = texts
+
         # Set the task type if it is not already set
         if task_type and not self.embedding_config:
             embedding_config = types.EmbedContentConfig(task_type=task_type)
@@ -260,11 +302,21 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         else:
             embedding_config = self.embedding_config
 
+        # safely remove unsupported task_type param for gemini_embedding-2
+        if is_gemini_emb_2 and embedding_config:
+            if hasattr(embedding_config, "model_dump"):
+                embedding_config = embedding_config.model_dump(exclude_unset=True)
+            elif hasattr(embedding_config, "dict"):
+                embedding_config = embedding_config.dict(exclude_unset=True)
+            else:
+                embedding_config = dict(embedding_config)
+            embedding_config.pop("task_type", None)
+
         # Create the embedding function with retry logic
         def embed_with_client() -> List[List[float]]:
             results = self._client.models.embed_content(
                 model=self.model_name,
-                contents=texts,
+                contents=texts_to_embed,
                 config=embedding_config,
             )
             return [result.values for result in results.embeddings]
@@ -284,6 +336,15 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         self, texts: List[str], task_type: Optional[str] = None
     ) -> List[List[float]]:
         """Asynchronously embed texts."""
+        is_gemini_emb_2 = "embedding-2" in self.model_name
+
+        if is_gemini_emb_2 and task_type:
+            texts_to_embed = self._format_texts_for_gemini_emb_2(texts, task_type)
+            # Nullify task_type so the standard config block below ignores it
+            task_type = None
+        else:
+            texts_to_embed = texts
+
         # Set the task type if it is not already set
         if task_type and not self.embedding_config:
             embedding_config = types.EmbedContentConfig(task_type=task_type)
@@ -293,11 +354,22 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         else:
             embedding_config = self.embedding_config
 
+        # Scrub task_type if it was hardcoded in self.embedding_config
+        if is_gemini_emb_2 and embedding_config:
+            if hasattr(embedding_config, "model_dump"):
+                embedding_config = embedding_config.model_dump(exclude_unset=True)
+            elif hasattr(embedding_config, "dict"):
+                embedding_config = embedding_config.dict(exclude_unset=True)
+            else:
+                embedding_config = dict(embedding_config)
+
+            embedding_config.pop("task_type", None)
+
         # Create the async embedding function with retry logic
         async def aembed_with_client() -> List[List[float]]:
             results = await self._client.aio.models.embed_content(
                 model=self.model_name,
-                contents=texts,
+                contents=texts_to_embed,
                 config=embedding_config,
             )
             return [result.values for result in results.embeddings]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
@@ -1,5 +1,6 @@
 """Gemini embeddings file."""
 
+import logging
 import os
 from importlib.metadata import PackageNotFoundError, version
 from tenacity import (
@@ -23,6 +24,8 @@ import google.genai
 import google.auth.credentials
 import google.genai.types as types
 from google.genai.errors import APIError
+
+logger = logging.getLogger(__name__)
 
 # Define generic types for functions that will be wrapped with retry
 T = TypeVar("T")
@@ -284,6 +287,10 @@ class GoogleGenAIEmbedding(BaseEmbedding):
                     formatted_texts.append(f"{prefix}{text}")
             else:
                 # fallback to RETRIEVAL_QUERY if task_type is unrecognised
+                logger.warning(
+                    f"Unknown task_type {task_type!r} for gemini-embedding-2. "
+                    "Falling back to 'RETRIEVAL_QUERY' prefix."
+                )
                 formatted_texts.append(f"task: search result | query: {text}")
 
         return formatted_texts

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
@@ -261,8 +261,16 @@ class GoogleGenAIEmbedding(BaseEmbedding):
             "CLUSTERING": "task: clustering | query: ",
         }
 
+        # Normalize to upper to catch edge cases where users passed lowercase string
+        task_type = task_type.upper() if task_type else task_type
+
         formatted_texts = []
         for text in texts:
+            # skip empty strings
+            if not text.strip():
+                formatted_texts.append(text)
+                continue
+
             if task_type == "RETRIEVAL_DOCUMENT":
                 if text.startswith("title: ") and " | text: " in text:
                     formatted_texts.append(text)
@@ -275,10 +283,22 @@ class GoogleGenAIEmbedding(BaseEmbedding):
                 else:
                     formatted_texts.append(f"{prefix}{text}")
             else:
-                # fallback to RETRIEVAL_QUERY if task_type is unrecognised or None
+                # fallback to RETRIEVAL_QUERY if task_type is unrecognised
                 formatted_texts.append(f"task: search result | query: {text}")
 
         return formatted_texts
+
+    def _get_effective_task_type(self, task_type: Optional[str]) -> Optional[str]:
+        """Safely resolve task_type from method args or class-level config."""
+        if task_type:
+            return task_type
+
+        if self.embedding_config:
+            if isinstance(self.embedding_config, dict):
+                return self.embedding_config.get("task_type")
+            return getattr(self.embedding_config, "task_type", None)
+
+        return None
 
     def _embed_texts(
         self, texts: List[str], task_type: Optional[str] = None
@@ -286,8 +306,12 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         """Embed texts."""
         is_gemini_emb_2 = "embedding-2" in self.model_name
 
-        if is_gemini_emb_2 and task_type:
-            texts_to_embed = self._format_texts_for_gemini_emb_2(texts, task_type)
+        effective_task_type = self._get_effective_task_type(task_type)
+
+        if is_gemini_emb_2 and effective_task_type:
+            texts_to_embed = self._format_texts_for_gemini_emb_2(
+                texts, effective_task_type
+            )
             # Nullify task_type so the standard config block below ignores it
             task_type = None
         else:
@@ -338,8 +362,12 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         """Asynchronously embed texts."""
         is_gemini_emb_2 = "embedding-2" in self.model_name
 
-        if is_gemini_emb_2 and task_type:
-            texts_to_embed = self._format_texts_for_gemini_emb_2(texts, task_type)
+        effective_task_type = self._get_effective_task_type(task_type)
+
+        if is_gemini_emb_2 and effective_task_type:
+            texts_to_embed = self._format_texts_for_gemini_emb_2(
+                texts, effective_task_type
+            )
             # Nullify task_type so the standard config block below ignores it
             task_type = None
         else:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-google-genai"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index embeddings google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/tests/test_embeddings_gemini.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/tests/test_embeddings_gemini.py
@@ -41,7 +41,7 @@ def test_embed_texts_mock(mock_client_class):
 
 
 @patch("google.genai.Client")
-def test_task_type_setting_mock(mock_client_class):
+def test_emb_1_task_type_setting_mock(mock_client_class):
     # Setup mock client
     mock_client = mock_client_class.return_value
     mock_models = mock_client.models
@@ -55,8 +55,10 @@ def test_task_type_setting_mock(mock_client_class):
     mock_result.embeddings = [mock_embedding]
     mock_embed_content.return_value = mock_result
 
+    # Force gemini-embedding-001 model to test backwards compatibility
+    emb = GoogleGenAIEmbedding(model_name="gemini-embedding-001", api_key="fake_key")
+
     # Test query embedding (should use RETRIEVAL_QUERY task type)
-    emb = GoogleGenAIEmbedding(api_key="fake_key")
     emb.get_query_embedding("test query")
 
     # Check if task_type was set correctly in the call
@@ -72,6 +74,58 @@ def test_task_type_setting_mock(mock_client_class):
     # Check if task_type was set correctly in the call
     _, kwargs = mock_embed_content.call_args
     assert kwargs.get("config").task_type == "RETRIEVAL_DOCUMENT"
+
+
+@patch("google.genai.Client")
+def test_emb_2_task_type_setting_mock(mock_client_class):
+    # Setup mock client
+    mock_client = mock_client_class.return_value
+    mock_models = mock_client.models
+    mock_embed_content = mock_models.embed_content
+
+    # Create mock embedding result
+    mock_embedding = MagicMock()
+    mock_embedding.values = [0.1, 0.2, 0.3]
+
+    mock_result = MagicMock()
+    mock_result.embeddings = [mock_embedding]
+    mock_embed_content.return_value = mock_result
+
+    # Default is gemini-embedding-2
+    emb = GoogleGenAIEmbedding(api_key="fake_key")
+
+    # Test query embedding (should use RETRIEVAL_QUERY task type)
+    emb.get_query_embedding("test query")
+
+    _, kwargs = mock_embed_content.call_args
+    # Task type shouldn't be in config for gemini-embedding-2
+    assert getattr(kwargs.get("config", None), "task_type", None) is None
+    # String should be formatted
+    assert kwargs.get("contents") == ["task: search result | query: test query"]
+
+    # Reset mock
+    mock_embed_content.reset_mock()
+
+    # Test standard document formatting
+    emb.get_text_embedding("test text")
+
+    _, kwargs = mock_embed_content.call_args
+    assert getattr(kwargs.get("config", None), "task_type", None) is None
+    assert kwargs.get("contents") == ["title: none | text: test text"]
+
+    # Test pre-formatted query (prevent double prefix)
+    emb.get_query_embedding("task: search result | query: existing query")
+    _, kwargs = mock_embed_content.call_args
+    assert getattr(kwargs.get("config", None), "task_type", None) is None
+    assert kwargs.get("contents") == ["task: search result | query: existing query"]
+
+    mock_embed_content.reset_mock()
+
+    # Test pre-formatted document with custom title (prevent double prefix)
+    emb.get_text_embedding("title: My Custom Title | text: existing text")
+    _, kwargs = mock_embed_content.call_args
+    assert getattr(kwargs.get("config", None), "task_type", None) is None
+    assert kwargs.get("contents") == ["title: My Custom Title | text: existing text"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description
Google recently released `gemini-embedding-2` which introduces a breaking change to how `task_type` is handled. The `task_type` parameter is no longer supported in the request payload `EmbedContentConfig`.

As verified in #21535 , the API silently ignores the config parameter for v2 models instead of throwing an error. This results in LlamaIndex users receiving generic, unoptimized embeddings even when explicitly requesting `RETRIEVAL_DOCUMENT` or `CODE_RETRIEVAL_QUERY`.

To fix this, the Gemini API now requires the task instruction to be prefixed directly to the text strings (e.g., `task: search result | query: {text}` vs `title: none | text: {text}`).

Fixes #21535

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
