### PR TITLE
fix(core): preserve IndexNode obj metadata serialization

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/utils.py
+++ b/llama-index-core/llama_index/core/vector_stores/utils.py
@@ -47,7 +47,10 @@ def node_to_metadata_dict(
     """Common logic for saving Node data into metadata dict."""
     # Using mode="json" here because BaseNode may have fields of type bytes (e.g. images in ImageBlock),
     # which would cause serialization issues.
-    node_dict = node.model_dump(mode="json")
+    if isinstance(node, IndexNode):
+        node_dict = node.dict(mode="json")
+    else:
+        node_dict = node.model_dump(mode="json")
     metadata: Dict[str, Any] = node_dict.get("metadata", {})
 
     if flat_metadata:

--- a/llama-index-core/tests/vector_stores/test_utils.py
+++ b/llama-index-core/tests/vector_stores/test_utils.py
@@ -80,6 +80,24 @@ def test_index_node_serdes(index_node: IndexNode):
     assert deserialized_node.index_id == index_node.index_id
 
 
+def test_index_node_with_obj_node_serdes():
+    obj_node = TextNode(id_="obj_node", text="Object node text")
+    index_node = IndexNode(
+        id_="index_node_with_obj",
+        text="Index node text",
+        index_id="123",
+        obj=obj_node,
+    )
+
+    serialized_node = node_to_metadata_dict(index_node)
+    deserialized_node = metadata_dict_to_node(serialized_node)
+
+    assert isinstance(deserialized_node, IndexNode)
+    assert isinstance(deserialized_node.obj, TextNode)
+    assert deserialized_node.obj.node_id == obj_node.node_id
+    assert deserialized_node.obj.text == obj_node.text
+
+
 def test_multimedia_node_serdes(multimedia_node: Node):
     serialized_node: dict[str, Any] = node_to_metadata_dict(multimedia_node)
     assert "multimedia_node" in serialized_node["_node_content"]


### PR DESCRIPTION
# Description

Fixes #21611.

This PR fixes an `IndexNode.obj` metadata serialization round-trip issue in `node_to_metadata_dict()`.

`IndexNode` has custom `dict()` serialization behavior for `obj`, which wraps node objects through the existing document serialization path. The generic `model_dump(mode="json")` path bypasses that custom behavior, causing `metadata_dict_to_node()` to deserialize the object incorrectly.

This change preserves the existing `IndexNode.dict(mode="json")` path only for `IndexNode`, while keeping `model_dump(mode="json")` for all other node types.

No new dependencies are required.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Validation run locally:

- `cd llama-index-core && uv run -- pytest tests/vector_stores/test_utils.py -k index_node_with_obj_node_serdes`
  - Failed before the fix, then passed after the fix: 1 passed, 5 deselected
- `cd llama-index-core && uv run -- pytest tests -k "metadata_dict_to_node or node_to_metadata_dict or indexnode"`
  - Passed: 1 passed, 1384 deselected
- `cd llama-index-core && uv run -- pytest tests/vector_stores/test_utils.py`
  - Passed: 6 passed
- `cd llama-index-core && uv run -- pytest tests`
  - Passed: 1358 passed, 22 skipped, 5 xfailed
- `uv run make lint`
  - Passed
- `git diff --check`
  - Passed

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods