### PR TITLE
fix(core): close file handles in HotpotQA evaluation benchmark

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
+++ b/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
@@ -35,18 +35,20 @@ class HotpotQAEvaluator:
             url = DEV_DISTRACTOR_URL
             try:
                 os.makedirs(dataset_full_path, exist_ok=True)
-                save_file = open(
-                    os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
-                )
-                response = requests.get(url, stream=True)
-
-                # Define the size of each chunk
-                chunk_size = 1024
-
-                # Loop over the chunks and parse the JSON data
-                for chunk in tqdm.tqdm(response.iter_content(chunk_size=chunk_size)):
-                    if chunk:
-                        save_file.write(chunk)
+                # Use context managers so the file handle and HTTP connection
+                # are always released, even if the download is interrupted.
+                with (
+                    open(
+                        os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
+                    ) as save_file,
+                    requests.get(url, stream=True) as response,
+                ):
+                    chunk_size = 1024
+                    for chunk in tqdm.tqdm(
+                        response.iter_content(chunk_size=chunk_size)
+                    ):
+                        if chunk:
+                            save_file.write(chunk)
             except Exception as e:
                 if os.path.exists(dataset_full_path):
                     print(
@@ -71,8 +73,8 @@ class HotpotQAEvaluator:
         print("Evaluating on dataset:", dataset)
         print("-------------------------------------")
 
-        f = open(dataset_path)
-        query_objects = json.loads(f.read())
+        with open(dataset_path) as f:
+            query_objects = json.load(f)
         if queries_fraction:
             queries_to_load = int(len(query_objects) * queries_fraction)
         else:


### PR DESCRIPTION
## Summary

Closes #21610.

Fixes two file-handle leaks (plus one HTTP connection leak) in `llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py`:

1. **`_download_datasets`** (line 38): `save_file = open(...)` had no matching `close()`. If the chunked download raised, the descriptor leaked. The streaming `requests.get(..., stream=True)` response was likewise never explicitly closed.
2. **`run`** (line 74): `f = open(dataset_path)` was never closed.

## Changes

- Wrapped the download in a parenthesized `with` block holding both the destination file and the streaming `Response`.
- Wrapped the dataset read in a `with` block.
- Drive-by: replaced `json.loads(f.read())` with `json.load(f)` (one less full-file string allocation).

## Test plan

- [x] AST parse clean
- [x] `ruff check` clean (locally)
- [x] `ruff format --check` clean (locally)
- [ ] HotpotQA download still works end-to-end (skipped locally — would re-download a public dataset; happy to run if reviewer requests)

## Notes

Followed the plan I posted in #21610. Used Python 3.10+ parenthesized `with` syntax (matches `requires-python = ">=3.10"` in `llama-index-core/pyproject.toml`).
