### PR TITLE
Add llama-index-tools-ejentum integration

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-ejentum/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+## [0.1.0]
+
+- Initial release.
+- `EjentumToolSpec` subclasses `McpToolSpec` and pre-configures the hosted Ejentum MCP server at `https://api.ejentum.com/mcp` with Bearer authentication.
+- Four harness tools exposed: `harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`.
+- Mode-subset shorthand via the `modes=` constructor argument.

--- a/llama-index-integrations/tools/llama-index-tools-ejentum/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ejentum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-ejentum/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/README.md
@@ -1,0 +1,80 @@
+# LlamaIndex Tool: Ejentum Reasoning Harness
+
+Wraps the hosted [Ejentum](https://ejentum.com) MCP server as a LlamaIndex tool spec. Exposes four cognitive-harness tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`) an agent calls before generating, each returning a structured scaffold the agent absorbs to harden its next response against named failure modes.
+
+## Installation
+
+```bash
+pip install llama-index-tools-ejentum
+```
+
+## Requirements
+
+- Python >= 3.10
+- `llama-index-core` >= 0.13.0,<0.15 (transitive)
+- `llama-index-tools-mcp` >= 0.4.0 (transitive)
+- `EJENTUM_API_KEY` environment variable. Free and paid tiers at <https://ejentum.com/auth/register>.
+
+## Usage
+
+### Minimal
+
+```python
+import os
+from llama_index.tools.ejentum import EjentumToolSpec
+
+os.environ["EJENTUM_API_KEY"] = "..."  # or set in your shell
+
+spec = EjentumToolSpec()
+tools = spec.to_tool_list()
+```
+
+### Subset of modes
+
+```python
+# Only expose reasoning and code harnesses
+spec = EjentumToolSpec(modes=["reasoning", "code"])
+tools = spec.to_tool_list()
+```
+
+Valid mode names: `reasoning`, `code`, `anti_deception`, `memory`.
+
+### With a ReActAgent
+
+```python
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.ejentum import EjentumToolSpec
+
+tools = EjentumToolSpec().to_tool_list()
+agent = ReActAgent.from_tools(tools, llm=OpenAI(model="gpt-4o-mini"))
+
+response = await agent.achat(
+    "Why might our microservice return 503s only under specific load patterns?"
+)
+```
+
+The agent routes to `harness_reasoning` based on the tool description. The returned scaffold (failure pattern, procedure, suppression vectors, falsification test) is fed back into the agent's context for the next generation step.
+
+## What each harness returns
+
+Each `harness_*` call returns four labeled sections:
+
+- `[NEGATIVE GATE]` / `[DECEPTION PATTERN]` / `[CODE FAILURE]` / `[PERCEPTION FAILURE]`: the named failure mode to avoid.
+- `[PROCEDURE]` (or `[INTEGRITY PROCEDURE]`): an executable step-by-step the model follows internally.
+- `Amplify:` and `Suppress:` vectors: signals to activate or block.
+- `[FALSIFICATION TEST]` (or `[INTEGRITY CHECK]`): verification criterion to self-check the next response.
+
+Section labels differ per harness (see the [Ejentum docs](https://ejentum.com/docs) for the per-mode field map).
+
+## About the underlying MCP server
+
+This package is a thin subclass of [`llama-index-tools-mcp`](https://pypi.org/project/llama-index-tools-mcp/)'s `McpToolSpec`, pre-configured with the hosted endpoint and Bearer authentication. For raw MCP usage against arbitrary servers, use `McpToolSpec` directly.
+
+The same MCP server is available across other surfaces: stdio via `npx -y ejentum-mcp`, hosted at `https://api.ejentum.com/mcp` (Streamable HTTP), and listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.ejentum/ejentum-mcp`.
+
+## Links
+
+- [Source repository](https://github.com/ejentum/ejentum-mcp)
+- [Install guide for other clients](https://ejentum.com/docs/mcp_guide)
+- [MCP Registry entry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.ejentum/ejentum-mcp)

--- a/llama-index-integrations/tools/llama-index-tools-ejentum/examples/from_env.py
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/examples/from_env.py
@@ -1,0 +1,35 @@
+"""Minimal runnable example for the Ejentum Reasoning Harness tool spec.
+
+Requires:
+    pip install llama-index-tools-ejentum llama-index-llms-openai
+    export EJENTUM_API_KEY=...
+    export OPENAI_API_KEY=...
+"""
+
+import asyncio
+
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.ejentum import EjentumToolSpec
+
+
+async def main() -> None:
+    # Reads EJENTUM_API_KEY from the environment. Pass api_key=... to override.
+    spec = EjentumToolSpec()
+    tools = spec.to_tool_list()
+    print(f"Loaded tools: {[t.metadata.name for t in tools]}")
+
+    agent = ReActAgent.from_tools(
+        tools,
+        llm=OpenAI(model="gpt-4o-mini"),
+        verbose=True,
+    )
+
+    response = await agent.achat(
+        "Why might our microservice return 503s only under specific load patterns?"
+    )
+    print(response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/llama-index-integrations/tools/llama-index-tools-ejentum/llama_index/tools/ejentum/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/llama_index/tools/ejentum/__init__.py
@@ -1,0 +1,5 @@
+from llama_index.tools.ejentum.base import EjentumToolSpec
+
+__all__ = ["EjentumToolSpec"]
+
+__version__ = "0.1.0"

--- a/llama-index-integrations/tools/llama-index-tools-ejentum/llama_index/tools/ejentum/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/llama_index/tools/ejentum/base.py
@@ -1,0 +1,87 @@
+"""Ejentum Reasoning Harness tool spec."""
+
+import os
+from typing import List, Optional
+
+from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
+
+
+DEFAULT_API_URL = "https://api.ejentum.com/mcp"
+SUPPORTED_MODES = ("reasoning", "code", "anti_deception", "memory")
+
+
+class EjentumToolSpec(McpToolSpec):
+    """
+    Ejentum Reasoning Harness as a LlamaIndex tool spec.
+
+    Wraps the hosted Ejentum MCP server (``https://api.ejentum.com/mcp``) and
+    exposes its four cognitive-harness tools as LlamaIndex ``FunctionTool``
+    objects an agent can route to:
+
+    - ``harness_reasoning`` for analytical, diagnostic, planning, and
+      multi-step decision tasks.
+    - ``harness_code`` for code generation, refactoring, and architecture
+      decisions.
+    - ``harness_anti_deception`` for validation requests, ethical reasoning,
+      and adversarial framings.
+    - ``harness_memory`` for perception sharpening across multi-turn context.
+
+    Each call returns a structured scaffold (named failure pattern, executable
+    procedure, suppression vectors, and falsification test) that the calling
+    agent absorbs before generating its next response.
+
+    This class is a thin subclass of
+    :class:`llama_index.tools.mcp.McpToolSpec` that pre-configures the hosted
+    endpoint with Bearer authentication and exposes a mode-subset shorthand.
+    For raw MCP usage against arbitrary servers, use ``McpToolSpec`` directly.
+
+    Args:
+        api_key: Ejentum API key. Falls back to the ``EJENTUM_API_KEY``
+            environment variable. Free and paid tiers at
+            https://ejentum.com/auth/register.
+        modes: Optional subset of harness modes to expose. Values are short
+            names without the ``harness_`` prefix, e.g.
+            ``["reasoning", "code"]``. Defaults to all four modes.
+        api_url: Override the hosted MCP endpoint. Defaults to
+            ``https://api.ejentum.com/mcp``.
+        timeout: HTTP timeout in seconds. Defaults to 30.
+
+    Example:
+        >>> from llama_index.tools.ejentum import EjentumToolSpec
+        >>> spec = EjentumToolSpec()  # reads EJENTUM_API_KEY from env
+        >>> tools = spec.to_tool_list()
+        >>> # ...pass ``tools`` to your LlamaIndex agent
+
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        modes: Optional[List[str]] = None,
+        api_url: str = DEFAULT_API_URL,
+        timeout: int = 30,
+    ) -> None:
+        resolved_key = api_key or os.getenv("EJENTUM_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "EJENTUM_API_KEY is not set. Pass api_key= explicitly or set "
+                "the environment variable. Sign up at "
+                "https://ejentum.com/auth/register."
+            )
+
+        allowed_tools: Optional[List[str]] = None
+        if modes is not None:
+            unknown = [m for m in modes if m not in SUPPORTED_MODES]
+            if unknown:
+                raise ValueError(
+                    f"Unknown mode(s): {unknown}. "
+                    f"Supported modes: {list(SUPPORTED_MODES)}."
+                )
+            allowed_tools = [f"harness_{m}" for m in modes]
+
+        client = BasicMCPClient(
+            api_url,
+            headers={"Authorization": f"Bearer {resolved_key}"},
+            timeout=timeout,
+        )
+        super().__init__(client=client, allowed_tools=allowed_tools)

--- a/llama-index-integrations/tools/llama-index-tools-ejentum/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==9.0.3",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=6.1.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+]
+
+[project]
+name = "llama-index-tools-ejentum"
+version = "0.1.0"
+description = "Ejentum Reasoning Harness MCP server as a LlamaIndex tool spec"
+authors = [{name = "Ejentum", email = "info@ejentum.com"}]
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10,<4.0"
+keywords = [
+    "mcp",
+    "reasoning",
+    "anti-deception",
+    "cognitive-harness",
+    "agent",
+    "model-context-protocol",
+]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "llama-index-tools-mcp>=0.4.1,<0.5",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = true
+import_path = "llama_index.tools.ejentum"
+
+[tool.llamahub.class_authors]
+EjentumToolSpec = "ejentum"

--- a/llama-index-integrations/tools/llama-index-tools-ejentum/tests/test_tools_ejentum.py
+++ b/llama-index-integrations/tools/llama-index-tools-ejentum/tests/test_tools_ejentum.py
@@ -1,0 +1,64 @@
+"""Tests for the Ejentum Reasoning Harness tool spec."""
+
+import os
+
+import pytest
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.ejentum import EjentumToolSpec
+from llama_index.tools.ejentum.base import DEFAULT_API_URL, SUPPORTED_MODES
+from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
+
+
+def test_class_is_subclass_of_mcp_tool_spec() -> None:
+    assert issubclass(EjentumToolSpec, McpToolSpec)
+    assert issubclass(EjentumToolSpec, BaseToolSpec)
+
+
+def test_init_with_explicit_api_key() -> None:
+    spec = EjentumToolSpec(api_key="test-key")
+    assert isinstance(spec.client, BasicMCPClient)
+    assert spec.client.command_or_url == DEFAULT_API_URL
+    assert spec.client.headers == {"Authorization": "Bearer test-key"}
+    assert spec.allowed_tools is None
+
+
+def test_init_reads_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EJENTUM_API_KEY", "env-key")
+    spec = EjentumToolSpec()
+    assert spec.client.headers == {"Authorization": "Bearer env-key"}
+
+
+def test_init_raises_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EJENTUM_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="EJENTUM_API_KEY"):
+        EjentumToolSpec()
+
+
+def test_modes_subset_filters_allowed_tools() -> None:
+    spec = EjentumToolSpec(api_key="k", modes=["reasoning", "code"])
+    assert spec.allowed_tools == ["harness_reasoning", "harness_code"]
+
+
+def test_modes_unknown_value_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown mode"):
+        EjentumToolSpec(api_key="k", modes=["reasoning", "nonexistent"])
+
+
+def test_custom_api_url_and_timeout() -> None:
+    spec = EjentumToolSpec(
+        api_key="k",
+        api_url="https://example.com/mcp",
+        timeout=10,
+    )
+    assert spec.client.command_or_url == "https://example.com/mcp"
+    assert spec.client.timeout == 10
+
+
+def test_supported_modes_constant_matches_four_harnesses() -> None:
+    assert set(SUPPORTED_MODES) == {
+        "reasoning",
+        "code",
+        "anti_deception",
+        "memory",
+    }


### PR DESCRIPTION
# Description

Introduce `llama-index-tools-ejentum`: a `ToolSpec` that bridges LlamaIndex agents with the hosted [Ejentum MCP server](https://api.ejentum.com/mcp). It exposes Ejentum's four cognitive-harness tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`) as LlamaIndex `FunctionTool` objects an agent can route to before generating.

Each harness call returns a structured scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the agent absorbs to harden its next response against named failure modes (attention decay, reasoning shortcuts, sycophantic capitulation, perception drift).

This package is a thin subclass of `llama-index-tools-mcp`'s `McpToolSpec` that pre-configures the hosted endpoint with Bearer authentication and exposes a mode-subset shorthand. For raw MCP usage against arbitrary servers, `McpToolSpec` remains the recommended path.

Motivation: enable one-step cognitive-scaffold workflows in LlamaIndex and ensure the package is listed/discoverable in the LlamaHub Tools catalog via `tool.llamahub` metadata. Same pattern as the recently merged `llama-index-tools-mcp-discovery` (#20502) and `llama-index-tools-signnow` (#20057).

Affiliation: maintainer of `ejentum-mcp`.

## New Package?

- [x] Yes
- [ ] No

## Version Bump?

- [x] Yes (initial `v0.1.0`)
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Tests verify: class inherits `McpToolSpec` + `BaseToolSpec`, explicit `api_key` flow, env-var fallback, missing-key error, `modes=` subset filter, unknown-mode rejection, custom `api_url` + `timeout`, and the `SUPPORTED_MODES` constant. Pattern mirrors `llama-index-tools-signnow/tests/`.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README + CHANGELOG + example)
- [ ] I have added Google Colab support for the newly added notebooks _(N/A — no notebooks added; runnable example is a plain `.py` file under `examples/`)_
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes _(verified Python syntax via `py_compile` and TOML validity; deferring full `uv run` to CI since the monorepo `uv` env wasn't installed locally)_
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods _(same reason; happy to address any lint output the CI surfaces)_
