### PR TITLE
Fix/improve embedding error message

### DIFF
--- a/llama-index-core/llama_index/core/embeddings/loading.py
+++ b/llama-index-core/llama_index/core/embeddings/loading.py
@@ -46,8 +46,7 @@ def load_embed_model(data: dict) -> BaseEmbedding:
     if name not in RECOGNIZED_EMBEDDINGS:
         available = ", ".join(sorted(RECOGNIZED_EMBEDDINGS.keys()))
         raise ValueError(
-            f"Invalid Embedding name: {name}. "
-            f"Available embeddings: {available}"
+            f"Invalid Embedding name: {name}. Available embeddings: {available}"
         )
 
     return RECOGNIZED_EMBEDDINGS[name].from_dict(data)

--- a/llama-index-core/llama_index/core/embeddings/loading.py
+++ b/llama-index-core/llama_index/core/embeddings/loading.py
@@ -44,6 +44,10 @@ def load_embed_model(data: dict) -> BaseEmbedding:
     if name is None:
         raise ValueError("Embedding loading requires a class_name")
     if name not in RECOGNIZED_EMBEDDINGS:
-        raise ValueError(f"Invalid Embedding name: {name}")
+        available = ", ".join(sorted(RECOGNIZED_EMBEDDINGS.keys()))
+        raise ValueError(
+            f"Invalid Embedding name: {name}. "
+            f"Available embeddings: {available}"
+        )
 
     return RECOGNIZED_EMBEDDINGS[name].from_dict(data)

--- a/llama-index-core/tests/embeddings/test_loading.py
+++ b/llama-index-core/tests/embeddings/test_loading.py
@@ -1,0 +1,33 @@
+"""Tests for load_embed_model in loading.py"""
+import pytest
+from llama_index.core.embeddings.loading import (
+    RECOGNIZED_EMBEDDINGS,
+    load_embed_model,
+)
+
+
+def test_load_embed_model_missing_class_name():
+    """Raises ValueError when class_name key is absent."""
+    with pytest.raises(ValueError, match="Embedding loading requires a class_name"):
+        load_embed_model({})
+
+
+def test_load_embed_model_invalid_name_shows_available():
+    """Error message for bad name must list available embeddings."""
+    with pytest.raises(ValueError) as exc_info:
+        load_embed_model({"class_name": "NonExistentEmbedding"})
+
+    error_msg = str(exc_info.value)
+    assert "Invalid Embedding name: NonExistentEmbedding" in error_msg
+    assert "Available embeddings:" in error_msg
+    # Every key in the live registry must appear in the message
+    for key in RECOGNIZED_EMBEDDINGS.keys():
+        assert key in error_msg
+
+
+def test_load_embed_model_valid_mock():
+    """MockEmbedding (always present) loads without error."""
+    from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+
+    model = load_embed_model(MockEmbedding(embed_dim=8).to_dict())
+    assert isinstance(model, MockEmbedding)

--- a/llama-index-core/tests/embeddings/test_loading.py
+++ b/llama-index-core/tests/embeddings/test_loading.py
@@ -22,7 +22,7 @@ def test_load_embed_model_invalid_name_shows_available():
     assert "Invalid Embedding name: NonExistentEmbedding" in error_msg
     assert "Available embeddings:" in error_msg
     # Every key in the live registry must appear in the message
-    for key in RECOGNIZED_EMBEDDINGS:
+    for key in sorted(RECOGNIZED_EMBEDDINGS):
         assert key in error_msg
 
 

--- a/llama-index-core/tests/embeddings/test_loading.py
+++ b/llama-index-core/tests/embeddings/test_loading.py
@@ -1,4 +1,5 @@
 """Tests for load_embed_model in loading.py"""
+
 import pytest
 from llama_index.core.embeddings.loading import (
     RECOGNIZED_EMBEDDINGS,
@@ -21,7 +22,7 @@ def test_load_embed_model_invalid_name_shows_available():
     assert "Invalid Embedding name: NonExistentEmbedding" in error_msg
     assert "Available embeddings:" in error_msg
     # Every key in the live registry must appear in the message
-    for key in RECOGNIZED_EMBEDDINGS.keys():
+    for key in RECOGNIZED_EMBEDDINGS:
         assert key in error_msg
 
 


### PR DESCRIPTION
# Description

Improves the developer error message in `load_embed_model` when an
unrecognized embedding name is provided. The error now lists all
available embedding names registered in `RECOGNIZED_EMBEDDINGS`,
making it easier to debug misspelled or outdated embedding class names.

Fixes #21597

## New Package?
- [x] No

## Version Bump?
- [x] No (change is in llama-index-core)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `ruff format` and `ruff check` on all changed files