### PR TITLE
Validate legacy ref_doc_id/doc_id/document_id kwargs on BaseNode

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -49,6 +49,7 @@ from llama_index.core.bridge.pydantic import (
     field_serializer,
     field_validator,
     model_serializer,
+    model_validator,
 )
 from llama_index.core.bridge.pydantic_core import CoreSchema
 from llama_index.core.instrumentation import DispatcherSpanMixin
@@ -267,6 +268,27 @@ class BaseNode(BaseComponent):
 
     Generic abstract interface for retrievable nodes
 
+    Note:
+        ``ref_doc_id``, ``doc_id``, and ``document_id`` are not constructor
+        arguments. They are read-only properties derived from
+        ``relationships[NodeRelationship.SOURCE]``. To set the source
+        document for a node, assign a ``RelatedNodeInfo`` to the
+        ``SOURCE`` relationship explicitly, for example::
+
+            from llama_index.core.schema import (
+                NodeRelationship,
+                RelatedNodeInfo,
+                TextNode,
+            )
+
+            node = TextNode(text="hello")
+            node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+                node_id="my-doc-id"
+            )
+
+        Passing these legacy keys to the constructor raises a ``ValueError``
+        rather than being silently dropped by pydantic.
+
     """
 
     # hash is computed on local field, during the validation process
@@ -318,6 +340,34 @@ class BaseNode(BaseComponent):
         description="Separator between metadata fields when converting to string.",
         alias="metadata_seperator",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_legacy_source_kwargs(cls, values: Any) -> Any:
+        """
+        Reject legacy ``ref_doc_id``/``doc_id``/``document_id`` kwargs.
+
+        These names look like fields but are actually derived properties on
+        :class:`BaseNode`. Pydantic silently drops unknown kwargs, so users
+        passing them got a node with no source relationship and no warning
+        (see issue #19292). Raise a ``ValueError`` directing callers at the
+        canonical ``relationships[NodeRelationship.SOURCE]`` assignment.
+        """
+        if not isinstance(values, dict):
+            return values
+
+        legacy_keys = ("ref_doc_id", "doc_id", "document_id")
+        found = [key for key in legacy_keys if key in values]
+        if found:
+            raise ValueError(
+                f"{', '.join(found)} is not a valid constructor argument for "
+                f"{cls.__name__}. These are read-only properties derived from "
+                "the node's SOURCE relationship. Set the source document "
+                "explicitly instead, e.g.:\n"
+                "    node.relationships[NodeRelationship.SOURCE] = "
+                "RelatedNodeInfo(node_id=...)"
+            )
+        return values
 
     @classmethod
     @abstractmethod
@@ -763,7 +813,16 @@ class Node(BaseNode):
 
 
 class TextNode(BaseNode):
-    """Provided for backward compatibility."""
+    """
+    Provided for backward compatibility.
+
+    Note:
+        ``ref_doc_id``, ``doc_id``, and ``document_id`` are not valid
+        constructor kwargs; they are read-only properties derived from
+        ``relationships[NodeRelationship.SOURCE]``. See :class:`BaseNode`
+        for the recommended replacement pattern.
+
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Make TextNode forward-compatible with Node by supporting 'text_resource' in the constructor."""

--- a/llama-index-core/tests/schema/test_base_node.py
+++ b/llama-index-core/tests/schema/test_base_node.py
@@ -9,6 +9,7 @@ from llama_index.core.schema import (
     NodeRelationship,
     ObjectType,
     RelatedNodeInfo,
+    TextNode,
 )
 
 
@@ -170,3 +171,29 @@ def test_get_embedding(MyNode):
 def test_as_related_node_info(MyNode):
     n = MyNode(id_="test_node")
     assert n.as_related_node_info().node_id == "test_node"
+
+
+@pytest.mark.parametrize("legacy_key", ["ref_doc_id", "doc_id", "document_id"])
+def test_textnode_rejects_legacy_source_kwargs(legacy_key):
+    """
+    Legacy ``ref_doc_id``/``doc_id``/``document_id`` kwargs were silently
+    dropped by pydantic (see issue #19292). They should now raise a
+    ``ValueError`` pointing at the canonical ``relationships`` assignment.
+    """
+    with pytest.raises(ValueError, match=legacy_key):
+        TextNode(text="hi", **{legacy_key: "abc"})
+
+    with pytest.raises(ValueError, match="NodeRelationship.SOURCE"):
+        TextNode(text="hi", **{legacy_key: "abc"})
+
+
+def test_textnode_accepts_source_relationship():
+    """
+    The recommended replacement should construct a node with a working
+    ``ref_doc_id`` property derived from the SOURCE relationship.
+    """
+    node = TextNode(
+        text="hi",
+        relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="abc")},
+    )
+    assert node.ref_doc_id == "abc"

--- a/llama-index-core/tests/vector_stores/test_utils.py
+++ b/llama-index-core/tests/vector_stores/test_utils.py
@@ -24,9 +24,10 @@ def source_node():
 
 @pytest.fixture
 def text_node(source_node: Document):
-    return TextNode(
-        id_="text_node", text="Hello, world!", ref_doc_id=source_node.ref_doc_id
-    )
+    # The SOURCE relationship is set inside the individual tests that need
+    # it; ``ref_doc_id`` is a read-only property and cannot be set via the
+    # constructor (see issue #19292).
+    return TextNode(id_="text_node", text="Hello, world!")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #19292.

`TextNode(text=\"hi\", ref_doc_id=\"abc\")` (and the analogous `doc_id` / `document_id` kwargs) currently look like they work but pydantic silently drops the unknown keyword. The resulting node has no SOURCE relationship and `node_to_metadata_dict` returns `\"None\"` for the identity fields, which is the surprising behaviour the original reporter hit.

logan-markewich confirmed in [#19292](https://github.com/run-llama/llama_index/issues/19292#issuecomment-3267954461) that these are derived properties, not constructor kwargs, and the discussion identified this as a docs + validation gap.

This PR:

- Adds a `@model_validator(mode=\"before\")` on `BaseNode` that detects the three legacy keys (`ref_doc_id`, `doc_id`, `document_id`) in the input dict and raises a `ValueError` pointing at the canonical replacement:

  ```python
  node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=...)
  ```

- Updates the `BaseNode` and `TextNode` docstrings with a Note describing the migration.

- `Document` is unaffected because `Document.__init__` already pops `doc_id` (mapping it to `id_`) before the super call, so the legacy alias on `Document` keeps working.

- Updates one test fixture (`tests/vector_stores/test_utils.py::text_node`) that was passing `ref_doc_id` to the `TextNode` constructor; the keyword was being silently dropped before, and the test only worked because the next line overrode `relationships[SOURCE]` directly. The fixture now constructs the node without the broken kwarg.

## Test plan

- [x] `pytest llama-index-core/tests/schema/` — 58 pass (4 new tests cover the three legacy keys + the recommended replacement pattern).
- [x] `pytest llama-index-core/tests/vector_stores/test_utils.py` — 5 pass after the fixture fix.
- [x] `ruff check` + `ruff format --check` clean on the touched files.
- [x] Manual smoke: `Document(text=\"hi\", doc_id=\"abc\")` still works (back-compat alias on `Document` preserved), `TextNode(text=\"hi\", ref_doc_id=\"abc\")` now raises with a clear error message.