### PR TITLE
feat(bedrock-embeddings): add async_client param to reuse a shared aioboto3 client

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -122,6 +122,7 @@ class BedrockEmbedding(BaseEmbedding):
     _config: Any = PrivateAttr()
     _client: Any = PrivateAttr()
     _asession: Any = PrivateAttr()
+    _async_client: Any = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -132,6 +133,7 @@ class BedrockEmbedding(BaseEmbedding):
         aws_session_token: Optional[str] = None,
         region_name: Optional[str] = None,
         client: Optional[Any] = None,
+        async_client: Optional[Any] = None,
         botocore_session: Optional[Any] = None,
         botocore_config: Optional[Any] = None,
         additional_kwargs: Optional[Dict[str, Any]] = None,
@@ -218,6 +220,8 @@ class BedrockEmbedding(BaseEmbedding):
             self._client = session.client("bedrock-runtime", config=self._config)
         else:
             self._client = session.client("bedrock", config=self._config)
+
+        self._async_client = async_client
 
     @staticmethod
     def list_supported_models() -> Dict[str, List[str]]:
@@ -537,16 +541,14 @@ class BedrockEmbedding(BaseEmbedding):
             Union[Embedding, List[Embedding]]: The embedding or list of embeddings for the given payload. If the payload is a list of strings, then the response will be a list of embeddings.
 
         """
-        if self._asession is None:
+        if self._async_client is None and self._asession is None:
             raise ValueError("Client not set")
 
         provider = self._get_provider()
         request_body = self._get_request_body(provider, payload, type)
 
-        async with self._asession.client(
-            "bedrock-runtime", config=self._config
-        ) as client:
-            response = await client.invoke_model(
+        if self._async_client is not None:
+            response = await self._async_client.invoke_model(
                 body=request_body,
                 modelId=self.application_inference_profile_arn or self.model_name,
                 accept="application/json",
@@ -554,6 +556,18 @@ class BedrockEmbedding(BaseEmbedding):
             )
             streaming_body = await response.get("body").read()
             resp = json.loads(streaming_body.decode("utf-8"))
+        else:
+            async with self._asession.client(
+                "bedrock-runtime", config=self._config
+            ) as client:
+                response = await client.invoke_model(
+                    body=request_body,
+                    modelId=self.application_inference_profile_arn or self.model_name,
+                    accept="application/json",
+                    contentType="application/json",
+                )
+                streaming_body = await response.get("body").read()
+                resp = json.loads(streaming_body.decode("utf-8"))
 
         identifiers = PROVIDER_SPECIFIC_IDENTIFIERS.get(provider)
         if identifiers is None:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-bedrock"
-version = "0.8.0"
+version = "0.9.0"
 description = "llama-index embeddings bedrock integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
@@ -100,6 +100,7 @@ async def test_aget_text_embedding_uses_async_client_when_provided(
     async_client = AsyncMockClient()
     bedrock_embedding = BedrockEmbedding(
         model_name=Models.TITAN_EMBEDDING,
+        client=aioboto3.Session().client("bedrock-runtime", region_name="us-east-1"),
         async_client=async_client,
     )
 
@@ -122,6 +123,7 @@ async def test_aget_query_embedding_uses_async_client_when_provided(
     async_client = AsyncMockClient()
     bedrock_embedding = BedrockEmbedding(
         model_name=Models.TITAN_EMBEDDING,
+        client=aioboto3.Session().client("bedrock-runtime", region_name="us-east-1"),
         async_client=async_client,
     )
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
@@ -90,3 +90,47 @@ async def test_application_inference_profile_in_invoke_model_request(
             patched_invoke.call_args.kwargs["modelId"]
             == application_inference_profile_arn
         )
+
+
+@pytest.mark.asyncio
+async def test_aget_text_embedding_uses_async_client_when_provided(
+    mock_aioboto3_session,
+):
+    """When async_client is provided, _aget_embedding uses it directly without opening a session client."""
+    async_client = AsyncMockClient()
+    bedrock_embedding = BedrockEmbedding(
+        model_name=Models.TITAN_EMBEDDING,
+        async_client=async_client,
+    )
+
+    with mock.patch.object(
+        AsyncMockClient, "invoke_model", wraps=async_client.invoke_model
+    ) as patched_invoke:
+        with mock.patch.object(AsyncMockSession, "client") as patched_session_client:
+            response = await bedrock_embedding._aget_text_embedding(EXP_REQUEST)
+            patched_invoke.assert_called_once()
+            patched_session_client.assert_not_called()
+
+    assert response == EXP_RESPONSE["embedding"]
+
+
+@pytest.mark.asyncio
+async def test_aget_query_embedding_uses_async_client_when_provided(
+    mock_aioboto3_session,
+):
+    """When async_client is provided, query embeddings also reuse it directly."""
+    async_client = AsyncMockClient()
+    bedrock_embedding = BedrockEmbedding(
+        model_name=Models.TITAN_EMBEDDING,
+        async_client=async_client,
+    )
+
+    with mock.patch.object(
+        AsyncMockClient, "invoke_model", wraps=async_client.invoke_model
+    ) as patched_invoke:
+        with mock.patch.object(AsyncMockSession, "client") as patched_session_client:
+            response = await bedrock_embedding._aget_query_embedding(EXP_REQUEST)
+            patched_invoke.assert_called_once()
+            patched_session_client.assert_not_called()
+
+    assert response == EXP_RESPONSE["embedding"]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/uv.lock
@@ -1902,7 +1902,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-bedrock"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

Literally https://github.com/run-llama/llama_index/pull/21556 but for BedrockEmbeddings instead of BedrockConverse

Fixes # (no existing issue — happy to open one if preferred)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
