### PR TITLE
fix(evaluation): close file handles in HotpotQA evaluation benchmark

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
+++ b/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
@@ -35,18 +35,20 @@ class HotpotQAEvaluator:
             url = DEV_DISTRACTOR_URL
             try:
                 os.makedirs(dataset_full_path, exist_ok=True)
-                save_file = open(
-                    os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
-                )
                 response = requests.get(url, stream=True)
 
                 # Define the size of each chunk
                 chunk_size = 1024
 
                 # Loop over the chunks and parse the JSON data
-                for chunk in tqdm.tqdm(response.iter_content(chunk_size=chunk_size)):
-                    if chunk:
-                        save_file.write(chunk)
+                with open(
+                    os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
+                ) as save_file:
+                    for chunk in tqdm.tqdm(
+                        response.iter_content(chunk_size=chunk_size)
+                    ):
+                        if chunk:
+                            save_file.write(chunk)
             except Exception as e:
                 if os.path.exists(dataset_full_path):
                     print(
@@ -71,8 +73,8 @@ class HotpotQAEvaluator:
         print("Evaluating on dataset:", dataset)
         print("-------------------------------------")
 
-        f = open(dataset_path)
-        query_objects = json.loads(f.read())
+        with open(dataset_path) as f:
+            query_objects = json.loads(f.read())
         if queries_fraction:
             queries_to_load = int(len(query_objects) * queries_fraction)
         else:


### PR DESCRIPTION
## Summary

Fixes resource leaks in the HotpotQA evaluation benchmark by properly closing file handles using context managers.

**Issue**: #21610

## Changes

- Wrap file download handle in `with` statement (line 37-50)
- Wrap dataset file handle in `with` statement (line 74)

## Impact

File descriptors are now properly released even if exceptions occur during download or parsing, preventing file descriptor exhaustion in long-running processes.

## Test Plan

- ✅ Syntax validation: Python compiles successfully
- ✅ Module import: HotpotQAEvaluator class imports without errors
- ✅ Pre-commit hooks: All checks pass (formatting, linting, type checking)