### PR TITLE
Block dunder access via str.format field paths in evaporate sandbox

### DIFF
--- a/llama-index-integrations/program/llama-index-program-evaporate/llama_index/program/evaporate/extractor.py
+++ b/llama-index-integrations/program/llama-index-program-evaporate/llama_index/program/evaporate/extractor.py
@@ -157,6 +157,40 @@ _SANDBOX_ALLOWED_IMPORTS = {
 }
 
 
+def _format_string_has_dunder_field(format_string: str) -> bool:
+    """
+    Return True if ``format_string`` references a dunder attribute via a
+    field-path expression such as ``{0.__class__.__bases__}``.
+
+    ``str.format`` / ``str.format_map`` evaluate field paths through CPython's
+    C-level ``_PyObject_LookupAttr`` in the ``_string`` module, which bypasses
+    the AST-level dunder check below. Without validating the format string
+    itself, sandboxed code can write::
+
+        '{0.__class__.__bases__[0].__subclasses__}'.format(any_value)
+
+    and traverse dunder attributes the sandbox is trying to forbid.
+    """
+    import string as _string_module
+
+    try:
+        parsed = list(_string_module.Formatter().parse(format_string))
+    except (ValueError, TypeError):
+        # Malformed format strings will raise their normal error at call time.
+        return False
+
+    for _literal_text, field_name, _format_spec, _conversion in parsed:
+        if not field_name:
+            continue
+        # field_name examples: "0", "0.foo", "0.foo.bar[2]", "name.attr".
+        # Split on '.' and '[' to inspect every attribute segment.
+        for segment in re.split(r"[\.\[]", field_name):
+            segment = segment.rstrip("]")
+            if segment.startswith("__"):
+                return True
+    return False
+
+
 def _validate_generated_code(code: str) -> None:
     """Reject generated code that accesses dunder/private attrs or unsafe imports."""
     tree = ast.parse(code)
@@ -186,6 +220,20 @@ def _validate_generated_code(code: str) -> None:
             raise RuntimeError(
                 f"Generated code accesses a dunder attribute '{node.attr}' "
                 f"which is not allowed in the sandbox"
+            )
+        # ``str.format`` / ``str.format_map`` bypass the AST-level dunder check
+        # above because the dunder traversal lives inside a string literal
+        # rather than as an ast.Attribute node. Reject string-constant format
+        # strings whose field paths reference dunders.
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and _format_string_has_dunder_field(node.value)
+        ):
+            raise RuntimeError(
+                "Generated code contains a format string with a dunder "
+                "field-path (e.g. '{0.__class__}'); str.format / str.format_map "
+                "would otherwise traverse dunder attributes the sandbox forbids."
             )
 
 


### PR DESCRIPTION
## Summary

The `EvaporateExtractor` sandbox in `llama-index-program-evaporate` validates LLM-generated code via `_validate_generated_code()` before `exec()`. The validator rejects AST nodes that reference dunder names (`ast.Name`) or dunder attributes (`ast.Attribute`):

```python
# extractor.py, current main, ~line 160-189
if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
    raise RuntimeError("Generated code accesses a dunder attribute ...")
```

However `str.format` and `str.format_map` evaluate field-path expressions like `{0.__class__.__bases__}` through CPython's C-level `_PyObject_LookupAttr` in the `_string` module, **bypassing the AST check** — the dunder traversal lives inside a string literal rather than as an `ast.Attribute` node.

## Reproducer

```python
# This code passes _validate_generated_code() and runs in the sandbox today:
def get_foo_field(node_text):
    return "{0.__class__.__bases__[0].__subclasses__}".format(node_text)
```

At `exec()` time the return value is:

```
<built-in method __subclasses__ of type object at 0x7f...>
```

The result is the `repr()` of the leaked method (not the method itself), so this is **information disclosure**, not direct RCE. But the leak still:

- enumerates class hierarchies the sandbox intends to hide
- discloses memory addresses (ASLR side channel)
- probes dunder method presence on `node_text` and any other object reachable from the format

This weakens the sandbox's defense-in-depth and could become a stepping stone toward chaining a higher-severity escape.

## Fix

Two pieces:

1. **`_format_string_has_dunder_field`** — parses a format string with `string.Formatter().parse()` and flags any field-name segment starting with `__`. Handles bracket subscripts (`{0.foo[1]}`) and chained traversal (`{0.a.b.c}`).

2. **Hook in `_validate_generated_code`** — walks every `ast.Constant` whose value is a `str`, and rejects the constant if it would traverse a dunder field path. This catches both `str.format` and `str.format_map` call sites because both consume the same format-string literal.

## Tested behavior

```
PASS: '{0.__class__.__bases__[0].__subclasses__}'.format(x) → blocked (was: validated and leaked)
PASS: 'hello {0}'.format(x)                                 → still allowed (benign, unaffected)
PASS: '{a.__class__}'.format_map({'a': x})                  → blocked
PASS: '{0.upper}'.format(x)                                 → still allowed (non-dunder field path)
```

## Notes for reviewers

- I parse with the stdlib's `string.Formatter().parse()` rather than a regex over `{...}` so escapes (`{{`, `}}`) and format-spec syntax are handled correctly.
- Malformed format strings are left for `str.format` to raise its usual `ValueError` at call time; the validator doesn't mask those.
- The same vulnerability class was reported and fixed for `huggingface/smolagents` in https://github.com/huggingface/smolagents/pull/2271 (CWE-200 / Exposure of Sensitive Information). This PR mirrors that fix's shape, adapted to evaporate's AST-validator architecture.

## Severity

Low / Medium. Information disclosure that bypasses an intended sandbox control. Not direct RCE in isolation, but a useful primitive for chained escapes and a real weakening of the dunder filter the validator is meant to enforce.