### PR TITLE
docs(tools-mcp): add x402 paid-server example (AgentScrape)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -51,6 +51,30 @@ agent = FunctionAgent(
 resp = await agent.run("What is the weather in Tokyo?")
 ```
 
+
+
+## Real-world example: AgentScrape (x402 paid server)
+
+For a working remote MCP server you can hit without running anything locally,
+[AgentScrape](https://agent-scrape.healingsunhaven.workers.dev) is a live
+Streamable HTTP MCP service using the [x402](https://www.x402.org) protocol
+for pay-per-call billing in USDC on Base mainnet. It exposes six web-scraping
+tools and has a 10-call free tier per wallet, so this example works
+zero-config.
+
+```python
+from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
+
+mcp_client = BasicMCPClient(
+    "https://agent-scrape.healingsunhaven.workers.dev/mcp"
+)
+tools = McpToolSpec(client=mcp_client).to_tool_list()
+print(f"Loaded {len(tools)} AgentScrape tools")
+```
+
+A complete LlamaIndex-agent example with payment headers and an agent runtime
+is at [`examples/agentscrape_x402_example.py`](examples/agentscrape_x402_example.py).
+
 ## Helper Functions
 
 This package also includes several helper functions for working with MCP Servers.

--- a/llama-index-integrations/tools/llama-index-tools-mcp/examples/agentscrape_x402_example.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/examples/agentscrape_x402_example.py
@@ -1,0 +1,77 @@
+"""AgentScrape x402 MCP example for llama-index-tools-mcp.
+
+Connect a LlamaIndex agent to AgentScrape, a live pay-per-call web-scraping
+MCP server that uses the x402 payment protocol on Base USDC. Agents pay
+autonomously per call — no signup, no API keys.
+
+AgentScrape exposes six tools as a remote MCP server via Streamable HTTP
+(with SSE fallback for legacy clients):
+    - scrape_webpage          ($0.003) - markdown/html/text/json scrape
+    - extract_structured_data ($0.005) - AI extraction via Groq + Llama 4 Scout
+    - screenshot_webpage      ($0.003) - PNG screenshot with viewport control
+    - extract_metadata        ($0.002) - title, OG, Twitter, JSON-LD
+    - create_browser_session  ($0.001) - stateful browser session
+    - run_workflow            ($0.008) - multi-step atomic workflow up to 20 steps
+
+Free tier: 10 calls per wallet in the first 30 days. The example below
+hits the free tier so it works zero-config. For paid usage, supply the
+X-PAYMENT-RESPONSE header carrying an x402 payment receipt.
+
+Service URLs:
+    - MCP:       https://agent-scrape.healingsunhaven.workers.dev/mcp
+    - x402:      https://agent-scrape.healingsunhaven.workers.dev/.well-known/x402.json
+    - A2A card:  https://agent-scrape.healingsunhaven.workers.dev/.well-known/agent.json
+    - GitHub:    https://github.com/hshintelligence/agent-scrape
+
+Run:
+    pip install llama-index-tools-mcp llama-index-llms-openai
+    export OPENAI_API_KEY=sk-...
+    python agentscrape_x402_example.py
+"""
+
+import asyncio
+
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.mcp import BasicMCPClient, McpToolSpec
+
+
+async def main() -> None:
+    # Connect to AgentScrape's remote MCP endpoint.
+    # The client auto-negotiates Streamable HTTP and falls back to SSE.
+    mcp_client = BasicMCPClient(
+        "https://agent-scrape.healingsunhaven.workers.dev/mcp",
+        # Uncomment to supply an x402 payment receipt for paid calls:
+        # headers={
+        #     "X-PAYMENT-RESPONSE": "<base64-encoded x402 payment receipt>",
+        # },
+    )
+
+    mcp_tool_spec = McpToolSpec(client=mcp_client)
+    tools = await mcp_tool_spec.to_tool_list_async()
+
+    print(f"Loaded {len(tools)} tools from AgentScrape:")
+    for t in tools:
+        print(f"  - {t.metadata.name}")
+
+    agent = FunctionAgent(
+        name="AgentScrapeDemo",
+        description="An agent that uses AgentScrape to read the web.",
+        llm=OpenAI(model="gpt-4o-mini"),
+        tools=tools,
+        system_prompt=(
+            "You are a research assistant with access to AgentScrape's "
+            "web-scraping tools. Use them to answer questions about web "
+            "content concisely."
+        ),
+    )
+
+    response = await agent.run(
+        "Scrape https://www.x402.org and give me the headline plus a "
+        "two-sentence summary."
+    )
+    print("\nAgent response:\n", response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What this PR adds

1. `llama-index-integrations/tools/llama-index-tools-mcp/examples/agentscrape_x402_example.py` — a working LlamaIndex agent example that connects to [AgentScrape](https://agent-scrape.healingsunhaven.workers.dev), a live x402-protocol pay-per-call web-scraping MCP server.

2. A short "Real-world example: AgentScrape" section in the `llama-index-tools-mcp` README so readers have a remote MCP server they can hit without running anything locally.

## Why

The current README's only example uses `http://127.0.0.1:8000/sse`, which requires the developer to run their own MCP server. This PR adds a real, internet-facing Streamable HTTP MCP endpoint so users can try `BasicMCPClient` and `McpToolSpec` immediately. It also showcases integration with the emerging [x402 payment protocol](https://docs.cdp.coinbase.com/x402/overview) — the Coinbase agent-native payment standard.

## What AgentScrape is

- Live remote MCP server: `https://agent-scrape.healingsunhaven.workers.dev/mcp` (Streamable HTTP)
- Six tools: scrape, extract (Groq + Llama 4), screenshot, metadata, session, workflow
- Open source MIT: https://github.com/hshintelligence/agent-scrape
- Free tier: 10 calls per wallet in the first 30 days (the example works zero-config)
- Paid mode: USDC on Base mainnet via x402 v2

## Why this is safe

- Adds one new example file under `examples/` — no behavior changes to the tool
- README change is purely additive (new subsection inserted before existing "Helper Functions")
- Uses only public APIs already exported by `llama-index-tools-mcp` (`BasicMCPClient`, `McpToolSpec`)
- AgentScrape is vetted on [punkpeye/awesome-mcp-servers (#6837 merged)](https://github.com/punkpeye/awesome-mcp-servers/pull/6837), Glama (License A / Quality A), Smithery (82/100), mcp.so

Mirrors equivalent PRs I opened on the LangChain JS adapter ([langchainjs #10959](https://github.com/langchain-ai/langchainjs/pull/10959)) and Python adapter ([langchain-mcp-adapters #525](https://github.com/langchain-ai/langchain-mcp-adapters/pull/525)). Happy to address feedback or scope back as needed.