### PR TITLE
feat(bedrock-converse): add async_client param to reuse a shared aioboto3 client

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -190,6 +190,7 @@ class BedrockConverse(FunctionCallingLLM):
     _config: Any = PrivateAttr()
     _client: Any = PrivateAttr()
     _asession: Any = PrivateAttr()
+    _async_client: Any = PrivateAttr(default=None)
     _boto_client_kwargs: Any = PrivateAttr()
 
     def __init__(
@@ -208,6 +209,7 @@ class BedrockConverse(FunctionCallingLLM):
         endpoint_url: Optional[str] = None,
         botocore_session: Optional[Any] = None,
         client: Optional[Any] = None,
+        async_client: Optional[Any] = None,
         timeout: Optional[float] = 60.0,
         max_retries: Optional[int] = 10,
         botocore_config: Optional[Any] = None,
@@ -344,6 +346,8 @@ class BedrockConverse(FunctionCallingLLM):
                 config=self._config,
                 **self._boto_client_kwargs,
             )
+
+        self._async_client = async_client
 
     @classmethod
     def class_name(cls) -> str:
@@ -747,6 +751,7 @@ class BedrockConverse(FunctionCallingLLM):
             guardrail_version=self.guardrail_version,
             trace=self.trace,
             boto_client_kwargs=self._boto_client_kwargs,
+            client=self._async_client,
             **all_kwargs,
         )
 
@@ -801,6 +806,7 @@ class BedrockConverse(FunctionCallingLLM):
             guardrail_stream_processing_mode=self.guardrail_stream_processing_mode,
             trace=self.trace,
             boto_client_kwargs=self._boto_client_kwargs,
+            client=self._async_client,
             **all_kwargs,
         )
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -805,6 +805,7 @@ async def converse_with_retry_async(
     guardrail_stream_processing_mode: Optional[Literal["sync", "async"]] = None,
     trace: Optional[str] = None,
     boto_client_kwargs: Optional[Dict[str, Any]] = None,
+    client: Optional[Any] = None,
     **kwargs: Any,
 ) -> Any:
     """Use tenacity to retry the completion call."""
@@ -881,23 +882,30 @@ async def converse_with_retry_async(
 
     @retry_decorator
     async def _conversion_with_retry(**kwargs: Any) -> Any:
+        if client is not None:
+            return await client.converse(**kwargs)
         async with session.client(
             "bedrock-runtime",
             config=config,
             **_boto_client_kwargs,
-        ) as client:
-            return await client.converse(**kwargs)
+        ) as c:
+            return await c.converse(**kwargs)
 
     @retry_decorator
     async def _conversion_stream_with_retry(**kwargs: Any) -> Any:
-        async with session.client(
-            "bedrock-runtime",
-            config=config,
-            **_boto_client_kwargs,
-        ) as client:
+        if client is not None:
             response = await client.converse_stream(**kwargs)
             async for event in response["stream"]:
                 yield event
+        else:
+            async with session.client(
+                "bedrock-runtime",
+                config=config,
+                **_boto_client_kwargs,
+            ) as c:
+                response = await c.converse_stream(**kwargs)
+                async for event in response["stream"]:
+                    yield event
 
     if stream:
         return _conversion_stream_with_retry(**converse_kwargs)

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.9"
+version = "0.14.10"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
@@ -845,6 +845,56 @@ async def test_converse_with_retry_async_guardrail_stream_processing_mode_withou
         assert "streamProcessingMode" not in call_kwargs["guardrailConfig"]
 
 
+@pytest.mark.asyncio
+async def test_converse_with_retry_async_uses_provided_client(
+    mock_aioboto3_session,
+):
+    """When client is provided, converse_with_retry_async uses it directly without opening a session client."""
+    session = aioboto3.Session()
+    async_client = AsyncMockClient()
+
+    with patch.object(
+        AsyncMockClient, "converse", wraps=async_client.converse
+    ) as patched_converse:
+        with patch.object(MockAsyncSession, "client") as patched_session_client:
+            await converse_with_retry_async(
+                session=session,
+                config=Config(),
+                model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+                messages=[],
+                stream=False,
+                client=async_client,
+            )
+            patched_converse.assert_called_once()
+            patched_session_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_converse_with_retry_async_uses_provided_client_streaming(
+    mock_aioboto3_session,
+):
+    """When client is provided, streaming in converse_with_retry_async uses it directly without opening a session client."""
+    session = aioboto3.Session()
+    async_client = AsyncMockClient()
+
+    with patch.object(
+        AsyncMockClient, "converse_stream", wraps=async_client.converse_stream
+    ) as patched_stream:
+        with patch.object(MockAsyncSession, "client") as patched_session_client:
+            response_gen = await converse_with_retry_async(
+                session=session,
+                config=Config(),
+                model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+                messages=[],
+                stream=True,
+                client=async_client,
+            )
+            async for _ in response_gen:
+                pass
+            patched_stream.assert_called_once()
+            patched_session_client.assert_not_called()
+
+
 def test_thinking_dict_enabled_requires_budget():
     td: ThinkingDict = {"type": "enabled", "budget_tokens": 1024}
     assert td["type"] == "enabled"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_llms_bedrock_converse.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_llms_bedrock_converse.py
@@ -2,6 +2,7 @@ import random
 import string
 import json
 import os
+from unittest.mock import patch
 from llama_index.core.base.llms.types import ImageBlock, TextBlock
 import pytest
 from llama_index.llms.bedrock_converse import BedrockConverse
@@ -355,6 +356,53 @@ async def test_astream_chat(bedrock_converse):
     assert final_response.additional_kwargs["prompt_tokens"] == 15
     assert final_response.additional_kwargs["completion_tokens"] == 26
     assert final_response.additional_kwargs["total_tokens"] == 41
+
+
+@pytest.mark.asyncio
+async def test_achat_uses_async_client_when_provided(
+    mock_boto3_session, mock_aioboto3_session
+):
+    """When async_client is provided, achat uses it directly without opening a session client."""
+    async_mock = AsyncMockClient()
+    llm = BedrockConverse(
+        model=EXP_MODEL,
+        max_tokens=EXP_MAX_TOKENS,
+        async_client=async_mock,
+    )
+
+    with patch.object(
+        AsyncMockClient, "converse", wraps=async_mock.converse
+    ) as patched_converse:
+        with patch.object(MockAsyncSession, "client") as patched_session_client:
+            response = await llm.achat(messages)
+            patched_converse.assert_called_once()
+            patched_session_client.assert_not_called()
+
+    assert isinstance(response, ChatResponse)
+    assert response.message.content == EXP_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_uses_async_client_when_provided(
+    mock_boto3_session, mock_aioboto3_session
+):
+    """When async_client is provided, astream_chat uses it directly without opening a session client."""
+    async_mock = AsyncMockClient()
+    llm = BedrockConverse(
+        model=EXP_MODEL,
+        max_tokens=EXP_MAX_TOKENS,
+        async_client=async_mock,
+    )
+
+    with patch.object(
+        AsyncMockClient, "converse_stream", wraps=async_mock.converse_stream
+    ) as patched_stream:
+        with patch.object(MockAsyncSession, "client") as patched_session_client:
+            response_stream = await llm.astream_chat(messages)
+            async for _ in response_stream:
+                pass
+            patched_stream.assert_called_once()
+            patched_session_client.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

The async inference path (`achat`, `astream_chat`) creates a new `aioboto3` client on every request via `async with session.client(...)`, which tears down the aiohttp connection pool after each call and forces a fresh TCP + TLS handshake on the next one. The sync path already accepts a `client` parameter that short-circuits this — this PR brings the async path to parity.

### Changes

- **`BedrockConverse.__init__`**: adds `async_client: Optional[Any] = None`. When provided, it is stored and passed through to async inference calls instead of the per-request session context manager.
- **`converse_with_retry_async`** (`utils.py`): adds `client: Optional[Any] = None`. When provided, `client.converse()` / `client.converse_stream()` are called directly, bypassing `async with session.client(...)`.

Fixes # (no existing issue — happy to open one if preferred)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No (not a new package)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes (`0.14.9` → `0.14.10`)
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Four new tests added:
- `test_converse_with_retry_async_uses_provided_client` — verifies `converse_with_retry_async` calls the provided client directly for non-streaming and does not open a session client
- `test_converse_with_retry_async_uses_provided_client_streaming` — same for streaming
- `test_achat_uses_async_client_when_provided` — verifies `BedrockConverse.achat` routes through `async_client` when provided
- `test_astream_chat_uses_async_client_when_provided` — same for `astream_chat`

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

## Usage Example

```python
import aioboto3

# Create once at app startup; close at shutdown
session = aioboto3.Session()
async_client = await session.create_client("bedrock-runtime", region_name="us-east-1").__aenter__()

llm = BedrockConverse(
    model="anthropic.claude-sonnet-4-20250514-v1:0",
    async_client=async_client,
)

# All async calls now reuse the shared client and its underlying connection pool
response = await llm.achat(messages)
```

> Note: This PR was developed with AI assistance (Claude). All code has been reviewed, tested, and is understood by the author.