### PR TITLE
fix: apply retriever_weights in reciprocal_rerank fusion (#21444)

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -123,8 +123,10 @@ class QueryFusionRetriever(BaseRetriever):
         fused_scores = {}
         hash_to_node = {}
 
-        # compute reciprocal rank scores
-        for nodes_with_scores in results.values():
+        # compute reciprocal rank scores, weighted by retriever
+        for query_tuple, nodes_with_scores in results.items():
+            retriever_idx = query_tuple[1]
+            weight = self._retriever_weights[retriever_idx]
             for rank, node_with_score in enumerate(
                 sorted(nodes_with_scores, key=lambda x: x.score or 0.0, reverse=True)
             ):
@@ -132,7 +134,7 @@ class QueryFusionRetriever(BaseRetriever):
                 hash_to_node[hash] = node_with_score
                 if hash not in fused_scores:
                     fused_scores[hash] = 0.0
-                fused_scores[hash] += 1.0 / (rank + k)
+                fused_scores[hash] += weight * (1.0 / (rank + k))
 
         # sort results
         reranked_results = dict(

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -33,3 +33,108 @@ async def test_aretrieve_uses_async_query_generation():
     await retriever.aretrieve("test query")
 
     assert async_called
+
+
+def _make_fusion(weights=None):
+    return QueryFusionRetriever(
+        retrievers=[MockRetriever(), MockRetriever()],
+        llm=MockLLM(),
+        mode="reciprocal_rerank",
+        num_queries=1,
+        retriever_weights=weights,
+    )
+
+
+def _node(text: str, score: float = 1.0) -> NodeWithScore:
+    return NodeWithScore(node=TextNode(text=text), score=score)
+
+
+def test_reciprocal_rerank_applies_retriever_weights():
+    """
+    `_reciprocal_rerank_fusion` must scale each RRF contribution by the
+    retriever's normalized weight.
+
+    Regression test for the case where `retriever_weights` was silently
+    ignored in `reciprocal_rerank` mode while it was honored in
+    `relative_score` mode (issue #21444).
+    """
+    retriever = _make_fusion(weights=[3.0, 1.0])
+    results = {("q", 0): [_node("a")], ("q", 1): [_node("b")]}
+
+    fused = {
+        nws.node.text: nws.score for nws in retriever._reciprocal_rerank_fusion(results)
+    }
+
+    # Normalized weights are [0.75, 0.25]; both docs are at rank 0 so the
+    # only differentiator is the weight. Score ratio must equal weight ratio.
+    assert fused["a"] == pytest.approx(0.75 / 60.0)
+    assert fused["b"] == pytest.approx(0.25 / 60.0)
+    assert fused["a"] == pytest.approx(fused["b"] * 3)
+
+
+def test_reciprocal_rerank_equal_weights_preserve_ordering():
+    """
+    Equal weights must not change the *ordering* relative to the unweighted
+    baseline — only the absolute score magnitude.
+
+    Guards against accidentally introducing a weight-dependent tiebreaker.
+    """
+    results = {
+        ("q", 0): [_node("doc_x"), _node("doc_y")],
+        ("q", 1): [_node("doc_y"), _node("doc_x")],
+    }
+
+    fused = _make_fusion(weights=[1.0, 1.0])._reciprocal_rerank_fusion(results)
+    scores = {nws.node.text: nws.score for nws in fused}
+
+    # doc_x: rank0 from r0, rank1 from r1. doc_y: rank1 from r0, rank0 from r1.
+    # Symmetric → scores must tie.
+    assert scores["doc_x"] == pytest.approx(scores["doc_y"])
+
+
+def test_reciprocal_rerank_zero_weight_suppresses_retriever():
+    """
+    A retriever with weight 0 must contribute 0 to fused scores — so a doc
+    that only appears from that retriever ends up with score 0 and ranks
+    behind any doc with non-zero weight contributions.
+    """
+    results = {
+        ("q", 0): [_node("only_from_r0")],
+        ("q", 1): [_node("only_from_r1")],
+    }
+    fused = _make_fusion(weights=[1.0, 0.0])._reciprocal_rerank_fusion(results)
+    scores = {nws.node.text: nws.score for nws in fused}
+
+    assert scores["only_from_r0"] > 0
+    assert scores["only_from_r1"] == pytest.approx(0.0)
+    # Returned in score-desc order.
+    assert fused[0].node.text == "only_from_r0"
+
+
+def test_reciprocal_rerank_weight_promotes_relevant_doc():
+    """
+    Semantic / impact test: when one retriever ranks the relevant doc first
+    and the other ranks an irrelevant doc first, weighting the *good*
+    retriever higher must make the relevant doc win, and weighting the
+    *bad* retriever higher must reverse the outcome.
+    """
+
+    # r0 is the "good" retriever: relevant doc at rank 0.
+    # r1 is the "bad" retriever: irrelevant doc at rank 0.
+    # Note: `_reciprocal_rerank_fusion` mutates `node_with_score.score`
+    # on its inputs, so build fresh node lists for each call.
+    def fresh_inputs():
+        return {
+            ("q", 0): [_node("relevant"), _node("irrelevant")],
+            ("q", 1): [_node("irrelevant"), _node("relevant")],
+        }
+
+    favor_good = _make_fusion(weights=[5.0, 1.0])._reciprocal_rerank_fusion(
+        fresh_inputs()
+    )
+    favor_bad = _make_fusion(weights=[1.0, 5.0])._reciprocal_rerank_fusion(
+        fresh_inputs()
+    )
+
+    assert favor_good[0].node.text == "relevant"
+    assert favor_bad[0].node.text == "irrelevant"


### PR DESCRIPTION

  ## Description

  `QueryFusionRetriever._reciprocal_rerank_fusion` iterated `results.values()`, which discards the per-query retriever
  index and silently ignored `self._retriever_weights`. The other fusion modes (`_relative_score_fusion`,
  `_dist_based_score_fusion`) already weight scores by retriever, so passing `retriever_weights=[...]` had a confusing,
  mode-dependent behavior.

  This PR switches to iterating `results.items()` to recover the retriever index and multiplies each RRF contribution by
   the corresponding (normalized) weight — bringing `reciprocal_rerank` mode in line with the other fusion modes.

  Fixes #21444

  ### What the bug looked like in practice

  The user constructs a fusion retriever with two retrievers, weighting the BM25 retriever 4× higher than the vector
  retriever:

  ```python
  from llama_index.core.retrievers import QueryFusionRetriever

  fusion_retriever = QueryFusionRetriever(
      retrievers=[bm25_retriever, vector_retriever],
      mode="reciprocal_rerank",
      retriever_weights=[4.0, 1.0],   # ← silently ignored before this fix
      similarity_top_k=5,
      num_queries=1,
  )

  nodes = fusion_retriever.retrieve("query")
  ```

  **Before the fix:** the output is identical no matter what `retriever_weights` is set to — `[4.0, 1.0]`, `[1.0, 4.0]`,
   `[1.0, 1.0]`, or omitted entirely all produce the exact same fused ranking. The `retriever_weights` argument was
  accepted, stored, and never used.
  
  **After the fix:** weights shift the fused score in the expected direction. For a document that BM25 ranks first and
  the vector retriever ranks second, the BM25 boost matters: with `[4.0, 1.0]` BM25 wins ties; with `[1.0, 4.0]` the
  vector retriever wins.
  
  ### Minimal worked example

  ```python
  # Two retrievers disagreeing on top result:
  #   r0 (BM25):     [doc_A, doc_B]
  #   r1 (vector):   [doc_B, doc_A]
  # (both with score 1.0 from their respective backends)

  # Before this PR — `retriever_weights` is ignored:
  #   weights=[1.0, 1.0]  →  doc_A score = doc_B score = 1/60  (tie)
  #   weights=[5.0, 1.0]  →  doc_A score = doc_B score = 1/60  (still a tie!)
  #   weights=[1.0, 5.0]  →  doc_A score = doc_B score = 1/60  (still!)

  # After this PR — weights drive the fusion:
  #   weights=[1.0, 1.0]  →  doc_A = doc_B = 0.5/60 + 0.5/61      (tie, as expected)
  #   weights=[5.0, 1.0]  →  doc_A wins   (BM25's first pick is favored)
  #   weights=[1.0, 5.0]  →  doc_B wins   (vector's first pick is favored)
  ```

  ### Behavior change — please review
  
  With equal weights (the default `[1/n, …, 1/n]`), the *ordering* of fused results is unchanged, but the *absolute 
  score magnitudes* are now `1/n` of what they were before (because each contribution is multiplied by a normalized
  weight that sums to 1 instead of being summed un-normalized). Users who rely on the absolute fused score value (e.g.
  for a hard cutoff threshold) may need to adjust. The relative ordering — which is what matters for `similarity_top_k`
  and downstream consumers — is preserved.

  ## New Package?

  - [ ] Yes
  - [x] No

  ## Version Bump?

  - [ ] Yes
  - [x] No (`llama-index-core`, exempt per CONTRIBUTING)

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

  ## How Has This Been Tested?

  - [x] I added new unit tests to cover this change
  - [ ] I believe this change is already covered by existing unit tests

  Added four regression tests in `llama-index-core/tests/retrievers/test_fusion_retriever.py`:

  | Test | What it asserts |
  |---|---|
  | `test_reciprocal_rerank_applies_retriever_weights` | With weights `[3.0, 1.0]`, the fused score ratio is exactly
  `3:1` (was `1:1` before). |
  | `test_reciprocal_rerank_equal_weights_preserve_ordering` | Equal weights produce a symmetric tie — guards against
  introducing a weight-dependent tiebreaker. |
  | `test_reciprocal_rerank_zero_weight_suppresses_retriever` | A retriever with weight `0` contributes `0` to fused
  scores. |
  | `test_reciprocal_rerank_weight_promotes_relevant_doc` | Semantic / impact test: when two retrievers disagree on the
  top result, swapping `retriever_weights` swaps which document ranks first. |

  All four tests **fail** on `main` (verified by running them against the un-patched function) and **pass** with this
  change.

  ## Suggested Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added Google Colab support for the newly added notebooks.
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I ran `uv run make format; uv run make lint` to appease the lint gods