### PR TITLE
fix: handle multi-block messages in streaming chat history

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -40,6 +41,25 @@ def is_function(message: ChatMessage) -> bool:
         "tool_calls" in message.additional_kwargs
         and len(message.additional_kwargs["tool_calls"]) > 0
     )
+
+
+def _set_message_content(message: ChatMessage, content: str) -> None:
+    """Set final text content without assuming the message has one text block."""
+    updated_blocks = []
+    added_text_block = False
+
+    for block in message.blocks:
+        if isinstance(block, TextBlock):
+            if not added_text_block:
+                updated_blocks.append(TextBlock(text=content))
+                added_text_block = True
+        else:
+            updated_blocks.append(block)
+
+    if not added_text_block:
+        updated_blocks.insert(0, TextBlock(text=content))
+
+    message.blocks = updated_blocks
 
 
 class ChatResponseMode(str, Enum):
@@ -191,7 +211,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_content(chat.message, final_text.strip())
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -249,7 +269,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_content(chat.message, final_text.strip())
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -1,17 +1,23 @@
-import gc
 import asyncio
-from llama_index.core.memory import ChatMemoryBuffer
+import gc
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
     CompletionResponse,
     CompletionResponseGen,
+    ImageBlock,
+    MessageRole,
+    TextBlock,
 )
-from typing import Any
-from llama_index.core.llms.callbacks import llm_completion_callback
-from llama_index.core.llms.mock import MockLLM
-import pytest
-from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.chat_engine.simple import SimpleChatEngine
+from llama_index.core.llms.callbacks import llm_chat_callback, llm_completion_callback
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.memory import ChatMemoryBuffer
 
 
 def test_simple_chat_engine() -> None:
@@ -71,6 +77,40 @@ async def test_simple_chat_engine_astream():
     assert num_iters > 10
     assert "Hello World!" in response.unformatted_response
     assert "What is the capital of the moon?" in response.unformatted_response
+
+
+@pytest.mark.asyncio
+async def test_simple_chat_engine_astream_multi_block_message_history() -> None:
+    class MultiBlockStreamLLM(MockLLM):
+        @llm_chat_callback()
+        async def astream_chat(
+            self, messages: Sequence[ChatMessage], **kwargs: Any
+        ) -> ChatResponseAsyncGen:
+            message = ChatMessage(
+                role=MessageRole.ASSISTANT,
+                blocks=[TextBlock(text="stale"), ImageBlock()],
+            )
+
+            async def gen() -> ChatResponseAsyncGen:
+                yield ChatResponse(message=message, delta="hel")
+                yield ChatResponse(message=message, delta="lo")
+
+            return gen()
+
+    engine = SimpleChatEngine.from_defaults(
+        llm=MultiBlockStreamLLM(is_chat_model=True),
+        memory=ChatMemoryBuffer.from_defaults(),
+    )
+
+    response = await engine.astream_chat("Hello World!")
+    chunks = [chunk async for chunk in response.async_response_gen()]
+
+    assert chunks == ["hel", "lo"]
+    assert len(engine.chat_history) == 2
+    assistant_message = engine.chat_history[-1]
+    assert assistant_message.role == MessageRole.ASSISTANT
+    assert assistant_message.content == "hello"
+    assert assistant_message.blocks == [TextBlock(text="hello"), ImageBlock()]
 
 
 def test_simple_chat_engine_astream_exception_handling():


### PR DESCRIPTION
## Summary
- Avoid assigning to `ChatMessage.content` when finalizing streamed chat responses.
- Update the final text block directly while preserving non-text blocks on multi-block messages.
- Add an async `SimpleChatEngine` regression test for a streamed assistant message with multiple blocks.

Fixes #21679.

## Testing
- `uv run pytest tests/chat_engine/test_simple.py -q`
- `uv run ruff check llama_index/core/chat_engine/types.py tests/chat_engine/test_simple.py`
- `uv run ruff format --check llama_index/core/chat_engine/types.py tests/chat_engine/test_simple.py`
