### PR TITLE
fix(bedrock): add support for OSS and Qwen models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
@@ -92,6 +92,11 @@ CHAT_ONLY_MODELS = {
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": 200000,
     "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": 200000,
     "apac.anthropic.claude-3-5-sonnet-20241022-v2:0": 200000,
+    "openai.gpt-oss-120b-1:0": 128000,
+    "openai.gpt-oss-20b-1:0": 128000,
+    "qwen.qwen-2.5-72b-instruct-v1:0": 128000,
+    "qwen.qwen-2.5-7b-instruct-v1:0": 128000,
+    "qwen.qwen-2.5-14b-instruct-v1:0": 128000,
 }
 BEDROCK_FOUNDATION_LLMS = {**COMPLETION_MODELS, **CHAT_ONLY_MODELS}
 
@@ -259,6 +264,28 @@ class MistralProvider(Provider):
         return response["outputs"][0]["text"]
 
 
+class OpenAIProvider(Provider):
+    max_tokens_key = "max_tokens"
+
+    def __init__(self) -> None:
+        self.messages_to_prompt = messages_to_llama_prompt
+        self.completion_to_prompt = completion_to_llama_prompt
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["choices"][0]["message"]["content"]
+
+
+class QwenProvider(Provider):
+    max_tokens_key = "max_tokens"
+
+    def __init__(self) -> None:
+        self.messages_to_prompt = messages_to_llama_prompt
+        self.completion_to_prompt = completion_to_llama_prompt
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["output"]["text"]
+
+
 class ProviderType(Enum):
     AMAZON = ("amazon", AmazonProvider)
     AI21 = ("ai21", Ai21Provider)
@@ -266,6 +293,8 @@ class ProviderType(Enum):
     COHERE = ("cohere", CohereProvider)
     META = ("meta", MetaProvider)
     MISTRAL = ("mistral", MistralProvider)
+    OPENAI = ("openai", OpenAIProvider)
+    QWEN = ("qwen", QwenProvider)
 
     def __init__(self, value: str, provider_class: type) -> None:
         self._value_ = value

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_utils.py
@@ -8,6 +8,8 @@ from llama_index.llms.bedrock.utils import (
     AnthropicProvider,
     CohereProvider,
     Ai21Provider,
+    OpenAIProvider,
+    QwenProvider,
 )
 
 
@@ -47,6 +49,16 @@ from llama_index.llms.bedrock.utils import (
         (
             "arn:aws:bedrock:us-east-1::foundation-model/ai21.jamba-1-5-large-v1:0",
             Ai21Provider,
+        ),
+        ("openai.gpt-oss-120b-1:0", OpenAIProvider),
+        (
+            "arn:aws:bedrock:us-east-1::foundation-model/openai.gpt-oss-120b-1:0",
+            OpenAIProvider,
+        ),
+        ("qwen.qwen-2.5-72b-instruct-v1:0", QwenProvider),
+        (
+            "arn:aws:bedrock:us-east-1::foundation-model/qwen.qwen-2.5-72b-instruct-v1:0",
+            QwenProvider,
         ),
     ],
 )


### PR DESCRIPTION
The legacy Bedrock class was missing support for newer AWS Bedrock models including OSS (gpt-oss-120b-1:0, gpt-oss-20b-1:0) and Qwen (qwen.qwen-2.5-72b-instruct-v1:0, qwen.qwen-2.5-7b-instruct-v1:0, qwen.qwen-2.5-14b-instruct-v1:0) models. This caused model initialization to fail with a ValueError when context_size was not explicitly provided.

This fix adds the missing models to the CHAT_ONLY_MODELS dictionary in llama_index/llms/bedrock/utils.py with appropriate context window sizes (128000 tokens). It also adds Provider and QwenProvider classes to handle response parsing for these model families, and registers them in the ProviderType enum so the automatic provider detection logic works correctly.

Users can now instantiate the Bedrock class with these models without needing to explicitly pass context_size. While the legacy Bedrock class is deprecated in favor of BedrockConverse, this change provides backward compatibility for existing code.

Test cases have been added to verify the provider selection logic works correctly for both model IDs and ARN formats.

Fixes #21636