### PR TITLE
[Bug] Preserve streaming chunks in refine synthesizers

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -96,6 +96,10 @@ class DefaultRefineProgram(BasePydanticProgram):
     def output_cls(self) -> Type[BaseModel]:
         return StructuredRefineResponse
 
+    @property
+    def streams_plain_text(self) -> bool:
+        return self._output_cls is None
+
     def __call__(self, *args: Any, **kwds: Any) -> StructuredRefineResponse:
         if self._output_cls is not None:
             answer = self._llm.structured_predict(
@@ -158,6 +162,12 @@ class DefaultRefineProgram(BasePydanticProgram):
                 answer += token
             yield StructuredRefineResponse(answer=answer.strip(), query_satisfied=True)
 
+    def stream_answer(self, *args: Any, **kwds: Any) -> Generator[str, None, None]:
+        yield from self._llm.stream(
+            self._prompt,
+            **kwds,
+        )
+
     async def astream_call(
         self, *args: Any, **kwds: Any
     ) -> AsyncGenerator[StructuredRefineResponse, None]:
@@ -198,6 +208,15 @@ class DefaultRefineProgram(BasePydanticProgram):
                     )
 
         return gen()
+
+    async def astream_answer(
+        self, *args: Any, **kwds: Any
+    ) -> AsyncGenerator[str, None]:
+        async for token in await self._llm.astream(
+            self._prompt,
+            **kwds,
+        ):
+            yield token
 
 
 class Refine(BaseSynthesizer):
@@ -344,6 +363,8 @@ class Refine(BaseSynthesizer):
             except (ValidationError, ValueError, TypeError) as e:
                 logger.warning(f"Structured response error: {e}", exc_info=True)
         elif self._streaming:
+            if isinstance(program, DefaultRefineProgram) and program.streams_plain_text:
+                return program.stream_answer(**program_kwargs, **response_kwargs)
             try:
                 structured_response_gen = program.stream_call(
                     **program_kwargs,
@@ -394,6 +415,8 @@ class Refine(BaseSynthesizer):
             except (ValidationError, ValueError, TypeError) as e:
                 logger.warning(f"Structured response error: {e}", exc_info=True)
         elif self._streaming:
+            if isinstance(program, DefaultRefineProgram) and program.streams_plain_text:
+                return program.astream_answer(**program_kwargs, **response_kwargs)
             try:
                 structured_response_gen = await program.astream_call(
                     **program_kwargs,

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -43,10 +43,13 @@ def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
     response = chat_engine.stream_chat("Hello World!")
 
     num_iters = 0
-    for _ in response.response_gen:
+    response_text = ""
+    for chunk in response.response_gen:
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -54,10 +57,13 @@ def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
     response = chat_engine.stream_chat("What is the capital of the moon?")
 
     num_iters = 0
-    for _ in response.response_gen:
+    response_text = ""
+    for chunk in response.response_gen:
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -119,10 +125,13 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     response = await chat_engine.astream_chat("Hello World!")
 
     num_iters = 0
-    async for _ in response.async_response_gen():
+    response_text = ""
+    async for chunk in response.async_response_gen():
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -130,10 +139,13 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     response = await chat_engine.astream_chat("What is the capital of the moon?")
 
     num_iters = 0
-    async for _ in response.async_response_gen():
+    response_text = ""
+    async for chunk in response.async_response_gen():
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -51,10 +51,13 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     response = chat_engine.stream_chat("Hello World!")
 
     num_iters = 0
-    for _ in response.response_gen:
+    response_text = ""
+    for chunk in response.response_gen:
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -62,10 +65,13 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     response = chat_engine.stream_chat("What is the capital of the moon?")
 
     num_iters = 0
-    for _ in response.response_gen:
+    response_text = ""
+    for chunk in response.response_gen:
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -75,9 +81,12 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     q = QueryBundle("Hello World through QueryBundle")
     response = chat_engine.stream_chat(q)
     num_iters = 0
-    for _ in response.response_gen:
+    response_text = ""
+    for chunk in response.response_gen:
         num_iters += 1
-    assert num_iters == 1
+        response_text += chunk
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])
@@ -109,10 +118,13 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     response = await chat_engine.astream_chat("Hello World!")
 
     num_iters = 0
-    async for _ in response.async_response_gen():
+    response_text = ""
+    async for chunk in response.async_response_gen():
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -120,10 +132,13 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     response = await chat_engine.astream_chat("What is the capital of the moon?")
 
     num_iters = 0
-    async for _ in response.async_response_gen():
+    response_text = ""
+    async for chunk in response.async_response_gen():
         num_iters += 1
+        response_text += chunk
 
-    assert num_iters == 1
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -133,9 +148,12 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     q = QueryBundle("Hello World through QueryBundle")
     response = await chat_engine.astream_chat(q)
     num_iters = 0
-    async for _ in response.async_response_gen():
+    response_text = ""
+    async for chunk in response.async_response_gen():
         num_iters += 1
-    assert num_iters == 1
+        response_text += chunk
+    assert num_iters > 1
+    assert response_text.rstrip() == str(response)
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])

--- a/llama-index-core/tests/response_synthesizers/test_compact_and_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_compact_and_refine.py
@@ -128,6 +128,16 @@ class TestCompactAndRefine:
             "information2",
         ]
 
+    def test_synthesize__streaming_preserves_last_call_chunks(
+        self, nodes: list[NodeWithScore]
+    ) -> None:
+        llm = MockLLMWithChatMemoryOfLastCall(max_tokens=4)
+        synthesizer = CompactAndRefine(llm=llm, streaming=True)
+
+        response = synthesizer.synthesize(query="test", nodes=nodes)
+
+        assert list(response.response_gen) == ["text ", "text ", "text ", "text"]
+
     def test_synthesize__multimodal(
         self, multimodal_nodes: list[NodeWithScore]
     ) -> None:
@@ -266,6 +276,18 @@ class TestCompactAndRefine:
             "context",
             "information2",
         ]
+
+    @pytest.mark.asyncio
+    async def test_asynthesize__streaming_preserves_last_call_chunks(
+        self, nodes: list[NodeWithScore]
+    ) -> None:
+        llm = MockLLMWithChatMemoryOfLastCall(max_tokens=4)
+        synthesizer = CompactAndRefine(llm=llm, streaming=True)
+
+        response = await synthesizer.asynthesize(query="test", nodes=nodes)
+
+        chunks = [chunk async for chunk in response.response_gen]
+        assert chunks == ["text ", "text ", "text ", "text"]
 
     @pytest.mark.asyncio
     async def test_asynthesize__multimodal(

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -532,6 +532,19 @@ class TestRefine:
             assert llm.last_called_chat_function == []
             assert llm.last_chat_messages is None
 
+    def test_synthesize__streaming_default_refine_program_streams_last_call(
+        self,
+    ) -> None:
+        llm = MockLLMWithChatMemoryOfLastCall(max_tokens=4)
+        synthesizer = Refine(llm=llm, streaming=True)
+
+        response = synthesizer.synthesize(
+            query="test", nodes=[NodeWithScore(node=TextNode(text="input"), score=1.0)]
+        )
+
+        assert isinstance(response, StreamingResponse)
+        assert list(response.response_gen) == ["text ", "text ", "text ", "text"]
+
     @pytest.mark.asyncio
     async def test_asynthesize__streaming_default_refine_program(
         self, llm_case: LLMCase, nodes: list[NodeWithScore]
@@ -552,6 +565,21 @@ class TestRefine:
         else:
             assert llm.last_called_chat_function == []
             assert llm.last_chat_messages is None
+
+    @pytest.mark.asyncio
+    async def test_asynthesize__streaming_default_refine_program_streams_last_call(
+        self,
+    ) -> None:
+        llm = MockLLMWithChatMemoryOfLastCall(max_tokens=4)
+        synthesizer = Refine(llm=llm, streaming=True)
+
+        response = await synthesizer.asynthesize(
+            query="test", nodes=[NodeWithScore(node=TextNode(text="input"), score=1.0)]
+        )
+
+        assert isinstance(response, AsyncStreamingResponse)
+        chunks = [chunk async for chunk in response.response_gen]
+        assert chunks == ["text ", "text ", "text ", "text"]
 
     def test_synthesize__structured_answer_filtering_default_text_completion_refine_program(
         self,


### PR DESCRIPTION
Fixes #21740

## What changed

Preserve plain-text streaming in `Refine` and `CompactAndRefine` when `streaming=True`.

Previously, the default refine path consumed the LLM stream and returned a single concatenated chunk through `StreamingResponse.response_gen`, even when the underlying LLM yielded multiple deltas.

## Why

This broke incremental rendering for query engine streaming use cases such as Ollama + `index.as_query_engine(streaming=True)`.

The root cause was in the refine synthesizer layer: plain-text streaming was being materialized before being exposed to the caller.

## Impact

- `response.response_gen` now yields incremental chunks for the normal text refine path.
- Structured answer filtering and structured output paths keep their existing behavior.
- `Refine` and `CompactAndRefine` streaming tests now cover the last-call token stream behavior.

## Validation

- `uv run pytest llama-index-core/tests/response_synthesizers`
- `uv run ruff check llama-index-core/llama_index/core/response_synthesizers/refine.py llama-index-core/tests/response_synthesizers/test_refine.py llama-index-core/tests/response_synthesizers/test_compact_and_refine.py`
- `uv run ruff format --check llama-index-core/llama_index/core/response_synthesizers/refine.py llama-index-core/tests/response_synthesizers/test_refine.py llama-index-core/tests/response_synthesizers/test_compact_and_refine.py`