### PR TITLE
fix(sharepoint): list_resources respects sharepoint_folder_id when no path is given

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -825,12 +825,20 @@ class SharePointReader(
             )
             self._drive_id = self._get_drive_id()
 
-            if sharepoint_folder_path:
-                if not sharepoint_folder_id:
-                    sharepoint_folder_id = self._get_sharepoint_folder_id(
-                        sharepoint_folder_path
-                    )
-                # Fetch folder contents
+            if sharepoint_folder_id:
+                # folder_id is authoritative; resolve from path only when absent
+                folder_contents = self._list_folder_contents(
+                    sharepoint_folder_id,
+                    recursive,
+                    os.path.join(
+                        sharepoint_site_name, sharepoint_folder_path or ""
+                    ),
+                )
+                file_paths.extend(folder_contents)
+            elif sharepoint_folder_path:
+                sharepoint_folder_id = self._get_sharepoint_folder_id(
+                    sharepoint_folder_path
+                )
                 folder_contents = self._list_folder_contents(
                     sharepoint_folder_id,
                     recursive,


### PR DESCRIPTION
Fixes #19764.

`SharePointReader.list_resources()` documents that `sharepoint_folder_id` overrides `sharepoint_folder_path`, but the implementation did the opposite. The outer conditional was:

```python
if sharepoint_folder_path:
    ...   # only path enters here
else:
    # drive root — reached even when folder_id was provided
    drive_contents = self._list_drive_contents()
```

So passing only a folder ID — a perfectly reasonable thing to do when the folder ID is stable and known — caused the reader to silently list the entire drive root instead of the intended folder. Users got wrong or empty results with no error to explain why.

The fix reorders the priority to match the documented contract: check `sharepoint_folder_id` first (it is authoritative), resolve an ID from `sharepoint_folder_path` when only a path is supplied, and fall back to the drive root only when neither is provided. The `folder_path or ""` guard keeps the display path argument valid for the ID-only case.

```python
if sharepoint_folder_id:
    # folder_id is authoritative; resolve from path only when absent
    folder_contents = self._list_folder_contents(
        sharepoint_folder_id,
        recursive,
        os.path.join(sharepoint_site_name, sharepoint_folder_path or ""),
    )
    file_paths.extend(folder_contents)
elif sharepoint_folder_path:
    sharepoint_folder_id = self._get_sharepoint_folder_id(sharepoint_folder_path)
    folder_contents = self._list_folder_contents(
        sharepoint_folder_id,
        recursive,
        os.path.join(sharepoint_site_name, sharepoint_folder_path),
    )
    file_paths.extend(folder_contents)
else:
    drive_contents = self._list_drive_contents()
    file_paths.extend(drive_contents)
```

The change is limited to `list_resources`; the analogous code in `_download_files_from_sharepoint` already had the correct `if not sharepoint_folder_id and sharepoint_folder_path:` guard (line 582) and is unaffected.