### PR TITLE
fix: lazily create Google rerank async client

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/llama_index/postprocessor/google_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/llama_index/postprocessor/google_rerank/base.py
@@ -53,7 +53,8 @@ class GoogleRerank(BaseNodePostprocessor):
     )
 
     _client: Any = PrivateAttr()
-    _async_client: Any = PrivateAttr()
+    _async_client: Any = PrivateAttr(default=None)
+    _credentials: Any = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -81,10 +82,15 @@ class GoogleRerank(BaseNodePostprocessor):
             _, resolved_project = google.auth.default()
             self.project_id = resolved_project
 
+        self._credentials = credentials
         self._client = discoveryengine.RankServiceClient(credentials=credentials)
-        self._async_client = discoveryengine.RankServiceAsyncClient(
-            credentials=credentials
-        )
+
+    def _get_async_client(self) -> Any:
+        if self._async_client is None:
+            self._async_client = discoveryengine.RankServiceAsyncClient(
+                credentials=self._credentials
+            )
+        return self._async_client
 
     @classmethod
     def class_name(cls) -> str:
@@ -185,7 +191,7 @@ class GoogleRerank(BaseNodePostprocessor):
             records=records,
         )
 
-        response = await self._async_client.rank(request=request)
+        response = await self._get_async_client().rank(request=request)
 
         new_nodes = []
         for record in response.records:

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/tests/test_postprocessor_google_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/tests/test_postprocessor_google_rerank.py
@@ -90,6 +90,7 @@ async def test_google_rerank_async():
             {"index": 0, "score": 0.70},
         ]
     )
+    reranker._async_client = MagicMock()
     reranker._async_client.rank = AsyncMock(return_value=mock_response)
 
     input_nodes = [
@@ -108,6 +109,35 @@ async def test_google_rerank_async():
     assert actual_nodes[1].node.get_content() == "hello world"
     assert actual_nodes[1].score == pytest.approx(0.70)
     reranker._async_client.rank.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_google_rerank_async_client_created_lazily():
+    mock_response = _make_mock_response([{"index": 0, "score": 0.95}])
+    mock_async_client = MagicMock()
+    mock_async_client.rank = AsyncMock(return_value=mock_response)
+
+    with mock.patch(
+        "llama_index.postprocessor.google_rerank.base.discoveryengine",
+        create=True,
+    ) as mock_discoveryengine:
+        mock_discoveryengine.RankServiceClient.return_value = MagicMock()
+        mock_discoveryengine.RankServiceAsyncClient.return_value = mock_async_client
+
+        reranker = GoogleRerank(project_id="test-project")
+
+        mock_discoveryengine.RankServiceAsyncClient.assert_not_called()
+
+        actual_nodes = await reranker.apostprocess_nodes(
+            [NodeWithScore(node=TextNode(id_="1", text="hello world"))],
+            query_bundle=QueryBundle(query_str="hello"),
+        )
+
+    assert len(actual_nodes) == 1
+    assert actual_nodes[0].node.get_content() == "hello world"
+    assert actual_nodes[0].score == pytest.approx(0.95)
+    mock_discoveryengine.RankServiceAsyncClient.assert_called_once()
+    mock_async_client.rank.assert_called_once()
 
 
 def test_google_rerank_empty_nodes():


### PR DESCRIPTION
## Summary
- create the Google rerank async Discovery Engine client only when the async postprocessor path runs
- preserve the existing synchronous rerank client behavior
- add regression coverage that the async client is not created during initialization

Fixes #21150

## Validation
- `uv run --frozen pytest tests/test_postprocessor_google_rerank.py`
- `uv run --frozen ruff check llama_index/postprocessor/google_rerank/base.py tests/test_postprocessor_google_rerank.py`
- `uv run --frozen ruff format --check llama_index/postprocessor/google_rerank/base.py tests/test_postprocessor_google_rerank.py`
- `git diff --check`