### PR TITLE
fix(google-genai): expose Gemini thoughts and cached-content token counts as additional_kwargs

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG — llama-index-llms-genai
 
+## [v0.9.6]
+
+### Fixed
+
+- Forward `thoughts_token_count` and `cached_content_token_count` from `usage_metadata` into `ChatResponse.additional_kwargs` so Gemini 2.5 thinking-token and prompt-cache usage is visible to `TokenCountingHandler` and OpenInference instrumentation (#19293).
+
 ## [v0.9.4]
 
 ### Changed

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -167,7 +167,8 @@ def chat_from_gemini_response(
     if response.usage_metadata:
         raw["usage_metadata"] = response.usage_metadata.model_dump()
 
-        # Set token usage information as required by MLFlow Tracing
+        # Set token usage information as required by MLFlow Tracing and
+        # consumed by TokenCountingHandler / OpenInference instrumentation.
         additional_kwargs["prompt_tokens"] = response.usage_metadata.prompt_token_count
         additional_kwargs["completion_tokens"] = (
             response.usage_metadata.candidates_token_count
@@ -176,6 +177,14 @@ def chat_from_gemini_response(
 
         if response.usage_metadata.thoughts_token_count:
             thought_tokens = response.usage_metadata.thoughts_token_count
+            # Surface reasoning tokens for Gemini 2.5 thinking models so
+            # observability tools can break them out from completion tokens.
+            additional_kwargs["thoughts_token_count"] = thought_tokens
+
+        if response.usage_metadata.cached_content_token_count:
+            additional_kwargs["cached_content_token_count"] = (
+                response.usage_metadata.cached_content_token_count
+            )
 
     if hasattr(response, "cached_content") and response.cached_content:
         raw["cached_content"] = response.cached_content

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.5"
+version = "0.9.6"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -1045,6 +1045,99 @@ def test_thoughts_in_response() -> None:
     assert chat_response.message.content == "This is not a thought."
 
 
+def test_usage_metadata_in_additional_kwargs() -> None:
+    """
+    Token counts from usage_metadata are exposed via additional_kwargs.
+
+    Regression test for #19293: TokenCountingHandler and OpenInference
+    instrumentation read prompt_tokens / completion_tokens / total_tokens
+    from ChatResponse.additional_kwargs. For Gemini 2.5 thinking models the
+    response also carries thoughts_token_count, which should be surfaced
+    alongside the standard counters.
+    """
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock()]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.candidates[0].content.role = "model"
+    mock_response.candidates[0].content.parts = [MagicMock()]
+    mock_response.candidates[0].content.parts[0].text = "Hello."
+    mock_response.candidates[0].content.parts[0].inline_data = None
+    mock_response.candidates[0].content.parts[0].thought = None
+    mock_response.candidates[0].content.parts[0].function_call = None
+    mock_response.candidates[0].content.parts[0].function_response = None
+    mock_response.candidates[0].content.parts[0].model_dump = MagicMock(return_value={})
+    mock_response.candidates[0].model_dump = MagicMock(return_value={})
+    mock_response.prompt_feedback = None
+    mock_response.function_calls = None
+    del mock_response.cached_content
+
+    mock_response.usage_metadata = MagicMock()
+    mock_response.usage_metadata.prompt_token_count = 11
+    mock_response.usage_metadata.candidates_token_count = 22
+    mock_response.usage_metadata.total_token_count = 40
+    mock_response.usage_metadata.thoughts_token_count = 7
+    mock_response.usage_metadata.cached_content_token_count = 3
+    mock_response.usage_metadata.model_dump.return_value = {
+        "prompt_token_count": 11,
+        "candidates_token_count": 22,
+        "total_token_count": 40,
+        "thoughts_token_count": 7,
+        "cached_content_token_count": 3,
+    }
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert chat_response.additional_kwargs["prompt_tokens"] == 11
+    assert chat_response.additional_kwargs["completion_tokens"] == 22
+    assert chat_response.additional_kwargs["total_tokens"] == 40
+    assert chat_response.additional_kwargs["thoughts_token_count"] == 7
+    assert chat_response.additional_kwargs["cached_content_token_count"] == 3
+
+    # The same kwargs are mirrored onto the inner ChatMessage so callbacks
+    # that read message.additional_kwargs see the same values.
+    assert chat_response.message.additional_kwargs["prompt_tokens"] == 11
+    assert chat_response.message.additional_kwargs["thoughts_token_count"] == 7
+
+
+def test_usage_metadata_without_thoughts_token_count() -> None:
+    """Non-thinking Gemini responses omit thoughts_token_count entirely."""
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock()]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.candidates[0].content.role = "model"
+    mock_response.candidates[0].content.parts = [MagicMock()]
+    mock_response.candidates[0].content.parts[0].text = "Hello."
+    mock_response.candidates[0].content.parts[0].inline_data = None
+    mock_response.candidates[0].content.parts[0].thought = None
+    mock_response.candidates[0].content.parts[0].function_call = None
+    mock_response.candidates[0].content.parts[0].function_response = None
+    mock_response.candidates[0].content.parts[0].model_dump = MagicMock(return_value={})
+    mock_response.candidates[0].model_dump = MagicMock(return_value={})
+    mock_response.prompt_feedback = None
+    mock_response.function_calls = None
+    del mock_response.cached_content
+
+    mock_response.usage_metadata = MagicMock()
+    mock_response.usage_metadata.prompt_token_count = 5
+    mock_response.usage_metadata.candidates_token_count = 8
+    mock_response.usage_metadata.total_token_count = 13
+    mock_response.usage_metadata.thoughts_token_count = None
+    mock_response.usage_metadata.cached_content_token_count = None
+    mock_response.usage_metadata.model_dump.return_value = {
+        "prompt_token_count": 5,
+        "candidates_token_count": 8,
+        "total_token_count": 13,
+    }
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert chat_response.additional_kwargs["prompt_tokens"] == 5
+    assert chat_response.additional_kwargs["completion_tokens"] == 8
+    assert chat_response.additional_kwargs["total_tokens"] == 13
+    assert "thoughts_token_count" not in chat_response.additional_kwargs
+    assert "cached_content_token_count" not in chat_response.additional_kwargs
+
+
 def test_thoughts_without_thought_response() -> None:
     """Test response processing when thought summaries are not present."""
     # Mock response without cached_content

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-google-genai"
-version = "0.9.4"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },


### PR DESCRIPTION
## Summary

Fixes #19293.

`response.usage_metadata.thoughts_token_count` (Gemini 2.5 reasoning tokens) and `cached_content_token_count` are already captured into `ChatResponse.raw["usage_metadata"]`, but they were never forwarded to `ChatResponse.additional_kwargs` the way `prompt_tokens`, `completion_tokens`, and `total_tokens` are. As a result, `TokenCountingHandler` and OpenInference instrumentation reported zero reasoning / cache tokens for Gemini 2.5 thinking models, which is what the original bug report screenshotted.

This patch surfaces both fields in `additional_kwargs` at the single chat conversion site (`chat_from_gemini_response`), which is shared by `chat`, `achat`, `stream_chat`, `astream_chat`, and the completion shims that wrap them, so every entry point benefits without per-method changes.

Scope note: PR #21135 covers the same observability gap but only for the `structured_predict` / `astructured_predict` / `stream_structured_predict` / `astream_structured_predict` paths via OTEL spans. This PR is complementary, it patches the general chat path where the issue was originally reported.

### Changes

- `utils.py`: in `chat_from_gemini_response`, forward `thoughts_token_count` and `cached_content_token_count` into `additional_kwargs` when present in `usage_metadata`.
- `tests/test_llms_google_genai.py`: add `test_usage_metadata_in_additional_kwargs` and `test_usage_metadata_without_thoughts_token_count` to assert the keys are populated for thinking models and omitted otherwise.
- Bump package version `0.9.5` -> `0.9.6` and add a CHANGELOG entry.

## Test plan

- [x] `uv run pytest tests/` for `llama-index-llms-google-genai` passes locally (33 passed, 46 skipped, all skips gated on `GOOGLE_API_KEY`).
- [x] `uv run ruff format` and `uv run ruff check` are clean.
- [x] New tests verify both the Gemini-2.5 case (all four token keys plus cache) and the legacy case (no `thoughts_token_count` / `cached_content_token_count` key when the response omits them).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (`0.9.5` -> `0.9.6`)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run ruff format` and `uv run ruff check` to appease the lint gods