### PR TITLE
fix: handle multiblock streaming chat history writes

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -249,7 +250,13 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                final_text = final_text.strip()
+                if len(chat.message.blocks) == 1 and isinstance(
+                    chat.message.blocks[0], TextBlock
+                ):
+                    chat.message.content = final_text  # final message
+                else:
+                    chat.message.blocks = [TextBlock(text=final_text)]
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -1,15 +1,20 @@
 import gc
 import asyncio
+from typing import Any, Sequence
+
+import pytest
 from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
     CompletionResponse,
     CompletionResponseGen,
+    LLMMetadata,
+    TextBlock,
 )
-from typing import Any
 from llama_index.core.llms.callbacks import llm_completion_callback
 from llama_index.core.llms.mock import MockLLM
-import pytest
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.chat_engine.simple import SimpleChatEngine
 
@@ -130,3 +135,40 @@ def test_simple_chat_engine_astream_exception_handling():
         pytest.fail(
             "Exception was not correctly handled - ended up in asyncio cleanup performed during garbage collection"
         )
+
+
+class MultiBlockMockLLM(MockLLM):
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(is_chat_model=True)
+
+    def stream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        def gen() -> ChatResponseAsyncGen:
+            yield ChatResponse(
+                message=ChatMessage(
+                    role=MessageRole.ASSISTANT,
+                    blocks=[
+                        TextBlock(text="hello "),
+                        TextBlock(text="world"),
+                    ],
+                ),
+                delta="hello world",
+            )
+
+        return gen()
+
+
+@pytest.mark.asyncio
+async def test_simple_chat_engine_astream_multiblock_message() -> None:
+    engine = SimpleChatEngine.from_defaults(llm=MultiBlockMockLLM())
+    response = await engine.astream_chat("Hello world")
+
+    num_iters = 0
+    async for _ in response.async_response_gen():
+        num_iters += 1
+
+    assert num_iters > 0
+    assert len(engine.chat_history) == 2
+    assert engine.chat_history[-1].content == "hello world"


### PR DESCRIPTION
# Description

Fixes a regression in `StreamingAgentChatResponse.awrite_response_to_history()` where streamed assistant messages with multiple blocks would still be written back through `ChatMessage.content`, triggering a `ValueError`.

This change preserves the final streamed text while safely updating chat history for both single-block and multi-block assistant messages.

Fixes #21679

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run pytest llama-index-core/tests/chat_engine/test_simple.py -q` to verify the fix
