### PR TITLE
fix(chat_engine): use blocks instead of content setter for multi-block messages

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -191,7 +192,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                chat.message.blocks = [TextBlock(text=final_text.strip())]
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -249,7 +250,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                chat.message.blocks = [TextBlock(text=final_text.strip())]
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))


### PR DESCRIPTION
## Description

Fixes `ValueError: ChatMessage contains multiple blocks` crash in `SimpleChatEngine` streaming when the final assistant message contains multiple blocks.

## Root Cause

`write_response_to_history` and `awrite_response_to_history` use `chat.message.content = final_text.strip()` which raises `ValueError` when the ChatMessage has multiple blocks (the `.content` setter only supports single-TextBlock messages per its validation logic).

## Fix

Replace `chat.message.content = final_text.strip()` with `chat.message.blocks = [TextBlock(text=final_text.strip())]` in both sync and async paths. This directly sets the blocks list without going through the restrictive setter, and correctly consolidates the streamed text into a single TextBlock for history storage.

## Test plan
- [ ] Verify `SimpleChatEngine.astream_chat()` no longer raises ValueError when LLM returns multi-block responses
- [ ] Verify single-block responses still work correctly
- [ ] Existing chat engine tests pass

Closes #21679

🤖 Generated with [Claude Code](https://claude.com/claude-code)