### PR TITLE
fix(ollama): handle Pydantic model responses in get_additional_kwargs

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -55,8 +55,10 @@ dispatcher = get_dispatcher(__name__)
 
 
 def get_additional_kwargs(
-    response: Dict[str, Any], exclude: Tuple[str, ...]
+    response: Any, exclude: Tuple[str, ...]
 ) -> Dict[str, Any]:
+    if hasattr(response, "model_dump"):
+        response = response.model_dump()
     return {k: v for k, v in response.items() if k not in exclude}
 
 

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_utils.py
@@ -1,8 +1,29 @@
+from pydantic import BaseModel
+
 from llama_index.llms.ollama.base import get_additional_kwargs
 
 
 def test_get_additional_kwargs():
     response = {"key1": "value1", "key2": "value2", "exclude_me": "value3"}
+    exclude = ("exclude_me", "exclude_me_too")
+
+    expected = {"key1": "value1", "key2": "value2"}
+
+    actual = get_additional_kwargs(response, exclude)
+
+    assert actual == expected
+
+
+def test_get_additional_kwargs_pydantic_model():
+    """Test that get_additional_kwargs handles Pydantic models (e.g. GenerateResponse
+    from ollama>=0.4) in addition to plain dicts."""
+
+    class FakeGenerateResponse(BaseModel):
+        key1: str = "value1"
+        key2: str = "value2"
+        exclude_me: str = "value3"
+
+    response = FakeGenerateResponse()
     exclude = ("exclude_me", "exclude_me_too")
 
     expected = {"key1": "value1", "key2": "value2"}


### PR DESCRIPTION
Starting with ollama>=0.4, the Python client returns typed Pydantic objects (e.g. `GenerateResponse`) instead of plain dicts from its API calls. The helper function `get_additional_kwargs` in `llama_index/llms/ollama/base.py` called `.items()` directly on the response, which works for dicts but raises an `AttributeError` when the response is a Pydantic model instance.

The fix adds a check at the top of `get_additional_kwargs`: if the incoming response object has a `model_dump` method (the standard Pydantic v2 serialization method), it is converted to a plain dict before the key filtering is applied. The function signature is updated from `Dict[str, Any]` to `Any` to reflect that it now accepts both types.

A new test `test_get_additional_kwargs_pydantic_model` is added in `tests/test_utils.py` to verify that a Pydantic model response is correctly serialized and filtered, matching the behavior of the existing dict-based test.

Fixes #17105
