### PR TITLE
fix: redact OpenAI API keys from serialization

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/base.py
@@ -239,7 +239,7 @@ class OpenAIEmbedding(BaseEmbedding):
         default_factory=dict, description="Additional kwargs for the OpenAI API."
     )
 
-    api_key: str = Field(description="The OpenAI API key.")
+    api_key: str = Field(description="The OpenAI API key.", exclude=True, repr=False)
     api_base: Optional[str] = Field(
         default=DEFAULT_OPENAI_API_BASE, description="The base URL for OpenAI API."
     )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/tests/test_embeddings_openai.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/tests/test_embeddings_openai.py
@@ -10,6 +10,14 @@ def test_openai_embedding_class():
     assert BaseEmbedding.__name__ in names_of_base_classes
 
 
+def test_openai_embedding_api_key_is_redacted_from_serialization():
+    secret = "sk-" + ("a" * 48)
+    embedding = OpenAIEmbedding(api_key=secret)
+
+    assert "api_key" not in embedding.model_dump()
+    assert secret not in repr(embedding)
+
+
 @pytest.fixture()
 def embedding_instance():
     """Fixture for creating an OpenAIEmbedding instance."""

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -226,7 +226,9 @@ class OpenAI(FunctionCallingLLM):
         ),
     )
 
-    api_key: Optional[str] = Field(default=None, description="The OpenAI API key.")
+    api_key: Optional[str] = Field(
+        default=None, description="The OpenAI API key.", exclude=True, repr=False
+    )
     api_base: Optional[str] = Field(
         default=None, description="The base URL for OpenAI API."
     )

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -262,7 +262,9 @@ class OpenAIResponses(FunctionCallingLLM):
     default_headers: Optional[Dict[str, str]] = Field(
         default=None, description="The default headers for API requests."
     )
-    api_key: Optional[str] = Field(default=None, description="The OpenAI API key.")
+    api_key: Optional[str] = Field(
+        default=None, description="The OpenAI API key.", exclude=True, repr=False
+    )
     api_base: str = Field(description="The base URL for OpenAI API.")
     api_version: str = Field(description="The API version for OpenAI API.")
     context_window: Optional[int] = Field(

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
@@ -429,6 +429,14 @@ def test_validates_api_key_is_present() -> None:
         assert OpenAI(api_key="sk-" + ("a" * 48))
 
 
+def test_openai_api_key_is_redacted_from_serialization() -> None:
+    secret = "sk-" + ("a" * 48)
+    llm = OpenAI(api_key=secret)
+
+    assert "api_key" not in llm.model_dump()
+    assert secret not in repr(llm)
+
+
 @patch("llama_index.llms.openai.base.SyncOpenAI")
 def test_completion_model_with_retry(MockSyncOpenAI: MagicMock) -> None:
     mock_instance = MockSyncOpenAI.return_value

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -64,6 +64,17 @@ def test_init_and_properties(default_responses_llm):
     assert metadata.is_chat_model is True
 
 
+def test_openai_responses_api_key_is_redacted_from_serialization():
+    """Test API key is not exposed through model serialization or repr."""
+    secret = "sk-" + ("a" * 48)
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            llm = OpenAIResponses(api_key=secret)
+
+    assert "api_key" not in llm.model_dump()
+    assert secret not in repr(llm)
+
+
 def test_get_model_name():
     """Test different model name formats are properly handled."""
     with patch("llama_index.llms.openai.responses.SyncOpenAI"):


### PR DESCRIPTION
## Summary
- prevent OpenAI API keys from appearing in Pydantic serialization for OpenAI LLM, OpenAI Responses, and OpenAI embedding classes
- hide those API key fields from object repr output
- add regression coverage for all three affected classes

## Security impact
The OpenAI integrations keep API credentials on model fields so the clients can be constructed lazily. Before this change, common serialization and logging paths such as model_dump() and repr() included the raw api_key value, which could expose credentials in application logs, debugging output, or persisted configuration snapshots. This is a low-severity credential exposure hardening fix, related to CWE-532 / CWE-200.

The API key is still retained internally and passed to the OpenAI client via _get_credential_kwargs(); only public serialization and repr output are redacted.

## Tests
- cd llama-index-integrations/llms/llama-index-llms-openai && ../../../.venv/bin/python -m pytest tests/test_openai.py::test_validates_api_key_is_present tests/test_openai.py::test_openai_api_key_is_redacted_from_serialization tests/test_openai_responses.py::test_openai_responses_api_key_is_redacted_from_serialization
- cd llama-index-integrations/embeddings/llama-index-embeddings-openai && ../../../.venv/bin/python -m pytest tests/test_embeddings_openai.py::test_openai_embedding_api_key_is_redacted_from_serialization