### PR TITLE
fix(milvus): resolve issue with string_expr and filter precedence for…

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/CHANGELOG.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.1.1]
+
+### Fixed
+
+- Fixed a `TypeError` in `aquery` when `string_expr` was passed via `vector_store_kwargs`, which caused duplicate argument errors during hybrid/sparse search. Filters now take precedence over `string_expr` when both are provided.
+
 ## [v0.9.6]
 
 ### Changed

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/llama_index/vector_stores/milvus/base.py
@@ -897,7 +897,16 @@ class MilvusVectorStore(BasePydanticVectorStore):
         else:
             raise ValueError(f"Milvus does not support {query.mode} yet.")
 
-        string_expr, output_fields = self._prepare_before_search(query, **kwargs)
+        filter_string_expr, output_fields = self._prepare_before_search(query, **kwargs)
+        custom_string_expr = kwargs.pop("string_expr", "")
+        if len(filter_string_expr) != 0:
+            if len(custom_string_expr) != 0:
+                logger.warning(
+                    "string_expr in vector_store_kwargs is ignored because filters are provided."
+                )
+            string_expr = filter_string_expr
+        else:
+            string_expr = custom_string_expr
 
         # Perform the search
         if query.mode == VectorStoreQueryMode.MMR:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-milvus"
-version = "1.1.0"
+version = "1.1.1"
 description = "llama-index vector_stores milvus integration"
 authors = []
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-milvus/uv.lock
@@ -1888,7 +1888,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-vector-stores-milvus"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
Resolve issue with `string_expr` and filter precedence for `aquery` likes `query` method

# Description

Fixed a `TypeError` in `aquery` when `string_expr` was passed via `vector_store_kwargs`, which caused duplicate argument errors during hybrid/sparse search. Filters now take precedence over `string_expr` when both are provided.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
