### PR TITLE
fix: match nodes missing the filtered key for NE/NIN metadata filters

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/utils.py
+++ b/llama-index-core/llama_index/core/vector_stores/utils.py
@@ -115,7 +115,10 @@ def build_metadata_filter_fn(
         ) -> bool:
             """Evaluate a single filter operator against a metadata value."""
             if metadata_value is None:
-                return False
+                # A missing value is, trivially, not equal to / not contained in
+                # the requested value, so negation operators should match. This
+                # keeps `key != value` consistent with `NOT(key == value)`.
+                return operator in (FilterOperator.NE, FilterOperator.NIN)
 
             if operator == FilterOperator.EQ:
                 return metadata_value == value

--- a/llama-index-core/tests/vector_stores/test_metadata_filters_logic.py
+++ b/llama-index-core/tests/vector_stores/test_metadata_filters_logic.py
@@ -99,6 +99,60 @@ def test_is_empty_matches_missing_and_empty_values() -> None:
     assert fn("n3")
 
 
+def test_ne_matches_nodes_missing_the_key() -> None:
+    # A node that does not have the filtered key is, trivially, not equal to the
+    # given value and should therefore match a `!=` filter. This also keeps
+    # `key != value` consistent with `NOT(key == value)`.
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", operator=FilterOperator.NE, value="news")
+        ]
+    )
+    fn = build_metadata_filter_fn(_METADATA_BY_ID.__getitem__, filters)
+
+    # None of the nodes have a "category" key, so all should match.
+    assert fn("n1")
+    assert fn("n2")
+    assert fn("n3")
+
+
+def test_nin_matches_nodes_missing_the_key() -> None:
+    # A node that does not have the filtered key is not contained in the given
+    # list and should match a `nin` filter, mirroring `NOT(key in value)`.
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", operator=FilterOperator.NIN, value=["news"])
+        ]
+    )
+    fn = build_metadata_filter_fn(_METADATA_BY_ID.__getitem__, filters)
+
+    # None of the nodes have a "category" key, so all should match.
+    assert fn("n1")
+    assert fn("n2")
+    assert fn("n3")
+
+
+def test_ne_on_missing_key_matches_not_eq_condition() -> None:
+    # `key != value` must produce the same result as `NOT(key == value)` for a
+    # node that is missing the key entirely.
+    ne_filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", operator=FilterOperator.NE, value="news")
+        ]
+    )
+    not_eq_filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", operator=FilterOperator.EQ, value="news")
+        ],
+        condition=FilterCondition.NOT,
+    )
+    ne_fn = build_metadata_filter_fn(_METADATA_BY_ID.__getitem__, ne_filters)
+    not_eq_fn = build_metadata_filter_fn(_METADATA_BY_ID.__getitem__, not_eq_filters)
+
+    for node_id in _METADATA_BY_ID:
+        assert ne_fn(node_id) == not_eq_fn(node_id)
+
+
 def test_text_match_insensitive_uses_case_insensitive_search() -> None:
     filters = MetadataFilters(
         filters=[


### PR DESCRIPTION
# Description

`build_metadata_filter_fn` in `llama-index-core` short-circuits with `return False` for **every** operator when a node's metadata value for a key is missing (`None`):

```python
if metadata_value is None:
    return False
```

For the negation operators `NE` (`!=`) and `NIN` (`nin`) this is incorrect. A node that does not have the filtered key is, trivially, *not equal to* / *not contained in* the requested value, so it should match. The current behaviour also makes `key != value` inconsistent with the logically-equivalent `NOT(key == value)` — for a node missing the key, the two produce **opposite** results.

This affects the in-memory `SimpleVectorStore` and any store that uses `build_metadata_filter_fn` for metadata filtering.

**Root cause:** the blanket `metadata_value is None -> False` early-return is applied uniformly, including to the negation operators.

**Fix:** when the value is missing, return `True` for `NE`/`NIN` and keep returning `False` for the positive operators (`EQ`, `IN`, `GT`, `CONTAINS`, ...). This is a one-line change plus a clarifying comment.

```python
if metadata_value is None:
    # A missing value is, trivially, not equal to / not contained in
    # the requested value, so negation operators should match. This
    # keeps `key != value` consistent with `NOT(key == value)`.
    return operator in (FilterOperator.NE, FilterOperator.NIN)
```

Fixes #21750

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (change is in `llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added three tests in `tests/vector_stores/test_metadata_filters_logic.py`:
- `test_ne_matches_nodes_missing_the_key` — `NE` matches nodes missing the key.
- `test_nin_matches_nodes_missing_the_key` — `NIN` matches nodes missing the key.
- `test_ne_on_missing_key_matches_not_eq_condition` — `key != value` agrees with `NOT(key == value)`.

The new tests fail on `main` and pass with this change. The full existing `tests/vector_stores/` suite (operator coverage incl. `EQ`/`IN`/`CONTAINS` and the `NOT` condition) stays green. `ruff` and `mypy` are clean on the changed files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

---

Developed with AI coding assistance; reviewed and validated by the author (reproduced the bug, wrote and ran the tests, and confirmed lint/type checks pass).