### PR TITLE
fix: flatten fact memory tool history

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
+++ b/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
@@ -1,7 +1,8 @@
 import re
+from html import escape
 from typing import Any, List, Optional, Union
 
-from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.base.llms.types import ChatMessage, MessageRole, TextBlock
 from llama_index.core.bridge.pydantic import Field, field_validator
 from llama_index.core.llms import LLM
 from llama_index.core.memory.memory import BaseMemoryBlock
@@ -63,6 +64,25 @@ def get_default_llm() -> LLM:
     return Settings.llm
 
 
+def _get_text_from_message(message: ChatMessage) -> str:
+    """Extract provider-agnostic text from a chat message."""
+    return "\n".join(
+        block.text for block in message.blocks if isinstance(block, TextBlock)
+    )
+
+
+def _messages_to_text(messages: List[ChatMessage]) -> str:
+    """Format chat history as text so memory LLMs do not receive tool blocks."""
+    texts = []
+    for message in messages:
+        text = _get_text_from_message(message)
+        if not text:
+            continue
+        role = escape(message.role.value, quote=True)
+        texts.append(f"<message role='{role}'>{escape(text, quote=False)}</message>")
+    return "\n".join(texts)
+
+
 class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
     """
     A memory block that extracts key facts from conversation history using an LLM.
@@ -121,6 +141,14 @@ class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
         if not messages:
             return
 
+        conversation_text = _messages_to_text(messages)
+        if not conversation_text:
+            return
+        conversation_message = ChatMessage(
+            role=MessageRole.USER,
+            content=conversation_text,
+        )
+
         # Format existing facts for the prompt
         existing_facts_text = ""
         if self.facts:
@@ -134,7 +162,9 @@ class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
         )
 
         # Get the facts extraction
-        response = await self.llm.achat(messages=[*messages, *prompt_messages])
+        response = await self.llm.achat(
+            messages=[conversation_message, *prompt_messages]
+        )
 
         # Parse the XML response to extract facts
         facts_text = response.message.content or ""
@@ -155,7 +185,9 @@ class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
                 existing_facts=existing_facts_text,
                 max_facts=self.max_facts,
             )
-            response = await self.llm.achat(messages=[*messages, *prompt_messages])
+            response = await self.llm.achat(
+                messages=[conversation_message, *prompt_messages]
+            )
             new_facts = self._parse_facts_xml(response.message.content or "")
             self.facts = new_facts
 

--- a/llama-index-core/tests/memory/blocks/test_fact.py
+++ b/llama-index-core/tests/memory/blocks/test_fact.py
@@ -1,12 +1,17 @@
 import pytest
-from typing import List
+from typing import Any, List
 
 from llama_index.core.memory.memory_blocks.fact import (
     FactExtractionMemoryBlock,
     DEFAULT_FACT_EXTRACT_PROMPT,
     DEFAULT_FACT_CONDENSE_PROMPT,
 )
-from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    MessageRole,
+    TextBlock,
+    ToolCallBlock,
+)
 from llama_index.core.base.llms.types import ChatResponse
 from llama_index.core.llms import MockLLM
 
@@ -18,8 +23,14 @@ class MyMockLLM(MockLLM):
         super().__init__(*args, **kwargs)
         self._responses = responses
         self._index = 0
+        self._messages_history: List[List[ChatMessage]] = []
 
-    async def achat(self, messages: List[ChatMessage], **kwargs) -> ChatResponse:
+    @property
+    def messages_history(self) -> List[List[ChatMessage]]:
+        return self._messages_history
+
+    async def achat(self, messages: List[ChatMessage], **kwargs: Any) -> ChatResponse:
+        self.messages_history.append(messages)
         response = self._responses[self._index]
         self._index += 1
         return response
@@ -50,6 +61,30 @@ def sample_messages():
         ChatMessage(
             role=MessageRole.USER,
             content="I work as a software engineer and I'm allergic to peanuts.",
+        ),
+    ]
+
+
+@pytest.fixture
+def tool_history_messages():
+    """Create messages with provider-native tool content."""
+    return [
+        ChatMessage(role=MessageRole.USER, content="Find my next flight."),
+        ChatMessage(
+            role=MessageRole.ASSISTANT,
+            blocks=[
+                ToolCallBlock(
+                    tool_call_id="call_123",
+                    tool_name="lookup_flight",
+                    tool_kwargs={"destination": "Paris"},
+                )
+            ],
+            additional_kwargs={"tool_calls": [{"name": "lookup_flight"}]},
+        ),
+        ChatMessage(
+            role=MessageRole.TOOL,
+            content="Flight AF123 leaves at 5pm.",
+            additional_kwargs={"tool_call_id": "call_123"},
         ),
     ]
 
@@ -127,6 +162,90 @@ async def test_aput_with_duplicate_facts(mock_extraction_llm, sample_messages):
         "John lives in New York",
         "John is a software engineer",
     ]
+
+
+@pytest.mark.asyncio
+async def test_aput_flattens_tool_history_before_fact_extraction(
+    tool_history_messages,
+):
+    """Test aput flattens tool blocks before calling the fact LLM."""
+    mock_llm = MyMockLLM(
+        responses=[
+            ChatResponse(
+                message=ChatMessage(
+                    content="<facts><fact>User asked about a flight</fact></facts>"
+                )
+            ),
+        ]
+    )
+    memory_block = FactExtractionMemoryBlock(llm=mock_llm)
+
+    await memory_block.aput(tool_history_messages)
+
+    assert len(mock_llm.messages_history) == 1
+    fact_messages = mock_llm.messages_history[0]
+    assert all(message.role != MessageRole.TOOL for message in fact_messages)
+    assert all(
+        not isinstance(block, ToolCallBlock)
+        for message in fact_messages
+        for block in message.blocks
+    )
+
+    conversation_message = fact_messages[0]
+    assert conversation_message.role == MessageRole.USER
+    assert len(conversation_message.blocks) == 1
+    assert isinstance(conversation_message.blocks[0], TextBlock)
+    conversation_text = conversation_message.blocks[0].text
+    assert "<message role='user'>Find my next flight.</message>" in conversation_text
+    assert "<message role='tool'>Flight AF123 leaves at 5pm." in conversation_text
+    assert "lookup_flight" not in conversation_text
+    assert "tool_call_id" not in conversation_text
+    assert memory_block.facts == ["User asked about a flight"]
+
+
+@pytest.mark.asyncio
+async def test_aput_flattens_tool_history_before_condensing(
+    tool_history_messages,
+):
+    """Test condensing uses the same flattened history as extraction."""
+    mock_llm = MyMockLLM(
+        responses=[
+            ChatResponse(
+                message=ChatMessage(
+                    content=(
+                        "<facts>"
+                        "<fact>User asked about a flight</fact>"
+                        "<fact>Flight AF123 leaves at 5pm</fact>"
+                        "</facts>"
+                    )
+                )
+            ),
+            ChatResponse(
+                message=ChatMessage(
+                    content="<facts><fact>User asked about AF123</fact></facts>"
+                )
+            ),
+        ]
+    )
+    memory_block = FactExtractionMemoryBlock(llm=mock_llm, max_facts=1)
+
+    await memory_block.aput(tool_history_messages)
+
+    assert len(mock_llm.messages_history) == 2
+    for llm_messages in mock_llm.messages_history:
+        assert all(message.role != MessageRole.TOOL for message in llm_messages)
+        assert all(
+            not isinstance(block, ToolCallBlock)
+            for message in llm_messages
+            for block in message.blocks
+        )
+        assert llm_messages[0].role == MessageRole.USER
+        conversation_text = llm_messages[0].content or ""
+        assert "Flight AF123 leaves at 5pm." in conversation_text
+        assert "lookup_flight" not in conversation_text
+        assert "tool_call_id" not in conversation_text
+
+    assert memory_block.facts == ["User asked about AF123"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #19841.

`FactExtractionMemoryBlock` was forwarding flushed chat history directly into its auxiliary fact-extraction LLM. When that history contains provider-native tool blocks, providers such as Bedrock Converse can reject the call because tool-use/tool-result content is present without the agent's tool configuration.

This change flattens the incoming history into a single text-only conversation message before fact extraction and condensing:

- includes only `TextBlock` content from flushed messages
- skips assistant messages that only contain `ToolCallBlock`s
- preserves textual tool results as plain transcript text
- omits `additional_kwargs` so provider tool metadata does not leak into the memory LLM prompt

## Tests

- `../llama-index-18694/.venv/bin/pytest llama-index-core/tests/memory/blocks/test_fact.py -q`
- `../llama-index-18694/.venv/bin/pytest llama-index-core/tests/memory/blocks/test_fact.py llama-index-core/tests/memory/blocks/test_vector.py llama-index-core/tests/memory/test_memory_base.py -q`
- `../llama-index-18694/.venv/bin/ruff check llama-index-core/llama_index/core/memory/memory_blocks/fact.py llama-index-core/tests/memory/blocks/test_fact.py`
- `../llama-index-18694/.venv/bin/ruff format --check llama-index-core/llama_index/core/memory/memory_blocks/fact.py llama-index-core/tests/memory/blocks/test_fact.py`
- `git diff --check`