### PR TITLE
fix(deps): drop removed huggingface-hub[inference] extra in HF embedding packages

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
@@ -35,7 +35,7 @@ license = "MIT"
 dependencies = [
     "llama-index-utils-huggingface>=0.4.0,<0.5",
     "llama-index-core>=0.13.0,<0.15",
-    "huggingface-hub[inference]>=0.31.0",
+    "huggingface-hub>=0.31.0",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
@@ -35,7 +35,7 @@ license = "MIT"
 dependencies = [
     "sentence-transformers>=2.6.1",
     "llama-index-core>=0.13.0,<0.15",
-    "huggingface-hub[inference]>=0.19.0",
+    "huggingface-hub>=0.19.0",
 ]
 
 [tool.codespell]


### PR DESCRIPTION
## Summary

The `[inference]` optional-dependency group was removed from `huggingface-hub` in v1.x — the `InferenceClient` and `AsyncInferenceClient` classes were promoted to the core package and no longer require any optional extra to be installed. Referencing a non-existent extra (`huggingface-hub[inference]`) causes a warning on every `uv sync` (and similar resolvers):

```
warning: The package `huggingface-hub==1.13.0` does not have an extra named `inference`
```

This PR removes `[inference]` from the `huggingface-hub` dependency specification in both affected packages:

- `llama-index-embeddings-huggingface`: `huggingface-hub[inference]>=0.19.0` → `huggingface-hub>=0.19.0`
- `llama-index-embeddings-huggingface-api`: `huggingface-hub[inference]>=0.31.0` → `huggingface-hub>=0.31.0`

No source code changes are needed — `InferenceClient`, `AsyncInferenceClient`, and `ModelInfo` are all available from `huggingface_hub` core in every version that satisfies these minimum version constraints.

## Issue

Fixes #21549

## Local verification

```
$ ruff check llama-index-integrations/embeddings/llama-index-embeddings-huggingface/ \
             llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/
All checks passed!

$ python3 -c "from huggingface_hub import InferenceClient, AsyncInferenceClient; from huggingface_hub.hf_api import ModelInfo; print('All imports OK')"
All imports OK

$ python3 -c "
with open('llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml') as f:
    c = f.read()
assert 'huggingface-hub[inference]' not in c
assert 'huggingface-hub>=0.19.0' in c
print('PASS: embeddings-huggingface dependency fixed')

with open('llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml') as f:
    c = f.read()
assert 'huggingface-hub[inference]' not in c
assert 'huggingface-hub>=0.31.0' in c
print('PASS: embeddings-huggingface-api dependency fixed')
"
PASS: embeddings-huggingface dependency fixed
PASS: embeddings-huggingface-api dependency fixed
=== LOCAL_TEST_PASSED ===
```

## Risk

Pure dependency-metadata change with no code modifications. `InferenceClient` and `AsyncInferenceClient` are stable parts of `huggingface-hub` core since ≥0.19.0, so removing the extra does not change installed or available symbols at any supported version. The only affected users are those with strict extra-validation in their resolvers (e.g., `uv`), who will now see the warning resolved rather than regressed.
