### PR TITLE
docs: surface 'Azure DocumentDB' as primary product name in azurecosmosmongo vector store

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/README.md
@@ -1,1 +1,5 @@
 # LlamaIndex Vector_Stores Integration: Azurecosmosmongo
+
+A LlamaIndex vector store backed by **Azure DocumentDB (with MongoDB compatibility)**.
+
+Azure DocumentDB is Microsoft's managed MongoDB-compatible database service ([docs](https://learn.microsoft.com/azure/documentdb/)). The package name (`llama-index-vector-stores-azurecosmosmongo`) and class name (`AzureCosmosDBMongoDBVectorSearch`) are preserved for backward compatibility.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/llama_index/vector_stores/azurecosmosmongo/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/llama_index/vector_stores/azurecosmosmongo/base.py
@@ -1,5 +1,5 @@
 """
-Azure CosmosDB MongoDB vCore Vector store index.
+Azure DocumentDB (with MongoDB compatibility) Vector store index.
 
 An index that is built on top of an existing vector store.
 
@@ -28,11 +28,11 @@ logger = logging.getLogger(__name__)
 
 class AzureCosmosDBMongoDBVectorSearch(BasePydanticVectorStore):
     """
-    Azure CosmosDB MongoDB vCore Vector Store.
+    Azure DocumentDB (with MongoDB compatibility) Vector Store.
 
     To use, you should have both:
     - the ``pymongo`` python package installed
-    - a connection string associated with an Azure Cosmodb MongoDB vCore Cluster
+    - a connection string associated with an Azure DocumentDB cluster
 
     Examples:
         `pip install llama-index-vector-stores-azurecosmosmongo`


### PR DESCRIPTION
Microsoft's managed MongoDB-compatible database service is **Azure DocumentDB (with MongoDB compatibility)**. See https://learn.microsoft.com/azure/documentdb/

This is a docs-only update so users searching for the new product name find this integration.

### Changes

User-facing docstrings and README updated in:
- `llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/llama_index/vector_stores/azurecosmosmongo/base.py` (module + class docstring)
- `llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosmongo/README.md`

### Backward compatibility

- ✅ Package name (`llama-index-vector-stores-azurecosmosmongo`) unchanged
- ✅ Class name (`AzureCosmosDBMongoDBVectorSearch`) unchanged
- ✅ All public APIs unchanged
- ✅ No tests affected