### PR TITLE
Harden pickle deserialization in bge-m3 and txtai integrations

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
@@ -13,6 +13,46 @@ from llama_index.core.storage.docstore.types import RefDocInfo
 from llama_index.core.storage.storage_context import StorageContext
 
 
+_SAFE_PICKLE_GLOBALS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # Builtins
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "frozenset"),
+        ("builtins", "tuple"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        ("builtins", "bytearray"),
+        ("builtins", "int"),
+        ("builtins", "float"),
+        ("builtins", "complex"),
+        ("builtins", "bool"),
+        ("builtins", "NoneType"),
+        # NumPy (required for dense/colbert vectors and sparse weights arrays)
+        ("numpy", "dtype"),
+        ("numpy", "ndarray"),
+        ("numpy.core.numeric", "_frombuffer"),
+        ("numpy._core.numeric", "_frombuffer"),
+        ("numpy.core.multiarray", "_reconstruct"),
+        ("numpy._core.multiarray", "_reconstruct"),
+    }
+)
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that restricts globals to an allowlist (CWE-502)."""
+
+    def find_class(self, module: str, name: str) -> object:  # type: ignore[override]
+        if (module, name) in _SAFE_PICKLE_GLOBALS:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to unpickle '{module}.{name}': global not in allowlist. "
+            "If you need to load custom object types, use a purpose-built "
+            "serialization format instead of pickle."
+        )
+
+
 class BGEM3Index(BaseIndex[IndexDict]):
     """
     Store for BGE-M3 with PLAID indexing.
@@ -154,9 +194,8 @@ class BGEM3Index(BaseIndex[IndexDict]):
             int(k): v for k, v in index.index_struct.nodes_dict.items()
         }
         index._docs_pos_to_node_id = docs_pos_to_node_id
-        index._multi_embed_store = pickle.load(
-            open(Path(persist_dir) / "multi_embed_store.pkl", "rb")
-        )
+        with open(Path(persist_dir) / "multi_embed_store.pkl", "rb") as f:
+            index._multi_embed_store = _RestrictedUnpickler(f).load()
         return index
 
     def query(self, query_str: str, top_k: int = 10) -> List[NodeWithScore]:

--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/tests/test_bge_m3_pickle_security.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/tests/test_bge_m3_pickle_security.py
@@ -1,0 +1,42 @@
+import os
+import pickle
+
+import numpy as np
+import pytest
+
+from llama_index.indices.managed.bge_m3.base import _RestrictedUnpickler
+
+
+def test_restricted_unpickler_allows_expected_numpy_payload(tmp_path):
+    store = {
+        "dense_vecs": np.random.rand(2, 3).astype("float32"),
+        "colbert_vecs": np.random.rand(2, 4, 5).astype("float32"),
+        # BGEM3FlagModel returns lexical_weights as an array of dictionaries.
+        "lexical_weights": np.array([{1: 0.1}, {2: 0.2}], dtype=object),
+    }
+
+    path = tmp_path / "multi_embed_store.pkl"
+    with open(path, "wb") as f:
+        pickle.dump(store, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    with open(path, "rb") as f:
+        loaded = _RestrictedUnpickler(f).load()
+
+    np.testing.assert_allclose(loaded["dense_vecs"], store["dense_vecs"])
+    np.testing.assert_allclose(loaded["colbert_vecs"], store["colbert_vecs"])
+    assert loaded["lexical_weights"].tolist() == store["lexical_weights"].tolist()
+
+
+def test_restricted_unpickler_rejects_malicious_payload(tmp_path):
+    class _Exploit:
+        def __reduce__(self):
+            return (os.system, ("echo exploited",))
+
+    path = tmp_path / "multi_embed_store.pkl"
+    with open(path, "wb") as f:
+        pickle.dump(_Exploit(), f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    with open(path, "rb") as f:
+        with pytest.raises(pickle.UnpicklingError):
+            _RestrictedUnpickler(f).load()
+

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-txtai/llama_index/vector_stores/txtai/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-txtai/llama_index/vector_stores/txtai/base.py
@@ -28,6 +28,38 @@ from llama_index.core.vector_stores.types import (
 
 logger = logging.getLogger()
 
+_SAFE_PICKLE_GLOBALS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "frozenset"),
+        ("builtins", "tuple"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        ("builtins", "bytearray"),
+        ("builtins", "int"),
+        ("builtins", "float"),
+        ("builtins", "complex"),
+        ("builtins", "bool"),
+        ("builtins", "NoneType"),
+    }
+)
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that restricts globals to an allowlist (CWE-502)."""
+
+    def find_class(self, module: str, name: str) -> object:  # type: ignore[override]
+        if (module, name) in _SAFE_PICKLE_GLOBALS:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to unpickle '{module}.{name}': global not in allowlist. "
+            "If you need to load custom object types, use a purpose-built "
+            "serialization format instead of pickle."
+        )
+
+
 DEFAULT_PERSIST_PATH = os.path.join(
     DEFAULT_PERSIST_DIR, f"{DEFAULT_VECTOR_STORE}{NAMESPACE_SEP}{DEFAULT_PERSIST_FNAME}"
 )
@@ -123,7 +155,7 @@ class TxtaiVectorStore(BasePydanticVectorStore):
         config_path = config_path if jsonconfig else parent_directory / "config"
         # Load configuration
         with open(config_path, "r" if jsonconfig else "rb") as f:
-            config = json.load(f) if jsonconfig else pickle.load(f)
+            config = json.load(f) if jsonconfig else _RestrictedUnpickler(f).load()
 
         logger.info(f"Loading {__name__} from {persist_path}.")
         txtai_index = txtai.ann.ANNFactory.create(config)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-txtai/tests/test_vector_stores_txtai.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-txtai/tests/test_vector_stores_txtai.py
@@ -1,3 +1,9 @@
+import os
+import pickle
+import types
+
+import pytest
+
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
 from llama_index.vector_stores.txtai import TxtaiVectorStore
 
@@ -5,3 +11,71 @@ from llama_index.vector_stores.txtai import TxtaiVectorStore
 def test_class():
     names_of_base_classes = [b.__name__ for b in TxtaiVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+def _install_fake_txtai(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a minimal `txtai` module so tests don't need the real dependency."""
+
+    txtai = types.ModuleType("txtai")
+    ann = types.ModuleType("txtai.ann")
+
+    class ANN:  # noqa: D401 - simple dummy protocol for typing/cast
+        pass
+
+    class _FakeIndex:
+        def __init__(self, config: object) -> None:
+            self.config = config
+            self.loaded_path: str | None = None
+
+        def load(self, path: str) -> None:
+            self.loaded_path = path
+
+    class ANNFactory:
+        @staticmethod
+        def create(config: object) -> _FakeIndex:
+            return _FakeIndex(config)
+
+    ann.ANN = ANN
+    ann.ANNFactory = ANNFactory
+    txtai.ann = ann
+
+    monkeypatch.setitem(__import__("sys").modules, "txtai", txtai)
+    monkeypatch.setitem(__import__("sys").modules, "txtai.ann", ann)
+
+
+def test_from_persist_path_allows_safe_pickle_config(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    _install_fake_txtai(monkeypatch)
+
+    persist_path = tmp_path / "vector_store.json"
+    persist_path.write_text("{}", encoding="utf-8")
+
+    config_path = tmp_path / "config"
+    with open(config_path, "wb") as f:
+        pickle.dump({"backend": "numpy"}, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    store = TxtaiVectorStore.from_persist_path(str(persist_path), fs=None)
+    assert isinstance(store, TxtaiVectorStore)
+
+
+def test_from_persist_path_rejects_malicious_pickle_config(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    _install_fake_txtai(monkeypatch)
+
+    persist_path = tmp_path / "vector_store.json"
+    persist_path.write_text("{}", encoding="utf-8")
+
+    # If this payload were unpickled with pickle.load(), it would execute
+    # os.system(). Our loader should reject it before execution.
+    class _Exploit:
+        def __reduce__(self):
+            return (os.system, ("echo exploited",))
+
+    config_path = tmp_path / "config"
+    with open(config_path, "wb") as f:
+        pickle.dump(_Exploit(), f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    with pytest.raises(pickle.UnpicklingError):
+        TxtaiVectorStore.from_persist_path(str(persist_path), fs=None)


### PR DESCRIPTION
This PR hardens two integration loaders that currently deserialize local state with unrestricted pickle.load().

- llama-index-indices-managed-bge-m3: BGEM3Index.load_from_disk() now uses a RestrictedUnpickler allowlist (builtins + NumPy globals needed for arrays) when loading multi_embed_store.pkl. This mitigates CWE-502 (arbitrary code execution) if an attacker can place a crafted pickle in the persist directory. The old behavior matches the previously-reported BGEM3Index unsafe-deserialization issue (e.g., CVE-2024-14021); this keeps the existing on-disk format but blocks unsafe globals.
- llama-index-vector-stores-txtai: TxtaiVectorStore.from_persist_path() now uses a RestrictedUnpickler allowlist (builtins only) when loading the legacy pickled config file (when config.json is absent).

Tests:
- Added regression tests that show safe payloads still load and crafted payloads are rejected with pickle.UnpicklingError.