### PR TITLE
Fix Google rerank async postprocessing

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/llama_index/postprocessor/google_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/llama_index/postprocessor/google_rerank/base.py
@@ -1,5 +1,6 @@
 """Google Rerank postprocessor using Discovery Engine Ranking API."""
 
+import asyncio
 import os
 from typing import Any, List, Optional
 
@@ -160,42 +161,4 @@ class GoogleRerank(BaseNodePostprocessor):
         nodes: List[NodeWithScore],
         query_bundle: Optional[QueryBundle] = None,
     ) -> List[NodeWithScore]:
-        dispatcher.event(
-            ReRankStartEvent(
-                query=query_bundle,
-                nodes=nodes,
-                top_n=self.top_n,
-                model_name=self.model,
-            )
-        )
-
-        if query_bundle is None:
-            raise ValueError("Missing query bundle in extra info.")
-        if len(nodes) == 0:
-            return []
-
-        records = self._build_records(nodes)
-        top_n = min(self.top_n, len(nodes))
-
-        request = discoveryengine.RankRequest(
-            ranking_config=self._build_ranking_config_path(),
-            model=self.model,
-            top_n=top_n,
-            query=query_bundle.query_str,
-            records=records,
-        )
-
-        response = await self._async_client.rank(request=request)
-
-        new_nodes = []
-        for record in response.records:
-            index = int(record.id)
-            new_nodes.append(
-                NodeWithScore(
-                    node=nodes[index].node,
-                    score=record.score,
-                )
-            )
-
-        dispatcher.event(ReRankEndEvent(nodes=new_nodes))
-        return new_nodes
+        return await asyncio.to_thread(self._postprocess_nodes, nodes, query_bundle)

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/tests/test_postprocessor_google_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/tests/test_postprocessor_google_rerank.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -90,7 +90,7 @@ async def test_google_rerank_async():
             {"index": 0, "score": 0.70},
         ]
     )
-    reranker._async_client.rank = AsyncMock(return_value=mock_response)
+    reranker._client.rank.return_value = mock_response
 
     input_nodes = [
         NodeWithScore(node=TextNode(id_="1", text="hello world")),
@@ -107,7 +107,8 @@ async def test_google_rerank_async():
     assert actual_nodes[0].score == pytest.approx(0.90)
     assert actual_nodes[1].node.get_content() == "hello world"
     assert actual_nodes[1].score == pytest.approx(0.70)
-    reranker._async_client.rank.assert_called_once()
+    reranker._client.rank.assert_called_once()
+    reranker._async_client.rank.assert_not_called()
 
 
 def test_google_rerank_empty_nodes():


### PR DESCRIPTION
# Description

Fixes #21150.

This PR fixes the Google reranker async postprocessing path. The async implementation was using `RankServiceAsyncClient`, which can fail in production deployments. The async method now delegates to the existing synchronous `_postprocess_nodes()` implementation via `asyncio.to_thread()`, matching the default async postprocessor behavior while avoiding duplicated client logic.

No new dependencies are required.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
