### PR TITLE
test(core): cover async multimodal tool outputs

### DIFF
--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -538,3 +538,24 @@ def test_function_tool_output_document_and_text_blocks() -> None:
     assert isinstance(tool_output.blocks[0], DocumentBlock)
     assert isinstance(tool_output.blocks[1], TextBlock)
     assert tool_output.content == "Summary of the document"
+
+
+@pytest.mark.asyncio
+async def test_function_tool_async_output_document_and_video_blocks() -> None:
+    """Test that async tools preserve document and video output blocks."""
+
+    async def get_blocks() -> list:
+        return [
+            DocumentBlock(data=b"fake-pdf-bytes", document_mimetype="application/pdf"),
+            VideoBlock(video=b"fake-video-bytes", video_mimetype="video/mp4"),
+            TextBlock(text="Summary of the assets"),
+        ]
+
+    tool = FunctionTool.from_defaults(get_blocks)
+    tool_output = await tool.acall()
+
+    assert len(tool_output.blocks) == 3
+    assert isinstance(tool_output.blocks[0], DocumentBlock)
+    assert isinstance(tool_output.blocks[1], VideoBlock)
+    assert isinstance(tool_output.blocks[2], TextBlock)
+    assert tool_output.content == "Summary of the assets"


### PR DESCRIPTION
## Summary
- add async FunctionTool coverage for DocumentBlock and VideoBlock outputs
- assert async tool output keeps binary/media blocks intact while exposing only text blocks through ToolOutput.content

## Context
PR #21678 added passthrough handling for DocumentBlock and VideoBlock outputs. Existing coverage exercises the sync path; this adds direct coverage for the async path used by agent workflows.

## Validation
- `uv run --frozen pytest tests/tools/test_base.py -q`
- `uv run --frozen ruff check tests/tools/test_base.py`
- `uv run --frozen ruff format --check tests/tools/test_base.py`
- `git diff --check`

Prepared with AI assistance and manually reviewed/validated.