### PR TITLE
Fix OTel context detach noise

### DIFF
--- a/llama-index-integrations/observability/llama-index-observability-otel/llama_index/observability/otel/base.py
+++ b/llama-index-integrations/observability/llama-index-observability-otel/llama_index/observability/otel/base.py
@@ -56,6 +56,7 @@ class OTelCompatibleSpanHandler(SimpleSpanHandler):
     _context_tokens: Dict[str, Token[context.Context]] = PrivateAttr(
         default_factory=dict
     )
+    _previous_contexts: Dict[str, context.Context] = PrivateAttr(default_factory=dict)
     all_spans: Dict[str, trace.Span] = Field(
         default_factory=dict, description="All the registered OpenTelemetry spans."
     )
@@ -84,6 +85,7 @@ class OTelCompatibleSpanHandler(SimpleSpanHandler):
         self._tracer_provider = tracer_provider
         self._events_by_span = {}
         self._context_tokens = {}
+        self._previous_contexts = {}
         self.debug = debug
 
     def close(self) -> None:
@@ -140,9 +142,17 @@ class OTelCompatibleSpanHandler(SimpleSpanHandler):
 
     def _detach_context_and_end_span(self, id_: str, span: trace.Span) -> None:
         token = self._context_tokens.pop(id_, None)
+        previous_context = self._previous_contexts.pop(id_, None)
         try:
             if token is not None:
-                context.detach(token)
+                token.var.reset(token)
+        except ValueError as err:
+            if "different Context" not in str(err):
+                _logger.warning(
+                    "Error detaching OTel context for %s", id_, exc_info=True
+                )
+            elif previous_context is not None and trace.get_current_span() is span:
+                context.attach(previous_context)
         except BaseException:
             _logger.warning("Error detaching OTel context for %s", id_, exc_info=True)
         finally:
@@ -173,8 +183,10 @@ class OTelCompatibleSpanHandler(SimpleSpanHandler):
         otel_span = self._tracer.start_span(name=span_name, context=ctx)
         self.all_spans.update({id_: otel_span})
 
+        current_context = context.get_current()
         token = context.attach(set_span_in_context(otel_span))
         self._context_tokens[id_] = token
+        self._previous_contexts[id_] = current_context
 
         # Record instrument_tags as span attributes
         if tags is not None:

--- a/llama-index-integrations/observability/llama-index-observability-otel/pyproject.toml
+++ b/llama-index-integrations/observability/llama-index-observability-otel/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-observability-otel"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index observability integration with OpenTelemetry"
 authors = [{name = "Clelia Astra Bertelli", email = "clelia@runllama.ai"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/observability/llama-index-observability-otel/tests/test_otel.py
+++ b/llama-index-integrations/observability/llama-index-observability-otel/tests/test_otel.py
@@ -1,6 +1,8 @@
 import functools
 import inspect
+import logging
 from collections import OrderedDict
+from contextvars import copy_context
 from typing import Any, Optional, Sequence
 
 from llama_index.observability.otel import LlamaIndexOpenTelemetry
@@ -451,18 +453,23 @@ def test_otel_context_is_source_of_truth_when_external_spans_interleave() -> Non
         context.detach(clean_token)
 
 
-def test_span_exit_ends_span_when_context_detach_fails(monkeypatch: Any) -> None:
+def test_span_exit_ends_span_when_context_detach_fails() -> None:
     exporter, handler, provider = make_handler()
     clean_token = context.attach(context.Context())
-    original_detach = context.detach
 
     try:
         handler.span_enter(id_="root-uuid", bound_args=_bound)
 
-        def fail_detach(token: Any) -> None:
-            raise RuntimeError("detach failed")
+        class FailingTokenVar:
+            def reset(self, token: Any) -> None:
+                raise RuntimeError("detach failed")
 
-        monkeypatch.setattr(context, "detach", fail_detach)
+        class FailingToken:
+            var = FailingTokenVar()
+
+        handler._context_tokens["root-uuid"] = (  # type: ignore[assignment]
+            FailingToken()
+        )
         handler.span_exit(id_="root-uuid", bound_args=_bound)
         provider.force_flush()
 
@@ -472,7 +479,25 @@ def test_span_exit_ends_span_when_context_detach_fails(monkeypatch: Any) -> None
         assert handler.all_spans == {}
         assert handler._context_tokens == {}
     finally:
-        monkeypatch.setattr(context, "detach", original_detach)
+        context.detach(clean_token)
+
+
+def test_span_exit_from_copied_context_does_not_log_detach_error(caplog: Any) -> None:
+    exporter, handler, provider = make_handler()
+    clean_token = context.attach(context.Context())
+
+    try:
+        handler.span_enter(id_="root-uuid", bound_args=_bound)
+        caplog.set_level(logging.ERROR, logger="opentelemetry.context")
+
+        copy_context().run(handler.span_exit, id_="root-uuid", bound_args=_bound)
+        provider.force_flush()
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].end_time is not None
+        assert "Failed to detach context" not in caplog.text
+    finally:
         context.detach(clean_token)
 
 


### PR DESCRIPTION
A workflow step can start a LlamaIndex OTel span in one Python `contextvars.Context`, then exit from a copied continuation context later.

That copied context still sees the child OTel span as current, but the reset token belongs to the original context. Calling `context.detach(token)` from the continuation fails with `ValueError: token was created in a different Context`. OpenTelemetry catches that and logs `Failed to detach context`, even though the span can still be ended.

This changes span exit to reset the stored token directly so we can handle that specific cross-context failure ourselves. If the copied context still points at the span being ended, we attach the saved previous OTel context there. That avoids leaving an ended span as current for later work in the same continuation.

The regression test recreates the continuation with `contextvars.copy_context()` and asserts that OTel does not emit the detach error log.
