### PR TITLE
docs: update reader install examples

### DIFF
--- a/docs/src/content/docs/framework/community/integrations/chatgpt_plugins.md
+++ b/docs/src/content/docs/framework/community/integrations/chatgpt_plugins.md
@@ -24,12 +24,15 @@ over 65 data loaders from various API's and document formats.
 Here is a sample code snippet of showing how to load a document from LlamaHub
 into the JSON format that `/upsert` expects:
 
+```bash
+pip install llama-index-readers-web
+```
+
 ```python
-from llama_index.core import download_loader, Document
+from llama_index.core import Document
 from typing import Dict, List
 import json
 
-# download loader, load documents
 from llama_index.readers.web import SimpleWebPageReader
 
 loader = SimpleWebPageReader(html_to_text=True)

--- a/docs/src/content/docs/framework/module_guides/loading/connector/index.mdx
+++ b/docs/src/content/docs/framework/module_guides/loading/connector/index.mdx
@@ -17,7 +17,7 @@ A data connector (aka `Reader`) ingest data from different data sources and data
 ## LlamaHub
 
 Our data connectors are offered through [LlamaHub](https://llamahub.ai/) 🦙.
-LlamaHub is an open-source repository containing data loaders that you can easily plug and play into any LlamaIndex application.
+LlamaHub is a registry of data loader packages that you can install and plug into any LlamaIndex application.
 
 ![](./../../../_static/data_connectors/llamahub.png)
 
@@ -25,9 +25,11 @@ LlamaHub is an open-source repository containing data loaders that you can easil
 
 Get started with:
 
-```python
-from llama_index.core import download_loader
+```bash
+pip install llama-index-readers-google
+```
 
+```python
 from llama_index.readers.google import GoogleDocsReader
 
 loader = GoogleDocsReader()

--- a/docs/src/content/docs/framework/module_guides/loading/connector/usage_pattern.md
+++ b/docs/src/content/docs/framework/module_guides/loading/connector/usage_pattern.md
@@ -4,13 +4,16 @@ title: Usage Pattern
 
 ## Get Started
 
-Each data loader contains a "Usage" section showing how that loader can be used. At the core of using each loader is a `download_loader` function, which
-downloads the loader file into a module that you can use within your application.
+Each data loader contains a "Usage" section showing how that loader can be used. Install the reader package you need, then import the reader directly in your application.
 
 Example usage:
 
+```bash
+pip install llama-index-readers-google
+```
+
 ```python
-from llama_index.core import VectorStoreIndex, download_loader
+from llama_index.core import VectorStoreIndex
 
 from llama_index.readers.google import GoogleDocsReader
 

--- a/docs/src/content/docs/framework/understanding/rag/loading/index.md
+++ b/docs/src/content/docs/framework/understanding/rag/loading/index.md
@@ -28,13 +28,15 @@ documents = SimpleDirectoryReader("./data").load_data()
 
 ### Using Readers from LlamaHub
 
-Because there are so many possible places to get data, they are not all built-in. Instead, you download them from our registry of data connectors, [LlamaHub](/python/framework/understanding/rag/loading/llamahub).
+Because there are so many possible places to get data, they are not all built-in. Instead, install the reader package you need from our registry of data connectors, [LlamaHub](/python/framework/understanding/rag/loading/llamahub).
 
-In this example LlamaIndex downloads and installs the connector called [DatabaseReader](https://llamahub.ai/l/readers/llama-index-readers-database), which runs a query against a SQL database and returns every row of the results as a `Document`:
+In this example the [DatabaseReader](https://llamahub.ai/l/readers/llama-index-readers-database) connector runs a query against a SQL database and returns every row of the results as a `Document`:
+
+```bash
+pip install llama-index-readers-database
+```
 
 ```python
-from llama_index.core import download_loader
-
 from llama_index.readers.database import DatabaseReader
 
 reader = DatabaseReader(

--- a/docs/src/content/docs/framework/understanding/rag/loading/llamahub.md
+++ b/docs/src/content/docs/framework/understanding/rag/loading/llamahub.md
@@ -3,7 +3,7 @@ title: LlamaHub
 ---
 
 Our data connectors are offered through [LlamaHub](https://llamahub.ai/) 🦙.
-LlamaHub contains a registry of open-source data connectors that you can easily plug into any LlamaIndex application (+ Agent Tools, and Llama Packs).
+LlamaHub contains a registry of open-source data connector packages that you can easily plug into any LlamaIndex application (+ Agent Tools, and Llama Packs).
 
 ![](./../../../_static/data_connectors/llamahub.png)
 
@@ -11,9 +11,11 @@ LlamaHub contains a registry of open-source data connectors that you can easily 
 
 Get started with:
 
-```python
-from llama_index.core import download_loader
+```bash
+pip install llama-index-readers-google
+```
 
+```python
 from llama_index.readers.google import GoogleDocsReader
 
 loader = GoogleDocsReader()

--- a/llama-index-integrations/readers/README.md
+++ b/llama-index-integrations/readers/README.md
@@ -9,7 +9,7 @@ pip install llama-index-readers-google
 For example, see the code snippets below using the Google Docs Loader.
 
 ```python
-from llama_index.core import VectorStoreIndex, download_loader
+from llama_index.core import VectorStoreIndex
 from llama_index.readers.google import GoogleDocsReader
 
 gdoc_ids = ["1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec"]


### PR DESCRIPTION
# Description

Updates the LlamaHub reader docs to use the current install-and-import flow for reader packages instead of the removed `download_loader` helper.

Addresses #21703.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Local checks run:

- `git diff --check`
- `codespell docs/src/content/docs/framework/community/integrations/chatgpt_plugins.md docs/src/content/docs/framework/module_guides/loading/connector/index.mdx docs/src/content/docs/framework/module_guides/loading/connector/usage_pattern.md docs/src/content/docs/framework/understanding/rag/loading/index.md docs/src/content/docs/framework/understanding/rag/loading/llamahub.md llama-index-integrations/readers/README.md`
- `rg -n "from llama_index\.core import .*download_loader|download_loader" docs/src/content/docs/framework/module_guides docs/src/content/docs/framework/understanding docs/src/content/docs/framework/community llama-index-integrations/readers/README.md -S`

Note: `uv` is not installed in this local environment, so I could not run `uv run make lint`.
