### PR TITLE
feat: add GitDealFlow tool spec for engineering acceleration signals

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## [0.1.0]
+
+- Initial release.

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/README.md
@@ -1,0 +1,59 @@
+# GitDealFlow Engineering Signal Tool
+
+This tool connects to the public, no-auth [GitDealFlow](https://signals.gitdealflow.com) API and exposes engineering acceleration signals on venture-backed startups derived from public GitHub data: weekly scores, sector rankings, methodology citations, and grounded free-text Q&A.
+
+The methodology is published on SSRN (id `6606558`) under CC BY 4.0; the dataset covers ~400 tracked startups across 20 sectors and is updated weekly.
+
+## Usage
+
+This tool exposes five spec functions:
+
+- `get_signals_summary` — current weekly summary (trending startups + sector rankings)
+- `get_startup_signal` — single startup's engineering acceleration signal
+- `search_startups_by_sector` — top tracked startups in a sector
+- `answer_question` — free-text question with citations
+- `get_methodology` — published HowTo methodology, for citing in agent output
+
+```python
+from llama_index.tools.gitdealflow import GitDealFlowToolSpec
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+tool_spec = GitDealFlowToolSpec()
+
+agent = FunctionAgent(
+    tools=tool_spec.to_tool_list(),
+    llm=OpenAI(model="gpt-4.1"),
+)
+
+await agent.run(
+    "Which AI/ML startups are accelerating fastest right now?"
+)
+await agent.run(
+    "Compare engineering momentum at langchain and modal-labs."
+)
+await agent.run(
+    "Find dark horses in fintech with breakout signals."
+)
+```
+
+This tool is designed to be used as a way to load engineering-acceleration data into a research agent.
+
+## Configuration
+
+The tool defaults to the public host. Override `base_url` if pointing at a self-hosted mirror or a staging environment:
+
+```python
+GitDealFlowToolSpec(
+    base_url="https://signals.gitdealflow.com",
+    timeout=20,
+)
+```
+
+No API key is required. All endpoints are read-only and unauthenticated.
+
+## License & citation
+
+The underlying dataset is published under CC BY 4.0. Cite as:
+
+> VC Deal Flow Signal (signals.gitdealflow.com), 2026 data. SSRN: 6606558.

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/llama_index/tools/gitdealflow/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/llama_index/tools/gitdealflow/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.gitdealflow.base import GitDealFlowToolSpec
+
+__all__ = ["GitDealFlowToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/llama_index/tools/gitdealflow/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/llama_index/tools/gitdealflow/base.py
@@ -1,0 +1,212 @@
+"""GitDealFlow tool spec."""
+
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
+import requests
+from llama_index.core.schema import Document
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+DEFAULT_BASE_URL = "https://signals.gitdealflow.com"
+DEFAULT_TIMEOUT = 20
+DEFAULT_USER_AGENT = "llama-index-tools-gitdealflow/0.1.0"
+
+
+class GitDealFlowToolSpec(BaseToolSpec):
+    """
+    GitDealFlow tool spec for engineering acceleration signals on
+    venture-backed startups.
+
+    GitDealFlow publishes a public, no-auth read API derived from public
+    GitHub data: weekly engineering acceleration scores across ~400
+    venture-backed startups, ranked across 20 sectors.
+
+    Methodology paper: SSRN 6606558. License: CC BY 4.0.
+
+    All endpoints are GET-only and unauthenticated. Use this tool to:
+      * answer "what's accelerating?" / "find dark horses" questions,
+      * pull a single startup's signal score and history,
+      * compare multiple companies, or
+      * cite the methodology in research output.
+    """
+
+    spec_functions = [
+        "get_signals_summary",
+        "get_startup_signal",
+        "search_startups_by_sector",
+        "answer_question",
+        "get_methodology",
+    ]
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: int = DEFAULT_TIMEOUT,
+        user_agent: str = DEFAULT_USER_AGENT,
+    ) -> None:
+        """
+        Initialize the GitDealFlow tool.
+
+        Args:
+            base_url: API host (default: https://signals.gitdealflow.com).
+            timeout: HTTP timeout in seconds.
+            user_agent: User-Agent header sent with every request.
+
+        """
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.headers = {
+            "Accept": "application/json",
+            "User-Agent": user_agent,
+        }
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        url = f"{self.base_url}{path}"
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        response = requests.get(url, headers=self.headers, timeout=self.timeout)
+        response.raise_for_status()
+        return response.json()
+
+    def get_signals_summary(self) -> List[Document]:
+        """
+        Return the current weekly summary of trending startups and sector
+        rankings.
+
+        Useful starting point for "what's hot right now?" questions.
+
+        Returns:
+            A list with a single Document containing the JSON payload as
+            text. The payload has keys ``meta``, ``trending``, and
+            ``sectors``.
+
+        """
+        data = self._get("/api/v1/signals.json")
+        return [
+            Document(
+                text=str(data),
+                metadata={"source": f"{self.base_url}/api/v1/signals.json"},
+            )
+        ]
+
+    def get_startup_signal(self, company: str) -> List[Document]:
+        """
+        Look up a single startup's engineering acceleration signal.
+
+        Args:
+            company: Company slug or GitHub-org name (e.g. ``langchain``,
+                ``modal-labs``). Lowercase, dash-separated.
+
+        Returns:
+            A list with a single Document. If the company is not tracked,
+            the document text contains a ``status: no_data`` payload with
+            a CTA pointing back to the public dashboard.
+
+        """
+        data = self._get("/api/signal", params={"company": company})
+        return [
+            Document(
+                text=str(data),
+                metadata={
+                    "source": f"{self.base_url}/api/signal?company={company}",
+                    "company": company,
+                },
+            )
+        ]
+
+    def search_startups_by_sector(
+        self, sector: str, limit: int = 10
+    ) -> List[Document]:
+        """
+        List the top tracked startups in a sector by engineering signal.
+
+        Args:
+            sector: Sector slug. One of: ai-ml, fintech, devtools,
+                cybersecurity, climate, healthtech, cleantech, agtech,
+                robotics, web3, gaming, biotech, deeptech, hardware,
+                edtech, legaltech, foodtech, govtech, mobility,
+                logistics.
+            limit: Maximum number of results (default: 10).
+
+        Returns:
+            A list of Documents, one per startup, ordered by signal score
+            desc.
+
+        """
+        data = self._get(f"/api/markets/{sector}")
+        items = []
+        if isinstance(data, dict):
+            items = data.get("startups") or data.get("results") or []
+        elif isinstance(data, list):
+            items = data
+        items = items[:limit]
+        return [
+            Document(
+                text=str(item),
+                metadata={
+                    "source": f"{self.base_url}/api/markets/{sector}",
+                    "sector": sector,
+                },
+            )
+            for item in items
+        ]
+
+    def answer_question(self, question: str) -> List[Document]:
+        """
+        Ask a free-text question against the GitDealFlow corpus.
+
+        The remote ``/api/answer`` endpoint returns a grounded answer
+        with citations to the underlying public dataset.
+
+        Args:
+            question: Natural-language question about startup engineering
+                momentum, sector trends, or a specific tracked company.
+
+        Returns:
+            A list with a single Document containing the answer text and
+            a ``citations`` field in metadata.
+
+        """
+        data = self._get("/api/answer", params={"q": question})
+        text = ""
+        citations: List[Any] = []
+        if isinstance(data, dict):
+            text = data.get("answer") or data.get("text") or str(data)
+            citations = data.get("citations") or []
+        else:
+            text = str(data)
+        return [
+            Document(
+                text=text,
+                metadata={
+                    "source": f"{self.base_url}/api/answer",
+                    "question": question,
+                    "citations": citations,
+                },
+            )
+        ]
+
+    def get_methodology(self) -> List[Document]:
+        """
+        Return the published methodology (HowTo schema) for how
+        engineering acceleration scores are computed.
+
+        Use this when an agent needs to cite or explain the scoring
+        approach in its final answer.
+
+        Returns:
+            A list with a single Document containing the methodology
+            payload as text.
+
+        """
+        data = self._get("/api/v1/methodology.json")
+        return [
+            Document(
+                text=str(data),
+                metadata={
+                    "source": f"{self.base_url}/api/v1/methodology.json",
+                    "license": "CC BY 4.0",
+                    "ssrn": "6606558",
+                },
+            )
+        ]

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-cov>=6.1.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+]
+
+[project]
+name = "llama-index-tools-gitdealflow"
+version = "0.1.0"
+description = "llama-index tools gitdealflow integration"
+authors = [{name = "kindrat86", email = "kindrat86@users.noreply.github.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = [
+    "github",
+    "research",
+    "venture-capital",
+    "startups",
+    "signals",
+]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "requests>=2.28.0",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.gitdealflow"
+
+[tool.llamahub.class_authors]
+GitDealFlowToolSpec = "kindrat86"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/requirements.txt
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/llama-index-integrations/tools/llama-index-tools-gitdealflow/tests/test_tools_gitdealflow.py
+++ b/llama-index-integrations/tools/llama-index-tools-gitdealflow/tests/test_tools_gitdealflow.py
@@ -1,0 +1,39 @@
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.gitdealflow import GitDealFlowToolSpec
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in GitDealFlowToolSpec.__mro__]
+    assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_spec_functions_registered():
+    tool_spec = GitDealFlowToolSpec()
+    assert "get_signals_summary" in tool_spec.spec_functions
+    assert "get_startup_signal" in tool_spec.spec_functions
+    assert "search_startups_by_sector" in tool_spec.spec_functions
+    assert "answer_question" in tool_spec.spec_functions
+    assert "get_methodology" in tool_spec.spec_functions
+
+
+def test_default_base_url():
+    tool_spec = GitDealFlowToolSpec()
+    assert tool_spec.base_url == "https://signals.gitdealflow.com"
+
+
+def test_custom_base_url_strips_trailing_slash():
+    tool_spec = GitDealFlowToolSpec(base_url="https://example.com/")
+    assert tool_spec.base_url == "https://example.com"
+
+
+def test_to_tool_list_has_all_functions():
+    tool_spec = GitDealFlowToolSpec()
+    tools = tool_spec.to_tool_list()
+    names = {t.metadata.name for t in tools}
+    assert names == {
+        "get_signals_summary",
+        "get_startup_signal",
+        "search_startups_by_sector",
+        "answer_question",
+        "get_methodology",
+    }


### PR DESCRIPTION
## Summary

Adds `llama-index-tools-gitdealflow`, a new Tool spec wrapping the public, no-auth [GitDealFlow](https://signals.gitdealflow.com) API. The tool gives a llama-index agent five read-only functions for retrieving engineering acceleration signals on venture-backed startups derived from public GitHub data.

The underlying dataset covers ~400 startups across 20 sectors, refreshes weekly, and is published under CC BY 4.0 (methodology: [SSRN 6606558](https://ssrn.com/abstract=6606558)). All endpoints are unauthenticated, so the tool needs no API key.

## What's in the package

Standard layout, mirrors `llama-index-tools-arxiv`/`llama-index-tools-brave-search`:

- `pyproject.toml` (hatchling, `llama-index-core>=0.13.0,<0.15`, `requests`)
- `llama_index/tools/gitdealflow/{__init__.py,base.py}` — `GitDealFlowToolSpec(BaseToolSpec)` with five spec functions
- `tests/test_tools_gitdealflow.py` — 5 unit tests
- `README.md`, `CHANGELOG.md`, `Makefile`, `LICENSE`, `.gitignore`, `requirements.txt`

## Spec functions

| Function | Purpose |
|---|---|
| `get_signals_summary` | Current weekly summary — trending startups + sector rankings |
| `get_startup_signal(company)` | Single startup engineering acceleration signal |
| `search_startups_by_sector(sector, limit)` | Top tracked startups in a sector |
| `answer_question(question)` | Free-text Q&A with citations |
| `get_methodology` | Published HowTo methodology, for citing in agent output |

## Usage

```python
from llama_index.tools.gitdealflow import GitDealFlowToolSpec
from llama_index.core.agent.workflow import FunctionAgent
from llama_index.llms.openai import OpenAI

tool_spec = GitDealFlowToolSpec()
agent = FunctionAgent(tools=tool_spec.to_tool_list(), llm=OpenAI(model="gpt-4.1"))

await agent.run("Which AI/ML startups are accelerating fastest right now?")
await agent.run("Compare engineering momentum at langchain and modal-labs.")
```

## Verification

Locally on Python 3.13:

```
pip install -e .
pytest tests/  # 5 passed in 0.71s
```

Plus a live smoke against the public API — `get_methodology`, `get_signals_summary`, `get_startup_signal`, `to_tool_list` all return the expected shapes.

## Test plan

- [x] Package installs editable
- [x] Import succeeds: `from llama_index.tools.gitdealflow import GitDealFlowToolSpec`
- [x] All 5 spec functions registered
- [x] `to_tool_list()` returns 5 tools with correct names
- [x] Live API calls return real `Document`s
- [x] 5 unit tests pass