### PR TITLE
fix(core): add DocumentBlock and VideoBlock to FunctionTool._parse_tool_output

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -27,6 +27,8 @@ from llama_index.core.base.llms.types import (
     CitableBlock,
     CitationBlock,
     ContentBlock,
+    DocumentBlock,
+    VideoBlock,
 )
 from llama_index.core.bridge.pydantic import BaseModel, FieldInfo
 from llama_index.core.tools.types import AsyncBaseTool, ToolMetadata, ToolOutput
@@ -289,12 +291,30 @@ class FunctionTool(AsyncBaseTool):
     def _parse_tool_output(self, raw_output: Any) -> List[ContentBlock]:
         """Parse tool output into content blocks."""
         if isinstance(
-            raw_output, (TextBlock, ImageBlock, AudioBlock, CitableBlock, CitationBlock)
+            raw_output,
+            (
+                TextBlock,
+                ImageBlock,
+                AudioBlock,
+                CitableBlock,
+                CitationBlock,
+                DocumentBlock,
+                VideoBlock,
+            ),
         ):
             return [raw_output]
         elif isinstance(raw_output, list) and all(
             isinstance(
-                item, (TextBlock, ImageBlock, AudioBlock, CitableBlock, CitationBlock)
+                item,
+                (
+                    TextBlock,
+                    ImageBlock,
+                    AudioBlock,
+                    CitableBlock,
+                    CitationBlock,
+                    DocumentBlock,
+                    VideoBlock,
+                ),
             )
             for item in raw_output
         ):

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel, Field
-from llama_index.core.llms import TextBlock, ImageBlock
+from llama_index.core.llms import TextBlock, ImageBlock, DocumentBlock, VideoBlock
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.schema import Document, TextNode
 from llama_index.core.workflow.context import Context
@@ -492,3 +492,49 @@ async def test_function_tool_contextvar_propagation() -> None:
     var.set("expected")
     result = await tool.acall()
     assert result.raw_output == "expected"
+
+
+def test_function_tool_output_single_document_block() -> None:
+    """Test that a single DocumentBlock passes through without str() wrapping."""
+
+    def get_doc() -> DocumentBlock:
+        return DocumentBlock(
+            data=b"fake-pdf-bytes", document_mimetype="application/pdf"
+        )
+
+    tool = FunctionTool.from_defaults(get_doc)
+    tool_output = tool.call()
+
+    assert len(tool_output.blocks) == 1
+    assert isinstance(tool_output.blocks[0], DocumentBlock)
+
+
+def test_function_tool_output_single_video_block() -> None:
+    """Test that a single VideoBlock passes through without str() wrapping."""
+
+    def get_video() -> VideoBlock:
+        return VideoBlock(video=b"fake-video-bytes", video_mimetype="video/mp4")
+
+    tool = FunctionTool.from_defaults(get_video)
+    tool_output = tool.call()
+
+    assert len(tool_output.blocks) == 1
+    assert isinstance(tool_output.blocks[0], VideoBlock)
+
+
+def test_function_tool_output_document_and_text_blocks() -> None:
+    """Test that a list of [DocumentBlock, TextBlock] passes through as-is."""
+
+    def get_blocks() -> list:
+        return [
+            DocumentBlock(data=b"fake-pdf-bytes", document_mimetype="application/pdf"),
+            TextBlock(text="Summary of the document"),
+        ]
+
+    tool = FunctionTool.from_defaults(get_blocks)
+    tool_output = tool.call()
+
+    assert len(tool_output.blocks) == 2
+    assert isinstance(tool_output.blocks[0], DocumentBlock)
+    assert isinstance(tool_output.blocks[1], TextBlock)
+    assert tool_output.content == "Summary of the document"


### PR DESCRIPTION
# Description

FunctionTool._parse_tool_output missing DocumentBlock and VideoBlock in passthrough check

When a tool returns a `DocumentBlock` (e.g. PDF bytes from a document-reading tool), the `_parse_tool_output` method falls through to the `else` branch and calls `str()` on it. This converts the entire binary content to a Pydantic model repr string, wraps it in a `TextBlock`, and sends it to the LLM as text — inflating token counts by 10-12x and massively increasing cost.

The fix adds `DocumentBlock` and `VideoBlock` to the existing isinstance check, consistent with how `ImageBlock` and `AudioBlock` are already handled.

## New Package?
- [x] No

## Version Bump?
- [x] No (llama-index-core)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change