### PR TITLE
fix: serialize Postgres chat store provider tool calls

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py
@@ -1,9 +1,8 @@
-import base64
 import json
 from typing import Any, Optional
 from urllib.parse import urlparse
 
-from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.llms import ChatMessage
 from llama_index.core.storage.chat_store.base import BaseChatStore
 from sqlalchemy import (
@@ -22,30 +21,26 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.dialects.postgresql import JSON, ARRAY, JSONB, VARCHAR
 
 
-def _jsonable(value: Any) -> Any:
-    if isinstance(value, BaseModel):
-        return value.model_dump(mode="json")
-    if isinstance(value, dict):
-        return {key: _jsonable(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_jsonable(item) for item in value]
-    if isinstance(value, bytes):
-        return base64.b64encode(value).decode("utf-8")
-
+def _normalize_proto_plus(value: Any) -> Any:
     # google.ai.generativelanguage FunctionCall is a proto-plus message. Its
     # JSON conversion is exposed on the class rather than the instance.
     to_dict = getattr(type(value), "to_dict", None)
     if hasattr(value, "_pb") and callable(to_dict):
-        return _jsonable(to_dict(value))
+        return _normalize_proto_plus(to_dict(value))
+
+    if isinstance(value, dict):
+        return {key: _normalize_proto_plus(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_proto_plus(item) for item in value]
 
     return value
 
 
 def _message_to_json(message: ChatMessage) -> str:
     message = message.model_copy(
-        update={"additional_kwargs": _jsonable(message.additional_kwargs)}
+        update={"additional_kwargs": _normalize_proto_plus(message.additional_kwargs)}
     )
-    return json.dumps(message.model_dump(mode="json"))
+    return message.model_dump_json()
 
 
 def _message_from_stored_value(value: Any) -> ChatMessage:

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py
@@ -1,6 +1,11 @@
+import base64
+import json
 from typing import Any, Optional
 from urllib.parse import urlparse
 
+from llama_index.core.bridge.pydantic import BaseModel, Field, PrivateAttr
+from llama_index.core.llms import ChatMessage
+from llama_index.core.storage.chat_store.base import BaseChatStore
 from sqlalchemy import (
     Index,
     Column,
@@ -13,11 +18,40 @@ from sqlalchemy import (
     inspect,
 )
 from sqlalchemy.orm import sessionmaker, declarative_base
-from llama_index.core.llms import ChatMessage
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.dialects.postgresql import JSON, ARRAY, JSONB, VARCHAR
-from llama_index.core.bridge.pydantic import Field, PrivateAttr
-from llama_index.core.storage.chat_store.base import BaseChatStore
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {key: _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("utf-8")
+
+    # google.ai.generativelanguage FunctionCall is a proto-plus message. Its
+    # JSON conversion is exposed on the class rather than the instance.
+    to_dict = getattr(type(value), "to_dict", None)
+    if hasattr(value, "_pb") and callable(to_dict):
+        return _jsonable(to_dict(value))
+
+    return value
+
+
+def _message_to_json(message: ChatMessage) -> str:
+    message = message.model_copy(
+        update={"additional_kwargs": _jsonable(message.additional_kwargs)}
+    )
+    return json.dumps(message.model_dump(mode="json"))
+
+
+def _message_from_stored_value(value: Any) -> ChatMessage:
+    if isinstance(value, str):
+        value = json.loads(value)
+    return ChatMessage.model_validate(value)
 
 
 def get_data_model(
@@ -236,7 +270,7 @@ class PostgresChatStore(BaseChatStore):
 
             params = {
                 "key": key,
-                "value": [message.model_dump_json() for message in messages],
+                "value": [_message_to_json(message) for message in messages],
             }
 
             # Execute the bulk upsert
@@ -258,7 +292,7 @@ class PostgresChatStore(BaseChatStore):
 
             params = {
                 "key": key,
-                "value": [message.model_dump_json() for message in messages],
+                "value": [_message_to_json(message) for message in messages],
             }
 
             # Execute the bulk upsert
@@ -272,7 +306,7 @@ class PostgresChatStore(BaseChatStore):
             result = result.scalars().first()
             if result:
                 return [
-                    ChatMessage.model_validate(removed_message)
+                    _message_from_stored_value(removed_message)
                     for removed_message in result.value
                 ]
             return []
@@ -284,7 +318,7 @@ class PostgresChatStore(BaseChatStore):
             result = result.scalars().first()
             if result:
                 return [
-                    ChatMessage.model_validate(removed_message)
+                    _message_from_stored_value(removed_message)
                     for removed_message in result.value
                 ]
             return []
@@ -301,7 +335,7 @@ class PostgresChatStore(BaseChatStore):
                     value = array_cat({self._table_class.__tablename__}.value, :value);
                 """
             )
-            params = {"key": key, "value": [message.model_dump_json()]}
+            params = {"key": key, "value": [_message_to_json(message)]}
             session.execute(stmt, params)
             session.commit()
 
@@ -317,7 +351,7 @@ class PostgresChatStore(BaseChatStore):
                     value = array_cat({self._table_class.__tablename__}.value, :value);
                 """
             )
-            params = {"key": key, "value": [message.model_dump_json()]}
+            params = {"key": key, "value": [_message_to_json(message)]}
             await session.execute(stmt, params)
             await session.commit()
 
@@ -364,7 +398,7 @@ class PostgresChatStore(BaseChatStore):
             session.execute(stmt, params)
             session.commit()
 
-            return ChatMessage.model_validate(removed_message)
+            return _message_from_stored_value(removed_message)
 
     async def adelete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
         """Async version of Delete specific message for a key."""
@@ -395,7 +429,7 @@ class PostgresChatStore(BaseChatStore):
             await session.execute(stmt, params)
             await session.commit()
 
-            return ChatMessage.model_validate(removed_message)
+            return _message_from_stored_value(removed_message)
 
     def delete_last_message(self, key: str) -> Optional[ChatMessage]:
         """Delete last message for a key."""
@@ -422,7 +456,7 @@ class PostgresChatStore(BaseChatStore):
             session.execute(stmt, params)
             session.commit()
 
-            return ChatMessage.model_validate(removed_message)
+            return _message_from_stored_value(removed_message)
 
     async def adelete_last_message(self, key: str) -> Optional[ChatMessage]:
         """Async version of Delete last message for a key."""
@@ -449,7 +483,7 @@ class PostgresChatStore(BaseChatStore):
             await session.execute(stmt, params)
             await session.commit()
 
-            return ChatMessage.model_validate(removed_message)
+            return _message_from_stored_value(removed_message)
 
     def get_keys(self) -> list[str]:
         """Get all keys."""

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
@@ -47,15 +47,25 @@ def test_message_to_json_serializes_proto_plus_function_call():
         content="",
         role="assistant",
         additional_kwargs={
-            "tool_calls": [ProtoPlusFunctionCall(name="add", args={"a": 1, "b": 2})]
+            "tool_calls": [ProtoPlusFunctionCall(name="add", args={"a": 1, "b": 2})],
+            "raw_bytes": b"binary",
         },
     )
 
     stored_message = json.loads(_message_to_json(message))
+    expected_message = message.model_copy(
+        update={
+            "additional_kwargs": {
+                "tool_calls": [{"name": "add", "args": {"a": 1, "b": 2}}],
+                "raw_bytes": b"binary",
+            }
+        }
+    )
 
     assert stored_message["additional_kwargs"]["tool_calls"] == [
         {"name": "add", "args": {"a": 1, "b": 2}}
     ]
+    assert stored_message == json.loads(expected_message.model_dump_json())
     assert _message_from_stored_value(stored_message).additional_kwargs[
         "tool_calls"
     ] == [{"name": "add", "args": {"a": 1, "b": 2}}]

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
@@ -1,16 +1,19 @@
+import json
 import time
-from typing import Dict, Generator, Union
+from typing import Any, Dict, Generator
 
 import pytest
-import docker
-from docker.models.containers import Container
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import declarative_base
 
 from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
 from llama_index.core.storage.chat_store.base import BaseChatStore
 from llama_index.storage.chat_store.postgres import PostgresChatStore
-from llama_index.storage.chat_store.postgres.base import get_data_model
+from llama_index.storage.chat_store.postgres.base import (
+    _message_from_stored_value,
+    _message_to_json,
+    get_data_model,
+)
 
 try:
     import asyncpg  # noqa
@@ -27,8 +30,47 @@ def test_class():
     assert BaseChatStore.__name__ in names_of_base_classes
 
 
+class ProtoPlusFunctionCall:
+    _pb = object()
+
+    def __init__(self, name: str, args: Dict[str, int]) -> None:
+        self.name = name
+        self.args = args
+
+    @classmethod
+    def to_dict(cls, value: "ProtoPlusFunctionCall") -> Dict[str, object]:
+        return {"name": value.name, "args": value.args}
+
+
+def test_message_to_json_serializes_proto_plus_function_call():
+    message = ChatMessage(
+        content="",
+        role="assistant",
+        additional_kwargs={
+            "tool_calls": [ProtoPlusFunctionCall(name="add", args={"a": 1, "b": 2})]
+        },
+    )
+
+    stored_message = json.loads(_message_to_json(message))
+
+    assert stored_message["additional_kwargs"]["tool_calls"] == [
+        {"name": "add", "args": {"a": 1, "b": 2}}
+    ]
+    assert _message_from_stored_value(stored_message).additional_kwargs[
+        "tool_calls"
+    ] == [{"name": "add", "args": {"a": 1, "b": 2}}]
+
+
+def test_message_from_stored_value_accepts_legacy_json_string():
+    message = ChatMessage(content="hello", role="user")
+
+    assert _message_from_stored_value(_message_to_json(message)).content == "hello"
+
+
 @pytest.fixture(scope="session")
-def postgres_container() -> Generator[Dict[str, Union[str, Container]], None, None]:
+def postgres_container() -> Generator[Dict[str, Any], None, None]:
+    docker = pytest.importorskip("docker")
+
     # Define PostgreSQL settings
     postgres_image = "postgres:latest"
     postgres_env = {
@@ -71,10 +113,12 @@ def postgres_container() -> Generator[Dict[str, Union[str, Container]], None, No
 
 
 @pytest.fixture()
-@pytest.mark.skipif(no_packages, reason="asyncpg, psycopg and sqlalchemy not installed")
 def postgres_chat_store(
-    postgres_container: Dict[str, Union[str, Container]],
+    postgres_container: Dict[str, Any],
 ) -> Generator[PostgresChatStore, None, None]:
+    if no_packages:
+        pytest.skip("asyncpg, psycopg and sqlalchemy not installed")
+
     chat_store = None
     try:
         chat_store = PostgresChatStore.from_uri(
@@ -300,7 +344,7 @@ async def test_async_multimodal_messages(postgres_chat_store: PostgresChatStore)
 
 @pytest.mark.skipif(no_packages, reason="asyncpg, psycopg and sqlalchemy not installed")
 def test_table_name_without_prefix(
-    postgres_container: Dict[str, Union[str, Container]],
+    postgres_container: Dict[str, Any],
 ):
     table_name = "custom_chat_store"
     chat_store = PostgresChatStore.from_uri(
@@ -327,7 +371,7 @@ def test_table_name_without_prefix(
 
 @pytest.mark.skipif(no_packages, reason="asyncpg, psycopg and sqlalchemy not installed")
 def test_legacy_table_name_detection(
-    postgres_container: Dict[str, Union[str, Container]],
+    postgres_container: Dict[str, Any],
 ):
     table_name = "legacy_chat_store"
 
@@ -369,7 +413,7 @@ def test_legacy_table_name_detection(
 
 @pytest.mark.skipif(no_packages, reason="asyncpg, psycopg and sqlalchemy not installed")
 def test_empty_table_name_defaults_to_chatstore(
-    postgres_container: Dict[str, Union[str, Container]],
+    postgres_container: Dict[str, Any],
 ):
     table_name = ""
     default_table_name = "chatstore"


### PR DESCRIPTION
## Summary

Fixes #19992.

`PostgresChatStore` serialized chat messages with `ChatMessage.model_dump_json()`, which fails when FunctionAgent history contains provider-native Gemini `FunctionCall` objects in `additional_kwargs`. This normalizes message `additional_kwargs` before persistence, including proto-plus values that expose class-level `to_dict()`, then stores the same JSON-string shape the integration already used.

The read path now also accepts already-decoded dict rows in addition to the existing stored JSON strings, preserving compatibility with the current storage format while making future/direct JSON use tolerant.

## Validation

- `.venv/bin/pytest llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py -k "message_to_json or message_from_stored_value" -q`
- `.venv/bin/ruff check llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py`
- `.venv/bin/black --check llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py`
- `git diff --check HEAD~1..HEAD`

I could not run the live Postgres container tests in this environment because Docker is unavailable, so coverage is focused on the DB-free serialization path that caused the reported failure.