### PR TITLE
fix(redis): use removeprefix() instead of strip() to preserve node IDs

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -356,7 +356,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         )
         logger.info(f"Added {len(keys)} documents to index {self._async_index.name}")
         return [
-            key.strip(self._async_index.prefix + self._async_index.key_separator)
+            key.removeprefix(self._async_index.prefix + self._async_index.key_separator)
             for key in keys
         ]
 
@@ -408,7 +408,7 @@ class RedisVectorStore(BasePydanticVectorStore):
         keys = self._index.load(data, id_field=NODE_ID_FIELD_NAME, **add_kwargs)
         logger.info(f"Added {len(keys)} documents to index {self._index.name}")
         return [
-            key.strip(self._index.prefix + self._index.key_separator) for key in keys
+            key.removeprefix(self._index.prefix + self._index.key_separator) for key in keys
         ]
 
     def _build_node_id_filter_expression(self, node_ids: list[str]) -> FilterExpression:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/tests/test_vector_stores_redis.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/tests/test_vector_stores_redis.py
@@ -663,3 +663,42 @@ async def test_async_unindexed_embedding_query_returns_no_matches(
     finally:
         index = None
         await vector_store.async_delete_index()
+
+
+def test_removeprefix_preserves_uuid_starting_with_prefix_chars():
+    """Regression test for issue #21483.
+
+    ``str.strip(chars)`` removes *any combination* of the supplied characters
+    from both ends of the string, which corrupts UUID-based node IDs when the
+    Redis prefix shares characters with the UUID (e.g. prefix ``doc`` strips
+    the leading ``d`` from ``d7b95ae7-...``).
+
+    ``str.removeprefix(prefix)`` removes the exact substring and is the
+    correct approach.
+    """
+    prefix = "semantic_cache_doc"
+    separator = ":"
+    stripped_prefix = prefix + separator
+
+    test_cases = [
+        # (node_id, expected_full_key)
+        ("e7b95ae7-6369-404d-8287-1f4504121563", "semantic_cache_doc:e7b95ae7-6369-404d-8287-1f4504121563"),
+        ("doc-abc-1234-5678", "semantic_cache_doc:doc-abc-1234-5678"),
+        ("a1b2c3d4-uuid-starts-with-a", "semantic_cache_doc:a1b2c3d4-uuid-starts-with-a"),
+        ("cab-starts-with-prefix-chars", "semantic_cache_doc:cab-starts-with-prefix-chars"),
+        ("normal-uuid-not-overlapping", "semantic_cache_doc:normal-uuid-not-overlapping"),
+    ]
+
+    for node_id, full_key in test_cases:
+        # The old buggy behaviour: .strip() corrupts the ID
+        broken_result = full_key.strip(stripped_prefix)
+        assert broken_result != node_id, (
+            f"Expected .strip() to corrupt '{node_id}' but it didn't — "
+            f"test case needs a different prefix/ID overlap"
+        )
+
+        # The correct behaviour with .removeprefix()
+        correct_result = full_key.removeprefix(stripped_prefix)
+        assert correct_result == node_id, (
+            f".removeprefix() should return '{node_id}', got '{correct_result}'"
+        )


### PR DESCRIPTION
## Summary

Fixes #21483 — `RedisVectorStore.add()` and `async_add()` return corrupted node IDs when the Redis prefix shares characters with UUID-based node IDs.

## Root Cause

`str.strip(chars)` removes **any combination** of the provided characters from both ends of the string, not the exact substring. For example, with prefix `semantic_cache_doc` and key separator `:`, calling `.strip("semantic_cache_doc:")` on `semantic_cache_doc:e7b95ae7-...` strips the leading `e` (present in the prefix), returning `7b95ae7-...` instead of the original UUID.

## Fix

Replaced `.strip(prefix + separator)` with `.removeprefix(prefix + separator)` in both the sync `add()` and async `async_add()` methods. `str.removeprefix()` (Python 3.9+) removes the exact substring from the beginning, preserving the original node ID.

## Changes

- `llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py`: 2 lines changed (`.strip()` → `.removeprefix()`)
- `llama-index-integrations/vector_stores/llama-index-vector-stores-redis/tests/test_vector_stores_redis.py`: Added regression test with 5 test cases demonstrating the bug and fix

## Reproduction

```python
# With prefix "semantic_cache_doc" and separator ":"
key = "semantic_cache_doc:e7b95ae7-6369-404d-8287-1f4504121563"

# Old (buggy):
key.strip("semantic_cache_doc:")  # → "7b95ae7-6369-404d-8287-1f4504121563" (missing 'e')

# New (fixed):
key.removeprefix("semantic_cache_doc:")  # → "e7b95ae7-6369-404d-8287-1f4504121563" (correct)
```