### PR TITLE
fix(agent): copy initial_state in AgentWorkflow to prevent cross-run leaks

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -284,7 +284,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 },
             )
         if not await ctx.store.get("state", default=None):
-            await ctx.store.set("state", self.initial_state)
+            await ctx.store.set("state", self.initial_state.copy())
         if not await ctx.store.get("current_agent_name", default=None):
             await ctx.store.set("current_agent_name", self.root_agent)
         if not await ctx.store.get("handoff_output_prompt", default=None):

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -365,6 +365,65 @@ async def test_workflow_with_state():
 
 
 @pytest.mark.asyncio
+async def test_initial_state_not_leaked_across_runs():
+    """Regression for #21774: initial_state must not leak mutations across runs."""
+
+    async def increment(ctx_val: Context):
+        state = await ctx_val.store.get("state")
+        state["counter"] += 1
+        await ctx_val.store.set("state", state)
+        return f"counter={state['counter']}"
+
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[increment],
+        llm=MockFunctionCallingLLM(
+            response_generator=_response_generator_from_list(
+                [
+                    ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        content="incrementing",
+                        additional_kwargs={
+                            "tool_calls": [
+                                ToolSelection(
+                                    tool_id="one",
+                                    tool_name="increment",
+                                    tool_kwargs={},
+                                )
+                            ]
+                        },
+                    ),
+                    ChatMessage(
+                        role=MessageRole.ASSISTANT, content="done"
+                    ),
+                ]
+            )
+        ),
+    )
+
+    workflow = AgentWorkflow(
+        agents=[agent],
+        initial_state={"counter": 0},
+        state_prompt="State: {state}. {msg}",
+    )
+
+    # First run — counter goes 0 → 1
+    handler1 = workflow.run(user_msg="go")
+    await handler1
+    state1 = await handler1.ctx.store.get("state")
+    assert state1["counter"] == 1
+
+    # Second run must start fresh from 0, not from the leaked 1
+    handler2 = workflow.run(user_msg="go again")
+    await handler2
+    state2 = await handler2.ctx.store.get("state")
+    assert state2["counter"] == 1, (
+        f"expected counter=1 on second run (fresh initial_state), got {state2['counter']}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_agent_with_hitl():
     """Test agent with hitl."""
 


### PR DESCRIPTION
## Description

Closes #21774

`AgentWorkflow._init_context` stored a direct reference to `self.initial_state` in the context store. When the agent mutated the state dict during a run, those mutations leaked back into `self.initial_state`, causing subsequent runs to start with stale values instead of a clean slate.

This applies `.copy()` when setting the state — matching the correct pattern already used in `BaseWorkflowAgent._init_context` (line 292 of `base_agent.py`).

## Changes

- **`llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py`**: `self.initial_state` → `self.initial_state.copy()` at line 287
- **`llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py`**: Add `test_initial_state_not_leaked_across_runs` — runs the same workflow twice and verifies the second run starts with counter=0