### PR TITLE
fix: use utf-8 for adapter config files

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-adapter/llama_index/embeddings/adapter/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-adapter/llama_index/embeddings/adapter/utils.py
@@ -36,14 +36,14 @@ class BaseAdapter(nn.Module):
     def save(self, output_path: str) -> None:
         """Save model."""
         os.makedirs(output_path, exist_ok=True)
-        with open(os.path.join(output_path, "config.json"), "w") as fOut:
+        with open(os.path.join(output_path, "config.json"), "w", encoding="utf-8") as fOut:
             json.dump(self.get_config_dict(), fOut)
         torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
 
     @classmethod
     def load(cls, input_path: str) -> "BaseAdapter":
         """Load model."""
-        with open(os.path.join(input_path, "config.json")) as fIn:
+        with open(os.path.join(input_path, "config.json"), encoding="utf-8") as fIn:
             config = json.load(fIn)
         model = cls(**config)
         model.load_state_dict(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-adapter/llama_index/embeddings/adapter/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-adapter/llama_index/embeddings/adapter/utils.py
@@ -36,7 +36,9 @@ class BaseAdapter(nn.Module):
     def save(self, output_path: str) -> None:
         """Save model."""
         os.makedirs(output_path, exist_ok=True)
-        with open(os.path.join(output_path, "config.json"), "w", encoding="utf-8") as fOut:
+        with open(
+            os.path.join(output_path, "config.json"), "w", encoding="utf-8"
+        ) as fOut:
             json.dump(self.get_config_dict(), fOut)
         torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
 


### PR DESCRIPTION
## Summary
- read and write embedding adapter `config.json` files with explicit UTF-8 encoding

## Before / after
Before, `BaseAdapter.save()` and `BaseAdapter.load()` used the platform default text encoding for `config.json`.
After, both paths use UTF-8 explicitly, making adapter config files portable across non-UTF-8 locales.

## Verification
- Single-file change reviewed against `llama-index-embeddings-adapter` utils
- Change is limited to adding explicit text encoding for JSON read/write paths
