### PR TITLE
fix(core): preserve multi-block streaming chat history

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,8 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    ContentBlock,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -40,6 +42,30 @@ def is_function(message: ChatMessage) -> bool:
         "tool_calls" in message.additional_kwargs
         and len(message.additional_kwargs["tool_calls"]) > 0
     )
+
+
+def _set_message_content(message: ChatMessage, content: str) -> None:
+    """Set text content on a message without dropping non-text blocks."""
+    if not message.blocks or (
+        len(message.blocks) == 1 and isinstance(message.blocks[0], TextBlock)
+    ):
+        message.content = content
+        return
+
+    updated_blocks: list[ContentBlock] = []
+    content_added = False
+    for block in message.blocks:
+        if isinstance(block, TextBlock):
+            if not content_added:
+                updated_blocks.append(TextBlock(text=content))
+                content_added = True
+        else:
+            updated_blocks.append(block)
+
+    if not content_added:
+        updated_blocks.insert(0, TextBlock(text=content))
+
+    message.blocks = updated_blocks
 
 
 class ChatResponseMode(str, Enum):
@@ -191,7 +217,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_content(chat.message, final_text.strip())  # final message
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -249,7 +275,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_content(chat.message, final_text.strip())  # final message
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -1,16 +1,20 @@
-import gc
 import asyncio
-from llama_index.core.memory import ChatMemoryBuffer
+import gc
+from typing import Any, Sequence
+
+import pytest
+
 from llama_index.core.base.llms.types import (
     ChatMessage,
     CompletionResponse,
     CompletionResponseGen,
+    ImageBlock,
+    MessageRole,
+    TextBlock,
 )
-from typing import Any
 from llama_index.core.llms.callbacks import llm_completion_callback
-from llama_index.core.llms.mock import MockLLM
-import pytest
-from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.llms.mock import MockFunctionCallingLLM, MockLLM
+from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.core.chat_engine.simple import SimpleChatEngine
 
 
@@ -71,6 +75,59 @@ async def test_simple_chat_engine_astream():
     assert num_iters > 10
     assert "Hello World!" in response.unformatted_response
     assert "What is the capital of the moon?" in response.unformatted_response
+
+
+@pytest.mark.asyncio
+async def test_simple_chat_engine_astream_multi_block_response_writes_history() -> None:
+    def response_generator(messages: Sequence[ChatMessage]) -> ChatMessage:
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            blocks=[
+                TextBlock(text="answer"),
+                ImageBlock(image=b"image"),
+            ],
+        )
+
+    engine = SimpleChatEngine.from_defaults(
+        llm=MockFunctionCallingLLM(response_generator=response_generator),
+        memory=ChatMemoryBuffer.from_defaults(),
+    )
+
+    response = await engine.astream_chat("Hello World!")
+    chunks = [chunk async for chunk in response.async_response_gen()]
+
+    assert chunks == ["answer"]
+    assert response.response == "answer"
+    history = engine.chat_history
+    assert len(history) == 2
+    assert history[-1].content == "answer"
+    assert isinstance(history[-1].blocks[1], ImageBlock)
+
+
+def test_simple_chat_engine_stream_multi_block_response_writes_history() -> None:
+    def response_generator(messages: Sequence[ChatMessage]) -> ChatMessage:
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            blocks=[
+                TextBlock(text="answer"),
+                ImageBlock(image=b"image"),
+            ],
+        )
+
+    engine = SimpleChatEngine.from_defaults(
+        llm=MockFunctionCallingLLM(response_generator=response_generator),
+        memory=ChatMemoryBuffer.from_defaults(),
+    )
+
+    response = engine.stream_chat("Hello World!")
+    chunks = list(response.response_gen)
+
+    assert chunks == ["answer"]
+    assert response.response == "answer"
+    history = engine.chat_history
+    assert len(history) == 2
+    assert history[-1].content == "answer"
+    assert isinstance(history[-1].blocks[1], ImageBlock)
 
 
 def test_simple_chat_engine_astream_exception_handling():


### PR DESCRIPTION
## Summary

Fixes run-llama/llama_index#21679.

`StreamingAgentChatResponse.write_response_to_history()` and `awrite_response_to_history()` assign the final streamed text through `chat.message.content`. That setter raises when the final assistant `ChatMessage` contains multiple content blocks, so `SimpleChatEngine.astream_chat()` can fail while writing the completed response to memory.

This PR adds a small helper that updates the text content through `ChatMessage.blocks` when the message has multiple blocks. It preserves non-text blocks and only consolidates/replaces text blocks with the final streamed text. The helper is used by both sync and async streaming history writes.

## Validation

- `.venv/bin/python -m pytest llama-index-core/tests/chat_engine/test_simple.py::test_simple_chat_engine_stream_multi_block_response_writes_history llama-index-core/tests/chat_engine/test_simple.py::test_simple_chat_engine_astream_multi_block_response_writes_history`
- `.venv/bin/python -m pytest llama-index-core/tests/chat_engine/test_simple.py`
- `.venv/bin/python -m pytest llama-index-core/tests/chat_engine`
- `.venv/bin/python -m ruff check llama-index-core/llama_index/core/chat_engine/types.py llama-index-core/tests/chat_engine/test_simple.py`
- `git diff --check`

## Notes

Prepared with AI assistance and manually reviewed/validated with the checks above.
