### PR TITLE
Preserve URL-backed video and document memory blocks

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -67,6 +67,14 @@ DEFAULT_MEMORY_BLOCKS_TEMPLATE = RichPromptTemplate(
       {% elif block.path %}
         {{ (block.path | string) | audio }}
       {% endif %}
+    {% elif block.block_type == "video" %}
+      {% if block.url %}
+        {{ (block.url | string) | video }}
+      {% endif %}
+    {% elif block.block_type == "document" %}
+      {% if block.url %}
+        {{ (block.url | string) | document }}
+      {% endif %}
     {% endif %}
   {% endfor %}
 </{{ block_name }}>

--- a/llama-index-core/tests/memory/test_memory_blocks_base.py
+++ b/llama-index-core/tests/memory/test_memory_blocks_base.py
@@ -1,7 +1,13 @@
 import pytest
 from typing import List, Any, Optional, Union
 
-from llama_index.core.base.llms.types import ChatMessage, TextBlock, ContentBlock
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    TextBlock,
+    ContentBlock,
+    VideoBlock,
+    DocumentBlock,
+)
 from llama_index.core.memory.memory import Memory, BaseMemoryBlock, InsertMethod
 
 
@@ -38,6 +44,26 @@ class ContentBlocksMemoryBlock(BaseMemoryBlock[List[ContentBlock]]):
         if not content:
             return None
         return content[:-1]
+
+
+class UrlBackedMediaMemoryBlock(BaseMemoryBlock[List[ContentBlock]]):
+    """Memory block that returns URL-backed media content blocks."""
+
+    async def _aget(
+        self, messages: List[ChatMessage], **kwargs: Any
+    ) -> List[ContentBlock]:
+        return [
+            TextBlock(text="Media context"),
+            VideoBlock(url="https://example.com/video.mp4"),
+            DocumentBlock(
+                url="https://example.com/document.pdf",
+                document_mimetype="application/pdf",
+            ),
+        ]
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        # Just a no-op for testing
+        pass
 
 
 class ChatMessagesMemoryBlock(BaseMemoryBlock[List[ChatMessage]]):
@@ -290,6 +316,34 @@ async def test_memory_with_all_block_types(memory_with_blocks):
         msg for msg in messages if msg.content == "Historical user message"
     ]
     assert len(user_historical) > 0
+
+
+@pytest.mark.asyncio
+async def test_default_memory_preserves_url_backed_video_and_document_blocks():
+    """Test URL-backed video and document blocks survive default memory insertion."""
+    memory = Memory(
+        token_limit=4096,
+        token_flush_size=700,
+        chat_history_token_ratio=0.9,
+        session_id="test_url_backed_media_blocks",
+        memory_blocks=[UrlBackedMediaMemoryBlock(name="media_block", priority=1)],
+    )
+
+    messages = await memory.aget()
+
+    system_messages = [msg for msg in messages if msg.role == "system"]
+    assert len(system_messages) == 1
+
+    blocks = system_messages[0].blocks
+    text_blocks = [block for block in blocks if isinstance(block, TextBlock)]
+    video_blocks = [block for block in blocks if isinstance(block, VideoBlock)]
+    document_blocks = [block for block in blocks if isinstance(block, DocumentBlock)]
+
+    assert any("Media context" in block.text for block in text_blocks)
+    assert len(video_blocks) == 1
+    assert str(video_blocks[0].url) == "https://example.com/video.mp4"
+    assert len(document_blocks) == 1
+    assert document_blocks[0].url == "https://example.com/document.pdf"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Preserves URL-backed `VideoBlock` and `DocumentBlock` values when memory blocks are rendered through the default memory insertion template.

Previously, the default template handled text, image, and audio blocks, but did not render video or document blocks. As a result, URL-backed video/document content returned by memory blocks could be dropped from the inserted system memory message.

Fixes #

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Ran from `llama-index-core`:

```bash
uv run -- pytest tests/memory/test_memory_blocks_base.py::test_default_memory_preserves_url_backed_video_and_document_blocks
uv run -- pytest tests/memory/test_memory_blocks_base.py
```

Results:

- `1 passed`
- `10 passed`