### PR TITLE
fix(core): preserve insert_kwargs/update_kwargs for all documents in refresh_ref_docs (fixes #21518)

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -436,17 +436,21 @@ class BaseIndex(Generic[IS], ABC):
         updating documents that have any changes in text or metadata. It
         will also insert any documents that previously were not stored.
         """
+        # Extract per-operation kwargs once, outside the loop.  Using .pop()
+        # inside the loop consumed these keys after the first document, so all
+        # subsequent documents silently received empty dicts.  See
+        # https://github.com/run-llama/llama_index/issues/21518
+        insert_kwargs = update_kwargs.get("insert_kwargs", {})
+        doc_update_kwargs = update_kwargs.get("update_kwargs", {})
         with self._callback_manager.as_trace("refresh_ref_docs"):
             refreshed_documents = [False] * len(documents)
             for i, document in enumerate(documents):
                 existing_doc_hash = self._docstore.get_document_hash(document.id_)
                 if existing_doc_hash is None:
-                    self.insert(document, **update_kwargs.pop("insert_kwargs", {}))
+                    self.insert(document, **insert_kwargs)
                     refreshed_documents[i] = True
                 elif existing_doc_hash != document.hash:
-                    self.update_ref_doc(
-                        document, **update_kwargs.pop("update_kwargs", {})
-                    )
+                    self.update_ref_doc(document, **doc_update_kwargs)
                     refreshed_documents[i] = True
 
             return refreshed_documents
@@ -461,6 +465,10 @@ class BaseIndex(Generic[IS], ABC):
         updating documents that have any changes in text or metadata. It
         will also insert any documents that previously were not stored.
         """
+        # Extract per-operation kwargs once, outside the loop (same fix as the
+        # sync version — .pop() inside the loop drops keys after first use).
+        insert_kwargs = update_kwargs.get("insert_kwargs", {})
+        doc_update_kwargs = update_kwargs.get("update_kwargs", {})
         with self._callback_manager.as_trace("arefresh_ref_docs"):
             refreshed_documents = [False] * len(documents)
             for i, document in enumerate(documents):
@@ -468,14 +476,10 @@ class BaseIndex(Generic[IS], ABC):
                     document.id_
                 )
                 if existing_doc_hash is None:
-                    await self.ainsert(
-                        document, **update_kwargs.pop("insert_kwargs", {})
-                    )
+                    await self.ainsert(document, **insert_kwargs)
                     refreshed_documents[i] = True
                 elif existing_doc_hash != document.hash:
-                    await self.aupdate_ref_doc(
-                        document, **update_kwargs.pop("update_kwargs", {})
-                    )
+                    await self.aupdate_ref_doc(document, **doc_update_kwargs)
                     refreshed_documents[i] = True
             return refreshed_documents
 

--- a/llama-index-core/tests/indices/list/test_index.py
+++ b/llama-index-core/tests/indices/list/test_index.py
@@ -1,10 +1,10 @@
 """Test summary index."""
 
-from typing import List
+from typing import Any, List
 
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.indices.list.base import ListRetrieverMode, SummaryIndex
-from llama_index.core.schema import Document
+from llama_index.core.schema import BaseNode, Document, TransformComponent
 
 
 def test_build_list(documents: List[Document], patch_token_text_splitter) -> None:
@@ -128,6 +128,38 @@ def test_list_delete(documents: List[Document], patch_token_text_splitter) -> No
     assert nodes[1].get_content() == "This is a test."
     assert nodes[2].ref_doc_id == "test_id_3"
     assert nodes[2].get_content() == "This is a test v2."
+
+
+def test_refresh_ref_docs_insert_kwargs_propagated_to_all_documents() -> None:
+    """Regression test for https://github.com/run-llama/llama_index/issues/21518.
+
+    insert_kwargs passed to refresh_ref_docs() must be forwarded to every
+    inserted document, not just the first.  The bug was that .pop() was called
+    on update_kwargs inside the document loop, consuming 'insert_kwargs' after
+    the first document and silently passing {} to subsequent ones.
+    """
+
+    received: list[dict] = []
+
+    class RecordKwargs(TransformComponent):
+        def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+            received.append(dict(kwargs))
+            return nodes
+
+    docs = [
+        Document(text=f"doc {i}", id_=f"doc-{i}") for i in range(3)
+    ]
+    index = SummaryIndex([], transformations=[RecordKwargs()])
+
+    received.clear()
+    index.refresh_ref_docs(docs, insert_kwargs={"my_flag": True})
+
+    # All three documents must have been inserted (index was empty)
+    assert len(received) == 3, f"Expected 3 inserts, got {len(received)}"
+    for i, kwargs in enumerate(received):
+        assert kwargs.get("my_flag") is True, (
+            f"Document {i} did not receive insert_kwargs: got {kwargs}"
+        )
 
 
 def test_as_retriever(documents: List[Document]) -> None:


### PR DESCRIPTION
## Summary

Fixes #21518 — `insert_kwargs` and `update_kwargs` passed to `refresh_ref_docs()` / `arefresh_ref_docs()` are silently dropped after the first matching document.

**Root cause:** both methods called `.pop()` on the shared `update_kwargs` dict inside the document loop:
```python
for i, document in enumerate(documents):
    if existing_doc_hash is None:
        self.insert(document, **update_kwargs.pop("insert_kwargs", {}))  # consumed!
    elif existing_doc_hash != document.hash:
        self.update_ref_doc(document, **update_kwargs.pop("update_kwargs", {}))  # consumed!
```
After the first document is inserted/updated, the corresponding key is gone. All subsequent documents silently receive `{}`, making kwargs only effective for the first match.

**Fix:** extract the sub-dicts once **before** the loop using `.get()`:
```python
insert_kwargs = update_kwargs.get("insert_kwargs", {})
doc_update_kwargs = update_kwargs.get("update_kwargs", {})
for i, document in enumerate(documents):
    if existing_doc_hash is None:
        self.insert(document, **insert_kwargs)
    elif existing_doc_hash != document.hash:
        self.update_ref_doc(document, **doc_update_kwargs)
```

Applied identically to both `refresh_ref_docs` (sync) and `arefresh_ref_docs` (async).

## Changes

**`llama-index-core/llama_index/core/indices/base.py`**
- `refresh_ref_docs`: hoist `.get("insert_kwargs", {})` and `.get("update_kwargs", {})` above the loop
- `arefresh_ref_docs`: same fix for the async variant

**`llama-index-core/tests/indices/list/test_index.py`**
New test `test_refresh_ref_docs_insert_kwargs_propagated_to_all_documents`:
- Builds a `SummaryIndex` with a custom `RecordKwargs` transform that captures received kwargs
- Calls `refresh_ref_docs(docs, insert_kwargs={"my_flag": True})` on 3 new documents
- Asserts that all 3 inserts received `my_flag=True` (not just the first)

## Test plan
- [x] All 7 tests in `tests/indices/list/test_index.py` pass: `python -m pytest tests/indices/list/test_index.py -v` → `7 passed`