### PR TITLE
docs: add Vaultak runtime security to observability guide

### DIFF
--- a/docs/src/content/docs/framework/module_guides/observability/callbacks/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/callbacks/index.md
@@ -39,3 +39,4 @@ Currently supported callbacks are as follows:
 - [AimCallback](/python/examples/observability/aimcallback) -> Tracking of LLM inputs and outputs. Example usage can be found in the notebook below.
 - [OpenInferenceCallbackHandler](/python/examples/observability/openinferencecallback) -> Tracking of AI model inferences. Example usage can be found in the notebook below.
 - [OpenAIFineTuningHandler](https://github.com/jerryjliu/llama_index/blob/main/experimental/openai_fine_tuning/openai_fine_tuning.ipynb) -> Records all LLM inputs and outputs. Then, provides a function `save_finetuning_events()` to save inputs and outputs in a format suitable for fine-tuning with OpenAI.
+- [VaultakCallbackHandler](/python/framework/module_guides/observability#vaultak) -> Runtime security monitoring — risk-scores every function call, enforces policy rules, masks PII in outputs, and triggers rollback on exceptions.

--- a/docs/src/content/docs/framework/module_guides/observability/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/index.md
@@ -704,6 +704,80 @@ print(f"Response: {response}")
 
 ![tracing](https://cdn.getmaxim.ai/public/images/llamaindex.gif)
 
+### Vaultak
+
+[Vaultak](https://vaultak.com) is a runtime security platform that wraps every LlamaIndex query,
+agent action, and tool call with real-time protection. Every `FUNCTION_CALL` is risk-scored (0–10)
+and checked against your policy rules before it executes. PII is masked from tool outputs before it
+reaches the LLM. Exceptions trigger automatic rollback and alerts in your Vaultak dashboard.
+
+#### Install
+
+```bash
+pip install llama-index-callbacks-vaultak
+```
+
+Sign up at [vaultak.com](https://vaultak.com) to get your API key (starts with `vtk_`).
+
+#### Usage Pattern
+
+**With a query engine:**
+
+```python
+from llama_index.core.callbacks import CallbackManager
+from llama_index.callbacks.vaultak import VaultakCallbackHandler
+
+handler = VaultakCallbackHandler(api_key="vtk_...")
+callback_manager = CallbackManager([handler])
+
+query_engine = index.as_query_engine(callback_manager=callback_manager)
+response = query_engine.query("Summarize our Q3 revenue data")
+```
+
+**With a ReAct agent:**
+
+```python
+from llama_index.core.agent import ReActAgent
+from llama_index.core.callbacks import CallbackManager
+from llama_index.callbacks.vaultak import VaultakCallbackHandler
+
+handler = VaultakCallbackHandler(
+    api_key="vtk_...",
+    agent_name="prod-agent",
+    block_on_high_risk=True,
+    risk_threshold=6.0,
+)
+
+agent = ReActAgent.from_tools(tools, callback_manager=CallbackManager([handler]))
+```
+
+**Set globally (applies to all LlamaIndex operations):**
+
+```python
+from llama_index.core import Settings
+from llama_index.core.callbacks import CallbackManager
+from llama_index.callbacks.vaultak import VaultakCallbackHandler
+
+Settings.callback_manager = CallbackManager([
+    VaultakCallbackHandler(api_key="vtk_...", agent_name="my-app")
+])
+```
+
+| LlamaIndex event | Vaultak action |
+|---|---|
+| `FUNCTION_CALL` start | Risk-scores the action (0–10); blocks if above threshold |
+| `FUNCTION_CALL` start | Checks tool call against your policy rules |
+| `FUNCTION_CALL` end | Scans output for PII and masks it |
+| `LLM` start | Checks LLM inputs against policy |
+| `EXCEPTION` | Sends alert + triggers rollback |
+| `QUERY` end | Scans final response for PII |
+
+#### Guides
+
+- [Vaultak documentation](https://docs.vaultak.com)
+- [PyPI package](https://pypi.org/project/llama-index-callbacks-vaultak)
+- [GitHub](https://github.com/vaultak/llama-index-vaultak)
+
 ## Other Partner `One-Click` Integrations (Legacy Modules)
 
 These partner integrations use our legacy `CallbackManager` or third-party calls.


### PR DESCRIPTION
## Summary

Adds a `### Vaultak` section to the existing observability guide for [Vaultak](https://vaultak.com) — a runtime security platform that wraps LlamaIndex query engines, agents, and workflows with real-time protection via the `CallbackManager` interface.

**This PR is docs-only — no new packages, no `pyproject.toml`.**

Install: `pip install llama-index-callbacks-vaultak`

## Changes

**`docs/src/content/docs/framework/module_guides/observability/index.md`**

Adds a `### Vaultak` section (placed before the "Other Partner / Legacy Modules" section) with:
- Install snippet
- Three usage examples: query engine, ReAct agent, and global `Settings.callback_manager`
- Event-coverage table mapping LlamaIndex `CBEventType` values to Vaultak actions:
  - `FUNCTION_CALL` start → risk-score + policy check (blocks if above threshold)
  - `FUNCTION_CALL` end → PII masking
  - `LLM` start → policy check
  - `EXCEPTION` → alert + rollback
  - `QUERY` end → PII scan on final response

**`docs/src/content/docs/framework/module_guides/observability/callbacks/index.md`**

Adds `VaultakCallbackHandler` to the supported-callbacks module list with a link back to the new section.

## Test plan

- [ ] Vaultak section renders correctly in the observability guide
- [ ] Anchor link from callbacks/index.md resolves to the Vaultak section
- [ ] Code snippets are syntactically correct

🤖 Generated with [Claude Code](https://claude.ai/claude-code)