### PR TITLE
fix(core): redact api_key from EventPayload.SERIALIZED callback payload

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -152,7 +152,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -199,7 +199,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -387,7 +387,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -435,7 +435,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -500,7 +500,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 )
                 with self.callback_manager.event(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 ) as event:
                     if self.rate_limiter is not None:
                         self.rate_limiter.acquire()
@@ -554,7 +554,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 )
                 event_id = self.callback_manager.on_event_start(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 )
                 callback_payloads.append((event_id, cur_batch))
 

--- a/llama-index-core/llama_index/core/embeddings/multi_modal_base.py
+++ b/llama-index-core/llama_index/core/embeddings/multi_modal_base.py
@@ -38,8 +38,10 @@ class MultiModalEmbedding(BaseEmbedding):
         """
         Embed the input image.
         """
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             image_embedding = self._get_image_embedding(img_file_path)
 
@@ -53,8 +55,10 @@ class MultiModalEmbedding(BaseEmbedding):
 
     async def aget_image_embedding(self, img_file_path: ImageType) -> Embedding:
         """Get image embedding."""
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             image_embedding = await self._aget_image_embedding(img_file_path)
 
@@ -98,6 +102,8 @@ class MultiModalEmbedding(BaseEmbedding):
         """Get a list of image embeddings, with batching."""
         cur_batch: List[ImageType] = []
         result_embeddings: List[Embedding] = []
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
 
         queue_with_progress = enumerate(
             get_tqdm_iterable(
@@ -114,7 +120,7 @@ class MultiModalEmbedding(BaseEmbedding):
                 # flush
                 with self.callback_manager.event(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 ) as event:
                     embeddings = self._get_image_embeddings(cur_batch)
                     result_embeddings.extend(embeddings)
@@ -136,6 +142,8 @@ class MultiModalEmbedding(BaseEmbedding):
         callback_payloads: List[Tuple[str, List[ImageType]]] = []
         result_embeddings: List[Embedding] = []
         embeddings_coroutines: List[Coroutine] = []
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
         for idx, img_file_path in enumerate(img_file_paths):
             cur_batch.append(img_file_path)
             if (
@@ -145,7 +153,7 @@ class MultiModalEmbedding(BaseEmbedding):
                 # flush
                 event_id = self.callback_manager.on_event_start(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 )
                 callback_payloads.append((event_id, cur_batch))
                 embeddings_coroutines.append(self._aget_image_embeddings(cur_batch))

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -69,7 +69,7 @@ def llm_chat_callback() -> Callable:
                     payload={
                         EventPayload.MESSAGES: messages,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
                 if _self.rate_limiter is not None:
@@ -171,7 +171,7 @@ def llm_chat_callback() -> Callable:
                     payload={
                         EventPayload.MESSAGES: messages,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
                 if _self.rate_limiter is not None:
@@ -335,7 +335,7 @@ def llm_completion_callback() -> Callable:
                     payload={
                         EventPayload.PROMPT: prompt,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
 
@@ -437,7 +437,7 @@ def llm_completion_callback() -> Callable:
                     payload={
                         EventPayload.PROMPT: prompt,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
                 if _self.rate_limiter is not None:

--- a/llama-index-core/tests/llms/test_callbacks.py
+++ b/llama-index-core/tests/llms/test_callbacks.py
@@ -1,5 +1,10 @@
+from typing import Any, List, Optional
+
 import pytest
 from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core.callbacks.base_handler import BaseCallbackHandler
+from llama_index.core.callbacks.schema import EventPayload
 from llama_index.core.llms.llm import LLM
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.llms.mock import MockLLMWithNonyieldingChatStream
@@ -81,3 +86,46 @@ def test_llm_stream_complete_throws_if_duplicate_prompt(llm: LLM, prompt: str) -
 def test_llm_stream_complete_throws_if_no_prompt(llm: LLM) -> None:
     with pytest.raises(ValueError):
         llm.stream_complete()
+
+
+class _KeyedMockLLM(MockLLM):
+    api_key: Optional[str] = "sk-secret-should-not-leak"
+
+
+class _SerializedCaptureHandler(BaseCallbackHandler):
+    def __init__(self) -> None:
+        super().__init__(event_starts_to_ignore=[], event_ends_to_ignore=[])
+        self.serialized: List[dict] = []
+
+    def on_event_start(
+        self, event_type, payload=None, event_id="", parent_id="", **kwargs: Any
+    ) -> str:
+        if payload and EventPayload.SERIALIZED in payload:
+            self.serialized.append(payload[EventPayload.SERIALIZED])
+        return event_id
+
+    def on_event_end(self, event_type, payload=None, event_id="", **kwargs: Any) -> None:
+        ...
+
+    def start_trace(self, trace_id=None) -> None:
+        ...
+
+    def end_trace(self, trace_id=None, trace_map=None) -> None:
+        ...
+
+
+# Regression test: the EventPayload.SERIALIZED callback payload must not
+# contain api_key. It mirrors the model_dict the instrumentation event already
+# redacts; leaking it exposes the credential to every callback handler.
+def test_llm_callback_serialized_payload_redacts_api_key() -> None:
+    handler = _SerializedCaptureHandler()
+    llm = _KeyedMockLLM(callback_manager=CallbackManager([handler]))
+
+    llm.complete("hello")
+    llm.chat([ChatMessage(role="user", content="hello")])
+
+    assert handler.serialized, "no SERIALIZED payload was captured"
+    for serialized in handler.serialized:
+        assert "api_key" not in serialized
+        # other model config is still present (we did not over-strip)
+        assert serialized.get("class_name") == llm.class_name()


### PR DESCRIPTION
## Description

The LLM and embedding callback wrappers already build a **sanitized** model dict for the instrumentation event:

```python
model_dict = _self.to_dict()
model_dict.pop("api_key", None)
dispatcher.event(LLMChatStartEvent(model_dict=model_dict, ...))
```

…but then pass an **un-sanitized** `_self.to_dict()` — which still contains the plaintext `api_key` — as `EventPayload.SERIALIZED` to the legacy callback manager:

```python
callback_manager.on_event_start(
    CBEventType.LLM,
    payload={..., EventPayload.SERIALIZED: _self.to_dict()},  # api_key still here
)
```

`EventPayload.SERIALIZED` is delivered to **every** registered `BaseCallbackHandler` on every chat / completion / embedding call. `OpenAI.api_key` / `OpenAIEmbedding.api_key` are plain string fields (no `SecretStr`, no `exclude=True`), so the built-in `LlamaDebugHandler` (which stores event payloads and exposes them via `get_llm_inputs_outputs()`), and any attached tracing/observability handler, receive the API key in plaintext. The instrumentation path two lines above already treats this dict as something that must have `api_key` removed; the callback payload is simply inconsistent with it.

## Fix

Reuse the already-sanitized `model_dict` for the callback payload instead of calling `to_dict()` again:

- `llama_index/core/llms/callbacks.py` — 4 sites (sync/async × chat/complete)
- `llama_index/core/base/embeddings/base.py` — 6 sites
- `llama_index/core/embeddings/multi_modal_base.py` — 4 sites (had no redaction at all; added the same idiom)

Behavior is unchanged apart from `api_key` no longer being present in the callback payload (it was already absent from the sibling instrumentation event). This also removes a redundant second `to_dict()` call per invocation.

## Tests

- All existing `tests/llms/test_callbacks.py`, `tests/embeddings`, `tests/llms` tests pass (45 passed).
- Adds a regression test asserting `EventPayload.SERIALIZED` contains no `api_key` while the rest of the model config (e.g. `class_name`) is preserved.

## Note

A field-level `pydantic.SecretStr` / `Field(exclude=True)` on the two `api_key` fields would be a stronger defense-in-depth (covering `repr()` / direct `to_dict()` / serialization-to-disk as well). I kept this PR to the callback payload to stay minimal and behavior-safe; happy to follow up separately.