### PR TITLE
docs: add naxytra discovery note

### DIFF
--- a/docs/src/content/docs/framework/community/integrations.md
+++ b/docs/src/content/docs/framework/community/integrations.md
@@ -19,6 +19,7 @@ The full set of data loaders are found on [LlamaHub](https://llamahub.ai/)
 The full set of agent tools are found on [LlamaHub](https://llamahub.ai/)
 
 - [MCP Toolbox](/python/examples/tools/mcp_toolbox)
+- [naxytra machine discovery agent](https://www.naxytra.com/v1/agent-discovery-index) - public discovery entry for a live MCP server and A2A card
 
 ## LLMs
 


### PR DESCRIPTION
## Summary
- Adds a public MCP discovery note to the LlamaIndex community integrations page.
- Points readers to the canonical naxytra discovery index, A2A card, and live MCP endpoint.

## Why
- LlamaIndex users looking for community MCP examples should have a concrete public reference.
- This keeps the community integrations page aligned with the live public entry surfaces without exposing private code.

## Links
- https://www.naxytra.com/v1/agent-discovery-index
- https://www.naxytra.com/.well-known/agent.json
- https://xytara-mcp-executor.onrender.com/mcp
