### PR TITLE
fix: safely serialize raw agent workflow responses

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -500,7 +500,7 @@ class BaseWorkflowAgent(
         output = AgentOutput(
             response=response.message,
             tool_calls=[],
-            raw=response.raw,
+            raw=maybe_model_dump(response.raw),
             current_agent_name=self.name,
         )
 

--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -33,6 +33,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     ToolCall,
     ToolCallResult,
 )
+from llama_index.core.agent.workflow.utils import maybe_model_dump
 from llama_index.core.bridge.pydantic import (
     BaseModel,
     Field,
@@ -320,11 +321,7 @@ class BaseWorkflowAgent(
             response_stream = await target_llm.astream_chat(llm_input)
             last_response = None
             async for last_response in response_stream:
-                raw = (
-                    last_response.raw.model_dump()
-                    if isinstance(last_response.raw, BaseModel)
-                    else last_response.raw
-                )
+                raw = maybe_model_dump(last_response.raw)
                 if ctx.is_running:
                     ctx.write_event_to_stream(
                         AgentStream(

--- a/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
@@ -11,8 +11,9 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentStream,
     ToolCallResult,
 )
+from llama_index.core.agent.workflow.utils import maybe_model_dump
 from llama_index.core.base.llms.types import ChatResponse
-from llama_index.core.bridge.pydantic import BaseModel, Field
+from llama_index.core.bridge.pydantic import Field
 from llama_index.core.llms import ChatMessage
 from llama_index.core.llms.llm import ToolSelection, LLM
 from llama_index.core.llms.function_calling import FunctionCallingLLM
@@ -236,11 +237,7 @@ class CodeActAgent(BaseWorkflowAgent):
             full_response_text += delta
 
             # Create a raw object for the event stream
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = maybe_model_dump(last_chat_response.raw)
 
             # Write delta to the event stream
             ctx.write_event_to_stream(
@@ -336,11 +333,7 @@ class CodeActAgent(BaseWorkflowAgent):
         await ctx.store.set(self.scratchpad_key, scratchpad)
 
         # Create the raw object for the output
-        raw = (
-            chat_response.raw.model_dump()
-            if isinstance(chat_response.raw, BaseModel)
-            else chat_response.raw
-        )
+        raw = maybe_model_dump(chat_response.raw)
 
         return AgentOutput(
             response=message,

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -8,8 +8,9 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentStream,
     ToolCallResult,
 )
+from llama_index.core.agent.workflow.utils import maybe_model_dump
 from llama_index.core.base.llms.types import ChatResponse
-from llama_index.core.bridge.pydantic import BaseModel, Field
+from llama_index.core.bridge.pydantic import Field
 from llama_index.core.llms import ChatMessage
 from llama_index.core.memory import BaseMemory
 from llama_index.core.tools import AsyncBaseTool
@@ -78,11 +79,7 @@ class FunctionAgent(BaseWorkflowAgent):
             tool_calls = self.llm.get_tool_calls_from_response(  # type: ignore
                 last_chat_response, error_on_no_tool_call=False
             )
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = maybe_model_dump(last_chat_response.raw)
             ctx.write_event_to_stream(
                 AgentStream(
                     delta=last_chat_response.delta or "",
@@ -133,11 +130,7 @@ class FunctionAgent(BaseWorkflowAgent):
         scratchpad.append(last_chat_response.message)
         await ctx.store.set(self.scratchpad_key, scratchpad)
 
-        raw = (
-            last_chat_response.raw.model_dump()
-            if isinstance(last_chat_response.raw, BaseModel)
-            else last_chat_response.raw
-        )
+        raw = maybe_model_dump(last_chat_response.raw)
         return AgentOutput(
             response=last_chat_response.message,
             tool_calls=tool_calls or [],

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -43,6 +43,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentWorkflowStartEvent,
     AgentStreamStructuredOutput,
 )
+from llama_index.core.agent.workflow.utils import maybe_model_dump
 from llama_index.core.llms import ChatMessage, ChatResponse, TextBlock
 from llama_index.core.llms.llm import LLM
 from llama_index.core.memory import BaseMemory, ChatMemoryBuffer
@@ -321,11 +322,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             response_stream = await agent.llm.astream_chat(llm_input)
             last_response = None
             async for last_response in response_stream:
-                raw = (
-                    last_response.raw.model_dump()
-                    if isinstance(last_response.raw, BaseModel)
-                    else last_response.raw
-                )
+                raw = maybe_model_dump(last_response.raw)
                 if ctx.is_running:
                     ctx.write_event_to_stream(
                         AgentStream(

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -503,7 +503,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         output = AgentOutput(
             response=response.message,
             tool_calls=[],
-            raw=response.raw,
+            raw=maybe_model_dump(response.raw),
             current_agent_name=agent.name,
         )
 

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -18,8 +18,9 @@ from llama_index.core.agent.workflow.workflow_events import (
     AgentStream,
     ToolCallResult,
 )
+from llama_index.core.agent.workflow.utils import maybe_model_dump
 from llama_index.core.base.llms.types import ChatResponse, TextBlock
-from llama_index.core.bridge.pydantic import BaseModel, Field, model_validator
+from llama_index.core.bridge.pydantic import Field, model_validator
 from llama_index.core.llms import ChatMessage
 from llama_index.core.llms.llm import ToolSelection
 from llama_index.core.memory import BaseMemory
@@ -95,11 +96,7 @@ class ReActAgent(BaseWorkflowAgent):
         # We initialize it so it's valid even when 'response' is empty
         last_chat_response = ChatResponse(message=ChatMessage())
         async for last_chat_response in response:
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = maybe_model_dump(last_chat_response.raw)
             # some code paths (namely react agent via llm.predict_and_call for non function calling llms) pass through a context without starting the workflow.
             # They do so in order to conform to the interface, and share state between tools, however the events are discarded and not exposed to the caller,
             # so just don't write events if the context is not running.
@@ -173,11 +170,7 @@ class ReActAgent(BaseWorkflowAgent):
                 "Thought: <what you are thinking>\n"
                 "Answer: <your final response to the user>"
             )
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = maybe_model_dump(last_chat_response.raw)
 
             return AgentOutput(
                 response=last_chat_response.message,
@@ -208,11 +201,7 @@ class ReActAgent(BaseWorkflowAgent):
                 "```\n"
             )
 
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = maybe_model_dump(last_chat_response.raw)
             # Return with retry messages to let the LLM fix the error
             return AgentOutput(
                 response=last_chat_response.message,
@@ -229,11 +218,7 @@ class ReActAgent(BaseWorkflowAgent):
         await ctx.store.set(self.reasoning_key, current_reasoning)
 
         # If response step, we're done
-        raw = (
-            last_chat_response.raw.model_dump()
-            if isinstance(last_chat_response.raw, BaseModel)
-            else last_chat_response.raw
-        )
+        raw = maybe_model_dump(last_chat_response.raw)
         if reasoning_step.is_done:
             return AgentOutput(
                 response=last_chat_response.message,

--- a/llama-index-core/llama_index/core/agent/workflow/utils.py
+++ b/llama-index-core/llama_index/core/agent/workflow/utils.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from llama_index.core.bridge.pydantic import BaseModel
+
+
+def maybe_model_dump(raw: Any) -> Any:
+    """Best-effort serialization for raw provider responses."""
+    try:
+        is_pydantic_model = isinstance(raw, BaseModel)
+    except Exception:
+        return raw
+
+    if not is_pydantic_model:
+        return raw
+
+    try:
+        return raw.model_dump()
+    except Exception:
+        return raw

--- a/llama-index-core/tests/agent/workflow/test_react_agent.py
+++ b/llama-index-core/tests/agent/workflow/test_react_agent.py
@@ -45,6 +45,13 @@ class PydanticRaw(BaseModel):
     value: str
 
 
+class FailingDumpRaw(BaseModel):
+    value: str
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("dump failed")
+
+
 class ProblematicRaw:
     def __getattr__(self, name: str) -> Any:
         if name == "__pydantic_validator__":
@@ -85,6 +92,16 @@ async def test_react_agent_dumps_pydantic_raw_response():
     response = await agent.run(user_msg="hello")
 
     assert response.raw == {"value": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_react_agent_preserves_raw_response_when_model_dump_fails():
+    raw = FailingDumpRaw(value="ok")
+    agent = ReActAgent(llm=RawResponseLLM(raw), tools=[])
+
+    response = await agent.run(user_msg="hello")
+
+    assert response.raw is raw
 
 
 @pytest.mark.asyncio

--- a/llama-index-core/tests/agent/workflow/test_react_agent.py
+++ b/llama-index-core/tests/agent/workflow/test_react_agent.py
@@ -1,6 +1,56 @@
+from typing import Any, AsyncGenerator, Sequence
+
+import pytest
+
 from llama_index.core.agent.workflow import ReActAgent
+from llama_index.core.agent.workflow.workflow_events import AgentStream
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse
+from llama_index.core.bridge.pydantic import BaseModel, PrivateAttr
 from llama_index.core.llms import MockLLM
 from llama_index.core.prompts import PromptTemplate
+
+
+class RawResponseLLM(MockLLM):
+    _raw: Any = PrivateAttr()
+
+    def __init__(self, raw: Any) -> None:
+        super().__init__(is_chat_model=True)
+        self._raw = raw
+
+    async def achat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        content = "Thought: I can answer\nAnswer: done"
+        return ChatResponse(
+            message=ChatMessage(role="assistant", content=content),
+            raw=self._raw,
+        )
+
+    async def astream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> AsyncGenerator[ChatResponse, None]:
+        content = "Thought: I can answer\nAnswer: done"
+
+        async def gen() -> AsyncGenerator[ChatResponse, None]:
+            yield ChatResponse(
+                message=ChatMessage(role="assistant", content=content),
+                delta=content,
+                raw=self._raw,
+            )
+
+        return gen()
+
+
+class PydanticRaw(BaseModel):
+    value: str
+
+
+class ProblematicRaw:
+    def __getattr__(self, name: str) -> Any:
+        if name == "__pydantic_validator__":
+            raise KeyError(name)
+
+        raise AttributeError(name)
 
 
 def test_react_agent_prompts():
@@ -25,3 +75,30 @@ def test_react_agent_prompts():
     prompts = agent.get_prompts()
     assert len(prompts) == 1
     assert new_prompt == prompts["react_header"]
+
+
+@pytest.mark.asyncio
+async def test_react_agent_dumps_pydantic_raw_response():
+    raw = PydanticRaw(value="ok")
+    agent = ReActAgent(llm=RawResponseLLM(raw), tools=[])
+
+    response = await agent.run(user_msg="hello")
+
+    assert response.raw == {"value": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_react_agent_preserves_problematic_raw_response_object():
+    raw = ProblematicRaw()
+    agent = ReActAgent(llm=RawResponseLLM(raw), tools=[], streaming=True)
+
+    handler = agent.run(user_msg="hello")
+    streamed_raw = []
+    async for event in handler.stream_events():
+        if isinstance(event, AgentStream):
+            streamed_raw.append(event.raw)
+
+    response = await handler
+
+    assert streamed_raw == [raw]
+    assert response.raw is raw


### PR DESCRIPTION
## Summary

Fixes run-llama/llama_index#18694.

Some providers return raw response objects that are not Pydantic models but expose dynamic attribute handling. Pydantic's `BaseModel` instance check can probe `__pydantic_validator__`, and provider objects like the DashScope raw response can raise non-`AttributeError` exceptions during that probe. The agent workflow raw serialization path then crashes before returning the agent response.

This PR:

- adds a small best-effort helper for raw provider response serialization
- preserves `model_dump()` behavior for real Pydantic raw responses
- falls back to the original raw object when the Pydantic check or dump is unsafe
- replaces duplicated workflow raw-dump patterns with the shared helper
- adds ReAct regressions for both Pydantic raw dumping and problematic provider raw objects

## Validation

- `.venv/bin/pytest llama-index-core/tests/agent/workflow/test_react_agent.py -q`
- `.venv/bin/pytest llama-index-core/tests/agent/workflow/test_react_agent.py llama-index-core/tests/agent/workflow/test_single_agent_workflow.py llama-index-core/tests/agent/workflow/test_thinking_delta.py llama-index-core/tests/agent/workflow/test_code_act_agent.py -q`
- `.venv/bin/ruff check llama-index-core/llama_index/core/agent/workflow/utils.py llama-index-core/llama_index/core/agent/workflow/react_agent.py llama-index-core/llama_index/core/agent/workflow/function_agent.py llama-index-core/llama_index/core/agent/workflow/codeact_agent.py llama-index-core/llama_index/core/agent/workflow/base_agent.py llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py llama-index-core/tests/agent/workflow/test_react_agent.py`
- `.venv/bin/ruff format --check llama-index-core/llama_index/core/agent/workflow/utils.py llama-index-core/llama_index/core/agent/workflow/react_agent.py llama-index-core/llama_index/core/agent/workflow/function_agent.py llama-index-core/llama_index/core/agent/workflow/codeact_agent.py llama-index-core/llama_index/core/agent/workflow/base_agent.py llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py llama-index-core/tests/agent/workflow/test_react_agent.py`
- `git diff --check`

`uv` was not available in this environment, so the validation used a checkout-local virtualenv. The focused tests pass; they emit existing Pydantic/workflows deprecation warnings.