### PR TITLE
fix(workflow): deep copy initial_state to prevent mutation leaks across runs

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+import copy
 import functools
 import warnings
 import inspect
@@ -289,7 +290,7 @@ class BaseWorkflowAgent(
             )
             await ctx.store.set("memory", default_memory)
         if not await ctx.store.get("state", default=None):
-            await ctx.store.set("state", self.initial_state.copy())
+            await ctx.store.set("state", copy.deepcopy(self.initial_state))
 
         if not await ctx.store.get("max_iterations", default=None):
             max_iterations = (

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta
+import copy
 import inspect
 import warnings
 from typing import (
@@ -284,7 +285,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 },
             )
         if not await ctx.store.get("state", default=None):
-            await ctx.store.set("state", self.initial_state)
+            await ctx.store.set("state", copy.deepcopy(self.initial_state))
         if not await ctx.store.get("current_agent_name", default=None):
             await ctx.store.set("current_agent_name", self.root_agent)
         if not await ctx.store.get("handoff_output_prompt", default=None):


### PR DESCRIPTION
## Description

Fixes `AgentWorkflow` leaking `initial_state` mutations across `run()` calls when the same workflow instance is reused.

## Problem

- **Multi-agent path** (`AgentWorkflow`): stores `self.initial_state` in the context by direct reference, so in-place mutations modify the workflow's own state
- **Single-agent path** (`BaseWorkflowAgent`): uses `.copy()` (shallow copy), which avoids top-level leakage but still leaks nested mutable values (lists, dicts)

This violates the documented behavior that workflows are stateless between runs unless a `Context` is explicitly reused.

## Fix

Use `copy.deepcopy()` in both paths to ensure each `run()` gets a fully independent copy of `initial_state`.

## Changes

- `multi_agent_workflow.py`: `copy.deepcopy(self.initial_state)` instead of `self.initial_state`
- `base_agent.py`: `copy.deepcopy(self.initial_state)` instead of `self.initial_state.copy()`

## Reproduction (from issue)

```python
workflow = AgentWorkflow.from_tools_or_functions(
    [bump_counter], llm=MockFunctionCallingLLM(),
    initial_state={"counter": 0},
)
await workflow.run(user_msg="bump it")  # counter -> 1
state = await (await workflow.run(user_msg="bump it")).ctx.store.get("state")
# Before fix: {'counter': 2}  (leaked from first run)
# After fix:  {'counter': 1}  (independent copy)
```

Fixes #21774