### PR TITLE
fix: avoid catastrophic backtracking in DynamicLLMPathExtractor fallback parsers

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/dynamic_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/dynamic_llm.py
@@ -17,6 +17,12 @@ from llama_index.core.prompts.default_prompts import (
 )
 from llama_index.core.schema import TransformComponent, BaseNode, MetadataMode
 
+# Upper bound on input length handed to the regex fallback path. The fallback is
+# only meant to recover from minor JSON drift in a short LLM response; anything
+# significantly larger than a normal response is rejected here so a malformed or
+# adversarial payload cannot pin a worker inside re.findall.
+_MAX_FALLBACK_INPUT_LEN = 50_000
+
 
 def default_parse_dynamic_triplets(
     llm_output: str,
@@ -53,8 +59,14 @@ def default_parse_dynamic_triplets(
                 triplets.append((head_node, relation_node, tail_node))
 
     except json.JSONDecodeError:
-        # Flexible pattern to match the key-value pairs for head, head_type, relation, tail, and tail_type
-        pattern = r'[\{"\']head[\}"\']\s*:\s*[\{"\'](.*?)[\}"\'],\s*[\{"\']head_type[\}"\']\s*:\s*[\{"\'](.*?)[\}"\'],\s*[\{"\']relation[\}"\']\s*:\s*[\{"\'](.*?)[\}"\'],\s*[\{"\']tail[\}"\']\s*:\s*[\{"\'](.*?)[\}"\'],\s*[\{"\']tail_type[\}"\']\s*:\s*[\{"\'](.*?)[\}"\']'
+        if len(llm_output) > _MAX_FALLBACK_INPUT_LEN:
+            return triplets
+
+        # Flexible pattern to match the key-value pairs for head, head_type, relation, tail, and tail_type.
+        # The value groups use a negated character class instead of the lazy `.*?` so the regex runs in
+        # linear time on malformed input (avoids catastrophic backtracking when the LLM produces text
+        # that partially matches the key prefix but never satisfies the full chain).
+        pattern = r'[\{"\']head[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\'],\s*[\{"\']head_type[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\'],\s*[\{"\']relation[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\'],\s*[\{"\']tail[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\'],\s*[\{"\']tail_type[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\']'
 
         # Find all matches in the output
         matches = re.findall(pattern, llm_output)
@@ -114,8 +126,15 @@ def default_parse_dynamic_triplets_with_props(
                 )
                 triplets.append((head_node, relation_node, tail_node))
     except json.JSONDecodeError:
-        # Flexible pattern to match the key-value pairs for head, head_type, head_props, relation, relation_props, tail, tail_type, and tail_props
-        pattern = r'[\{"\']head[\}"\']\s*:\s*[\{"\'](.*?)[\}"\']\s*,\s*[\{"\']head_type[\}"\']\s*:\s*[\{"\'](.*?)[\}"\']\s*,\s*[\{"\']head_props[\}"\']\s*:\s*\{(.*?)\}\s*,\s*[\{"\']relation[\}"\']\s*:\s*[\{"\'](.*?)[\}"\']\s*,\s*[\{"\']relation_props[\}"\']\s*:\s*\{(.*?)\}\s*,\s*[\{"\']tail[\}"\']\s*:\s*[\{"\'](.*?)[\}"\']\s*,\s*[\{"\']tail_type[\}"\']\s*:\s*[\{"\'](.*?)[\}"\']\s*,\s*[\{"\']tail_props[\}"\']\s*:\s*\{(.*?)\}\s*'
+        if len(llm_output) > _MAX_FALLBACK_INPUT_LEN:
+            return triplets
+
+        # Flexible pattern to match the key-value pairs for head, head_type, head_props, relation,
+        # relation_props, tail, tail_type, and tail_props. Lazy `.*?` groups have been replaced with
+        # negated character classes so the regex runs in linear time on malformed input — the previous
+        # form admitted catastrophic backtracking because the lazy groups could consume the same
+        # characters used as delimiters.
+        pattern = r'[\{"\']head[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\']\s*,\s*[\{"\']head_type[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\']\s*,\s*[\{"\']head_props[\}"\']\s*:\s*\{([^{}]*)\}\s*,\s*[\{"\']relation[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\']\s*,\s*[\{"\']relation_props[\}"\']\s*:\s*\{([^{}]*)\}\s*,\s*[\{"\']tail[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\']\s*,\s*[\{"\']tail_type[\}"\']\s*:\s*[\{"\']([^\}"\']*)[\}"\']\s*,\s*[\{"\']tail_props[\}"\']\s*:\s*\{([^{}]*)\}\s*'
 
         # Find all matches in the output
         matches = re.findall(pattern, llm_output)

--- a/llama-index-core/tests/indices/property_graph/test_dynamic_llm_parser.py
+++ b/llama-index-core/tests/indices/property_graph/test_dynamic_llm_parser.py
@@ -1,0 +1,105 @@
+"""Regression tests for the DynamicLLMPathExtractor JSON-fallback parsers.
+
+The two ``default_parse_dynamic_triplets*`` helpers fall back to a regex when
+``json.loads`` fails. The original regexes used long chains of ``(.*?)`` lazy
+groups between delimiter classes that admitted the same characters the groups
+could consume, which produced catastrophic backtracking on attacker-influenced
+or naturally-malformed LLM output (huntr report
+https://huntr.com/bounties/3e4d9d96-a6d1-42aa-a2cc-aea2059f7c0d).
+
+These tests both pin the linear-time behaviour and exercise the happy paths so
+the fallback still recovers triplets from minor JSON drift.
+"""
+
+import time
+
+from llama_index.core.indices.property_graph.transformations.dynamic_llm import (
+    default_parse_dynamic_triplets,
+    default_parse_dynamic_triplets_with_props,
+)
+
+
+# Generous timeouts so this stays stable on slow CI runners; the vulnerable
+# regexes spent tens of seconds to many minutes on these same payloads.
+_REDOS_TIMEOUT_S = 2.0
+
+
+def test_default_parse_dynamic_triplets_recovers_from_minor_json_drift() -> None:
+    # Single-quoted keys would make json.loads fail and exercise the regex path.
+    llm_output = (
+        "[{'head': 'Paris', 'head_type': 'City', 'relation': 'capital_of',"
+        " 'tail': 'France', 'tail_type': 'Country'}]"
+    )
+    triplets = default_parse_dynamic_triplets(llm_output)
+    assert len(triplets) == 1
+    head, rel, tail = triplets[0]
+    assert head.name == "Paris"
+    assert head.label == "City"
+    assert rel.label == "capital_of"
+    assert tail.name == "France"
+    assert tail.label == "Country"
+
+
+def test_default_parse_dynamic_triplets_redos_payload_is_fast() -> None:
+    # Polynomial-blowup payload from the huntr PoC (sink #1). Pre-fix this
+    # took ~30s for 8 KB and ~8 minutes for 17 KB.
+    payload = (
+        '"head":"a","head_type":"b","relation":"r",' * 400
+    ) + ("c" * 400)
+
+    start = time.perf_counter()
+    triplets = default_parse_dynamic_triplets(payload)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < _REDOS_TIMEOUT_S, (
+        f"default_parse_dynamic_triplets took {elapsed:.2f}s on a {len(payload)}B "
+        "fallback input (suspected ReDoS regression)"
+    )
+    # The payload is intentionally incomplete (no tail/tail_type) so no triplets
+    # should be produced; the important guarantee is that we return promptly.
+    assert triplets == []
+
+
+def test_default_parse_dynamic_triplets_with_props_recovers_from_minor_json_drift() -> None:
+    llm_output = (
+        "[{'head': 'Paris', 'head_type': 'City', 'head_props': {\"pop\": \"2M\"},"
+        " 'relation': 'capital_of', 'relation_props': {\"since\": \"987\"},"
+        " 'tail': 'France', 'tail_type': 'Country', 'tail_props': {\"area\": \"643801\"}}]"
+    )
+    triplets = default_parse_dynamic_triplets_with_props(llm_output)
+    assert len(triplets) == 1
+    head, rel, tail = triplets[0]
+    assert head.name == "Paris"
+    assert head.properties.get("pop") == "2M"
+    assert rel.label == "capital_of"
+    assert rel.properties.get("since") == "987"
+    assert tail.properties.get("area") == "643801"
+
+
+def test_default_parse_dynamic_triplets_with_props_redos_payload_is_fast() -> None:
+    # Exponential-blowup payload from the huntr PoC (sink #2). Pre-fix this
+    # took ~22s for ~4.7 KB and roughly doubled per +10 repetitions.
+    payload = (
+        '"head":"a","head_type":"b","head_props":{},"relation":"r",' * 80
+    ) + ("c" * 80)
+
+    start = time.perf_counter()
+    triplets = default_parse_dynamic_triplets_with_props(payload)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < _REDOS_TIMEOUT_S, (
+        f"default_parse_dynamic_triplets_with_props took {elapsed:.2f}s on a "
+        f"{len(payload)}B fallback input (suspected ReDoS regression)"
+    )
+    assert triplets == []
+
+
+def test_oversized_fallback_input_is_rejected() -> None:
+    # Defense-in-depth: anything past the fallback length cap returns [] without
+    # touching the regex engine at all.
+    payload = "x" * 200_000
+    start = time.perf_counter()
+    assert default_parse_dynamic_triplets(payload) == []
+    assert default_parse_dynamic_triplets_with_props(payload) == []
+    elapsed = time.perf_counter() - start
+    assert elapsed < _REDOS_TIMEOUT_S


### PR DESCRIPTION
## What

Both `default_parse_dynamic_triplets` and `default_parse_dynamic_triplets_with_props` in `dynamic_llm.py` fall back to `re.findall(...)` when `json.loads` fails on the LLM output. The fallback regexes use long chains of `(.*?)` lazy groups separated by `[\{"\']` / `[\}"\']` character classes. Because those classes admit the same characters the lazy groups can already consume, any input that *partially* matches the key prefix without ever satisfying the full chain forces the regex engine to try every cartesian split across the lazy groups before giving up — polynomial blowup for the 5-group sink and exponential blowup for the 8-group one.

In practice this is reachable on the documented public API (`DynamicLLMPathExtractor`) via the JSON-decode fallback, which is the expected error-recovery path whenever the model produces less-than-perfectly-formatted JSON. Numbers from the PoC on `llama-index-core==0.14.21`:

| Sink | Input | Pre-fix runtime |
| --- | --- | --- |
| `default_parse_dynamic_triplets` (5 groups) | 8.6 KB | ~31 s |
| `default_parse_dynamic_triplets` (5 groups) | 17.2 KB | ~480 s |
| `default_parse_dynamic_triplets_with_props` (8 groups) | 4.7 KB | ~22 s |

That's a single malformed response pinning one worker for tens of seconds to many minutes; with the default `num_workers=4` a handful of poisoned chunks serialises the whole ingestion pool.

## Fix

Two small changes, in the same spot, no new dependencies:

1. Replace each `(.*?)` between delimiter classes with a negated character class — `[^\}"\']*` for the value groups, `[^{}]*` for the `{...}` property blobs. The engine can no longer match a delimiter inside a group, so the cartesian blowup is gone and matching is linear in input length. The patterns still accept exactly the well-formed inputs they used to (the regression tests below cover this).
2. Add a 50 KB length cap on the input fed to the fallback regex. This is well above any realistic LLM response and well below the PoC payloads, and is meant purely as defense-in-depth in case future edits to the patterns reintroduce a backtracking corner case.

After the fix, the same PoC payloads complete in well under a millisecond.

## Tests

Added `llama-index-core/tests/indices/property_graph/test_dynamic_llm_parser.py` with five cases:

- happy paths: single-quoted-key inputs still recover correctly through the fallback for both parsers, including properties round-tripping for the `_with_props` variant;
- regression: the two PoC payloads (5-group polynomial and 8-group exponential) must each complete in under 2 seconds — pre-fix they take tens of seconds to minutes, so this is a comfortable margin even on slow CI;
- the oversized-input guard returns `[]` immediately for inputs larger than the cap.

All five pass locally against the patched module.

## Reference

Reported via huntr: https://huntr.com/bounties/3e4d9d96-a6d1-42aa-a2cc-aea2059f7c0d

The affected sinks were introduced in `4ae491d0df` (PR #15085) and are present in all releases since, including current `main`.