### PR TITLE
fix(agent): correct swapped agent names in handoff restriction error message

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -81,7 +81,12 @@ async def handoff(ctx: Context, to_agent: str, reason: str) -> str:
     if can_handoff_to.get(
         current_agent_name, []
     ) is not None and to_agent not in can_handoff_to.get(current_agent_name, []):
-        return f"Agent {to_agent} cannot hand off to {current_agent_name}. Please select a valid agent to hand off to."
+        valid_targets = ", ".join(can_handoff_to.get(current_agent_name) or [])
+        return (
+            f"Agent {current_agent_name} is not allowed to hand off to {to_agent}. "
+            f"Please select a valid agent to hand off to. "
+            f"Valid targets: {valid_targets}"
+        )
 
     await ctx.store.set("next_agent", to_agent)
     handoff_output_prompt = await ctx.store.get(

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -306,6 +306,79 @@ async def test_invalid_handoff():
 
 
 @pytest.mark.asyncio
+async def test_restricted_handoff_error_message():
+    """Handoff to an agent outside can_handoff_to must name the *source* agent
+    in the error, not the destination agent."""
+    # agent1 may only hand off to agent2; agent3 is explicitly excluded.
+    agent1 = FunctionAgent(
+        name="agent1",
+        description="test",
+        can_handoff_to=["agent2"],
+        llm=MockFunctionCallingLLM(
+            response_generator=_response_generator_from_list(
+                [
+                    ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        content="handoff agent3 Trying a forbidden target",
+                        additional_kwargs={
+                            "tool_calls": [
+                                ToolSelection(
+                                    tool_id="one",
+                                    tool_name="handoff",
+                                    tool_kwargs={
+                                        "to_agent": "agent3",
+                                        "reason": "Trying a forbidden target",
+                                    },
+                                )
+                            ]
+                        },
+                    ),
+                    ChatMessage(
+                        role=MessageRole.ASSISTANT, content="ok staying here"
+                    ),
+                ]
+            )
+        ),
+    )
+    agent2 = FunctionAgent(
+        **agent1.model_dump(exclude={"llm", "name", "can_handoff_to"}),
+        name="agent2",
+        can_handoff_to=None,
+        llm=MockFunctionCallingLLM(
+            response_generator=_response_generator_from_list([])
+        ),
+    )
+    agent3 = FunctionAgent(
+        **agent1.model_dump(exclude={"llm", "name", "can_handoff_to"}),
+        name="agent3",
+        can_handoff_to=None,
+        llm=MockFunctionCallingLLM(
+            response_generator=_response_generator_from_list([])
+        ),
+    )
+
+    workflow = AgentWorkflow(
+        agents=[agent1, agent2, agent3],
+        root_agent="agent1",
+    )
+
+    handler = workflow.run(user_msg="test")
+    events = []
+    async for event in handler.stream_events():
+        events.append(event)
+    await handler
+
+    events_str = str(events)
+    # The error must identify the SOURCE (agent1) as the one lacking permission,
+    # not the destination (agent3).  Before the fix these were swapped.
+    assert "agent1" in events_str, "source agent should appear in error"
+    assert "agent3" in events_str, "target agent should appear in error"
+    # Old (buggy) message had agent3 as subject and agent1 as the target.
+    assert "agent3 is not allowed" not in events_str, "target must not be the subject"
+    assert "agent1 is not allowed" in events_str, "source must be the subject"
+
+
+@pytest.mark.asyncio
 async def test_workflow_with_state():
     """Test workflow with state management."""
 


### PR DESCRIPTION
## Bug

In `multi_agent_workflow.py`, when an agent attempts to hand off to a target
outside its `can_handoff_to` list, the error message has the **source** and
**destination** names transposed:

```python
# Before (wrong direction):
return f"Agent {to_agent} cannot hand off to {current_agent_name}. ..."
# => "Agent billing cannot hand off to router." — backwards!
```

`to_agent` is the *destination*; `current_agent_name` is the *source*.
The sentence says the destination agent cannot hand off to the source,
which is the opposite of what occurred and breaks any downstream logic
(or LLM self-correction) that reads the error.

## Fix

Swap the names so the message correctly names the source agent as the one
lacking permission, and also surfaces the permitted targets so the LLM can
self-correct without an extra round-trip:

```python
# After (correct):
return (
    f"Agent {current_agent_name} is not allowed to hand off to {to_agent}. "
    f"Please select a valid agent to hand off to. "
    f"Valid targets: {valid_targets}"
)
```

## Test

New test `test_restricted_handoff_error_message` asserts that:
1. The source agent (`agent1`) is the grammatical subject of the error.
2. The destination agent (`agent3`) is the object.
3. The old (buggy) phrasing `"agent3 is not allowed"` does not appear.

Both the new test and the pre-existing `test_invalid_handoff` pass.