### PR TITLE
feat(bedrock-converse): Support thinking display & ensure that reasoningContent without text is captured

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -558,10 +558,9 @@ class BedrockConverse(FunctionCallingLLM):
                     content = join_two_dicts(content, content_delta)
 
                     thinking_delta_value = None
-                    if "reasoningContent" in content_delta:
+                    if reasoning_content := content_delta.get("reasoningContent"):
                         # For ConverseStream (streaming) requests, reasoning text, signature,
                         # redacted content are stored within `reasoningContent`.
-                        reasoning_content = content_delta.get("reasoningContent", {})
                         reasoning_text = reasoning_content.get("text", "")
                         thinking += reasoning_text
                         thinking_delta_value = reasoning_text
@@ -600,7 +599,7 @@ class BedrockConverse(FunctionCallingLLM):
                     blocks: List[Union[TextBlock, ThinkingBlock, ToolCallBlock]] = [
                         TextBlock(text=content.get("text", ""))
                     ]
-                    if thinking != "":
+                    if thinking != "" or thinking_signature != "":
                         blocks.insert(
                             0,
                             ThinkingBlock(
@@ -657,7 +656,7 @@ class BedrockConverse(FunctionCallingLLM):
                     blocks: List[Union[TextBlock, ThinkingBlock, ToolCallBlock]] = [
                         TextBlock(text=content.get("text", ""))
                     ]
-                    if thinking != "":
+                    if thinking != "" or thinking_signature != "":
                         blocks.insert(
                             0,
                             ThinkingBlock(
@@ -704,7 +703,7 @@ class BedrockConverse(FunctionCallingLLM):
                         blocks: List[Union[TextBlock, ThinkingBlock, ToolCallBlock]] = [
                             TextBlock(text=content.get("text", ""))
                         ]
-                        if thinking != "":
+                        if thinking != "" or thinking_signature != "":
                             blocks.insert(
                                 0,
                                 ThinkingBlock(
@@ -850,10 +849,9 @@ class BedrockConverse(FunctionCallingLLM):
                     content = join_two_dicts(content, content_delta)
 
                     thinking_delta_value = None
-                    if "reasoningContent" in content_delta:
+                    if reasoning_content := content_delta.get("reasoningContent"):
                         # For ConverseStream (streaming) requests, reasoning text, signature,
                         # redacted content are stored within `reasoningContent`.
-                        reasoning_content = content_delta.get("reasoningContent", {})
                         reasoning_text = reasoning_content.get("text", "")
                         thinking += reasoning_text
                         thinking_delta_value = reasoning_text
@@ -891,7 +889,7 @@ class BedrockConverse(FunctionCallingLLM):
                     blocks: List[Union[TextBlock, ThinkingBlock, ToolCallBlock]] = [
                         TextBlock(text=content.get("text", ""))
                     ]
-                    if thinking != "":
+                    if thinking != "" or thinking_signature != "":
                         blocks.insert(
                             0,
                             ThinkingBlock(
@@ -949,7 +947,7 @@ class BedrockConverse(FunctionCallingLLM):
                     blocks: List[Union[TextBlock, ThinkingBlock, ToolCallBlock]] = [
                         TextBlock(text=content.get("text", ""))
                     ]
-                    if thinking != "":
+                    if thinking != "" or thinking_signature != "":
                         blocks.insert(
                             0,
                             ThinkingBlock(
@@ -996,7 +994,7 @@ class BedrockConverse(FunctionCallingLLM):
                         blocks: List[Union[TextBlock, ThinkingBlock, ToolCallBlock]] = [
                             TextBlock(text=content.get("text", ""))
                         ]
-                        if thinking != "":
+                        if thinking != "" or thinking_signature != "":
                             blocks.insert(
                                 0,
                                 ThinkingBlock(

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -368,16 +368,14 @@ def _content_block_to_bedrock_format(
             )
             return {"text": block.content}
 
-        if block.content:
+        signature = block.additional_information.get("signature")
+        if block.content or signature:
             thinking_data = {
-                "reasoningContent": {"reasoningText": {"text": block.content}}
+                "reasoningContent": {"reasoningText": {"text": block.content or ""}}
             }
-            if (
-                "signature" in block.additional_information
-                and block.additional_information["signature"]
-            ):
+            if signature:
                 thinking_data["reasoningContent"]["reasoningText"]["signature"] = (
-                    block.additional_information["signature"]
+                    signature
                 )
 
             return thinking_data
@@ -1061,3 +1059,4 @@ def join_two_dicts(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> Dict[str, An
 class ThinkingDict(TypedDict):
     type: Literal["enabled", "adaptive"]
     budget_tokens: NotRequired[int]
+    display: NotRequired[Literal["summarized", "omitted"]]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.16"
+version = "0.15.0"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_thinking_delta.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_thinking_delta.py
@@ -1,12 +1,11 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from llama_index.core.base.llms.types import (
     ChatMessage,
     MessageRole,
-    ThinkingBlock,
     TextBlock,
+    ThinkingBlock,
 )
 from llama_index.llms.bedrock_converse import BedrockConverse
 
@@ -81,6 +80,71 @@ def test_thinking_delta_populated_in_stream_chat(
     assert len(thinking_responses) == 2
     assert thinking_responses[0].additional_kwargs["thinking_delta"] == "Let me think"
     assert thinking_responses[1].additional_kwargs["thinking_delta"] == " about this"
+
+    text_responses = [
+        r
+        for r in responses
+        if r.delta and r.additional_kwargs.get("thinking_delta") is None
+    ]
+    assert len(text_responses) >= 1
+    assert text_responses[0].delta == "The answer is"
+
+
+def test_empty_thinking_delta_populated_in_stream_chat(
+    bedrock_with_thinking, mock_bedrock_client
+):
+    mock_bedrock_client.converse_stream.return_value = {
+        "stream": [
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "reasoningContent": {
+                            "text": "",
+                            "signature": "sig1",
+                        }
+                    },
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "reasoningContent": {
+                            "signature": "sig2",
+                        }
+                    },
+                    "contentBlockIndex": 0,
+                }
+            },
+            {
+                "contentBlockDelta": {
+                    "delta": {"text": "The answer is"},
+                    "contentBlockIndex": 1,
+                }
+            },
+            {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 10,
+                        "outputTokens": 20,
+                        "totalTokens": 30,
+                    }
+                }
+            },
+        ]
+    }
+
+    messages = [ChatMessage(role=MessageRole.USER, content="Test")]
+    responses = list(bedrock_with_thinking.stream_chat(messages))
+
+    assert len(responses) > 0
+
+    thinking_responses = [
+        r for r in responses if r.additional_kwargs.get("thinking_delta") is not None
+    ]
+    assert len(thinking_responses) == 2
+    assert thinking_responses[0].additional_kwargs["thinking_delta"] == ""
+    assert thinking_responses[1].additional_kwargs["thinking_delta"] == ""
 
     text_responses = [
         r
@@ -169,6 +233,83 @@ async def test_thinking_delta_populated_in_astream_chat(
     assert text_responses[0].delta == "The answer is"
 
 
+@pytest.mark.asyncio
+async def test_empty_thinking_delta_populated_in_astream_chat(
+    bedrock_with_thinking, monkeypatch
+):
+    events = [
+        {
+            "contentBlockDelta": {
+                "delta": {
+                    "reasoningContent": {
+                        "text": "",
+                        "signature": "sig1",
+                    }
+                },
+                "contentBlockIndex": 0,
+            }
+        },
+        {
+            "contentBlockDelta": {
+                "delta": {
+                    "reasoningContent": {
+                        "signature": "sig2",
+                    }
+                },
+                "contentBlockIndex": 0,
+            }
+        },
+        {
+            "contentBlockDelta": {
+                "delta": {"text": "The answer is"},
+                "contentBlockIndex": 1,
+            }
+        },
+        {
+            "metadata": {
+                "usage": {
+                    "inputTokens": 10,
+                    "outputTokens": 20,
+                    "totalTokens": 30,
+                }
+            }
+        },
+    ]
+
+    async def _fake_converse_with_retry_async(**_kwargs):
+        async def _gen():
+            for event in events:
+                yield event
+
+        return _gen()
+
+    monkeypatch.setattr(
+        "llama_index.llms.bedrock_converse.base.converse_with_retry_async",
+        _fake_converse_with_retry_async,
+    )
+
+    messages = [ChatMessage(role=MessageRole.USER, content="Test")]
+    response_stream = await bedrock_with_thinking.astream_chat(messages)
+    responses = [r async for r in response_stream]
+
+    assert len(responses) > 0
+
+    thinking_responses = [
+        r for r in responses if r.additional_kwargs.get("thinking_delta") is not None
+    ]
+    assert len(thinking_responses) == 2
+    assert thinking_responses[0].additional_kwargs["thinking_delta"] == ""
+    assert thinking_responses[1].additional_kwargs["thinking_delta"] == ""
+
+    text_responses = [
+        r
+        for r in responses
+        if r.delta and r.additional_kwargs.get("thinking_delta") is None
+    ]
+    assert len(text_responses) >= 1
+    assert text_responses[0].delta == "The answer is"
+
+
 def test_thinking_delta_none_for_non_thinking_content(
     bedrock_with_thinking, mock_bedrock_client
 ):
@@ -207,17 +348,22 @@ def test_thinking_delta_none_for_non_thinking_content(
     )
 
 
-def test_thinking_block_in_message_blocks(bedrock_with_thinking, mock_bedrock_client):
+@pytest.mark.parametrize(
+    "reasoning_content",
+    [
+        {"text": "Thinking content", "signature": "sig"},
+        {"text": "", "signature": "sig"},
+        {"signature": "sig"},
+    ],
+)
+def test_thinking_block_in_message_blocks(
+    bedrock_with_thinking, mock_bedrock_client, reasoning_content: dict[str, str]
+):
     mock_bedrock_client.converse_stream.return_value = {
         "stream": [
             {
                 "contentBlockDelta": {
-                    "delta": {
-                        "reasoningContent": {
-                            "text": "Thinking content",
-                            "signature": "sig",
-                        }
-                    },
+                    "delta": {"reasoningContent": reasoning_content},
                     "contentBlockIndex": 0,
                 }
             },
@@ -243,32 +389,39 @@ def test_thinking_block_in_message_blocks(bedrock_with_thinking, mock_bedrock_cl
     responses = list(bedrock_with_thinking.stream_chat(messages))
 
     final_response = responses[-1]
-    assert len(final_response.message.blocks) >= 2
+    assert len(final_response.message.blocks) == 2
 
     thinking_blocks = [
         b for b in final_response.message.blocks if isinstance(b, ThinkingBlock)
     ]
     assert len(thinking_blocks) == 1
-    assert thinking_blocks[0].content == "Thinking content"
+    assert thinking_blocks[0].content == reasoning_content.get("text", "")
+    assert (
+        thinking_blocks[0].additional_information.get("signature")
+        == reasoning_content["signature"]
+    )
 
     text_blocks = [b for b in final_response.message.blocks if isinstance(b, TextBlock)]
     assert len(text_blocks) >= 1
 
 
-def test_thinking_delta_populated_in_chat(bedrock_with_thinking, mock_bedrock_client):
+@pytest.mark.parametrize(
+    "reasoning_content",
+    [
+        {"text": "I am thinking", "signature": "sig"},
+        {"text": "", "signature": "sig"},
+        {"signature": "sig"},
+    ],
+)
+def test_thinking_delta_populated_in_chat(
+    bedrock_with_thinking, mock_bedrock_client, reasoning_content: dict[str, str]
+):
     mock_bedrock_client.converse.return_value = {
         "output": {
             "message": {
                 "role": "assistant",
                 "content": [
-                    {
-                        "reasoningContent": {
-                            "reasoningText": {
-                                "text": "I am thinking",
-                                "signature": "sig",
-                            }
-                        }
-                    },
+                    {"reasoningContent": {"reasoningText": reasoning_content}},
                     {"text": "The answer is 42"},
                 ],
             }
@@ -286,10 +439,81 @@ def test_thinking_delta_populated_in_chat(bedrock_with_thinking, mock_bedrock_cl
     thinking_block = next(
         b for b in response.message.blocks if isinstance(b, ThinkingBlock)
     )
-    assert thinking_block.content == "I am thinking"
+    assert thinking_block.content == reasoning_content.get("text")
+    assert (
+        thinking_block.additional_information.get("signature")
+        == reasoning_content["signature"]
+    )
 
 
-def test_thinking_block_round_trip(bedrock_with_thinking, mock_bedrock_client):
+@pytest.mark.parametrize(
+    "reasoning_content",
+    [
+        {"text": "I am thinking", "signature": "sig"},
+        {"text": "", "signature": "sig"},
+        {"signature": "sig"},
+    ],
+)
+@pytest.mark.asyncio
+async def test_thinking_delta_populated_in_achat(
+    bedrock_with_thinking,
+    mock_bedrock_client,
+    monkeypatch,
+    reasoning_content: dict[str, str],
+):
+    mock_bedrock_client.converse.return_value = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"reasoningContent": {"reasoningText": reasoning_content}},
+                    {"text": "The answer is 42"},
+                ],
+            }
+        },
+        "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+    }
+
+    async def _fake_converse_with_retry_async(**_kwargs):
+        return {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"reasoningContent": {"reasoningText": reasoning_content}},
+                        {"text": "The answer is 42"},
+                    ],
+                }
+            },
+            "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+        }
+
+    monkeypatch.setattr(
+        "llama_index.llms.bedrock_converse.base.converse_with_retry_async",
+        _fake_converse_with_retry_async,
+    )
+
+    messages = [ChatMessage(role=MessageRole.USER, content="Test")]
+    response = await bedrock_with_thinking.achat(messages)
+
+    # In non-streaming chat, thinking_delta should NOT be in additional_kwargs
+    assert "thinking_delta" not in response.additional_kwargs
+    # But it should be in blocks as a ThinkingBlock
+    assert any(isinstance(b, ThinkingBlock) for b in response.message.blocks)
+    thinking_block = next(
+        b for b in response.message.blocks if isinstance(b, ThinkingBlock)
+    )
+    assert thinking_block.content == reasoning_content.get("text")
+    assert (
+        thinking_block.additional_information.get("signature")
+        == reasoning_content["signature"]
+    )
+
+
+@pytest.mark.parametrize("thinking_content", ["I need to calculate", "", None])
+def test_thinking_block_round_trip(
+    bedrock_with_thinking, mock_bedrock_client, thinking_content: str | None
+):
     from llama_index.llms.bedrock_converse.utils import messages_to_converse_messages
 
     messages = [
@@ -298,7 +522,7 @@ def test_thinking_block_round_trip(bedrock_with_thinking, mock_bedrock_client):
             role=MessageRole.ASSISTANT,
             blocks=[
                 ThinkingBlock(
-                    content="I need to calculate",
+                    content=thinking_content,
                     additional_information={"signature": "sig123"},
                 ),
                 TextBlock(text="It is the meaning of life"),
@@ -314,9 +538,8 @@ def test_thinking_block_round_trip(bedrock_with_thinking, mock_bedrock_client):
     assert assistant_msg["role"] == "assistant"
     assert len(assistant_msg["content"]) == 2
     assert "reasoningContent" in assistant_msg["content"][0]
-    assert (
-        assistant_msg["content"][0]["reasoningContent"]["reasoningText"]["text"]
-        == "I need to calculate"
+    assert assistant_msg["content"][0]["reasoningContent"]["reasoningText"]["text"] == (
+        thinking_content or ""
     )
     assert (
         assistant_msg["content"][0]["reasoningContent"]["reasoningText"]["signature"]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -1935,7 +1935,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.15"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

This PR contains two features:
1. Adds support for controlling **thinking display** (`"summarized"` or `"omitted"`) when using Adaptive/Extended thinking with Claude models, which is needed when working with models like Claude Opus 4.7 that hide thinking text by default via `thinking.display` being set to `"omitted"`
  - https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#controlling-thinking-display
  - https://platform.claude.com/docs/en/build-with-claude/extended-thinking#controlling-thinking-display

> Thinking blocks still appear in the response stream on Claude Opus 4.7, but their thinking field is empty unless you explicitly opt in. This is a silent change from Claude Opus 4.6, where the default was to return summarized thinking text. To restore summarized thinking content on Claude Opus 4.7, set thinking.display to "summarized"

2. Ensures that reasoningContent from Converse/ConverseStream without `text` (but with a `signature`) is captured via `ToolCallBlock` and provided back to Converse/ConverseStream for multi-turn continuity.
  - Converse: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningTextBlock.html
  - ConverseStream: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html

> The display field on the thinking configuration controls how thinking content is returned in API responses. It accepts two values:
>    - "summarized": Thinking blocks contain summarized thinking text. See [Summarized thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#summarized-thinking) for details. This is the default on Claude Opus 4.6, Claude Sonnet 4.6, and earlier Claude 4 models.
>    - "omitted": Thinking blocks are returned with an empty thinking field. **The signature field still carries the encrypted full thinking for multi-turn continuity** (see [Thinking encryption](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#thinking-encryption)). This is the default on Claude Opus 4.7 and [Claude Mythos Preview](https://anthropic.com/glasswing).

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
