### PR TITLE
fix(llms): keep LiteLLM stream tool call ids stable

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-litellm/llama_index/llms/litellm/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-litellm/llama_index/llms/litellm/utils.py
@@ -388,9 +388,7 @@ def update_tool_calls(
 
                     # Update ID if present
                     if "id" in delta_dict:
-                        if "id" not in existing_tool:
-                            existing_tool["id"] = ""
-                        existing_tool["id"] += delta_dict.get("id", "")
+                        existing_tool["id"] = delta_dict["id"]
 
                     # Update type if present
                     if "type" in delta_dict:

--- a/llama-index-integrations/llms/llama-index-llms-litellm/tests/test_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-litellm/tests/test_utils.py
@@ -341,6 +341,26 @@ def test_update_tool_calls_partial_arguments():
     assert result[0]["function"]["arguments"] == '{"key":'
 
 
+def test_update_tool_calls_repeated_id_is_not_appended():
+    """Tool call IDs are stable identifiers, not streamed text fragments."""
+    tool_calls = [
+        {
+            "id": "call_123",
+            "type": "function",
+            "index": 0,
+            "function": {"name": "test_function", "arguments": "{"},
+        }
+    ]
+
+    delta = ChatCompletionDeltaToolCall(
+        index=0, id="call_123", function={"arguments": '"key":1}'}
+    )
+
+    result = update_tool_calls(tool_calls, [delta])
+    assert result[0]["id"] == "call_123"
+    assert result[0]["function"]["arguments"] == '{"key":1}'
+
+
 def test_update_tool_calls_multiple_parallel():
     """Test handling multiple parallel tool calls."""
     tool_calls = [


### PR DESCRIPTION
﻿## Summary

LiteLLM streaming tool-call chunks can repeat the same completed tool call id while continuing to stream function arguments. `update_tool_calls` treated `id` like text delta and appended it to the existing id, so a repeated `call_123` chunk became `call_123call_123`.

This keeps the latest id value instead of concatenating it. Function name and argument chunks still use the existing append behavior.

## Tests

- `uv run --project llama-index-integrations\llms\llama-index-llms-litellm ruff check llama-index-integrations\llms\llama-index-llms-litellm`
- `uv run --project llama-index-integrations\llms\llama-index-llms-litellm pytest llama-index-integrations\llms\llama-index-llms-litellm\tests -q`

`mypy` was also tried for this package, but the pinned mypy 0.991 currently hits an internal error inside pydantic's installed `root_model.py` before reaching this change.
