### PR TITLE
fix: use asyncio.Lock in rate limiter async_acquire to avoid blocking the event loop

### DIFF
--- a/llama-index-core/llama_index/core/rate_limiter.py
+++ b/llama-index-core/llama_index/core/rate_limiter.py
@@ -107,6 +107,7 @@ class TokenBucketRateLimiter(BaseRateLimiter, BaseModel):
     _token_refill_rate: float = PrivateAttr(default=0.0)
     _last_refill_time: float = PrivateAttr(default=0.0)
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _async_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)
@@ -206,7 +207,7 @@ class TokenBucketRateLimiter(BaseRateLimiter, BaseModel):
 
         """
         while True:
-            with self._lock:
+            async with self._async_lock:
                 self._refill()
                 wait = self._wait_time(num_tokens)
                 if wait <= 0:
@@ -284,6 +285,7 @@ class SlidingWindowRateLimiter(BaseRateLimiter, BaseModel):
     _request_timestamps: Deque[float] = PrivateAttr(default_factory=deque)
     _token_usage: Deque[Tuple[float, float]] = PrivateAttr(default_factory=deque)
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _async_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 
     @model_validator(mode="after")
     def _check_limits(self) -> "SlidingWindowRateLimiter":
@@ -388,7 +390,7 @@ class SlidingWindowRateLimiter(BaseRateLimiter, BaseModel):
         """
         while True:
             now = time.monotonic()
-            with self._lock:
+            async with self._async_lock:
                 self._prune_request_timestamps(now)
                 self._prune_token_usage(now)
                 wait = self._wait_time(now, num_tokens)


### PR DESCRIPTION
## Summary

- Replaces `threading.Lock` with `asyncio.Lock` in the `async_acquire()` methods of both `TokenBucketRateLimiter` and `SlidingWindowRateLimiter`.

`threading.Lock.acquire()` is a blocking OS syscall. When called inside a coroutine on the asyncio event loop thread, it freezes every other concurrent coroutine for the duration of the lock hold. Under high concurrency this causes latency spikes and throughput collapse in any async LLM/embedding pipeline that uses a `rate_limiter`.

The fix adds a dedicated `asyncio.Lock` (`_async_lock`) for the async code path so coroutines yield cooperatively. The existing `threading.Lock` is preserved for the synchronous `acquire()` method, keeping thread-safety intact for sync callers.

## Test plan

- [ ] Existing unit tests in `tests/test_rate_limiter.py` continue to pass
- [ ] The reproduction script from the issue (heartbeat + 500 concurrent `async_acquire` calls) no longer shows event-loop blocking

Closes #21603

---

*This contribution was made with AI-agent assistance.*