### PR TITLE
test(core): cover SimpleVectorStore persistence fallback paths

### DIFF
--- a/llama-index-core/tests/vector_stores/test_simple.py
+++ b/llama-index-core/tests/vector_stores/test_simple.py
@@ -1,6 +1,8 @@
+import json
 import unittest
 from pathlib import Path
 from typing import List
+from unittest.mock import patch
 
 import pytest
 
@@ -485,3 +487,59 @@ def test_from_namespaced_persist_dir(persist_dir: str) -> None:
         persist_dir=persist_dir
     )
     assert vector_store is not None
+
+
+def test_from_namespaced_persist_dir_listdir_failure_fallback(monkeypatch):
+    """Test fallback when directory listing fails."""
+
+    def mock_listdir(_):
+        raise Exception("listdir failed")
+
+    monkeypatch.setattr("os.listdir", mock_listdir)
+
+    with patch.object(
+        SimpleVectorStore,
+        "from_persist_dir",
+        return_value=SimpleVectorStore(),
+    ):
+        stores = SimpleVectorStore.from_namespaced_persist_dir()
+
+    assert "default" in stores
+
+
+def test_from_namespaced_persist_dir_backward_compat_fallback(monkeypatch):
+    """Test fallback to backward compatibility load."""
+    call_count = 0
+
+    def mock_from_persist_dir(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+        if call_count == 1:
+            raise Exception("default namespace load failed")
+
+        return SimpleVectorStore()
+
+    monkeypatch.setattr(
+        SimpleVectorStore,
+        "from_persist_dir",
+        mock_from_persist_dir,
+    )
+
+    monkeypatch.setattr(
+        "os.listdir",
+        lambda _: (_ for _ in ()).throw(Exception("listdir failed")),
+    )
+
+    stores = SimpleVectorStore.from_namespaced_persist_dir()
+
+    assert "default" in stores
+
+
+def test_from_persist_path_invalid_json(tmp_path):
+    """Test corrupted persisted file raises JSONDecodeError."""
+    persist_file = tmp_path / "vector_store.json"
+    persist_file.write_text("{invalid json")
+
+    with pytest.raises(json.JSONDecodeError):
+        SimpleVectorStore.from_persist_path(str(persist_file))


### PR DESCRIPTION
# Description

Adds regression tests for SimpleVectorStore persistence fallback behavior.

These tests cover:
- fallback behavior when directory listing fails in `from_namespaced_persist_dir`
- backward compatibility fallback loading when default namespace loading fails
- invalid JSON handling in `from_persist_path`

This change improves test coverage for persistence edge cases and helps prevent regressions in fallback loading logic.

Fixes # (leave blank if no linked issue)

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Tested locally with:

`pytest llama-index-core/tests/vector_stores/test_simple.py`

All 30 tests passed.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
