### PR TITLE
fix: lazily create Milvus async client

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -253,6 +253,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
 
     _milvusclient: MilvusClient = PrivateAttr()
     _async_milvusclient: Optional[AsyncMilvusClient] = PrivateAttr()
+    _async_milvusclient_kwargs: Dict[str, Any] = PrivateAttr()
     _collection_initialized: bool = PrivateAttr(default=False)
 
     def __init__(
@@ -323,14 +324,8 @@ class MilvusVectorStore(BasePydanticVectorStore):
         # As of writing, milvus sets alias internally in the async client.
         # This will cause an error if not removed.
         kwargs.pop("alias", None)
-        if use_async_client:
-            self._async_milvusclient = AsyncMilvusClient(
-                uri=uri,
-                token=token,
-                **kwargs,  # pass additional arguments such as server_pem_path
-            )
-        else:
-            self._async_milvusclient = None
+        self._async_milvusclient_kwargs = {"uri": uri, "token": token, **kwargs}
+        self._async_milvusclient = None
 
         # Delete previous collection if overwriting
         if overwrite and collection_name in self.client.list_collections():
@@ -431,6 +426,10 @@ class MilvusVectorStore(BasePydanticVectorStore):
     @property
     def aclient(self) -> Optional[AsyncMilvusClient]:
         """Get async client."""
+        if self._async_milvusclient is None and self.use_async_client:
+            self._async_milvusclient = AsyncMilvusClient(
+                **self._async_milvusclient_kwargs
+            )
         return self._async_milvusclient
 
     def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
@@ -506,7 +505,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         **add_kwargs: Any,
     ) -> List[str]:
         """Asynchronous version of the add method."""
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         insert_list = []
@@ -597,7 +596,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
 
     async def adelete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """Asynchronous version of the delete method."""
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         # Adds ability for multiple doc delete in future.
@@ -665,7 +664,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         **delete_kwargs: Any,
     ) -> None:
         """Asynchronous version of the delete_nodes method."""
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         filters_cpy = deepcopy(filters) or MetadataFilters(filters=[])
@@ -694,7 +693,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
 
     async def aclear(self) -> None:
         """Asynchronous version of the clear method."""
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         await self.aclient.drop_collection(self.collection_name)
@@ -768,7 +767,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         **kwargs,
     ) -> List[BaseNode]:
         """Asynchronous version of the get_nodes method."""
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         if node_ids is None and filters is None:
@@ -878,7 +877,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         self, query: VectorStoreQuery, **kwargs: Any
     ) -> VectorStoreQueryResult:
         """Asynchronous version of the query method."""
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         if query.mode == VectorStoreQueryMode.DEFAULT:
@@ -1003,7 +1002,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         """
         Perform asynchronous default search.
         """
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         res = await self.aclient.search(
@@ -1093,7 +1092,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         """
         Perform asynchronous MMR search.
         """
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         mmr_threshold = kwargs.get("mmr_threshold")
@@ -1189,7 +1188,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         """
         Perform asynchronous sparse search.
         """
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         search_params = {"params": {"drop_ratio_search": 0.2}}
@@ -1295,7 +1294,7 @@ class MilvusVectorStore(BasePydanticVectorStore):
         """
         Perform asynchronous hybrid search.
         """
-        assert self._async_milvusclient is not None, (
+        assert self.aclient is not None, (
             "Async Client should be non-null to perform async operations. Pass `use_async_client = True` to the constructor to instantiate an async client"
         )
         if isinstance(self.sparse_embedding_function, BaseSparseEmbeddingFunction):

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-milvus"
-version = "1.1.0"
+version = "1.1.1"
 description = "llama-index vector_stores milvus integration"
 authors = []
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/test_vector_stores_milvus.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/tests/test_vector_stores_milvus.py
@@ -1,0 +1,69 @@
+from llama_index.core.vector_stores.types import BasePydanticVectorStore
+from llama_index.vector_stores.milvus import MilvusVectorStore
+
+
+class FakeMilvusClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def list_collections(self):
+        return ["llamacollection"]
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in MilvusVectorStore.__mro__]
+    assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+def test_async_client_is_created_lazily(monkeypatch):
+    async_client_calls = []
+
+    class FakeAsyncMilvusClient:
+        def __init__(self, **kwargs):
+            async_client_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "llama_index.vector_stores.milvus.base.MilvusClient", FakeMilvusClient
+    )
+    monkeypatch.setattr(
+        "llama_index.vector_stores.milvus.base.AsyncMilvusClient",
+        FakeAsyncMilvusClient,
+    )
+    monkeypatch.setattr(
+        MilvusVectorStore,
+        "_create_index_if_required",
+        lambda self: None,
+    )
+
+    vector_store = MilvusVectorStore(
+        uri="http://localhost:19530",
+        token="token",
+        alias="default",
+        server_pem_path="/tmp/cert.pem",
+    )
+
+    assert async_client_calls == []
+
+    assert isinstance(vector_store.aclient, FakeAsyncMilvusClient)
+    assert async_client_calls == [
+        {
+            "uri": "http://localhost:19530",
+            "token": "token",
+            "server_pem_path": "/tmp/cert.pem",
+        }
+    ]
+
+
+def test_async_client_stays_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "llama_index.vector_stores.milvus.base.MilvusClient", FakeMilvusClient
+    )
+    monkeypatch.setattr(
+        MilvusVectorStore,
+        "_create_index_if_required",
+        lambda self: None,
+    )
+
+    vector_store = MilvusVectorStore(use_async_client=False)
+
+    assert vector_store.aclient is None

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/uv.lock
@@ -1888,7 +1888,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-vector-stores-milvus"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
## Summary

- defer `AsyncMilvusClient` construction until `aclient` or an async operation is used
- keep sync `MilvusVectorStore(...)` construction from eagerly requiring an async event loop
- add focused mocked Milvus regression coverage for lazy async-client construction

Fixes #20313.

## Context

#20687 added a `use_async_client` escape hatch, but current `main` still eagerly constructs `AsyncMilvusClient` when `use_async_client=True`, which is the default. This keeps the default sync-construction path exposed to pymilvus event-loop requirements even for sync-only callers.

## Validation

From `llama-index-integrations/vector_stores/llama-index-vector-stores-milvus`:

- `uv run --frozen --python /usr/bin/python3.12 -- pytest tests/test_vector_stores_milvus.py -q` -> 3 passed
- `uv run --frozen --python /usr/bin/python3.12 -- ruff check llama_index/vector_stores/milvus/base.py tests/test_vector_stores_milvus.py` -> passed
- `uv run --frozen --python /usr/bin/python3.12 -- ruff format --check llama_index/vector_stores/milvus/base.py tests/test_vector_stores_milvus.py` -> passed
- `git diff --check` -> passed

`uv lock --check` still hits the package dev dependency conflict between pytest 9 and pytest-asyncio <0.24, so validation used the committed lockfile with `--frozen`.