### PR TITLE
fix(tools): propagate ContextVars in sync_to_async for non-async tools

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from contextvars import copy_context
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -46,7 +47,9 @@ def sync_to_async(fn: Callable[..., Any]) -> AsyncCallable:
 
     async def _async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, lambda: fn(*args, **kwargs))
+        # Copy current context to propagate ContextVars to the executor thread
+        ctx = copy_context()
+        return await loop.run_in_executor(None, lambda: ctx.run(fn, *args, **kwargs))
 
     return _async_wrapped_fn
 


### PR DESCRIPTION
## Summary

Fixes #21555

## Bug

When using sync functions as tools, `ContextVar` values are not propagated to the tool execution. This is because `sync_to_async` uses `loop.run_in_executor()` which runs the function in a separate thread, losing the current thread's context.

Async tools work correctly because they execute in the same async context.

## Fix

Use `contextvars.copy_context()` to capture the current context and `ctx.run()` to execute the function with that context in the executor thread:

```python
from contextvars import copy_context

def sync_to_async(fn: Callable[..., Any]) -> AsyncCallable:
    async def _async_wrapped_fn(*args: Any, **kwargs: Any) -> Any:
        loop = asyncio.get_running_loop()
        ctx = copy_context()
        return await loop.run_in_executor(None, lambda: ctx.run(fn, *args, **kwargs))
    return _async_wrapped_fn
```

## Impact

- Sync tools now correctly receive ContextVar values from the calling context
- Behavior matches async tools
- No breaking changes for tools that don't use ContextVars
