### PR TITLE
docs: fix Qdrant Python client URL

### DIFF
--- a/docs/src/content/docs/framework/community/integrations/vector_stores.md
+++ b/docs/src/content/docs/framework/community/integrations/vector_stores.md
@@ -1144,7 +1144,7 @@ reader = QdrantReader(host="localhost")
 query_vector = [n1, n2, n3, ...]
 
 # NOTE: Required args are collection_name, query_vector.
-# See the Python client: https;//github.com/qdrant/qdrant_client
+# See the Python client: https://github.com/qdrant/qdrant_client
 # for more details
 
 documents = reader.load_data(


### PR DESCRIPTION
# Description

Fixes a malformed Qdrant Python client link in the vector store integration docs.

The docs currently use `https;//github.com/qdrant/qdrant_client`, which is not a valid URL. This updates it to `https://github.com/qdrant/qdrant_client`.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Targeted validation for this docs-only URL fix:

- Confirmed no open upstream PR already fixes the exact malformed URL.
- Confirmed `https;//github.com/qdrant/qdrant_client` is absent and `https://github.com/qdrant/qdrant_client` is present.
- Ran `git diff --check`.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Full docs build and lint were not run because this PR changes one URL character in a Markdown docs file.
