### PR TITLE
fix: add explicit encoding='utf-8' to llama-index-core text-mode file I/O

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/prompts.py
+++ b/llama-index-core/llama_index/core/agent/react/prompts.py
@@ -5,7 +5,7 @@ from pathlib import Path
 # TODO: have formatting instructions be a part of react output parser
 with (
     Path(__file__).parents[0] / Path("templates") / Path("system_header_template.md")
-).open("r") as f:
+).open("r", encoding="utf-8") as f:
     __BASE_REACT_CHAT_SYSTEM_HEADER = f.read()
 
 REACT_CHAT_SYSTEM_HEADER = __BASE_REACT_CHAT_SYSTEM_HEADER.replace(

--- a/llama-index-core/llama_index/core/command_line/upgrade.py
+++ b/llama-index-core/llama_index/core/command_line/upgrade.py
@@ -116,7 +116,7 @@ def _parse_hub_downloads(
 def parse_lines(
     lines: List[str], installed_modules: List[str], verbose: bool = False
 ) -> Tuple[List[str], List[str]]:
-    with open(mappings_path) as f:
+    with open(mappings_path, encoding="utf-8") as f:
         mappings = json.load(f)
 
     new_installs = []
@@ -203,7 +203,7 @@ def _format_new_installs(new_installs: List[str]) -> List[str]:
 
 def upgrade_nb_file(file_path: str) -> None:
     print(f"\n=====================\n{file_path}\n", flush=True)
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         notebook = json.load(f)
 
     verbose = False
@@ -243,18 +243,18 @@ def upgrade_nb_file(file_path: str) -> None:
 
     cur_cells = [cell for cell in cur_cells if not _cell_installs_llama_hub(cell)]
     notebook["cells"] = cur_cells
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         json.dump(notebook, f, indent=1, ensure_ascii=False)
 
 
 def upgrade_py_md_file(file_path: str) -> None:
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         lines = f.readlines()
 
     installed_modules = ["llama-index-core"]  # default installs
     new_lines, new_installs = parse_lines(lines, installed_modules)
 
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         f.write("".join(new_lines))
 
     if len(new_installs) > 0:

--- a/llama-index-core/llama_index/core/embeddings/utils.py
+++ b/llama-index-core/llama_index/core/embeddings/utils.py
@@ -15,13 +15,13 @@ EmbedType = Union[BaseEmbedding, "LCEmbeddings", str]
 
 def save_embedding(embedding: List[float], file_path: str) -> None:
     """Save embedding to file."""
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         f.write(",".join([str(x) for x in embedding]))
 
 
 def load_embedding(file_path: str) -> List[float]:
     """Load embedding from file. Will only return first embedding in file."""
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         for line in f:
             return [float(x) for x in line.strip().split(",")]
     raise ValueError(f"The embedding file {file_path} is empty.")

--- a/llama-index-core/llama_index/core/evaluation/dataset_generation.py
+++ b/llama-index-core/llama_index/core/evaluation/dataset_generation.py
@@ -99,13 +99,13 @@ class QueryResponseDataset(BaseModel):
 
     def save_json(self, path: str) -> None:
         """Save json."""
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(self.model_dump(), f, indent=4)
 
     @classmethod
     def from_json(cls, path: str) -> QueryResponseDataset:
         """Load json."""
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         return cls(**data)
 


### PR DESCRIPTION
## Description

Several text-mode `open()` calls in `llama-index-core` read or write package-bundled templates, user-provided JSON files, notebooks and embeddings without an explicit `encoding=` argument. Python falls back to `locale.getpreferredencoding()`, which is `cp1252` on Windows and `utf-8` on Linux/macOS — so the package's bundled markdown template or a user's saved JSON can fail to load on Windows / non-utf-8 locales, and the same content round-tripped between machines may silently mis-decode.

The most user-visible case is `agent/react/prompts.py`, which loads the bundled `templates/system_header_template.md` at import time — meaning a Windows install in a non-utf-8 locale can fail to even import `llama_index.core.agent.react` if a future template adds a non-ASCII character.

## Affected sites (10 total, 4 files)

- `llama-index-core/llama_index/core/agent/react/prompts.py` — 1 site loading the bundled system-header markdown template at import time.
- `llama-index-core/llama_index/core/command_line/upgrade.py` — 5 sites reading the `mappings.json` and reading/writing user notebooks + `.py`/`.md` files during the v1 → v2 upgrade.
- `llama-index-core/llama_index/core/evaluation/dataset_generation.py` — 2 sites in `QueryResponseDataset.save_json` / `from_json`.
- `llama-index-core/llama_index/core/embeddings/utils.py` — 2 sites in `save_embedding` / `load_embedding`.

Total: 4 files, +10/-10 lines.

## Why

- Reliability across Windows / Linux / macOS / Docker, particularly for the `llama upgrade` CLI command which reads users' Jupyter notebooks (notebook source frequently contains non-ASCII markdown cells, emoji, CJK).
- PEP 597 recommends always specifying `encoding=` for text-mode opens.
- Eliminates `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` (Python 3.10+).
- No behaviour change on systems where the default is already utf-8.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Pure keyword-argument addition to existing `open()` calls; no logic touched. Verified all 4 files parse cleanly with `python -m py_compile`.

- [X] I stay in the same scope as suggested in commented files or README sections.
- [X] I added new unit tests to cover this change — _N/A: pure annotation/kwarg change with no new code paths._

## Suggested Checklist

- [X] I have read the [Contributor Guide](https://docs.llamaindex.ai/en/stable/contributing/contributing.html).
- [X] My changes have been formatted with `ruff format` (n/a — annotation-only).
- [X] My code passes the linter (`ruff check`) on the touched files.
- [X] I have added relevant tests (n/a — pure kwarg addition).
- [X] All previous tests pass.
- [X] PR title follows conventional commits.