### PR TITLE
fix: reject Vertex AI file uploads in google genai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
 
 logger = logging.getLogger(__name__)
+GEMINI_INLINE_FILE_SIZE_LIMIT = 20 * 1024 * 1024
 
 ROLES_TO_GEMINI: dict[MessageRole, MessageRole] = {
     MessageRole.USER: MessageRole.USER,
@@ -281,12 +282,12 @@ async def create_file_part(
     display_name: Optional[str] = None,
 ) -> tuple[types.Part, Optional[str]]:
     """Create a Part or File object for the given file depending on its size."""
-    if file_mode in ("inline", "hybrid"):
-        file_buffer.seek(0, 2)  # Seek to end
-        size = file_buffer.tell()  # Get file size
-        file_buffer.seek(0)  # Reset to beginning
+    file_buffer.seek(0, 2)  # Seek to end
+    size = file_buffer.tell()  # Get file size
+    file_buffer.seek(0)  # Reset to beginning
 
-        if size < 20 * 1024 * 1024:  # 20MB is the Gemini inline data size limit
+    if file_mode in ("inline", "hybrid"):
+        if size < GEMINI_INLINE_FILE_SIZE_LIMIT:
             return types.Part.from_bytes(
                 data=file_buffer.read(),
                 mime_type=mime_type,
@@ -296,6 +297,12 @@ async def create_file_part(
 
     if client is None:
         raise ValueError("A Google GenAI client must be provided for use with FileAPI.")
+
+    if getattr(client, "vertexai", False) is True:
+        raise ValueError(
+            "File API uploads are not supported with Vertex AI. Use file_mode='inline' "
+            "with files smaller than 20MB."
+        )
 
     upload_config = types.UploadFileConfig(mime_type=mime_type)
     if display_name is not None:

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -26,6 +26,7 @@ from llama_index.llms.google_genai.utils import (
     create_file_part,
     prepare_chat_params,
     chat_from_gemini_response,
+    GEMINI_INLINE_FILE_SIZE_LIMIT,
 )
 
 
@@ -60,6 +61,35 @@ class Schema(BaseModel):
 
     schema_name: str = Field(description="Schema name")
     tables: List[Table] = Field(description="List of random Table objects")
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_rejects_fileapi_with_vertexai_client() -> None:
+    client = MagicMock()
+    client.vertexai = True
+
+    with pytest.raises(ValueError, match="File API uploads are not supported"):
+        await create_file_part(
+            BytesIO(b"small pdf"),
+            "application/pdf",
+            "fileapi",
+            client,
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_file_part_rejects_large_hybrid_vertexai_file() -> None:
+    client = MagicMock()
+    client.vertexai = True
+    file_buffer = BytesIO(b"x" * GEMINI_INLINE_FILE_SIZE_LIMIT)
+
+    with pytest.raises(ValueError, match="File API uploads are not supported"):
+        await create_file_part(
+            file_buffer,
+            "application/pdf",
+            "hybrid",
+            client,
+        )
 
 
 # Define the models to test against


### PR DESCRIPTION
﻿## Summary
- raise a clear `ValueError` before Google GenAI File API uploads are attempted with a Vertex AI client
- keep small `hybrid` files on the inline path
- add regression coverage for `fileapi` mode and large `hybrid` files with Vertex AI

Fixes #21639.

## To verify
- `python -m py_compile llama_index\llms\google_genai\utils.py tests\test_llms_google_genai.py`
- `python -m ruff check llama_index\llms\google_genai\utils.py tests\test_llms_google_genai.py`
- `python -m ruff format --check llama_index\llms\google_genai\utils.py tests\test_llms_google_genai.py`
- `python -m pytest tests\test_llms_google_genai.py -q`
