### PR TITLE
Fix RankLLM PromptMode import compatibility

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/llama_index/postprocessor/rankllm_rerank/base.py
@@ -11,7 +11,8 @@ from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle
 
 dispatcher = get_dispatcher(__name__)
 
-from rank_llm.rerank.reranker import Reranker, PromptMode
+from rank_llm.rerank.rankllm import PromptMode
+from rank_llm.rerank.reranker import Reranker
 from rank_llm.data import Request, Query, Candidate
 
 

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-rankllm-rerank"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index postprocessor rankllm-rerank integration"
 authors = [{name = "Ryan Nguyen", email = "ryan.nguyen@uwaterloo.ca"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/tests/test_postprocessor_rankllm-rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/tests/test_postprocessor_rankllm-rerank.py
@@ -76,9 +76,7 @@ def test_import_with_prompt_mode_from_rankllm_module(monkeypatch):
 
     _clear_rankllm_rerank_modules(monkeypatch)
 
-    rankllm_rerank = importlib.import_module(
-        "llama_index.postprocessor.rankllm_rerank"
-    )
+    rankllm_rerank = importlib.import_module("llama_index.postprocessor.rankllm_rerank")
 
     names_of_base_classes = [b.__name__ for b in rankllm_rerank.RankLLMRerank.__mro__]
     assert BaseNodePostprocessor.__name__ in names_of_base_classes

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/tests/test_postprocessor_rankllm-rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/tests/test_postprocessor_rankllm-rerank.py
@@ -1,7 +1,86 @@
+import importlib
+import sys
+from enum import Enum
+from types import ModuleType
+
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
-from llama_index.postprocessor.rankllm_rerank import RankLLMRerank
+
+
+RANKLLM_RERANK_MODULES = [
+    "llama_index.postprocessor.rankllm_rerank",
+    "llama_index.postprocessor.rankllm_rerank.base",
+]
+
+
+def _clear_rankllm_rerank_modules(monkeypatch):
+    for module_name in RANKLLM_RERANK_MODULES:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+
+def _mock_rankllm_modules(monkeypatch):
+    rank_llm_module = ModuleType("rank_llm")
+    rank_llm_module.__path__ = []
+
+    rerank_module = ModuleType("rank_llm.rerank")
+    rerank_module.__path__ = []
+
+    reranker_module = ModuleType("rank_llm.rerank.reranker")
+    rankllm_module = ModuleType("rank_llm.rerank.rankllm")
+    data_module = ModuleType("rank_llm.data")
+
+    class Reranker:
+        pass
+
+    class PromptMode(Enum):
+        RANK_GPT = "rank_gpt"
+
+    class Request:
+        pass
+
+    class Query:
+        pass
+
+    class Candidate:
+        pass
+
+    reranker_module.Reranker = Reranker
+    rankllm_module.PromptMode = PromptMode
+    data_module.Request = Request
+    data_module.Query = Query
+    data_module.Candidate = Candidate
+
+    rank_llm_module.rerank = rerank_module
+    rank_llm_module.data = data_module
+    rerank_module.reranker = reranker_module
+    rerank_module.rankllm = rankllm_module
+
+    monkeypatch.setitem(sys.modules, "rank_llm", rank_llm_module)
+    monkeypatch.setitem(sys.modules, "rank_llm.rerank", rerank_module)
+    monkeypatch.setitem(sys.modules, "rank_llm.rerank.reranker", reranker_module)
+    monkeypatch.setitem(sys.modules, "rank_llm.rerank.rankllm", rankllm_module)
+    monkeypatch.setitem(sys.modules, "rank_llm.data", data_module)
+
+    return PromptMode, reranker_module
 
 
 def test_class():
+    from llama_index.postprocessor.rankllm_rerank import RankLLMRerank
+
     names_of_base_classes = [b.__name__ for b in RankLLMRerank.__mro__]
     assert BaseNodePostprocessor.__name__ in names_of_base_classes
+
+
+def test_import_with_prompt_mode_from_rankllm_module(monkeypatch):
+    prompt_mode, reranker_module = _mock_rankllm_modules(monkeypatch)
+    assert not hasattr(reranker_module, "PromptMode")
+
+    _clear_rankllm_rerank_modules(monkeypatch)
+
+    rankllm_rerank = importlib.import_module(
+        "llama_index.postprocessor.rankllm_rerank"
+    )
+
+    names_of_base_classes = [b.__name__ for b in rankllm_rerank.RankLLMRerank.__mro__]
+    assert BaseNodePostprocessor.__name__ in names_of_base_classes
+    reranker = rankllm_rerank.RankLLMRerank(top_n=1, batch_size=1)
+    assert reranker.prompt_mode == prompt_mode.RANK_GPT

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/uv.lock
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-rankllm-rerank/uv.lock
@@ -2649,7 +2649,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-postprocessor-rankllm-rerank"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

Fixes an import compatibility issue in `llama-index-postprocessor-rankllm-rerank` when newer `rank-llm` versions no longer expose `PromptMode` from `rank_llm.rerank.reranker`.

This change imports `PromptMode` from `rank_llm.rerank.rankllm` while keeping `Reranker` imported from `rank_llm.rerank.reranker`. It also adds a regression test that verifies the integration can still be imported when `rank_llm.rerank.reranker` does not expose `PromptMode`.

Fixes #

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Tested with:

- `UV_CACHE_DIR=/tmp/uv-cache-llama-index-rankllm-host uv lock --check`
- `UV_CACHE_DIR=/tmp/uv-cache-llama-index-rankllm-host uv run --no-sync -- pytest -q --disable-warnings --disable-pytest-warnings`
- `UV_CACHE_DIR=/tmp/uv-cache-llama-index-rankllm-host uv run --no-sync -- pytest -q --disable-warnings --disable-pytest-warnings --cov=. --cov-report=xml`
- `UV_CACHE_DIR=/tmp/uv-cache-llama-index-rankllm-host uv run --no-sync -- ruff check llama_index tests`
- `git diff --check`