### PR TITLE
docs: add Auxen LLM example notebook

### DIFF
--- a/docs/examples/llm/auxen.ipynb
+++ b/docs/examples/llm/auxen.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "auxen-colab-banner",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/llm/auxen.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-intro",
+   "metadata": {},
+   "source": [
+    "# Auxen\n",
+    "\n",
+    "# LlamaIndex Llms Integration: Auxen\n",
+    "\n",
+    "[Auxen](https://auxen.ai) hosts per-customer **dedicated** LLM endpoints (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) on stable HTTPS URLs with an OpenAI-compatible `/v1/chat/completions` API.\n",
+    "\n",
+    "Each Auxen instance is a dedicated GPU billed per-minute of runtime, not per token.\n",
+    "\n",
+    "Since Auxen instances are OpenAI-wire-compatible, this notebook uses LlamaIndex's `OpenAILike` LLM with a per-instance `api_base` and `api_key` issued by the Auxen dashboard.\n",
+    "\n",
+    "Visit [auxen.ai](https://auxen.ai) to provision an instance and obtain the credentials shown below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-setup",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the `llama-index-llms-openai-like` integration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auxen-install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-llms-openai-like"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-credentials",
+   "metadata": {},
+   "source": [
+    "Provision an Auxen instance from the [Auxen dashboard](https://auxen.ai). You will be issued two values:\n",
+    "\n",
+    "- A per-instance **base URL** of the form `https://api.auxen.ai/v1/inst_xxx/v1`\n",
+    "- A per-instance **API key** prefixed `auxk_`\n",
+    "\n",
+    "Set these as environment variables or pass them directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auxen-construct",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from llama_index.llms.openai_like import OpenAILike\n",
+    "\n",
+    "llm = OpenAILike(\n",
+    "    model=\"llama-3.1-8b\",\n",
+    "    api_base=os.environ[\"AUXEN_API_BASE\"],\n",
+    "    api_key=os.environ[\"AUXEN_API_KEY\"],\n",
+    "    is_chat_model=True,\n",
+    "    is_function_calling_model=True,\n",
+    "    context_window=131072,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-complete-section",
+   "metadata": {},
+   "source": [
+    "#### Call `complete` with a prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auxen-complete-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = llm.complete(\"What is dedicated GPU inference?\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-chat-section",
+   "metadata": {},
+   "source": [
+    "#### Call `chat` with a list of messages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auxen-chat-call",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.llms import ChatMessage\n",
+    "\n",
+    "messages = [\n",
+    "    ChatMessage(role=\"system\", content=\"You are a concise assistant.\"),\n",
+    "    ChatMessage(role=\"user\", content=\"Why might a developer choose a dedicated LLM endpoint?\"),\n",
+    "]\n",
+    "resp = llm.chat(messages)\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-streaming-section",
+   "metadata": {},
+   "source": [
+    "### Streaming\n",
+    "\n",
+    "Using `stream_complete`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auxen-stream-complete",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = llm.stream_complete(\"Count from 1 to 5.\")\n",
+    "for r in response:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-stream-chat-section",
+   "metadata": {},
+   "source": [
+    "Using `stream_chat`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auxen-stream-chat",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.llms import ChatMessage\n",
+    "\n",
+    "messages = [ChatMessage(role=\"user\", content=\"Name three open-source LLMs.\")]\n",
+    "resp = llm.stream_chat(messages)\n",
+    "for r in resp:\n",
+    "    print(r.delta, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auxen-catalog",
+   "metadata": {},
+   "source": [
+    "## Catalog\n",
+    "\n",
+    "Auxen-hosted models (set the `model` argument to one of these — your instance is provisioned with one model at creation):\n",
+    "\n",
+    "- `llama-3.1-8b`, `llama-3.1-70b`, `llama-3.2-3b`\n",
+    "- `qwen2.5-7b`, `qwen2.5-14b`, `qwen2.5-32b`\n",
+    "- `mistral-7b`, `mistral-nemo-12b`, `mixtral-8x7b`\n",
+    "- `gemma2-9b`, `phi-3-mini`, `command-r-7b`\n",
+    "\n",
+    "## Pricing model\n",
+    "\n",
+    "Auxen bills per-minute of dedicated GPU runtime, not per token. See [auxen.ai/pricing](https://auxen.ai/pricing) for hourly rates by model size."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a notebook example showing how to use [Auxen](https://auxen.ai) — per-customer dedicated LLM endpoints with an OpenAI-compatible \`/v1/chat/completions\` API — via LlamaIndex's existing \`OpenAILike\` integration. No new partner package is required.

The notebook lives at \`docs/examples/llm/auxen.ipynb\` and mirrors the structure of existing OpenAI-compatible LLM example notebooks (\`deepseek.ipynb\`, \`together.ipynb\`, etc.). It covers:

- Construction with per-instance \`api_base\` + \`api_key\`
- \`complete()\` and \`chat()\` calls
- \`stream_complete()\` and \`stream_chat()\` streaming
- The open-source model catalog (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R)

## About Auxen

Each Auxen instance is a dedicated GPU running one open-source LLM behind a stable HTTPS endpoint, billed per-minute of runtime (not per-token). Since the wire format is OpenAI-compatible, the LlamaIndex integration reuses \`OpenAILike\` rather than introducing a new partner package.

## Companion PRs (Auxen distribution series)

- [BerriAI/litellm#28532](https://github.com/BerriAI/litellm/pull/28532) — LiteLLM provider
- [vercel/ai#15536](https://github.com/vercel/ai/pull/15536) — Vercel AI SDK community provider
- [langchain-ai/docs#4146](https://github.com/langchain-ai/docs/pull/4146) — LangChain docs (Python + JS)
- npm: [\`@auxen/ai-sdk-provider\`](https://www.npmjs.com/package/@auxen/ai-sdk-provider) (live)

Happy to also submit a partner package (\`llama-index-llms-auxen\`) if the team would prefer that over a docs-only example — let me know.