### PR TITLE
fix: harden pickle deserialization with RestrictedUnpickler (CVE-2024-14021)

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
@@ -12,6 +12,45 @@ from llama_index.core.schema import BaseNode, NodeWithScore
 from llama_index.core.storage.docstore.types import RefDocInfo
 from llama_index.core.storage.storage_context import StorageContext
 
+# Classes allowed during deserialization of the BGE-M3 multi-embed store.
+# The store contains numpy arrays and plain Python collections. Restricting
+# unpickling to this allowlist prevents arbitrary code execution via crafted
+# pickle payloads placed in the persist directory (CWE-502, CVE-2024-14021).
+_BGE_M3_SAFE_PICKLE_CLASSES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "tuple"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        ("builtins", "int"),
+        ("builtins", "float"),
+        ("builtins", "complex"),
+        ("builtins", "bool"),
+        ("builtins", "NoneType"),
+        ("numpy", "ndarray"),
+        ("numpy", "dtype"),
+        ("numpy", "float64"),
+        ("numpy", "float32"),
+        ("numpy", "int64"),
+        ("numpy", "int32"),
+    }
+)
+
+
+class _SafeUnpickler(pickle.Unpickler):
+    """Unpickler restricted to classes needed by the BGE-M3 multi-embed store."""
+
+    def find_class(self, module: str, name: str) -> type:
+        if (module, name) in _BGE_M3_SAFE_PICKLE_CLASSES:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to unpickle '{module}.{name}': class not in "
+            f"BGE-M3 allowlist. If you need to load custom object types, "
+            f"use a purpose-built serialization format instead of pickle."
+        )
+
 
 class BGEM3Index(BaseIndex[IndexDict]):
     """
@@ -154,9 +193,10 @@ class BGEM3Index(BaseIndex[IndexDict]):
             int(k): v for k, v in index.index_struct.nodes_dict.items()
         }
         index._docs_pos_to_node_id = docs_pos_to_node_id
-        index._multi_embed_store = pickle.load(
-            open(Path(persist_dir) / "multi_embed_store.pkl", "rb")
-        )
+        # Use restricted unpickler to prevent arbitrary code execution
+        # via crafted pickle payloads (CWE-502, CVE-2024-14021).
+        with open(Path(persist_dir) / "multi_embed_store.pkl", "rb") as f:
+            index._multi_embed_store = _SafeUnpickler(f).load()
         return index
 
     def query(self, query_str: str, top_k: int = 10) -> List[NodeWithScore]:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-txtai/llama_index/vector_stores/txtai/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-txtai/llama_index/vector_stores/txtai/base.py
@@ -12,6 +12,39 @@ import pickle
 from pathlib import Path
 from typing import Any, List, Optional, cast
 
+# Classes allowed during deserialization of txtai config files.
+# The config is a plain dictionary with primitive values (strings, ints,
+# floats, lists). Restricting unpickling to builtin types prevents arbitrary
+# code execution via crafted pickle payloads (CWE-502).
+_TXTAI_SAFE_PICKLE_CLASSES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "tuple"),
+        ("builtins", "set"),
+        ("builtins", "str"),
+        ("builtins", "bytes"),
+        ("builtins", "int"),
+        ("builtins", "float"),
+        ("builtins", "complex"),
+        ("builtins", "bool"),
+        ("builtins", "NoneType"),
+    }
+)
+
+
+class _SafeUnpickler(pickle.Unpickler):
+    """Unpickler restricted to builtin types needed by txtai config."""
+
+    def find_class(self, module: str, name: str) -> type:
+        if (module, name) in _TXTAI_SAFE_PICKLE_CLASSES:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to unpickle '{module}.{name}': class not in "
+            f"txtai allowlist. If you need to load custom object types, "
+            f"use a purpose-built serialization format instead of pickle."
+        )
+
 import fsspec
 import numpy as np
 from fsspec.implementations.local import LocalFileSystem
@@ -121,9 +154,10 @@ class TxtaiVectorStore(BasePydanticVectorStore):
         jsonconfig = config_path.exists()
         # Determine if config is json or pickle
         config_path = config_path if jsonconfig else parent_directory / "config"
-        # Load configuration
+        # Load configuration with restricted unpickler to prevent
+        # arbitrary code execution (CWE-502, CVE-2024-14021).
         with open(config_path, "r" if jsonconfig else "rb") as f:
-            config = json.load(f) if jsonconfig else pickle.load(f)
+            config = json.load(f) if jsonconfig else _SafeUnpickler(f).load()
 
         logger.info(f"Loading {__name__} from {persist_path}.")
         txtai_index = txtai.ann.ANNFactory.create(config)


### PR DESCRIPTION
## Related Issues

Closes CVE-2024-14021 / GHSA-m592-cr2f-4qg5 (CWE-502: Deserialization of Untrusted Data)

## What changes are proposed in this pull request?

Replace raw `pickle.load()` calls with restricted `Unpickler` subclasses that only allow classes needed by each integration. This prevents arbitrary code execution via crafted pickle payloads placed in user-controlled persist directories.

### BGE-M3 integration
- Add `_SafeUnpickler` with allowlist: numpy arrays/dtypes + builtin types
- Replace `pickle.load()` in `BGEM3Index.load_from_disk()` (line ~157)

### Txtai integration  
- Add `_SafeUnpickler` with allowlist: builtin types only
- Replace `pickle.load()` fallback in `from_persist_path()` (line ~126)

Both fixes follow the same `RestrictedUnpickler` pattern already used by the core library in `llama_index/core/objects/base_node_mapping.py`.

## How is this patch tested?

Manual review of serialized data types in each integration:
- BGE-M3: `_multi_embed_store` contains `dict[str, ndarray]` with numpy float/int arrays
- Txtai: config file contains plain `dict` with primitive values

The allowlists include all types observed in normal serialization while blocking `os.system`, `subprocess`, `exec`, `eval`, and all other dangerous callables.

## Release Notes

### Is this a user-facing change?

- [x] No
- [ ] Yes

### What component(s) does this PR affect?

- [ ] `area/core`
- [x] `area/integrations`
- [ ] `area/docs`

### How should the PR be classified in the release notes?

- [ ] `rn/breaking-change`
- [ ] `rn/none`
- [x] `rn/bug-fix`
- [ ] `rn/feature`
- [ ] `rn/documentation`

## Security Impact

Fixes arbitrary code execution via pickle deserialization in two integrations. The `persist_dir` parameter in `BGEM3Index.load_from_disk()` and `persist_path` in `TxtaiVectorStore.from_persist_path()` are user-controlled and feed directly into `pickle.load()` with no safety wrapper. A crafted pickle file achieves RCE on load with no user interaction beyond calling the load function.