### PR TITLE
fix(core): match missing metadata for NE and NIN filters

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/utils.py
+++ b/llama-index-core/llama_index/core/vector_stores/utils.py
@@ -115,7 +115,7 @@ def build_metadata_filter_fn(
         ) -> bool:
             """Evaluate a single filter operator against a metadata value."""
             if metadata_value is None:
-                return False
+                return operator in (FilterOperator.NE, FilterOperator.NIN)
 
             if operator == FilterOperator.EQ:
                 return metadata_value == value

--- a/llama-index-core/tests/vector_stores/test_metadata_filters_logic.py
+++ b/llama-index-core/tests/vector_stores/test_metadata_filters_logic.py
@@ -99,6 +99,27 @@ def test_is_empty_matches_missing_and_empty_values() -> None:
     assert fn("n3")
 
 
+def test_ne_and_nin_match_missing_metadata_values() -> None:
+    ne_filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="missing", operator=FilterOperator.NE, value="a"),
+        ]
+    )
+    nin_filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="missing", operator=FilterOperator.NIN, value=["a"]),
+        ]
+    )
+
+    ne_fn = build_metadata_filter_fn(_METADATA_BY_ID.__getitem__, ne_filters)
+    nin_fn = build_metadata_filter_fn(_METADATA_BY_ID.__getitem__, nin_filters)
+
+    # Missing metadata values are not equal to, and not contained in, the
+    # filtered value. This keeps NE/NIN consistent with NOT(EQ)/NOT(IN).
+    assert ne_fn("n1")
+    assert nin_fn("n1")
+
+
 def test_text_match_insensitive_uses_case_insensitive_search() -> None:
     filters = MetadataFilters(
         filters=[


### PR DESCRIPTION
## Summary
- Treat missing metadata values as matches for negation operators `NE` and `NIN`
- Preserve existing behavior for positive operators and `IS_EMPTY`
- Add regression coverage for missing-key `NE`/`NIN` filtering

Fixes #21750

## Tests
- `uv run --group dev pytest llama-index-core/tests/vector_stores/test_metadata_filters_logic.py`
- `uv run --group dev ruff check llama-index-core/llama_index/core/vector_stores/utils.py llama-index-core/tests/vector_stores/test_metadata_filters_logic.py`