### PR TITLE
docs: fix duplicate word typos across 5 files

### DIFF
--- a/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
+++ b/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
@@ -13,7 +13,7 @@ Currently, the following components are `Transformation` objects:
 
 ## Usage Pattern
 
-While transformations are best used with with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
+While transformations are best used with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
 
 ```python
 from llama_index.core.node_parser import SentenceSplitter

--- a/llama-index-integrations/indices/llama-index-indices-managed-google/llama_index/indices/managed/google/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-google/llama_index/indices/managed/google/base.py
@@ -219,7 +219,7 @@ class GoogleIndex(BaseManagedIndex):
             will follow with the originally provided passages, which will have
             a score from the retrieval.
 
-            `Response`'s `metadata` may also have have an entry with key
+            `Response`'s `metadata` may also have an entry with key
             `answerable_probability`, which is the probability that the grounded
             answer is likely correct.
 

--- a/llama-index-integrations/readers/llama-index-readers-imdb-review/llama_index/readers/imdb_review/scraper.py
+++ b/llama-index-integrations/readers/llama-index-readers-imdb-review/llama_index/readers/imdb_review/scraper.py
@@ -103,7 +103,7 @@ def process_muted_text(mute_text: str) -> (float, float):
     Post processing the muted text.
 
     Args:
-        mute_text (str): text on how many people people found it helpful
+        mute_text (str): text on how many people found it helpful
 
     Returns:
         found_helpful (float): Number of people found the review helpful

--- a/llama-index-integrations/response_synthesizers/llama-index-response-synthesizers-google/llama_index/response_synthesizers/google/base.py
+++ b/llama-index-integrations/response_synthesizers/llama-index-response-synthesizers-google/llama_index/response_synthesizers/google/base.py
@@ -195,7 +195,7 @@ class GoogleTextSynthesizer(BaseSynthesizer):
             will follow with the originally provided passages, which will have
             a score from the retrieval.
 
-            Response's `metadata` may also have have an entry with key
+            Response's `metadata` may also have an entry with key
             `answerable_probability`, which is the model's estimate of the
             probability that its answer is correct and grounded in the input
             passages.

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/README.md
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/README.md
@@ -39,7 +39,7 @@ You can use any of the following AWS arguments to setup the required `boto3` res
 - `aws_access_key_id`
 - `aws_secret_access_key`
 - `aws_session_token`
-- `botocore_session` - A pre-existing existing Botocore session.
+- `botocore_session` - A pre-existing Botocore session.
 - `botocore_config`
 
 As an example, if you have already assumed an AWS profile in your local environment or within an AWS compute


### PR DESCRIPTION
## Summary

Fixed accidental duplicate words in user-facing documentation and docstrings across 5 files. Pure text fixes — no behavior change.

| File | Before | After |
|------|--------|-------|
| `docs/.../ingestion_pipeline/transformations.md` | `best used with with an` | `best used with an` |
| `chat-store-dynamodb/README.md` | `pre-existing existing` | `pre-existing` |
| `imdb-review/scraper.py` (docstring) | `how many people people found` | `how many people found` |
| `indices-managed-google/base.py` (docstring) | `may also have have an entry` | `may also have an entry` |
| `response-synthesizers-google/base.py` (docstring) | `may also have have an entry` | `may also have an entry` |

Found by running a duplicate-word scanner across `.py` and `.md` files, then manually verifying each was an actual typo (not intentional sample data, test fixtures, or correctly-doubled words like commands `litellm --config config.yaml`).
