### PR TITLE
fix(bedrock): parse tool_kwargs from JSON string to dict in streaming (fixes #21579)

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/base.py
@@ -594,7 +594,9 @@ class BedrockConverse(FunctionCallingLLM):
                         for tool_call in tool_calls:
                             blocks.append(
                                 ToolCallBlock(
-                                    tool_kwargs=tool_call.get("input", {}),
+                                    tool_kwargs=json.loads(tool_call["input"])
+                                    if isinstance(tool_call.get("input"), str)
+                                    else tool_call.get("input", {}),
                                     tool_name=tool_call.get("name", ""),
                                     tool_call_id=tool_call.get("toolUseId"),
                                 )
@@ -650,7 +652,9 @@ class BedrockConverse(FunctionCallingLLM):
                         for tool_call in tool_calls:
                             blocks.append(
                                 ToolCallBlock(
-                                    tool_kwargs=tool_call.get("input", {}),
+                                    tool_kwargs=json.loads(tool_call["input"])
+                                    if isinstance(tool_call.get("input"), str)
+                                    else tool_call.get("input", {}),
                                     tool_name=tool_call.get("name", ""),
                                     tool_call_id=tool_call.get("toolUseId"),
                                 )
@@ -880,7 +884,9 @@ class BedrockConverse(FunctionCallingLLM):
                         for tool_call in tool_calls:
                             blocks.append(
                                 ToolCallBlock(
-                                    tool_kwargs=tool_call.get("input", {}),
+                                    tool_kwargs=json.loads(tool_call["input"])
+                                    if isinstance(tool_call.get("input"), str)
+                                    else tool_call.get("input", {}),
                                     tool_name=tool_call.get("name", ""),
                                     tool_call_id=tool_call.get("toolUseId"),
                                 )
@@ -936,7 +942,9 @@ class BedrockConverse(FunctionCallingLLM):
                         for tool_call in tool_calls:
                             blocks.append(
                                 ToolCallBlock(
-                                    tool_kwargs=tool_call.get("input", {}),
+                                    tool_kwargs=json.loads(tool_call["input"])
+                                    if isinstance(tool_call.get("input"), str)
+                                    else tool_call.get("input", {}),
                                     tool_name=tool_call.get("name", ""),
                                     tool_call_id=tool_call.get("toolUseId"),
                                 )


### PR DESCRIPTION
Closes #21579

## Summary
Fixed a P1 bug in the Bedrock Converse integration where streaming tool calls produced raw JSON strings instead of parsed dictionaries for tool_kwargs.

## Changes
- Updated \stream_chat\ and \stream_chat\ in \llama_index/llms/bedrock_converse/base.py\ to parse \	ool_call['input']\ from JSON string to dict if needed when constructing \ToolCallBlock\.