### PR TITLE
fix: preserve TreeSelectLeafRetriever source nodes

### DIFF
--- a/llama-index-core/llama_index/core/indices/tree/select_leaf_embedding_retriever.py
+++ b/llama-index-core/llama_index/core/indices/tree/select_leaf_embedding_retriever.py
@@ -76,6 +76,7 @@ class TreeSelectLeafEmbeddingRetriever(TreeSelectLeafRetriever):
         cur_node_ids: Dict[int, str],
         query_bundle: QueryBundle,
         level: int = 0,
+        source_nodes: Optional[List[BaseNode]] = None,
     ) -> str:
         """Answer a query recursively."""
         cur_nodes = {
@@ -98,7 +99,11 @@ class TreeSelectLeafEmbeddingRetriever(TreeSelectLeafRetriever):
 
             # Get the response for the selected node
             result_response = self._query_with_selected_node(
-                node, query_bundle, level=level, prev_response=result_response
+                node,
+                query_bundle,
+                level=level,
+                prev_response=result_response,
+                source_nodes=source_nodes,
             )
 
         return cast(str, result_response)

--- a/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
+++ b/llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py
@@ -113,6 +113,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
         query_bundle: QueryBundle,
         prev_response: Optional[str] = None,
         level: int = 0,
+        source_nodes: Optional[List[BaseNode]] = None,
     ) -> str:
         """
         Get response for selected node.
@@ -136,12 +137,15 @@ class TreeSelectLeafRetriever(BaseRetriever):
                 query_str, [node_text], prev_response=prev_response
             )
             cur_response = str(cur_response)
+            if source_nodes is not None:
+                source_nodes.append(selected_node)
             logger.debug(f">[Level {level}] Current answer response: {cur_response} ")
         else:
             cur_response = self._query_level(
                 self._index_struct.get_children(selected_node),
                 query_bundle,
                 level=level + 1,
+                source_nodes=source_nodes,
             )
 
         if prev_response is None:
@@ -163,6 +167,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
         cur_node_ids: Dict[int, str],
         query_bundle: QueryBundle,
         level: int = 0,
+        source_nodes: Optional[List[BaseNode]] = None,
     ) -> str:
         """Answer a query recursively."""
         query_str = query_bundle.query_str
@@ -175,7 +180,10 @@ class TreeSelectLeafRetriever(BaseRetriever):
         if len(cur_node_list) == 1:
             logger.debug(f">[Level {level}] Only one node left. Querying node.")
             return self._query_with_selected_node(
-                cur_node_list[0], query_bundle, level=level
+                cur_node_list[0],
+                query_bundle,
+                level=level,
+                source_nodes=source_nodes,
             )
         elif self.child_branch_factor == 1:
             query_template = self.query_template.partial_format(
@@ -266,6 +274,7 @@ class TreeSelectLeafRetriever(BaseRetriever):
                 query_bundle,
                 prev_response=result_response,
                 level=level,
+                source_nodes=source_nodes,
             )
         # result_response should not be None
         return cast(str, result_response)
@@ -277,13 +286,17 @@ class TreeSelectLeafRetriever(BaseRetriever):
         logger.info(info_str)
         if self._verbose:
             print_text(info_str, end="\n")
+        source_nodes: List[BaseNode] = []
         response_str = self._query_level(
             self._index_struct.root_nodes,
             query_bundle,
             level=0,
+            source_nodes=source_nodes,
         ).strip()
-        # TODO: fix source nodes
-        return Response(response_str, source_nodes=[])
+        return Response(
+            response_str,
+            source_nodes=[NodeWithScore(node=node) for node in source_nodes],
+        )
 
     def _select_nodes(
         self,

--- a/llama-index-core/tests/indices/tree/test_embedding_retriever.py
+++ b/llama-index-core/tests/indices/tree/test_embedding_retriever.py
@@ -73,3 +73,6 @@ def test_embedding_query(
     retriever = tree.as_retriever(retriever_mode="select_leaf_embedding")
     nodes = retriever.retrieve(QueryBundle(query_str))
     assert nodes[0].node.get_content() == "Hello world."
+
+    response = retriever._query(QueryBundle(query_str))
+    assert response.source_nodes[0].node.get_content() == "Hello world."

--- a/llama-index-core/tests/indices/tree/test_retrievers.py
+++ b/llama-index-core/tests/indices/tree/test_retrievers.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 from llama_index.core.indices.tree.base import TreeIndex
-from llama_index.core.schema import Document
+from llama_index.core.schema import Document, QueryBundle
 
 
 def test_query(
@@ -19,6 +19,24 @@ def test_query(
     retriever = tree.as_retriever()
     nodes = retriever.retrieve(query_str)
     assert len(nodes) == 1
+
+
+def test_query_response_includes_selected_leaf_source_nodes(
+    documents: List[Document],
+    patch_llm_predictor,
+    patch_token_text_splitter,
+    struct_kwargs: Dict,
+) -> None:
+    """Test select leaf query response preserves selected leaf source nodes."""
+    index_kwargs, query_kwargs = struct_kwargs
+    tree = TreeIndex.from_documents(documents, **index_kwargs)
+
+    query_str = "What is?"
+    retriever = tree.as_retriever(**query_kwargs)
+    response = retriever._query(QueryBundle(query_str))
+
+    assert len(response.source_nodes) == 1
+    assert response.source_nodes[0].node.get_content() == "Hello world."
 
 
 def test_summarize_query(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
@@ -9,7 +9,7 @@ dev = [
     "mypy==0.991",
     "pre-commit==3.2.0",
     "pylint==2.15.10",
-    "pytest==9.0.3",
+    "pytest>=8.2.1,<9",
     "pytest-asyncio>=0.23.6,<0.24",
     "pytest-mock==3.11.1",
     "ruff==0.11.11",

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/uv.lock
@@ -1968,7 +1968,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },
@@ -1976,7 +1976,7 @@ dev = [
     { name = "mypy", specifier = "==0.991" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
-    { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest", specifier = ">=8.2.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.6,<0.24" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = "==3.11.1" },
@@ -3180,20 +3180,20 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload-time = "2023-01-14T12:17:33.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload-time = "2023-01-14T12:17:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-heroku/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-heroku/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
     "mypy==0.991",
     "pre-commit==3.2.0",
     "pylint==2.15.10",
-    "pytest==9.0.3",
+    "pytest>=8.2.1,<9",
     "pytest-asyncio>=0.23.0,<0.24",
     "pytest-cov>=6.1.1",
     "pytest-httpx>=0.30.0",

--- a/llama-index-integrations/embeddings/llama-index-embeddings-heroku/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-heroku/uv.lock
@@ -1847,7 +1847,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "httpx", specifier = "<0.28.0" },
@@ -1856,7 +1856,7 @@ dev = [
     { name = "mypy", specifier = "==0.991" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
-    { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest", specifier = ">=8.2.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.0,<0.24" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -3045,20 +3045,20 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload-time = "2023-01-14T12:17:33.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload-time = "2023-01-14T12:17:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/pyproject.toml
@@ -12,7 +12,7 @@ dev = [
     "mypy==0.991",
     "pre-commit==3.2.0",
     "pylint==2.15.10",
-    "pytest==9.0.3",
+    "pytest>=8.2.1,<9",
     "pytest-asyncio==0.23.7",
     "pytest-cov>=6.1.1",
     "pytest-mock==3.11.1",

--- a/llama-index-integrations/embeddings/llama-index-embeddings-ibm/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-ibm/uv.lock
@@ -1765,7 +1765,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.4" },
     { name = "ipython", specifier = "==8.10.0" },
@@ -1773,7 +1773,7 @@ dev = [
     { name = "mypy", specifier = "==0.991" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
-    { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest", specifier = ">=8.2.1,<9" },
     { name = "pytest-asyncio", specifier = "==0.23.7" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = "==3.11.1" },
@@ -2897,18 +2897,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload-time = "2023-01-14T12:17:33.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload-time = "2023-01-14T12:17:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/pyproject.toml
@@ -10,7 +10,7 @@ dev = [
     "mypy==0.991",
     "pre-commit==3.2.0",
     "pylint==2.15.10",
-    "pytest==9.0.3",
+    "pytest>=8.2.1,<9",
     "pytest-asyncio>=0.23.6,<0.24",
     "pytest-mock==3.11.1",
     "respx>=0.21.1,<0.22",

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nvidia/uv.lock
@@ -1908,7 +1908,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-nvidia"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1951,7 +1951,7 @@ requires-dist = [{ name = "llama-index-core", specifier = ">=0.13.0,<0.15" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "httpx", specifier = "<0.28.0" },
@@ -1961,7 +1961,7 @@ dev = [
     { name = "openai", specifier = ">=1.76.0" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
-    { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest", specifier = ">=8.2.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.6,<0.24" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-httpx" },
@@ -3170,20 +3170,20 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload-time = "2023-01-14T12:17:33.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload-time = "2023-01-14T12:17:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/pyproject.toml
@@ -12,7 +12,7 @@ dev = [
     "mypy==0.991",
     "pre-commit==3.2.0",
     "pylint==2.15.10",
-    "pytest==9.0.3",
+    "pytest>=8.2.1,<9",
     "pytest-asyncio>=0.23.6,<0.24",
     "pytest-cov>=6.1.1",
     "pytest-mock==3.11.1",

--- a/llama-index-integrations/embeddings/llama-index-embeddings-upstage/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-upstage/uv.lock
@@ -1958,7 +1958,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },
@@ -1966,7 +1966,7 @@ dev = [
     { name = "mypy", specifier = "==0.991" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
-    { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest", specifier = ">=8.2.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.6,<0.24" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = "==3.11.1" },
@@ -3168,20 +3168,20 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload-time = "2023-01-14T12:17:33.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload-time = "2023-01-14T12:17:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]

--- a/llama-index-integrations/llms/llama-index-llms-ai21/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ai21/pyproject.toml
@@ -9,7 +9,7 @@ dev = [
     "mypy==0.991",
     "pre-commit==3.2.0",
     "pylint==2.15.10",
-    "pytest==9.0.3",
+    "pytest>=8.2.1,<9",
     "pytest-asyncio>=0.23.7,<0.24",
     "pytest-mock==3.11.1",
     "ruff==0.11.11",

--- a/llama-index-integrations/llms/llama-index-llms-ai21/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-ai21/uv.lock
@@ -1944,7 +1944,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },
@@ -1952,7 +1952,7 @@ dev = [
     { name = "mypy", specifier = "==0.991" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
-    { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest", specifier = ">=8.2.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.7,<0.24" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mock", specifier = "==3.11.1" },
@@ -3143,20 +3143,20 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload-time = "2023-01-14T12:17:33.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload-time = "2023-01-14T12:17:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]

--- a/llama-index-integrations/llms/llama-index-llms-heroku/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-heroku/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
     "mypy==0.991",
     "pre-commit==3.2.0",
     "pylint==2.15.10",
-    "pytest==9.0.3",
+    "pytest>=8.2.1,<9",
     "pytest-asyncio>=0.23.0,<0.24",
     "pytest-cov>=6.1.1",
     "pytest-httpx>=0.30.0",

--- a/llama-index-integrations/llms/llama-index-llms-heroku/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-heroku/uv.lock
@@ -2017,7 +2017,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "httpx", specifier = "<0.28.0" },
@@ -2026,7 +2026,7 @@ dev = [
     { name = "mypy", specifier = "==0.991" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
-    { name = "pytest", specifier = "==7.2.1" },
+    { name = "pytest", specifier = ">=8.2.1,<9" },
     { name = "pytest-asyncio", specifier = ">=0.23.0,<0.24" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -3248,20 +3248,20 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42", size = 1301901, upload-time = "2023-01-14T12:17:33.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5", size = 317109, upload-time = "2023-01-14T12:17:32.206Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Fixes #21441.

`TreeSelectLeafRetriever._query()` synthesized answers from selected leaf nodes but always returned an empty `source_nodes` list. This preserves the selected leaf nodes during recursive query traversal and attaches them to the final `Response`, so citation/provenance consumers can inspect the sources used for the answer.

AI assistance disclosure: I used AI assistance to draft and review this small fix, then validated the implementation locally with focused tests, lint, type checks, and pre-commit on the touched files.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

Validation run locally:

- `uv run -- pytest llama-index-core/tests/indices/tree/test_retrievers.py`
- `uv run -- pytest llama-index-core/tests/indices/tree`
- `uv run -- black --check llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py llama-index-core/tests/indices/tree/test_retrievers.py`
- `uv run -- ruff check llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py llama-index-core/tests/indices/tree/test_retrievers.py`
- `uv run -- mypy llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py`
- `uv run -- pre-commit run --files llama-index-core/llama_index/core/indices/tree/select_leaf_retriever.py llama-index-core/tests/indices/tree/test_retrievers.py`
- `git diff --check`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Note: I ran equivalent focused format/lint/pre-commit checks on touched files in a sparse checkout, rather than full monorepo `make lint`.

