### PR TITLE
fix: propagate contextvars in sync_to_async for FunctionTool

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -48,9 +48,7 @@ def sync_to_async(fn: Callable[..., Any]) -> AsyncCallable:
     async def _async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:
         loop = asyncio.get_running_loop()
         ctx = contextvars.copy_context()
-        return await loop.run_in_executor(
-            None, lambda: ctx.run(fn, *args, **kwargs)
-        )
+        return await loop.run_in_executor(None, lambda: ctx.run(fn, *args, **kwargs))
 
     return _async_wrapped_fn
 

--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import inspect
 from typing import (
     TYPE_CHECKING,
@@ -46,7 +47,8 @@ def sync_to_async(fn: Callable[..., Any]) -> AsyncCallable:
 
     async def _async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, lambda: fn(*args, **kwargs))
+        ctx = contextvars.copy_context()
+        return await loop.run_in_executor(None, ctx.run, fn, *args, **kwargs)
 
     return _async_wrapped_fn
 

--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -48,7 +48,9 @@ def sync_to_async(fn: Callable[..., Any]) -> AsyncCallable:
     async def _async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:
         loop = asyncio.get_running_loop()
         ctx = contextvars.copy_context()
-        return await loop.run_in_executor(None, ctx.run, fn, *args, **kwargs)
+        return await loop.run_in_executor(
+            None, lambda: ctx.run(fn, *args, **kwargs)
+        )
 
     return _async_wrapped_fn
 

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -490,3 +490,4 @@ async def test_function_tool_contextvar_propagation() -> None:
     var.set("expected")
     result = await tool.acall()
     assert result.raw_output == "expected"
+

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -481,7 +481,9 @@ def test_function_tool_field_default() -> None:
 @pytest.mark.asyncio
 async def test_function_tool_contextvar_propagation() -> None:
     """Test that contextvars are propagated into sync fn via acall."""
-    var: contextvars.ContextVar[str] = contextvars.ContextVar("test_var", default="default")
+    var: contextvars.ContextVar[str] = contextvars.ContextVar(
+        "test_var", default="default"
+    )
 
     def sync_fn() -> str:
         return var.get()
@@ -490,4 +492,3 @@ async def test_function_tool_contextvar_propagation() -> None:
     var.set("expected")
     result = await tool.acall()
     assert result.raw_output == "expected"
-

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -1,5 +1,6 @@
 """Test tools."""
 
+import contextvars
 import json
 from typing import List, Optional
 
@@ -475,3 +476,17 @@ def test_function_tool_field_default() -> None:
     # Calling with an explicit arg should override the default
     result = tool.call(location="Munich")
     assert result.content == "weather in Munich"
+
+
+@pytest.mark.asyncio
+async def test_function_tool_contextvar_propagation() -> None:
+    """Test that contextvars are propagated into sync fn via acall."""
+    var: contextvars.ContextVar[str] = contextvars.ContextVar("test_var", default="default")
+
+    def sync_fn() -> str:
+        return var.get()
+
+    tool = FunctionTool.from_defaults(fn=sync_fn, name="ctx_test", description="test")
+    var.set("expected")
+    result = await tool.acall()
+    assert result.raw_output == "expected"


### PR DESCRIPTION
## Description

When a sync function is wrapped for async execution via `sync_to_async`, the default executor thread does not inherit the caller's `contextvars` context. This breaks `ContextVar` propagation (e.g. OpenTelemetry spans) for sync tools invoked through `acall()`.

The fix snapshots `contextvars.copy_context()` and runs `fn` inside `ctx.run(...)` within the executor thread, mirroring the existing fix already present in `async_utils.py`'s `asyncio_run()`.

Fixes #21555

## New Package?

- [ ] Yes
- [ ] No

## Version Bump?

- [ ] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added `test_function_tool_contextvar_propagation` to `tests/tools/test_base.py` which sets a `ContextVar` and asserts it is propagated into a sync `FunctionTool` called via `acall()`.
- Existing test suite (`tests/tools/test_base.py`) passes locally (24/24).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
