### PR TITLE
fix(bedrock): add OSS model support to legacy Bedrock class

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/llama_index/llms/bedrock/utils.py
@@ -92,6 +92,8 @@ CHAT_ONLY_MODELS = {
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": 200000,
     "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": 200000,
     "apac.anthropic.claude-3-5-sonnet-20241022-v2:0": 200000,
+    "openai.gpt-oss-120b-1:0": 128000,
+    "openai.gpt-oss-20b-1:0": 128000,
 }
 BEDROCK_FOUNDATION_LLMS = {**COMPLETION_MODELS, **CHAT_ONLY_MODELS}
 
@@ -134,6 +136,8 @@ STREAMING_MODELS = {
     "apac.anthropic.claude-3-sonnet-20240229-v1:0",
     "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
     "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "openai.gpt-oss-120b-1:0",
+    "openai.gpt-oss-20b-1:0",
 }
 
 
@@ -259,6 +263,17 @@ class MistralProvider(Provider):
         return response["outputs"][0]["text"]
 
 
+class OpenAIProvider(Provider):
+    max_tokens_key = "max_tokens"
+
+    def __init__(self) -> None:
+        self.messages_to_prompt = messages_to_llama_prompt
+        self.completion_to_prompt = completion_to_llama_prompt
+
+    def get_text_from_response(self, response: dict) -> str:
+        return response["choices"][0]["message"]["content"]
+
+
 class ProviderType(Enum):
     AMAZON = ("amazon", AmazonProvider)
     AI21 = ("ai21", Ai21Provider)
@@ -266,6 +281,7 @@ class ProviderType(Enum):
     COHERE = ("cohere", CohereProvider)
     META = ("meta", MetaProvider)
     MISTRAL = ("mistral", MistralProvider)
+    OPENAI = ("openai", OpenAIProvider)
 
     def __init__(self, value: str, provider_class: type) -> None:
         self._value_ = value

--- a/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock/tests/test_utils.py
@@ -8,6 +8,7 @@ from llama_index.llms.bedrock.utils import (
     AnthropicProvider,
     CohereProvider,
     Ai21Provider,
+    OpenAIProvider,
 )
 
 
@@ -48,6 +49,8 @@ from llama_index.llms.bedrock.utils import (
             "arn:aws:bedrock:us-east-1::foundation-model/ai21.jamba-1-5-large-v1:0",
             Ai21Provider,
         ),
+        ("openai.gpt-oss-120b-1:0", OpenAIProvider),
+        ("openai.gpt-oss-20b-1:0", OpenAIProvider),
     ],
 )
 def test_get_provider(model: str, provider_cls):


### PR DESCRIPTION
The legacy `Bedrock` class (deprecated in favor of `BedrockConverse`) did not recognize OSS models like `gpt-oss-120b-1:0` and `gpt-oss-20b-1:0`, causing validation errors when users tried to instantiate these models. 

The root cause was missing model entries in the `CHAT_ONLY_MODELS` and `STREAMING_MODELS` dictionaries in `llama_index/llms/bedrock/utils.py`, and the absence of a `Provider` class to handle the model prefix.

This fix adds the two OSS models to the model dictionaries with a 128K context size (matching the `BedrockConverse` implementation), creates a `Provider` class to handle model requests, and adds the provider to the `ProviderType` enum. Users can now instantiate the legacy Bedrock class with OSS models without errors, though migration to `BedrockConverse` is still recommended for full feature support.

Fixes #21636