### PR TITLE
fix(llama-index-vector-stores-db2): escape SQL string literals to prevent injection

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-db2/llama_index/vector_stores/db2/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-db2/llama_index/vector_stores/db2/base.py
@@ -83,11 +83,11 @@ def _handle_exceptions(func: T) -> T:
 
 
 def _escape_str(value: str) -> str:
-    BS = "\\"
-    must_escape = (BS, "'")
-    return (
-        "".join(f"{BS}{c}" if c in must_escape else c for c in value) if value else ""
-    )
+    """Escape single quotes for Db2 SQL string literals.
+
+    Db2 requires single quotes inside string constants to be doubled ('').
+    """
+    return value.replace("'", "''") if value else ""
 
 
 column_config: Dict = {
@@ -115,7 +115,7 @@ column_config: Dict = {
 
 
 def _stringify_list(lst: List) -> str:
-    return "(" + ",".join(f"'{item}'" for item in lst) + ")"
+    return "(" + ",".join(f"'{_escape_str(item)}'" for item in lst) + ")"
 
 
 def table_exists(connection: Connection, table_name: str) -> bool:
@@ -268,7 +268,7 @@ class DB2LlamaVS(BasePydanticVectorStore):
         self, where_str: Optional[str], exact_match_filter: list
     ) -> str:
         filter_str = " AND ".join(
-            f"JSON_VALUE({self.metadata_column}, '$.{filter_item.key}') = '{filter_item.value}'"
+            f"JSON_VALUE({self.metadata_column}, '$.{_escape_str(filter_item.key)}') = '{_escape_str(str(filter_item.value))}'"
             for filter_item in exact_match_filter
         )
         if where_str is None:
@@ -330,7 +330,7 @@ class DB2LlamaVS(BasePydanticVectorStore):
 
     @_handle_exceptions
     def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
-        ddl = f"DELETE FROM {self.table_name} WHERE doc_id = '{ref_doc_id}'"
+        ddl = f"DELETE FROM {self.table_name} WHERE doc_id = '{_escape_str(ref_doc_id)}'"
         cursor = self._client.cursor()
         try:
             cursor.execute(ddl)


### PR DESCRIPTION
## Summary

Fixes SQL injection vulnerabilities in the IBM Db2 vector store (`llama-index-vector-stores-db2`). This package was added after CVE-2025-1793 (multi-store SQLi) was patched, but was not included in that fix — it contains the same vulnerable pattern of f-string interpolation of user-controlled values into SQL.

## Vulnerability Details

Three sinks are patched:

1. **`delete(ref_doc_id)`** at `base.py:333`
   - `ddl = f"DELETE FROM {self.table_name} WHERE doc_id = '{ref_doc_id}'"`
   - User-controlled `ref_doc_id` is interpolated without escaping.

2. **`query()` via `_stringify_list(query.doc_ids)`** at `base.py:117` + `349`
   - `where_str = f"doc_id in {_stringify_list(query.doc_ids)}"`
   - Items in the list are wrapped in single quotes without escaping.

3. **`query()` via `_append_meta_filter_condition`** at `base.py:271`
   - `filter_str = f"JSON_VALUE(..., '$.{filter_item.key}') = '{filter_item.value}'"`
   - Both `key` and `value` are interpolated without escaping.

## Fix

Applied `_escape_str()` (existing helper) to all user-controlled string values interpolated into SQL. Also corrected `_escape_str()` to use **Db2-standard quote-doubling** (`''`) instead of backslash escaping, which Db2 does not support.

## Verification

- [x] PoC confirmed all three sinks are exploitable in `main`
- [x] PoC re-run after patch confirms all three sinks are closed
- [x] Legitimate operations (delete, query with doc_ids, query with filters) still work correctly

## Related

- CVE-2025-1793: same bug class, different stores (fixed in PR #18316 — Db2 was not included)
- Disclosure report: https://huntr.com/bounties/eed3f4fc-bc47-4332-9cf1-c9635584fb5b
