### PR TITLE
fix: correct documentation typos in You.com and YugabyteDB docs.

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
@@ -81,7 +81,7 @@ class You(CustomLLM):
     )
     ydc_api_key: Optional[str] = Field(
         None,
-        description="You.com API key, if `YDC_API_KEY` is not set in the envrioment",
+        description="You.com API key, if `YDC_API_KEY` is not set in the environment",
     )
 
     @property

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-yugabytedb/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-yugabytedb/README.md
@@ -28,4 +28,4 @@ vector_store = YBVectorStore.from_params(
 )
 ```
 
-> **Note**: Please see the YugabyteDB psycopge2 driver documentation for more yugabytedb specific parameters [here](https://docs.yugabyte.com/preview/drivers-orms/python/yugabyte-psycopg2/#step-2-set-up-the-database-connection).
+> **Note**: Please see the YugabyteDB psycopg2 driver documentation for more yugabytedb specific parameters [here](https://docs.yugabyte.com/preview/drivers-orms/python/yugabyte-psycopg2/#step-2-set-up-the-database-connection).


### PR DESCRIPTION
**Summary**

* Corrected a typo in the `ydc_api_key` field description in You.com LLM (`envrioment` → `environment`)
* Corrected the YugabyteDB README driver name (`psycopge2` → `psycopg2`)
* No behavioral or functional changes

**Details**

These are documentation-only typo fixes intended to improve readability and accuracy.
Both changes are self-contained within their respective files, with no impact on functionality or logic.

**You.com Field Description**

Before
```python
ydc_api_key: Optional[str] = Field(
    None,
    description="You.com API key, if `YDC_API_KEY` is not set in the envrioment",
)
```

After
```python
ydc_api_key: Optional[str] = Field(
    None,
    description="You.com API key, if `YDC_API_KEY` is not set in the environment",
)
```

**YugabyteDB README Driver Name**

Before
```
Note: Please see the YugabyteDB psycopge2 driver documentation for more yugabytedb specific parameters here.
```

After
```
Note: Please see the YugabyteDB psycopg2 driver documentation for more yugabytedb specific parameters here.
```

Verified that no other references to the misspelled terms exist in the codebase.

---