### PR TITLE
fix(tree): populate source_nodes in TreeSelectLeafRetriever._query()

### DIFF
--- a/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
+++ b/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
@@ -1,7 +1,7 @@
 """Leaf query mechanism."""
 
 import logging
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.response.schema import Response
@@ -113,13 +113,14 @@ class TreeSelectLeafRetriever(BaseRetriever):
         query_bundle: QueryBundle,
         prev_response: Optional[str] = None,
         level: int = 0,
-    ) -> str:
+    ) -> Tuple[str, List[BaseNode]]:
         """
         Get response for selected node.
 
         If not leaf node, it will recursively call _query on the child nodes.
         If prev_response is provided, we will update prev_response with the answer.
 
+        Returns a tuple of (response_str, leaf_nodes) so callers can surface provenance.
         """
         query_str = query_bundle.query_str
 
@@ -137,15 +138,16 @@ class TreeSelectLeafRetriever(BaseRetriever):
             )
             cur_response = str(cur_response)
             logger.debug(f">[Level {level}] Current answer response: {cur_response} ")
+            leaf_nodes: List[BaseNode] = [selected_node]
         else:
-            cur_response = self._query_level(
+            cur_response, leaf_nodes = self._query_level(
                 self._index_struct.get_children(selected_node),
                 query_bundle,
                 level=level + 1,
             )
 
         if prev_response is None:
-            return cur_response
+            return cur_response, leaf_nodes
         else:
             context_msg = selected_node.get_content(metadata_mode=MetadataMode.LLM)
             cur_response = self._llm.predict(
@@ -156,15 +158,15 @@ class TreeSelectLeafRetriever(BaseRetriever):
             )
 
             logger.debug(f">[Level {level}] Current refined response: {cur_response} ")
-            return str(cur_response)
+            return str(cur_response), leaf_nodes
 
     def _query_level(
         self,
         cur_node_ids: Dict[int, str],
         query_bundle: QueryBundle,
         level: int = 0,
-    ) -> str:
-        """Answer a query recursively."""
+    ) -> Tuple[str, List[BaseNode]]:
+        """Answer a query recursively, returning (response_str, leaf_nodes)."""
         query_str = query_bundle.query_str
         cur_nodes = {
             index: self._docstore.get_node(node_id)
@@ -229,8 +231,9 @@ class TreeSelectLeafRetriever(BaseRetriever):
             if self._verbose:
                 print_text(debug_str, end="\n")
             # just join text from current nodes as response
-            return response
+            return response, []
         result_response = None
+        all_leaf_nodes: List[BaseNode] = []
         for number_str in numbers:
             number = int(number_str)
             if number > len(cur_node_list):
@@ -238,7 +241,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
                     f">[Level {level}] Invalid response: {response} - "
                     f"number {number} out of range"
                 )
-                return response
+                return response, all_leaf_nodes
 
             # number is 1-indexed, so subtract 1
             selected_node = cur_node_list[number - 1]
@@ -261,14 +264,15 @@ class TreeSelectLeafRetriever(BaseRetriever):
             logger.debug(full_debug_str)
             if self._verbose:
                 print_text(full_debug_str, end="\n")
-            result_response = self._query_with_selected_node(
+            result_response, leaf_nodes = self._query_with_selected_node(
                 selected_node,
                 query_bundle,
                 prev_response=result_response,
                 level=level,
             )
+            all_leaf_nodes.extend(leaf_nodes)
         # result_response should not be None
-        return cast(str, result_response)
+        return cast(str, result_response), all_leaf_nodes
 
     def _query(self, query_bundle: QueryBundle) -> Response:
         """Answer a query."""
@@ -277,13 +281,15 @@ class TreeSelectLeafRetriever(BaseRetriever):
         logger.info(info_str)
         if self._verbose:
             print_text(info_str, end="\n")
-        response_str = self._query_level(
+        response_str, leaf_nodes = self._query_level(
             self._index_struct.root_nodes,
             query_bundle,
             level=0,
-        ).strip()
-        # TODO: fix source nodes
-        return Response(response_str, source_nodes=[])
+        )
+        return Response(
+            response_str.strip(),
+            source_nodes=[NodeWithScore(node=n) for n in leaf_nodes],
+        )
 
     def _select_nodes(
         self,

--- a/llama-index-core/tests/indices/tree/test_retrievers.py
+++ b/llama-index-core/tests/indices/tree/test_retrievers.py
@@ -21,6 +21,29 @@ def test_query(
     assert len(nodes) == 1
 
 
+def test_query_source_nodes_populated(
+    documents: List[Document],
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    struct_kwargs: Dict,
+) -> None:
+    """_query() must return source_nodes referencing the selected leaf nodes (issue #21441)."""
+    index_kwargs, query_kwargs = struct_kwargs
+    tree = TreeIndex.from_documents(documents, **index_kwargs)
+
+    from llama_index.core.indices.tree.select_leaf_retriever import (
+        TreeSelectLeafRetriever,
+    )
+    from llama_index.core.indices.query.schema import QueryBundle
+
+    retriever = TreeSelectLeafRetriever(tree, **query_kwargs)
+    response = retriever._query(QueryBundle("What is?"))
+
+    assert len(response.source_nodes) > 0, (
+        "source_nodes must not be empty — _query() was returning [] before fix for #21441"
+    )
+
+
 def test_summarize_query(
     documents: List[Document],
     patch_llm_predictor,


### PR DESCRIPTION
## Summary

`TreeSelectLeafRetriever._query()` has carried a `# TODO: fix source nodes` comment
since the method was written: it always returned `Response(response_str, source_nodes=[])`,
silently discarding every leaf node that the tree traversal selected.
The root cause is that `_query_level()` and `_query_with_selected_node()` returned only
a `str` response, with no way for the caller to learn which nodes were actually used.
This PR changes both helpers to return `Tuple[str, List[BaseNode]]`, accumulates the
selected leaf nodes at each recursive level, and passes them to the `Response` as
`NodeWithScore` objects — resolving the TODO and making citation / provenance features
work for this retriever.

## Issue

Fixes #21441

## Local verification

```
# Syntax + logic check (no network required)
cd llama-index-core
python -c "
from llama_index.core.indices.tree.select_leaf_retriever import TreeSelectLeafRetriever
import inspect
src = inspect.getsource(TreeSelectLeafRetriever._query_with_selected_node)
assert 'Tuple[str, List[BaseNode]]' in src
src2 = inspect.getsource(TreeSelectLeafRetriever._query_level)
assert 'Tuple[str, List[BaseNode]]' in src2
src3 = inspect.getsource(TreeSelectLeafRetriever._query)
assert 'leaf_nodes' in src3
assert 'source_nodes=[NodeWithScore' in src3
assert 'TODO' not in src3
print('All assertions passed')
"

# Unit test with tiktoken mocked (tiktoken requires network in CI-less env)
python -c "
import tiktoken
class FakeEncoding:
    def encode(self, text, allowed_special=None, disallowed_special=None):
        return list(text.encode('utf-8'))
    def decode(self, tokens): return bytes(tokens).decode('utf-8', errors='replace')
    def __len__(self): return 100256
    name = 'cl100k_base'
fake_enc = FakeEncoding()
tiktoken.get_encoding = lambda name: fake_enc
tiktoken.encoding_for_model = lambda model: fake_enc
import pytest, sys
result = pytest.main(['tests/indices/tree/test_retrievers.py', '-v', '-p', 'no:cacheprovider'])
sys.exit(result)
"

# Output:
# tests/indices/tree/test_retrievers.py::test_query PASSED
# tests/indices/tree/test_retrievers.py::test_query_source_nodes_populated PASSED
# tests/indices/tree/test_retrievers.py::test_summarize_query PASSED
# 3 passed in 0.03s

# Ruff lint
ruff check llama_index/core/indices/tree/select_leaf_retriever.py
# → All checks passed!

=== LOCAL_TEST_PASSED ===
```

## Risk

Only `_query()` / `_query_level()` / `_query_with_selected_node()` are changed — the
`_retrieve()` path (used by the base-class `retrieve()`) is untouched.
The return type of the two private helpers changes from `str` to `Tuple[str, List[BaseNode]]`,
but they are not part of any public API and are only called from within this class.
Any subclass that overrides `_query_with_selected_node` or `_query_level` would need
updating, but a quick search finds no such subclasses in this repo.
