### PR TITLE
openai: accept 'reasoning' field as fallback for vLLM-served Qwen3 models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -568,9 +568,13 @@ class OpenAI(FunctionCallingLLM):
                 content_delta = delta.content or ""
                 content += content_delta
 
-                # Extract reasoning_content for chain-of-thought streaming.
-                # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # Extract reasoning content for chain-of-thought streaming.
+                # Most OpenAI-compatible providers surface this as
+                # ``reasoning_content``; vLLM (>=0.20.x) uses ``reasoning``
+                # for Qwen3-family reasoning models. Accept either.
+                raw_reasoning = getattr(delta, "reasoning_content", None) or getattr(
+                    delta, "reasoning", None
+                )
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )
@@ -864,9 +868,13 @@ class OpenAI(FunctionCallingLLM):
                 content_delta = delta.content or ""
                 content += content_delta
 
-                # Extract reasoning_content for chain-of-thought streaming.
-                # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # Extract reasoning content for chain-of-thought streaming.
+                # Most OpenAI-compatible providers surface this as
+                # ``reasoning_content``; vLLM (>=0.20.x) uses ``reasoning``
+                # for Qwen3-family reasoning models. Accept either.
+                raw_reasoning = getattr(delta, "reasoning_content", None) or getattr(
+                    delta, "reasoning", None
+                )
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -833,9 +833,13 @@ def from_openai_message(
     role = openai_message.role
     blocks: List[ContentBlock] = []
 
-    # Extract reasoning_content if present (used by many OpenAI-compatible
-    # providers for chain-of-thought responses)
-    reasoning_content = getattr(openai_message, "reasoning_content", None)
+    # Extract reasoning content if present (used by many OpenAI-compatible
+    # providers for chain-of-thought responses). vLLM (>=0.20.x) exposes
+    # the field as ``reasoning`` for Qwen3-family reasoning models, while
+    # most other providers use ``reasoning_content``; accept either.
+    reasoning_content = getattr(openai_message, "reasoning_content", None) or getattr(
+        openai_message, "reasoning", None
+    )
     if isinstance(reasoning_content, str) and reasoning_content:
         blocks.append(ThinkingBlock(content=reasoning_content))
 


### PR DESCRIPTION
`from_openai_message` and the streaming reasoning extraction read only the `reasoning_content` attribute. vLLM `>=0.20.x` surfaces the same chain-of-thought as `reasoning` for Qwen3-family reasoning models, so the trace was silently dropped and `ThinkingBlock` never appended.

Fall back to `reasoning` when `reasoning_content` is absent, in both the non-streaming `from_openai_message` helper (`utils.py`) and the sync/async streaming branches (`base.py`).

Fixes #21582