### PR TITLE
fix(bedrock-converse): serialize rich content blocks in tool results

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -481,11 +481,22 @@ def messages_to_converse_messages(
                         )
 
         elif message.role in [MessageRole.FUNCTION, MessageRole.TOOL]:
-            # convert tool output to the AWS Bedrock Converse format
+            # Serialize tool result blocks using the same converter as user
+            # messages.  Falls back to legacy message.content for plain-text
+            # tool results.
+            tool_content: list[dict[str, Any]] = []
+            for block in message.blocks:
+                bedrock_block = _content_block_to_bedrock_format(
+                    block, MessageRole.USER
+                )
+                if bedrock_block:
+                    tool_content.append(bedrock_block)
+            if not tool_content and message.content:
+                tool_content = [{"text": message.content}]
             content = {
                 "toolResult": {
                     "toolUseId": message.additional_kwargs["tool_call_id"],
-                    "content": [{"text": message.content}] if message.content else [],
+                    "content": tool_content,
                 }
             }
             if status := message.additional_kwargs.get("status"):

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.10"
+version = "0.14.11"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
@@ -1,3 +1,4 @@
+import base64
 from io import BytesIO
 from typing import Literal
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ from llama_index.core.base.llms.types import (
     CacheControl,
     CachePoint,
     ChatMessage,
+    DocumentBlock,
     ImageBlock,
     MessageRole,
     TextBlock,
@@ -639,6 +641,93 @@ def test_messages_to_converse_messages_tool_calls():
     )  # Bedrock requires tool results as user role
     assert "toolResult" in converse_messages[1]["content"][0]
     assert converse_messages[1]["content"][0]["toolResult"]["toolUseId"] == "tool_123"
+
+
+def test_messages_to_converse_messages_tool_result_with_document_block():
+    """Tool results containing a DocumentBlock should serialize the document."""
+    doc_block = DocumentBlock(
+        data=base64.b64encode(b"fake-pdf-content"),
+        document_mimetype="application/pdf",
+        title="test_doc",
+    )
+    messages = [
+        ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="Let me read that file.",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "toolUseId": "tool_doc",
+                        "name": "read_file",
+                        "input": {"path": "report.pdf"},
+                    }
+                ]
+            },
+        ),
+        ChatMessage(
+            role=MessageRole.TOOL,
+            blocks=[doc_block],
+            additional_kwargs={"tool_call_id": "tool_doc"},
+        ),
+    ]
+
+    converse_messages, _ = messages_to_converse_messages(messages)
+
+    tool_result_msg = converse_messages[1]
+    assert tool_result_msg["role"] == "user"
+    tool_result = tool_result_msg["content"][0]["toolResult"]
+    assert tool_result["toolUseId"] == "tool_doc"
+    assert len(tool_result["content"]) == 1
+
+    doc = tool_result["content"][0]
+    assert "document" in doc
+    assert doc["document"]["format"] == "pdf"
+    assert doc["document"]["name"] == "test_doc"
+    assert doc["document"]["source"]["bytes"] == b"fake-pdf-content"
+
+
+@patch("llama_index.core.base.llms.types.ImageBlock.resolve_image")
+def test_messages_to_converse_messages_tool_result_with_image_block(mock_resolve):
+    """Tool results containing an ImageBlock should serialize the image."""
+    mock_bytes = BytesIO(b"fake_image_data")
+    mock_bytes.read = MagicMock(return_value=b"fake_image_data")
+    mock_resolve.return_value = mock_bytes
+
+    image_block = ImageBlock(image=b"", image_mimetype="image/png")
+    messages = [
+        ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="Let me look at that image.",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "toolUseId": "tool_img",
+                        "name": "get_image",
+                        "input": {"url": "http://example.com/img.png"},
+                    }
+                ]
+            },
+        ),
+        ChatMessage(
+            role=MessageRole.TOOL,
+            blocks=[image_block],
+            additional_kwargs={"tool_call_id": "tool_img"},
+        ),
+    ]
+
+    converse_messages, _ = messages_to_converse_messages(messages)
+
+    tool_result_msg = converse_messages[1]
+    assert tool_result_msg["role"] == "user"
+    tool_result = tool_result_msg["content"][0]["toolResult"]
+    assert tool_result["toolUseId"] == "tool_img"
+    assert len(tool_result["content"]) == 1
+
+    img = tool_result["content"][0]
+    assert "image" in img
+    assert img["image"]["format"] == "png"
+    assert img["image"]["source"]["bytes"] == b"fake_image_data"
+    mock_resolve.assert_called_once()
 
 
 # Tests for converse_with_retry function


### PR DESCRIPTION
## Description

Bedrock Converse: serialize rich content blocks (DocumentBlock, ImageBlock) in tool results

The `messages_to_converse_messages` function currently serializes tool-role messages using only `message.content` (a legacy string field), ignoring `message.blocks`. This means when a tool returns a `DocumentBlock` (e.g., PDF bytes) or `ImageBlock`, the content is silently dropped — the tool result is sent to Bedrock with empty content.

The Bedrock Converse API supports `document`, `image`, and `text` content types inside `toolResult.content` (see [ToolResultContentBlock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultContentBlock.html)). This fix reuses the existing `_content_block_to_bedrock_format()` helper to properly serialize tool result blocks, falling back to `message.content` for backward compatibility with plain-text tools.

## New Package?
- [x] No

## Version Bump?
- [x] Yes (0.14.10 → 0.14.11)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change
  - `test_messages_to_converse_messages_tool_result_with_document_block` — verifies a tool message with `DocumentBlock` serializes to `toolResult.content[0].document`
  - `test_messages_to_converse_messages_tool_result_with_image_block` — verifies a tool message with `ImageBlock` serializes to `toolResult.content[0].image`
  - Existing `test_messages_to_converse_messages_tool_calls` continues to pass (plain-text backward compatibility)