### PR TITLE
fix: handle multi-block streamed chat history

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -40,6 +41,14 @@ def is_function(message: ChatMessage) -> bool:
         "tool_calls" in message.additional_kwargs
         and len(message.additional_kwargs["tool_calls"]) > 0
     )
+
+
+def _set_streamed_message_content(message: ChatMessage, content: str) -> None:
+    """Set streamed text while preserving any non-text blocks on the message."""
+    non_text_blocks = [
+        block for block in message.blocks if not isinstance(block, TextBlock)
+    ]
+    message.blocks = [TextBlock(text=content), *non_text_blocks]
 
 
 class ChatResponseMode(str, Enum):
@@ -191,7 +200,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_streamed_message_content(chat.message, final_text.strip())
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -249,7 +258,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_streamed_message_content(chat.message, final_text.strip())
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -1,17 +1,62 @@
-import gc
 import asyncio
-from llama_index.core.memory import ChatMemoryBuffer
+import gc
+from collections.abc import AsyncGenerator, Generator, Sequence
+from typing import Any
+
+import pytest
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    ChatResponse,
     CompletionResponse,
     CompletionResponseGen,
+    MessageRole,
+    TextBlock,
 )
-from typing import Any
-from llama_index.core.llms.callbacks import llm_completion_callback
-from llama_index.core.llms.mock import MockLLM
-import pytest
-from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.chat_engine.simple import SimpleChatEngine
+from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.memory import ChatMemoryBuffer
+
+
+class MultiBlockStreamingLLM(MockLLM):
+    @classmethod
+    def class_name(cls) -> str:
+        return "MultiBlockStreamingLLM"
+
+    @llm_chat_callback()
+    def stream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> Generator[ChatResponse, None, None]:
+        for delta in ["Hello", " ", "world"]:
+            yield ChatResponse(
+                message=ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    blocks=[
+                        TextBlock(text="stale text"),
+                        TextBlock(text="second stale text"),
+                    ],
+                ),
+                delta=delta,
+            )
+
+    @llm_chat_callback()
+    async def astream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> AsyncGenerator[ChatResponse, None]:
+        async def gen() -> AsyncGenerator[ChatResponse, None]:
+            for delta in ["Hello", " ", "world"]:
+                yield ChatResponse(
+                    message=ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        blocks=[
+                            TextBlock(text="stale text"),
+                            TextBlock(text="second stale text"),
+                        ],
+                    ),
+                    delta=delta,
+                )
+
+        return gen()
 
 
 def test_simple_chat_engine() -> None:
@@ -71,6 +116,29 @@ async def test_simple_chat_engine_astream():
     assert num_iters > 10
     assert "Hello World!" in response.unformatted_response
     assert "What is the capital of the moon?" in response.unformatted_response
+
+
+def test_simple_chat_engine_stream_multiblock_message_history() -> None:
+    engine = SimpleChatEngine.from_defaults(llm=MultiBlockStreamingLLM())
+    response = engine.stream_chat("Hello?")
+
+    assert "".join(response.response_gen) == "Hello world"
+    assert engine.chat_history[-1].content == "Hello world"
+    assert engine.chat_history[-1].blocks == [TextBlock(text="Hello world")]
+
+
+@pytest.mark.asyncio
+async def test_simple_chat_engine_astream_multiblock_message_history() -> None:
+    engine = SimpleChatEngine.from_defaults(llm=MultiBlockStreamingLLM())
+    response = await engine.astream_chat("Hello?")
+
+    chunks = []
+    async for chunk in response.async_response_gen():
+        chunks.append(chunk)
+
+    assert "".join(chunks) == "Hello world"
+    assert engine.chat_history[-1].content == "Hello world"
+    assert engine.chat_history[-1].blocks == [TextBlock(text="Hello world")]
 
 
 def test_simple_chat_engine_astream_exception_handling():


### PR DESCRIPTION
## Summary

Fixes #21679.

`StreamingAgentChatResponse` rewrites the final assistant message before saving streamed responses to memory. It previously assigned through `ChatMessage.content`, which raises `ValueError` when the streamed LLM returns a `ChatMessage` with multiple blocks.

This change updates the streamed text by replacing text blocks directly and preserving any non-text blocks, avoiding the legacy `content` setter for both sync and async streaming paths.

## Validation

- `uv run -- pytest tests/chat_engine/test_simple.py`
- `uv run -- ruff check llama_index/core/chat_engine/types.py tests/chat_engine/test_simple.py`

Full repository tests were not run; this is scoped to `llama-index-core` chat engine streaming history behavior.