### PR TITLE
Add tool calling mock LLM

### DIFF
--- a/llama-index-core/llama_index/core/llms/__init__.py
+++ b/llama-index-core/llama_index/core/llms/__init__.py
@@ -23,7 +23,7 @@ from llama_index.core.llms.llm import LLM
 from llama_index.core.llms.mock import (
     MockLLM,
     MockFunctionCallingLLM,
-    MockToolCallingLLM,
+    _tool_calling_response_generator,
 )
 
 __all__ = [
@@ -40,7 +40,7 @@ __all__ = [
     "MessageRole",
     "MockLLM",
     "MockFunctionCallingLLM",
-    "MockToolCallingLLM",
+    "_tool_calling_response_generator",
     "ImageBlock",
     "TextBlock",
     "AudioBlock",

--- a/llama-index-core/llama_index/core/llms/__init__.py
+++ b/llama-index-core/llama_index/core/llms/__init__.py
@@ -20,7 +20,11 @@ from llama_index.core.base.llms.types import (
 )
 from llama_index.core.llms.custom import CustomLLM
 from llama_index.core.llms.llm import LLM
-from llama_index.core.llms.mock import MockLLM, MockFunctionCallingLLM
+from llama_index.core.llms.mock import (
+    MockLLM,
+    MockFunctionCallingLLM,
+    MockToolCallingLLM,
+)
 
 __all__ = [
     "CustomLLM",
@@ -36,6 +40,7 @@ __all__ = [
     "MessageRole",
     "MockLLM",
     "MockFunctionCallingLLM",
+    "MockToolCallingLLM",
     "ImageBlock",
     "TextBlock",
     "AudioBlock",

--- a/llama-index-core/llama_index/core/llms/mock.py
+++ b/llama-index-core/llama_index/core/llms/mock.py
@@ -284,7 +284,7 @@ BlockToContentCallback: TypeAlias = Callable[
 ]
 
 ResponseGenerator: TypeAlias = Callable[
-    [Sequence[ChatMessage]],
+    ...,
     ChatMessage
     | Generator[ChatMessage, None, None]
     | AsyncGenerator[ChatMessage, None],
@@ -340,7 +340,9 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
             return self._response_generator
 
         # Return a default generator that uses instance's blocks_to_content_callback
-        def default_generator(messages: Sequence[ChatMessage]) -> ChatMessage:
+        def default_generator(
+            messages: Sequence[ChatMessage], **kwargs: Any
+        ) -> ChatMessage:
             if not messages:
                 return ChatMessage(role="assistant", content="<empty>")
 
@@ -404,7 +406,7 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
     def stream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseGen:
-        response_msg_or_gen = self._get_response_generator()(messages)
+        response_msg_or_gen = self._get_response_generator()(messages, **kwargs)
 
         def _gen() -> Generator[ChatResponse, None, None]:
             if isinstance(response_msg_or_gen, ChatMessage):
@@ -424,7 +426,7 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
     async def astream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponseAsyncGen:
-        response_msg_or_gen = self._get_response_generator()(messages)
+        response_msg_or_gen = self._get_response_generator()(messages, **kwargs)
 
         async def _gen() -> AsyncGenerator[ChatResponse, None]:
             if isinstance(response_msg_or_gen, ChatMessage):
@@ -442,7 +444,9 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
 
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
-        response_msg = cast(ChatMessage, self._get_response_generator()(messages))
+        response_msg = cast(
+            ChatMessage, self._get_response_generator()(messages, **kwargs)
+        )
         content = response_msg.content or ""
         return ChatResponse(
             message=response_msg,
@@ -454,7 +458,7 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
     async def achat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
     ) -> ChatResponse:
-        return self.chat(messages=messages)
+        return self.chat(messages=messages, **kwargs)
 
     def _prepare_chat_with_tools(
         self,
@@ -517,92 +521,36 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
         return tool_selections
 
 
-class MockToolCallingLLM(MockFunctionCallingLLM):
-    """
-    A mock LLM that calls all tools with their pre-filled arguments.
-    """
+def _tool_calling_response_generator(
+    messages: Sequence[ChatMessage], **kwargs: Any
+) -> ChatMessage:
+    """Response generator that calls all provided tools with their default arguments."""
+    if any(message.role == MessageRole.TOOL for message in messages):
+        return ChatMessage(role=MessageRole.ASSISTANT, content="Tool calls complete.")
 
-    @classmethod
-    def class_name(cls) -> str:
-        return "MockToolCallingLLM"
+    tools: Sequence["BaseTool"] = kwargs.get("tools") or []
+    if not tools:
+        return ChatMessage(role=MessageRole.ASSISTANT, content="No tools available.")
 
-    def _build_tool_kwargs(self, tool: "BaseTool") -> dict[str, Any]:
+    tool_call_blocks: list[ToolCallBlock] = []
+    for tool in tools:
         schema = getattr(getattr(tool, "metadata", None), "fn_schema", None)
-        if schema is None:
-            return {}
-
         tool_kwargs: dict[str, Any] = {}
-        for field_name, field_info in schema.model_fields.items():
-            if not field_info.is_required():
-                tool_kwargs[field_name] = field_info.get_default(
-                    call_default_factory=True
-                )
-        return tool_kwargs
-
-    def _has_tool_result(self, messages: Sequence[ChatMessage]) -> bool:
-        return any(message.role == MessageRole.TOOL for message in messages)
-
-    def _build_tool_call_blocks(
-        self, tools: Sequence["BaseTool"]
-    ) -> list[ToolCallBlock]:
-        return [
+        if schema is not None:
+            for field_name, field_info in schema.model_fields.items():
+                if not field_info.is_required():
+                    tool_kwargs[field_name] = field_info.get_default(
+                        call_default_factory=True
+                    )
+        tool_call_blocks.append(
             ToolCallBlock(
                 tool_call_id=f"mock-tool-call-{uuid4().hex}",
                 tool_name=tool.metadata.name or "",
-                tool_kwargs=self._build_tool_kwargs(tool),
+                tool_kwargs=tool_kwargs,
             )
-            for tool in tools
-        ]
+        )
 
-    def _chat_response(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponse:
-        if self._has_tool_result(messages):
-            message = ChatMessage(
-                role=MessageRole.ASSISTANT, content="Tool calls complete."
-            )
-            return ChatResponse(message=message, delta=message.content or "")
-
-        tools = kwargs.get("tools") or []
-        tool_call_blocks = self._build_tool_call_blocks(tools)
-        if not tool_call_blocks:
-            message = ChatMessage(
-                role=MessageRole.ASSISTANT, content="No tools available."
-            )
-            return ChatResponse(message=message, delta=message.content or "")
-
-        message = ChatMessage(role=MessageRole.ASSISTANT, blocks=tool_call_blocks)
-        return ChatResponse(message=message, delta="")
-
-    @llm_chat_callback()
-    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
-        return self._chat_response(messages, **kwargs)
-
-    @llm_chat_callback()
-    def stream_chat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponseGen:
-        def _gen() -> ChatResponseGen:
-            yield self._chat_response(messages, **kwargs)
-
-        return _gen()
-
-    @llm_chat_callback()
-    async def achat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponse:
-        return self._chat_response(messages=messages, **kwargs)
-
-    @llm_chat_callback()
-    async def astream_chat(
-        self, messages: Sequence[ChatMessage], **kwargs: Any
-    ) -> ChatResponseAsyncGen:
-        response = self._chat_response(messages, **kwargs)
-
-        async def _gen() -> ChatResponseAsyncGen:
-            yield response
-
-        return _gen()
+    return ChatMessage(role=MessageRole.ASSISTANT, blocks=tool_call_blocks)
 
 
 class MockFunctionCallingLLMWithChatMemoryOfLastCall(MockFunctionCallingLLM):

--- a/llama-index-core/llama_index/core/llms/mock.py
+++ b/llama-index-core/llama_index/core/llms/mock.py
@@ -340,9 +340,15 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
             return self._response_generator
 
         # Return a default generator that uses instance's blocks_to_content_callback
+        # and calls all tools if provided
         def default_generator(
             messages: Sequence[ChatMessage], **kwargs: Any
         ) -> ChatMessage:
+            # If tools are provided or tool results exist, delegate to tool-calling generator
+            has_tool_results = any(m.role == MessageRole.TOOL for m in messages)
+            if kwargs.get("tools") or has_tool_results:
+                return _tool_calling_response_generator(messages, **kwargs)
+
             if not messages:
                 return ChatMessage(role="assistant", content="<empty>")
 

--- a/llama-index-core/llama_index/core/llms/mock.py
+++ b/llama-index-core/llama_index/core/llms/mock.py
@@ -291,18 +291,6 @@ ResponseGenerator: TypeAlias = Callable[
 ]
 
 
-def _default_response_generator(messages: Sequence[ChatMessage]) -> ChatMessage:
-    """Default response generator that echoes the last message's content."""
-    if not messages:
-        return ChatMessage(role="assistant", content="<empty>")
-
-    tool_calls: List[ToolCallBlock] = []
-    content = _default_blocks_to_content_callback(messages[-1].blocks, tool_calls)
-    if not content:
-        content = "<empty>"
-    return ChatMessage(role="assistant", content=content)
-
-
 class MockFunctionCallingLLM(FunctionCallingLLM):
     tool_calls: List[ToolCallBlock] = Field(default_factory=list)
     blocks_to_content_callback: BlockToContentCallback = Field(

--- a/llama-index-core/llama_index/core/llms/mock.py
+++ b/llama-index-core/llama_index/core/llms/mock.py
@@ -15,6 +15,7 @@ from typing import (
 from typing_extensions import TypeAlias
 from base64 import b64decode
 from json import JSONDecodeError
+from uuid import uuid4
 from llama_index.core.base.llms.types import (
     ChatResponseGen,
     CompletionResponse,
@@ -526,6 +527,94 @@ class MockFunctionCallingLLM(FunctionCallingLLM):
                 )
             )
         return tool_selections
+
+
+class MockToolCallingLLM(MockFunctionCallingLLM):
+    """
+    A mock LLM that calls all tools with their pre-filled arguments.
+    """
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "MockToolCallingLLM"
+
+    def _build_tool_kwargs(self, tool: "BaseTool") -> dict[str, Any]:
+        schema = getattr(getattr(tool, "metadata", None), "fn_schema", None)
+        if schema is None:
+            return {}
+
+        tool_kwargs: dict[str, Any] = {}
+        for field_name, field_info in schema.model_fields.items():
+            if not field_info.is_required():
+                tool_kwargs[field_name] = field_info.get_default(
+                    call_default_factory=True
+                )
+        return tool_kwargs
+
+    def _has_tool_result(self, messages: Sequence[ChatMessage]) -> bool:
+        return any(message.role == MessageRole.TOOL for message in messages)
+
+    def _build_tool_call_blocks(
+        self, tools: Sequence["BaseTool"]
+    ) -> list[ToolCallBlock]:
+        return [
+            ToolCallBlock(
+                tool_call_id=f"mock-tool-call-{uuid4().hex}",
+                tool_name=tool.metadata.name or "",
+                tool_kwargs=self._build_tool_kwargs(tool),
+            )
+            for tool in tools
+        ]
+
+    def _chat_response(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        if self._has_tool_result(messages):
+            message = ChatMessage(
+                role=MessageRole.ASSISTANT, content="Tool calls complete."
+            )
+            return ChatResponse(message=message, delta=message.content or "")
+
+        tools = kwargs.get("tools") or []
+        tool_call_blocks = self._build_tool_call_blocks(tools)
+        if not tool_call_blocks:
+            message = ChatMessage(
+                role=MessageRole.ASSISTANT, content="No tools available."
+            )
+            return ChatResponse(message=message, delta=message.content or "")
+
+        message = ChatMessage(role=MessageRole.ASSISTANT, blocks=tool_call_blocks)
+        return ChatResponse(message=message, delta="")
+
+    @llm_chat_callback()
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        return self._chat_response(messages, **kwargs)
+
+    @llm_chat_callback()
+    def stream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseGen:
+        def _gen() -> ChatResponseGen:
+            yield self._chat_response(messages, **kwargs)
+
+        return _gen()
+
+    @llm_chat_callback()
+    async def achat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        return self._chat_response(messages=messages, **kwargs)
+
+    @llm_chat_callback()
+    async def astream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        response = self._chat_response(messages, **kwargs)
+
+        async def _gen() -> ChatResponseAsyncGen:
+            yield response
+
+        return _gen()
 
 
 class MockFunctionCallingLLMWithChatMemoryOfLastCall(MockFunctionCallingLLM):

--- a/llama-index-core/tests/agent/workflow/test_code_act_agent.py
+++ b/llama-index-core/tests/agent/workflow/test_code_act_agent.py
@@ -180,7 +180,9 @@ async def test_code_act_agent_workflow_integration():
     # Track call count to return different responses
     call_count = [0]
 
-    def multi_response_generator(messages: Sequence[ChatMessage]) -> ChatMessage:
+    def multi_response_generator(
+        messages: Sequence[ChatMessage], **kwargs
+    ) -> ChatMessage:
         call_count[0] += 1
         if call_count[0] == 1:
             # First call: return code to execute

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -25,7 +25,7 @@ def _response_generator_from_list(responses: List[ChatMessage]):
     """Helper to create a response generator from a list of responses."""
     index = 0
 
-    def generator(messages: List[ChatMessage]) -> ChatMessage:
+    def generator(messages: List[ChatMessage], **kwargs) -> ChatMessage:
         nonlocal index
         if not responses:
             return ChatMessage(role=MessageRole.ASSISTANT, content=None)

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -18,7 +18,7 @@ def _response_generator_from_list(responses: List[ChatMessage]):
     """Helper to create a response generator from a list of responses."""
     index = 0
 
-    def generator(messages: List[ChatMessage]) -> ChatMessage:
+    def generator(messages: List[ChatMessage], **kwargs) -> ChatMessage:
         nonlocal index
         if not responses:
             return ChatMessage(role=MessageRole.ASSISTANT, content=None)

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -444,8 +444,17 @@ async def test_function_agent_with_context_and_chat_message():
         """A no-op function for testing."""
         return "noop executed"
 
+    # Use an echo response generator that ignores tools
+    def echo_generator(messages, **kwargs):
+        if not messages:
+            return ChatMessage(role=MessageRole.ASSISTANT, content="<empty>")
+        content = "".join(
+            block.text for block in messages[-1].blocks if isinstance(block, TextBlock)
+        )
+        return ChatMessage(role=MessageRole.ASSISTANT, content=content or "<empty>")
+
     # Step 1: Construct FunctionAgent
-    llm = MockFunctionCallingLLM()
+    llm = MockFunctionCallingLLM(response_generator=echo_generator)
     function_tools = [FunctionTool.from_defaults(fn=noop)]
     constructor_kwargs = {
         "llm": llm,

--- a/llama-index-core/tests/llms/test_mock.py
+++ b/llama-index-core/tests/llms/test_mock.py
@@ -251,7 +251,7 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
         FunctionTool.from_defaults(add),
     ]
     llm = MockToolCallingLLM()
-    agent = FunctionAgent(llm=llm, tools=tools)
+    agent = FunctionAgent(llm=llm, tools=tools, allow_parallel_tool_calls=False)
 
     handler = agent.run(user_msg="call the tools")
     tool_call_results = []
@@ -293,7 +293,7 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_params() -> None:
         FunctionTool.from_defaults(mul),
     ]
     llm = MockToolCallingLLMWithParams()
-    agent = FunctionAgent(llm=llm, tools=tools)
+    agent = FunctionAgent(llm=llm, tools=tools, allow_parallel_tool_calls=False)
 
     handler = agent.run(user_msg="call the tools with params")
     tool_call_results = []

--- a/llama-index-core/tests/llms/test_mock.py
+++ b/llama-index-core/tests/llms/test_mock.py
@@ -1,13 +1,14 @@
 import pytest
 import json
 
-from typing import Optional
+from typing import ClassVar, Optional
 from llama_index.core.llms import MockLLM
 from llama_index.core.llms.mock import (
     MockFunctionCallingLLM,
     MockToolCallingLLM,
     BlockToContentCallback,
 )
+from llama_index.core.agent.workflow import FunctionAgent, ToolCallResult
 from llama_index.core.llms.llm import ToolSelection
 from llama_index.core.tools import FunctionTool
 from llama_index.core.base.llms.types import (
@@ -237,7 +238,8 @@ def test_mock_function_calling_llm_get_tool_calls_from_response_empty() -> None:
     assert len(tool_calls) == 0
 
 
-def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
+@pytest.mark.asyncio
+async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
     def get_weather(location: str = "Berlin") -> str:
         return f"weather in {location}"
 
@@ -249,17 +251,61 @@ def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
         FunctionTool.from_defaults(add),
     ]
     llm = MockToolCallingLLM()
+    agent = FunctionAgent(llm=llm, tools=tools)
 
-    response = llm.chat_with_tools(tools=tools, user_msg="call the tools")
-    tool_calls = llm.get_tool_calls_from_response(response)
+    handler = agent.run(user_msg="call the tools")
+    tool_call_results = []
+    async for event in handler.stream_events():
+        if isinstance(event, ToolCallResult):
+            tool_call_results.append(event)
 
-    assert [tool_call.tool_name for tool_call in tool_calls] == [
-        "get_weather",
-        "add",
+    await handler
+
+    assert [result.tool_output.raw_output for result in tool_call_results] == [
+        "weather in Berlin",
+        3,
     ]
-    assert [tool_call.tool_kwargs for tool_call in tool_calls] == [
-        {"location": "Berlin"},
-        {"a": 1, "b": 2},
+
+
+@pytest.mark.asyncio
+async def test_mock_tool_calling_llm_calls_all_tools_with_params() -> None:
+    def get_weather(location: str = "Berlin") -> str:
+        return f"weather in {location}"
+
+    def mul(a: int = 1, b: int = 2) -> int:
+        return a * b
+
+    class MockToolCallingLLMWithParams(MockToolCallingLLM):
+        tool_kwargs_by_name: ClassVar[dict[str, dict[str, object]]] = {
+            "get_weather": {"location": "Chicago"},
+            "mul": {"a": 10, "b": 20},
+        }
+
+        def _build_tool_kwargs(self, tool) -> dict[str, object]:
+            return self.tool_kwargs_by_name[tool.metadata.name]
+
+    tools = [
+        FunctionTool.from_defaults(get_weather),
+        FunctionTool.from_defaults(mul),
+    ]
+    llm = MockToolCallingLLMWithParams()
+    agent = FunctionAgent(llm=llm, tools=tools)
+
+    handler = agent.run(user_msg="call the tools with params")
+    tool_call_results = []
+    async for event in handler.stream_events():
+        if isinstance(event, ToolCallResult):
+            tool_call_results.append(event)
+
+    await handler
+
+    assert [result.tool_output.raw_input["kwargs"] for result in tool_call_results] == [
+        {"location": "Chicago"},
+        {"a": 10, "b": 20},
+    ]
+    assert [result.tool_output.raw_output for result in tool_call_results] == [
+        "weather in Chicago",
+        200,
     ]
 
 

--- a/llama-index-core/tests/llms/test_mock.py
+++ b/llama-index-core/tests/llms/test_mock.py
@@ -5,7 +5,6 @@ from typing import Any, Optional, Sequence
 from llama_index.core.llms import MockLLM
 from llama_index.core.llms.mock import (
     MockFunctionCallingLLM,
-    _tool_calling_response_generator,
     BlockToContentCallback,
 )
 from llama_index.core.agent.workflow import FunctionAgent, ToolCallResult
@@ -250,7 +249,7 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
         FunctionTool.from_defaults(get_weather),
         FunctionTool.from_defaults(add),
     ]
-    llm = MockFunctionCallingLLM(response_generator=_tool_calling_response_generator)
+    llm = MockFunctionCallingLLM()
     agent = FunctionAgent(llm=llm, tools=tools)
 
     handler = agent.run(user_msg="call the tools")
@@ -344,7 +343,7 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_params() -> None:
 def test_mock_tool_calling_response_generator_returns_completion_after_tool_result() -> (
     None
 ):
-    llm = MockFunctionCallingLLM(response_generator=_tool_calling_response_generator)
+    llm = MockFunctionCallingLLM()
 
     response = llm.chat(
         messages=[

--- a/llama-index-core/tests/llms/test_mock.py
+++ b/llama-index-core/tests/llms/test_mock.py
@@ -3,10 +3,16 @@ import json
 
 from typing import Optional
 from llama_index.core.llms import MockLLM
-from llama_index.core.llms.mock import MockFunctionCallingLLM, BlockToContentCallback
+from llama_index.core.llms.mock import (
+    MockFunctionCallingLLM,
+    MockToolCallingLLM,
+    BlockToContentCallback,
+)
 from llama_index.core.llms.llm import ToolSelection
+from llama_index.core.tools import FunctionTool
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    MessageRole,
     TextBlock,
     DocumentBlock,
     ImageBlock,
@@ -229,3 +235,42 @@ def test_mock_function_calling_llm_get_tool_calls_from_response_empty() -> None:
 
     tool_calls = llm.get_tool_calls_from_response(response)
     assert len(tool_calls) == 0
+
+
+def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
+    def get_weather(location: str = "Berlin") -> str:
+        return f"weather in {location}"
+
+    def add(a: int = 1, b: int = 2) -> int:
+        return a + b
+
+    tools = [
+        FunctionTool.from_defaults(get_weather),
+        FunctionTool.from_defaults(add),
+    ]
+    llm = MockToolCallingLLM()
+
+    response = llm.chat_with_tools(tools=tools, user_msg="call the tools")
+    tool_calls = llm.get_tool_calls_from_response(response)
+
+    assert [tool_call.tool_name for tool_call in tool_calls] == [
+        "get_weather",
+        "add",
+    ]
+    assert [tool_call.tool_kwargs for tool_call in tool_calls] == [
+        {"location": "Berlin"},
+        {"a": 1, "b": 2},
+    ]
+
+
+def test_mock_tool_calling_llm_returns_completion_after_tool_result() -> None:
+    llm = MockToolCallingLLM()
+
+    response = llm.chat(
+        messages=[
+            ChatMessage(role=MessageRole.USER, content="call the tools"),
+            ChatMessage(role=MessageRole.TOOL, content="tool result"),
+        ]
+    )
+
+    assert response.message.content == "Tool calls complete."

--- a/llama-index-core/tests/llms/test_mock.py
+++ b/llama-index-core/tests/llms/test_mock.py
@@ -1,11 +1,11 @@
 import pytest
 import json
 
-from typing import ClassVar, Optional
+from typing import Any, Optional, Sequence
 from llama_index.core.llms import MockLLM
 from llama_index.core.llms.mock import (
     MockFunctionCallingLLM,
-    MockToolCallingLLM,
+    _tool_calling_response_generator,
     BlockToContentCallback,
 )
 from llama_index.core.agent.workflow import FunctionAgent, ToolCallResult
@@ -250,7 +250,7 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
         FunctionTool.from_defaults(get_weather),
         FunctionTool.from_defaults(add),
     ]
-    llm = MockToolCallingLLM()
+    llm = MockFunctionCallingLLM(response_generator=_tool_calling_response_generator)
     agent = FunctionAgent(llm=llm, tools=tools)
 
     handler = agent.run(user_msg="call the tools")
@@ -279,26 +279,42 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
 
 @pytest.mark.asyncio
 async def test_mock_tool_calling_llm_calls_all_tools_with_params() -> None:
+    from uuid import uuid4
+
     def get_weather(location: str = "Berlin") -> str:
         return f"weather in {location}"
 
     def mul(a: int = 1, b: int = 2) -> int:
         return a * b
 
-    class MockToolCallingLLMWithParams(MockToolCallingLLM):
-        tool_kwargs_by_name: ClassVar[dict[str, dict[str, object]]] = {
-            "get_weather": {"location": "Chicago"},
-            "mul": {"a": 10, "b": 20},
-        }
+    tool_kwargs_by_name: dict[str, dict[str, object]] = {
+        "get_weather": {"location": "Chicago"},
+        "mul": {"a": 10, "b": 20},
+    }
 
-        def _build_tool_kwargs(self, tool) -> dict[str, object]:
-            return self.tool_kwargs_by_name[tool.metadata.name]
+    def custom_tool_response_generator(
+        messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatMessage:
+        if any(m.role == MessageRole.TOOL for m in messages):
+            return ChatMessage(
+                role=MessageRole.ASSISTANT, content="Tool calls complete."
+            )
+        tools = kwargs.get("tools") or []
+        blocks = [
+            ToolCallBlock(
+                tool_call_id=f"mock-tool-call-{uuid4().hex}",
+                tool_name=tool.metadata.name or "",
+                tool_kwargs=tool_kwargs_by_name[tool.metadata.name],
+            )
+            for tool in tools
+        ]
+        return ChatMessage(role=MessageRole.ASSISTANT, blocks=blocks)
 
     tools = [
         FunctionTool.from_defaults(get_weather),
         FunctionTool.from_defaults(mul),
     ]
-    llm = MockToolCallingLLMWithParams()
+    llm = MockFunctionCallingLLM(response_generator=custom_tool_response_generator)
     agent = FunctionAgent(llm=llm, tools=tools)
 
     handler = agent.run(user_msg="call the tools with params")
@@ -325,8 +341,10 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_params() -> None:
     assert tool_results_by_name["mul"].tool_output.raw_output == 200
 
 
-def test_mock_tool_calling_llm_returns_completion_after_tool_result() -> None:
-    llm = MockToolCallingLLM()
+def test_mock_tool_calling_response_generator_returns_completion_after_tool_result() -> (
+    None
+):
+    llm = MockFunctionCallingLLM(response_generator=_tool_calling_response_generator)
 
     response = llm.chat(
         messages=[

--- a/llama-index-core/tests/llms/test_mock.py
+++ b/llama-index-core/tests/llms/test_mock.py
@@ -251,7 +251,7 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
         FunctionTool.from_defaults(add),
     ]
     llm = MockToolCallingLLM()
-    agent = FunctionAgent(llm=llm, tools=tools, allow_parallel_tool_calls=False)
+    agent = FunctionAgent(llm=llm, tools=tools)
 
     handler = agent.run(user_msg="call the tools")
     tool_call_results = []
@@ -261,14 +261,20 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
 
     await handler
 
-    assert [result.tool_output.raw_input["kwargs"] for result in tool_call_results] == [
-        {"location": "Berlin"},
-        {"a": 1, "b": 2},
-    ]
-    assert [result.tool_output.raw_output for result in tool_call_results] == [
-        "weather in Berlin",
-        3,
-    ]
+    tool_results_by_name = {result.tool_name: result for result in tool_call_results}
+    assert set(tool_results_by_name) == {"get_weather", "add"}
+    assert tool_results_by_name["get_weather"].tool_output.raw_input["kwargs"] == {
+        "location": "Berlin"
+    }
+    assert (
+        tool_results_by_name["get_weather"].tool_output.raw_output
+        == "weather in Berlin"
+    )
+    assert tool_results_by_name["add"].tool_output.raw_input["kwargs"] == {
+        "a": 1,
+        "b": 2,
+    }
+    assert tool_results_by_name["add"].tool_output.raw_output == 3
 
 
 @pytest.mark.asyncio
@@ -293,7 +299,7 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_params() -> None:
         FunctionTool.from_defaults(mul),
     ]
     llm = MockToolCallingLLMWithParams()
-    agent = FunctionAgent(llm=llm, tools=tools, allow_parallel_tool_calls=False)
+    agent = FunctionAgent(llm=llm, tools=tools)
 
     handler = agent.run(user_msg="call the tools with params")
     tool_call_results = []
@@ -303,14 +309,20 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_params() -> None:
 
     await handler
 
-    assert [result.tool_output.raw_input["kwargs"] for result in tool_call_results] == [
-        {"location": "Chicago"},
-        {"a": 10, "b": 20},
-    ]
-    assert [result.tool_output.raw_output for result in tool_call_results] == [
-        "weather in Chicago",
-        200,
-    ]
+    tool_results_by_name = {result.tool_name: result for result in tool_call_results}
+    assert set(tool_results_by_name) == {"get_weather", "mul"}
+    assert tool_results_by_name["get_weather"].tool_output.raw_input["kwargs"] == {
+        "location": "Chicago"
+    }
+    assert (
+        tool_results_by_name["get_weather"].tool_output.raw_output
+        == "weather in Chicago"
+    )
+    assert tool_results_by_name["mul"].tool_output.raw_input["kwargs"] == {
+        "a": 10,
+        "b": 20,
+    }
+    assert tool_results_by_name["mul"].tool_output.raw_output == 200
 
 
 def test_mock_tool_calling_llm_returns_completion_after_tool_result() -> None:

--- a/llama-index-core/tests/llms/test_mock.py
+++ b/llama-index-core/tests/llms/test_mock.py
@@ -261,6 +261,10 @@ async def test_mock_tool_calling_llm_calls_all_tools_with_defaults() -> None:
 
     await handler
 
+    assert [result.tool_output.raw_input["kwargs"] for result in tool_call_results] == [
+        {"location": "Berlin"},
+        {"a": 1, "b": 2},
+    ]
     assert [result.tool_output.raw_output for result in tool_call_results] == [
         "weather in Berlin",
         3,

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -209,7 +209,7 @@ def tool_call_json_from_messages(
 def mock_chat_message_with_tool_call_generator(
     input_to_query_satisfied,
 ) -> Callable[[Sequence[ChatMessage]], ChatMessage]:
-    def func(messages: Sequence[ChatMessage]) -> ChatMessage:
+    def func(messages: Sequence[ChatMessage], **kwargs) -> ChatMessage:
         tool_args_json = tool_call_json_from_messages(
             messages, input_to_query_satisfied
         )
@@ -232,7 +232,9 @@ def mock_chat_message_with_tool_call_generator(
 def mock_streaming_chat_message_with_tool_call_generator(
     input_to_query_satisfied,
 ) -> Callable[[Sequence[ChatMessage]], Generator[ChatMessage, None, None]]:
-    def func(messages: Sequence[ChatMessage]) -> Generator[ChatMessage, None, None]:
+    def func(
+        messages: Sequence[ChatMessage], **kwargs
+    ) -> Generator[ChatMessage, None, None]:
         tool_args_json = tool_call_json_from_messages(
             messages, input_to_query_satisfied
         )
@@ -271,10 +273,10 @@ def mock_async_streaming_chat_message_with_tool_call_generator(
     input_to_query_satisfied, mock_streaming_chat_message_with_tool_call_generator
 ) -> Coroutine[None, None, AsyncGenerator[ChatMessage, None]]:
     async def coro(
-        messages: Sequence[ChatMessage],
+        messages: Sequence[ChatMessage], **kwargs
     ) -> AsyncGenerator[ChatMessage, None]:
         for chat_message in mock_streaming_chat_message_with_tool_call_generator(
-            messages
+            messages, **kwargs
         ):
             yield chat_message
 


### PR DESCRIPTION
# Description
The MockFunctionCallingLLM doesn't actually call tools; it just echoes its input. I'd like to provide a mock LLM that calls all of the tools it was provided.

Use case: wanting to integration test tool implementations all the way through llama-index without having to use a real LLM (non-deterministic and potentially expensive).

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package? (N/A)

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
