### PR TITLE
fix: await DynamoDB chat store async table init

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/llama_index/storage/chat_store/dynamodb/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/llama_index/storage/chat_store/dynamodb/base.py
@@ -111,7 +111,7 @@ class DynamoDBChatStore(BaseChatStore):
     _client: ServiceResource = PrivateAttr()
     _table: Any = PrivateAttr()
     _aclient: ServiceResource = PrivateAttr()
-    _atable: Any = PrivateAttr()
+    _atable: Any = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -227,7 +227,7 @@ class DynamoDBChatStore(BaseChatStore):
         self._table.put_item(Item=item)
 
     async def aset_messages(self, key: str, messages: List[ChatMessage]) -> None:
-        self.init_async_table()
+        await self.init_async_table()
 
         item = {self.primary_key: key, "History": _messages_to_dict(messages)}
 
@@ -258,7 +258,7 @@ class DynamoDBChatStore(BaseChatStore):
         return [_dict_to_message(message) for message in message_history]
 
     async def aget_messages(self, key: str) -> List[ChatMessage]:
-        self.init_async_table()
+        await self.init_async_table()
         response = await self._atable.get_item(Key={self.primary_key: key})
 
         if response and "Item" in response:
@@ -293,7 +293,7 @@ class DynamoDBChatStore(BaseChatStore):
         self._table.put_item(Item=item)
 
     async def async_add_message(self, key: str, message: ChatMessage) -> None:
-        self.init_async_table()
+        await self.init_async_table()
         current_messages = _messages_to_dict(await self.aget_messages(key))
         current_messages.append(_message_to_dict(message))
 
@@ -322,7 +322,7 @@ class DynamoDBChatStore(BaseChatStore):
         return messages_to_delete
 
     async def adelete_messages(self, key: str) -> Optional[List[ChatMessage]]:
-        self.init_async_table()
+        await self.init_async_table()
         messages_to_delete = await self.aget_messages(key)
         await self._atable.delete_item(Key={self.primary_key: key})
         return messages_to_delete
@@ -353,7 +353,7 @@ class DynamoDBChatStore(BaseChatStore):
             return None
 
     async def adelete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
-        self.init_async_table()
+        await self.init_async_table()
         current_messages = await self.aget_messages(key)
         try:
             message_to_delete = current_messages[idx]
@@ -381,7 +381,7 @@ class DynamoDBChatStore(BaseChatStore):
         return self.delete_message(key, -1)
 
     async def adelete_last_message(self, key: str) -> Optional[ChatMessage]:
-        return self.adelete_message(key, -1)
+        return await self.adelete_message(key, -1)
 
     def get_keys(self) -> List[str]:
         """
@@ -402,7 +402,7 @@ class DynamoDBChatStore(BaseChatStore):
         return keys
 
     async def aget_keys(self) -> List[str]:
-        self.init_async_table()
+        await self.init_async_table()
         response = await self._atable.scan(ProjectionExpression=self.primary_key)
         keys = [item[self.primary_key] for item in response["Items"]]
         while "LastEvaluatedKey" in response:

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-storage-chat-store-dynamodb"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index storage-chat-store aws dynamodb integration"
 authors = [{name = "brycecf", email = "26725654+brycecf@users.noreply.github.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/tests/test_chat_store_dynamodb_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/tests/test_chat_store_dynamodb_chat_store.py
@@ -1,9 +1,47 @@
+import asyncio
+import inspect
+import time
+
+import boto3
 import pytest
 from moto import mock_aws
-import boto3
-import time
-from llama_index.storage.chat_store.dynamodb.base import DynamoDBChatStore
+
 from llama_index.core.base.llms.types import ChatMessage
+from llama_index.storage.chat_store.dynamodb.base import DynamoDBChatStore
+
+
+class FakeAsyncDynamoDBTable:
+    def __init__(self, primary_key: str) -> None:
+        self.primary_key = primary_key
+        self.items = {}
+
+    async def put_item(self, Item):
+        self.items[Item[self.primary_key]] = Item
+
+    async def get_item(self, Key):
+        key = Key[self.primary_key]
+        if key not in self.items:
+            return {}
+        return {"Item": self.items[key]}
+
+    async def delete_item(self, Key):
+        self.items.pop(Key[self.primary_key], None)
+
+    async def scan(self, ProjectionExpression, ExclusiveStartKey=None):
+        keys = sorted(self.items)
+        if ExclusiveStartKey is None and len(keys) > 1:
+            return {
+                "Items": [{ProjectionExpression: keys[0]}],
+                "LastEvaluatedKey": {self.primary_key: keys[0]},
+            }
+
+        if ExclusiveStartKey is None:
+            page_keys = keys
+        else:
+            last_key = ExclusiveStartKey[self.primary_key]
+            page_keys = keys[keys.index(last_key) + 1 :]
+
+        return {"Items": [{ProjectionExpression: key} for key in page_keys]}
 
 
 @pytest.fixture()
@@ -119,6 +157,62 @@ def test_get_keys(chat_store):
     assert len(keys) == 2
     assert "1" in keys
     assert "2" in keys
+
+
+def test_async_table_defaults_to_none(chat_store):
+    assert chat_store._atable is None
+
+
+def test_async_methods_initialize_table_and_return_values(chat_store, monkeypatch):
+    table = FakeAsyncDynamoDBTable(primary_key=chat_store.primary_key)
+    init_calls = 0
+
+    async def init_async_table(self):
+        nonlocal init_calls
+        init_calls += 1
+        self._atable = table
+
+    monkeypatch.setattr(DynamoDBChatStore, "init_async_table", init_async_table)
+
+    async def run_test():
+        await chat_store.aset_messages(
+            "TestSession",
+            [ChatMessage(content="Hello"), ChatMessage(content="World")],
+        )
+        retrieved_messages = await chat_store.aget_messages("TestSession")
+        assert [message.content for message in retrieved_messages] == [
+            "Hello",
+            "World",
+        ]
+
+        await chat_store.async_add_message("TestSession", ChatMessage(content="Added"))
+        retrieved_messages = await chat_store.aget_messages("TestSession")
+        assert [message.content for message in retrieved_messages] == [
+            "Hello",
+            "World",
+            "Added",
+        ]
+
+        deleted_message = await chat_store.adelete_message("TestSession", 1)
+        assert deleted_message is not None
+        assert deleted_message.content == "World"
+
+        last_message = await chat_store.adelete_last_message("TestSession")
+        assert not inspect.iscoroutine(last_message)
+        assert last_message is not None
+        assert last_message.content == "Added"
+
+        deleted_messages = await chat_store.adelete_messages("TestSession")
+        assert deleted_messages is not None
+        assert [message.content for message in deleted_messages] == ["Hello"]
+        assert await chat_store.aget_messages("TestSession") == []
+
+        await chat_store.aset_messages("KeyA", [])
+        await chat_store.aset_messages("KeyB", [])
+        assert await chat_store.aget_keys() == ["KeyA", "KeyB"]
+
+    asyncio.run(run_test())
+    assert init_calls > 0
 
 
 def test_ttl_set_messages(chat_store_with_ttl):

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/uv.lock
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb/uv.lock
@@ -1960,7 +1960,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-storage-chat-store-dynamodb"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
# Description

Fixes a DynamoDB chat store async API bug where async methods called `init_async_table()` without awaiting it before using `_atable`. This could leave the async table uninitialized and cause runtime failures. It also fixes `adelete_last_message()` so it returns the deleted `ChatMessage` instead of a coroutine object.

No linked issue. This is a small self-contained bugfix found in the DynamoDB chat store integration.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Focused local checks run from `llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-dynamodb`:

- `pytest tests/test_chat_store_dynamodb_chat_store.py -q` (`12 passed`)
- `ruff check llama_index/storage/chat_store/dynamodb/base.py tests/test_chat_store_dynamodb_chat_store.py`
- `ruff format --check llama_index/storage/chat_store/dynamodb/base.py tests/test_chat_store_dynamodb_chat_store.py`
- `python -m py_compile llama_index/storage/chat_store/dynamodb/base.py tests/test_chat_store_dynamodb_chat_store.py`
- `git diff --check`
- `uv lock --check`
