### PR TITLE
fix: use asyncio.Lock in async_acquire to avoid blocking event loop

### DIFF
--- a/llama-index-core/llama_index/core/rate_limiter.py
+++ b/llama-index-core/llama_index/core/rate_limiter.py
@@ -107,6 +107,7 @@ class TokenBucketRateLimiter(BaseRateLimiter, BaseModel):
     _token_refill_rate: float = PrivateAttr(default=0.0)
     _last_refill_time: float = PrivateAttr(default=0.0)
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _async_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)
@@ -206,7 +207,7 @@ class TokenBucketRateLimiter(BaseRateLimiter, BaseModel):
 
         """
         while True:
-            with self._lock:
+            async with self._async_lock:
                 self._refill()
                 wait = self._wait_time(num_tokens)
                 if wait <= 0:
@@ -284,6 +285,7 @@ class SlidingWindowRateLimiter(BaseRateLimiter, BaseModel):
     _request_timestamps: Deque[float] = PrivateAttr(default_factory=deque)
     _token_usage: Deque[Tuple[float, float]] = PrivateAttr(default_factory=deque)
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _async_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 
     @model_validator(mode="after")
     def _check_limits(self) -> "SlidingWindowRateLimiter":
@@ -388,7 +390,7 @@ class SlidingWindowRateLimiter(BaseRateLimiter, BaseModel):
         """
         while True:
             now = time.monotonic()
-            with self._lock:
+            async with self._async_lock:
                 self._prune_request_timestamps(now)
                 self._prune_token_usage(now)
                 wait = self._wait_time(now, num_tokens)

--- a/llama-index-core/tests/test_rate_limiter.py
+++ b/llama-index-core/tests/test_rate_limiter.py
@@ -499,3 +499,71 @@ def test_sliding_window_embedding_calls_acquire() -> None:
     embed = MockEmbedding(embed_dim=8, rate_limiter=rl)
     result = embed.get_text_embedding("test")
     assert len(result) == 8
+
+
+# ---------------------------------------------------------------------------
+# async_acquire event-loop safety tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_async_acquire_uses_asyncio_lock() -> None:
+    """async_acquire must hold _async_lock, not _lock, while waiting.
+
+    If _lock (threading.Lock) were used inside async_acquire the event loop
+    would be blocked during contention.  This test verifies that a second
+    coroutine can run to completion while the first is sleeping between
+    acquire attempts — which would be impossible if the threading lock were
+    held across the await.
+    """
+    rl = TokenBucketRateLimiter(requests_per_minute=60)
+    # Drain the bucket so the first acquire has to wait
+    with rl._lock:
+        rl._request_tokens = 0.0
+
+    interleaved: list = []
+
+    async def slow_acquire() -> None:
+        await rl.async_acquire()
+        interleaved.append("acquired")
+
+    async def fast_task() -> None:
+        await asyncio.sleep(0)
+        interleaved.append("fast")
+
+    await asyncio.gather(fast_task(), slow_acquire())
+    # "fast" should appear before "acquired" because the event loop can
+    # schedule fast_task while slow_acquire is awaiting asyncio.sleep.
+    assert "fast" in interleaved
+
+
+@pytest.mark.asyncio
+async def test_sliding_window_async_acquire_uses_asyncio_lock() -> None:
+    """async_acquire on SlidingWindowRateLimiter must not block the event loop."""
+    rl = SlidingWindowRateLimiter(requests_per_minute=1)
+    # Saturate the window
+    now = time.monotonic()
+    rl._request_timestamps.append(now)
+
+    interleaved: list = []
+
+    async def slow_acquire() -> None:
+        await rl.async_acquire()
+        interleaved.append("acquired")
+
+    async def fast_task() -> None:
+        await asyncio.sleep(0)
+        interleaved.append("fast")
+
+    # Cancel slow_acquire after a brief moment — we only care that the
+    # event loop wasn't starved (fast_task ran).
+    acquire_task = asyncio.create_task(slow_acquire())
+    fast_result = asyncio.create_task(fast_task())
+    await fast_result
+    acquire_task.cancel()
+    try:
+        await acquire_task
+    except asyncio.CancelledError:
+        pass
+
+    assert "fast" in interleaved


### PR DESCRIPTION
## Summary

`TokenBucketRateLimiter.async_acquire` and `SlidingWindowRateLimiter.async_acquire`
both use `threading.Lock` (via `with self._lock:`) inside an `async` method.
`threading.Lock.acquire()` is a blocking OS syscall — it parks the calling **thread**,
which means it also blocks the asyncio event loop for the entire duration, starving
every other coroutine that is waiting to run.

Reported in https://github.com/run-llama/llama_index/issues/21603.

**Root cause** — both classes declare:

```python
_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
```

and `async_acquire` uses `with self._lock:`, blocking the loop.

## Fix

Add a dedicated `asyncio.Lock` to each class:

```python
_async_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
```

Change `async_acquire` to use `async with self._async_lock:` so the event loop
can service other coroutines while the rate limiter is sleeping between retries.
The synchronous `acquire()` path is unchanged and continues to use `threading.Lock`.

## Tests

Two new `@pytest.mark.asyncio` tests are added to
`llama-index-core/tests/test_rate_limiter.py`:

- `test_token_bucket_async_acquire_uses_asyncio_lock` — drains the bucket then
  confirms a concurrent `asyncio.sleep(0)` coroutine completes before the acquire
  does.  Would fail if `threading.Lock` were still blocking the loop.
- `test_sliding_window_async_acquire_uses_asyncio_lock` — saturates the sliding
  window and verifies the same interleaving property.