### PR TITLE
Avoid evaluating raw SQL rows in RetryGuidelineQueryEngine

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/retry_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/retry_query_engine.py
@@ -19,6 +19,18 @@ from llama_index.core.schema import QueryBundle
 logger = logging.getLogger(__name__)
 
 
+def _get_response_for_guideline_evaluation(response: Response) -> Response:
+    """Return a bounded response for guideline evaluation when SQL is available."""
+    sql_query = response.metadata.get("sql_query") if response.metadata else None
+    if isinstance(sql_query, str) and sql_query.strip():
+        return Response(
+            response=sql_query,
+            source_nodes=response.source_nodes,
+            metadata=response.metadata,
+        )
+    return response
+
+
 class RetryQueryEngine(BaseQueryEngine):
     """
     Does retry on query engine if it fails evaluation.
@@ -123,8 +135,9 @@ class RetryGuidelineQueryEngine(BaseQueryEngine):
         typed_response = (
             response if isinstance(response, Response) else response.get_response()
         )
+        eval_response = _get_response_for_guideline_evaluation(typed_response)
         query_str = query_bundle.query_str
-        eval = self._guideline_evaluator.evaluate_response(query_str, typed_response)
+        eval = self._guideline_evaluator.evaluate_response(query_str, eval_response)
         if eval.passing:
             logger.debug("Evaluation returned True.")
             return response

--- a/llama-index-core/tests/query_engine/test_retry_query_engine.py
+++ b/llama-index-core/tests/query_engine/test_retry_query_engine.py
@@ -1,0 +1,92 @@
+from typing import Any, Optional, Sequence
+
+import pytest
+
+from llama_index.core.base.base_query_engine import BaseQueryEngine
+from llama_index.core.base.response.schema import Response
+from llama_index.core.callbacks.base import CallbackManager
+from llama_index.core.evaluation.base import BaseEvaluator, EvaluationResult
+from llama_index.core.prompts.mixin import PromptDictType, PromptMixinType
+from llama_index.core.query_engine.retry_query_engine import RetryGuidelineQueryEngine
+from llama_index.core.schema import QueryBundle
+
+
+class FakeQueryEngine(BaseQueryEngine):
+    def __init__(self, response: Response) -> None:
+        super().__init__(callback_manager=CallbackManager([]))
+        self._response = response
+
+    def _get_prompt_modules(self) -> PromptMixinType:
+        return {}
+
+    def _query(self, query_bundle: QueryBundle) -> Response:
+        return self._response
+
+    async def _aquery(self, query_bundle: QueryBundle) -> Response:
+        return self._response
+
+
+class RecordingEvaluator(BaseEvaluator):
+    def __init__(self) -> None:
+        self.responses: list[Optional[str]] = []
+
+    def _get_prompts(self) -> PromptDictType:
+        return {}
+
+    def _update_prompts(self, prompts: PromptDictType) -> None:
+        pass
+
+    async def aevaluate(
+        self,
+        query: Optional[str] = None,
+        response: Optional[str] = None,
+        contexts: Optional[Sequence[str]] = None,
+        **kwargs: Any,
+    ) -> EvaluationResult:
+        self.responses.append(response)
+        return EvaluationResult(
+            query=query,
+            response=response,
+            contexts=contexts,
+            passing=True,
+            feedback="ok",
+        )
+
+
+def test_retry_guideline_evaluates_sql_query_metadata_instead_of_raw_rows() -> None:
+    raw_rows = "RAW_ROW\n" * 1000
+    query_engine = FakeQueryEngine(
+        Response(response=raw_rows, metadata={"sql_query": "SELECT id FROM users"})
+    )
+    evaluator = RecordingEvaluator()
+    engine = RetryGuidelineQueryEngine(query_engine, evaluator)
+
+    response = engine.query("show user IDs")
+
+    assert response.response == raw_rows
+    assert evaluator.responses == ["SELECT id FROM users"]
+
+
+def test_retry_guideline_preserves_normal_response_evaluation() -> None:
+    query_engine = FakeQueryEngine(Response(response="normal answer"))
+    evaluator = RecordingEvaluator()
+    engine = RetryGuidelineQueryEngine(query_engine, evaluator)
+
+    engine.query("normal question")
+
+    assert evaluator.responses == ["normal answer"]
+
+
+@pytest.mark.asyncio
+async def test_retry_guideline_async_uses_sql_query_metadata_for_evaluation() -> None:
+    raw_rows = "RAW_ROW\n" * 1000
+    query_engine = FakeQueryEngine(
+        Response(response=raw_rows, metadata={"sql_query": "SELECT id FROM users"})
+    )
+    evaluator = RecordingEvaluator()
+    engine = RetryGuidelineQueryEngine(query_engine, evaluator)
+
+    response = await engine.aquery("show user IDs")
+
+    assert response.response == raw_rows
+    assert evaluator.responses == ["SELECT id FROM users"]


### PR DESCRIPTION
## Summary

Fixes #20300.

When `RetryGuidelineQueryEngine` wraps a SQL query engine with `synthesize_response=False`, the returned `Response.response` can contain raw SQL result rows. Passing that full payload into `GuidelineEvaluator` can create extremely large evaluation/retry prompts.

This change keeps the original query response unchanged, but uses `metadata["sql_query"]` as the guideline evaluation target when it is available.

## Tests

Added focused coverage for:

- SQL responses with `metadata["sql_query"]` use the generated SQL for guideline evaluation instead of raw rows.
- Normal responses without `sql_query` metadata keep the existing behavior.
- Async query path preserves the same SQL metadata behavior.

## Validation

```bash
python -m pytest tests/query_engine/test_retry_query_engine.py -q