### PR TITLE
GoogleGenAIEmbedding with "gemini-embedding-2" produces aggregated embeddings instead of individual ones with google-genai SDK v1.71.0+

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
@@ -260,11 +260,15 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         else:
             embedding_config = self.embedding_config
 
+        # Wrap each input in an explicit Content so google-genai>=1.71 returns
+        # one embedding per input instead of aggregating the list into one.
+        contents = [types.Content(parts=[types.Part(text=text)]) for text in texts]
+
         # Create the embedding function with retry logic
         def embed_with_client() -> List[List[float]]:
             results = self._client.models.embed_content(
                 model=self.model_name,
-                contents=texts,
+                contents=contents,
                 config=embedding_config,
             )
             return [result.values for result in results.embeddings]
@@ -293,11 +297,15 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         else:
             embedding_config = self.embedding_config
 
+        # Wrap each input in an explicit Content so google-genai>=1.71 returns
+        # one embedding per input instead of aggregating the list into one.
+        contents = [types.Content(parts=[types.Part(text=text)]) for text in texts]
+
         # Create the async embedding function with retry logic
         async def aembed_with_client() -> List[List[float]]:
             results = await self._client.aio.models.embed_content(
                 model=self.model_name,
-                contents=texts,
+                contents=contents,
                 config=embedding_config,
             )
             return [result.values for result in results.embeddings]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-google-genai"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index embeddings google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/tests/test_embeddings_gemini.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/tests/test_embeddings_gemini.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import requests
+import google.genai.types as types
 from google.genai.errors import APIError
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.embeddings.google_genai import GoogleGenAIEmbedding
@@ -38,6 +39,72 @@ def test_embed_texts_mock(mock_client_class):
     assert len(result) == 1
     assert result[0] == [0.1, 0.2, 0.3]
     mock_embed_content.assert_called_once()
+
+
+@patch("google.genai.Client")
+def test_embed_texts_wraps_inputs_in_content(mock_client_class):
+    """
+    Ensure each text is wrapped in a distinct types.Content.
+
+    Passing a plain list[str] to google-genai>=1.71 produces a single aggregated
+    embedding instead of one per input. Wrapping in types.Content forces per-input
+    embeddings (issue #21658).
+    """
+    mock_client = mock_client_class.return_value
+    mock_embed_content = mock_client.models.embed_content
+
+    mock_result = MagicMock()
+    mock_result.embeddings = [
+        MagicMock(values=[0.1, 0.2]),
+        MagicMock(values=[0.3, 0.4]),
+        MagicMock(values=[0.5, 0.6]),
+    ]
+    mock_embed_content.return_value = mock_result
+
+    emb = GoogleGenAIEmbedding(api_key="fake_key")
+    texts = ["Hello world", "This is a test", "Embeddings are useful"]
+    result = emb.get_text_embedding_batch(texts)
+
+    assert len(result) == 3
+    _, kwargs = mock_embed_content.call_args
+    contents = kwargs["contents"]
+    assert isinstance(contents, list)
+    assert len(contents) == len(texts)
+    for content, text in zip(contents, texts):
+        assert isinstance(content, types.Content)
+        assert content.parts is not None
+        assert len(content.parts) == 1
+        assert content.parts[0].text == text
+
+
+@pytest.mark.asyncio
+@patch("google.genai.Client")
+async def test_aembed_texts_wraps_inputs_in_content(mock_client_class):
+    """Async variant of the input-wrapping check for issue #21658."""
+    mock_client = mock_client_class.return_value
+    mock_aio_models = MagicMock()
+    mock_client.aio = MagicMock(models=mock_aio_models)
+
+    mock_result = MagicMock()
+    mock_result.embeddings = [
+        MagicMock(values=[0.1, 0.2]),
+        MagicMock(values=[0.3, 0.4]),
+    ]
+    mock_aembed_content = AsyncMock(return_value=mock_result)
+    mock_aio_models.embed_content = mock_aembed_content
+
+    emb = GoogleGenAIEmbedding(api_key="fake_key")
+    texts = ["foo", "bar"]
+    result = await emb.aget_text_embedding_batch(texts)
+
+    assert len(result) == 2
+    _, kwargs = mock_aembed_content.call_args
+    contents = kwargs["contents"]
+    assert isinstance(contents, list)
+    assert len(contents) == len(texts)
+    for content, text in zip(contents, texts):
+        assert isinstance(content, types.Content)
+        assert content.parts[0].text == text
 
 
 @patch("google.genai.Client")

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/uv.lock
@@ -1868,7 +1868,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-google-genai"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },


### PR DESCRIPTION
## Description

`_embed_texts` and `_aembed_texts` in `llama-index-embeddings-google-genai` passed `contents=texts` (a `list[str]`) to `client.models.embed_content`, which `google-genai>=1.71.0` now interprets as a single aggregated input and returns one embedding regardless of input length. Each input is now wrapped in an explicit `types.Content(parts=[types.Part(text=text)])` so the SDK treats them as a batch and returns one embedding per text.

## New Package?

No.

- [ ] Yes
- [x] No

## Version Bump?

Bumped `llama-index-embeddings-google-genai` to `0.5.1`.

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Updated unit tests in `tests/test_embeddings_gemini.py` to assert that `_embed_texts` and `_aembed_texts` return one embedding per input text and that each call passes a `types.Content` wrapper to `client.models.embed_content`.

- [x] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:

- [x] performed a self-review of my own code
- [x] commented my code, particularly in hard-to-understand areas
- [x] made corresponding changes to the documentation
- [x] added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

Closes #21658