### PR TITLE
fix: use running loop in ingestion pipeline

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -826,7 +826,7 @@ class IngestionPipeline(BaseModel):
                 )
                 num_workers = num_cpus
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             with ProcessPoolExecutor(max_workers=num_workers) as p:
                 node_batches = self._node_batcher(
                     num_batches=num_workers, nodes=nodes_to_run


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in the async ingestion pipeline worker path

## Problem
The ingestion pipeline uses the event loop to run CPU-bound transformation batches in a `ProcessPoolExecutor`. This code path is already inside an async method, so `asyncio.get_running_loop()` is the clearer modern API and avoids relying on legacy event-loop policy behavior.

## Before / After
Before:

```py
loop = asyncio.get_event_loop()
```

After:

```py
loop = asyncio.get_running_loop()
```

The executor behavior is unchanged; the loop reference now comes from the coroutine's active running loop.

## Verification
- `python -m compileall -q llama-index-core\llama_index\core\ingestion\pipeline.py`
- `git diff --check`

I used a sparse checkout for this one because the full repository has Windows long-path checkout issues in this environment.