### PR TITLE
docs: add CVFile reader discovery links

### DIFF
--- a/docs/src/content/docs/framework/community/integrations.md
+++ b/docs/src/content/docs/framework/community/integrations.md
@@ -12,7 +12,9 @@ The full set of LlamaPacks is available on [LlamaHub](https://llamahub.ai/). Che
 
 ## Data Loaders
 
-The full set of data loaders are found on [LlamaHub](https://llamahub.ai/)
+The full set of data loaders are found on [LlamaHub](https://llamahub.ai/).
+
+- [CVFile Reader](https://pypi.org/project/llama-index-readers-cvfile/) loads `.cv` resume/CV files via the `llama-index-readers-cvfile` package.
 
 ## Agent Tools
 

--- a/docs/src/content/docs/framework/module_guides/loading/connector/index.mdx
+++ b/docs/src/content/docs/framework/module_guides/loading/connector/index.mdx
@@ -45,6 +45,7 @@ Some sample data connectors:
 - [Google Docs](https://developers.google.com/docs/api) (`GoogleDocsReader`)
 - [Slack](https://api.slack.com/) (`SlackReader`)
 - [Discord](https://discord.com/developers/docs/intro) (`DiscordReader`)
+- [CVFile](https://pypi.org/project/llama-index-readers-cvfile/) (`CVFileReader`) for `.cv` resume/CV files
 - [Apify Actors](https://llamahub.ai/l/readers/llama-index-readers-apify) (`ApifyActor`). Can crawl the web, scrape webpages, extract text content, download files including `.pdf`, `.jpg`, `.png`, `.docx`, etc.
 
 See the [modules guide](/python/framework/module_guides/loading/connector/modules) for more details.

--- a/docs/src/content/docs/framework/module_guides/loading/connector/modules.md
+++ b/docs/src/content/docs/framework/module_guides/loading/connector/modules.md
@@ -26,5 +26,6 @@ title: Module Guides
 - [Make Reader](/python/examples/data_connectors/makedemo)
 - [Deplot Reader](/python/examples/data_connectors/deplot/deplotreader)
 - [Docling Reader](/python/examples/data_connectors/doclingreaderdemo)
+- [CVFile Reader](https://pypi.org/project/llama-index-readers-cvfile/) for `.cv` resume/CV files
 - [Google AlloyDB Reader](/python/examples/data_connectors/alloydbreaderdemo)
 - [Google Cloud SQL for PostgreSQL Reader](/python/examples/data_connectors/cloudsqlpgreaderdemo)


### PR DESCRIPTION
# Description

Add CVFile Reader discovery links to the data connector docs so users can find the existing `llama-index-readers-cvfile` package from the loading guides and community integrations page.

Fixes #21626

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Validated docs-only changes with:

- `python3` link/content check for the changed docs files
- `git diff --check`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
