### PR TITLE
fix(openai): support vLLM 'reasoning' field alongside 'reasoning_content'

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -569,8 +569,8 @@ class OpenAI(FunctionCallingLLM):
                 content += content_delta
 
                 # Extract reasoning_content for chain-of-thought streaming.
-                # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # OpenAI/DeepSeek use "reasoning_content"; vLLM (>=0.20) uses "reasoning".
+                raw_reasoning = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )
@@ -865,8 +865,8 @@ class OpenAI(FunctionCallingLLM):
                 content += content_delta
 
                 # Extract reasoning_content for chain-of-thought streaming.
-                # Many OpenAI-compatible providers surface this extra field.
-                raw_reasoning = getattr(delta, "reasoning_content", None)
+                # OpenAI/DeepSeek use "reasoning_content"; vLLM (>=0.20) uses "reasoning".
+                raw_reasoning = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
                 reasoning_delta = (
                     raw_reasoning if isinstance(raw_reasoning, str) else ""
                 )

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -834,8 +834,11 @@ def from_openai_message(
     blocks: List[ContentBlock] = []
 
     # Extract reasoning_content if present (used by many OpenAI-compatible
-    # providers for chain-of-thought responses)
-    reasoning_content = getattr(openai_message, "reasoning_content", None)
+    # providers for chain-of-thought responses).
+    # OpenAI/DeepSeek use "reasoning_content"; vLLM (>=0.20) uses "reasoning".
+    reasoning_content = getattr(openai_message, "reasoning_content", None) or getattr(
+        openai_message, "reasoning", None
+    )
     if isinstance(reasoning_content, str) and reasoning_content:
         blocks.append(ThinkingBlock(content=reasoning_content))
 


### PR DESCRIPTION
## Description

Fixes chain-of-thought reasoning being silently dropped when using vLLM-served Qwen3 models with LlamaIndex's OpenAI-compatible LLM client.

## Problem

vLLM (>=0.20) exposes reasoning traces via a `reasoning` field on the message object, while OpenAI/DeepSeek use `reasoning_content`. LlamaIndex only checks `reasoning_content`, so `ThinkingBlock` is never populated for vLLM users.

| Provider | Field name |
|----------|-----------|
| OpenAI / DeepSeek | `message.reasoning_content` |
| vLLM (Qwen3) | `message.reasoning` |

## Fix

Check both field names using `or` fallback in all three code paths:

```python
reasoning_content = getattr(msg, "reasoning_content", None) or getattr(msg, "reasoning", None)
```

**Locations fixed:**
- `utils.py`: `from_openai_message()` — non-streaming responses
- `base.py`: `gen()` — sync streaming deltas
- `base.py`: `agen()` — async streaming deltas

## Testing

Verified that:
- OpenAI responses with `reasoning_content` still work (no regression)
- vLLM responses with `reasoning` field now produce `ThinkingBlock`
- Responses with neither field produce no `ThinkingBlock` (no error)

Fixes #21582