### PR TITLE
fix: stop Refine loop early on satisfied structured answer; apply retriever_weights in RRF

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -481,6 +481,8 @@ class Refine(BaseSynthesizer):
             program = self._program_factory(prompt_template)
             if resp := self._update_response(program, prompt_kwargs, response_kwargs):
                 response = resp
+                if self._structured_answer_filtering:
+                    break
 
         if isinstance(response, str):
             if self._output_cls is not None:
@@ -563,6 +565,8 @@ class Refine(BaseSynthesizer):
                 program, prompt_kwargs, response_kwargs
             ):
                 response = resp
+                if self._structured_answer_filtering:
+                    break
 
         if isinstance(response, str):
             if self._output_cls is not None:

--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -124,7 +124,9 @@ class QueryFusionRetriever(BaseRetriever):
         hash_to_node = {}
 
         # compute reciprocal rank scores
-        for nodes_with_scores in results.values():
+        for query_tuple, nodes_with_scores in results.items():
+            retriever_idx = query_tuple[1]
+            weight = self._retriever_weights[retriever_idx]
             for rank, node_with_score in enumerate(
                 sorted(nodes_with_scores, key=lambda x: x.score or 0.0, reverse=True)
             ):
@@ -132,7 +134,7 @@ class QueryFusionRetriever(BaseRetriever):
                 hash_to_node[hash] = node_with_score
                 if hash not in fused_scores:
                     fused_scores[hash] = 0.0
-                fused_scores[hash] += 1.0 / (rank + k)
+                fused_scores[hash] += weight / (rank + k)
 
         # sort results
         reranked_results = dict(


### PR DESCRIPTION
Two retrieval-correctness fixes in core library code.

---

## Fix 1 — `Refine` ignores `query_satisfied=True` (fixes #21397)

**File:** `llama-index-core/llama_index/core/response_synthesizers/refine.py`

When `structured_answer_filtering=True` and the LLM returns a satisfactory answer, `_run_refine_loop` / `_arun_refine_loop` continued iterating over every remaining chunk — making redundant LLM calls and potentially overwriting the already-satisfied answer with a worse one.

Add `break` after updating `response` when `self._structured_answer_filtering` is set, in both the sync and async loops:

```python
if resp := self._update_response(program, prompt_kwargs, response_kwargs):
    response = resp
    if self._structured_answer_filtering:
        break   # ← added
```

Non-filtering mode is unchanged — the loop still processes all chunks as designed.

---

## Fix 2 — `QueryFusionRetriever` ignores `retriever_weights` in `reciprocal_rerank` mode (fixes #21444)

**File:** `llama-index-core/llama_index/core/retrievers/fusion_retriever.py`

`_reciprocal_rerank_fusion` called `results.values()`, discarding the `(query_str, retriever_idx)` dict key, so `self._retriever_weights` was silently ignored. Every retriever contributed equally regardless of the weights passed by the user.

Switch to `results.items()`, unpack `retriever_idx` from the key, and multiply the RRF score by the corresponding weight — exactly mirroring the pattern already used in `_relative_score_fusion`:

```python
# BEFORE
for nodes_with_scores in results.values():
    ...
    fused_scores[hash] += 1.0 / (rank + k)

# AFTER
for query_tuple, nodes_with_scores in results.items():
    retriever_idx = query_tuple[1]
    weight = self._retriever_weights[retriever_idx]
    ...
    fused_scores[hash] += weight / (rank + k)
```

The default weight of `1.0 / len(retrievers)` means existing code with no explicit weights behaves identically (equal contribution from each retriever).