### PR TITLE
fix(google-genai): pass DocumentBlock.title as display_name to File API

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
@@ -1,1 +1,7 @@
 # CHANGELOG — llama-index-llms-genai
+
+## [v0.9.3]
+
+### Fixed
+
+- Pass `DocumentBlock.title` as `display_name` when uploading files via the Google GenAI File API, fixing title mismatches between prompts and DocumentBlocks

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -278,6 +278,7 @@ async def create_file_part(
     mime_type: str,
     file_mode: Literal["inline", "fileapi", "hybrid"],
     client: Optional[Client],
+    display_name: Optional[str] = None,
 ) -> tuple[types.Part, Optional[str]]:
     """Create a Part or File object for the given file depending on its size."""
     if file_mode in ("inline", "hybrid"):
@@ -296,9 +297,11 @@ async def create_file_part(
     if client is None:
         raise ValueError("A Google GenAI client must be provided for use with FileAPI.")
 
-    file = await client.aio.files.upload(
-        file=file_buffer, config=types.UploadFileConfig(mime_type=mime_type)
-    )
+    upload_config = types.UploadFileConfig(mime_type=mime_type)
+    if display_name is not None:
+        upload_config.display_name = display_name
+
+    file = await client.aio.files.upload(file=file_buffer, config=upload_config)
 
     # Wait for file processing
     while file.state.name == "PROCESSING":
@@ -378,7 +381,7 @@ async def chat_message_to_gemini(
             )
 
             part, file_api_name = await create_file_part(
-                file_buffer, mime_type, file_mode, client
+                file_buffer, mime_type, file_mode, client, display_name=block.title
             )
         elif isinstance(block, ThinkingBlock):
             if block.content:

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.2"
+version = "0.9.3"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1,6 +1,7 @@
 import os
+from io import BytesIO
 from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.genai import types
@@ -22,6 +23,7 @@ from google.genai.types import GenerateContentConfig, ThinkingConfig
 from llama_index.llms.google_genai import GoogleGenAI
 from llama_index.llms.google_genai.utils import (
     convert_schema_to_function_declaration,
+    create_file_part,
     prepare_chat_params,
     chat_from_gemini_response,
 )
@@ -1983,3 +1985,53 @@ def test_metadata_fetching(scenario: Dict[str, Any]) -> None:
         else:
             # confirm model metadata was not fetched
             mock_client.models.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_passes_display_name_to_file_api():
+    mock_file = MagicMock()
+    mock_file.state.name = "ACTIVE"
+    mock_file.uri = "https://generativelanguage.googleapis.com/v1beta/files/abc123"
+    mock_file.name = "files/abc123"
+
+    mock_client = MagicMock()
+    mock_client.aio.files.upload = AsyncMock(return_value=mock_file)
+
+    file_buffer = BytesIO(b"fake pdf content")
+
+    part, file_api_name = await create_file_part(
+        file_buffer,
+        "application/pdf",
+        "fileapi",
+        mock_client,
+        display_name="my_report",
+    )
+
+    mock_client.aio.files.upload.assert_called_once()
+    call_kwargs = mock_client.aio.files.upload.call_args
+    upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+    assert upload_config.display_name == "my_report"
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_no_display_name_by_default():
+    mock_file = MagicMock()
+    mock_file.state.name = "ACTIVE"
+    mock_file.uri = "https://generativelanguage.googleapis.com/v1beta/files/abc123"
+    mock_file.name = "files/abc123"
+
+    mock_client = MagicMock()
+    mock_client.aio.files.upload = AsyncMock(return_value=mock_file)
+
+    file_buffer = BytesIO(b"fake pdf content")
+
+    part, file_api_name = await create_file_part(
+        file_buffer,
+        "application/pdf",
+        "fileapi",
+        mock_client,
+    )
+
+    call_kwargs = mock_client.aio.files.upload.call_args
+    upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+    assert upload_config.display_name is None


### PR DESCRIPTION
## Description

The `google_genai` integration was not passing `DocumentBlock.title` when uploading documents via the Google GenAI File API. This caused a mismatch between the title set in the prompt and the actual `display_name` of the uploaded file, since `UploadFileConfig` was only receiving `mime_type`.

Other integrations (OpenAI, Bedrock Converse, Anthropic) already pass this field correctly.

## Changes

- Added optional `display_name` parameter to `create_file_part()` in `utils.py`
- Pass `block.title` as `display_name` when handling `DocumentBlock` in `chat_message_to_gemini()`
- The `display_name` is forwarded to `UploadFileConfig` when uploading via the File API (files > 20MB or `fileapi` mode)
- Bumped version to `0.9.3`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added unit tests for `create_file_part` verifying `display_name` is passed through to `UploadFileConfig`
- [x] Added unit test verifying `display_name` defaults to `None` when not provided
- [x] All 24 existing non-integration tests continue to pass
- [x] Pre-commit hooks (ruff, mypy, codespell, etc.) all pass

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (CHANGELOG.md)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` with no errors
- [x] I have bumped the version in `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)