### PR TITLE
fix(retrievers): handle None scores in QueryFusionRetriever._relative_score_fusion

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -179,11 +179,14 @@ class QueryFusionRetriever(BaseRetriever):
         for query_tuple, nodes_with_scores in results.items():
             for node_with_score in nodes_with_scores:
                 min_score, max_score = min_max_scores[query_tuple]
-                # Scale the score to be between 0 and 1
+                # Scale the score to be between 0 and 1.
+                # node_with_score.score is Optional[float]; treat None as 0.0,
+                # consistent with how min/max bounds are computed above.
+                raw_score = node_with_score.score or 0.0
                 if max_score == min_score:
                     node_with_score.score = 1.0 if max_score > 0 else 0.0
                 else:
-                    node_with_score.score = (node_with_score.score - min_score) / (
+                    node_with_score.score = (raw_score - min_score) / (
                         max_score - min_score
                     )
                 # Scale by the weight of the retriever

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -4,12 +4,55 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.retrievers import QueryFusionRetriever
+from llama_index.core.retrievers.fusion_retriever import FUSION_MODES
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 
 
 class MockRetriever(BaseRetriever):
     def _retrieve(self, query_bundle: QueryBundle):
         return [NodeWithScore(node=TextNode(text="result"), score=1.0)]
+
+
+def test_relative_score_fusion_handles_none_scores():
+    """_relative_score_fusion must not raise TypeError when node scores are None.
+
+    NodeWithScore.score is Optional[float]; some retrievers legitimately return
+    nodes without a score (score=None).  When the result set contains a mix of
+    scored and unscored nodes the min/max bounds are computed with ``score or
+    0.0`` (treating None as 0.0), but the per-node normalisation previously
+    used ``node_with_score.score`` directly, raising::
+
+        TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
+
+    After the fix, None scores are coerced to 0.0 before subtraction,
+    consistent with the bounds computation.
+    """
+    retriever = QueryFusionRetriever.__new__(QueryFusionRetriever)
+    retriever._retriever_weights = [1.0]
+    retriever.num_queries = 1
+    retriever.similarity_top_k = 10
+    retriever.mode = FUSION_MODES.RELATIVE_SCORE
+
+    node_with_score = NodeWithScore(node=TextNode(text="scored"), score=1.0)
+    node_without_score = NodeWithScore(node=TextNode(text="unscored"), score=None)
+
+    # Build the results dict the same way _run_sync_queries / _run_async_queries
+    # would: keys are (query_str, retriever_idx), values are list of NodeWithScore.
+    results = {
+        ("test query", 0): [node_with_score, node_without_score],
+    }
+
+    # Must not raise TypeError
+    reranked = retriever._relative_score_fusion(results)
+
+    assert len(reranked) == 2
+    # Scored node (1.0) should outrank the unscored node (treated as 0.0)
+    assert reranked[0].node.text == "scored"
+    assert reranked[1].node.text == "unscored"
+    # All scores should be valid floats, not None
+    for node in reranked:
+        assert node.score is not None
+        assert isinstance(node.score, float)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`QueryFusionRetriever._relative_score_fusion` crashed with a `TypeError` whenever a result set contained a mix of scored and unscored nodes (`NodeWithScore.score = None`).

`NodeWithScore.score` is `Optional[float]`; retrievers that do not produce similarity scores return nodes with `score=None`. The min/max bounds computation already guards against this:

```python
scores = [node_with_score.score or 0.0 for node_with_score in nodes_with_scores]
```

But the per-node normalisation step that follows did not:

```python
node_with_score.score = (node_with_score.score - min_score) / (max_score - min_score)
#                        ^^^^^^^^^^^^^^^^^^^^^ — None when score is absent → TypeError
```

**Traceback (before fix):**
```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```

## Fix

Capture `raw_score = node_with_score.score or 0.0` before the normalisation and use it in the arithmetic, consistent with how the bounds are already computed:

```python
raw_score = node_with_score.score or 0.0
if max_score == min_score:
    node_with_score.score = 1.0 if max_score > 0 else 0.0
else:
    node_with_score.score = (raw_score - min_score) / (max_score - min_score)
```

## Test

`test_relative_score_fusion_handles_none_scores` in `tests/retrievers/test_fusion_retriever.py`:

- Creates a result set with one scored node (`score=1.0`) and one unscored node (`score=None`).
- Verifies no `TypeError` is raised.
- Asserts the scored node ranks above the unscored one.
- Asserts all output scores are valid (non-None) floats.

The test reproduces the crash against the unfixed code and passes cleanly with the fix.