### PR TITLE
feat(tools): add voidly-pay x402 payment tool

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/README.md
@@ -1,0 +1,80 @@
+# Voidly Pay Tool
+
+[Voidly Pay](https://voidly.ai/pay) is an x402 payment rail for AI agents — let your LlamaIndex
+agent autonomously pay for HTTP 402 endpoints, no API keys, no Stripe customer object. Identity
+is an Ed25519 keypair on disk.
+
+Settlement happens off-chain in Voidly Pay credits (Stage 1) or on-chain USDC on Base mainnet
+(Stage 2). The vault is Sourcify-verified at
+[`0xb592...1c12`](https://basescan.org/address/0xb592512932a7b354969bb48039c2dc7ad6ad1c12) with
+public reserves at [voidly.ai/pay/proof](https://voidly.ai/pay/proof).
+
+## Installation
+
+```bash
+pip install llama-index-tools-voidly-pay
+```
+
+## Provision a wallet (10 free credits, no install)
+
+Visit [voidly.ai/pay/claim](https://voidly.ai/pay/claim) — generates an Ed25519 keypair in your
+browser and grants 10 credits via the public faucet. Save the keypair to
+`~/.voidly-pay-keypair.json` and you're ready to call paid endpoints.
+
+## Usage
+
+```python
+from llama_index.tools.voidly_pay import VoidlyPayToolSpec
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+voidly_tool = VoidlyPayToolSpec()  # uses ~/.voidly-pay-keypair.json by default
+
+agent = FunctionAgent(
+    tools=voidly_tool.to_tool_list(),
+    llm=OpenAI(model="gpt-4o"),
+)
+
+await agent.run(
+    "Browse the Voidly Pay marketplace, find a Wikipedia summary endpoint, "
+    "and pay 1¢ to fetch the summary for 'Alan Turing'."
+)
+```
+
+## Available Functions
+
+- `pay_for_url(url, method, params, body)` — call any URL; auto-pays a `402 Payment Required`
+  response by signing a transfer envelope, retries with `X-Payment`, and returns the body plus
+  the signed receipt.
+- `discover_paid_endpoints()` — list all paid endpoints currently advertised on the facilitator.
+- `marketplace_browse(category)` — browse the open Voidly Pay marketplace
+  ([api.voidly.ai/v1/pay/marketplace](https://api.voidly.ai/v1/pay/marketplace)).
+- `health_check()` — run the 6-check trust report (facilitator reachability, vault verification,
+  wallet balance, keypair validity, settlement health). Useful before a long-running paid task.
+- `list_listing(name, endpoint_url, price_usdc, description, category)` — list your own paid
+  endpoint on the marketplace.
+
+## How x402 works
+
+1. Agent calls a tool that hits a `402 Payment Required` endpoint
+2. Endpoint returns a signed quote (price, recipient, expiry)
+3. SDK signs a transfer envelope with the agent's Ed25519 keypair
+4. Endpoint verifies and returns the actual response
+
+One round-trip after the first 402. Sub-200ms typical settlement on the live facilitator.
+
+## List your own paid endpoint
+
+Visit [voidly.ai/pay/list-your-service](https://voidly.ai/pay/list-your-service) — browser-only
+Ed25519 keypair, no install. Once listed, every Voidly-aware agent (LlamaIndex, LangChain,
+Vercel AI, MCP) can find and call your URL. Voidly takes zero platform cut on Stage 1.
+
+## Resources
+
+- [Voidly Pay docs](https://voidly.ai/pay)
+- [Live marketplace JSON](https://api.voidly.ai/v1/pay/marketplace)
+- [Sourcify-verified vault](https://repo.sourcify.dev/contracts/full_match/8453/0xb592512932A7B354969BB48039C2dC7Ad6AD1c12/)
+- [Public reserves dashboard](https://voidly.ai/pay/proof)
+- [voidly-pay PyPI SDK](https://pypi.org/project/voidly-pay/) (this tool wraps it)
+
+This loader is designed to be used as a way to load Voidly Pay primitives as Tools in an Agent.

--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/llama_index/tools/voidly_pay/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/llama_index/tools/voidly_pay/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.voidly_pay.base import VoidlyPayToolSpec
+
+__all__ = ["VoidlyPayToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/llama_index/tools/voidly_pay/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/llama_index/tools/voidly_pay/base.py
@@ -1,0 +1,145 @@
+"""Voidly Pay tool spec — pay for HTTP 402 endpoints from a LlamaIndex agent."""
+
+from typing import Any, Dict, List, Optional
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+
+class VoidlyPayToolSpec(BaseToolSpec):
+    """
+    Voidly Pay tool spec.
+
+    Lets a LlamaIndex agent autonomously pay for HTTP 402 endpoints via the
+    x402 protocol. Settlement happens off-chain in Voidly Pay credits
+    (Stage 1) or on-chain USDC on Base mainnet (Stage 2). The vault is
+    Sourcify-verified at 0xb592512932a7b354969bb48039c2dc7ad6ad1c12 with
+    public reserves at https://voidly.ai/pay/proof.
+
+    Wraps the official `voidly-pay` PyPI SDK. Identity is an Ed25519 keypair
+    on disk — no API keys, no Stripe customer object.
+    """
+
+    spec_functions = [
+        "pay_for_url",
+        "discover_paid_endpoints",
+        "marketplace_browse",
+        "health_check",
+        "list_listing",
+    ]
+
+    def __init__(
+        self,
+        keypair_path: Optional[str] = None,
+        facilitator_url: str = "https://api.voidly.ai/v1/pay/x402",
+    ) -> None:
+        """
+        Initialize the Voidly Pay tool spec.
+
+        Args:
+            keypair_path: Path to the Ed25519 keypair JSON. If None, uses the
+                default `~/.voidly-pay-keypair.json` (provisioned via
+                https://voidly.ai/pay/claim with a 10-credit faucet grant).
+            facilitator_url: Voidly Pay x402 facilitator endpoint.
+
+        """
+        from voidly_pay import VoidlyPay
+
+        self.client = VoidlyPay(
+            keypair_path=keypair_path,
+            facilitator_url=facilitator_url,
+        )
+
+    def pay_for_url(
+        self,
+        url: str,
+        method: str = "GET",
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Call an x402-paywalled URL, auto-paying any 402 challenge.
+
+        Args:
+            url: The endpoint to call.
+            method: HTTP method (default: GET).
+            params: Query parameters.
+            body: JSON body for POST/PUT.
+
+        Returns:
+            A dict with `status_code`, `body`, and (if a 402 was settled)
+            `payment_receipt` containing the signed transfer envelope and
+            settlement timestamp.
+
+        """
+        return self.client.fetch(url, method=method, params=params, json=body)
+
+    def discover_paid_endpoints(self) -> List[Dict[str, Any]]:
+        """
+        List all paid endpoints currently advertised on the facilitator.
+
+        Returns:
+            A list of endpoint descriptors with `url`, `price_usdc`,
+            `recipient_did`, and `description`.
+
+        """
+        return self.client.discover()
+
+    def marketplace_browse(
+        self, category: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Browse the open Voidly Pay marketplace.
+
+        Args:
+            category: Optional category filter (e.g. "data", "scraping",
+                "compute").
+
+        Returns:
+            A list of marketplace listings — Voidly's own 17 paid endpoints
+            plus self-served third-party listings. Each item has `name`,
+            `pricing`, `endpoint_url`, and `description`.
+
+        """
+        return self.client.marketplace.browse(category=category)
+
+    def health_check(self) -> Dict[str, Any]:
+        """
+        Run the Voidly Pay 6-check trust report.
+
+        Returns:
+            A dict with checks for facilitator reachability, vault
+            verification, wallet balance, keypair validity, and recent
+            settlement health. Useful before a long-running paid task.
+
+        """
+        return self.client.health_check()
+
+    def list_listing(
+        self,
+        name: str,
+        endpoint_url: str,
+        price_usdc: float,
+        description: str,
+        category: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        List your own paid endpoint on the Voidly Pay marketplace.
+
+        Args:
+            name: Human-readable name.
+            endpoint_url: Your URL that returns 402 with a Voidly Pay quote.
+            price_usdc: Price per call in USDC.
+            description: What the endpoint does.
+            category: Optional category.
+
+        Returns:
+            The created listing with its assigned id and discoverability URL.
+
+        """
+        return self.client.marketplace.list(
+            name=name,
+            endpoint_url=endpoint_url,
+            price_usdc=price_usdc,
+            description=description,
+            category=category,
+        )

--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/pyproject.toml
@@ -1,0 +1,73 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "responses>=0.25.0",
+]
+
+[project]
+name = "llama-index-tools-voidly-pay"
+version = "0.1.0"
+description = "llama-index tools voidly-pay integration — pay for HTTP 402 endpoints via x402"
+authors = [{name = "Voidly", email = "ai@voidly.ai"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "voidly-ai"}]
+keywords = [
+    "x402",
+    "payments",
+    "agent",
+    "tools",
+    "voidly",
+]
+dependencies = [
+    "voidly-pay>=1.0.0",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.voidly_pay"
+
+[tool.llamahub.class_authors]
+VoidlyPayToolSpec = "voidly-ai"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/tools/llama-index-tools-voidly-pay/tests/test_voidly_pay.py
+++ b/llama-index-integrations/tools/llama-index-tools-voidly-pay/tests/test_voidly_pay.py
@@ -1,0 +1,181 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.voidly_pay import VoidlyPayToolSpec
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in VoidlyPayToolSpec.__mro__]
+    assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_spec_functions():
+    """Test that spec_functions exposes all public methods."""
+    expected = {
+        "pay_for_url",
+        "discover_paid_endpoints",
+        "marketplace_browse",
+        "health_check",
+        "list_listing",
+    }
+    assert expected.issubset(set(VoidlyPayToolSpec.spec_functions))
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_init_default(mock_voidly_pay):
+    """Test init uses default facilitator URL."""
+    VoidlyPayToolSpec()
+    mock_voidly_pay.assert_called_once_with(
+        keypair_path=None,
+        facilitator_url="https://api.voidly.ai/v1/pay/x402",
+    )
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_init_custom_keypair(mock_voidly_pay):
+    """Test init accepts a custom keypair path."""
+    VoidlyPayToolSpec(keypair_path="/tmp/my-key.json")
+    mock_voidly_pay.assert_called_once_with(
+        keypair_path="/tmp/my-key.json",
+        facilitator_url="https://api.voidly.ai/v1/pay/x402",
+    )
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_pay_for_url_get(mock_voidly_pay):
+    """Test pay_for_url calls fetch with GET defaults."""
+    mock_client = MagicMock()
+    mock_client.fetch.return_value = {
+        "status_code": 200,
+        "body": {"summary": "Alan Turing was a mathematician."},
+        "payment_receipt": {"transfer_id": "abc123", "amount_usdc": 0.01},
+    }
+    mock_voidly_pay.return_value = mock_client
+
+    tool = VoidlyPayToolSpec()
+    result = tool.pay_for_url("https://api.voidly.ai/v1/pay/wikipedia/Alan_Turing")
+
+    mock_client.fetch.assert_called_once_with(
+        "https://api.voidly.ai/v1/pay/wikipedia/Alan_Turing",
+        method="GET",
+        params=None,
+        json=None,
+    )
+    assert result["status_code"] == 200
+    assert "payment_receipt" in result
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_pay_for_url_post(mock_voidly_pay):
+    """Test pay_for_url with POST + body."""
+    mock_client = MagicMock()
+    mock_client.fetch.return_value = {"status_code": 200, "body": {}}
+    mock_voidly_pay.return_value = mock_client
+
+    tool = VoidlyPayToolSpec()
+    tool.pay_for_url(
+        "https://api.example.com/scrape",
+        method="POST",
+        body={"url": "https://example.com"},
+    )
+
+    mock_client.fetch.assert_called_once_with(
+        "https://api.example.com/scrape",
+        method="POST",
+        params=None,
+        json={"url": "https://example.com"},
+    )
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_discover_paid_endpoints(mock_voidly_pay):
+    """Test discover delegates to client."""
+    mock_client = MagicMock()
+    mock_client.discover.return_value = [
+        {
+            "url": "https://api.voidly.ai/v1/pay/wikipedia/{title}",
+            "price_usdc": 0.01,
+            "recipient_did": "did:voidly:abc",
+            "description": "Wikipedia summary",
+        }
+    ]
+    mock_voidly_pay.return_value = mock_client
+
+    tool = VoidlyPayToolSpec()
+    result = tool.discover_paid_endpoints()
+
+    mock_client.discover.assert_called_once()
+    assert len(result) == 1
+    assert result[0]["price_usdc"] == 0.01
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_marketplace_browse(mock_voidly_pay):
+    """Test marketplace browse with category filter."""
+    mock_client = MagicMock()
+    mock_marketplace = MagicMock()
+    mock_marketplace.browse.return_value = [
+        {"name": "PDF→text", "pricing": {"amount_usdc": 0.02}}
+    ]
+    mock_client.marketplace = mock_marketplace
+    mock_voidly_pay.return_value = mock_client
+
+    tool = VoidlyPayToolSpec()
+    result = tool.marketplace_browse(category="data")
+
+    mock_marketplace.browse.assert_called_once_with(category="data")
+    assert result[0]["name"] == "PDF→text"
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_health_check(mock_voidly_pay):
+    """Test health check returns 6-check report."""
+    mock_client = MagicMock()
+    mock_client.health_check.return_value = {
+        "facilitator_reachable": True,
+        "vault_verified": True,
+        "wallet_balance_credits": 10,
+        "keypair_valid": True,
+        "recent_settlements_ok": True,
+        "all_checks_passed": True,
+    }
+    mock_voidly_pay.return_value = mock_client
+
+    tool = VoidlyPayToolSpec()
+    report = tool.health_check()
+
+    assert report["all_checks_passed"] is True
+    assert report["wallet_balance_credits"] == 10
+
+
+@patch("voidly_pay.VoidlyPay")
+def test_list_listing(mock_voidly_pay):
+    """Test creating a marketplace listing."""
+    mock_client = MagicMock()
+    mock_marketplace = MagicMock()
+    mock_marketplace.list.return_value = {
+        "id": "lst_xyz",
+        "discoverability_url": "https://voidly.ai/pay/listings/lst_xyz",
+    }
+    mock_client.marketplace = mock_marketplace
+    mock_voidly_pay.return_value = mock_client
+
+    tool = VoidlyPayToolSpec()
+    result = tool.list_listing(
+        name="My API",
+        endpoint_url="https://api.example.com/paid",
+        price_usdc=0.05,
+        description="Does X",
+        category="data",
+    )
+
+    mock_marketplace.list.assert_called_once_with(
+        name="My API",
+        endpoint_url="https://api.example.com/paid",
+        price_usdc=0.05,
+        description="Does X",
+        category="data",
+    )
+    assert result["id"] == "lst_xyz"


### PR DESCRIPTION
Adds `llama-index-tools-voidly-pay`, a `BaseToolSpec` that lets a LlamaIndex agent pay for HTTP 402 endpoints via Voidly Pay (Stage 2 vault on Base mainnet, USDC settlement). Wraps the existing [`voidly-pay`](https://pypi.org/project/voidly-pay/) PyPI SDK. Follows the pattern of `llama-index-tools-mcp` and `llama-index-tools-tavily-research`. Marketplace JSON at [api.voidly.ai/v1/pay/marketplace](https://api.voidly.ai/v1/pay/marketplace). Honest disclosure: vault has $4 USDC and ~0 sustained external paying users — we're shipping the rail before the demand exists.