### PR TITLE
fix: support vLLM 'reasoning' field in from_openai_message and streaming

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -570,7 +570,10 @@ class OpenAI(FunctionCallingLLM):
 
                 # Extract reasoning_content for chain-of-thought streaming.
                 # Many OpenAI-compatible providers surface this extra field.
+                # vLLM uses "reasoning" instead of "reasoning_content".
                 raw_reasoning = getattr(delta, "reasoning_content", None)
+                if not raw_reasoning:
+                    raw_reasoning = getattr(delta, "reasoning", None)
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )
@@ -866,7 +869,10 @@ class OpenAI(FunctionCallingLLM):
 
                 # Extract reasoning_content for chain-of-thought streaming.
                 # Many OpenAI-compatible providers surface this extra field.
+                # vLLM uses "reasoning" instead of "reasoning_content".
                 raw_reasoning = getattr(delta, "reasoning_content", None)
+                if not raw_reasoning:
+                    raw_reasoning = getattr(delta, "reasoning", None)
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -836,6 +836,9 @@ def from_openai_message(
     # Extract reasoning_content if present (used by many OpenAI-compatible
     # providers for chain-of-thought responses)
     reasoning_content = getattr(openai_message, "reasoning_content", None)
+    if not reasoning_content:
+        # vLLM uses "reasoning" instead of "reasoning_content"
+        reasoning_content = getattr(openai_message, "reasoning", None)
     if isinstance(reasoning_content, str) and reasoning_content:
         blocks.append(ThinkingBlock(content=reasoning_content))
 


### PR DESCRIPTION
## Summary

- Adds a fallback to check for the `reasoning` field when `reasoning_content` is absent, supporting vLLM's Qwen3-family reasoning models.

vLLM's OpenAI-compatible server exposes the chain-of-thought trace as `message.reasoning` (not `message.reasoning_content`). This causes `ThinkingBlock` to never be populated when using LlamaIndex against vLLM-served reasoning models (Qwen3, Qwen3.5, Qwen3.6).

The fix adds a fallback in three locations:
1. `from_openai_message` in `utils.py` (non-streaming)
2. `stream_chat` in `base.py` (sync streaming)
3. `astream_chat` in `base.py` (async streaming)

If `reasoning_content` is absent or empty, we check for `reasoning` before constructing the `ThinkingBlock`.

## Test plan

- [ ] Existing `test_from_openai_message_with_reasoning_content` continues to pass
- [ ] vLLM-served Qwen3 models now produce `ThinkingBlock` in both streaming and non-streaming paths

Closes #21582

---

*This contribution was made with AI-agent assistance.*