### PR TITLE
Google LLMs: Error earlier if file is too large with vertexai client

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -290,8 +290,12 @@ async def create_file_part(
                 data=file_buffer.read(),
                 mime_type=mime_type,
             ), None
-        elif file_mode == "inline" or (client is not None and client.vertexai):
+        elif file_mode == "inline":
             raise ValueError("Files in inline mode must be smaller than 20MB.")
+        elif client is not None and client.vertexai:
+            # The vertexai client doesn't support uploads, so rather than falling through and
+            # letting it fail we'll produce a nicer error here.
+            raise ValueError("Files with vertexai client must be smaller than 20MB.")
 
     if client is None:
         raise ValueError("A Google GenAI client must be provided for use with FileAPI.")

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -290,7 +290,7 @@ async def create_file_part(
                 data=file_buffer.read(),
                 mime_type=mime_type,
             ), None
-        elif file_mode == "inline":
+        elif file_mode == "inline" or (client is not None and client.vertexai):
             raise ValueError("Files in inline mode must be smaller than 20MB.")
 
     if client is None:

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -732,7 +732,7 @@ async def test_create_file_part_rejects_large_hybrid_file_for_vertexai() -> None
     mock_client = MagicMock()
     mock_client.vertexai = True
 
-    with pytest.raises(ValueError, match="smaller than 20MB"):
+    with pytest.raises(ValueError, match="vertexai client" and "smaller than 20MB"):
         await create_file_part(file_buffer, "video/mp4", "hybrid", mock_client)
 
     mock_client.aio.files.upload.assert_not_called()

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import os
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,7 @@ from google.genai.types import GenerateContentConfig, ThinkingConfig
 from llama_index.llms.google_genai import GoogleGenAI
 from llama_index.llms.google_genai.utils import (
     convert_schema_to_function_declaration,
+    create_file_part,
     prepare_chat_params,
     chat_from_gemini_response,
 )
@@ -722,6 +724,18 @@ def test_optional_lists_nested_gemini(llm: GoogleGenAI) -> None:
     )
     assert isinstance(blogpost, BlogPost)
     assert len(blogpost.contents) >= 3
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_rejects_large_hybrid_file_for_vertexai() -> None:
+    file_buffer = BytesIO(b"x" * (20 * 1024 * 1024))
+    mock_client = MagicMock()
+    mock_client.vertexai = True
+
+    with pytest.raises(ValueError, match="smaller than 20MB"):
+        await create_file_part(file_buffer, "video/mp4", "hybrid", mock_client)
+
+    mock_client.aio.files.upload.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description
When interacting with Google LLMs and using vertexai, uploading a file >20MB results in a cryptic error. Since we know the google client will fail when we fall through, let's proactively error instead.

Fixes #21639

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
