### PR TITLE
fix(core): guard four recursive walkers against RecursionError DoS

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -1267,7 +1267,18 @@ class ChatMessage(BaseRecursiveContentBlock):
 
     @field_serializer("additional_kwargs", check_fields=False)
     def serialize_additional_kwargs(self, value: Any, _info: Any) -> Any:
-        return self._recursive_serialization(value)
+        # Guard against deeply nested user-controlled data in
+        # additional_kwargs (e.g. raw LLM response fields or persisted
+        # chat-history payloads) blowing the Python stack and breaking
+        # every subsequent persist / model_dump / event-dispatch call.
+        try:
+            return self._recursive_serialization(value)
+        except RecursionError:
+            _logger.warning(
+                "ChatMessage.additional_kwargs is too deeply nested to serialize; "
+                "returning an empty dict instead."
+            )
+            return {}
 
 
 class LogProb(BaseModel):

--- a/llama-index-core/llama_index/core/graph_stores/utils.py
+++ b/llama-index-core/llama_index/core/graph_stores/utils.py
@@ -4,9 +4,12 @@ Borrowed from Langchain's Neo4j graph utility functions.
 https://github.com/langchain-ai/langchain/blob/95c3e5f85f8ed8026a11e351b57bfae488d654c4/libs/community/langchain_community/graphs/neo4j_graph.py
 """
 
+import logging
 from typing import Any
 
 LIST_LIMIT = 128
+
+_logger = logging.getLogger(__name__)
 
 
 def clean_string_values(text: str) -> str:
@@ -22,19 +25,33 @@ def value_sanitize(d: Any) -> Any:
     generating answers in a LLM context. These properties, if left in
     results, can occupy significant context space and detract from
     the LLM's performance by introducing unnecessary noise and cost.
+
+    Pathologically nested inputs are dropped (treated the same as the
+    function's existing "irrelevant value" branches) rather than allowed
+    to blow the Python stack with a raw RecursionError.
     """
+    try:
+        return _value_sanitize_impl(d)
+    except RecursionError:
+        _logger.warning(
+            "Graph value is too deeply nested to sanitize; dropping the value."
+        )
+        return None
+
+
+def _value_sanitize_impl(d: Any) -> Any:
     if isinstance(d, dict):
         new_dict = {}
         for key, value in d.items():
             if isinstance(value, dict):
-                sanitized_value = value_sanitize(value)
+                sanitized_value = _value_sanitize_impl(value)
                 if (
                     sanitized_value is not None
                 ):  # Check if the sanitized value is not None
                     new_dict[key] = sanitized_value
             elif isinstance(value, list):
                 if len(value) < LIST_LIMIT:
-                    sanitized_value = value_sanitize(value)
+                    sanitized_value = _value_sanitize_impl(value)
                     if (
                         sanitized_value is not None
                     ):  # Check if the sanitized value is not None
@@ -46,7 +63,9 @@ def value_sanitize(d: Any) -> Any:
     elif isinstance(d, list):
         if len(d) < LIST_LIMIT:
             return [
-                value_sanitize(item) for item in d if value_sanitize(item) is not None
+                _value_sanitize_impl(item)
+                for item in d
+                if _value_sanitize_impl(item) is not None
             ]
         else:
             return None

--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/text_to_cypher.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/text_to_cypher.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Callable, List, Optional, Union
 
 from llama_index.core.graph_stores.types import PropertyGraphStore
@@ -6,6 +7,8 @@ from llama_index.core.llms import LLM
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 from llama_index.core.settings import Settings
+
+_logger = logging.getLogger(__name__)
 
 DEFAULT_RESPONSE_TEMPLATE = (
     "Generated Cypher query:\n{query}\n\nCypher Response:\n{response}"
@@ -111,6 +114,19 @@ class TextToCypherRetriever(BasePGRetriever):
 
     def _clean_query_output(self, query_output: Any) -> Any:
         """Iterate the cypher response, looking for the allowed fields."""
+        try:
+            return self._clean_query_output_impl(query_output)
+        except RecursionError:
+            # A pathologically nested graph result would otherwise propagate
+            # a raw RecursionError out of retrieve() / aretrieve(). Drop the
+            # poisoned result so the retriever keeps serving other queries.
+            _logger.warning(
+                "Cypher query result is too deeply nested to clean; "
+                "dropping the result."
+            )
+            return None
+
+    def _clean_query_output_impl(self, query_output: Any) -> Any:
         if isinstance(query_output, dict):
             filtered_dict = {}
             for key, value in query_output.items():
@@ -120,14 +136,14 @@ class TextToCypherRetriever(BasePGRetriever):
                 ):
                     filtered_dict[key] = value
                 elif isinstance(value, (dict, list)):
-                    filtered_value = self._clean_query_output(value)
+                    filtered_value = self._clean_query_output_impl(value)
                     if filtered_value:
                         filtered_dict[key] = filtered_value
             return filtered_dict
         elif isinstance(query_output, list):
             filtered_list = []
             for item in query_output:
-                filtered_item = self._clean_query_output(item)
+                filtered_item = self._clean_query_output_impl(item)
                 if filtered_item:
                     filtered_list.append(filtered_item)
             return filtered_list

--- a/llama-index-core/llama_index/core/output_parsers/selection.py
+++ b/llama-index-core/llama_index/core/output_parsers/selection.py
@@ -96,7 +96,14 @@ class SelectionOutputParser(BaseOutputParser):
         if not isinstance(json_obj, list):
             raise ValueError(f"Failed to convert output to JSON: {output!r}")
 
-        json_output = self._format_output(json_obj)
+        # Guard against pathologically nested LLM-produced JSON triggering a
+        # raw RecursionError in _filter_dict's recursive descent.
+        try:
+            json_output = self._format_output(json_obj)
+        except RecursionError as exc:
+            raise OutputParserException(
+                "Selector output JSON is too deeply nested to parse."
+            ) from exc
         answers = [Answer.from_dict(json_dict) for json_dict in json_output]
         return StructuredOutput(raw_output=output, parsed_output=answers)
 

--- a/llama-index-core/tests/test_recursive_walker_dos.py
+++ b/llama-index-core/tests/test_recursive_walker_dos.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for the unguarded recursive walkers in `llama-index-core`.
+
+These mirror the defect class fixed by PR #18877 for `JSONReader` (CVE-2025-5302 /
+CVE-2025-5472) and cover the remaining sinks reported in the huntr advisory at
+https://huntr.com/bounties/412a8af2-d173-402d-aa9b-f4989bfaa4c7:
+
+1. ChatMessage._recursive_serialization (via serialize_additional_kwargs)
+2. SelectionOutputParser._filter_dict (via parse)
+3. graph_stores.utils.value_sanitize
+4. TextToCypherRetriever._clean_query_output
+"""
+
+import json
+import sys
+
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.graph_stores.utils import value_sanitize
+from llama_index.core.indices.property_graph.sub_retrievers.text_to_cypher import (
+    TextToCypherRetriever,
+)
+from llama_index.core.output_parsers.base import OutputParserException
+from llama_index.core.output_parsers.selection import SelectionOutputParser
+
+
+def _make_nested(depth: int):
+    d = "leaf"
+    for _ in range(depth):
+        d = {"k": d}
+    return d
+
+
+# Use a depth comfortably above Python's default recursion limit (1000) so the
+# test deterministically exercises the RecursionError guard regardless of any
+# constant per-call frame overhead inside the walkers.
+_DEEP = sys.getrecursionlimit() + 500
+
+
+def test_chat_message_additional_kwargs_deeply_nested_does_not_raise() -> None:
+    msg = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        content="ok",
+        additional_kwargs={"x": _make_nested(_DEEP)},
+    )
+
+    # Before the fix, this raised PydanticSerializationError wrapping
+    # RecursionError, which broke every downstream persist / event-dispatch.
+    dumped = msg.model_dump()
+
+    assert dumped["additional_kwargs"] == {}
+
+
+def test_selection_output_parser_deeply_nested_raises_output_parser_exception() -> None:
+    parser = SelectionOutputParser()
+    # JSON missing both `choice` and `reason` falls into the recursive
+    # `_filter_dict` path.
+    poison = json.dumps(_make_nested(_DEEP))
+
+    with pytest.raises(OutputParserException, match="deeply nested"):
+        parser.parse(poison)
+
+
+def test_value_sanitize_deeply_nested_returns_none() -> None:
+    # Before the fix this raised a raw RecursionError out of every graph
+    # property-cleaning call.
+    assert value_sanitize(_make_nested(_DEEP)) is None
+
+
+def test_text_to_cypher_clean_query_output_deeply_nested_returns_none() -> None:
+    class _Stub:
+        allowed_output_fields = ["only_a_safe_key"]
+        _clean_query_output = TextToCypherRetriever._clean_query_output
+        _clean_query_output_impl = TextToCypherRetriever._clean_query_output_impl
+
+    # Before the fix this raised a raw RecursionError out of retrieve() /
+    # aretrieve() on every poisoned input.
+    assert _Stub()._clean_query_output(_make_nested(_DEEP)) is None


### PR DESCRIPTION
## Summary

Fixes the huntr report [Multiple unguarded recursive walkers in `llama-index-core`](https://huntr.com/bounties/412a8af2-d173-402d-aa9b-f4989bfaa4c7) — the same `RecursionError` defect class that PR #18877 already accepted as bountiable for `JSONReader._depth_first_yield` (CVE-2025-5302 / CVE-2025-5472), remaining in four sibling recursive walkers that the prior fix left unguarded.

Each of these walks `dict` / `list` data with no depth limit and no `try/except RecursionError` guard, and each is reachable from a documented public API processing externally-influenced data (LLM responses, persisted state, graph DB results). A 7–11 KB JSON nested ~1000 levels triggers a raw `RecursionError` (or a `PydanticSerializationError` wrapping it).

### Sinks patched

| # | File | Function | Failure mode before fix |
|---|---|---|---|
| 1 | `llama-index-core/llama_index/core/base/llms/types.py` | `ChatMessage._recursive_serialization` (via `serialize_additional_kwargs`) | Poisoned `additional_kwargs` permanently breaks every `persist` / `model_dump` / `LLMChatEndEvent` dispatch on the containing chat store |
| 2 | `llama-index-core/llama_index/core/output_parsers/selection.py` | `SelectionOutputParser._filter_dict` (via `parse`) | Raw `RecursionError` out of every `LLMSingleSelector` / `LLMMultiSelector` / `RouterQueryEngine` call |
| 3 | `llama-index-core/llama_index/core/graph_stores/utils.py` | `value_sanitize` | Raw `RecursionError` out of every property-graph property-cleaning call |
| 4 | `llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/text_to_cypher.py` | `TextToCypherRetriever._clean_query_output` | Raw `RecursionError` out of `retrieve()` / `aretrieve()` when `allowed_output_fields` is set |

### Fix shape

Each sink is wrapped in `try/except RecursionError`, matching the maintainer-accepted shape of PR #18877. The graceful-degradation behavior is chosen per call site:

- **Sink 1** — return an empty `dict` and log a warning so the message itself stays valid and the store stays serializable.
- **Sink 2** — raise `OutputParserException("Selector output JSON is too deeply nested to parse.")` so callers can route it through their normal output-parsing error path.
- **Sink 3** — return `None`, matching `value_sanitize`'s existing "irrelevant value" branches (oversized lists already return `None`).
- **Sink 4** — return `None`, dropping the poisoned result so the retriever keeps serving other queries.

### Trigger conditions (in scope per SECURITY.md)

> "algorithmic complexity issues inside the library are in scope"

- Trigger is **library-internal recursion** — not an exposed HTTP endpoint.
- Reproducible with a minimal Python script, no web framework, payload ≤ 11 KB.
- Not a prompt-injection finding — flows include self-hosted LLM `tool_calls`, imported chat history, third-party graph stores, replayed event logs.

## Test plan

- [x] `pytest tests/test_recursive_walker_dos.py` — new module, 4 tests, one per sink, each exercises depth above `sys.getrecursionlimit()` and asserts the new graceful behavior.
- [x] `pytest tests/output_parsers/test_selection.py tests/graph_stores/` — pre-existing tests still green.
- [x] `uv run ruff check` and `uv run ruff format --check` clean on the five touched files.

```
tests/test_recursive_walker_dos.py::test_chat_message_additional_kwargs_deeply_nested_does_not_raise PASSED
tests/test_recursive_walker_dos.py::test_selection_output_parser_deeply_nested_raises_output_parser_exception PASSED
tests/test_recursive_walker_dos.py::test_value_sanitize_deeply_nested_returns_none PASSED
tests/test_recursive_walker_dos.py::test_text_to_cypher_clean_query_output_deeply_nested_returns_none PASSED
```

## References

- huntr report: https://huntr.com/bounties/412a8af2-d173-402d-aa9b-f4989bfaa4c7
- Prior fix for the same defect class: #18877 (CVE-2025-5302 / CVE-2025-5472)
- [CWE-674: Uncontrolled Recursion](https://cwe.mitre.org/data/definitions/674.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)