### PR TITLE
fix(azureaisearch): preserve falsy metadata values (0, empty string, False)

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc


### PR DESCRIPTION
## Problem

In `AzureAISearchVectorStore._build_index_doc()`, the guard that copies
metadata fields into the index document uses a truthiness check:

```python
metadata_value = metadata.get(metadata_field_name)
if metadata_value:          # ← bug: falsy values are dropped
    index_doc[index_field_name] = metadata_value
```

Any valid but falsy value — `0`, `0.0`, `""`, `False`, `[]` — evaluates
to `False` and is silently discarded.  When the document is later
retrieved, that field comes back as `None` instead of its actual value.

**Example:** a node with `metadata={"priority": 0}` stores `None` for
`priority`; a node with `metadata={"active": False}` stores `None` for
`active`.

## Fix

Replace the truthiness guard with an explicit `is not None` check so that
any stored value — including `0`, `""`, and `False` — is preserved:

```python
if metadata_value is not None:
    index_doc[index_field_name] = metadata_value
```

Fixes #21385.