### PR TITLE
feat(bedrock-converse, anthropic): add Claude Opus 4.8

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -68,6 +68,7 @@ BEDROCK_INFERENCE_PROFILE_CLAUDE_MODELS: Dict[str, int] = {
     "anthropic.claude-opus-4-6-v1:0": 200000,
     "anthropic.claude-sonnet-4-6": 1000000,
     "anthropic.claude-opus-4-7": 1000000,
+    "anthropic.claude-opus-4-8": 1000000,
 }
 
 # GCP Vertex AI Anthropic identifiers
@@ -84,6 +85,7 @@ VERTEX_CLAUDE_MODELS: Dict[str, int] = {
     "claude-opus-4-6": 200000,
     "claude-sonnet-4-6": 1000000,
     "claude-opus-4-7": 1000000,
+    "claude-opus-4-8": 1000000,
 }
 
 # Anthropic API/SDK identifiers
@@ -111,6 +113,7 @@ ANTHROPIC_MODELS: Dict[str, int] = {
     "claude-opus-4-6": 200000,
     "claude-sonnet-4-6": 1000000,
     "claude-opus-4-7": 1000000,
+    "claude-opus-4-8": 1000000,
 }
 
 # All provider Anthropic identifiers
@@ -124,6 +127,8 @@ CLAUDE_MODELS: Dict[str, int] = {
 ANTHROPIC_NO_TEMP_MODELS: Tuple[str, ...] = (
     "anthropic.claude-opus-4-7",
     "claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
+    "claude-opus-4-8",
 )
 
 

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-anthropic"
-version = "0.11.4"
+version = "0.11.5"
 description = "llama-index llms anthropic integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -68,6 +68,7 @@ BEDROCK_MODELS = {
     "anthropic.claude-opus-4-5-20251101-v1:0": 200000,
     "anthropic.claude-opus-4-6-v1": 1000000,
     "anthropic.claude-opus-4-7": 1000000,
+    "anthropic.claude-opus-4-8": 1000000,
     "anthropic.claude-sonnet-4-20250514-v1:0": 200000,
     "anthropic.claude-sonnet-4-5-20250929-v1:0": 200000,
     "anthropic.claude-sonnet-4-6": 1000000,
@@ -127,6 +128,7 @@ BEDROCK_FUNCTION_CALLING_MODELS = (
     "anthropic.claude-opus-4-5-20251101-v1:0",
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -167,6 +169,7 @@ BEDROCK_INFERENCE_PROFILE_SUPPORTED_MODELS = (
     "anthropic.claude-opus-4-5-20251101-v1:0",
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -191,6 +194,7 @@ BEDROCK_PROMPT_CACHING_SUPPORTED_MODELS = (
     "anthropic.claude-opus-4-5-20251101-v1:0",
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -210,6 +214,7 @@ BEDROCK_REASONING_MODELS = (
     "anthropic.claude-opus-4-5-20251101-v1:0",
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -222,10 +227,14 @@ BEDROCK_REASONING_MODELS = (
 BEDROCK_ADAPTIVE_THINKING_SUPPORTED_MODELS = (
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
     "anthropic.claude-sonnet-4-6",
 )
 
-BEDROCK_NO_TEMP_MODELS = ("anthropic.claude-opus-4-7",)
+BEDROCK_NO_TEMP_MODELS = (
+    "anthropic.claude-opus-4-7",
+    "anthropic.claude-opus-4-8",
+)
 
 
 def is_reasoning(model_name: str) -> bool:

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.12"
+version = "0.14.13"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
# Description

Add `anthropic.claude-opus-4-8` (Anthropic's latest Opus model, released 2025-05-28) to all relevant Bedrock model allowlists in `utils.py`:

- `BEDROCK_MODELS` — 1M token context window
- `BEDROCK_FUNCTION_CALLING_MODELS`
- `BEDROCK_INFERENCE_PROFILE_SUPPORTED_MODELS`
- `BEDROCK_PROMPT_CACHING_SUPPORTED_MODELS`
- `BEDROCK_REASONING_MODELS`
- `BEDROCK_ADAPTIVE_THINKING_SUPPORTED_MODELS`
- `BEDROCK_NO_TEMP_MODELS` — Bedrock rejects the `temperature` parameter for this model

Without these entries, `BedrockConverse` raises `ValueError` when attempting to use the model via cross-region inference profiles.

## New Package?

- [x] No

## Version Bump?

- [x] Yes — `0.14.12` → `0.14.13`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

Verified end-to-end: registered the model in a downstream service, started the server, and confirmed successful streaming inference responses from Bedrock.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods