### PR TITLE
fix(core): avoid blocking event loop in async rate limiters

### DIFF
--- a/llama-index-core/llama_index/core/rate_limiter.py
+++ b/llama-index-core/llama_index/core/rate_limiter.py
@@ -206,12 +206,15 @@ class TokenBucketRateLimiter(BaseRateLimiter, BaseModel):
 
         """
         while True:
-            with self._lock:
+            await asyncio.to_thread(self._lock.acquire)
+            try:
                 self._refill()
                 wait = self._wait_time(num_tokens)
                 if wait <= 0:
                     self._consume(num_tokens)
                     return
+            finally:
+                self._lock.release()
             await asyncio.sleep(wait)
 
 
@@ -388,13 +391,16 @@ class SlidingWindowRateLimiter(BaseRateLimiter, BaseModel):
         """
         while True:
             now = time.monotonic()
-            with self._lock:
+            await asyncio.to_thread(self._lock.acquire)
+            try:
                 self._prune_request_timestamps(now)
                 self._prune_token_usage(now)
                 wait = self._wait_time(now, num_tokens)
                 if wait <= 0:
                     self._record_usage(now, num_tokens)
                     return
+            finally:
+                self._lock.release()
             await asyncio.sleep(wait)
 
 

--- a/llama-index-core/tests/test_rate_limiter.py
+++ b/llama-index-core/tests/test_rate_limiter.py
@@ -1,6 +1,7 @@
 """Tests for the rate limiter module."""
 
 import asyncio
+import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +15,46 @@ from llama_index.core.rate_limiter import (
     SlidingWindowRateLimiter,
     TokenBucketRateLimiter,
 )
+
+
+async def _assert_async_acquire_does_not_block_on_sync_lock(
+    limiter: TokenBucketRateLimiter | SlidingWindowRateLimiter,
+) -> None:
+    """Regression coverage for async paths avoiding the threading lock."""
+    limiter._lock.acquire()
+    cancel_unlock = threading.Event()
+
+    def unlock_later() -> None:
+        if cancel_unlock.wait(timeout=0.5):
+            return
+        try:
+            limiter._lock.release()
+        except RuntimeError:
+            pass
+
+    unlock_thread = threading.Thread(target=unlock_later)
+    unlock_thread.start()
+    acquire_task = asyncio.create_task(limiter.async_acquire())
+    start = time.monotonic()
+    heartbeat_ticks = 0
+
+    async def heartbeat() -> None:
+        nonlocal heartbeat_ticks
+        while time.monotonic() - start < 0.1:
+            heartbeat_ticks += 1
+            await asyncio.sleep(0.01)
+
+    try:
+        await heartbeat()
+        assert heartbeat_ticks > 1
+        assert time.monotonic() - start < 0.4
+        assert not acquire_task.done()
+    finally:
+        cancel_unlock.set()
+        if limiter._lock.locked():
+            limiter._lock.release()
+        unlock_thread.join(timeout=1.0)
+    await asyncio.wait_for(acquire_task, timeout=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -153,15 +194,13 @@ async def test_async_acquire_tpm_limiting() -> None:
             "llama_index.core.rate_limiter.asyncio.sleep",
             new_callable=AsyncMock,
         ) as mock_sleep,
-        patch("llama_index.core.rate_limiter.time.monotonic") as mock_time,
     ):
-        base = 1000.0
-        # Align internal clock with mock timeline
-        rl._last_refill_time = base
+
+        async def advance_time(_wait: float) -> None:
+            rl._last_refill_time = time.monotonic() - 60.0
+
         rl._token_tokens = 0.0
-        # First monotonic(): no elapsed time, need 50 tokens but 0 available -> sleep
-        # Second monotonic(): 60s elapsed -> refills 100 tokens -> acquire succeeds
-        mock_time.side_effect = [base, base + 60.0]
+        mock_sleep.side_effect = advance_time
         await rl.async_acquire(num_tokens=50)
         mock_sleep.assert_called_once()
 
@@ -179,6 +218,12 @@ async def test_concurrent_async_rate_limiting() -> None:
     tasks = [worker(i) for i in range(20)]
     await asyncio.gather(*tasks)
     assert len(results) == 20
+
+
+@pytest.mark.asyncio
+async def test_async_acquire_does_not_block_on_sync_lock() -> None:
+    rl = RateLimiter(requests_per_minute=1000)
+    await _assert_async_acquire_does_not_block_on_sync_lock(rl)
 
 
 # ---------------------------------------------------------------------------
@@ -468,6 +513,12 @@ async def test_sliding_window_concurrent_async() -> None:
     tasks = [worker(i) for i in range(25)]
     await asyncio.gather(*tasks)
     assert len(results) == 25
+
+
+@pytest.mark.asyncio
+async def test_sliding_window_async_acquire_does_not_block_on_sync_lock() -> None:
+    rl = SlidingWindowRateLimiter(requests_per_minute=1000)
+    await _assert_async_acquire_does_not_block_on_sync_lock(rl)
 
 
 def test_sliding_window_llm_sync_calls_acquire() -> None:


### PR DESCRIPTION
# Description

Fixes #21603.

This PR updates the async acquisition paths for the core rate limiters so they no longer call blocking `threading.Lock.acquire()` directly on the asyncio event loop.

The synchronous `acquire()` methods continue using the existing shared `_lock`. The asynchronous `async_acquire()` methods now acquire that same lock through `asyncio.to_thread(...)`, preserving shared-state protection between sync and async callers while avoiding direct event-loop blocking.

No new dependencies are required.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Validation run locally:

- `cd llama-index-core && uv run -- pytest tests/test_rate_limiter.py`
  - Passed: 47 passed
- `cd llama-index-core && uv run -- pytest tests -k rate_limiter`
  - Passed: 47 passed, 1339 deselected
- `cd llama-index-core && uv run --frozen -- pytest tests`
  - Passed: 1359 passed, 22 skipped, 5 xfailed
- `uv run --frozen make lint`
  - Passed
- `git diff --check`
  - Passed

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods