### PR TITLE
Upgrade mem0 to 2.x (llama-index-memory-mem0)

### DIFF
--- a/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/base.py
@@ -78,13 +78,13 @@ class Mem0Context(BaseModel):
             )
 
     def build_filter(self) -> dict[str, Any]:
-        flt = {"OR": []}
+        flt: dict[str, Any] = {}
         if self.user_id is not None:
-            flt["OR"].append({"user_id": self.user_id})
+            flt["user_id"] = self.user_id
         if self.run_id is not None:
-            flt["OR"].append({"run_id": self.run_id})
+            flt["run_id"] = self.run_id
         if self.agent_id is not None:
-            flt["OR"].append({"agent_id": self.agent_id})
+            flt["agent_id"] = self.agent_id
         return flt
 
     @model_serializer
@@ -198,12 +198,8 @@ class Mem0Memory(BaseMem0):
         """Get chat history. With memory system message."""
         messages = self.primary_memory.get(input=input, **kwargs)
         input = convert_messages_to_string(messages, input, limit=self.search_msg_limit)
-        ctx = self.context.model_dump()
-        if len(ctx) > 1:
-            flt = self.context.build_filter()
-            result = self.search(query=input, filters=flt)
-        else:
-            result = self.search(query=input, **ctx)
+        flt = self.context.build_filter()
+        result = self.search(query=input, filters=flt)
 
         search_results = result.get("results", [])
 

--- a/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-memory-mem0"
-version = "1.0.0"
+version = "2.0.0"
 description = "llama-index memory mem0 integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = "<4.0,>=3.9"
@@ -34,7 +34,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "llama-index-core>=0.13.0,<0.15",
-    "mem0ai>=1.0.0,<2",
+    "mem0ai>=2.0.0,<3.0.0",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/memory/llama-index-memory-mem0/tests/test_mem0.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/tests/test_mem0.py
@@ -260,7 +260,7 @@ def test_mem0_memory_get():
             dummy_messages, "How are you?", limit=mem0_memory.search_msg_limit
         )
         mock_client.search.assert_called_once_with(
-            query=expected_query, user_id="test_user"
+            query=expected_query, filters={"user_id": "test_user"}
         )
 
         # Assert that the result contains the correct number of messages
@@ -286,7 +286,7 @@ def test_mem0_memory_get():
             dummy_messages, limit=mem0_memory.search_msg_limit
         )
         mock_client.search.assert_called_once_with(
-            query=expected_query_no_input, user_id="test_user"
+            query=expected_query_no_input, filters={"user_id": "test_user"}
         )
 
         # Assert that the results are the same as before
@@ -391,7 +391,7 @@ def test_user_id_agent_id_separation() -> None:
         )
         mock_client.search.assert_called_once_with(
             query=expected_query,
-            filters={"OR": [{"user_id": "test_user"}, {"agent_id": "test_agent"}]},
+            filters={"user_id": "test_user", "agent_id": "test_agent"},
         )
         # Assert that the result contains the correct number of messages
         assert len(result) == len(dummy_messages) + 1  # +1 for the system message

--- a/llama-index-integrations/memory/llama-index-memory-mem0/uv.lock
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/uv.lock
@@ -2971,12 +2971,13 @@ wheels = [
 
 [[package]]
 name = "llama-index-memory-mem0"
-version = "1.0.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core", version = "0.14.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "llama-index-core", version = "0.14.21", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "mem0ai" },
+    { name = "mem0ai", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mem0ai", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.dev-dependencies]
@@ -3007,7 +3008,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
-    { name = "mem0ai", specifier = ">=1.0.0,<2" },
+    { name = "mem0ai", specifier = ">=2.0.0,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3203,22 +3204,49 @@ wheels = [
 
 [[package]]
 name = "mem0ai"
-version = "1.0.11"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "openai" },
-    { name = "posthog", version = "6.9.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "posthog", version = "7.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "pytz" },
-    { name = "qdrant-client", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "qdrant-client", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "sqlalchemy" },
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/1e/2f8a8cc4b8e7f6126f3367d27dc65eac5cd4ceb854888faa3a8f62a2c0a0/mem0ai-1.0.11.tar.gz", hash = "sha256:ddb803bedc22bd514606d262407782e88df929f6991b59f6972fb8a25cc06001", size = 201758, upload-time = "2026-04-06T11:31:43.695Z" }
+dependencies = [
+    { name = "openai", marker = "python_full_version < '3.10'" },
+    { name = "posthog", version = "6.9.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "protobuf", marker = "python_full_version < '3.10'" },
+    { name = "pydantic", marker = "python_full_version < '3.10'" },
+    { name = "pytz", marker = "python_full_version < '3.10'" },
+    { name = "qdrant-client", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sqlalchemy", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/41/4b786308d595ff5dc958b9916c0a5ae19af6337c7c09c4f22075400440d5/mem0ai-2.0.0.tar.gz", hash = "sha256:69a029d6e36d6f9cd30a3f2baab68b8e94e984ee91737ed5b6d78bc61df41cd8", size = 210776, upload-time = "2026-04-16T11:51:02.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/b5/f822c94e1b901f8a700af134c2473646de9a7db26364566f6a72d527d235/mem0ai-1.0.11-py3-none-any.whl", hash = "sha256:bcf4d678dc0a4d4e8eccaebe05562eae022fcdc825a0e3095d02f28cf61a5b6d", size = 297138, upload-time = "2026-04-06T11:31:41.716Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/433c9e433aa8eede63bc1538bf97a43af3b6eb9cd4cd78ae53dcd484b5e4/mem0ai-2.0.0-py3-none-any.whl", hash = "sha256:77b185d9a490358e806497c42164ab2464109ff44fde10e5fc834996b0011649", size = 298513, upload-time = "2026-04-16T11:51:00.233Z" },
+]
+
+[[package]]
+name = "mem0ai"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "openai", marker = "python_full_version >= '3.10'" },
+    { name = "posthog", version = "7.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "protobuf", marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", marker = "python_full_version >= '3.10'" },
+    { name = "pytz", marker = "python_full_version >= '3.10'" },
+    { name = "qdrant-client", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlalchemy", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/8f/86975bdf11a0aece78b6f4d5551b8b92c38b9bdf5f5764fc879e6cb1227b/mem0ai-2.0.2.tar.gz", hash = "sha256:482d11a55c8aa00dce29a66eeecbba2fd5f5c7501c054ce8ba606baee3755f99", size = 214627, upload-time = "2026-05-07T20:03:47.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/f8/59902456c1950e63b6b226634463bc8b24d81697e7114f0740059fd0a270/mem0ai-2.0.2-py3-none-any.whl", hash = "sha256:6fda32549c213fb63b393f4b1920f54961ea75c51d95b6492096108609accf3b", size = 302276, upload-time = "2026-05-07T20:03:45.706Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Mem0 recently released 2.x of their python SDK with massive benchmark improvements and breaking changes. This PR upgrades the SDK in the `llama-index-memory-mem0` memory integration.
- https://mem0.ai/blog/mem0-the-token-efficient-memory-algorithm 
- https://docs.mem0.ai/migration/oss-v2-to-v3 

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
