### PR TITLE
chore: allow `google-genai` 2.0+ SDKs

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/llama_index/embeddings/google_genai/base.py
@@ -264,7 +264,7 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         def embed_with_client() -> List[List[float]]:
             results = self._client.models.embed_content(
                 model=self.model_name,
-                contents=texts,
+                contents=[[t] for t in texts],
                 config=embedding_config,
             )
             return [result.values for result in results.embeddings]
@@ -297,7 +297,7 @@ class GoogleGenAIEmbedding(BaseEmbedding):
         async def aembed_with_client() -> List[List[float]]:
             results = await self._client.aio.models.embed_content(
                 model=self.model_name,
-                contents=texts,
+                contents=[[t] for t in texts],
                 config=embedding_config,
             )
             return [result.values for result in results.embeddings]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/pyproject.toml
@@ -27,14 +27,14 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-google-genai"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index embeddings google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "google-genai>=1.24.0,<2",
+    "google-genai>=1.24.0,<3",
     "llama-index-core>=0.13.0,<0.15",
 ]
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-google-genai/uv.lock
@@ -1868,7 +1868,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-google-genai"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },
@@ -1900,7 +1900,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "google-genai", specifier = ">=1.24.0,<2" },
+    { name = "google-genai", specifier = ">=1.24.0,<3" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
 ]
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG — llama-index-llms-genai
 
+## [v0.9.4]
+
+### Changed
+
+- Bump `google-genai` dependency to support v2.0 SDKs
+
 ## [v0.9.3]
 
 ### Fixed

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -35,7 +35,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "pillow>=10.2.0",
-    "google-genai>=1.52.0,<2",
+    "google-genai>=1.52.0,<3",
     "llama-index-core>=0.14.5,<0.15",
 ]
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-google-genai"
-version = "0.9.2"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },
@@ -1905,7 +1905,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "google-genai", specifier = ">=1.52.0,<2" },
+    { name = "google-genai", specifier = ">=1.52.0,<3" },
     { name = "llama-index-core", specifier = ">=0.14.5,<0.15" },
     { name = "pillow", specifier = ">=10.2.0" },
 ]

--- a/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/pyproject.toml
+++ b/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-voice-agents-gemini-live"
-version = "0.4.0"
+version = "0.4.1"
 description = "LlamaIndex x Gemini Live integration"
 authors = [{name = "Clelia Astra Bertelli", email = "clelia@runllama.ai"}]
 requires-python = ">=3.10,<4.0"
@@ -36,7 +36,7 @@ maintainers = [{name = "AstraBert"}]
 dependencies = [
     "pyaudio>=0.2.14,<0.3",
     "llama-index-core>=0.13.0,<0.15",
-    "google-genai>=1.52.0,<2",
+    "google-genai>=1.52.0,<3",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/uv.lock
+++ b/llama-index-integrations/voice_agents/llama-index-voice-agents-gemini-live/uv.lock
@@ -1818,7 +1818,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-core"
-version = "0.14.21"
+version = "0.14.22"
 source = { directory = "../../../llama-index-core" }
 dependencies = [
     { name = "aiohttp" },
@@ -1909,7 +1909,7 @@ dev = [
     { name = "rake-nltk", specifier = "==1.0.6" },
     { name = "ruff", specifier = "==0.11.11" },
     { name = "tree-sitter" },
-    { name = "tree-sitter-language-pack" },
+    { name = "tree-sitter-language-pack", specifier = "<1.0" },
     { name = "types-deprecated", specifier = ">=0.1.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.12,<7" },
     { name = "types-requests", specifier = ">=2.28.11.8" },
@@ -1931,7 +1931,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-voice-agents-gemini-live"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },
@@ -1963,7 +1963,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "google-genai", specifier = ">=1.52.0,<2" },
+    { name = "google-genai", specifier = ">=1.52.0,<3" },
     { name = "llama-index-core", directory = "../../../llama-index-core" },
     { name = "pyaudio", specifier = ">=0.2.14,<0.3" },
 ]


### PR DESCRIPTION
# Description

Bumps the version bound from `<2` to `<3` as there are no breaking changes in the move to 2.0.

The only functional change is that text-only embedding models supported 1-dimensional batching but MM models need to support concatenating images/text/etc so must be batched in dimension 2. I've updated the embedding code to support this too.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

- [x] Future-enabling I guess?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested: all 3 package test suites with Gemini keys.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
