### PR TITLE
fix(core): preserve IndexNode obj during model dump

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -959,23 +959,32 @@ class IndexNode(TextNode):
     index_id: str
     obj: Any = None
 
-    def dict(self, **kwargs: Any) -> Dict[str, Any]:
+    def _serialize_obj(self) -> Any:
         from llama_index.core.storage.docstore.utils import doc_to_json
-
-        data = super().dict(**kwargs)
 
         try:
             if self.obj is None:
-                data["obj"] = None
+                return None
             elif isinstance(self.obj, BaseNode):
-                data["obj"] = doc_to_json(self.obj)
+                return doc_to_json(self.obj)
             elif isinstance(self.obj, BaseModel):
-                data["obj"] = self.obj.model_dump()
+                return self.obj.model_dump()
             else:
-                data["obj"] = json.dumps(self.obj)
+                return json.dumps(self.obj)
         except Exception:
             raise ValueError("IndexNode obj is not serializable: " + str(self.obj))
 
+    @model_serializer(mode="wrap")
+    def custom_model_dump(
+        self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
+    ) -> Dict[str, Any]:
+        data = super().custom_model_dump(handler, info)
+        data["obj"] = self._serialize_obj()
+        return data
+
+    def dict(self, **kwargs: Any) -> Dict[str, Any]:
+        data = super().dict(**kwargs)
+        data["obj"] = self._serialize_obj()
         return data
 
     @classmethod

--- a/llama-index-core/tests/vector_stores/test_utils.py
+++ b/llama-index-core/tests/vector_stores/test_utils.py
@@ -80,6 +80,24 @@ def test_index_node_serdes(index_node: IndexNode):
     assert deserialized_node.index_id == index_node.index_id
 
 
+def test_index_node_with_node_obj_serdes():
+    obj_node = TextNode(id_="obj_node", text="Object node")
+    index_node = IndexNode(
+        id_="index_node",
+        text="Hello, world!",
+        index_id="123",
+        obj=obj_node,
+    )
+
+    serialized_node = node_to_metadata_dict(index_node)
+    deserialized_node = metadata_dict_to_node(serialized_node)
+
+    assert isinstance(deserialized_node, IndexNode)
+    assert isinstance(deserialized_node.obj, TextNode)
+    assert deserialized_node.obj.node_id == obj_node.node_id
+    assert deserialized_node.obj.text == obj_node.text
+
+
 def test_multimedia_node_serdes(multimedia_node: Node):
     serialized_node: dict[str, Any] = node_to_metadata_dict(multimedia_node)
     assert "multimedia_node" in serialized_node["_node_content"]


### PR DESCRIPTION
# Description

Fixes #21611

`node_to_metadata_dict()` serializes nodes through `model_dump(mode="json")`, but `IndexNode` only preserved its special `obj` serialization contract in `dict()`. This caused nested node objects to lose the `doc_to_json()` wrapper and fail to deserialize back into the original node.

This PR moves the existing `obj` serialization logic behind a shared helper and applies it to both `model_dump()` and `dict()`, preserving the existing round-trip behavior for `IndexNode.obj`.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Validated locally from `llama-index-core`:

- `uv run -- pytest tests/vector_stores/test_utils.py::test_index_node_with_node_obj_serdes -q`
- `uv run -- pytest tests/vector_stores/test_utils.py -q`
- `uv run -- pytest tests/vector_stores/test_utils.py tests/storage/docstore/test_legacy_json_to_doc.py -q`
- `uv run -- ruff check llama_index/core/schema.py tests/vector_stores/test_utils.py`
- `git diff --check`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods