### PR TITLE
fix(llama-dev): warn on dependant test failures instead of blocking CI

### DIFF
--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -311,7 +311,7 @@ def test(
         if r["status"] in (ResultStatus.TESTS_FAILED, ResultStatus.COVERAGE_FAILED)
         and r["package"] in changed_packages
     ]
-    failed_dependant = [
+    failed_dependent = [
         r["package"].relative_to(repo_root)
         for r in results
         if r["status"] in (ResultStatus.TESTS_FAILED, ResultStatus.COVERAGE_FAILED)
@@ -355,12 +355,12 @@ def test(
         for p in install_failed:
             print(p)
 
-    if failed_dependant:
+    if failed_dependent:
         console.print(
-            f"\n⚠️  {len(failed_dependant)} dependant packages had pre-existing test failures (not caused by this change):",
+            f"\n⚠️  {len(failed_dependent)} dependent packages had pre-existing test failures (not caused by this change):",
             style="warning",
         )
-        for p in failed_dependant:
+        for p in failed_dependent:
             console.print(f"  {p}", style="warning")
 
     if failed_direct:

--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -305,10 +305,17 @@ def test(
                 )
 
     # Print summary
-    failed = [
+    failed_direct = [
         r["package"].relative_to(repo_root)
         for r in results
         if r["status"] in (ResultStatus.TESTS_FAILED, ResultStatus.COVERAGE_FAILED)
+        and r["package"] in changed_packages
+    ]
+    failed_dependant = [
+        r["package"].relative_to(repo_root)
+        for r in results
+        if r["status"] in (ResultStatus.TESTS_FAILED, ResultStatus.COVERAGE_FAILED)
+        and r["package"] not in changed_packages
     ]
     install_failed = [
         r["package"].relative_to(repo_root)
@@ -348,9 +355,17 @@ def test(
         for p in install_failed:
             print(p)
 
-    if failed:
-        console.print(f"\n{len(failed)} packages had test failures:")
-        for p in failed:
+    if failed_dependant:
+        console.print(
+            f"\n⚠️  {len(failed_dependant)} dependant packages had pre-existing test failures (not caused by this change):",
+            style="warning",
+        )
+        for p in failed_dependant:
+            console.print(f"  {p}", style="warning")
+
+    if failed_direct:
+        console.print(f"\n{len(failed_direct)} packages had test failures:")
+        for p in failed_direct:
             console.print(p)
         exit(1)
     else:

--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -77,6 +77,15 @@ def _generate_status_table(
     help="Exit the command at the first failure",
 )
 @click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help=(
+        "Treat dependent package failures as hard failures (exit 1). "
+        "Default: dependent failures are warnings only and do not block."
+    ),
+)
+@click.option(
     "--cov",
     is_flag=True,
     default=False,
@@ -94,6 +103,7 @@ def _generate_status_table(
 def test(
     obj: dict,
     fail_fast: bool,
+    strict: bool,
     cov: bool,
     cov_fail_under: int,
     base_ref: str,
@@ -356,6 +366,14 @@ def test(
             print(p)
 
     if failed_dependent:
+        # Emit a GitHub Actions workflow command so the warning surfaces in
+        # the PR Checks tab even when CI logs are collapsed. Uses plain
+        # `print` (not Rich) so the annotation is parsed regardless of TTY.
+        print(
+            f"::warning::{len(failed_dependent)} dependent packages had "
+            f"pre-existing test failures: "
+            f"{', '.join(str(p) for p in failed_dependent)}"
+        )
         console.print(
             f"\n⚠️  {len(failed_dependent)} dependent packages had pre-existing test failures (not caused by this change):",
             style="warning",
@@ -367,6 +385,12 @@ def test(
         console.print(f"\n{len(failed_direct)} packages had test failures:")
         for p in failed_direct:
             console.print(p)
+        exit(1)
+    elif strict and failed_dependent:
+        console.print(
+            f"\nFailing due to --strict: {len(failed_dependent)} dependent package failures present.",
+            style="red",
+        )
         exit(1)
     else:
         console.print(

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -58,6 +58,36 @@ def mocked_success(*args, **kwargs):
     }
 
 
+def _mocked_dependant_fails(package_path, *args, **kwargs):
+    """Return TESTS_FAILED for 'test_integration', TESTS_PASSED for everything else."""
+    if package_path.name == "test_integration":
+        return {
+            "package": package_path,
+            "status": ResultStatus.TESTS_FAILED,
+            "stdout": "test output",
+            "stderr": "test failures",
+            "time": "0.1s",
+        }
+    return {
+        "package": package_path,
+        "status": ResultStatus.TESTS_PASSED,
+        "stdout": "",
+        "stderr": "",
+        "time": "0.1s",
+    }
+
+
+def _mocked_all_fail(package_path, *args, **kwargs):
+    """Return TESTS_FAILED for any package."""
+    return {
+        "package": package_path,
+        "status": ResultStatus.TESTS_FAILED,
+        "stdout": "test output",
+        "stderr": "test failures",
+        "time": "0.1s",
+    }
+
+
 @pytest.fixture
 def changed_packages():
     return {
@@ -143,9 +173,10 @@ def test_coverage_failures(
     monkeypatch,
     data_path,
 ):
-    mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
-    mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
-    mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
+    test_pkg = data_path / "test_integration"
+    mock_find_all_packages.return_value = {test_pkg}
+    mock_get_changed_files.return_value = {test_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {test_pkg}
     mock_get_dependants.return_value = set()
 
     monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_coverage_failed)
@@ -183,9 +214,10 @@ def test_install_failures(
     monkeypatch,
     data_path,
 ):
-    mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
-    mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
-    mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
+    test_pkg = data_path / "test_integration"
+    mock_find_all_packages.return_value = {test_pkg}
+    mock_get_changed_files.return_value = {test_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {test_pkg}
     mock_get_dependants.return_value = set()
 
     monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_install_failed)
@@ -214,9 +246,10 @@ def test_skip_failures_no_tests(
     monkeypatch,
     data_path,
 ):
-    mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
-    mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
-    mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
+    test_pkg = data_path / "test_integration"
+    mock_find_all_packages.return_value = {test_pkg}
+    mock_get_changed_files.return_value = {test_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {test_pkg}
     mock_get_dependants.return_value = set()
 
     monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_skip_failed_no_tests)
@@ -244,9 +277,10 @@ def test_skip_failures_unsupported_python(
     monkeypatch,
     data_path,
 ):
-    mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
-    mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
-    mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
+    test_pkg = data_path / "test_integration"
+    mock_find_all_packages.return_value = {test_pkg}
+    mock_get_changed_files.return_value = {test_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {test_pkg}
     mock_get_dependants.return_value = set()
 
     monkeypatch.setattr(
@@ -278,9 +312,10 @@ def test_success(
     monkeypatch,
     data_path,
 ):
-    mock_find_all_packages.return_value = {Path("/fake/repo/package1")}
-    mock_get_changed_files.return_value = {Path("/fake/repo/package1/file.py")}
-    mock_get_changed_packages.return_value = {Path("/fake/repo/package1")}
+    test_pkg = data_path / "test_integration"
+    mock_find_all_packages.return_value = {test_pkg}
+    mock_get_changed_files.return_value = {test_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {test_pkg}
     mock_get_dependants.return_value = set()
 
     monkeypatch.setattr(llama_dev_test, "_run_tests", mocked_success)
@@ -496,6 +531,74 @@ def test_coverage_failure(changed_packages, package_data):
 
         assert result["status"] == ResultStatus.COVERAGE_FAILED
         assert result["stderr"] == "coverage below threshold"
+
+
+@mock.patch("llama_dev.test.find_all_packages")
+@mock.patch("llama_dev.test.get_changed_files")
+@mock.patch("llama_dev.test.get_changed_packages")
+@mock.patch("llama_dev.test.get_dependants_packages")
+def test_dependant_failure_is_warning(
+    mock_get_dependants,
+    mock_get_changed_packages,
+    mock_get_changed_files,
+    mock_find_all_packages,
+    monkeypatch,
+    data_path,
+):
+    """Dependant-only test failures should produce a warning, not exit(1)."""
+    direct_pkg = data_path / "direct_pkg"
+    dependant_pkg = data_path / "test_integration"
+
+    mock_find_all_packages.return_value = {direct_pkg, dependant_pkg}
+    mock_get_changed_files.return_value = {direct_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {direct_pkg}
+    mock_get_dependants.return_value = {dependant_pkg}
+
+    monkeypatch.setattr(llama_dev_test, "_run_tests", _mocked_dependant_fails)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--repo-root", data_path, "test", "--base-ref", "main"],
+    )
+
+    assert result.exit_code == 0
+    assert "dependant packages had pre-existing test failures" in result.stdout
+    assert "test_integration" in result.stdout
+
+
+@mock.patch("llama_dev.test.find_all_packages")
+@mock.patch("llama_dev.test.get_changed_files")
+@mock.patch("llama_dev.test.get_changed_packages")
+@mock.patch("llama_dev.test.get_dependants_packages")
+def test_direct_failure_exits_nonzero_with_dependant_failures(
+    mock_get_dependants,
+    mock_get_changed_packages,
+    mock_get_changed_files,
+    mock_find_all_packages,
+    monkeypatch,
+    data_path,
+):
+    """When both direct and dependant packages fail, exit(1) for the direct failure."""
+    direct_pkg = data_path / "direct_pkg"
+    dependant_pkg = data_path / "test_integration"
+
+    mock_find_all_packages.return_value = {direct_pkg, dependant_pkg}
+    mock_get_changed_files.return_value = {direct_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {direct_pkg}
+    mock_get_dependants.return_value = {dependant_pkg}
+
+    monkeypatch.setattr(llama_dev_test, "_run_tests", _mocked_all_fail)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--repo-root", data_path, "test", "--base-ref", "main"],
+    )
+
+    assert result.exit_code == 1
+    assert "1 packages had test failures" in result.stdout
+    assert "dependant packages had pre-existing test failures" in result.stdout
 
 
 def test_successful_run(changed_packages, package_data):

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -88,6 +88,17 @@ def _mocked_all_fail(package_path, *args, **kwargs):
     }
 
 
+def _mocked_all_pass(package_path, *args, **kwargs):
+    """Return TESTS_PASSED for any package."""
+    return {
+        "package": package_path,
+        "status": ResultStatus.TESTS_PASSED,
+        "stdout": "",
+        "stderr": "",
+        "time": "0.1s",
+    }
+
+
 @pytest.fixture
 def changed_packages():
     return {
@@ -565,6 +576,7 @@ def test_dependent_failure_is_warning(
     assert result.exit_code == 0
     assert "dependent packages had pre-existing test failures" in result.stdout
     assert "test_integration" in result.stdout
+    assert "::warning::" in result.stdout
 
 
 @mock.patch("llama_dev.test.find_all_packages")
@@ -599,6 +611,76 @@ def test_direct_failure_exits_nonzero_with_dependent_failures(
     assert result.exit_code == 1
     assert "1 packages had test failures" in result.stdout
     assert "dependent packages had pre-existing test failures" in result.stdout
+    assert "::warning::" in result.stdout
+
+
+@mock.patch("llama_dev.test.find_all_packages")
+@mock.patch("llama_dev.test.get_changed_files")
+@mock.patch("llama_dev.test.get_changed_packages")
+@mock.patch("llama_dev.test.get_dependants_packages")
+def test_dependent_success_no_warning(
+    mock_get_dependants,
+    mock_get_changed_packages,
+    mock_get_changed_files,
+    mock_find_all_packages,
+    monkeypatch,
+    data_path,
+):
+    """When dependent packages all pass, no warning section is emitted."""
+    direct_pkg = data_path / "direct_pkg"
+    dependent_pkg = data_path / "test_integration"
+
+    mock_find_all_packages.return_value = {direct_pkg, dependent_pkg}
+    mock_get_changed_files.return_value = {direct_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {direct_pkg}
+    mock_get_dependants.return_value = {dependent_pkg}
+
+    monkeypatch.setattr(llama_dev_test, "_run_tests", _mocked_all_pass)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--repo-root", data_path, "test", "--base-ref", "main"],
+    )
+
+    assert result.exit_code == 0
+    assert "dependent packages had pre-existing test failures" not in result.stdout
+    assert "::warning::" not in result.stdout
+
+
+@mock.patch("llama_dev.test.find_all_packages")
+@mock.patch("llama_dev.test.get_changed_files")
+@mock.patch("llama_dev.test.get_changed_packages")
+@mock.patch("llama_dev.test.get_dependants_packages")
+def test_strict_flag_exits_nonzero_on_dependent_failures(
+    mock_get_dependants,
+    mock_get_changed_packages,
+    mock_get_changed_files,
+    mock_find_all_packages,
+    monkeypatch,
+    data_path,
+):
+    """With --strict, a dependent-only failure exits 1 instead of warning."""
+    direct_pkg = data_path / "direct_pkg"
+    dependent_pkg = data_path / "test_integration"
+
+    mock_find_all_packages.return_value = {direct_pkg, dependent_pkg}
+    mock_get_changed_files.return_value = {direct_pkg / "file.py"}
+    mock_get_changed_packages.return_value = {direct_pkg}
+    mock_get_dependants.return_value = {dependent_pkg}
+
+    monkeypatch.setattr(llama_dev_test, "_run_tests", _mocked_dependent_fails)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--repo-root", data_path, "test", "--strict", "--base-ref", "main"],
+    )
+
+    assert result.exit_code == 1
+    assert "dependent packages had pre-existing test failures" in result.stdout
+    assert "Failing due to --strict" in result.stdout
+    assert "::warning::" in result.stdout
 
 
 def test_successful_run(changed_packages, package_data):

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -58,7 +58,7 @@ def mocked_success(*args, **kwargs):
     }
 
 
-def _mocked_dependant_fails(package_path, *args, **kwargs):
+def _mocked_dependent_fails(package_path, *args, **kwargs):
     """Return TESTS_FAILED for 'test_integration', TESTS_PASSED for everything else."""
     if package_path.name == "test_integration":
         return {
@@ -537,7 +537,7 @@ def test_coverage_failure(changed_packages, package_data):
 @mock.patch("llama_dev.test.get_changed_files")
 @mock.patch("llama_dev.test.get_changed_packages")
 @mock.patch("llama_dev.test.get_dependants_packages")
-def test_dependant_failure_is_warning(
+def test_dependent_failure_is_warning(
     mock_get_dependants,
     mock_get_changed_packages,
     mock_get_changed_files,
@@ -545,16 +545,16 @@ def test_dependant_failure_is_warning(
     monkeypatch,
     data_path,
 ):
-    """Dependant-only test failures should produce a warning, not exit(1)."""
+    """Dependent-only test failures should produce a warning, not exit(1)."""
     direct_pkg = data_path / "direct_pkg"
-    dependant_pkg = data_path / "test_integration"
+    dependent_pkg = data_path / "test_integration"
 
-    mock_find_all_packages.return_value = {direct_pkg, dependant_pkg}
+    mock_find_all_packages.return_value = {direct_pkg, dependent_pkg}
     mock_get_changed_files.return_value = {direct_pkg / "file.py"}
     mock_get_changed_packages.return_value = {direct_pkg}
-    mock_get_dependants.return_value = {dependant_pkg}
+    mock_get_dependants.return_value = {dependent_pkg}
 
-    monkeypatch.setattr(llama_dev_test, "_run_tests", _mocked_dependant_fails)
+    monkeypatch.setattr(llama_dev_test, "_run_tests", _mocked_dependent_fails)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -563,7 +563,7 @@ def test_dependant_failure_is_warning(
     )
 
     assert result.exit_code == 0
-    assert "dependant packages had pre-existing test failures" in result.stdout
+    assert "dependent packages had pre-existing test failures" in result.stdout
     assert "test_integration" in result.stdout
 
 
@@ -571,7 +571,7 @@ def test_dependant_failure_is_warning(
 @mock.patch("llama_dev.test.get_changed_files")
 @mock.patch("llama_dev.test.get_changed_packages")
 @mock.patch("llama_dev.test.get_dependants_packages")
-def test_direct_failure_exits_nonzero_with_dependant_failures(
+def test_direct_failure_exits_nonzero_with_dependent_failures(
     mock_get_dependants,
     mock_get_changed_packages,
     mock_get_changed_files,
@@ -579,14 +579,14 @@ def test_direct_failure_exits_nonzero_with_dependant_failures(
     monkeypatch,
     data_path,
 ):
-    """When both direct and dependant packages fail, exit(1) for the direct failure."""
+    """When both direct and dependent packages fail, exit(1) for the direct failure."""
     direct_pkg = data_path / "direct_pkg"
-    dependant_pkg = data_path / "test_integration"
+    dependent_pkg = data_path / "test_integration"
 
-    mock_find_all_packages.return_value = {direct_pkg, dependant_pkg}
+    mock_find_all_packages.return_value = {direct_pkg, dependent_pkg}
     mock_get_changed_files.return_value = {direct_pkg / "file.py"}
     mock_get_changed_packages.return_value = {direct_pkg}
-    mock_get_dependants.return_value = {dependant_pkg}
+    mock_get_dependants.return_value = {dependent_pkg}
 
     monkeypatch.setattr(llama_dev_test, "_run_tests", _mocked_all_fail)
 
@@ -598,7 +598,7 @@ def test_direct_failure_exits_nonzero_with_dependant_failures(
 
     assert result.exit_code == 1
     assert "1 packages had test failures" in result.stdout
-    assert "dependant packages had pre-existing test failures" in result.stdout
+    assert "dependent packages had pre-existing test failures" in result.stdout
 
 
 def test_successful_run(changed_packages, package_data):


### PR DESCRIPTION
# Description

Fixes #21607.

Pre-existing broken tests in dependent packages were causing the `Unit Testing / test (3.10|3.11|3.12)` matrix to fail on every PR that touched `llama-index-core` — because `llama-dev test` computes the dependent packages of changed packages and tests them too. Any PR that changed core inherited ~23 broken integration test failures it couldn't fix, making it impossible to get a green CI signal.

This PR implements **Option 2** from the issue: distinguish between failures in directly-changed packages (hard failures) and failures in dependent-only packages (warnings by default, hard failures with `--strict`). Only direct failures cause `exit(1)` in the default mode.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No (not a new package)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No (`llama-dev` package — internal tooling, no version bump needed per repo policy)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

### Test commands and results

```
cd llama-dev
uv run -- pytest tests/test/test_test.py -v
# 24 passed in ~30s
```

```
uv run -- ruff check llama_dev/test/__init__.py tests/test/test_test.py
uv run -- ruff format --check llama_dev/test/__init__.py tests/test/test_test.py
# All checks pass; files already formatted.
```

```
uvx codespell --toml pyproject.toml llama-dev/llama_dev/test/__init__.py llama-dev/tests/test/test_test.py
# clean
```

## Changes

### `llama-dev/llama_dev/test/__init__.py`

- Split the failed list into `failed_direct` (packages whose path is in `changed_packages`) and `failed_dependent` (everything else that failed). `exit(1)` only fires when `failed_direct` is non-empty.
- Dependent failures print a `⚠️` warning section listing the affected packages but do not block CI by default.
- New `--strict` CLI flag restores the old "any failure → exit 1" contract. With `--strict`, dependent-only failures also cause `exit(1)` and a `Failing due to --strict` message prints. Default remains the new lenient behavior.
- The warning section also emits a GitHub Actions `::warning::` workflow command so dependent-package regressions surface in the PR Checks tab, not only in the collapsed CI test log.

### `llama-dev/tests/test/test_test.py`

- **Fixed 5 pre-existing broken tests** (`test_coverage_failures`, `test_install_failures`, `test_skip_failures_no_tests`, `test_skip_failures_unsupported_python`, `test_success`) — they used `Path("/fake/repo/package1")` for `changed_packages` while the mock returned `data_path / "test_integration"`, causing `Path.relative_to()` to raise a `ValueError` in the progress display loop.
- **Added 4 new tests:**
  - `test_dependent_failure_is_warning` — when only a dependent package fails, `exit_code == 0`, the warning message appears, and a `::warning::` annotation is emitted.
  - `test_direct_failure_exits_nonzero_with_dependent_failures` — when both a direct and a dependent package fail, `exit_code == 1` and both sections appear in the output.
  - `test_dependent_success_no_warning` — when dependents are present and all packages pass, no warning section or `::warning::` annotation is emitted.
  - `test_strict_flag_exits_nonzero_on_dependent_failures` — with `--strict`, a dependent-only failure exits 1 and the strict-mode message is printed.

## Risks

- **Visibility**: Pre-existing failures in dependent packages are still printed and visible in CI — both as a `⚠️` warning section in stdout and as a GitHub Actions `::warning::` annotation in the PR Checks tab. Regressions introduced by a PR in a dependent package will still appear in the warning section — they won't be missed, just won't block the PR by default.
- **Contract change**: The default exit-code behavior changes from "any failure → exit 1" to "direct failure → exit 1". Callers that depended on the old contract (e.g., release-validation pipelines) can pass `--strict` to restore it.
- **Backward compatibility**: No change to existing CLI flags or public API. `--fail-fast`, explicit package names, `--cov`, `--cov-fail-under`, `--base-ref`, `--workers` all work unchanged. The new `--strict` flag is opt-in.
- **Scope**: No changes to workflow YAML, no skip-list file to maintain.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run -- ruff check` and `uvx codespell` to satisfy lint (pre-commit `lint` job in CI is green)
