### PR TITLE
vllm: only pass best_of when set

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -247,13 +247,15 @@ class Vllm(LLM):
             "n": self.n,
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
-            "best_of": self.best_of,
             "ignore_eos": self.ignore_eos,
             "stop": self.stop,
             "logprobs": self.logprobs,
             "top_k": self.top_k,
             "top_p": self.top_p,
         }
+        # vLLM >=0.19 removed `best_of` from SamplingParams; only emit it when set.
+        if self.best_of is not None:
+            base_kwargs["best_of"] = self.best_of
         return {**base_kwargs}
 
     @atexit.register

--- a/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
@@ -1,5 +1,32 @@
+from unittest.mock import MagicMock
+
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.core.callbacks import CallbackManager
+
+
+def test_model_kwargs_best_of_conditional():
+    """Omits best_of when None, includes it when set. Regression for vLLM>=0.19 (#21371)."""
+    from llama_index.llms.vllm import Vllm
+
+    prop = Vllm._model_kwargs.fget
+
+    obj = MagicMock(
+        temperature=0.1,
+        max_new_tokens=64,
+        n=1,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        ignore_eos=False,
+        stop=[],
+        logprobs=None,
+        top_k=-1,
+        top_p=1.0,
+        best_of=None,
+    )
+    assert "best_of" not in prop(obj)
+
+    obj.best_of = 3
+    assert prop(obj)["best_of"] == 3
 
 
 def test_embedding_class():


### PR DESCRIPTION
Closes #21371. vllm>=0.19 removed `best_of` from `SamplingParams`; `Vllm.complete` was unusable. Only emit `best_of` when explicitly set.