### PR TITLE
fix(core): make MarkdownNodeParser linear instead of O(n^2) in document size

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/markdown.py
+++ b/llama-index-core/llama_index/core/node_parser/file/markdown.py
@@ -48,12 +48,25 @@ class MarkdownNodeParser(NodeParser):
     def get_nodes_from_node(self, node: BaseNode) -> List[TextNode]:
         """Get nodes from document by splitting on headers."""
         text = node.get_content(metadata_mode=MetadataMode.NONE)
-        markdown_nodes = []
         lines = text.split("\n")
         current_section = ""
         # Keep track of (markdown level, text) for headers
         header_stack: List[tuple[int, str]] = []
         code_block = False
+
+        # Collect (section text, header path) pairs in document order, then
+        # build every node in a single ``build_nodes_from_splits`` call.
+        # Building one split at a time recomputes the source document's hash
+        # (``ref_doc.as_related_node_info()``) once per section, which is
+        # O(sections * doc_size) -> quadratic for header-dense documents.
+        splits: List[str] = []
+        header_paths: List[str] = []
+
+        def add_section(section_text: str) -> None:
+            splits.append(section_text)
+            header_paths.append(
+                self.header_path_separator.join(h[1] for h in header_stack[:-1])
+            )
 
         for line in lines:
             # Track if we're inside a code block to avoid parsing headers in code
@@ -68,15 +81,7 @@ class MarkdownNodeParser(NodeParser):
                 if header_match:
                     # Save the previous section before starting a new one
                     if current_section.strip():
-                        markdown_nodes.append(
-                            self._build_node_from_split(
-                                current_section.strip(),
-                                node,
-                                self.header_path_separator.join(
-                                    h[1] for h in header_stack[:-1]
-                                ),
-                            )
-                        )
+                        add_section(current_section.strip())
 
                     header_level = len(header_match.group(1))
                     header_text = header_match.group(2)
@@ -96,33 +101,21 @@ class MarkdownNodeParser(NodeParser):
 
         # Add the final section
         if current_section.strip():
-            markdown_nodes.append(
-                self._build_node_from_split(
-                    current_section.strip(),
-                    node,
-                    self.header_path_separator.join(h[1] for h in header_stack[:-1]),
-                )
-            )
+            add_section(current_section.strip())
 
-        return markdown_nodes
-
-    def _build_node_from_split(
-        self,
-        text_split: str,
-        node: BaseNode,
-        header_path: str,
-    ) -> TextNode:
-        """Build node from single text split."""
-        node = build_nodes_from_splits([text_split], node, id_func=self.id_func)[0]
+        markdown_nodes = build_nodes_from_splits(splits, node, id_func=self.id_func)
 
         if self.include_metadata:
             separator = self.header_path_separator
-            node.metadata["header_path"] = (
-                # ex: "/header1/header2/" || "/"
-                separator + header_path + separator if header_path else separator
-            )
+            for markdown_node, header_path in zip(markdown_nodes, header_paths):
+                markdown_node.metadata["header_path"] = (
+                    # ex: "/header1/header2/" || "/"
+                    separator + header_path + separator
+                    if header_path
+                    else separator
+                )
 
-        return node
+        return markdown_nodes
 
     def _parse_nodes(
         self,

--- a/llama-index-core/tests/node_parser/test_markdown.py
+++ b/llama-index-core/tests/node_parser/test_markdown.py
@@ -1,3 +1,4 @@
+import llama_index.core.node_parser.file.markdown as markdown_module
 from llama_index.core.node_parser.file.markdown import MarkdownNodeParser
 from llama_index.core.schema import Document
 
@@ -202,3 +203,34 @@ Content
     assert splits[0].metadata == {"header_path": "/"}
     assert splits[1].metadata == {"header_path": "/Main Header/"}
     assert splits[2].metadata == {"header_path": "/Main Header/"}
+
+
+# Regression test for quadratic parsing: MarkdownNodeParser must call
+# build_nodes_from_splits once for the whole document instead of once per
+# header section. Calling it per section recomputes the source document hash
+# (ref_doc.as_related_node_info()) for every section, making parsing
+# O(sections * document_size) -- quadratic on header-dense documents.
+def test_builds_all_nodes_in_a_single_call(monkeypatch) -> None:
+    call_sizes = []
+    original = markdown_module.build_nodes_from_splits
+
+    def spy(text_splits, document, *args, **kwargs):
+        call_sizes.append(len(text_splits))
+        return original(text_splits, document, *args, **kwargs)
+
+    monkeypatch.setattr(markdown_module, "build_nodes_from_splits", spy)
+
+    parser = MarkdownNodeParser()
+    splits = parser.get_nodes_from_documents(
+        [Document(text="# A\nalpha\n\n# B\nbeta\n\n# C\ngamma\n")]
+    )
+
+    assert len(splits) == 3
+    # Exactly one batched call covering all sections, not one call per section.
+    assert call_sizes == [3]
+    assert splits[0].text == "# A\nalpha"
+    assert splits[1].text == "# B\nbeta"
+    assert splits[2].text == "# C\ngamma"
+    assert splits[0].metadata == {"header_path": "/"}
+    assert splits[1].metadata == {"header_path": "/"}
+    assert splits[2].metadata == {"header_path": "/"}


### PR DESCRIPTION
## Description

`MarkdownNodeParser.get_nodes_from_node` calls `build_nodes_from_splits` **once per header section**. `build_nodes_from_splits` recomputes the source document hash (`ref_doc.as_related_node_info()` → `Document.hash`, which `sha256`s the entire document text) on **every** call. For a document with `N` header sections this hashes the full text `N` times: **O(N · document_size)**, i.e. quadratic for header-dense documents (changelogs, API references, generated docs, glossaries).

`node_utils.py` already documents this exact hazard:

```python
# Calling as_related_node_info() on a document recomputes the hash for the whole
# text and metadata ... is terrible when adding a relationship between the node
# and a document, hence we create the relationship only once here
```

`MarkdownNodeParser` defeats that mitigation by invoking the helper per split. `SentenceSplitter` calls it once with all splits and is linear.

### Measured (llama-index-core 0.14.22, before → after)

| input (`# h` heading-dense markdown) | before | after |
|---|---|---|
| 200 KB | 5.79 s | 1.10 s |
| 400 KB | 21.2 s | 2.57 s |
| 800 KB | 84+ s | 4.88 s |

Benign prose of the same size parses in ~3 ms; the cost was algorithmic, not input volume. Scaling goes from ~×4 per input doubling (quadratic) to ~×2 (linear).

## Fix

Collect all section splits first, then build every node in a **single** `build_nodes_from_splits` call (the pattern `SentenceSplitter` already uses), and apply the per-section `header_path` metadata in a follow-up loop.

Behavior is unchanged: node text, order, `header_path` metadata and `SOURCE` relationships are identical; `default_id_func` returns a random `uuid4` so batching does not affect node ids. The now-unused private `_build_node_from_split` helper is removed (`HTMLNodeParser` has its own separate copy and is unaffected).

## Tests

- All existing `tests/node_parser/test_markdown.py` cases pass unchanged.
- Adds a regression test asserting `build_nodes_from_splits` is invoked exactly once for a multi-section document.

## Note

`HTMLNodeParser` and `JSONNodeParser` share the same per-split call shape and would benefit from the same change; happy to follow up in a separate PR to keep this one focused and fully tested.