### PR TITLE
fix(google-genai): error early on Vertex AI File API uploads

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG — llama-index-llms-genai
 
+## [v0.9.4]
+
+### Fixed
+
+- Raise a clear `ValueError` in `create_file_part` when a Vertex AI client is used with a file path going through the Gemini File API, replacing the cryptic `'This method is only supported in the Gemini Developer client.'` error from `google-genai` for `file_mode='fileapi'` and for `file_mode='hybrid'` with files larger than 20MB.
+
 ## [v0.9.3]
 
 ### Fixed

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -297,6 +297,16 @@ async def create_file_part(
     if client is None:
         raise ValueError("A Google GenAI client must be provided for use with FileAPI.")
 
+    if getattr(client, "vertexai", False):
+        # The Vertex AI Gemini API does not support uploads through the Gemini
+        # File API. Surface a clear error here instead of letting the call fail
+        # downstream with a cryptic googleapis error.
+        raise ValueError(
+            "Uploading files through the Gemini File API is not supported on "
+            "Vertex AI. Use file_mode='inline' for files smaller than 20MB, or "
+            "upload the file to Google Cloud Storage and reference it by URI."
+        )
+
     upload_config = types.UploadFileConfig(mime_type=mime_type)
     if display_name is not None:
         upload_config.display_name = display_name

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.3"
+version = "0.9.4"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1995,6 +1995,7 @@ async def test_create_file_part_passes_display_name_to_file_api():
     mock_file.name = "files/abc123"
 
     mock_client = MagicMock()
+    mock_client.vertexai = False
     mock_client.aio.files.upload = AsyncMock(return_value=mock_file)
 
     file_buffer = BytesIO(b"fake pdf content")
@@ -2021,6 +2022,7 @@ async def test_create_file_part_no_display_name_by_default():
     mock_file.name = "files/abc123"
 
     mock_client = MagicMock()
+    mock_client.vertexai = False
     mock_client.aio.files.upload = AsyncMock(return_value=mock_file)
 
     file_buffer = BytesIO(b"fake pdf content")
@@ -2035,3 +2037,76 @@ async def test_create_file_part_no_display_name_by_default():
     call_kwargs = mock_client.aio.files.upload.call_args
     upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
     assert upload_config.display_name is None
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_raises_on_vertexai_with_fileapi():
+    """
+    A Vertex AI client should surface a clear error before any upload.
+
+    The Gemini File API is not available on Vertex AI, so the call would
+    otherwise fail downstream in google-genai with the cryptic
+    'This method is only supported in the Gemini Developer client.'
+    """
+    mock_client = MagicMock()
+    mock_client.vertexai = True
+    mock_client.aio.files.upload = AsyncMock()
+
+    file_buffer = BytesIO(b"small pdf content")
+
+    with pytest.raises(ValueError, match="Vertex AI"):
+        await create_file_part(
+            file_buffer,
+            "application/pdf",
+            "fileapi",
+            mock_client,
+        )
+
+    mock_client.aio.files.upload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_raises_on_vertexai_with_large_hybrid_file():
+    """
+    A >20MB file in hybrid mode on Vertex AI falls through to the File API,
+    which Vertex does not support. The error should be raised before the call.
+    """
+    mock_client = MagicMock()
+    mock_client.vertexai = True
+    mock_client.aio.files.upload = AsyncMock()
+
+    file_buffer = BytesIO(b"x" * (21 * 1024 * 1024))
+
+    with pytest.raises(ValueError, match="Vertex AI"):
+        await create_file_part(
+            file_buffer,
+            "application/pdf",
+            "hybrid",
+            mock_client,
+        )
+
+    mock_client.aio.files.upload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_inline_still_works_on_vertexai():
+    """
+    Small files served via the inline path stay supported on Vertex AI
+    because they never touch the File API.
+    """
+    mock_client = MagicMock()
+    mock_client.vertexai = True
+    mock_client.aio.files.upload = AsyncMock()
+
+    file_buffer = BytesIO(b"small content")
+
+    part, file_api_name = await create_file_part(
+        file_buffer,
+        "application/pdf",
+        "inline",
+        mock_client,
+    )
+
+    assert file_api_name is None
+    assert part is not None
+    mock_client.aio.files.upload.assert_not_called()


### PR DESCRIPTION
## Description

The Vertex AI Gemini API does not support file uploads through the Gemini File API. In `create_file_part` (`llama-index-llms-google-genai`), any code path calling `client.aio.files.upload()` fails on a Vertex client with the cryptic error from `google-genai`:

```
This method is only supported in the Gemini Developer client.
```

The two cases hitting this on Vertex are:
- `file_mode='fileapi'` for files of any size
- `file_mode='hybrid'` with files larger than 20MB

Both used to surface the confusing message deep inside the upload call. Users get no signal indicating the real cause (Vertex does not expose this API at all) instead of a misconfiguration on their side.

This PR adds a pre-flight check on `client.vertexai` and raises a clear `ValueError` with a remediation path before the upload is attempted. Inline mode under 20MB continues to work on Vertex unchanged.

Fixes #21639

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Bumped `llama-index-llms-google-genai` from 0.9.3 to 0.9.4.

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added three unit tests under `tests/test_llms_google_genai.py`:

- `test_create_file_part_raises_on_vertexai_with_fileapi` — fileapi mode + Vertex client → `ValueError`, no upload attempted.
- `test_create_file_part_raises_on_vertexai_with_large_hybrid_file` — 21MB hybrid + Vertex → `ValueError`, no upload attempted.
- `test_create_file_part_inline_still_works_on_vertexai` — inline mode + Vertex + small file → returns `Part`, no upload attempted (regression guard).

Also updated the two pre-existing `create_file_part` tests to set `mock_client.vertexai = False`, since a bare `MagicMock` auto-generates a truthy `vertexai` attribute.

Local results:

- `uv run -- pytest tests/` → 33 passed, 46 skipped (skips need `GOOGLE_API_KEY` / `GOOGLE_GENAI_USE_VERTEXAI` env vars).
- `uv run -- ruff check` on the changed files → clean.
- `uv run -- ruff format --check` on the changed files → clean.
- `codespell` on the changed files → clean.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG entry)
- [ ] I have added Google Colab support for the newly added notebooks (N/A, no notebooks)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `ruff check` and `ruff format` on the modified files

## AI assistance disclosure (per CONTRIBUTING.md)

Drafted with Claude Code assistance. The fix is a 10-line guard plus three unit tests. I reviewed every line, traced the `google-genai` failure mode against the SDK source linked in the issue, and ran the full local test suite and the linters.